### PR TITLE
Disable MCP servers in CLI subprocess agents

### DIFF
--- a/src/autorac/harness/orchestrator.py
+++ b/src/autorac/harness/orchestrator.py
@@ -407,7 +407,17 @@ class Orchestrator:
         """Run via Claude Code CLI subprocess."""
         import subprocess
 
-        cmd = ["claude", "--print", "--model", self.model, "-p", prompt]
+        cmd = [
+            "claude",
+            "--print",
+            "--model",
+            self.model,
+            "--mcp-config",
+            "{}",
+            "--strict-mcp-config",
+            "-p",
+            prompt,
+        ]
 
         try:
             loop = asyncio.get_event_loop()


### PR DESCRIPTION
## Summary

When autorac spawns `claude --print` subprocesses for encoding, each one inherits the user's MCP server configuration and launches all configured MCP servers (including GUI apps like Granola via electron-playwright-mcp).

Fix: pass `--mcp-config '{}' --strict-mcp-config` to subprocess calls so they load zero MCP servers.

## Test plan

- [x] 567 tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)