### PR TITLE
Fix concrete issues from Axiom stack review

### DIFF
--- a/26_USC_1_VALIDATION_REPORT.md
+++ b/26_USC_1_VALIDATION_REPORT.md
@@ -1,5 +1,16 @@
 # 26 USC 1 Validation Report
 
+> **⚠️ STATUS: OUTDATED (as of 2026-04-16)**
+>
+> This report predates the live oracle validation pipeline
+> (PolicyEngine + TAXSIM via `rac-validators`). The methodology below uses a
+> manual, simplified federal-income-tax calculation rather than running the
+> encoded rules against an external oracle.
+>
+> A refreshed report using the current 3-tier validator pipeline
+> (CI → PolicyEngine/TAXSIM oracles → LLM reviewers) is pending. Until then,
+> treat the numbers below as historical context only.
+
 ## Validation Overview
 
 **Statute**: 26 USC Section 1 - Income Tax Rates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
 # Changelog
 
 All notable changes to autorac will be documented here.
+
+## Unreleased
+
+### Changed
+- Extracted model pricing rates into `src/autorac/harness/pricing_rates.toml`
+  with a `version` and `effective_date` so rate changes can be tracked
+  independently of Python code. Public pricing API is unchanged.
+- Added `__version__` constants and a versioning policy for embedded
+  encoder and reviewer prompts. See `docs/prompt-versioning.md`.
+- Defensive handling for reviewer output JSON parse failures in
+  `ValidatorPipeline._run_reviewer`: malformed output now returns a
+  `reviewer_parse_failed` result and logs a truncated warning instead of
+  relying on a generic exception catch.
+- Added a deprecation banner to `26_USC_1_VALIDATION_REPORT.md` noting that
+  the report predates the live oracle pipeline and is pending refresh.
+
+### Open TODOs needing design input
+These are tracked so they don't get lost in code:
+
+- `src/autorac/harness/encoder_harness.py` fallback formula — emitted when
+  encoding fails. The placeholder `return 0` is intentional; authoring a
+  real formula requires human review. Tagged inline as
+  `TODO(#issue-needed)`.

--- a/docs/prompt-versioning.md
+++ b/docs/prompt-versioning.md
@@ -1,0 +1,62 @@
+# Prompt versioning
+
+AutoRAC ships its agent prompts as Python string constants in
+`src/autorac/prompts/`. Because encoder and reviewer behaviour is largely
+determined by these prompts, we track their evolution with an explicit
+version field in addition to the automatically recorded prompt hash.
+
+## Why prompts are versioned
+
+- **Debuggability.** When we look at an old encoding run in the DB, the
+  prompt hash tells us *which* prompt ran, but a semantic version number
+  tells us *which generation* of the prompt ran, which is far easier to
+  reason about across many commits.
+- **Registry correlation.** Logs, dashboards, and paper experiments
+  reference encoder/reviewer generations. Humans read "encoder v3" much
+  faster than they read a 40-character hash.
+- **Rollback signalling.** A version bump is a clear signal in code review
+  that reviewers should think about compatibility with downstream artifacts
+  (cached runs, saved traces, reference encodings).
+
+## When to bump
+
+Bump the `__version__` in the relevant prompt module when the prompt text
+changes in a way that could materially affect model behaviour. Examples:
+
+| Change                                                             | Bump? |
+| ------------------------------------------------------------------ | ----- |
+| Adding or removing a numbered rule                                 | Yes   |
+| Changing the required JSON output schema                           | Yes   |
+| Adding a new blocking check                                        | Yes   |
+| Swapping examples that illustrate the rules                        | Yes   |
+| Fixing a typo that does not change meaning                         | No    |
+| Whitespace / formatting-only edits                                 | No    |
+
+If in doubt, bump. The cost of a spurious bump is negligible; the cost of
+missing a real semantic change is a confusing audit trail.
+
+## Module scope
+
+Each module owns its own version:
+
+- `autorac.prompts.encoder.__version__` — encoder prompt.
+- `autorac.prompts.reviewers.__version__` — **bundle** of all four reviewer
+  prompts. Any change to any reviewer prompt bumps this single integer.
+
+We deliberately keep reviewer prompts on a shared version to reflect the
+fact that they are run and consumed as a set.
+
+## Relationship to the encoding DB
+
+The encoding DB (see `src/autorac/harness/encoding_db.py`) records the raw
+SHA-256 of each prompt as part of every run. That hash is the authoritative
+fingerprint. `__version__` is a looser, human-friendly label that rides on
+top:
+
+- The hash uniquely identifies prompt text.
+- The version identifies a *generation* that may span several hashes
+  during development (because hash changes whenever any character changes,
+  including non-semantic edits).
+
+When analysing the DB, you should join on hash for correctness and use
+version as the user-facing grouping key.

--- a/src/autorac/cli.py
+++ b/src/autorac/cli.py
@@ -77,7 +77,9 @@ def _resolve_runtime_rac_checkout(policy_repo_root: Path | None = None) -> Path:
 
 def _resolve_validation_repo_roots(rac_file: Path) -> tuple[Path, Path]:
     """Resolve the policy repo root plus the core rac runtime for validation."""
-    policy_repo_root = find_policy_repo_root(rac_file) or _resolve_repo_checkout("rac-us")
+    policy_repo_root = find_policy_repo_root(rac_file) or _resolve_repo_checkout(
+        "rac-us"
+    )
     return policy_repo_root, _resolve_runtime_rac_checkout(policy_repo_root)
 
 
@@ -122,7 +124,11 @@ def _add_gpt_backend_argument(parser: argparse.ArgumentParser) -> None:
 
 def _resolved_gpt_backend(args) -> str | None:
     """Resolve the requested GPT backend override from args/env."""
-    return getattr(args, "gpt_backend", None) or os.getenv("AUTORAC_GPT_BACKEND") or "codex"
+    return (
+        getattr(args, "gpt_backend", None)
+        or os.getenv("AUTORAC_GPT_BACKEND")
+        or "codex"
+    )
 
 
 def _rewrite_gpt_runner_backend(spec: str, backend: str | None) -> str:
@@ -404,7 +410,9 @@ def main():
         "eval-source",
         help="Compare model runners on one arbitrary source-text slice",
     )
-    eval_source_parser.add_argument("source_id", help="Logical identifier for the source slice")
+    eval_source_parser.add_argument(
+        "source_id", help="Logical identifier for the source slice"
+    )
     eval_source_parser.add_argument(
         "source_file",
         type=Path,
@@ -2006,9 +2014,7 @@ def _print_eval_metrics(result) -> None:
             f"  taxsim={'yes' if result.metrics.taxsim_pass else 'no'} score={result.metrics.taxsim_score:.1%}"
         )
     if result.metrics.ungrounded_numeric_count:
-        offenders = [
-            item.raw for item in result.metrics.grounding if not item.grounded
-        ]
+        offenders = [item.raw for item in result.metrics.grounding if not item.grounded]
         print(f"  ungrounded_values={', '.join(offenders[:10])}")
 
 
@@ -2180,7 +2186,9 @@ def cmd_eval_akn_section(args):
     print(f"Output root: {args.output}")
     print(f"rac: {rac_path}")
     print(f"AKN file: {args.akn_file}")
-    section_labels = [value for value in [args.section_eid, *args.section_eids] if value]
+    section_labels = [
+        value for value in [args.section_eid, *args.section_eids] if value
+    ]
     print(f"Section: {', '.join(section_labels)}")
     if args.metadata_file:
         print(f"Metadata file: {args.metadata_file}")
@@ -2349,7 +2357,9 @@ def _serialize_readiness_summary(summary) -> dict:
     }
 
 
-def _build_eval_suite_payload(manifest, effective_runners, results, readiness, all_ready):
+def _build_eval_suite_payload(
+    manifest, effective_runners, results, readiness, all_ready
+):
     """Build the persisted eval-suite payload shared by text and JSON output."""
     return {
         "manifest": {
@@ -2842,7 +2852,9 @@ def _build_eval_suite_archive_metadata(
         "finished_at": state.get("finished_at"),
         "total_cases": state.get("total_cases"),
         "completed_cases": state.get("completed_cases"),
-        "result_count": state.get("result_count", len(results.get("results", []) or [])),
+        "result_count": state.get(
+            "result_count", len(results.get("results", []) or [])
+        ),
         "all_ready": summary.get("all_ready"),
         "rewritten_files": rewritten_files,
     }
@@ -2857,7 +2869,9 @@ def cmd_eval_suite_archive(args):
 
     state_path = source_output / "suite-run.json"
     if not state_path.exists():
-        print(f"Not an eval-suite output directory (missing suite-run.json): {source_output}")
+        print(
+            f"Not an eval-suite output directory (missing suite-run.json): {source_output}"
+        )
         sys.exit(1)
 
     archive_root = (
@@ -2871,7 +2885,9 @@ def cmd_eval_suite_archive(args):
     archive_dir = _unique_archive_dir(archive_root, base_name)
     shutil.copytree(source_output, archive_dir)
 
-    rewritten_files = _rewrite_archived_eval_suite_json_files(archive_dir, source_output)
+    rewritten_files = _rewrite_archived_eval_suite_json_files(
+        archive_dir, source_output
+    )
     metadata = _build_eval_suite_archive_metadata(
         archive_dir=archive_dir,
         source_root=source_output,
@@ -2895,7 +2911,10 @@ def cmd_eval_suite_archive(args):
         print(f"Rewrote archived paths in: {', '.join(rewritten_files)}")
     if metadata.get("status"):
         print(f"Status: {metadata['status']}")
-    if metadata.get("completed_cases") is not None and metadata.get("total_cases") is not None:
+    if (
+        metadata.get("completed_cases") is not None
+        and metadata.get("total_cases") is not None
+    ):
         print(
             f"Progress: {metadata['completed_cases']}/{metadata['total_cases']} cases"
         )
@@ -2950,7 +2969,9 @@ def _format_generalist_score(value: float | None) -> str:
     return f"{value:.2f}/10"
 
 
-def _build_eval_suite_report(payload: dict, left_runner: str, right_runner: str) -> dict:
+def _build_eval_suite_report(
+    payload: dict, left_runner: str, right_runner: str
+) -> dict:
     """Build a structured pairwise report from eval-suite JSON output."""
     results = payload.get("results", []) or []
     readiness = payload.get("readiness", {}) or {}
@@ -3009,7 +3030,9 @@ def _build_eval_suite_report(payload: dict, left_runner: str, right_runner: str)
             "left_policyengine_score": left_metrics.get("policyengine_score"),
             "right_policyengine_score": right_metrics.get("policyengine_score"),
             "left_estimated_cost_usd": left.get("estimated_cost_usd") if left else None,
-            "right_estimated_cost_usd": right.get("estimated_cost_usd") if right else None,
+            "right_estimated_cost_usd": right.get("estimated_cost_usd")
+            if right
+            else None,
             "left_duration_ms": left.get("duration_ms") if left else None,
             "right_duration_ms": right.get("duration_ms") if right else None,
             "left_output_file": left.get("output_file") if left else None,
@@ -3061,7 +3084,9 @@ def _build_eval_suite_report(payload: dict, left_runner: str, right_runner: str)
 
     runner_summaries: dict[str, dict] = {}
     for runner in [left_runner, right_runner]:
-        runner_results = [result for result in results if result.get("runner") == runner]
+        runner_results = [
+            result for result in results if result.get("runner") == runner
+        ]
         summary = dict(readiness.get(runner) or {})
         summary["mean_duration_ms"] = _mean_numeric(
             [result.get("duration_ms") for result in runner_results]
@@ -3112,11 +3137,7 @@ def _render_eval_suite_report_markdown(report: dict) -> str:
         f"- Left runner: `{left_runner}`",
         f"- Right runner: `{right_runner}`",
         "",
-        "| Metric | "
-        + left_runner
-        + " | "
-        + right_runner
-        + " |",
+        "| Metric | " + left_runner + " | " + right_runner + " |",
         "| --- | ---: | ---: |",
         f"| Cases | {left_summary.get('total_cases', left_summary.get('case_count', 'n/a'))} | {right_summary.get('total_cases', right_summary.get('case_count', 'n/a'))} |",
         f"| Success rate | {_format_percent(left_summary.get('success_rate'))} | {_format_percent(right_summary.get('success_rate'))} |",
@@ -3173,9 +3194,21 @@ def _render_eval_suite_report_markdown(report: dict) -> str:
             "| "
             + row["case"]
             + " | "
-            + ("pass" if row["left_compile_pass"] else "fail" if row["left_compile_pass"] is not None else "n/a")
+            + (
+                "pass"
+                if row["left_compile_pass"]
+                else "fail"
+                if row["left_compile_pass"] is not None
+                else "n/a"
+            )
             + " | "
-            + ("pass" if row["right_compile_pass"] else "fail" if row["right_compile_pass"] is not None else "n/a")
+            + (
+                "pass"
+                if row["right_compile_pass"]
+                else "fail"
+                if row["right_compile_pass"] is not None
+                else "n/a"
+            )
             + " | "
             + (_format_percent(left_pe) if left_pe is not None else "n/a")
             + " | "
@@ -3198,7 +3231,9 @@ def cmd_eval_suite_report(args):
         print(f"No runner results found in {args.result_json}")
         sys.exit(1)
 
-    left_runner = args.left_runner or (available_runners[0] if available_runners else None)
+    left_runner = args.left_runner or (
+        available_runners[0] if available_runners else None
+    )
     right_runner = args.right_runner or (
         available_runners[1] if len(available_runners) > 1 else None
     )
@@ -3218,7 +3253,9 @@ def cmd_eval_suite_report(args):
     if args.csv_out:
         args.csv_out.parent.mkdir(parents=True, exist_ok=True)
         with args.csv_out.open("w", newline="") as fh:
-            fieldnames = list(report["case_rows"][0].keys()) if report["case_rows"] else []
+            fieldnames = (
+                list(report["case_rows"][0].keys()) if report["case_rows"] else []
+            )
             writer = csv.DictWriter(fh, fieldnames=fieldnames)
             if fieldnames:
                 writer.writeheader()

--- a/src/autorac/harness/__init__.py
+++ b/src/autorac/harness/__init__.py
@@ -26,6 +26,13 @@ from .encoding_db import (
     ReviewResults,
     create_run,
 )
+from .evals import (
+    EvalResult,
+    EvalRunnerSpec,
+    evaluate_artifact,
+    parse_runner_spec,
+    run_model_eval,
+)
 from .metrics import (
     CalibrationMetrics,
     CalibrationSnapshot,
@@ -34,7 +41,6 @@ from .metrics import (
     print_calibration_report,
     save_calibration_snapshot,
 )
-from .evals import EvalResult, EvalRunnerSpec, evaluate_artifact, parse_runner_spec, run_model_eval
 from .orchestrator import Orchestrator
 from .validator_pipeline import (
     PipelineResult,

--- a/src/autorac/harness/backends.py
+++ b/src/autorac/harness/backends.py
@@ -483,7 +483,6 @@ class CodexCLIBackend(EncoderBackend):
         }
 
 
-
 class AgentSDKBackend(EncoderBackend):
     """
     Backend using Claude API (anthropic SDK).

--- a/src/autorac/harness/dependency_stubs.py
+++ b/src/autorac/harness/dependency_stubs.py
@@ -37,7 +37,9 @@ class ResolvedCanonicalConcept:
     source_file: Path
 
 
-_REGISTERED_DEFINED_TERM_PATTERNS: tuple[tuple[re.Pattern[str], ResolvedDefinedTerm], ...] = (
+_REGISTERED_DEFINED_TERM_PATTERNS: tuple[
+    tuple[re.Pattern[str], ResolvedDefinedTerm], ...
+] = (
     (
         re.compile(r"\bmixed-age couple\b", re.IGNORECASE),
         ResolvedDefinedTerm(
@@ -92,7 +94,10 @@ def resolve_canonical_concepts_from_text(
     index: dict[str, list[ResolvedCanonicalConcept]] = {}
 
     for candidate_file in sorted(corpus_root.rglob("*.rac")):
-        if current_file is not None and candidate_file.resolve() == current_file.resolve():
+        if (
+            current_file is not None
+            and candidate_file.resolve() == current_file.resolve()
+        ):
             continue
 
         candidate = _build_canonical_concept_candidate(candidate_file, corpus_root)
@@ -155,7 +160,9 @@ def build_registered_stub_content(specs: Sequence[ResolvedDefinedTerm]) -> str:
         spec.import_target.split("#", 1)[0].removesuffix(".rac") for spec in specs
     }
     if len(base_paths) != 1:
-        raise ValueError("All registered stub specs must belong to the same target file")
+        raise ValueError(
+            "All registered stub specs must belong to the same target file"
+        )
 
     if len(specs) == 1:
         header = (
@@ -165,11 +172,7 @@ def build_registered_stub_content(specs: Sequence[ResolvedDefinedTerm]) -> str:
         )
     else:
         citations = ", ".join(sorted({spec.citation for spec in specs}))
-        header = (
-            '"""\nCanonical definition stubs.\n'
-            f"Resolved to {citations}.\n"
-            '"""\n\n'
-        )
+        header = f'"""\nCanonical definition stubs.\nResolved to {citations}.\n"""\n\n'
 
     blocks = []
     for spec in specs:
@@ -199,7 +202,9 @@ def materialize_registered_stub(
         raise ValueError("At least one stub spec is required")
 
     relative_path = import_target_to_relative_rac_path(specs[0].import_target)
-    target = root / prefix / relative_path if prefix is not None else root / relative_path
+    target = (
+        root / prefix / relative_path if prefix is not None else root / relative_path
+    )
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(build_registered_stub_content(specs))
     return target
@@ -218,7 +223,9 @@ def rac_file_has_stub_status(rac_file: Path) -> bool:
         return False
 
 
-def has_ingested_source_for_import_target(import_target: str, corpus_root: Path) -> bool:
+def has_ingested_source_for_import_target(
+    import_target: str, corpus_root: Path
+) -> bool:
     """Return whether the import target's official source is present locally."""
     return bool(find_ingested_source_artifacts(import_target, corpus_root))
 
@@ -325,7 +332,9 @@ def _source_text_mentions_term(source_text: str, term: str) -> bool:
         rf"\b(?:a|an|the|this|that|these|those|such|any|each|every)\s+{escaped}(?=$|[\s),.;:])",
         rf"\b(?:of|for|to|by|in|from|with|under|on|into)\s+(?:(?:a|an|the|this|that|these|those)\s+)?{escaped}(?=$|[\s),.;:])",
     )
-    return any(re.search(pattern, source_text, flags=re.IGNORECASE) for pattern in patterns)
+    return any(
+        re.search(pattern, source_text, flags=re.IGNORECASE) for pattern in patterns
+    )
 
 
 def _build_canonical_concept_candidate(
@@ -443,8 +452,7 @@ def _with_concept_term(
         period=candidate.period,
         dtype=candidate.dtype,
         label=(
-            f"`{term}` -> import `{candidate.import_target}` "
-            f"({candidate.citation})"
+            f"`{term}` -> import `{candidate.import_target}` ({candidate.citation})"
         ),
         source_file=candidate.source_file,
     )

--- a/src/autorac/harness/encoder_harness.py
+++ b/src/autorac/harness/encoder_harness.py
@@ -256,7 +256,10 @@ class EncoderHarness:
   label: "{citation}"
   description: "Auto-generated placeholder - encoding failed"
   formula: |
-    # TODO: Implement formula
+    # TODO(#issue-needed): Implement formula for {citation}.
+    # This fallback was emitted after the encoder failed. A human (or a
+    # retry with a stronger model) needs to author the real formula. See
+    # CHANGELOG.md for the tracked list of open encoder TODOs.
     return 0
   default: 0
 '''

--- a/src/autorac/harness/encoding_db.py
+++ b/src/autorac/harness/encoding_db.py
@@ -474,7 +474,9 @@ class EncodingDB:
         ]:
             try:
                 col_type = (
-                    "TEXT DEFAULT ''" if col == "autorac_version" else "INTEGER DEFAULT 0"
+                    "TEXT DEFAULT ''"
+                    if col == "autorac_version"
+                    else "INTEGER DEFAULT 0"
                 )
                 cursor.execute(f"ALTER TABLE sessions ADD COLUMN {col} {col_type}")
             except sqlite3.OperationalError:

--- a/src/autorac/harness/eval_prompt_surface.py
+++ b/src/autorac/harness/eval_prompt_surface.py
@@ -6,9 +6,7 @@ pipeline. The AutoAgent pilot should edit this file, not the corpus repos,
 promotion scripts, or Atlas integration.
 """
 
-AUTOAGENT_PILOT_EDITABLE_FILES = (
-    "src/autorac/harness/eval_prompt_surface.py",
-)
+AUTOAGENT_PILOT_EDITABLE_FILES = ("src/autorac/harness/eval_prompt_surface.py",)
 
 
 def render_uk_legislation_guidance() -> str:

--- a/src/autorac/harness/evals.py
+++ b/src/autorac/harness/evals.py
@@ -630,7 +630,8 @@ def _fetch_legislation_gov_uk_document(
     source_id, content_url = _normalize_legislation_gov_uk_source_ref(source_ref)
     source_base_dir = (
         Path(fetch_cache_root) / "_legislation_gov_uk_cache"
-        if fetch_cache_root is not None and Path(fetch_cache_root).resolve() != Path(output_root).resolve()
+        if fetch_cache_root is not None
+        and Path(fetch_cache_root).resolve() != Path(output_root).resolve()
         else Path(output_root) / "_legislation_gov_uk"
     )
     source_dir = source_base_dir / _slugify(source_id)
@@ -694,12 +695,19 @@ def _fetch_legislation_gov_uk_text(
 
 def _akn_title(element: ET.Element) -> str:
     return " ".join(
-        item for item in (_akn_child_text(element, "num"), _akn_child_text(element, "heading")) if item
+        item
+        for item in (
+            _akn_child_text(element, "num"),
+            _akn_child_text(element, "heading"),
+        )
+        if item
     ).strip()
 
 
 def _akn_ancestor_titles(root: ET.Element, section: ET.Element) -> list[str]:
-    parent_by_child = {child: parent for parent in root.iter() for child in list(parent)}
+    parent_by_child = {
+        child: parent for parent in root.iter() for child in list(parent)
+    }
     titles: list[str] = []
     current = parent_by_child.get(section)
     while current is not None:
@@ -802,13 +810,17 @@ def _append_akn_content_block_text(
                 _table_rows_from_element(table),
                 table_row_query=table_row_query,
             )
-            formatted_rows = [" | ".join(cell for cell in row if cell) for row in selected_rows]
+            formatted_rows = [
+                " | ".join(cell for cell in row if cell) for row in selected_rows
+            ]
             if formatted_rows:
                 parts.append("Structured table:\n" + "\n".join(formatted_rows))
 
 
 def _akn_ancestor_intro_text(root: ET.Element, section: ET.Element) -> list[str]:
-    parent_by_child = {child: parent for parent in root.iter() for child in list(parent)}
+    parent_by_child = {
+        child: parent for parent in root.iter() for child in list(parent)
+    }
     intros: list[str] = []
     current = parent_by_child.get(section)
     lineage: list[ET.Element] = []
@@ -854,7 +866,10 @@ def _resolve_akn_section_eid(
         child_eid = child.get("eId", "<unknown>")
         label = " ".join(
             item
-            for item in (_akn_child_text(child, "num"), _akn_child_text(child, "heading"))
+            for item in (
+                _akn_child_text(child, "num"),
+                _akn_child_text(child, "heading"),
+            )
             if item
         ).strip()
         child_summaries.append(f"{child_eid} ({label or 'child'})")
@@ -1054,9 +1069,7 @@ def load_eval_suite_manifest(path: Path) -> EvalSuiteManifest:
     gates = EvalReadinessGates(
         min_cases=int(gates_raw.get("min_cases", 1)),
         min_success_rate=_optional_float(gates_raw.get("min_success_rate")),
-        min_compile_pass_rate=_optional_float(
-            gates_raw.get("min_compile_pass_rate")
-        ),
+        min_compile_pass_rate=_optional_float(gates_raw.get("min_compile_pass_rate")),
         min_ci_pass_rate=_optional_float(gates_raw.get("min_ci_pass_rate")),
         min_zero_ungrounded_rate=_optional_float(
             gates_raw.get("min_zero_ungrounded_rate")
@@ -1085,15 +1098,12 @@ def load_eval_suite_manifest(path: Path) -> EvalSuiteManifest:
             raise ValueError(f"Unsupported eval suite case kind '{kind}'")
 
         case_mode = _coerce_eval_mode(item.get("mode", default_mode))
-        name = (
-            str(item.get("name", "")).strip()
-            or str(
-                item.get("citation")
-                or item.get("source_id")
-                or item.get("source_ref")
-                or item.get("section_eid")
-                or f"case-{index}"
-            )
+        name = str(item.get("name", "")).strip() or str(
+            item.get("citation")
+            or item.get("source_id")
+            or item.get("source_ref")
+            or item.get("section_eid")
+            or f"case-{index}"
         )
 
         case = EvalSuiteCase(
@@ -1270,7 +1280,10 @@ def run_eval_suite(
                     elif case.kind == "akn_section":
                         policy_repo_root = (
                             find_policy_repo_root(case.metadata_file or case.akn_file)
-                            if (case.metadata_file is not None or case.akn_file is not None)
+                            if (
+                                case.metadata_file is not None
+                                or case.akn_file is not None
+                            )
                             else None
                         ) or rac_path
                         case_results = run_akn_section_eval(
@@ -1310,7 +1323,9 @@ def run_eval_suite(
                             ),
                         )
                 except Exception as exc:
-                    case_results = _suite_case_failure_results(case, parsed_runners, exc)
+                    case_results = _suite_case_failure_results(
+                        case, parsed_runners, exc
+                    )
 
                 if (
                     attempt_index >= attempts - 1
@@ -1705,7 +1720,9 @@ def summarize_readiness(
 ) -> EvalReadinessSummary:
     """Summarize suite readiness for one runner."""
     total_cases = len(results)
-    success_rate = _fraction(sum(1 for result in results if result.success), total_cases)
+    success_rate = _fraction(
+        sum(1 for result in results if result.success), total_cases
+    )
     compile_pass_rate = _fraction(
         sum(
             1
@@ -1726,7 +1743,8 @@ def summarize_readiness(
         sum(
             1
             for result in results
-            if result.metrics is not None and result.metrics.ungrounded_numeric_count == 0
+            if result.metrics is not None
+            and result.metrics.ungrounded_numeric_count == 0
         ),
         total_cases,
     )
@@ -1895,7 +1913,11 @@ def _validate_eval_suite_case(case: EvalSuiteCase, index: int) -> None:
             raise ValueError(
                 f"Eval suite case #{index} is missing 'akn_file' or 'metadata_file'"
             )
-        if not case.section_eid and not case.section_eids and case.metadata_file is None:
+        if (
+            not case.section_eid
+            and not case.section_eids
+            and case.metadata_file is None
+        ):
             raise ValueError(
                 f"Eval suite case #{index} is missing 'section_eid' or 'section_eids'"
             )
@@ -1946,7 +1968,11 @@ def select_context_files(
     max_files: int = 6,
 ) -> list[Path]:
     """Select canonical implementation precedent files for repo-augmented evals."""
-    parts = citation if isinstance(citation, CitationParts) else parse_usc_citation(citation)
+    parts = (
+        citation
+        if isinstance(citation, CitationParts)
+        else parse_usc_citation(citation)
+    )
     section_root = Path(rac_us_root) / parts.title / parts.section
     target_rel = citation_to_relative_rac_path(parts)
     target_path = Path(rac_us_root) / target_rel
@@ -2021,7 +2047,9 @@ def prepare_eval_workspace(
             )
         source_metadata = payload
     else:
-        source_metadata_path, source_metadata = _load_source_metadata_for_path(source_path)
+        source_metadata_path, source_metadata = _load_source_metadata_for_path(
+            source_path
+        )
     source_metadata_file: Path | None = None
     if source_metadata is not None:
         source_metadata_file = workspace_root / "source-metadata.json"
@@ -2561,10 +2589,7 @@ def _run_single_eval(
         _hydrate_eval_root(output_file.parents[1], workspace)
 
     trace_file = (
-        Path(output_root)
-        / "traces"
-        / runner.name
-        / f"{_slugify(citation)}.json"
+        Path(output_root) / "traces" / runner.name / f"{_slugify(citation)}.json"
     )
     trace_file.parent.mkdir(parents=True, exist_ok=True)
     trace_file.write_text(json.dumps(response.trace or {}, indent=2, sort_keys=True))
@@ -2663,10 +2688,7 @@ def _run_single_source_eval(
         _hydrate_eval_root(output_file.parents[1], workspace)
 
     trace_file = (
-        Path(output_root)
-        / "traces"
-        / runner.name
-        / f"{_slugify(source_id)}.json"
+        Path(output_root) / "traces" / runner.name / f"{_slugify(source_id)}.json"
     )
     trace_file.parent.mkdir(parents=True, exist_ok=True)
     trace_file.write_text(json.dumps(response.trace or {}, indent=2, sort_keys=True))
@@ -3273,7 +3295,10 @@ def _expand_context_files(
         resolved = source_path.resolve()
         if resolved in seen:
             continue
-        if target_rel is not None and _relative_to_root(source_path, rac_us_root) == target_rel:
+        if (
+            target_rel is not None
+            and _relative_to_root(source_path, rac_us_root) == target_rel
+        ):
             continue
         seen.add(resolved)
         expanded.append((source_path, kind))
@@ -3449,9 +3474,7 @@ def _run_claude_prompt_eval(
             input_tokens=int(usage.get("input_tokens", 0) or 0),
             output_tokens=int(usage.get("output_tokens", 0) or 0),
             cache_read_tokens=int(usage.get("cache_read_input_tokens", 0) or 0),
-            cache_creation_tokens=int(
-                usage.get("cache_creation_input_tokens", 0) or 0
-            ),
+            cache_creation_tokens=int(usage.get("cache_creation_input_tokens", 0) or 0),
         )
         actual_cost = payload.get("total_cost_usd")
         text = payload.get("result", "") or ""
@@ -3513,9 +3536,10 @@ def _run_codex_prompt_eval(
     start = time.time()
     terminated_after_output = False
     timed_out = False
-    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as stdout_file, tempfile.NamedTemporaryFile(
-        mode="w+", delete=False
-    ) as stderr_file:
+    with (
+        tempfile.NamedTemporaryFile(mode="w+", delete=False) as stdout_file,
+        tempfile.NamedTemporaryFile(mode="w+", delete=False) as stderr_file,
+    ):
         stdout_path = Path(stdout_file.name)
         stderr_path = Path(stderr_file.name)
         process = subprocess.Popen(
@@ -3596,8 +3620,10 @@ def _run_codex_prompt_eval(
     if timed_out and not error and not final_text:
         error = "Codex eval timed out"
 
-    if process.returncode != 0 and not error and not (
-        (terminated_after_output and final_text) or (timed_out and final_text)
+    if (
+        process.returncode != 0
+        and not error
+        and not ((terminated_after_output and final_text) or (timed_out and final_text))
     ):
         error = (stdout_text + stderr_text).strip() or "Codex eval failed"
 
@@ -3939,8 +3965,10 @@ def _extract_generated_file_bundle(llm_response: str) -> dict[str, str]:
     files: dict[str, str] = {}
     for index, match in enumerate(matches):
         start = match.end()
-        end = matches[index + 1].start() if index + 1 < len(matches) else len(
-            llm_response
+        end = (
+            matches[index + 1].start()
+            if index + 1 < len(matches)
+            else len(llm_response)
         )
         content = llm_response[start:end].strip()
         if content:
@@ -3982,11 +4010,8 @@ def _normalize_rac_code_numeric_literals(content: str) -> str:
         closing_index = content.find('"""', 3)
         if closing_index != -1:
             code_start = closing_index + 3
-            return (
-                content[:code_start]
-                + _normalize_direct_scalar_numeric_expressions(
-                    _normalize_comma_numeric_literals(content[code_start:])
-                )
+            return content[:code_start] + _normalize_direct_scalar_numeric_expressions(
+                _normalize_comma_numeric_literals(content[code_start:])
             )
     return _normalize_direct_scalar_numeric_expressions(
         _normalize_comma_numeric_literals(content)
@@ -4005,7 +4030,9 @@ def _normalize_direct_scalar_numeric_expressions(content: str) -> str:
         if inline_match:
             expression = inline_match.group(2).strip()
             if _PURE_NUMERIC_EXPRESSION_PATTERN.fullmatch(expression):
-                if (formatted := _format_safe_numeric_expression(expression)) is not None:
+                if (
+                    formatted := _format_safe_numeric_expression(expression)
+                ) is not None:
                     rewritten.append(f"{inline_match.group(1)}{formatted}")
                     index += 1
                     continue
@@ -4022,7 +4049,9 @@ def _normalize_direct_scalar_numeric_expressions(content: str) -> str:
                     > len(line) - len(line.lstrip())
                 )
             ):
-                if (formatted := _format_safe_numeric_expression(expression)) is not None:
+                if (
+                    formatted := _format_safe_numeric_expression(expression)
+                ) is not None:
                     rewritten.append(f"{block_match.group(1)} {formatted}")
                     index += 2
                     continue
@@ -4050,7 +4079,10 @@ def _normalize_source_text_wrapper_rac_content(content: str) -> str:
     if not match:
         return content
 
-    doc_lines = [line[8:] if line.startswith("        ") else line for line in match.group("doc").splitlines()]
+    doc_lines = [
+        line[8:] if line.startswith("        ") else line
+        for line in match.group("doc").splitlines()
+    ]
     docstring = '"""\n' + "\n".join(doc_lines).strip("\n") + '\n"""\n'
     remainder = content[match.end() :].lstrip("\n")
     if remainder:
@@ -4065,7 +4097,8 @@ def _normalize_single_amount_row_rac_content(content: str) -> str:
         r"(^\s*from\s+\d{4}-\d{2}-\d{2}:\s*)if\b.+?:\s*(.+?)\s*(?:else:\s*0(?:\.0+)?)?\s*$",
         lambda match: (
             f"{match.group(1)}{formatted}"
-            if (formatted := _format_safe_numeric_expression(match.group(2))) is not None
+            if (formatted := _format_safe_numeric_expression(match.group(2)))
+            is not None
             else match.group(0)
         ),
         normalized,
@@ -4118,7 +4151,9 @@ def _evaluate_safe_numeric_expression(expression: str) -> float:
     def visit(current: ast.AST) -> float:
         if isinstance(current, ast.Expression):
             return visit(current.body)
-        if isinstance(current, ast.Constant) and isinstance(current.value, (int, float)):
+        if isinstance(current, ast.Constant) and isinstance(
+            current.value, (int, float)
+        ):
             return float(current.value)
         if isinstance(current, ast.UnaryOp) and isinstance(
             current.op, (ast.UAdd, ast.USub)
@@ -4158,7 +4193,8 @@ def _normalize_single_amount_row_test_content(
         return normalized
 
     annual_period = bool(
-        rac_content and re.search(r"^\s*period:\s*Year\s*$", rac_content, flags=re.MULTILINE)
+        rac_content
+        and re.search(r"^\s*period:\s*Year\s*$", rac_content, flags=re.MULTILINE)
     )
     effective_date = _extract_effective_date_for_tests(
         rac_content=rac_content,
@@ -4195,7 +4231,8 @@ def _normalize_single_amount_row_test_content(
             numeric_output = {
                 key: value
                 for key, value in output.items()
-                if value is None or (isinstance(value, (int, float)) and not isinstance(value, bool))
+                if value is None
+                or (isinstance(value, (int, float)) and not isinstance(value, bool))
             }
             if numeric_output:
                 normalized_case["output"] = numeric_output
@@ -4431,7 +4468,15 @@ def _normalize_test_case_value(value: object) -> object:
         key: _normalize_test_case_value(inner) for key, inner in value.items()
     }
     lowered_keys = {str(key).lower() for key in normalized.keys()}
-    metadata_keys = {"entity", "period", "dtype", "unit", "label", "description", "default"}
+    metadata_keys = {
+        "entity",
+        "period",
+        "dtype",
+        "unit",
+        "label",
+        "description",
+        "default",
+    }
 
     values_entries = [
         inner for key, inner in normalized.items() if str(key).lower() == "values"
@@ -4447,7 +4492,14 @@ def _normalize_test_case_value(value: object) -> object:
         for key, inner in normalized.items()
         if str(key).lower().startswith("from ")
     ]
-    if from_entries and lowered_keys.issubset(metadata_keys | {str(key).lower() for key in normalized.keys() if str(key).lower().startswith("from ")}):
+    if from_entries and lowered_keys.issubset(
+        metadata_keys
+        | {
+            str(key).lower()
+            for key in normalized.keys()
+            if str(key).lower().startswith("from ")
+        }
+    ):
         if len(from_entries) == 1:
             return _normalize_test_case_value(from_entries[0])
 
@@ -4539,9 +4591,7 @@ def _normalize_test_periods_to_effective_dates(
             if not isinstance(output, dict):
                 continue
             if any(
-                (
-                    isinstance(value, bool) and value
-                )
+                (isinstance(value, bool) and value)
                 or (
                     isinstance(value, (int, float))
                     and not isinstance(value, bool)
@@ -4568,8 +4618,10 @@ def _normalize_test_periods_to_effective_dates(
                 granularity=granularity,
             )
         elif granularity == "Month":
-            normalized_case["period"] = _normalize_placeholder_monthly_test_period_value(
-                normalized_case.get("period")
+            normalized_case["period"] = (
+                _normalize_placeholder_monthly_test_period_value(
+                    normalized_case.get("period")
+                )
             )
 
         for key in ("input", "inputs", "output"):
@@ -4579,9 +4631,9 @@ def _normalize_test_periods_to_effective_dates(
                     for child_key, child_value in normalized_case[key].items()
                 }
         if "expect" in normalized_case:
-                normalized_case["expect"] = _normalize_test_case_value(
-                    normalized_case["expect"]
-                )
+            normalized_case["expect"] = _normalize_test_case_value(
+                normalized_case["expect"]
+            )
         return normalized_case
 
     if cases is not None:
@@ -4598,10 +4650,13 @@ def _normalize_test_periods_to_effective_dates(
             ):
                 continue
             filtered_cases.append(case)
-        return yaml.safe_dump(
-            [normalize_case(case) for case in filtered_cases],
-            sort_keys=False,
-        ).strip() + "\n"
+        return (
+            yaml.safe_dump(
+                [normalize_case(case) for case in filtered_cases],
+                sort_keys=False,
+            ).strip()
+            + "\n"
+        )
 
     return normalized
 

--- a/src/autorac/harness/observability.py
+++ b/src/autorac/harness/observability.py
@@ -419,12 +419,8 @@ def _base_llm_attributes(
         attrs["gen_ai.usage.input_tokens"] = usage.input_tokens
         attrs["gen_ai.usage.output_tokens"] = usage.output_tokens
         attrs["gen_ai.usage.cache_read.input_tokens"] = usage.cache_read_tokens
-        attrs["gen_ai.usage.cache_creation.input_tokens"] = (
-            usage.cache_creation_tokens
-        )
-        attrs["autorac.usage.reasoning_output_tokens"] = (
-            usage.reasoning_output_tokens
-        )
+        attrs["gen_ai.usage.cache_creation.input_tokens"] = usage.cache_creation_tokens
+        attrs["autorac.usage.reasoning_output_tokens"] = usage.reasoning_output_tokens
 
     if cost_usd is not None:
         attrs["autorac.cost.total_usd"] = cost_usd
@@ -663,7 +659,9 @@ def _reasoning_span_events(
 ) -> list[tuple[str, Mapping[str, Any]]]:
     """Convert extracted reasoning entries into compact OTLP events."""
     events: list[tuple[str, Mapping[str, Any]]] = []
-    for index, entry in enumerate(extract_reasoning_entries(trace_payload)[:10], start=1):
+    for index, entry in enumerate(
+        extract_reasoning_entries(trace_payload)[:10], start=1
+    ):
         events.append(
             (
                 "autorac.reasoning",

--- a/src/autorac/harness/orchestrator.py
+++ b/src/autorac/harness/orchestrator.py
@@ -458,7 +458,9 @@ class Orchestrator:
             )
             run.agent_runs.append(analysis)
             self._log_agent_run(run.session_id, analysis)
-            self._log_analysis_provenance(run.session_id, citation, analysis.result or "")
+            self._log_analysis_provenance(
+                run.session_id, citation, analysis.result or ""
+            )
 
             # Phase 2: Encoding
             if analysis.result:
@@ -730,9 +732,7 @@ class Orchestrator:
                 },
             }
         except FileNotFoundError:
-            not_found_text = (
-                "Claude CLI not found - install with: npm install -g @anthropic-ai/claude-code"
-            )
+            not_found_text = "Claude CLI not found - install with: npm install -g @anthropic-ai/claude-code"
             return {
                 "text": not_found_text,
                 "trace": {
@@ -876,10 +876,7 @@ class Orchestrator:
             cache_read_tokens=int(input_details.get("cached_tokens", 0) or 0),
         )
         tokens.reasoning_output_tokens = int(
-            (
-                (usage.get("output_tokens_details") or {}).get("reasoning_tokens", 0)
-                or 0
-            )
+            ((usage.get("output_tokens_details") or {}).get("reasoning_tokens", 0) or 0)
         )
 
         text = self._extract_openai_response_text(payload)
@@ -1060,9 +1057,7 @@ class Orchestrator:
             ),
             (
                 "parameter_reviewer",
-                get_parameter_reviewer_prompt(
-                    citation, oracle_summary, review_context
-                ),
+                get_parameter_reviewer_prompt(citation, oracle_summary, review_context),
             ),
             (
                 "integration_reviewer",
@@ -1357,7 +1352,9 @@ Output path: {output_path}
             )
             wave_failures: list[str] = []
 
-            async def encode_one(task: SubsectionTask) -> tuple[SubsectionTask, AgentRun]:
+            async def encode_one(
+                task: SubsectionTask,
+            ) -> tuple[SubsectionTask, AgentRun]:
                 async with semaphore:
                     prompt = self._build_subsection_prompt(
                         task, citation, output_path, statute_text
@@ -1425,7 +1422,8 @@ Output path: {output_path}
                     self._log_provenance_decision(
                         session_id,
                         f"Compile repair attempt {repair_attempts} for subsection ({task.subsection_id})",
-                        compile_result.issues or [compile_result.error or "compile failed"],
+                        compile_result.issues
+                        or [compile_result.error or "compile failed"],
                         Phase.ENCODING,
                         metadata={
                             "subsection_id": task.subsection_id,
@@ -1635,14 +1633,16 @@ Output path: {output_path}
             return citation
 
         base_fragments = list(parts.fragments)
-        if base_fragments and subsection_fragments[: len(base_fragments)] == base_fragments:
+        if (
+            base_fragments
+            and subsection_fragments[: len(base_fragments)] == base_fragments
+        ):
             all_fragments = subsection_fragments
         else:
             all_fragments = base_fragments + subsection_fragments
 
-        return (
-            f"{parts.title} USC {parts.section}"
-            + "".join(f"({fragment})" for fragment in all_fragments)
+        return f"{parts.title} USC {parts.section}" + "".join(
+            f"({fragment})" for fragment in all_fragments
         )
 
     def _lookup_precise_subsection_text(
@@ -1724,7 +1724,9 @@ Output path: {output_path}
                 ]
             )
         elif statute_text:
-            prompt_parts.extend(["", "## Full statute text (excerpt)", statute_text[:5000]])
+            prompt_parts.extend(
+                ["", "## Full statute text (excerpt)", statute_text[:5000]]
+            )
 
         prompt_parts.extend(
             [
@@ -2017,7 +2019,8 @@ Read any .rac file for reference on style and patterns."""
             )
             if not result.passed:
                 failures.extend(
-                    f"{rac_file}: {issue}" for issue in (result.issues or [result.error or "compile failed"])
+                    f"{rac_file}: {issue}"
+                    for issue in (result.issues or [result.error or "compile failed"])
                 )
 
         if failures:
@@ -2271,7 +2274,9 @@ Read any .rac file for reference on style and patterns."""
 
             if registered_specs:
                 expected_path.parent.mkdir(parents=True, exist_ok=True)
-                expected_path.write_text(build_registered_stub_content(registered_specs))
+                expected_path.write_text(
+                    build_registered_stub_content(registered_specs)
+                )
                 created.append(expected_path)
                 print(f"    Wrote registered stub: {expected_path}", flush=True)
                 if session_id:
@@ -2462,9 +2467,7 @@ Return ONLY the .rac file content. No markdown fences, no explanation. The file 
         if not llm_response or "=== FILE:" not in llm_response:
             return {}
 
-        pattern = re.compile(
-            r"^=== FILE:\s*(?P<name>.+?)\s*===\s*$", re.MULTILINE
-        )
+        pattern = re.compile(r"^=== FILE:\s*(?P<name>.+?)\s*===\s*$", re.MULTILINE)
         matches = list(pattern.finditer(llm_response))
         if not matches:
             return {}
@@ -2472,8 +2475,10 @@ Return ONLY the .rac file content. No markdown fences, no explanation. The file 
         files: dict[str, str] = {}
         for index, match in enumerate(matches):
             start = match.end()
-            end = matches[index + 1].start() if index + 1 < len(matches) else len(
-                llm_response
+            end = (
+                matches[index + 1].start()
+                if index + 1 < len(matches)
+                else len(llm_response)
             )
             content = llm_response[start:end].strip()
             if content:
@@ -2859,7 +2864,9 @@ Return ONLY the .rac file content. No markdown fences, no explanation. The file 
 
         embedded_source_text = extract_embedded_source_text(content)
         source_text = embedded_source_text or fallback_source_text or ""
-        source_numbers = extract_numbers_from_text(source_text) if source_text else set()
+        source_numbers = (
+            extract_numbers_from_text(source_text) if source_text else set()
+        )
         numeric_values = extract_grounding_values(content)
         grounded = []
         ungrounded = []
@@ -2900,7 +2907,11 @@ Return ONLY the .rac file content. No markdown fences, no explanation. The file 
             )
         if embedded_source_text:
             excerpt = embedded_source_text.strip().replace("\n", " ")
-            lines.append("Source excerpt: " + excerpt[:400] + ("..." if len(excerpt) > 400 else ""))
+            lines.append(
+                "Source excerpt: "
+                + excerpt[:400]
+                + ("..." if len(excerpt) > 400 else "")
+            )
 
         return (
             "\n".join(lines),
@@ -3068,7 +3079,8 @@ Return ONLY the .rac file content. No markdown fences, no explanation. The file 
             f"Review result for {review_run.agent_type}",
             f"Passed: {passed}",
             f"Score: {score}",
-            "Issues: " + (", ".join(str(issue) for issue in issues) if issues else "none"),
+            "Issues: "
+            + (", ".join(str(issue) for issue in issues) if issues else "none"),
         ]
 
         self._log_session_event(

--- a/src/autorac/harness/pricing.py
+++ b/src/autorac/harness/pricing.py
@@ -1,10 +1,20 @@
-"""Model pricing helpers for eval and trace analysis."""
+"""Model pricing helpers for eval and trace analysis.
+
+Pricing rates are loaded from ``pricing_rates.toml`` (co-located with this
+module). The TOML file carries a ``version`` and ``effective_date`` so that
+rate changes can be tracked in source control without touching Python code.
+"""
 
 from __future__ import annotations
 
+import tomllib
 from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
 
 from .encoding_db import TokenUsage
+
+_PRICING_RATES_PATH = Path(__file__).with_name("pricing_rates.toml")
 
 
 @dataclass(frozen=True)
@@ -30,25 +40,48 @@ class UsageCostBreakdown:
     total_cost_usd: float
 
 
-_MODEL_PRICING: dict[str, ModelPricing] = {
-    "claude-opus-4-6": ModelPricing(
-        input_per_million=5.0,
-        output_per_million=25.0,
-        cache_read_per_million=0.50,
-        cache_create_per_million=6.25,
-    ),
-    "opus": ModelPricing(
-        input_per_million=5.0,
-        output_per_million=25.0,
-        cache_read_per_million=0.50,
-        cache_create_per_million=6.25,
-    ),
-    "gpt-5.4": ModelPricing(
-        input_per_million=2.5,
-        output_per_million=15.0,
-        cache_read_per_million=0.25,
-    ),
-}
+@dataclass(frozen=True)
+class PricingRates:
+    """Full pricing rate bundle loaded from ``pricing_rates.toml``."""
+
+    version: int
+    effective_date: str
+    models: dict[str, ModelPricing]
+
+
+def _load_pricing_rates(path: Path = _PRICING_RATES_PATH) -> PricingRates:
+    """Parse ``pricing_rates.toml`` into a :class:`PricingRates` bundle."""
+    with path.open("rb") as fh:
+        data = tomllib.load(fh)
+
+    raw_models = data.get("models", {}) or {}
+    models: dict[str, ModelPricing] = {}
+    for name, rates in raw_models.items():
+        models[name] = ModelPricing(
+            input_per_million=float(rates.get("input_per_million", 0.0)),
+            output_per_million=float(rates.get("output_per_million", 0.0)),
+            cache_read_per_million=float(rates.get("cache_read_per_million", 0.0)),
+            cache_create_per_million=float(rates.get("cache_create_per_million", 0.0)),
+        )
+
+    return PricingRates(
+        version=int(data.get("version", 0)),
+        effective_date=str(data.get("effective_date", "")),
+        models=models,
+    )
+
+
+@lru_cache(maxsize=1)
+def _cached_pricing_rates() -> PricingRates:
+    return _load_pricing_rates()
+
+
+def get_pricing_rates() -> PricingRates:
+    """Return the cached pricing rate bundle loaded from TOML."""
+    return _cached_pricing_rates()
+
+
+_MODEL_PRICING: dict[str, ModelPricing] = get_pricing_rates().models
 
 
 def get_model_pricing(model: str) -> ModelPricing | None:
@@ -91,9 +124,7 @@ def estimate_usage_cost_breakdown(
         usage.input_tokens - usage.cache_read_tokens - usage.cache_creation_tokens,
         0,
     )
-    input_cost_usd = (
-        non_cached_input_tokens * pricing.input_per_million / 1_000_000
-    )
+    input_cost_usd = non_cached_input_tokens * pricing.input_per_million / 1_000_000
     cache_read_cost_usd = (
         usage.cache_read_tokens * pricing.cache_read_per_million / 1_000_000
     )

--- a/src/autorac/harness/pricing_rates.toml
+++ b/src/autorac/harness/pricing_rates.toml
@@ -1,0 +1,25 @@
+# AutoRAC model pricing rates.
+#
+# Rates are per 1,000,000 tokens in USD, sourced from vendor public pricing.
+# When vendor pricing changes, bump `version` and update `effective_date`.
+
+version = 1
+effective_date = "2026-02-01"
+
+[models.claude-opus-4-6]
+input_per_million = 5.0
+output_per_million = 25.0
+cache_read_per_million = 0.50
+cache_create_per_million = 6.25
+
+[models.opus]
+input_per_million = 5.0
+output_per_million = 25.0
+cache_read_per_million = 0.50
+cache_create_per_million = 6.25
+
+[models."gpt-5.4"]
+input_per_million = 2.5
+output_per_million = 15.0
+cache_read_per_million = 0.25
+cache_create_per_million = 0.0

--- a/src/autorac/harness/validator_pipeline.py
+++ b/src/autorac/harness/validator_pipeline.py
@@ -17,6 +17,7 @@ Uses Claude Code CLI (subprocess) for reviewer agents - cheaper than direct API.
 import contextlib
 import hashlib
 import json
+import logging
 import os
 import re
 import shutil
@@ -43,6 +44,8 @@ from .dependency_stubs import (
     resolve_defined_terms_from_text,
 )
 from .encoding_db import EncodingDB, ReviewResult, ReviewResults
+
+logger = logging.getLogger(__name__)
 
 
 def run_claude_code(
@@ -216,9 +219,7 @@ _PE_US_VAR_ADAPTERS = (
         pe_var="snap_earned_income_deduction",
         monthly=True,
         spm=True,
-        direct_spm_overrides=(
-            ("snap_earned_income", "snap_earned_income"),
-        ),
+        direct_spm_overrides=(("snap_earned_income", "snap_earned_income"),),
         derived_spm_overrides=(
             (
                 "snap_earned_income",
@@ -250,7 +251,11 @@ _PE_US_VAR_ADAPTERS = (
         monthly=True,
         spm=True,
         derived_spm_overrides=(
-            ("snap_net_income", "difference", ("snap_household_income", "snap_deductions")),
+            (
+                "snap_net_income",
+                "difference",
+                ("snap_household_income", "snap_deductions"),
+            ),
         ),
     ),
     _PolicyEngineUSVarAdapter(
@@ -388,8 +393,7 @@ _PE_US_VAR_ADAPTERS = (
         rac_vars=("snap_homeless_shelter_deduction_available",),
         pe_var="snap_homeless_shelter_deduction_available",
         parameter_path=(
-            "gov.usda.snap.income.deductions.excess_shelter_expense."
-            "homeless.available"
+            "gov.usda.snap.income.deductions.excess_shelter_expense.homeless.available"
         ),
     ),
     _PolicyEngineUSVarAdapter(
@@ -566,9 +570,10 @@ def _run_subprocess_with_idle_timeout(
     poll_interval: float = 0.5,
 ) -> _SubprocessRunResult:
     """Run a subprocess, aborting if it stops emitting output for too long."""
-    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as stdout_file, tempfile.NamedTemporaryFile(
-        mode="w+", delete=False
-    ) as stderr_file:
+    with (
+        tempfile.NamedTemporaryFile(mode="w+", delete=False) as stdout_file,
+        tempfile.NamedTemporaryFile(mode="w+", delete=False) as stderr_file,
+    ):
         stdout_path = Path(stdout_file.name)
         stderr_path = Path(stderr_file.name)
         process = subprocess.Popen(
@@ -796,9 +801,7 @@ GROUNDING_MONTH_PERIOD_PATTERN = re.compile(r"\b\d{4}-\d{2}\b")
 GROUNDING_FORMULA_NUMBER_PATTERN = re.compile(
     r"(?<![\w./])(-?[\d,]+(?:\.\d+)?)(?![\w./])"
 )
-SOURCE_TEXT_NUMBER_PATTERN = re.compile(
-    r"(?:^|(?<=[\s$£€(\[,]))(-?[\d,]+(?:\.\d+)?)\b"
-)
+SOURCE_TEXT_NUMBER_PATTERN = re.compile(r"(?:^|(?<=[\s$£€(\[,]))(-?[\d,]+(?:\.\d+)?)\b")
 GROUNDING_METADATA_KEYS = {
     "entity",
     "period",
@@ -815,9 +818,7 @@ GROUNDING_METADATA_KEYS = {
 }
 
 IMPORT_ITEM_PATTERN = re.compile(r"^\s*-\s*(['\"]?)([^'\"]+?)\1\s*$")
-IMPORT_MAPPING_PATTERN = re.compile(
-    r"^\s*[A-Za-z_]\w*:\s*(['\"]?)([^'\"]+?)\1\s*$"
-)
+IMPORT_MAPPING_PATTERN = re.compile(r"^\s*[A-Za-z_]\w*:\s*(['\"]?)([^'\"]+?)\1\s*$")
 _EMBEDDED_SCALAR_BLOCK_HEADER = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*$")
 _EMBEDDED_SCALAR_TEMPORAL_LINE = re.compile(
     r"^(\s*)from\s+\d{4}-\d{2}-\d{2}:\s*(.*?)\s*$"
@@ -906,9 +907,7 @@ _SYNTHETIC_STATEWIDE_ALLOWANCE_RESTATEMENT_PATTERN = re.compile(
     r"^\s*For\s+[A-Za-z][A-Za-z .'-]*,\s+the\s+allowance\s+is\s+statewide\s+at\s+\$?\d+(?:\.\d+)?\.?\s*$",
     re.IGNORECASE,
 )
-_SOURCE_REFERENCE_TARGET_PATTERN = (
-    r"(?:\([^)]+\)|\d+[A-Za-z./-]*(?:\([^)]+\))*(?=$|[\s,.;:])|[ivxlcdm]+\b|[A-Z]{1,4}\b|[a-z]\b)"
-)
+_SOURCE_REFERENCE_TARGET_PATTERN = r"(?:\([^)]+\)|\d+[A-Za-z./-]*(?:\([^)]+\))*(?=$|[\s,.;:])|[ivxlcdm]+\b|[A-Z]{1,4}\b|[a-z]\b)"
 _SOURCE_REFERENCE_SEQUENCE_PATTERN = (
     rf"{_SOURCE_REFERENCE_TARGET_PATTERN}"
     rf"(?:\s*(?:,|or|and)\s*{_SOURCE_REFERENCE_TARGET_PATTERN})*"
@@ -957,7 +956,9 @@ _MONTH_DAY_OF_MONTH_PATTERN = re.compile(
     r"\b\d{1,2}(?:st|nd|rd|th)\s+day\s+of\s+(?:a|the)\s+month\b",
     re.IGNORECASE,
 )
-_TABLE_HEADING_PATTERN = re.compile(r"^\s*table\s+\d+[A-Za-z]?(?:\s*:.*)?$", re.IGNORECASE)
+_TABLE_HEADING_PATTERN = re.compile(
+    r"^\s*table\s+\d+[A-Za-z]?(?:\s*:.*)?$", re.IGNORECASE
+)
 _ORDINAL_NUMBER_PATTERN = re.compile(r"\b(\d+)(?:st|nd|rd|th)\b", re.IGNORECASE)
 _SCHEDULE_BLOCK_HEADING_PATTERN = re.compile(r"^[A-Z][A-Z0-9_ ]+:\s*$")
 _SCHEDULE_SIZE_ROW_PATTERN = re.compile(
@@ -1163,7 +1164,9 @@ def extract_grounding_values(content: str) -> list[tuple[int, str, float]]:
         if indent == 0 and symbol_match:
             candidate = symbol_match.group(1)
             current_symbol_name = (
-                None if candidate.lower() in _DEFINED_SYMBOL_METADATA_KEYS else candidate
+                None
+                if candidate.lower() in _DEFINED_SYMBOL_METADATA_KEYS
+                else candidate
             )
 
         if '"""' in stripped:
@@ -1314,7 +1317,9 @@ def _is_structural_schedule_index_literal(expression: str, literal: str) -> bool
     delta_pattern = re.compile(
         rf"(?:\(\s*)?{_SCHEDULE_INDEX_NAME_PATTERN}\s*-\s*{re.escape(literal)}(?:\s*\))?"
     )
-    return bool(comparison_pattern.search(normalized) or delta_pattern.search(normalized))
+    return bool(
+        comparison_pattern.search(normalized) or delta_pattern.search(normalized)
+    )
 
 
 def _is_structural_schedule_index_helper(name: str, value: float) -> bool:
@@ -1338,13 +1343,13 @@ def _is_structural_schedule_index_helper(name: str, value: float) -> bool:
         re.search(rf"(?:^|_)size_{index}(?:_|$)", normalized_name)
         or re.search(rf"(?:^|_)household_size_{index}(?:_|$)", normalized_name)
         or re.search(rf"(?:^|_)unit_size_{index}(?:_|$)", normalized_name)
-        or re.search(rf"(?:^|_){word}_person_(?:household_)?size(?:_|$)", normalized_name)
+        or re.search(
+            rf"(?:^|_){word}_person_(?:household_)?size(?:_|$)", normalized_name
+        )
         or re.search(rf"(?:^|_){word}_person_unit_size(?:_|$)", normalized_name)
         or re.search(rf"(?:^|_){word}_person_spm_unit_size(?:_|$)", normalized_name)
         or re.search(rf"(?:^|_)size_row_{index}(?:_|$)", normalized_name)
-        or re.search(
-            rf"(?:^|_)household_size_row_{index}(?:_|$)", normalized_name
-        )
+        or re.search(rf"(?:^|_)household_size_row_{index}(?:_|$)", normalized_name)
         or re.search(rf"(?:^|_)unit_size_row_{index}(?:_|$)", normalized_name)
         or (
             word is not None
@@ -1352,9 +1357,7 @@ def _is_structural_schedule_index_helper(name: str, value: float) -> bool:
         )
         or (
             word is not None
-            and re.search(
-                rf"(?:^|_)household_size_{word}(?:_|$)", normalized_name
-            )
+            and re.search(rf"(?:^|_)household_size_{word}(?:_|$)", normalized_name)
         )
         or (
             word is not None
@@ -1414,9 +1417,7 @@ def extract_numbers_from_text(text: str) -> set[float]:
         numbers.add(value)
         occupied_spans.append(span)
 
-    for match in re.finditer(
-        r"(?:^|(?<=[\s$£€(\[,]))(-?[\d,]+(?:\.\d+)?)\b", text
-    ):
+    for match in re.finditer(r"(?:^|(?<=[\s$£€(\[,]))(-?[\d,]+(?:\.\d+)?)\b", text):
         if _span_overlaps(match.span(1), occupied_spans):
             continue
         raw = match.group(1).replace(",", "")
@@ -1470,7 +1471,9 @@ def _iter_normalized_special_numeric_matches(
     ):
         for match in pattern.finditer(text):
             with contextlib.suppress(ValueError):
-                matches.append((match.span(), float(match.group(1).replace(",", "")) / 100))
+                matches.append(
+                    (match.span(), float(match.group(1).replace(",", "")) / 100)
+                )
 
     for match in _SUBPOUND_MONEY_PATTERN.finditer(text):
         with contextlib.suppress(ValueError):
@@ -1483,8 +1486,12 @@ def _iter_normalized_special_numeric_matches(
     return matches
 
 
-def _span_overlaps(span: tuple[int, int], occupied_spans: list[tuple[int, int]]) -> bool:
-    return any(not (span[1] <= start or span[0] >= end) for start, end in occupied_spans)
+def _span_overlaps(
+    span: tuple[int, int], occupied_spans: list[tuple[int, int]]
+) -> bool:
+    return any(
+        not (span[1] <= start or span[0] >= end) for start, end in occupied_spans
+    )
 
 
 def _clean_source_text_for_numeric_extraction(text: str) -> str:
@@ -1503,7 +1510,9 @@ def _clean_source_text_for_numeric_extraction(text: str) -> str:
             continue
         if _SYNTHETIC_MODELING_INSTRUCTION_PATTERN.match(structural_stripped):
             continue
-        if _SYNTHETIC_STATEWIDE_ALLOWANCE_RESTATEMENT_PATTERN.match(structural_stripped):
+        if _SYNTHETIC_STATEWIDE_ALLOWANCE_RESTATEMENT_PATTERN.match(
+            structural_stripped
+        ):
             continue
 
         normalized_line = line.lstrip(_STRUCTURAL_SOURCE_QUOTE_CHARS)
@@ -1605,8 +1614,8 @@ def _extract_collapsed_schedule_row_occurrences(
 def extract_numeric_occurrences_from_text(text: str) -> list[float]:
     """Extract substantive numeric occurrences from source text, preserving repeats."""
     cleaned = _clean_source_text_for_numeric_extraction(text)
-    collapsed_schedule_occurrences, cleaned = _extract_collapsed_schedule_row_occurrences(
-        cleaned
+    collapsed_schedule_occurrences, cleaned = (
+        _extract_collapsed_schedule_row_occurrences(cleaned)
     )
 
     occurrences: list[float] = list(collapsed_schedule_occurrences)
@@ -2011,7 +2020,9 @@ class ValidatorPipeline:
                 "LLM reviewers complete",
                 {
                     "scores": {
-                        k: results[k].score for k in llm_validators.keys() if k in results
+                        k: results[k].score
+                        for k in llm_validators.keys()
+                        if k in results
                     },
                     "duration_ms": int((time.time() - llm_start) * 1000),
                 },
@@ -2205,7 +2216,10 @@ class ValidatorPipeline:
     def _is_nonassertable_status_only_artifact(self, rac_file: Path) -> bool:
         """Return true when every declared variable is a non-assertable status-only stub."""
         content = rac_file.read_text()
-        if "status: deferred" not in content and "status: entity_not_supported" not in content:
+        if (
+            "status: deferred" not in content
+            and "status: entity_not_supported" not in content
+        ):
             return False
 
         variable_blocks = re.findall(
@@ -2221,7 +2235,9 @@ class ValidatorPipeline:
                     content,
                 )
             }
-            return bool(top_level_statuses) and top_level_statuses.issubset(allowed_statuses)
+            return bool(top_level_statuses) and top_level_statuses.issubset(
+                allowed_statuses
+            )
 
         for _, body in variable_blocks:
             statuses = {
@@ -2413,7 +2429,7 @@ class ValidatorPipeline:
                 continue
             issues.append(
                 "Defined term import missing: "
-                f'`{term.term}` resolves to {term.citation} but file does not import '
+                f"`{term.term}` resolves to {term.citation} but file does not import "
                 f"from {import_base}"
             )
         return issues
@@ -2441,7 +2457,7 @@ class ValidatorPipeline:
                 continue
             issues.append(
                 "Canonical concept import missing: "
-                f'`{concept.term}` resolves to {concept.citation} via '
+                f"`{concept.term}` resolves to {concept.citation} via "
                 f"{concept.import_target} but file does not import from {import_base}"
             )
         return issues
@@ -2456,7 +2472,9 @@ class ValidatorPipeline:
 
         if not rac_content_has_stub_status(rac_file.read_text()):
             return []
-        if not has_ingested_source_for_import_target(relative.with_suffix("").as_posix(), source_root):
+        if not has_ingested_source_for_import_target(
+            relative.with_suffix("").as_posix(), source_root
+        ):
             return []
 
         return [
@@ -2520,14 +2538,20 @@ class ValidatorPipeline:
         source_text = extract_embedded_source_text(content)
         if not source_text:
             return []
-        if not re.search(r"\bexcept where\b.+\bapplies\b", source_text, flags=re.IGNORECASE | re.DOTALL):
+        if not re.search(
+            r"\bexcept where\b.+\bapplies\b",
+            source_text,
+            flags=re.IGNORECASE | re.DOTALL,
+        ):
             return []
 
         issues: list[str] = []
         for block in self._extract_definition_blocks(content):
             if block["dtype"] != "Boolean":
                 continue
-            for line_number, expression in self._iter_true_on_applies_patterns(block["body_lines"]):
+            for line_number, expression in self._iter_true_on_applies_patterns(
+                block["body_lines"]
+            ):
                 issues.append(
                     "Carve-out logic inverted: "
                     f"{block['name']} line {line_number} treats `{expression}` as automatically satisfied "
@@ -2538,9 +2562,12 @@ class ValidatorPipeline:
     def _check_embedded_scalar_literals(self, rac_file: Path) -> list[str]:
         """Flag substantive scalar literals embedded inside formulas."""
         issues: list[str] = []
-        for line_number, name, literal, expression in self._collect_embedded_scalar_literals(
-            rac_file.read_text()
-        ):
+        for (
+            line_number,
+            name,
+            literal,
+            expression,
+        ) in self._collect_embedded_scalar_literals(rac_file.read_text()):
             issues.append(
                 "Embedded scalar literal: "
                 f"{name} line {line_number} embeds {literal} in `{expression}`; "
@@ -2565,21 +2592,33 @@ class ValidatorPipeline:
             tokens = set(occurrence.name.lower().split("_"))
             if not (_DATE_DECOMPOSITION_CUE_TOKENS & tokens):
                 continue
-            if "year" in tokens and occurrence.value.is_integer() and 1900 <= occurrence.value <= 2100:
+            if (
+                "year" in tokens
+                and occurrence.value.is_integer()
+                and 1900 <= occurrence.value <= 2100
+            ):
                 issues.append(
                     "Decomposed date scalar: "
                     f"{occurrence.name} line {occurrence.line} encodes calendar year "
                     f"{int(occurrence.value)} as a numeric scalar; keep legal date references "
                     "semantic instead of splitting them into year/month/day variables"
                 )
-            elif "month" in tokens and occurrence.value.is_integer() and 1 <= occurrence.value <= 12:
+            elif (
+                "month" in tokens
+                and occurrence.value.is_integer()
+                and 1 <= occurrence.value <= 12
+            ):
                 issues.append(
                     "Decomposed date scalar: "
                     f"{occurrence.name} line {occurrence.line} encodes calendar month "
                     f"{int(occurrence.value)} as a numeric scalar; keep legal date references "
                     "semantic instead of splitting them into year/month/day variables"
                 )
-            elif "day" in tokens and occurrence.value.is_integer() and 1 <= occurrence.value <= 31:
+            elif (
+                "day" in tokens
+                and occurrence.value.is_integer()
+                and 1 <= occurrence.value <= 31
+            ):
                 issues.append(
                     "Decomposed date scalar: "
                     f"{occurrence.name} line {occurrence.line} encodes calendar day "
@@ -2838,8 +2877,10 @@ class ValidatorPipeline:
                 formula_indent = len(formula_match.group(1))
                 continue
 
-            if (temporal_block or formula_block) and stripped and not self._is_direct_scalar_expression(
-                stripped
+            if (
+                (temporal_block or formula_block)
+                and stripped
+                and not self._is_direct_scalar_expression(stripped)
             ):
                 issues.extend(
                     (
@@ -2876,9 +2917,7 @@ class ValidatorPipeline:
                 continue
             if literal == "0.5" and half_up_rounding_expression:
                 continue
-            if _is_structural_schedule_index_literal(
-                scrubbed_expression, literal
-            ):
+            if _is_structural_schedule_index_literal(scrubbed_expression, literal):
                 continue
             literals.append(literal)
         return sorted(set(literals))
@@ -2975,9 +3014,11 @@ class ValidatorPipeline:
         resolved_file = rac_file.resolve()
         with contextlib.suppress(ValueError):
             relative = resolved_file.relative_to(resolved_root)
-            if relative.parts and re.fullmatch(
-                r"[0-9A-Za-z.-]+", relative.parts[0]
-            ) and any(ch.isdigit() for ch in relative.parts[0]):
+            if (
+                relative.parts
+                and re.fullmatch(r"[0-9A-Za-z.-]+", relative.parts[0])
+                and any(ch.isdigit() for ch in relative.parts[0])
+            ):
                 return relative.parts[0]
             return None
 
@@ -3112,8 +3153,37 @@ Output ONLY valid JSON:
                     f"Reviewer CLI exited {returncode}: {output_excerpt}"
                 )
 
-            # Parse JSON from output
-            data = _extract_json_object(output)
+            # Parse JSON from output. If parsing fails, return a
+            # structured "reviewer_parse_failed" result instead of
+            # letting the generic except below swallow the detail.
+            try:
+                data = _extract_json_object(output)
+            except (ValueError, json.JSONDecodeError) as parse_err:
+                duration = int((time.time() - start) * 1000)
+                raw_snippet = (output or "").strip()
+                truncated = raw_snippet[:500]
+                if len(raw_snippet) > 500:
+                    truncated += "... [truncated]"
+                logger.warning(
+                    "Reviewer %s output failed to parse as JSON: %s. "
+                    "Raw output (first 500 chars): %s",
+                    reviewer_type,
+                    parse_err,
+                    truncated,
+                )
+                return ValidationResult(
+                    validator_name=reviewer_type,
+                    passed=False,
+                    score=None,
+                    issues=[
+                        "reviewer_parse_failed",
+                        f"Could not parse reviewer JSON output: {parse_err}",
+                    ],
+                    duration_ms=duration,
+                    raw_output=output,
+                    error=f"reviewer_parse_failed: {parse_err}",
+                    prompt_sha256=prompt_sha256,
+                )
 
             score = float(data.get("score", 5.0))
             if reviewer_type == "generalist-reviewer":
@@ -3215,21 +3285,16 @@ Output ONLY valid JSON:
                 return env_python
 
         pe_venv_paths = [
-            Path.home() / "worktrees" / f"{repo_name}-main-view" / ".venv" / "bin" / "python",
+            Path.home()
+            / "worktrees"
+            / f"{repo_name}-main-view"
+            / ".venv"
+            / "bin"
+            / "python",
             Path.home() / "worktrees" / repo_name / ".venv" / "bin" / "python",
             Path.home() / repo_name / ".venv" / "bin" / "python",
-            Path.home()
-            / "RulesFoundation"
-            / repo_name
-            / ".venv"
-            / "bin"
-            / "python",
-            Path.home()
-            / "PolicyEngine"
-            / repo_name
-            / ".venv"
-            / "bin"
-            / "python",
+            Path.home() / "RulesFoundation" / repo_name / ".venv" / "bin" / "python",
+            Path.home() / "PolicyEngine" / repo_name / ".venv" / "bin" / "python",
         ]
         for pe_python in pe_venv_paths:
             if pe_python.exists() and _python_imports_policyengine(str(pe_python)):
@@ -3310,7 +3375,9 @@ Output ONLY valid JSON:
         """Return True when PE cannot evaluate the cited period or variable."""
         if not error_text:
             return False
-        return any(pattern.search(error_text) for pattern in _PE_UNSUPPORTED_ERROR_PATTERNS)
+        return any(
+            pattern.search(error_text) for pattern in _PE_UNSUPPORTED_ERROR_PATTERNS
+        )
 
     def _summarize_oracle_error(self, error_text: str) -> str:
         """Collapse multi-line stderr into a short human-readable issue."""
@@ -3405,16 +3472,8 @@ Output ONLY valid JSON:
             period = (
                 test.get("period")
                 or test.get("date")
-                or (
-                    inputs.get("period")
-                    if isinstance(inputs, dict)
-                    else None
-                )
-                or (
-                    inputs.get("date")
-                    if isinstance(inputs, dict)
-                    else None
-                )
+                or (inputs.get("period") if isinstance(inputs, dict) else None)
+                or (inputs.get("date") if isinstance(inputs, dict) else None)
                 or "2024-01"
             )
             period_str = str(period)
@@ -3466,7 +3525,9 @@ Output ONLY valid JSON:
                     )
                     inputs_with_period.setdefault(
                         "snap_utility_region_str",
-                        _default_snap_utility_region_for_jurisdiction(source_jurisdiction),
+                        _default_snap_utility_region_for_jurisdiction(
+                            source_jurisdiction
+                        ),
                     )
             scenario_script = self._build_pe_scenario_script(
                 pe_var,
@@ -3522,7 +3583,9 @@ Output ONLY valid JSON:
         if total == 0:
             duration = int((time.time() - start) * 1000)
             if unsupported_count:
-                issues.append("PolicyEngine could not evaluate any oracle-comparable tests")
+                issues.append(
+                    "PolicyEngine could not evaluate any oracle-comparable tests"
+                )
             return ValidationResult(
                 validator_name="policyengine",
                 passed=True,
@@ -3645,7 +3708,9 @@ Output ONLY valid JSON:
             if total == 0:
                 duration = int((time.time() - start) * 1000)
                 if unmappable:
-                    issues.append("TAXSIM could not evaluate any oracle-comparable tests")
+                    issues.append(
+                        "TAXSIM could not evaluate any oracle-comparable tests"
+                    )
                 return ValidationResult(
                     validator_name="taxsim",
                     passed=True,
@@ -4006,7 +4071,10 @@ print("BENCHMARK:" + json.dumps(result))
                 }
                 if "value" in lowered_keys:
                     other_keys = lowered_keys - {"value"}
-                    if len(other_keys) == 1 and next(iter(other_keys)) in singleton_entity_value_keys:
+                    if (
+                        len(other_keys) == 1
+                        and next(iter(other_keys)) in singleton_entity_value_keys
+                    ):
                         for key, inner in value.items():
                             if str(key).lower() == "value":
                                 return normalize_test_value(inner)
@@ -4154,9 +4222,11 @@ print("BENCHMARK:" + json.dumps(result))
                     #   period: ...
                     #   input: ...
                     #   output/expect: ...
-                    elif isinstance(value, dict) and any(
-                        io_key in value for io_key in ("input", "inputs")
-                    ) and any(io_key in value for io_key in ("output", "expect")):
+                    elif (
+                        isinstance(value, dict)
+                        and any(io_key in value for io_key in ("input", "inputs"))
+                        and any(io_key in value for io_key in ("output", "expect"))
+                    ):
                         outputs = value.get("output", value.get("expect"))
                         if isinstance(outputs, dict):
                             inputs = value.get("input", value.get("inputs", {}))
@@ -4432,8 +4502,9 @@ print("BENCHMARK:" + json.dumps(result))
     @staticmethod
     def _is_uk_pc_severe_disability_addition_var(rac_var: str) -> bool:
         rac_var_lower = rac_var.lower()
-        return "pc_severe_disability_addition" in rac_var_lower and not rac_var_lower.endswith(
-            "_applies"
+        return (
+            "pc_severe_disability_addition" in rac_var_lower
+            and not rac_var_lower.endswith("_applies")
         )
 
     @staticmethod
@@ -4464,8 +4535,9 @@ print("BENCHMARK:" + json.dumps(result))
     @staticmethod
     def _is_uk_pc_severely_disabled_child_addition_var(rac_var: str) -> bool:
         rac_var_lower = rac_var.lower()
-        return "pc_severely_disabled_child_addition" in rac_var_lower and not rac_var_lower.endswith(
-            "_applies"
+        return (
+            "pc_severely_disabled_child_addition" in rac_var_lower
+            and not rac_var_lower.endswith("_applies")
         )
 
     @staticmethod
@@ -4551,7 +4623,10 @@ print("BENCHMARK:" + json.dumps(result))
         rac_var_lower = rac_var.lower()
         return any(
             marker in rac_var_lower
-            for marker in ("uc_lcwra_element", "uc_limited_capability_for_work_related_activity")
+            for marker in (
+                "uc_lcwra_element",
+                "uc_limited_capability_for_work_related_activity",
+            )
         ) and not rac_var_lower.endswith("_applies")
 
     @staticmethod
@@ -4624,12 +4699,18 @@ print("BENCHMARK:" + json.dumps(result))
     @staticmethod
     def _is_uk_wtc_basic_element_var(rac_var: str) -> bool:
         rac_var_lower = rac_var.lower()
-        return "wtc_basic" in rac_var_lower or "working_tax_credit_basic_element" in rac_var_lower
+        return (
+            "wtc_basic" in rac_var_lower
+            or "working_tax_credit_basic_element" in rac_var_lower
+        )
 
     @staticmethod
     def _is_uk_wtc_lone_parent_element_var(rac_var: str) -> bool:
         rac_var_lower = rac_var.lower()
-        return "wtc_lone_parent" in rac_var_lower or "working_tax_credit_lone_parent_element" in rac_var_lower
+        return (
+            "wtc_lone_parent" in rac_var_lower
+            or "working_tax_credit_lone_parent_element" in rac_var_lower
+        )
 
     @staticmethod
     def _is_uk_wtc_couple_element_var(rac_var: str) -> bool:
@@ -4718,7 +4799,9 @@ print("BENCHMARK:" + json.dumps(result))
             ):
                 lowered_input_keys = {str(key).lower() for key in inputs}
                 unsupported_keys = {
-                    key for key in adapter.unsupported_input_keys if key.lower() in lowered_input_keys
+                    key
+                    for key in adapter.unsupported_input_keys
+                    if key.lower() in lowered_input_keys
                 }
                 for input_key in lowered_input_keys:
                     if any(
@@ -4767,26 +4850,26 @@ print("BENCHMARK:" + json.dumps(result))
                 for key, value in inputs.items()
                 if value is not None and not bool(value)
             }
-            if (
-                "is_child_or_qualifying_young_person" in explicit_false_keys
-                or (
-                    any("is_child" in key for key in explicit_false_keys)
-                    and any("qualifying_young_person" in key for key in explicit_false_keys)
-                )
+            if "is_child_or_qualifying_young_person" in explicit_false_keys or (
+                any("is_child" in key for key in explicit_false_keys)
+                and any("qualifying_young_person" in key for key in explicit_false_keys)
             ):
                 return (
                     False,
                     "RAC test negates child-or-qualifying-young-person subject status that PolicyEngine UK's statutory child benefit rate does not expose as a separate comparable branch",
                 )
-        if country == "uk" and self._is_uk_child_benefit_rate_var(
-            rac_var_lower
-        ) and rac_var_lower.endswith("_applies"):
+        if (
+            country == "uk"
+            and self._is_uk_child_benefit_rate_var(rac_var_lower)
+            and rac_var_lower.endswith("_applies")
+        ):
             return (
                 False,
                 "RAC helper boolean does not have a direct PolicyEngine UK analogue",
             )
-        if country == "uk" and self._is_uk_pension_credit_standard_minimum_guarantee_var(
-            rac_var_lower
+        if (
+            country == "uk"
+            and self._is_uk_pension_credit_standard_minimum_guarantee_var(rac_var_lower)
         ):
             if (
                 rac_var_lower.endswith("_applies")
@@ -4869,8 +4952,9 @@ print("BENCHMARK:" + json.dumps(result))
         rac_var_lower = rac_var.lower()
         if country == "uk" and self._is_uk_child_benefit_rate_var(rac_var_lower):
             return "child_benefit_respective_amount"
-        if country == "uk" and self._is_uk_pension_credit_standard_minimum_guarantee_var(
-            rac_var_lower
+        if (
+            country == "uk"
+            and self._is_uk_pension_credit_standard_minimum_guarantee_var(rac_var_lower)
         ):
             return "standard_minimum_guarantee"
         if country == "uk" and self._is_uk_pc_severe_disability_addition_var(
@@ -4989,6 +5073,7 @@ print("BENCHMARK:" + json.dumps(result))
 
     def _build_pe_us_scenario_script(self, pe_var: str, inputs: dict, year: str) -> str:
         """Build a Python script to run a US PolicyEngine scenario."""
+
         def derive_override_value(
             operation: str, source_values: list[float]
         ) -> float | None:
@@ -4997,7 +5082,10 @@ print("BENCHMARK:" + json.dumps(result))
                 derived_value = source_values[0] - sum(source_values[1:])
             elif operation == "difference_floor_zero" and len(source_values) >= 2:
                 derived_value = max(0.0, source_values[0] - sum(source_values[1:]))
-            elif operation == "difference_floor_zero_annualized" and len(source_values) >= 2:
+            elif (
+                operation == "difference_floor_zero_annualized"
+                and len(source_values) >= 2
+            ):
                 derived_value = (
                     max(0.0, source_values[0] - sum(source_values[1:])) * 12.0
                 )
@@ -5056,7 +5144,9 @@ print("BENCHMARK:" + json.dumps(result))
                 household_children = max(0, int(household_size) - num_adults)
 
         num_children = (
-            explicit_child_count if explicit_child_count is not None else household_children
+            explicit_child_count
+            if explicit_child_count is not None
+            else household_children
         )
         dependent_care_keys = (
             "snap_dependent_care_actual_costs",
@@ -5073,9 +5163,7 @@ print("BENCHMARK:" + json.dumps(result))
         # Determine period for calculation
         is_monthly = pe_var in self._PE_MONTHLY_VARS
         if is_monthly:
-            period = self._normalize_monthly_pe_period(
-                inputs.get("period"), year, "01"
-            )
+            period = self._normalize_monthly_pe_period(inputs.get("period"), year, "01")
             calc_period = f"'{period}'"
         else:
             calc_period = f"int('{year}')"
@@ -5099,20 +5187,16 @@ print("BENCHMARK:" + json.dumps(result))
                     continue
                 with contextlib.suppress(TypeError, ValueError):
                     annual_value = float(value) * 12
-                    adult_attrs.append(
-                        f"'{pe_attr}': {{'{year}': {annual_value}}}"
-                    )
+                    adult_attrs.append(f"'{pe_attr}': {{'{year}': {annual_value}}}")
             for rac_key, pe_attr in adapter.boolean_person_inputs:
                 if rac_key in inputs:
                     adult_attrs.append(
-                        f"'{pe_attr}': "
-                        f"{{'{year}': {bool(inputs[rac_key])}}}"
+                        f"'{pe_attr}': {{'{year}': {bool(inputs[rac_key])}}}"
                     )
             for rac_key, pe_attr in adapter.monthly_boolean_person_inputs:
                 if rac_key in inputs:
                     adult_attrs.append(
-                        f"'{pe_attr}': "
-                        f"{{'{period}': {bool(inputs[rac_key])}}}"
+                        f"'{pe_attr}': {{'{period}': {bool(inputs[rac_key])}}}"
                     )
 
         snap_eligible_member_proxy = None
@@ -5134,8 +5218,7 @@ print("BENCHMARK:" + json.dumps(result))
         ):
             has_eligible_member = snap_eligible_member_proxy
             adult_attrs.append(
-                f"'is_snap_ineligible_student': "
-                f"{{'{year}': {not has_eligible_member}}}"
+                f"'is_snap_ineligible_student': {{'{year}': {not has_eligible_member}}}"
             )
             adult_attrs.append(
                 f"'is_snap_immigration_status_eligible': "
@@ -5152,8 +5235,7 @@ print("BENCHMARK:" + json.dumps(result))
                 float(inputs["snap_number_of_members_eligible_to_participate"]) > 0
             )
             adult_attrs.append(
-                f"'is_snap_ineligible_student': "
-                f"{{'{year}': {not has_eligible_member}}}"
+                f"'is_snap_ineligible_student': {{'{year}': {not has_eligible_member}}}"
             )
             adult_attrs.append(
                 f"'is_snap_immigration_status_eligible': "
@@ -5205,13 +5287,17 @@ print("BENCHMARK:" + json.dumps(result))
                 if not all(source_key in inputs for source_key in source_keys):
                     continue
                 try:
-                    source_values = [float(inputs[source_key]) for source_key in source_keys]
+                    source_values = [
+                        float(inputs[source_key]) for source_key in source_keys
+                    ]
                 except (TypeError, ValueError):
                     continue
                 derived_value = derive_override_value(operation, source_values)
                 if derived_value is None:
                     continue
-                override_values[target_key] = int(derived_value) if derived_value.is_integer() else derived_value
+                override_values[target_key] = (
+                    int(derived_value) if derived_value.is_integer() else derived_value
+                )
         annual_override_values: dict[str, Any] = {}
         if adapter is not None:
             for rac_key, pe_key in adapter.annual_direct_spm_overrides:
@@ -5234,9 +5320,7 @@ print("BENCHMARK:" + json.dumps(result))
                 )
                 try:
                     source_values = [
-                        float(inputs[source_key])
-                        if source_key in inputs
-                        else 0.0
+                        float(inputs[source_key]) if source_key in inputs else 0.0
                         for source_key in source_keys
                         if source_key in inputs or missing_as_zero
                     ]
@@ -5254,17 +5338,11 @@ print("BENCHMARK:" + json.dumps(result))
         override_parts = []
         for pe_key, val in override_values.items():
             if is_monthly:
-                override_parts.append(
-                    f"'{pe_key}': {{'{period}': {pe_literal(val)}}}"
-                )
+                override_parts.append(f"'{pe_key}': {{'{period}': {pe_literal(val)}}}")
             else:
-                override_parts.append(
-                    f"'{pe_key}': {{'{year}': {pe_literal(val)}}}"
-                )
+                override_parts.append(f"'{pe_key}': {{'{year}': {pe_literal(val)}}}")
         for pe_key, val in annual_override_values.items():
-            override_parts.append(
-                f"'{pe_key}': {{'{year}': {pe_literal(val)}}}"
-            )
+            override_parts.append(f"'{pe_key}': {{'{year}': {pe_literal(val)}}}")
 
         spm_extra = ""
         if override_parts:
@@ -5273,15 +5351,10 @@ print("BENCHMARK:" + json.dumps(result))
         household_state = "CA"
         if adapter is not None and adapter.default_state_code is not None:
             household_state = adapter.default_state_code
-        if (
-            adapter is not None
-            and adapter.state_code_from_boolean_input is not None
-        ):
+        if adapter is not None and adapter.state_code_from_boolean_input is not None:
             input_key, true_state, false_state = adapter.state_code_from_boolean_input
             if input_key in inputs:
-                household_state = (
-                    true_state if bool(inputs[input_key]) else false_state
-                )
+                household_state = true_state if bool(inputs[input_key]) else false_state
         utility_region = None
         if "snap_utility_region" in inputs:
             utility_region = str(inputs["snap_utility_region"])
@@ -5304,9 +5377,7 @@ print("BENCHMARK:" + json.dumps(result))
         elif "state_name" in inputs:
             household_state = str(inputs["state_name"])
         elif utility_region is not None:
-            household_state = _normalize_state_code_from_utility_region(
-                utility_region
-            )
+            household_state = _normalize_state_code_from_utility_region(utility_region)
 
         household_extra_parts = [
             f"'state_name': {{'{year}': {repr(household_state)}}}",
@@ -5314,8 +5385,7 @@ print("BENCHMARK:" + json.dumps(result))
         ]
         if utility_region is not None:
             household_extra_parts.append(
-                f"'snap_utility_region_str': "
-                f"{{'{year}': {repr(utility_region)}}}"
+                f"'snap_utility_region_str': {{'{year}': {repr(utility_region)}}}"
             )
         if "state_group_str" in inputs:
             household_extra_parts.append(
@@ -5359,7 +5429,7 @@ situation = {{
     'spm_units': {{'spm': {{'members': {members_str}{spm_extra}}}}},
     'households': {{'hh': {{'members': {members_str}, {household_extra}}}}},
     'families': {{'fam': {{'members': {members_str}}}}},
-    'marital_units': {{'mu': {{'members': {['adult', 'spouse'] if joint_filing else ['adult']}}}}},
+    'marital_units': {{'mu': {{'members': {["adult", "spouse"] if joint_filing else ["adult"]}}}}},
 }}
 
 sim = Simulation(situation=situation)
@@ -5395,10 +5465,14 @@ print(f'RESULT:{{val}}')
                     for key, value in lowered.items()
                     if ("couple" in key or "joint" in key) and value is not None
                 )
-            under_25 = any(
-                marker in rac_var_lower
-                for marker in ("under_25", "aged_under_25", "young")
-            ) and "over_25" not in rac_var_lower and "25_or_over" not in rac_var_lower
+            under_25 = (
+                any(
+                    marker in rac_var_lower
+                    for marker in ("under_25", "aged_under_25", "young")
+                )
+                and "over_25" not in rac_var_lower
+                and "25_or_over" not in rac_var_lower
+            )
             if any(
                 ("25_or_over" in key or "over_25" in key) and value is not None
                 for key, value in lowered.items()
@@ -5487,9 +5561,7 @@ print(f'RESULT:{{val}}')
             )
 
             if target_is_first_higher:
-                people = (
-                    f"{{'child': {{'age': {{{year_key}: 10}}, 'birth_year': {{{year_key}: 2015}}}}}}"
-                )
+                people = f"{{'child': {{'age': {{{year_key}: 10}}, 'birth_year': {{{year_key}: 2015}}}}}}"
                 benunit_members = "['child']"
                 household_members = "['child']"
                 target_index = 0
@@ -5502,9 +5574,7 @@ print(f'RESULT:{{val}}')
                 household_members = "['older', 'child']"
                 target_index = 1
             else:
-                people = (
-                    f"{{'child': {{'age': {{{year_key}: 7}}, 'birth_year': {{{year_key}: 2018}}}}}}"
-                )
+                people = f"{{'child': {{'age': {{{year_key}: 7}}, 'birth_year': {{{year_key}: 2018}}}}}}"
                 benunit_members = "['child']"
                 household_members = "['child']"
                 target_index = 0
@@ -5525,8 +5595,9 @@ val = float(annual[target_index]) / 12
 print(f'RESULT:{{val}}')
 """
 
-        if pe_var == "uc_individual_disabled_child_element" and self._is_uk_uc_disabled_child_element_var(
-            rac_var_lower
+        if (
+            pe_var == "uc_individual_disabled_child_element"
+            and self._is_uk_uc_disabled_child_element_var(rac_var_lower)
         ):
             return f"""
 from policyengine_uk import Simulation
@@ -5543,8 +5614,9 @@ val = float(annual[0]) / 12
 print(f'RESULT:{{val}}')
 """
 
-        if pe_var == "uc_individual_severely_disabled_child_element" and self._is_uk_uc_severely_disabled_child_element_var(
-            rac_var_lower
+        if (
+            pe_var == "uc_individual_severely_disabled_child_element"
+            and self._is_uk_uc_severely_disabled_child_element_var(rac_var_lower)
         ):
             return f"""
 from policyengine_uk import Simulation
@@ -5608,8 +5680,9 @@ val = float(annual[0]) / 12
 print(f'RESULT:{{val}}')
 """
 
-        if pe_var == "uc_maximum_childcare_element_amount" and self._is_uk_uc_maximum_childcare_element_var(
-            rac_var_lower
+        if (
+            pe_var == "uc_maximum_childcare_element_amount"
+            and self._is_uk_uc_maximum_childcare_element_var(rac_var_lower)
         ):
             explicit_children = next(
                 (
@@ -5625,7 +5698,10 @@ print(f'RESULT:{{val}}')
             )
             if explicit_children is not None:
                 eligible_children = explicit_children
-            elif "two_or_more" in rac_var_lower or "two_or_more_children" in rac_var_lower:
+            elif (
+                "two_or_more" in rac_var_lower
+                or "two_or_more_children" in rac_var_lower
+            ):
                 eligible_children = 2
             else:
                 eligible_children = 1
@@ -5645,8 +5721,9 @@ val = float(annual[0]) / 12
 print(f'RESULT:{{val}}')
 """
 
-        if pe_var == "uc_individual_non_dep_deduction" and self._is_uk_uc_non_dep_deduction_amount_var(
-            rac_var_lower
+        if (
+            pe_var == "uc_individual_non_dep_deduction"
+            and self._is_uk_uc_non_dep_deduction_amount_var(rac_var_lower)
         ):
             explicit_exempt = next(
                 (
@@ -5711,21 +5788,15 @@ print(f'RESULT:{{val}}')
                 benunit_members = "['adult', 'spouse']"
                 household_members = "['adult', 'spouse']"
             elif pe_var == "WTC_disabled_element":
-                people = (
-                    f"{{'adult': {{'age': {{{year_key}: 30}}, 'weekly_hours': {{{year_key}: 30}}, 'working_tax_credit_reported': {{{year_key}: 1}}, 'is_disabled_for_benefits': {{{year_key}: True}}}}}}"
-                )
+                people = f"{{'adult': {{'age': {{{year_key}: 30}}, 'weekly_hours': {{{year_key}: 30}}, 'working_tax_credit_reported': {{{year_key}: 1}}, 'is_disabled_for_benefits': {{{year_key}: True}}}}}}"
                 benunit_members = "['adult']"
                 household_members = "['adult']"
             elif pe_var == "WTC_severely_disabled_element":
-                people = (
-                    f"{{'adult': {{'age': {{{year_key}: 30}}, 'weekly_hours': {{{year_key}: 30}}, 'working_tax_credit_reported': {{{year_key}: 1}}, 'is_disabled_for_benefits': {{{year_key}: True}}, 'is_severely_disabled_for_benefits': {{{year_key}: True}}}}}}"
-                )
+                people = f"{{'adult': {{'age': {{{year_key}: 30}}, 'weekly_hours': {{{year_key}: 30}}, 'working_tax_credit_reported': {{{year_key}: 1}}, 'is_disabled_for_benefits': {{{year_key}: True}}, 'is_severely_disabled_for_benefits': {{{year_key}: True}}}}}}"
                 benunit_members = "['adult']"
                 household_members = "['adult']"
             else:
-                people = (
-                    f"{{'adult': {{'age': {{{year_key}: 30}}, 'weekly_hours': {{{year_key}: 30}}, 'working_tax_credit_reported': {{{year_key}: 1}}}}}}"
-                )
+                people = f"{{'adult': {{'age': {{{year_key}: 30}}, 'weekly_hours': {{{year_key}: 30}}, 'working_tax_credit_reported': {{{year_key}: 1}}}}}}"
                 benunit_members = "['adult']"
                 household_members = "['adult']"
 
@@ -5744,8 +5815,9 @@ val = float(annual[0])
 print(f'RESULT:{{val}}')
 """
 
-        if pe_var == "standard_minimum_guarantee" and self._is_uk_pension_credit_standard_minimum_guarantee_var(
-            rac_var_lower
+        if (
+            pe_var == "standard_minimum_guarantee"
+            and self._is_uk_pension_credit_standard_minimum_guarantee_var(rac_var_lower)
         ):
             explicit_has_partner = next(
                 (
@@ -5771,7 +5843,9 @@ print(f'RESULT:{{val}}')
                 scenario_is_couple = explicit_has_partner
             elif relation_type is not None:
                 scenario_is_couple = "couple" in relation_type
-            elif any("no_partner" in key and bool(value) for key, value in lowered.items()):
+            elif any(
+                "no_partner" in key and bool(value) for key, value in lowered.items()
+            ):
                 scenario_is_couple = False
             elif any(
                 (
@@ -5792,9 +5866,7 @@ print(f'RESULT:{{val}}')
             benunit_members = "['adult']"
             household_members = "['adult']"
             if scenario_is_couple:
-                people = (
-                    f"{{'adult': {{'age': {{{year_key}: 70}}}}, 'spouse': {{'age': {{{year_key}: 70}}}}}}"
-                )
+                people = f"{{'adult': {{'age': {{{year_key}: 70}}}}, 'spouse': {{'age': {{{year_key}: 70}}}}}}"
                 benunit_members = "['adult', 'spouse']"
                 household_members = "['adult', 'spouse']"
 
@@ -5832,8 +5904,9 @@ scenario_is_couple = {scenario_is_couple}
 print(f'RESULT:{{val}}')
 """
 
-        if pe_var == "severe_disability_minimum_guarantee_addition" and self._is_uk_pc_severe_disability_addition_var(
-            rac_var_lower
+        if (
+            pe_var == "severe_disability_minimum_guarantee_addition"
+            and self._is_uk_pc_severe_disability_addition_var(rac_var_lower)
         ):
             explicit_eligible_adults = next(
                 (
@@ -5884,9 +5957,7 @@ print(f'RESULT:{{val}}')
                 )
                 members = "['adult', 'spouse']"
             elif eligible_adults == 1:
-                people = (
-                    f"{{'adult': {{'age': {{{year_key}: 70}}, 'attendance_allowance': {{{year_key}: 1}}}}}}"
-                )
+                people = f"{{'adult': {{'age': {{{year_key}: 70}}, 'attendance_allowance': {{{year_key}: 1}}}}}}"
                 members = "['adult']"
             else:
                 people = f"{{'adult': {{'age': {{{year_key}: 70}}}}}}"
@@ -5907,8 +5978,9 @@ val = float(annual[0]) / 52
 print(f'RESULT:{{val}}')
 """
 
-        if pe_var == "carer_minimum_guarantee_addition" and self._is_uk_pc_carer_addition_var(
-            rac_var_lower
+        if (
+            pe_var == "carer_minimum_guarantee_addition"
+            and self._is_uk_pc_carer_addition_var(rac_var_lower)
         ):
             explicit_eligible_carers = next(
                 (
@@ -5942,9 +6014,7 @@ print(f'RESULT:{{val}}')
                 )
                 members = "['adult', 'spouse']"
             elif eligible_carers == 1:
-                people = (
-                    f"{{'adult': {{'age': {{{year_key}: 70}}, 'carers_allowance': {{{year_key}: 1}}}}}}"
-                )
+                people = f"{{'adult': {{'age': {{{year_key}: 70}}, 'carers_allowance': {{{year_key}: 1}}}}}}"
                 members = "['adult']"
             else:
                 people = f"{{'adult': {{'age': {{{year_key}: 70}}}}}}"
@@ -5995,17 +6065,11 @@ print(f'RESULT:{{val}}')
                 target_mode = "disabled"
 
             if has_child:
-                base_people = (
-                    f"{{'adult': {{'age': {{{year_key}: 70}}}}, 'child': {{'age': {{{year_key}: 10}}}}}}"
-                )
+                base_people = f"{{'adult': {{'age': {{{year_key}: 70}}}}, 'child': {{'age': {{{year_key}: 10}}}}}}"
                 if target_mode == "disabled":
-                    target_people = (
-                        f"{{'adult': {{'age': {{{year_key}: 70}}}}, 'child': {{'age': {{{year_key}: 10}}, 'dla': {{{year_key}: 1}}}}}}"
-                    )
+                    target_people = f"{{'adult': {{'age': {{{year_key}: 70}}}}, 'child': {{'age': {{{year_key}: 10}}, 'dla': {{{year_key}: 1}}}}}}"
                 elif target_mode == "severe":
-                    target_people = (
-                        f"{{'adult': {{'age': {{{year_key}: 70}}}}, 'child': {{'age': {{{year_key}: 10}}, 'dla': {{{year_key}: 1}}, 'receives_highest_dla_sc': {{{year_key}: True}}}}}}"
-                    )
+                    target_people = f"{{'adult': {{'age': {{{year_key}: 70}}}}, 'child': {{'age': {{{year_key}: 10}}, 'dla': {{{year_key}: 1}}, 'receives_highest_dla_sc': {{{year_key}: True}}}}}}"
                 else:
                     target_people = base_people
                 members = "['adult', 'child']"
@@ -6017,7 +6081,9 @@ print(f'RESULT:{{val}}')
             if target_mode == "base":
                 result_logic = "val = float(target_annual[0]) / 52"
             else:
-                result_logic = "val = (float(target_annual[0]) - float(base_annual[0])) / 52"
+                result_logic = (
+                    "val = (float(target_annual[0]) - float(base_annual[0])) / 52"
+                )
 
             return f"""
 from policyengine_uk import Simulation
@@ -6041,8 +6107,9 @@ target_annual = target_sim.calculate('child_minimum_guarantee_addition', int('{y
 print(f'RESULT:{{val}}')
 """
 
-        if pe_var == "scottish_child_payment" and self._is_uk_scottish_child_payment_rate_var(
-            rac_var_lower
+        if (
+            pe_var == "scottish_child_payment"
+            and self._is_uk_scottish_child_payment_rate_var(rac_var_lower)
         ):
             in_scotland = next(
                 (
@@ -6132,21 +6199,26 @@ print(f'RESULT:{{val}}')
             elif "80a_2_d" in rac_var_lower:
                 branch_category = ("other", "outside_london", "mixed")
 
-            leaf_in_london = any(
-                marker in rac_var_lower
-                for marker in ("greater_london", "in_london", "london")
-            ) and "outside_london" not in rac_var_lower
-            leaf_is_single = (
-                any(marker in rac_var_lower for marker in ("single_claimant", "single"))
-                and not any(
+            leaf_in_london = (
+                any(
                     marker in rac_var_lower
-                    for marker in ("joint_claimant", "couple", "family")
+                    for marker in ("greater_london", "in_london", "london")
                 )
+                and "outside_london" not in rac_var_lower
             )
-            leaf_has_child = any(
+            leaf_is_single = any(
+                marker in rac_var_lower for marker in ("single_claimant", "single")
+            ) and not any(
                 marker in rac_var_lower
-                for marker in ("child", "young_person", "family")
-            ) and "no_child" not in rac_var_lower
+                for marker in ("joint_claimant", "couple", "family")
+            )
+            leaf_has_child = (
+                any(
+                    marker in rac_var_lower
+                    for marker in ("child", "young_person", "family")
+                )
+                and "no_child" not in rac_var_lower
+            )
             has_leaf_location_hint = any(
                 marker in rac_var_lower
                 for marker in (
@@ -6191,8 +6263,7 @@ print(f'RESULT:{{val}}')
                     if any("outside_london" in key for key in lowered_keys):
                         leaf_in_london = False
                     elif any(
-                        "not_resident_in_greater_london" in key
-                        for key in lowered_keys
+                        "not_resident_in_greater_london" in key for key in lowered_keys
                     ):
                         leaf_in_london = False
                     elif any("greater_london" in key for key in lowered_keys):
@@ -6244,7 +6315,8 @@ print(f'RESULT:{{val}}')
             if explicit_greater_london_keys:
                 in_london = any(explicit_greater_london_keys)
             elif any(
-                "not_resident_in_greater_london" in str(key).lower() and value is not None
+                "not_resident_in_greater_london" in str(key).lower()
+                and value is not None
                 for key, value in lowered.items()
             ):
                 in_london = not any(
@@ -6325,10 +6397,7 @@ print(f'RESULT:{{val}}')
             if explicit_responsible is not None:
                 has_child = explicit_responsible
             if any(
-                (
-                    "no_child" in str(key).lower()
-                    or "without_child" in str(key).lower()
-                )
+                ("no_child" in str(key).lower() or "without_child" in str(key).lower())
                 and bool(value)
                 for key, value in lowered.items()
             ):
@@ -6337,12 +6406,9 @@ print(f'RESULT:{{val}}')
                 explicit_not_responsible is None
                 and explicit_responsible is None
                 and any(
-                (
-                    "child" in str(key).lower()
-                    or "young_person" in str(key).lower()
-                )
-                and value is not None
-                for key, value in lowered.items()
+                    ("child" in str(key).lower() or "young_person" in str(key).lower())
+                    and value is not None
+                    for key, value in lowered.items()
                 )
             ):
                 has_child = any(
@@ -6448,10 +6514,7 @@ print(f'RESULT:{{val}}')
             (
                 bool(value)
                 for key, value in lowered.items()
-                if (
-                    "child_or_qualifying_young_person" in key
-                    or "child_or_qyp" in key
-                )
+                if ("child_or_qualifying_young_person" in key or "child_or_qyp" in key)
                 and value is not None
             ),
             True,
@@ -6468,7 +6531,8 @@ print(f'RESULT:{{val}}')
             (
                 bool(value)
                 for key, value in lowered.items()
-                if str(key).lower() == "is_qualifying_young_person" and value is not None
+                if str(key).lower() == "is_qualifying_young_person"
+                and value is not None
             ),
             None,
         )
@@ -6518,9 +6582,7 @@ print(f'RESULT:{{val}}')
         value_expr = "float(monthly[target_index]) * 12 / 52"
         use_other_child_branch = self._is_uk_child_benefit_other_child_rate_var(
             rac_var_lower
-        ) or (
-            rac_var_lower == "child_benefit_weekly_rate" and other_case is not None
-        )
+        ) or (rac_var_lower == "child_benefit_weekly_rate" and other_case is not None)
         if use_other_child_branch:
             result_logic = f"""
 if bool(eldest[target_index]):

--- a/src/autorac/prompts/encoder.py
+++ b/src/autorac/prompts/encoder.py
@@ -2,7 +2,22 @@
 RAC Encoder prompt -- embedded from rules-foundation-claude/agents/encoder.md.
 
 Encodes tax/benefit rules into RAC format.
+
+Versioning policy
+-----------------
+``__version__`` is a simple integer that identifies the currently shipped
+encoder prompt. Bump it whenever the prompt text below changes in a way that
+could materially affect encoder behaviour (new instructions, removed rules,
+changed output contract, etc.). Pure typo fixes do not require a bump.
+
+The encoding DB stores the prompt hash on each run, so this integer is an
+intentional, human-readable signal on top of that hash that makes diffs in
+the prompt registry easy to reason about.
+
+See ``docs/prompt-versioning.md`` for the full policy.
 """
+
+__version__ = 1
 
 ENCODER_PROMPT = """# RAC Encoder
 

--- a/src/autorac/prompts/reviewers.py
+++ b/src/autorac/prompts/reviewers.py
@@ -6,7 +6,20 @@ Four specialized reviewers:
 - Formula Reviewer: logic correctness, statutory fidelity
 - Parameter Reviewer: values, effective dates, units
 - Integration Reviewer: imports, dependencies, file connections
+
+Versioning policy
+-----------------
+``__version__`` identifies the currently shipped bundle of reviewer prompts.
+Bump it whenever ANY reviewer prompt below changes in a way that could affect
+reviewer verdicts (new/removed rules, changed JSON contract, changed rubric).
+
+The encoding DB records prompt hashes per reviewer run, so this integer is an
+additional human-readable signal; it is not an authoritative cache key.
+
+See ``docs/prompt-versioning.md`` for the full policy.
 """
+
+__version__ = 1
 
 RAC_REVIEWER_PROMPT = """# RAC Reviewer Agent
 

--- a/src/autorac/statute.py
+++ b/src/autorac/statute.py
@@ -39,32 +39,50 @@ def parse_usc_citation(citation: str) -> CitationParts:
 
     title = pieces[0]
     remainder = pieces[1].replace(" ", "")
-    match = re.match(r"^(?P<section>[0-9A-Za-z.-]+)(?P<tail>(?:\([^)]+\))*)$", remainder)
+    match = re.match(
+        r"^(?P<section>[0-9A-Za-z.-]+)(?P<tail>(?:\([^)]+\))*)$", remainder
+    )
     if not match:
         raise ValueError(f"Could not parse citation: {citation}")
 
     fragments = tuple(re.findall(r"\(([^)]+)\)", match.group("tail")))
-    return CitationParts(title=title, section=match.group("section"), fragments=fragments)
+    return CitationParts(
+        title=title, section=match.group("section"), fragments=fragments
+    )
 
 
 def citation_to_source_path(citation: str | CitationParts) -> str:
     """Convert a citation into the XML subsection source path format."""
-    parts = citation if isinstance(citation, CitationParts) else parse_usc_citation(citation)
+    parts = (
+        citation
+        if isinstance(citation, CitationParts)
+        else parse_usc_citation(citation)
+    )
     path_parts = [parts.title, parts.section, *parts.fragments]
     return "usc/" + "/".join(path_parts)
 
 
 def citation_to_relative_rac_path(citation: str | CitationParts) -> Path:
     """Convert a citation into the repo-relative RAC output path."""
-    parts = citation if isinstance(citation, CitationParts) else parse_usc_citation(citation)
+    parts = (
+        citation
+        if isinstance(citation, CitationParts)
+        else parse_usc_citation(citation)
+    )
     if not parts.fragments:
         return Path(parts.title) / parts.section / f"{parts.section}.rac"
-    return Path(parts.title) / parts.section / Path(*parts.fragments).with_suffix(".rac")
+    return (
+        Path(parts.title) / parts.section / Path(*parts.fragments).with_suffix(".rac")
+    )
 
 
 def uscode_xml_path(xml_root: Path, citation: str | CitationParts) -> Path:
     """Resolve the USC XML file for a citation."""
-    parts = citation if isinstance(citation, CitationParts) else parse_usc_citation(citation)
+    parts = (
+        citation
+        if isinstance(citation, CitationParts)
+        else parse_usc_citation(citation)
+    )
     return Path(xml_root) / f"usc{parts.title}.xml"
 
 

--- a/tests/test_autoagent_pilot.py
+++ b/tests/test_autoagent_pilot.py
@@ -48,9 +48,7 @@ def test_final_review_manifest_paths_resolve_existing_files():
 def test_pilot_editable_paths_point_at_prompt_surface():
     paths = pilot_editable_paths()
 
-    assert paths == [
-        autorac_repo_root() / "src/autorac/harness/eval_prompt_surface.py"
-    ]
+    assert paths == [autorac_repo_root() / "src/autorac/harness/eval_prompt_surface.py"]
 
 
 def test_program_path_resolves_autoresearch_program():
@@ -88,7 +86,10 @@ def test_seed_legislation_cache_copies_existing_local_cache(monkeypatch, tmp_pat
     assert copied["_legislation_gov_uk"] == 2
     assert copied["_legislation_gov_uk_cache"] == 2
     assert (
-        run_root / "_legislation_gov_uk_cache" / "uksi-2002-1792-2025-03-31" / "source.akn"
+        run_root
+        / "_legislation_gov_uk_cache"
+        / "uksi-2002-1792-2025-03-31"
+        / "source.akn"
     ).read_text() == "cached akn\n"
 
 
@@ -189,6 +190,8 @@ def test_build_mutation_prompt_mentions_only_editable_file():
     assert "Do not create, delete, or rename files." in prompt
     assert "separate holdout final-review set" in prompt
     assert "baseline training report is already fully ready" in prompt
-    assert "Do not make naming-only, readability-only, or token-count-only edits" in prompt
+    assert (
+        "Do not make naming-only, readability-only, or token-count-only edits" in prompt
+    )
     assert "Target at most one concrete failure cluster per iteration" in prompt
     assert "preserve that as a real disjunction" in prompt

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,10 +61,7 @@ from autorac.harness.evals import EvalArtifactMetrics
 
 class TestRunnerOverrides:
     def test_rewrites_openai_gpt_runner_to_codex(self):
-        assert (
-            _rewrite_gpt_runner_backend("openai:gpt-5.4", "codex")
-            == "codex:gpt-5.4"
-        )
+        assert _rewrite_gpt_runner_backend("openai:gpt-5.4", "codex") == "codex:gpt-5.4"
 
     def test_preserves_alias_when_rewriting_gpt_runner_backend(self):
         assert (
@@ -75,25 +72,28 @@ class TestRunnerOverrides:
     def test_effective_runner_specs_defaults_to_codex(self):
         args = SimpleNamespace(gpt_backend=None)
 
-        assert _effective_runner_specs(
-            ["openai:gpt-5.4", "claude:opus"], args
-        ) == ["codex:gpt-5.4", "claude:opus"]
+        assert _effective_runner_specs(["openai:gpt-5.4", "claude:opus"], args) == [
+            "codex:gpt-5.4",
+            "claude:opus",
+        ]
 
     def test_effective_runner_specs_uses_env_override(self, monkeypatch):
         monkeypatch.setenv("AUTORAC_GPT_BACKEND", "codex")
         args = SimpleNamespace(gpt_backend=None)
 
-        assert _effective_runner_specs(
-            ["openai:gpt-5.4", "claude:opus"], args
-        ) == ["codex:gpt-5.4", "claude:opus"]
+        assert _effective_runner_specs(["openai:gpt-5.4", "claude:opus"], args) == [
+            "codex:gpt-5.4",
+            "claude:opus",
+        ]
 
     def test_effective_runner_specs_allows_explicit_openai_override(self, monkeypatch):
         monkeypatch.delenv("AUTORAC_GPT_BACKEND", raising=False)
         args = SimpleNamespace(gpt_backend="openai")
 
-        assert _effective_runner_specs(
-            ["codex:gpt-5.4", "claude:opus"], args
-        ) == ["openai:gpt-5.4", "claude:opus"]
+        assert _effective_runner_specs(["codex:gpt-5.4", "claude:opus"], args) == [
+            "openai:gpt-5.4",
+            "claude:opus",
+        ]
 
 
 class TestMain:
@@ -340,7 +340,9 @@ class TestMain:
 class TestCmdEvalSuite:
     def test_exits_nonzero_when_runner_is_not_ready(self, tmp_path, capsys):
         manifest_file = tmp_path / "suite.yaml"
-        manifest_file.write_text("name: readiness\ncases:\n  - kind: source\n    source_id: x\n    source_file: ./source.txt\n")
+        manifest_file.write_text(
+            "name: readiness\ncases:\n  - kind: source\n    source_id: x\n    source_file: ./source.txt\n"
+        )
         (tmp_path / "source.txt").write_text("authoritative text")
         args = SimpleNamespace(
             manifest=manifest_file,
@@ -393,10 +395,10 @@ class TestCmdEvalSuite:
             gate_results=[],
         )
 
-        with patch("autorac.cli.load_eval_suite_manifest") as mock_load, patch(
-            "autorac.cli.run_eval_suite", return_value=[fake_result]
-        ) as mock_run, patch(
-            "autorac.cli.summarize_readiness", return_value=fake_summary
+        with (
+            patch("autorac.cli.load_eval_suite_manifest") as mock_load,
+            patch("autorac.cli.run_eval_suite", return_value=[fake_result]) as mock_run,
+            patch("autorac.cli.summarize_readiness", return_value=fake_summary),
         ):
             mock_load.return_value.name = "Readiness"
             mock_load.return_value.path = manifest_file
@@ -417,7 +419,9 @@ class TestCmdEvalSuite:
 
     def test_passes_resume_flag_to_run_eval_suite(self, tmp_path):
         manifest_file = tmp_path / "suite.yaml"
-        manifest_file.write_text("name: readiness\ncases:\n  - kind: source\n    source_id: x\n    source_file: ./source.txt\n")
+        manifest_file.write_text(
+            "name: readiness\ncases:\n  - kind: source\n    source_id: x\n    source_file: ./source.txt\n"
+        )
         (tmp_path / "source.txt").write_text("authoritative text")
         args = SimpleNamespace(
             manifest=manifest_file,
@@ -470,10 +474,10 @@ class TestCmdEvalSuite:
             gate_results=[],
         )
 
-        with patch("autorac.cli.load_eval_suite_manifest") as mock_load, patch(
-            "autorac.cli.run_eval_suite", return_value=[fake_result]
-        ) as mock_run, patch(
-            "autorac.cli.summarize_readiness", return_value=fake_summary
+        with (
+            patch("autorac.cli.load_eval_suite_manifest") as mock_load,
+            patch("autorac.cli.run_eval_suite", return_value=[fake_result]) as mock_run,
+            patch("autorac.cli.summarize_readiness", return_value=fake_summary),
         ):
             mock_load.return_value.name = "Readiness"
             mock_load.return_value.path = manifest_file
@@ -488,7 +492,9 @@ class TestCmdEvalSuite:
 
     def test_auto_resumes_after_unexpected_suite_exception(self, tmp_path):
         manifest_file = tmp_path / "suite.yaml"
-        manifest_file.write_text("name: readiness\ncases:\n  - kind: source\n    source_id: x\n    source_file: ./source.txt\n")
+        manifest_file.write_text(
+            "name: readiness\ncases:\n  - kind: source\n    source_id: x\n    source_file: ./source.txt\n"
+        )
         (tmp_path / "source.txt").write_text("authoritative text")
         args = SimpleNamespace(
             manifest=manifest_file,
@@ -541,12 +547,15 @@ class TestCmdEvalSuite:
             gate_results=[],
         )
 
-        with patch("autorac.cli.load_eval_suite_manifest") as mock_load, patch(
-            "autorac.cli.run_eval_suite",
-            side_effect=[RuntimeError("boom"), [fake_result]],
-        ) as mock_run, patch(
-            "autorac.cli.summarize_readiness", return_value=fake_summary
-        ), patch("autorac.cli.time.sleep") as mock_sleep:
+        with (
+            patch("autorac.cli.load_eval_suite_manifest") as mock_load,
+            patch(
+                "autorac.cli.run_eval_suite",
+                side_effect=[RuntimeError("boom"), [fake_result]],
+            ) as mock_run,
+            patch("autorac.cli.summarize_readiness", return_value=fake_summary),
+            patch("autorac.cli.time.sleep") as mock_sleep,
+        ):
             mock_load.return_value.name = "Readiness"
             mock_load.return_value.path = manifest_file
             mock_load.return_value.runners = ["openai:gpt-5.4"]
@@ -564,7 +573,9 @@ class TestCmdEvalSuite:
 
     def test_usage_limit_failure_does_not_trigger_auto_resume(self, tmp_path):
         manifest_file = tmp_path / "suite.yaml"
-        manifest_file.write_text("name: readiness\ncases:\n  - kind: source\n    source_id: x\n    source_file: ./source.txt\n")
+        manifest_file.write_text(
+            "name: readiness\ncases:\n  - kind: source\n    source_id: x\n    source_file: ./source.txt\n"
+        )
         (tmp_path / "source.txt").write_text("authoritative text")
         args = SimpleNamespace(
             manifest=manifest_file,
@@ -642,12 +653,15 @@ class TestCmdEvalSuite:
             )
             return [fake_result]
 
-        with patch("autorac.cli.load_eval_suite_manifest") as mock_load, patch(
-            "autorac.cli.run_eval_suite",
-            side_effect=fake_run_eval_suite,
-        ) as mock_run, patch(
-            "autorac.cli.summarize_readiness", return_value=fake_summary
-        ), patch("autorac.cli.time.sleep") as mock_sleep:
+        with (
+            patch("autorac.cli.load_eval_suite_manifest") as mock_load,
+            patch(
+                "autorac.cli.run_eval_suite",
+                side_effect=fake_run_eval_suite,
+            ) as mock_run,
+            patch("autorac.cli.summarize_readiness", return_value=fake_summary),
+            patch("autorac.cli.time.sleep") as mock_sleep,
+        ):
             mock_load.return_value.name = "Readiness"
             mock_load.return_value.path = manifest_file
             mock_load.return_value.runners = ["openai:gpt-5.4"]
@@ -777,7 +791,9 @@ class TestCmdEvalSuiteRevalidate:
         )
 
         source_output = tmp_path / "out"
-        rac_file = source_output / "01-case-a" / "openai-gpt-5.4" / "source" / "case-a.rac"
+        rac_file = (
+            source_output / "01-case-a" / "openai-gpt-5.4" / "source" / "case-a.rac"
+        )
         rac_file.parent.mkdir(parents=True)
         rac_file.write_text(
             '"""\nauthoritative source text\n"""\n\ncase_a:\n    entity: Household\n    period: Month\n    dtype: Money\n    unit: USD\n    from 2024-01-01: 1\n'
@@ -907,8 +923,11 @@ class TestCmdEvalSuiteRevalidate:
         )
         args.rac_path.mkdir()
 
-        with patch("autorac.cli.evaluate_artifact", return_value=fresh_metrics) as mock_eval, patch(
-            "autorac.cli.summarize_readiness", return_value=summary
+        with (
+            patch(
+                "autorac.cli.evaluate_artifact", return_value=fresh_metrics
+            ) as mock_eval,
+            patch("autorac.cli.summarize_readiness", return_value=summary),
         ):
             with pytest.raises(SystemExit) as exc_info:
                 cmd_eval_suite_revalidate(args)
@@ -1088,7 +1107,9 @@ class TestCmdEvalSuiteArchive:
         assert archived_result["context_manifest_file"].startswith(str(archive_dir))
         assert not archived_result["output_file"].startswith(str(source_output))
 
-        archived_row = json.loads((archive_dir / "suite-results.jsonl").read_text().strip())
+        archived_row = json.loads(
+            (archive_dir / "suite-results.jsonl").read_text().strip()
+        )
         assert archived_row["result"]["output_file"].startswith(str(archive_dir))
 
         metadata = json.loads((archive_dir / "archive-metadata.json").read_text())
@@ -1334,10 +1355,30 @@ class TestCmdValidate:
         }
         mock_result.to_actual_scores.return_value = ReviewResults(
             reviews=[
-                ReviewResult(reviewer="rac_reviewer", passed=True, items_checked=1, items_passed=1),
-                ReviewResult(reviewer="formula_reviewer", passed=True, items_checked=2, items_passed=2),
-                ReviewResult(reviewer="parameter_reviewer", passed=False, items_checked=2, items_passed=1),
-                ReviewResult(reviewer="integration_reviewer", passed=True, items_checked=1, items_passed=1),
+                ReviewResult(
+                    reviewer="rac_reviewer",
+                    passed=True,
+                    items_checked=1,
+                    items_passed=1,
+                ),
+                ReviewResult(
+                    reviewer="formula_reviewer",
+                    passed=True,
+                    items_checked=2,
+                    items_passed=2,
+                ),
+                ReviewResult(
+                    reviewer="parameter_reviewer",
+                    passed=False,
+                    items_checked=2,
+                    items_passed=1,
+                ),
+                ReviewResult(
+                    reviewer="integration_reviewer",
+                    passed=True,
+                    items_checked=1,
+                    items_passed=1,
+                ),
             ],
             policyengine_match=1.0,
             taxsim_match=None,
@@ -2947,7 +2988,9 @@ class TestCmdValidateEdgeCases:
 </akomaNtoso>
             """.strip()
         )
-        source_file.with_name("snap_standard_utility_allowance_tx.meta.yaml").write_text(
+        source_file.with_name(
+            "snap_standard_utility_allowance_tx.meta.yaml"
+        ).write_text(
             "version: 1\n"
             "source_backing:\n"
             "  kind: akn_section\n"
@@ -3015,7 +3058,9 @@ class TestCmdValidateEdgeCases:
         assert call_kwargs["rac_us_path"] == Path(
             "/Users/maxghenis/TheAxiomFoundation/rac-us"
         )
-        assert call_kwargs["rac_path"] == Path("/Users/maxghenis/TheAxiomFoundation/rac")
+        assert call_kwargs["rac_path"] == Path(
+            "/Users/maxghenis/TheAxiomFoundation/rac"
+        )
 
 
 class TestCmdCalibrationEdgeCases:

--- a/tests/test_encoder_harness.py
+++ b/tests/test_encoder_harness.py
@@ -486,7 +486,7 @@ test:
             result = harness._encode("26 USC 32", "EITC statute", output_path)
 
             assert '"""' in result
-            assert "TODO: Implement formula" in result
+            assert "TODO(#issue-needed): Implement formula" in result
             assert output_path.exists()
 
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -84,7 +84,9 @@ class TestParseRunnerSpec:
 
 
 class TestCodexPromptEval:
-    def test_wait_for_codex_process_terminates_after_stable_last_message(self, tmp_path):
+    def test_wait_for_codex_process_terminates_after_stable_last_message(
+        self, tmp_path
+    ):
         last_message = tmp_path / ".codex-last-message.txt"
         last_message.write_text("ready\n")
 
@@ -246,7 +248,9 @@ def test_eval_result_payload_round_trips_prompt_digests():
 
         assert process.terminated is True
 
-    def test_run_codex_prompt_eval_accepts_stable_last_message_on_termination(self, tmp_path):
+    def test_run_codex_prompt_eval_accepts_stable_last_message_on_termination(
+        self, tmp_path
+    ):
         runner = parse_runner_spec("codex:gpt-5.4")
         workspace = prepare_eval_workspace(
             citation="uksi/2002/1792/regulation/6/3/a",
@@ -258,10 +262,7 @@ def test_eval_result_payload_round_trips_prompt_digests():
             extra_context_paths=[],
         )
 
-        bundle = (
-            "=== FILE: example.rac ===\n"
-            "status: encoded\n"
-        )
+        bundle = "=== FILE: example.rac ===\nstatus: encoded\n"
         event_lines = "\n".join(
             [
                 json.dumps(
@@ -317,9 +318,12 @@ def test_eval_result_payload_round_trips_prompt_digests():
             process.wait()
             return True
 
-        with patch("autorac.harness.evals.subprocess.Popen", FakePopen), patch(
-            "autorac.harness.evals._wait_for_codex_process",
-            side_effect=fake_wait,
+        with (
+            patch("autorac.harness.evals.subprocess.Popen", FakePopen),
+            patch(
+                "autorac.harness.evals._wait_for_codex_process",
+                side_effect=fake_wait,
+            ),
         ):
             response = _run_codex_prompt_eval(runner, workspace, "prompt")
 
@@ -341,10 +345,7 @@ def test_eval_result_payload_round_trips_prompt_digests():
             extra_context_paths=[],
         )
 
-        bundle = (
-            "=== FILE: example.rac ===\n"
-            "status: encoded\n"
-        )
+        bundle = "=== FILE: example.rac ===\nstatus: encoded\n"
 
         class FakePopen:
             def __init__(self, cmd, stdout, stderr, text, cwd):
@@ -364,9 +365,14 @@ def test_eval_result_payload_round_trips_prompt_digests():
             def kill(self):
                 self.returncode = -9
 
-        with patch("autorac.harness.evals.subprocess.Popen", FakePopen), patch(
-            "autorac.harness.evals._wait_for_codex_process",
-            side_effect=subprocess.TimeoutExpired(cmd=["codex", "exec"], timeout=600),
+        with (
+            patch("autorac.harness.evals.subprocess.Popen", FakePopen),
+            patch(
+                "autorac.harness.evals._wait_for_codex_process",
+                side_effect=subprocess.TimeoutExpired(
+                    cmd=["codex", "exec"], timeout=600
+                ),
+            ),
         ):
             response = _run_codex_prompt_eval(runner, workspace, "prompt")
 
@@ -418,9 +424,12 @@ def test_eval_result_payload_round_trips_prompt_digests():
             process.returncode = 0
             return False
 
-        with patch("autorac.harness.evals.subprocess.Popen", FakePopen), patch(
-            "autorac.harness.evals._wait_for_codex_process",
-            side_effect=fake_wait,
+        with (
+            patch("autorac.harness.evals.subprocess.Popen", FakePopen),
+            patch(
+                "autorac.harness.evals._wait_for_codex_process",
+                side_effect=fake_wait,
+            ),
         ):
             response = _run_codex_prompt_eval(runner, workspace, "prompt")
 
@@ -436,7 +445,7 @@ class TestEvaluateArtifact:
             '"""\n(a) Allowance of credit There shall be allowed a credit of $1,000.\n"""\n'
             "status: encoded\n\n"
             "ctc_amount:\n"
-            "    description: \"Child tax credit amount\"\n"
+            '    description: "Child tax credit amount"\n'
             "    unit: USD\n"
             "    from 2018-01-01: 1000\n"
             "    from 2025-01-01: 2200\n"
@@ -445,12 +454,15 @@ class TestEvaluateArtifact:
         compile_result = ValidationResult("compile", passed=True)
         ci_result = ValidationResult("ci", passed=True)
 
-        with patch(
-            "autorac.harness.validator_pipeline.ValidatorPipeline._run_compile_check",
-            return_value=compile_result,
-        ), patch(
-            "autorac.harness.validator_pipeline.ValidatorPipeline._run_ci",
-            return_value=ci_result,
+        with (
+            patch(
+                "autorac.harness.validator_pipeline.ValidatorPipeline._run_compile_check",
+                return_value=compile_result,
+            ),
+            patch(
+                "autorac.harness.validator_pipeline.ValidatorPipeline._run_ci",
+                return_value=ci_result,
+            ),
         ):
             metrics = evaluate_artifact(
                 rac_file=rac_file,
@@ -619,9 +631,14 @@ example_amount:
         mock_reviewer.assert_called_once()
         assert mock_reviewer.call_args.args[0] == "generalist-reviewer"
         assert "atomic source slice" in mock_reviewer.call_args.kwargs["review_context"]
-        assert "stale, generic, or misleading" in mock_reviewer.call_args.kwargs["review_context"]
+        assert (
+            "stale, generic, or misleading"
+            in mock_reviewer.call_args.kwargs["review_context"]
+        )
 
-    def test_timing_clause_review_context_mentions_boolean_day_predicate(self, tmp_path):
+    def test_timing_clause_review_context_mentions_boolean_day_predicate(
+        self, tmp_path
+    ):
         rac_file = tmp_path / "example.rac"
         rac_file.write_text(
             '''"""
@@ -763,10 +780,18 @@ example_timing_rule:
         assert "one_month_threshold = 1" in prompt
         assert "the `one month` comparator is not a standalone numeric scalar" in prompt
         assert "do not invent `1`-valued threshold/count helpers" in prompt
-        assert "branch-specific output is a `Count` or other non-Boolean basis selector" in prompt
+        assert (
+            "branch-specific output is a `Count` or other non-Boolean basis selector"
+            in prompt
+        )
         assert "do not write an inline conditional without `else`" in prompt
-        assert "negative tests should usually assert only the `_applies` boolean" in prompt
-        assert "expect the principal basis-count output to remain the active legal basis" in prompt
+        assert (
+            "negative tests should usually assert only the `_applies` boolean" in prompt
+        )
+        assert (
+            "expect the principal basis-count output to remain the active legal basis"
+            in prompt
+        )
         assert "trigger decomposed-date CI failures" in prompt
 
     def test_build_eval_prompt_for_single_payment_period_discourages_parallel_units(
@@ -795,10 +820,15 @@ example_timing_rule:
             runner_backend="openai",
         )
 
-        assert "keep one canonical fact or classification for that single period" in prompt
+        assert (
+            "keep one canonical fact or classification for that single period" in prompt
+        )
         assert "parallel free inputs like `*_in_weeks` and `*_in_months`" in prompt
         assert "do not require a second independent duration input" in prompt
-        assert "do not feed the same legal period through contradictory units or categories" in prompt
+        assert (
+            "do not feed the same legal period through contradictory units or categories"
+            in prompt
+        )
 
     def test_build_eval_prompt_for_amount_included_determination_requires_applicability_bound_money_output(
         self, tmp_path
@@ -829,7 +859,10 @@ example_timing_rule:
 
         assert "do not leave that money output unconditional" in prompt
         assert "typically with an explicit `else: 0`" in prompt
-        assert "paragraph-level exceptions or a different payment period displace the limb" in prompt
+        assert (
+            "paragraph-level exceptions or a different payment period displace the limb"
+            in prompt
+        )
 
     def test_build_eval_prompt_for_subject_to_includes_leaf_discourages_blanket_negation(
         self, tmp_path
@@ -839,7 +872,7 @@ example_timing_rule:
             runner=parse_runner_spec("openai:gpt-5.4"),
             output_root=tmp_path / "out",
             source_text=(
-                "Subject to paragraphs (3), (4) and (4A), \"earnings\" in the case "
+                'Subject to paragraphs (3), (4) and (4A), "earnings" in the case '
                 "of employment as an employed earner, means any remuneration or "
                 "profit derived from that employment and includes—\n\n"
                 "(a)\n\n"
@@ -865,8 +898,13 @@ example_timing_rule:
         assert "Do not make a composite `subject_to_*_satisfied`" in prompt
         assert "branch-specific fact gate" in prompt
         assert "permits this branch to count" in prompt
-        assert "do not collapse all cited qualifications into one opaque helper" in prompt
-        assert "one paragraph-specific qualification input or import per cited paragraph" in prompt
+        assert (
+            "do not collapse all cited qualifications into one opaque helper" in prompt
+        )
+        assert (
+            "one paragraph-specific qualification input or import per cited paragraph"
+            in prompt
+        )
 
     def test_build_eval_prompt_for_payment_level_slice_discourages_blind_unsupported_fallback(
         self, tmp_path
@@ -933,8 +971,13 @@ example_timing_rule:
         )
 
         assert "Except where paragraph (2) and (4) apply" in prompt
-        assert "do not assume the exception is displaced only when both cited paragraphs apply simultaneously" in prompt
-        assert "treat the slice as inoperative when any cited paragraph applies" in prompt
+        assert (
+            "do not assume the exception is displaced only when both cited paragraphs apply simultaneously"
+            in prompt
+        )
+        assert (
+            "treat the slice as inoperative when any cited paragraph applies" in prompt
+        )
 
     def test_build_eval_prompt_for_payable_phrase_preserves_payability_fact(
         self, tmp_path
@@ -1055,7 +1098,10 @@ example_timing_rule:
             runner_backend="openai",
         )
 
-        assert "distinguish mere placement context from binding lead-in conjuncts" in prompt
+        assert (
+            "distinguish mere placement context from binding lead-in conjuncts"
+            in prompt
+        )
         assert "preserve both conjuncts" in prompt
         assert "do not drop the same-length requirement" in prompt
 
@@ -1089,7 +1135,10 @@ example_timing_rule:
 
         assert "treat `X` and `Y` as a positive conjunction for this branch" in prompt
         assert "Do not rewrite that as material implication like `not X or Y`" in prompt
-        assert "if the branch-triggering condition itself is false, the branch-specific output should usually be `false`" in prompt
+        assert (
+            "if the branch-triggering condition itself is false, the branch-specific output should usually be `false`"
+            in prompt
+        )
 
     def test_build_eval_prompt_for_disjunctive_payment_description_preserves_qualifier_scope(
         self, tmp_path
@@ -1125,8 +1174,14 @@ example_timing_rule:
             runner_backend="openai",
         )
 
-        assert "preserve the scope of the first qualifier across every antecedent payment type it grammatically modifies" in prompt
-        assert "do not narrow the first `where ...` clause to only the later-mentioned category" in prompt
+        assert (
+            "preserve the scope of the first qualifier across every antecedent payment type it grammatically modifies"
+            in prompt
+        )
+        assert (
+            "do not narrow the first `where ...` clause to only the later-mentioned category"
+            in prompt
+        )
         assert "preserve the paragraph-(a) path for retired pay and pension" in prompt
 
     def test_build_eval_prompt_for_royalties_slice_preserves_consideration_scope(
@@ -1160,7 +1215,10 @@ example_timing_rule:
             runner_backend="openai",
         )
 
-        assert "preserve the consideration-for-use/right-to-use qualifier across both `royalties` and `other sums`" in prompt
+        assert (
+            "preserve the consideration-for-use/right-to-use qualifier across both `royalties` and `other sums`"
+            in prompt
+        )
         assert "do not model `royalty` as a free-standing qualifying limb" in prompt
         assert "a bare `payment_is_royalty` fact is too broad" in prompt
 
@@ -1194,9 +1252,18 @@ example_timing_rule:
             runner_backend="openai",
         )
 
-        assert "preserve the shared qualifying employment/office across each alternative limb" in prompt
-        assert "do not decompose the rule into one free-standing `person_is_X` fact plus separate `under_A` and `in_B` facts" in prompt
-        assert "distribute the shared qualifier across the alternatives with branch-specific combined facts" in prompt
+        assert (
+            "preserve the shared qualifying employment/office across each alternative limb"
+            in prompt
+        )
+        assert (
+            "do not decompose the rule into one free-standing `person_is_X` fact plus separate `under_A` and `in_B` facts"
+            in prompt
+        )
+        assert (
+            "distribute the shared qualifier across the alternatives with branch-specific combined facts"
+            in prompt
+        )
 
     def test_build_eval_prompt_for_complete_capital_bands_discourages_fractional_division(
         self, tmp_path
@@ -1227,9 +1294,15 @@ example_timing_rule:
             runner_backend="openai",
         )
 
-        assert "treat `for each £500` as counting complete bands, not proportional fractions" in prompt
+        assert (
+            "treat `for each £500` as counting complete bands, not proportional fractions"
+            in prompt
+        )
         assert "derive the band count with `floor(excess / band_size)`" in prompt
-        assert "include a non-exact-multiple excess case like `£750` above threshold" in prompt
+        assert (
+            "include a non-exact-multiple excess case like `£750` above threshold"
+            in prompt
+        )
 
 
 class TestGeneratedBundleCleaning:
@@ -1246,9 +1319,7 @@ class TestGeneratedBundleCleaning:
         cleaned = _clean_generated_file_content(content)
 
         assert cleaned == (
-            "- name: base\n"
-            "  output:\n"
-            "    child_benefit_enhanced_rate: 26.05\n"
+            "- name: base\n  output:\n    child_benefit_enhanced_rate: 26.05\n"
         )
 
     def test_clean_generated_file_content_strips_inline_currency_suffixes(self):
@@ -1369,7 +1440,10 @@ class TestGeneratedBundleCleaning:
 
         assert wrote is True
         test_payload = yaml.safe_load(expected.with_suffix(".rac.test").read_text())
-        assert test_payload[0]["output"]["snap_homeless_shelter_deduction_available"] is True
+        assert (
+            test_payload[0]["output"]["snap_homeless_shelter_deduction_available"]
+            is True
+        )
 
     def test_materialize_eval_artifact_normalizes_test_arithmetic_literals(
         self, tmp_path
@@ -1491,9 +1565,7 @@ class TestGeneratedBundleCleaning:
             "    dtype: Money\n"
         )
         assert output_file.with_suffix(".rac.test").read_text() == (
-            "- name: base\n"
-            "  output:\n"
-            "    child_benefit_enhanced_rate: 26.05\n"
+            "- name: base\n  output:\n    child_benefit_enhanced_rate: 26.05\n"
         )
 
     def test_materialize_eval_artifact_salvages_workspace_files_when_response_is_summary(
@@ -1600,7 +1672,9 @@ class TestGeneratedBundleCleaning:
     def test_materialize_eval_artifact_normalizes_single_row_block_conditional_and_tests(
         self, tmp_path
     ):
-        output_file = tmp_path / "source" / "uksi-2002-2005-schedule-2-second-adult-element.rac"
+        output_file = (
+            tmp_path / "source" / "uksi-2002-2005-schedule-2-second-adult-element.rac"
+        )
         source_text = (
             "Editorial note: current text valid from 2024-04-06.\n\n"
             "Structured table:\n"
@@ -1652,7 +1726,9 @@ class TestGeneratedBundleCleaning:
     def test_materialize_eval_artifact_drops_annual_effective_date_boundary_for_single_row(
         self, tmp_path
     ):
-        output_file = tmp_path / "source" / "uksi-2002-2005-schedule-2-worker-element.rac"
+        output_file = (
+            tmp_path / "source" / "uksi-2002-2005-schedule-2-worker-element.rac"
+        )
         source_text = (
             "Editorial note: text valid from 2021-04-06.\n\n"
             "Structured table:\n"
@@ -1693,7 +1769,9 @@ class TestGeneratedBundleCleaning:
     def test_materialize_eval_artifact_infers_annual_base_period_when_missing(
         self, tmp_path
     ):
-        output_file = tmp_path / "source" / "uksi-2002-2005-schedule-2-worker-element.rac"
+        output_file = (
+            tmp_path / "source" / "uksi-2002-2005-schedule-2-worker-element.rac"
+        )
         source_text = (
             "Editorial note: text valid from 2021-04-06.\n\n"
             "Structured table:\n"
@@ -1729,8 +1807,7 @@ class TestGeneratedBundleCleaning:
     ):
         output_file = tmp_path / "source" / "uksi-2002-1792-regulation-9-a.rac"
         source_text = (
-            "Editorial note: current text valid from 2025-03-21.\n\n"
-            "working tax credit;"
+            "Editorial note: current text valid from 2025-03-21.\n\nworking tax credit;"
         )
         llm_response = (
             "=== FILE: uksi-2002-1792-regulation-9-a.rac ===\n"
@@ -1793,8 +1870,8 @@ class TestGeneratedBundleCleaning:
             output_file,
             source_text=(
                 "Current-effective Alabama SNAP rule excerpt:\n\n"
-                "\"The standard will be used for all food assistance households "
-                "reporting self-employment income. This procedure is automated.\""
+                '"The standard will be used for all food assistance households '
+                'reporting self-employment income. This procedure is automated."'
             ),
         )
 
@@ -1889,9 +1966,9 @@ class TestGeneratedBundleCleaning:
             "    period: Day\n"
             "    dtype: String\n"
             "    from 2025-03-21:\n"
-            "        \"\"\"\n"
+            '        """\n'
             "        Example source line.\n"
-            "        \"\"\"\n\n"
+            '        """\n\n'
             "example_fact:\n"
             "    entity: Person\n"
             "    period: Day\n"
@@ -2060,16 +2137,20 @@ class TestGeneratedBundleCleaning:
             issues=[],
         )
 
-        with patch(
-            "autorac.harness.validator_pipeline.ValidatorPipeline._run_compile_check",
-            return_value=compile_result,
-        ), patch(
-            "autorac.harness.validator_pipeline.ValidatorPipeline._run_ci",
-            return_value=ci_result,
-        ), patch(
-            "autorac.harness.validator_pipeline.ValidatorPipeline._run_policyengine",
-            return_value=pe_result,
-        ) as mock_policyengine:
+        with (
+            patch(
+                "autorac.harness.validator_pipeline.ValidatorPipeline._run_compile_check",
+                return_value=compile_result,
+            ),
+            patch(
+                "autorac.harness.validator_pipeline.ValidatorPipeline._run_ci",
+                return_value=ci_result,
+            ),
+            patch(
+                "autorac.harness.validator_pipeline.ValidatorPipeline._run_policyengine",
+                return_value=pe_result,
+            ) as mock_policyengine,
+        ):
             metrics = evaluate_artifact(
                 rac_file=rac_file,
                 rac_root=tmp_path,
@@ -2088,7 +2169,9 @@ class TestGeneratedBundleCleaning:
 
 
 class TestAknSectionEval:
-    def test_extract_akn_section_text_supports_standard_akn_subsection_tags(self, tmp_path):
+    def test_extract_akn_section_text_supports_standard_akn_subsection_tags(
+        self, tmp_path
+    ):
         akn_file = tmp_path / "doc.xml"
         akn_file.write_text(
             """
@@ -2117,7 +2200,9 @@ class TestAknSectionEval:
         assert "(1)" in text
         assert "Example subsection text." in text
 
-    def test_extract_akn_section_text_includes_parent_intro_for_leaf_levels(self, tmp_path):
+    def test_extract_akn_section_text_includes_parent_intro_for_leaf_levels(
+        self, tmp_path
+    ):
         akn_file = tmp_path / "doc.xml"
         akn_file.write_text(
             """
@@ -2229,7 +2314,9 @@ class TestAknSectionEval:
         assert "Standard allowance" in text
         assert "single claimant aged under 25 | £316.98" in text
         assert "single claimant aged 25 or over" not in text
-        assert "the amounts are those shown in the table for a single claimant" not in text
+        assert (
+            "the amounts are those shown in the table for a single claimant" not in text
+        )
 
     def test_extract_akn_section_text_matches_table_row_query_despite_inline_spacing_edits(
         self, tmp_path
@@ -2262,7 +2349,10 @@ class TestAknSectionEval:
             table_row_query="second and each subsequent each child or qualifying young person",
         )
 
-        assert "second and each subsequenteach child or qualifying young person | £292.81" in text
+        assert (
+            "second and each subsequenteach child or qualifying young person | £292.81"
+            in text
+        )
         assert "Child element—" in text
         assert "Element | Amount" in text
         assert "single claimant aged under 25" not in text
@@ -2294,7 +2384,9 @@ class TestAknSectionEval:
         assert "Effective date: 2024-07-01" in text
         assert "Grant table text." in text
 
-    def test_extract_akn_section_text_includes_expression_valid_from_date(self, tmp_path):
+    def test_extract_akn_section_text_includes_expression_valid_from_date(
+        self, tmp_path
+    ):
         akn_file = tmp_path / "doc.xml"
         akn_file.write_text(
             """
@@ -2375,7 +2467,15 @@ class TestAknSectionEval:
     ):
         arch_root = tmp_path / "arch"
         monkeypatch.setenv("AUTORAC_ARCH_ROOT", str(arch_root))
-        akn_file = arch_root / "us-tx" / "txhhs" / "twh" / "current-effective" / "akn" / "source.akn.xml"
+        akn_file = (
+            arch_root
+            / "us-tx"
+            / "txhhs"
+            / "twh"
+            / "current-effective"
+            / "akn"
+            / "source.akn.xml"
+        )
         akn_file.parent.mkdir(parents=True, exist_ok=True)
         akn_file.write_text(
             """
@@ -2421,9 +2521,14 @@ class TestAknSectionEval:
             )
 
         assert results == ["ok"]
-        assert mock_run_source_eval.call_args.kwargs["source_metadata_path"] == metadata_file
         assert (
-            mock_run_source_eval.call_args.kwargs["source_metadata_payload"]["relations"][0]["target"]
+            mock_run_source_eval.call_args.kwargs["source_metadata_path"]
+            == metadata_file
+        )
+        assert (
+            mock_run_source_eval.call_args.kwargs["source_metadata_payload"][
+                "relations"
+            ][0]["target"]
             == "cfr/7/273.9/d/6/iii#snap_standard_utility_allowance"
         )
 
@@ -2504,7 +2609,9 @@ class TestAknSectionEval:
             == "sec_3_606_1"
         )
 
-    def test_resolve_akn_section_eid_rejects_standard_akn_parent_sections(self, tmp_path):
+    def test_resolve_akn_section_eid_rejects_standard_akn_parent_sections(
+        self, tmp_path
+    ):
         akn_file = tmp_path / "doc.xml"
         akn_file.write_text(
             """
@@ -2627,14 +2734,18 @@ class TestUkLegislationFetch:
         assert str(first.akn_file).startswith(str(shared_cache_root))
         assert mock_get.call_count == 2
 
-    def test_resolve_legislation_gov_uk_fetch_cache_root_prefers_override(self, tmp_path):
+    def test_resolve_legislation_gov_uk_fetch_cache_root_prefers_override(
+        self, tmp_path
+    ):
         override = tmp_path / "shared-cache"
         with patch.dict(
             "os.environ",
             {"AUTORAC_SHARED_LEGISLATION_CACHE": str(override)},
             clear=False,
         ):
-            resolved = _resolve_legislation_gov_uk_fetch_cache_root(tmp_path / "run-root")
+            resolved = _resolve_legislation_gov_uk_fetch_cache_root(
+                tmp_path / "run-root"
+            )
 
         assert resolved == override.resolve()
 
@@ -2651,16 +2762,20 @@ class TestUkLegislationFetch:
         fetched.akn_file.write_text("<akomaNtoso/>")
         fetched.clml_file.write_text("<Legislation/>")
 
-        with patch(
-            "autorac.harness.evals._resolve_legislation_gov_uk_fetch_cache_root",
-            return_value=shared_root,
-        ), patch(
-            "autorac.harness.evals._fetch_legislation_gov_uk_document",
-            return_value=fetched,
-        ) as mock_fetch, patch(
-            "autorac.harness.evals.run_akn_section_eval",
-            return_value=[],
-        ) as mock_run:
+        with (
+            patch(
+                "autorac.harness.evals._resolve_legislation_gov_uk_fetch_cache_root",
+                return_value=shared_root,
+            ),
+            patch(
+                "autorac.harness.evals._fetch_legislation_gov_uk_document",
+                return_value=fetched,
+            ) as mock_fetch,
+            patch(
+                "autorac.harness.evals.run_akn_section_eval",
+                return_value=[],
+            ) as mock_run,
+        ):
             results = run_legislation_gov_uk_section_eval(
                 source_ref="https://www.legislation.gov.uk/uksi/2002/1792",
                 section_eid="regulation-1",
@@ -2686,14 +2801,17 @@ class TestUkLegislationFetch:
                     raise requests.HTTPError(response=self)
                 return None
 
-        with patch(
-            "requests.get",
-            side_effect=[
-                FakeResponse("bad gateway", 502),
-                FakeResponse("<akomaNtoso/>"),
-                FakeResponse("<Legislation/>"),
-            ],
-        ) as mock_get, patch("time.sleep"):
+        with (
+            patch(
+                "requests.get",
+                side_effect=[
+                    FakeResponse("bad gateway", 502),
+                    FakeResponse("<akomaNtoso/>"),
+                    FakeResponse("<Legislation/>"),
+                ],
+            ) as mock_get,
+            patch("time.sleep"),
+        ):
             fetched = _fetch_legislation_gov_uk_document(
                 "https://www.legislation.gov.uk/ukpga/2010/1/section/1",
                 tmp_path,
@@ -2716,18 +2834,21 @@ class TestUkLegislationFetch:
                     raise requests.HTTPError(response=self)
                 return None
 
-        with patch(
-            "requests.get",
-            side_effect=[
-                FakeResponse("<akomaNtoso/>"),
-                requests.exceptions.ReadTimeout("timed out"),
-                requests.exceptions.ReadTimeout("timed out"),
-                requests.exceptions.ReadTimeout("timed out"),
-                requests.exceptions.ReadTimeout("timed out"),
-                requests.exceptions.ReadTimeout("timed out"),
-                requests.exceptions.ReadTimeout("timed out"),
-            ],
-        ) as mock_get, patch("time.sleep"):
+        with (
+            patch(
+                "requests.get",
+                side_effect=[
+                    FakeResponse("<akomaNtoso/>"),
+                    requests.exceptions.ReadTimeout("timed out"),
+                    requests.exceptions.ReadTimeout("timed out"),
+                    requests.exceptions.ReadTimeout("timed out"),
+                    requests.exceptions.ReadTimeout("timed out"),
+                    requests.exceptions.ReadTimeout("timed out"),
+                    requests.exceptions.ReadTimeout("timed out"),
+                ],
+            ) as mock_get,
+            patch("time.sleep"),
+        ):
             fetched = _fetch_legislation_gov_uk_document(
                 "https://www.legislation.gov.uk/ukpga/2010/1/section/1",
                 tmp_path,
@@ -2764,12 +2885,15 @@ class TestUkLegislationFetch:
         )
         clml_file.write_text("<Legislation/>")
 
-        with patch(
-            "autorac.harness.evals._fetch_legislation_gov_uk_document"
-        ) as mock_fetch, patch(
-            "autorac.harness.evals.run_akn_section_eval",
-            return_value=["ok"],
-        ) as mock_run:
+        with (
+            patch(
+                "autorac.harness.evals._fetch_legislation_gov_uk_document"
+            ) as mock_fetch,
+            patch(
+                "autorac.harness.evals.run_akn_section_eval",
+                return_value=["ok"],
+            ) as mock_run,
+        ):
             mock_fetch.return_value.source_id = "ukpga/2010/1/section/1"
             mock_fetch.return_value.content_url = (
                 "https://www.legislation.gov.uk/ukpga/2010/1/section/1"
@@ -2815,7 +2939,10 @@ class TestEvalPrompt:
             include_tests=True,
         )
 
-        assert "Do not invent schema keys like `namespace:`, `parameter`, `variable`, or `rule:`." in prompt
+        assert (
+            "Do not invent schema keys like `namespace:`, `parameter`, `variable`, or `rule:`."
+            in prompt
+        )
         assert "entity:" in prompt
         assert "period:" in prompt
         assert "dtype:" in prompt
@@ -2880,7 +3007,10 @@ class TestEvalPrompt:
             include_tests=True,
         )
 
-        assert "If the source cannot be represented faithfully with the supported schema" in prompt
+        assert (
+            "If the source cannot be represented faithfully with the supported schema"
+            in prompt
+        )
         assert "`status: entity_not_supported`" in prompt
         assert "`status: deferred`" in prompt
         assert "leave `.rac.test` empty" in prompt
@@ -2915,7 +3045,10 @@ class TestEvalPrompt:
 
         assert "omitted/repealed text shown only by ellipses" in prompt
         assert "keep the embedded source/docstring showing that omission" in prompt
-        assert "editorially omitted or repealed text shown by ellipses or dotted placeholders" in prompt
+        assert (
+            "editorially omitted or repealed text shown by ellipses or dotted placeholders"
+            in prompt
+        )
         assert "leave `.rac.test` empty" in prompt
 
     def test_build_eval_prompt_forbids_python_inline_ternaries(self, tmp_path):
@@ -2965,7 +3098,10 @@ class TestEvalPrompt:
 
         assert "`if condition: value else: other_value`" in prompt
         assert "Do not use YAML-style `if:` / `then:` / `else:` blocks." in prompt
-        assert "Do not append a multiline conditional directly onto another expression" in prompt
+        assert (
+            "Do not append a multiline conditional directly onto another expression"
+            in prompt
+        )
 
     def test_build_eval_prompt_requires_decimal_ratios_for_rate_dtype(self, tmp_path):
         workspace = prepare_eval_workspace(
@@ -2987,23 +3123,41 @@ class TestEvalPrompt:
             include_tests=True,
         )
 
-        assert "For `dtype: Rate`, encode percentages as decimal ratios like `0.60` or `0.40`, never as `%` literals." in prompt
+        assert (
+            "For `dtype: Rate`, encode percentages as decimal ratios like `0.60` or `0.40`, never as `%` literals."
+            in prompt
+        )
         assert "Do not respond with summaries like `Both files written`" in prompt
-        assert "Do not use inline assignment syntax like `:=` inside `from` blocks" in prompt
-        assert "model truncation toward zero rather than toward negative infinity" in prompt
+        assert (
+            "Do not use inline assignment syntax like `:=` inside `from` blocks"
+            in prompt
+        )
+        assert (
+            "model truncation toward zero rather than toward negative infinity"
+            in prompt
+        )
         assert "rounded to the nearest whole dollar" in prompt
         assert "Model explicit half-up rounding instead" in prompt
         assert "keep that rounding on the downstream output" in prompt
         assert "Do not push it upstream into an intermediate component" in prompt
-        assert "Wrong for a clause like `allotment equals the thrifty food plan reduced by 30 per centum of income" in prompt
+        assert (
+            "Wrong for a clause like `allotment equals the thrifty food plan reduced by 30 per centum of income"
+            in prompt
+        )
         assert "keep `snap_expected_contribution = snap_net_income * 0.3`" in prompt
-        assert "Do not fabricate an `imports:` target from a cited section unless that exact `path#symbol` import target is listed" in prompt
+        assert (
+            "Do not fabricate an `imports:` target from a cited section unless that exact `path#symbol` import target is listed"
+            in prompt
+        )
         assert "instead of guessing a broken import like `statute/...#symbol`" in prompt
         assert "compute the pre-rounding amount exactly" in prompt
         assert "`251 * 0.08 = 20.08`, which still rounds to `20`, not `21`" in prompt
         assert "floor(amount + 0.5)" in prompt
         assert "if amount >= 0: floor(amount) else: ceil(amount)" in prompt
-        assert "Reserve bare `floor(...)` for instructions that explicitly say `round down`" in prompt
+        assert (
+            "Reserve bare `floor(...)` for instructions that explicitly say `round down`"
+            in prompt
+        )
         assert "unsupported operators such as `%`" in prompt
         assert "include a `.rac.test` case with a negative fractional amount" in prompt
 
@@ -3033,8 +3187,13 @@ class TestEvalPrompt:
             include_tests=True,
         )
 
-        assert 'Prefer `Person` when the source states an amount or condition "in respect of"' in prompt
-        assert "do not collapse it into an unconditional family-level constant" in prompt
+        assert (
+            'Prefer `Person` when the source states an amount or condition "in respect of"'
+            in prompt
+        )
+        assert (
+            "do not collapse it into an unconditional family-level constant" in prompt
+        )
 
     def test_build_eval_prompt_for_uk_pence_threshold_requires_gbp_decimal_and_weekly_cadence(
         self, tmp_path
@@ -3097,11 +3256,20 @@ class TestEvalPrompt:
         )
 
         assert "positive conditional leaves" in prompt
-        assert "the inapplicable case should usually be `0` for `dtype: Money` or `false` for `dtype: Boolean`" in prompt
+        assert (
+            "the inapplicable case should usually be `0` for `dtype: Money` or `false` for `dtype: Boolean`"
+            in prompt
+        )
         assert "do not use an unconditional amount or `else: true`" in prompt
-        assert "fixed supplement, allowance, or addition is payable only while an eligibility condition holds" in prompt
+        assert (
+            "fixed supplement, allowance, or addition is payable only while an eligibility condition holds"
+            in prompt
+        )
         assert "do not leave that money output unconditional" in prompt
-        assert "do not collapse those facts into an opaque local input like `*_eligible_for_*`" in prompt
+        assert (
+            "do not collapse those facts into an opaque local input like `*_eligible_for_*`"
+            in prompt
+        )
         assert "prefer direct facts like `client_is_pregnant_parent`" in prompt
 
     def test_build_eval_prompt_for_determination_limb_discourages_invented_fallback(
@@ -3132,19 +3300,46 @@ class TestEvalPrompt:
             runner_backend="openai",
         )
 
-        assert "do not invent sibling outcomes for non-applicable cases with `else: 0`" in prompt
+        assert (
+            "do not invent sibling outcomes for non-applicable cases with `else: 0`"
+            in prompt
+        )
         assert "leave other cases to sibling limbs" in prompt
         assert "keep a branch-specific money or rate output for that basis" in prompt
-        assert "do not invent sibling outcomes for inapplicable cases with `else: 0`" in prompt
-        assert "pair the branch-specific money or rate output with a separate applicability boolean" in prompt
-        assert "omit assertions about the branch-specific money or rate output" in prompt
-        assert "qualifies its averaging basis with operative parenthetical text" in prompt
-        assert "includes periods in which the claimant does no work but disregards other absences" in prompt
+        assert (
+            "do not invent sibling outcomes for inapplicable cases with `else: 0`"
+            in prompt
+        )
+        assert (
+            "pair the branch-specific money or rate output with a separate applicability boolean"
+            in prompt
+        )
+        assert (
+            "omit assertions about the branch-specific money or rate output" in prompt
+        )
+        assert (
+            "qualifies its averaging basis with operative parenthetical text" in prompt
+        )
+        assert (
+            "includes periods in which the claimant does no work but disregards other absences"
+            in prompt
+        )
         assert "generic `average_weekly_income_*` input" in prompt
-        assert "`such other payments as may ... enable the claimant's average weekly income to be determined more accurately`" in prompt
-        assert "do not leave the branch money output unconditionally equal to the input average" in prompt
-        assert "do not reuse the parent provision's generic final-amount phrase" in prompt
-        assert "name the principal money or rate output after this limb's own basis or method" in prompt
+        assert (
+            "`such other payments as may ... enable the claimant's average weekly income to be determined more accurately`"
+            in prompt
+        )
+        assert (
+            "do not leave the branch money output unconditionally equal to the input average"
+            in prompt
+        )
+        assert (
+            "do not reuse the parent provision's generic final-amount phrase" in prompt
+        )
+        assert (
+            "name the principal money or rate output after this limb's own basis or method"
+            in prompt
+        )
 
     def test_build_eval_prompt_for_purpose_limited_deeming_discourages_unsupported_fallback(
         self, tmp_path
@@ -3175,7 +3370,10 @@ class TestEvalPrompt:
 
         assert "purpose-limited deeming clauses" in prompt
         assert "do not use `status: entity_not_supported`" in prompt
-        assert "paragraph-(5) amounts treated as earnings for paragraph-(9)(b) only" in prompt
+        assert (
+            "paragraph-(5) amounts treated as earnings for paragraph-(9)(b) only"
+            in prompt
+        )
 
     def test_build_eval_prompt_for_uk_residual_determination_limb_requires_other_case_condition(
         self, tmp_path
@@ -3209,7 +3407,10 @@ class TestEvalPrompt:
         assert "Do not treat the shared parent triggers alone as sufficient" in prompt
         assert "model a local residual-case fact or applicability helper" in prompt
         assert "no more specific sibling case applies" in prompt
-        assert "include a case where the parent conditions hold but the residual `other case` condition is false" in prompt
+        assert (
+            "include a case where the parent conditions hold but the residual `other case` condition is false"
+            in prompt
+        )
 
     def test_build_eval_prompt_for_shall_be_treated_discourages_fact_input_and_vacuous_true(
         self, tmp_path
@@ -3240,9 +3441,18 @@ class TestEvalPrompt:
 
         assert "do not introduce a `*_fact` input" in prompt
         assert "do not use vacuous `else: true`" in prompt
-        assert "do not replace the amount-level legal effect with a `Person`/`Day` boolean stand-in" in prompt
-        assert "prefer `status: entity_not_supported` over a pseudo-boolean approximation" in prompt
-        assert "If the current ontology cannot faithfully tie the deeming effect to the same payment amount" in prompt
+        assert (
+            "do not replace the amount-level legal effect with a `Person`/`Day` boolean stand-in"
+            in prompt
+        )
+        assert (
+            "prefer `status: entity_not_supported` over a pseudo-boolean approximation"
+            in prompt
+        )
+        assert (
+            "If the current ontology cannot faithfully tie the deeming effect to the same payment amount"
+            in prompt
+        )
 
     def test_build_eval_prompt_for_claimant_incurred_expenses_preserves_claimant_predicate(
         self, tmp_path
@@ -3270,7 +3480,10 @@ class TestEvalPrompt:
             runner_backend="openai",
         )
 
-        assert "If an expenses limb says the expenses are `incurred by the claimant`" in prompt
+        assert (
+            "If an expenses limb says the expenses are `incurred by the claimant`"
+            in prompt
+        )
         assert "preserve that claimant-incurred predicate explicitly" in prompt
         assert "Do not collapse it into only an employer-made-payment fact" in prompt
 
@@ -3304,8 +3517,14 @@ class TestEvalPrompt:
 
         assert "preserve a single legally operative reference day" in prompt
         assert "model one canonical operative claim-date fact" in prompt
-        assert "do not encode separate `day_is_date_claim_was_made` and `day_is_date_claim_was_treated_as_made` facts and then combine them with `or`" in prompt
-        assert "include one no-supersession case for the operative claim date and one supersession case for the supersession date" in prompt
+        assert (
+            "do not encode separate `day_is_date_claim_was_made` and `day_is_date_claim_was_treated_as_made` facts and then combine them with `or`"
+            in prompt
+        )
+        assert (
+            "include one no-supersession case for the operative claim date and one supersession case for the supersession date"
+            in prompt
+        )
 
     def test_build_eval_prompt_for_subject_to_override_discourages_permission_gate(
         self, tmp_path
@@ -3334,9 +3553,14 @@ class TestEvalPrompt:
             runner_backend="openai",
         )
 
-        assert "treat the cited provision as a possible override or displacement" in prompt
+        assert (
+            "treat the cited provision as a possible override or displacement" in prompt
+        )
         assert "model a local override/displacement boolean" in prompt
-        assert "Do not encode those `Subject to ...` qualifiers as helper names like `*_permits_*`" in prompt
+        assert (
+            "Do not encode those `Subject to ...` qualifiers as helper names like `*_permits_*`"
+            in prompt
+        )
 
     def test_build_eval_prompt_for_subject_to_unavailable_imports_allows_paragraph_specific_inputs(
         self, tmp_path
@@ -3365,9 +3589,18 @@ class TestEvalPrompt:
             runner_backend="openai",
         )
 
-        assert "When canonical imports for those cited paragraphs are available in the workspace, import them." in prompt
-        assert "paragraph-specific local inputs are acceptable for an isolated slice artifact" in prompt
-        assert "preserve the cited paragraph numbers and the branch-specific legal effect" in prompt
+        assert (
+            "When canonical imports for those cited paragraphs are available in the workspace, import them."
+            in prompt
+        )
+        assert (
+            "paragraph-specific local inputs are acceptable for an isolated slice artifact"
+            in prompt
+        )
+        assert (
+            "preserve the cited paragraph numbers and the branch-specific legal effect"
+            in prompt
+        )
 
     def test_build_eval_prompt_for_pure_cross_reference_computation_preserves_distinct_cited_alternatives(
         self, tmp_path
@@ -3398,27 +3631,55 @@ class TestEvalPrompt:
             runner_backend="openai",
         )
 
-        assert "do not replace the cited computation with local boolean `*_route_is_satisfied` or `*_fact` placeholders" in prompt
+        assert (
+            "do not replace the cited computation with local boolean `*_route_is_satisfied` or `*_fact` placeholders"
+            in prompt
+        )
         assert "do not emit a top-level `status: deferred` stub" in prompt
-        assert "do not collapse those cited alternatives into one generic treatment gate" in prompt
-        assert "preserve the distinct cited alternatives with paragraph-specific imports or local facts/amounts" in prompt
+        assert (
+            "do not collapse those cited alternatives into one generic treatment gate"
+            in prompt
+        )
+        assert (
+            "preserve the distinct cited alternatives with paragraph-specific imports or local facts/amounts"
+            in prompt
+        )
         assert "do not invent an extra `no treatment applies` branch" in prompt
-        assert "do not make the cited route-selection flags part of whether the paragraph itself applies" in prompt
-        assert "do not encode the consequence as an unqualified `if paragraph_4_route: paragraph_4_amount else: paragraph_10_amount`" in prompt
-        assert "Paragraph (10) must be selected by a paragraph-(10) route fact/import or by a derived paragraph-(10) route helper" in prompt
+        assert (
+            "do not make the cited route-selection flags part of whether the paragraph itself applies"
+            in prompt
+        )
+        assert (
+            "do not encode the consequence as an unqualified `if paragraph_4_route: paragraph_4_amount else: paragraph_10_amount`"
+            in prompt
+        )
+        assert (
+            "Paragraph (10) must be selected by a paragraph-(10) route fact/import or by a derived paragraph-(10) route helper"
+            in prompt
+        )
         assert "prefer a single mutually exclusive route selector" in prompt
-        assert "Do not expose two independent route booleans that allow both routes or neither route to be selected" in prompt
+        assert (
+            "Do not expose two independent route booleans that allow both routes or neither route to be selected"
+            in prompt
+        )
         assert "a safe local-placeholder shape is" in prompt
-        assert "paragraph-(10) route is derived as the applicable paragraph with not paragraph-(4) route" in prompt
+        assert (
+            "paragraph-(10) route is derived as the applicable paragraph with not paragraph-(4) route"
+            in prompt
+        )
         assert "Do not create an invalid-route output branch that returns `0`" in prompt
         assert "self-employed earnings trigger the paragraph" in prompt
-        assert "regulation 13 paragraph (4) or paragraph (10) chooses the accounting route" in prompt
-        assert "avoid a false case that makes a self-employed-earner branch fail merely because neither local route flag was selected" in prompt
+        assert (
+            "regulation 13 paragraph (4) or paragraph (10) chooses the accounting route"
+            in prompt
+        )
+        assert (
+            "avoid a false case that makes a self-employed-earner branch fail merely because neither local route flag was selected"
+            in prompt
+        )
         assert "include separate cases for the distinct cited alternatives" in prompt
 
-    def test_build_eval_prompt_requires_calendar_date_test_periods(
-        self, tmp_path
-    ):
+    def test_build_eval_prompt_requires_calendar_date_test_periods(self, tmp_path):
         workspace = prepare_eval_workspace(
             citation="uksi/2002/1792/regulation/13A/3/b",
             runner=parse_runner_spec("openai:gpt-5.4"),
@@ -3472,7 +3733,10 @@ class TestEvalPrompt:
         assert "The `.rac.test` file must contain YAML only" in prompt
         assert "must be a YAML list of cases beginning with `- name:`" in prompt
         assert "Do not add speculative future-period tests" in prompt
-        assert "must contain factual predicates or quantities, not the output variable" in prompt
+        assert (
+            "must contain factual predicates or quantities, not the output variable"
+            in prompt
+        )
         assert "use concrete numeric literals in inputs and outputs" in prompt
         assert "Use `output:` mappings in `.rac.test` cases" in prompt
 
@@ -3600,7 +3864,9 @@ class TestEvalPrompt:
         assert "Do not invent sample ages like `2`, `3`, `24`, or `25`" in prompt
         assert "keep `.rac.test` outputs scalar" in prompt
         assert "keep the row-defining conditions satisfied" in prompt
-        assert "principal amount variable should usually be a grounded constant" in prompt
+        assert (
+            "principal amount variable should usually be a grounded constant" in prompt
+        )
         assert "Do not include `alternate_branch_*` tests" in prompt
         assert "write `2500`, not `2,500`" in prompt
 
@@ -3633,13 +3899,30 @@ class TestEvalPrompt:
             runner_backend="openai",
         )
 
-        assert "Every substantive numeric occurrence in `./source.txt` must be represented by a named scalar definition in RAC" in prompt
-        assert "If the same numeric value appears twice in materially different legal roles" in prompt
-        assert "reuse that named scalar everywhere the rule compares against or computes with that number" in prompt
-        assert 'If `./source.txt` says someone is "aged 18 or over", "under 25"' in prompt
+        assert (
+            "Every substantive numeric occurrence in `./source.txt` must be represented by a named scalar definition in RAC"
+            in prompt
+        )
+        assert (
+            "If the same numeric value appears twice in materially different legal roles"
+            in prompt
+        )
+        assert (
+            "reuse that named scalar everywhere the rule compares against or computes with that number"
+            in prompt
+        )
+        assert (
+            'If `./source.txt` says someone is "aged 18 or over", "under 25"' in prompt
+        )
         assert "Do not create scalar variables for citation numbers" in prompt
-        assert "Do not invent `dtype: String` variables just to restate the effective date" in prompt
-        assert "Do not decompose legal dates into numeric `year`, `month`, or `day` scalar variables" in prompt
+        assert (
+            "Do not invent `dtype: String` variables just to restate the effective date"
+            in prompt
+        )
+        assert (
+            "Do not decompose legal dates into numeric `year`, `month`, or `day` scalar variables"
+            in prompt
+        )
         assert "1st September following the person's 19th birthday" in prompt
         assert "Use `==` for equality comparisons inside RAC expressions" in prompt
 
@@ -3663,8 +3946,7 @@ class TestEvalPrompt:
             == "context/legislation/ukpga/2002/16/section/3ZA/3.rac"
         )
         assert (
-            definition_files[0].import_path
-            == "legislation/ukpga/2002/16/section/3ZA/3"
+            definition_files[0].import_path == "legislation/ukpga/2002/16/section/3ZA/3"
         )
         stub_path = workspace.root / definition_files[0].workspace_path
         assert stub_path.exists()
@@ -3732,7 +4014,16 @@ is_individual_responsibility_contract:
 
         _hydrate_eval_root(runner_root, workspace)
 
-        hydrated = runner_root / "legislation" / "ukpga" / "2002" / "16" / "section" / "3ZA" / "3.rac"
+        hydrated = (
+            runner_root
+            / "legislation"
+            / "ukpga"
+            / "2002"
+            / "16"
+            / "section"
+            / "3ZA"
+            / "3.rac"
+        )
         assert hydrated.exists()
         assert "is_member_of_mixed_age_couple" in hydrated.read_text()
 
@@ -3759,26 +4050,65 @@ is_individual_responsibility_contract:
 
         assert "Resolved definition files are available below." in prompt
         assert "mixed-age couple" in prompt
-        assert "legislation/ukpga/2002/16/section/3ZA/3#is_member_of_mixed_age_couple" in prompt
-        assert "import that canonical definition instead of inventing a leaf-local helper" in prompt
+        assert (
+            "legislation/ukpga/2002/16/section/3ZA/3#is_member_of_mixed_age_couple"
+            in prompt
+        )
+        assert (
+            "import that canonical definition instead of inventing a leaf-local helper"
+            in prompt
+        )
         assert "Exact RAC import syntax for a resolved definition:" in prompt
         assert "imports:" in prompt
         assert "Do not replace that import with a local deferred stub" in prompt
-        assert "Do not encode such local factual predicates as placeholder constants like `true` or `false`." in prompt
-        assert "Do not encode such local factual predicates as `status: deferred`" in prompt
-        assert "preserve that post-adjustment quantity directly as an input/helper" in prompt
-        assert "prefer an input like `countable_gross_earned_income_after_disregards` over raw `gross_earned_income`" in prompt
+        assert (
+            "Do not encode such local factual predicates as placeholder constants like `true` or `false`."
+            in prompt
+        )
+        assert (
+            "Do not encode such local factual predicates as `status: deferred`"
+            in prompt
+        )
+        assert (
+            "preserve that post-adjustment quantity directly as an input/helper"
+            in prompt
+        )
+        assert (
+            "prefer an input like `countable_gross_earned_income_after_disregards` over raw `gross_earned_income`"
+            in prompt
+        )
         assert "after all other applicable deductions have been allowed" in prompt
-        assert "do not truncate the logic to only the deduction categories exercised by the example tests" in prompt
-        assert "import those exact symbols instead of inventing renamed locals that overlap with the copied file" in prompt
-        assert "import that helper and alias the requested target to it instead of rebuilding the same arithmetic locally" in prompt
-        assert "alias `snap_net_income_pre_shelter` to `snap_income_after_non_shelter_deductions`" in prompt
+        assert (
+            "do not truncate the logic to only the deduction categories exercised by the example tests"
+            in prompt
+        )
+        assert (
+            "import those exact symbols instead of inventing renamed locals that overlap with the copied file"
+            in prompt
+        )
+        assert (
+            "import that helper and alias the requested target to it instead of rebuilding the same arithmetic locally"
+            in prompt
+        )
+        assert (
+            "alias `snap_net_income_pre_shelter` to `snap_income_after_non_shelter_deductions`"
+            in prompt
+        )
         assert "preserve that helper's nearest input surface in tests" in prompt
-        assert "prefer test inputs like `snap_gross_income` plus the applicable deduction symbols" in prompt
-        assert "creating near-duplicate locals such as `snap_excess_medical_deduction`" in prompt
+        assert (
+            "prefer test inputs like `snap_gross_income` plus the applicable deduction symbols"
+            in prompt
+        )
+        assert (
+            "creating near-duplicate locals such as `snap_excess_medical_deduction`"
+            in prompt
+        )
         assert "make it a real rate-valued helper" in prompt
         assert "encode `50 percent` as `0.5` and `130 percent` as `1.3`" in prompt
-        assert "do not collapse the principal output to an unconditional `true` or `false`" in prompt
+        assert (
+            "do not collapse the principal output to an unconditional `true` or `false`"
+            in prompt
+        )
         assert (
             'encode the SNAP category gate directly as `snap_utility_allowance_type == "SUA"` or `"BUA"`'
             in prompt
@@ -3787,9 +4117,7 @@ is_individual_responsibility_contract:
             "use the previous month (for example `2025-09` for a rule that starts `from 2025-10-01`)"
             in prompt
         )
-        assert (
-            "should not have a test like `period: 2025-10` expecting `0`" in prompt
-        )
+        assert "should not have a test like `period: 2025-10` expecting `0`" in prompt
         assert (
             "do not invent a `pre_effective_*` zero-output test unless `./source.txt` itself says the earlier period value was zero or unavailable"
             in prompt
@@ -3837,14 +4165,18 @@ is_individual_responsibility_contract:
             runner_backend="openai",
         )
 
-        assert "Resolved canonical concept files from this corpus are available below." in prompt
+        assert (
+            "Resolved canonical concept files from this corpus are available below."
+            in prompt
+        )
         assert "individual responsibility contract" in prompt
         assert "statute/crs/26-2-703/12#is_individual_responsibility_contract" in prompt
-        assert "import or re-export that exact canonical concept instead of duplicating it locally" in prompt
+        assert (
+            "import or re-export that exact canonical concept instead of duplicating it locally"
+            in prompt
+        )
 
-    def test_build_eval_prompt_includes_import_vs_local_helper_protocol(
-        self, tmp_path
-    ):
+    def test_build_eval_prompt_includes_import_vs_local_helper_protocol(self, tmp_path):
         workspace = prepare_eval_workspace(
             citation="26 USC 24(c)",
             runner=parse_runner_spec("codex:gpt-5.4"),
@@ -3864,15 +4196,27 @@ is_individual_responsibility_contract:
             include_tests=True,
         )
 
-        assert "emit the upstream import instead of restating the concept locally" in prompt
+        assert (
+            "emit the upstream import instead of restating the concept locally"
+            in prompt
+        )
         assert "says a value is determined `in accordance with section X`" in prompt
         assert "statute/7/2014/e#snap_net_income" in prompt
         assert "snap_household_income_under_2014_d_and_e" in prompt
-        assert "author it as an amendment layer targeting those canonical symbols" in prompt
+        assert (
+            "author it as an amendment layer targeting those canonical symbols"
+            in prompt
+        )
         assert "emit dated `amend` blocks for those canonical symbols" in prompt
-        assert "Do not import a canonical output like `snap_one_person_thrifty_food_plan_cost`" in prompt
+        assert (
+            "Do not import a canonical output like `snap_one_person_thrifty_food_plan_cost`"
+            in prompt
+        )
         assert "Wrong for annual parameter tables" in prompt
-        assert "do not create documentary scalar constants like `snap_household_size_four: 4`" in prompt
+        assert (
+            "do not create documentary scalar constants like `snap_household_size_four: 4`"
+            in prompt
+        )
         assert "Right pattern for the USDA SNAP FY2026 table" in prompt
         assert "amend snap_one_person_thrifty_food_plan_cost:" in prompt
         assert "amend snap_minimum_allotment:" in prompt
@@ -3880,8 +4224,13 @@ is_individual_responsibility_contract:
         assert "after the 15th day of a month" in prompt
         assert "do not decompose it into separate numeric `*_day`" in prompt
         assert "Do not add a documentary scalar like `*_cutoff_day: 15`" in prompt
-        assert "include at least one `.rac.test` case that exercises the positive non-zero path" in prompt
-        assert "Do not write only zero-output tests for a thresholded deduction" in prompt
+        assert (
+            "include at least one `.rac.test` case that exercises the positive non-zero path"
+            in prompt
+        )
+        assert (
+            "Do not write only zero-output tests for a thresholded deduction" in prompt
+        )
         assert "still emit the unresolved import path" in prompt
         assert "otherwise keep the helper local to this leaf" in prompt
 
@@ -3975,8 +4324,9 @@ class TestOpenAIEvalRequest:
         ok_response = Mock()
         ok_response.status_code = 200
 
-        with patch("autorac.harness.evals.requests.post") as mock_post, patch(
-            "autorac.harness.evals.time.sleep"
+        with (
+            patch("autorac.harness.evals.requests.post") as mock_post,
+            patch("autorac.harness.evals.time.sleep"),
         ):
             mock_post.side_effect = [error_response, ok_response]
 
@@ -3992,8 +4342,9 @@ class TestOpenAIEvalRequest:
         ok_response = Mock()
         ok_response.status_code = 200
 
-        with patch("autorac.harness.evals.requests.post") as mock_post, patch(
-            "autorac.harness.evals.time.sleep"
+        with (
+            patch("autorac.harness.evals.requests.post") as mock_post,
+            patch("autorac.harness.evals.time.sleep"),
         ):
             mock_post.side_effect = [
                 requests.exceptions.ReadTimeout("timed out"),
@@ -4070,9 +4421,7 @@ cases:
                     atlas_path=None,
                 )
 
-    def test_run_eval_suite_allows_complete_repeated_scalar_sibling_set(
-        self, tmp_path
-    ):
+    def test_run_eval_suite_allows_complete_repeated_scalar_sibling_set(self, tmp_path):
         akn_file = tmp_path / "source.akn"
         akn_file.write_text(
             """
@@ -4119,17 +4468,20 @@ cases:
         first = _fake_eval_result("claude-opus", "taper-no-work-allowance")
         second = _fake_eval_result("claude-opus", "taper-with-work-allowance")
 
-        with patch(
-            "autorac.harness.evals._fetch_legislation_gov_uk_document",
-            return_value=FetchedLegislationGovUkDocument(
-                source_id="uksi/2013/376/2025-04-07",
-                content_url="https://www.legislation.gov.uk/uksi/2013/376/2025-04-07",
-                akn_file=akn_file,
-                clml_file=clml_file,
+        with (
+            patch(
+                "autorac.harness.evals._fetch_legislation_gov_uk_document",
+                return_value=FetchedLegislationGovUkDocument(
+                    source_id="uksi/2013/376/2025-04-07",
+                    content_url="https://www.legislation.gov.uk/uksi/2013/376/2025-04-07",
+                    akn_file=akn_file,
+                    clml_file=clml_file,
+                ),
             ),
-        ), patch(
-            "autorac.harness.evals.run_legislation_gov_uk_section_eval",
-            side_effect=[[first], [second]],
+            patch(
+                "autorac.harness.evals.run_legislation_gov_uk_section_eval",
+                side_effect=[[first], [second]],
+            ),
         ):
             results = run_eval_suite(
                 manifest=manifest,
@@ -4266,16 +4618,20 @@ cases:
         uk_result = _fake_eval_result("codex-gpt-5.4", "child-benefit-enhanced")
         source_result = _fake_eval_result("codex-gpt-5.4", "co-tanf-f")
 
-        with patch(
-            "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
-            return_value=None,
-        ), patch(
-            "autorac.harness.evals.run_legislation_gov_uk_section_eval",
-            return_value=[uk_result],
-        ) as mock_uk, patch(
-            "autorac.harness.evals.run_source_eval",
-            return_value=[source_result],
-        ) as mock_source:
+        with (
+            patch(
+                "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
+                return_value=None,
+            ),
+            patch(
+                "autorac.harness.evals.run_legislation_gov_uk_section_eval",
+                return_value=[uk_result],
+            ) as mock_uk,
+            patch(
+                "autorac.harness.evals.run_source_eval",
+                return_value=[source_result],
+            ) as mock_source,
+        ):
             results = run_eval_suite(
                 manifest=manifest,
                 output_root=tmp_path / "out",
@@ -4303,15 +4659,20 @@ cases:
             """.strip()
         )
         manifest = load_eval_suite_manifest(manifest_file)
-        uk_result = _fake_eval_result("openai-gpt-5.4", "uc-standard-allowance-single-young")
+        uk_result = _fake_eval_result(
+            "openai-gpt-5.4", "uc-standard-allowance-single-young"
+        )
 
-        with patch(
-            "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
-            return_value=None,
-        ), patch(
-            "autorac.harness.evals.run_legislation_gov_uk_section_eval",
-            return_value=[uk_result],
-        ) as mock_uk:
+        with (
+            patch(
+                "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
+                return_value=None,
+            ),
+            patch(
+                "autorac.harness.evals.run_legislation_gov_uk_section_eval",
+                return_value=[uk_result],
+            ) as mock_uk,
+        ):
             results = run_eval_suite(
                 manifest=manifest,
                 output_root=tmp_path / "out",
@@ -4320,7 +4681,10 @@ cases:
             )
 
         assert results == [uk_result]
-        assert mock_uk.call_args.kwargs["table_row_query"] == "single claimant aged under 25"
+        assert (
+            mock_uk.call_args.kwargs["table_row_query"]
+            == "single claimant aged under 25"
+        )
 
     def test_run_eval_suite_passes_oracle_settings_to_uk_runner(self, tmp_path):
         manifest_file = tmp_path / "suite.yaml"
@@ -4341,13 +4705,16 @@ cases:
         manifest = load_eval_suite_manifest(manifest_file)
         uk_result = _fake_eval_result("openai-gpt-5.4", "regulation-2-1-a")
 
-        with patch(
-            "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
-            return_value=None,
-        ), patch(
-            "autorac.harness.evals.run_legislation_gov_uk_section_eval",
-            return_value=[uk_result],
-        ) as mock_uk:
+        with (
+            patch(
+                "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
+                return_value=None,
+            ),
+            patch(
+                "autorac.harness.evals.run_legislation_gov_uk_section_eval",
+                return_value=[uk_result],
+            ) as mock_uk,
+        ):
             results = run_eval_suite(
                 manifest=manifest,
                 output_root=tmp_path / "out",
@@ -4359,9 +4726,7 @@ cases:
         assert mock_uk.call_args.kwargs["oracle"] == "none"
         assert mock_uk.call_args.kwargs["policyengine_country"] == "auto"
 
-    def test_run_eval_suite_passes_shared_fetch_cache_root_to_uk_runner(
-        self, tmp_path
-    ):
+    def test_run_eval_suite_passes_shared_fetch_cache_root_to_uk_runner(self, tmp_path):
         manifest_file = tmp_path / "suite.yaml"
         manifest_file.write_text(
             """
@@ -4379,13 +4744,16 @@ cases:
         uk_result = _fake_eval_result("openai-gpt-5.4", "child-benefit-enhanced")
         output_root = tmp_path / "out"
 
-        with patch(
-            "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
-            return_value=None,
-        ), patch(
-            "autorac.harness.evals.run_legislation_gov_uk_section_eval",
-            return_value=[uk_result],
-        ) as mock_uk:
+        with (
+            patch(
+                "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
+                return_value=None,
+            ),
+            patch(
+                "autorac.harness.evals.run_legislation_gov_uk_section_eval",
+                return_value=[uk_result],
+            ) as mock_uk,
+        ):
             run_eval_suite(
                 manifest=manifest,
                 output_root=output_root,
@@ -4458,15 +4826,19 @@ cases:
 
         source_result = _fake_eval_result("openai-gpt-5.4", "co-tanf-f")
 
-        with patch(
-            "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
-            return_value=None,
-        ), patch(
-            "autorac.harness.evals.run_legislation_gov_uk_section_eval",
-            side_effect=RuntimeError("502 Server Error"),
-        ), patch(
-            "autorac.harness.evals.run_source_eval",
-            return_value=[source_result],
+        with (
+            patch(
+                "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
+                return_value=None,
+            ),
+            patch(
+                "autorac.harness.evals.run_legislation_gov_uk_section_eval",
+                side_effect=RuntimeError("502 Server Error"),
+            ),
+            patch(
+                "autorac.harness.evals.run_source_eval",
+                return_value=[source_result],
+            ),
         ):
             results = run_eval_suite(
                 manifest=manifest,
@@ -4507,15 +4879,19 @@ cases:
 
         source_result = _fake_eval_result("openai-gpt-5.4", "co-tanf-f")
 
-        with patch(
-            "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
-            return_value=None,
-        ), patch(
-            "autorac.harness.evals.run_legislation_gov_uk_section_eval",
-            side_effect=RuntimeError("502 Server Error"),
-        ), patch(
-            "autorac.harness.evals.run_source_eval",
-            return_value=[source_result],
+        with (
+            patch(
+                "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
+                return_value=None,
+            ),
+            patch(
+                "autorac.harness.evals.run_legislation_gov_uk_section_eval",
+                side_effect=RuntimeError("502 Server Error"),
+            ),
+            patch(
+                "autorac.harness.evals.run_source_eval",
+                return_value=[source_result],
+            ),
         ):
             run_eval_suite(
                 manifest=manifest,
@@ -4564,12 +4940,15 @@ cases:
             snapshots.append(json.loads((output_root / "suite-run.json").read_text()))
             return [source_result]
 
-        with patch(
-            "autorac.harness.evals.run_source_eval",
-            side_effect=fake_run_source_eval,
-        ), patch(
-            "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
-            return_value=None,
+        with (
+            patch(
+                "autorac.harness.evals.run_source_eval",
+                side_effect=fake_run_source_eval,
+            ),
+            patch(
+                "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
+                return_value=None,
+            ),
         ):
             run_eval_suite(
                 manifest=manifest,
@@ -4628,12 +5007,15 @@ cases:
         )
         source_result = _fake_eval_result("openai-gpt-5.4", "snap-tn-sua")
 
-        with patch(
-            "autorac.harness.evals.run_source_eval",
-            return_value=[source_result],
-        ) as mock_run_source_eval, patch(
-            "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
-            return_value=None,
+        with (
+            patch(
+                "autorac.harness.evals.run_source_eval",
+                return_value=[source_result],
+            ) as mock_run_source_eval,
+            patch(
+                "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
+                return_value=None,
+            ),
         ):
             run_eval_suite(
                 manifest=manifest,
@@ -4685,7 +5067,9 @@ cases:
 </akomaNtoso>
             """.strip()
         )
-        source_file.with_name("snap_standard_utility_allowance_tx.meta.yaml").write_text(
+        source_file.with_name(
+            "snap_standard_utility_allowance_tx.meta.yaml"
+        ).write_text(
             "version: 1\n"
             "source_backing:\n"
             "  kind: akn_section\n"
@@ -4719,12 +5103,15 @@ cases:
         )
         source_result = _fake_eval_result("openai-gpt-5.4", "snap-tx-sua")
 
-        with patch(
-            "autorac.harness.evals.run_source_eval",
-            return_value=[source_result],
-        ) as mock_run_source_eval, patch(
-            "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
-            return_value=None,
+        with (
+            patch(
+                "autorac.harness.evals.run_source_eval",
+                return_value=[source_result],
+            ) as mock_run_source_eval,
+            patch(
+                "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
+                return_value=None,
+            ),
         ):
             run_eval_suite(
                 manifest=manifest,
@@ -4872,12 +5259,15 @@ cases:
         ]
         second = _fake_eval_result("openai-gpt-5.4", "case-two")
 
-        with patch(
-            "autorac.harness.evals.run_source_eval",
-            side_effect=[[usage_limited], [second]],
-        ) as mock_source, patch(
-            "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
-            return_value=None,
+        with (
+            patch(
+                "autorac.harness.evals.run_source_eval",
+                side_effect=[[usage_limited], [second]],
+            ) as mock_source,
+            patch(
+                "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
+                return_value=None,
+            ),
         ):
             results = run_eval_suite(
                 manifest=manifest,
@@ -4920,12 +5310,15 @@ cases:
         ]
         recovered = _fake_eval_result("openai-gpt-5.4", "case-one")
 
-        with patch(
-            "autorac.harness.evals.run_source_eval",
-            side_effect=[[timed_out], [recovered]],
-        ) as mock_source, patch(
-            "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
-            return_value=None,
+        with (
+            patch(
+                "autorac.harness.evals.run_source_eval",
+                side_effect=[[timed_out], [recovered]],
+            ) as mock_source,
+            patch(
+                "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
+                return_value=None,
+            ),
         ):
             results = run_eval_suite(
                 manifest=manifest,
@@ -4995,12 +5388,15 @@ cases:
             + "\n"
         )
 
-        with patch(
-            "autorac.harness.evals.run_source_eval",
-            return_value=[second],
-        ) as mock_source, patch(
-            "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
-            return_value=None,
+        with (
+            patch(
+                "autorac.harness.evals.run_source_eval",
+                return_value=[second],
+            ) as mock_source,
+            patch(
+                "autorac.harness.evals._validate_uk_shared_scalar_sibling_sets",
+                return_value=None,
+            ),
         ):
             results = run_eval_suite(
                 manifest=manifest,
@@ -5259,7 +5655,9 @@ cases:
             ).resolve()
         ]
 
-    def test_repo_us_co_colorado_works_leaf_closeout_manifest_loads_expected_cases(self):
+    def test_repo_us_co_colorado_works_leaf_closeout_manifest_loads_expected_cases(
+        self,
+    ):
         repo_root = Path(__file__).resolve().parents[1]
         manifest = load_eval_suite_manifest(
             repo_root / "benchmarks" / "us_co_colorado_works_leaf_closeout.yaml"
@@ -5334,30 +5732,22 @@ cases:
             "snap-fy2026-cola-allotments",
         ]
         assert manifest.cases[0].allow_context == [
-            (repo_root.parent / "rac-us" / "statute" / "7" / "2014" / "e.rac").resolve(),
             (
-                repo_root.parent
-                / "rac-us"
-                / "statute"
-                / "7"
-                / "2014"
-                / "g"
-                / "1.rac"
+                repo_root.parent / "rac-us" / "statute" / "7" / "2014" / "e.rac"
+            ).resolve(),
+            (
+                repo_root.parent / "rac-us" / "statute" / "7" / "2014" / "g" / "1.rac"
             ).resolve(),
         ]
         assert manifest.cases[1].allow_context == [
             (repo_root.parent / "rac-us" / "statute" / "7" / "2017" / "a.rac").resolve()
         ]
         assert manifest.cases[2].allow_context == [
-            (repo_root.parent / "rac-us" / "statute" / "7" / "2017" / "a.rac").resolve(),
             (
-                repo_root.parent
-                / "rac-us"
-                / "statute"
-                / "7"
-                / "2017"
-                / "c"
-                / "1.rac"
+                repo_root.parent / "rac-us" / "statute" / "7" / "2017" / "a.rac"
+            ).resolve(),
+            (
+                repo_root.parent / "rac-us" / "statute" / "7" / "2017" / "c" / "1.rac"
             ).resolve(),
         ]
         assert manifest.cases[3].allow_context == [
@@ -5386,19 +5776,25 @@ cases:
         assert case.kind == "source"
         assert case.name == "snap-2017-c-3"
         assert case.source_id == "7 USC 2017(c)(3)"
-        assert case.source_file == (
-            repo_root.parent / "rac-us" / "sources" / "slices" / "7-USC" / "2017" / "c" / "3.txt"
-        ).resolve()
-        assert case.allow_context == [
-            (repo_root.parent / "rac-us" / "statute" / "7" / "2017" / "a.rac").resolve(),
-            (
+        assert (
+            case.source_file
+            == (
                 repo_root.parent
                 / "rac-us"
-                / "statute"
-                / "7"
+                / "sources"
+                / "slices"
+                / "7-USC"
                 / "2017"
                 / "c"
-                / "1.rac"
+                / "3.txt"
+            ).resolve()
+        )
+        assert case.allow_context == [
+            (
+                repo_root.parent / "rac-us" / "statute" / "7" / "2017" / "a.rac"
+            ).resolve(),
+            (
+                repo_root.parent / "rac-us" / "statute" / "7" / "2017" / "c" / "1.rac"
             ).resolve(),
         ]
 
@@ -5424,16 +5820,19 @@ cases:
         assert case.kind == "source"
         assert case.name == "snap-fy2026-cola-allotments"
         assert case.source_id == "USDA SNAP FY 2026 COLA allotment table"
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us"
-            / "sources"
-            / "slices"
-            / "usda"
-            / "snap"
-            / "fy-2026-cola"
-            / "allotment-table.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us"
+                / "sources"
+                / "slices"
+                / "usda"
+                / "snap"
+                / "fy-2026-cola"
+                / "allotment-table.txt"
+            ).resolve()
+        )
         assert case.allow_context == [
             (repo_root.parent / "rac-us" / "statute" / "7" / "2017" / "a.rac").resolve()
         ]
@@ -5458,24 +5857,22 @@ cases:
         assert case.kind == "source"
         assert case.name == "meets_snap_asset_test"
         assert case.source_id == "7 USC 2014(g)(1)"
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us"
-            / "sources"
-            / "slices"
-            / "7-USC"
-            / "2014"
-            / "g"
-            / "1.txt"
-        ).resolve()
-        assert case.allow_context == [
-            (
+        assert (
+            case.source_file
+            == (
                 repo_root.parent
                 / "rac-us"
-                / "usda"
-                / "snap"
-                / "fy-2026-cola"
-                / "2.rac"
+                / "sources"
+                / "slices"
+                / "7-USC"
+                / "2014"
+                / "g"
+                / "1.txt"
+            ).resolve()
+        )
+        assert case.allow_context == [
+            (
+                repo_root.parent / "rac-us" / "usda" / "snap" / "fy-2026-cola" / "2.rac"
             ).resolve()
         ]
         assert case.oracle == "policyengine"
@@ -5487,7 +5884,9 @@ cases:
     ):
         repo_root = Path(__file__).resolve().parents[1]
         manifest = load_eval_suite_manifest(
-            repo_root / "benchmarks" / "us_snap_asset_test_current_effective_refresh.yaml"
+            repo_root
+            / "benchmarks"
+            / "us_snap_asset_test_current_effective_refresh.yaml"
         )
 
         assert manifest.name == "SNAP asset test current-effective refresh"
@@ -5504,25 +5903,22 @@ cases:
         assert case.kind == "source"
         assert case.name == "meets_snap_asset_test_current_effective"
         assert case.source_id == "USDA SNAP FY2026 maximum asset limits"
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us"
-            / "sources"
-            / "slices"
-            / "usda"
-            / "snap"
-            / "fy-2026-cola"
-            / "asset-limits-current-effective.txt"
-        ).resolve()
-        assert case.allow_context == [
-            (
+        assert (
+            case.source_file
+            == (
                 repo_root.parent
                 / "rac-us"
-                / "statute"
-                / "7"
-                / "2014"
-                / "g"
-                / "1.rac"
+                / "sources"
+                / "slices"
+                / "usda"
+                / "snap"
+                / "fy-2026-cola"
+                / "asset-limits-current-effective.txt"
+            ).resolve()
+        )
+        assert case.allow_context == [
+            (
+                repo_root.parent / "rac-us" / "statute" / "7" / "2014" / "g" / "1.rac"
             ).resolve()
         ]
         assert case.oracle == "policyengine"
@@ -5549,33 +5945,25 @@ cases:
         assert case.kind == "source"
         assert case.name == "is_snap_eligible"
         assert case.source_id == "Federal SNAP current-effective household eligibility"
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us"
-            / "sources"
-            / "slices"
-            / "7-USC"
-            / "snap"
-            / "current-effective"
-            / "is_snap_eligible.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us"
+                / "sources"
+                / "slices"
+                / "7-USC"
+                / "snap"
+                / "current-effective"
+                / "is_snap_eligible.txt"
+            ).resolve()
+        )
         assert case.allow_context == [
             (
-                repo_root.parent
-                / "rac-us"
-                / "statute"
-                / "7"
-                / "2014"
-                / "c.rac"
+                repo_root.parent / "rac-us" / "statute" / "7" / "2014" / "c.rac"
             ).resolve(),
             (
-                repo_root.parent
-                / "rac-us"
-                / "statute"
-                / "7"
-                / "2014"
-                / "g"
-                / "1.rac"
+                repo_root.parent / "rac-us" / "statute" / "7" / "2014" / "g" / "1.rac"
             ).resolve(),
         ]
         assert case.oracle == "policyengine"
@@ -5597,17 +5985,22 @@ cases:
         case = manifest.cases[0]
         assert case.kind == "source"
         assert case.name == "snap_earned_income_deduction"
-        assert case.source_id == "SNAP earned income deduction under 7 USC 2014(e)(2)(B)"
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us"
-            / "sources"
-            / "slices"
-            / "7-USC"
-            / "snap"
-            / "current-effective"
-            / "snap_earned_income_deduction.txt"
-        ).resolve()
+        assert (
+            case.source_id == "SNAP earned income deduction under 7 USC 2014(e)(2)(B)"
+        )
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us"
+                / "sources"
+                / "slices"
+                / "7-USC"
+                / "snap"
+                / "current-effective"
+                / "snap_earned_income_deduction.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -5629,16 +6022,19 @@ cases:
         assert case.kind == "source"
         assert case.name == "snap_net_income_pre_shelter"
         assert case.source_id == "SNAP pre-shelter net income under 7 USC 2014(e)(6)(A)"
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us"
-            / "sources"
-            / "slices"
-            / "7-USC"
-            / "snap"
-            / "current-effective"
-            / "snap_net_income_pre_shelter.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us"
+                / "sources"
+                / "slices"
+                / "7-USC"
+                / "snap"
+                / "current-effective"
+                / "snap_net_income_pre_shelter.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -5649,7 +6045,9 @@ cases:
     ):
         repo_root = Path(__file__).resolve().parents[1]
         manifest = load_eval_suite_manifest(
-            repo_root / "benchmarks" / "us_snap_nc_standard_utility_allowance_refresh.yaml"
+            repo_root
+            / "benchmarks"
+            / "us_snap_nc_standard_utility_allowance_refresh.yaml"
         )
 
         assert manifest.name == "North Carolina SNAP standard utility allowance refresh"
@@ -5659,18 +6057,24 @@ cases:
         case = manifest.cases[0]
         assert case.kind == "source"
         assert case.name == "snap_standard_utility_allowance_nc"
-        assert case.source_id == "North Carolina SNAP standard utility allowance under FNS 360.01(A)(1)"
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-nc"
-            / "sources"
-            / "slices"
-            / "ncdhhs"
-            / "fns"
-            / "360"
-            / "current-effective"
-            / "snap_standard_utility_allowance_nc.txt"
-        ).resolve()
+        assert (
+            case.source_id
+            == "North Carolina SNAP standard utility allowance under FNS 360.01(A)(1)"
+        )
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-nc"
+                / "sources"
+                / "slices"
+                / "ncdhhs"
+                / "fns"
+                / "360"
+                / "current-effective"
+                / "snap_standard_utility_allowance_nc.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -5681,7 +6085,9 @@ cases:
     ):
         repo_root = Path(__file__).resolve().parents[1]
         manifest = load_eval_suite_manifest(
-            repo_root / "benchmarks" / "us_snap_nc_limited_utility_allowance_refresh.yaml"
+            repo_root
+            / "benchmarks"
+            / "us_snap_nc_limited_utility_allowance_refresh.yaml"
         )
 
         assert manifest.name == "North Carolina SNAP limited utility allowance refresh"
@@ -5695,17 +6101,20 @@ cases:
             case.source_id
             == "North Carolina SNAP basic utility allowance under FNS 360.01(A)(2)"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-nc"
-            / "sources"
-            / "slices"
-            / "ncdhhs"
-            / "fns"
-            / "360"
-            / "current-effective"
-            / "snap_limited_utility_allowance_nc.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-nc"
+                / "sources"
+                / "slices"
+                / "ncdhhs"
+                / "fns"
+                / "360"
+                / "current-effective"
+                / "snap_limited_utility_allowance_nc.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -5734,17 +6143,20 @@ cases:
             case.source_id
             == "North Carolina SNAP telephone utility allowance under FNS 360.01(A)(3)"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-nc"
-            / "sources"
-            / "slices"
-            / "ncdhhs"
-            / "fns"
-            / "360"
-            / "current-effective"
-            / "snap_individual_utility_allowance_nc.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-nc"
+                / "sources"
+                / "slices"
+                / "ncdhhs"
+                / "fns"
+                / "360"
+                / "current-effective"
+                / "snap_individual_utility_allowance_nc.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -5755,7 +6167,9 @@ cases:
     ):
         repo_root = Path(__file__).resolve().parents[1]
         manifest = load_eval_suite_manifest(
-            repo_root / "benchmarks" / "us_snap_tn_standard_utility_allowance_refresh.yaml"
+            repo_root
+            / "benchmarks"
+            / "us_snap_tn_standard_utility_allowance_refresh.yaml"
         )
 
         assert manifest.name == "Tennessee SNAP standard utility allowance refresh"
@@ -5769,16 +6183,19 @@ cases:
             case.source_id
             == "Tennessee SNAP standard utility allowance under TennCare ABD Manual 125.020 section 3.d.ii.1.c.i"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-tn"
-            / "sources"
-            / "slices"
-            / "tenncare"
-            / "post-eligibility"
-            / "current-effective"
-            / "snap_standard_utility_allowance_tn.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-tn"
+                / "sources"
+                / "slices"
+                / "tenncare"
+                / "post-eligibility"
+                / "current-effective"
+                / "snap_standard_utility_allowance_tn.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -5789,7 +6206,9 @@ cases:
     ):
         repo_root = Path(__file__).resolve().parents[1]
         manifest = load_eval_suite_manifest(
-            repo_root / "benchmarks" / "us_snap_tn_limited_utility_allowance_refresh.yaml"
+            repo_root
+            / "benchmarks"
+            / "us_snap_tn_limited_utility_allowance_refresh.yaml"
         )
 
         assert manifest.name == "Tennessee SNAP limited utility allowance refresh"
@@ -5803,16 +6222,19 @@ cases:
             case.source_id
             == "Tennessee SNAP limited utility allowance under TennCare ABD Manual 125.020 section 3.d.ii.1.c.ii"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-tn"
-            / "sources"
-            / "slices"
-            / "tenncare"
-            / "post-eligibility"
-            / "current-effective"
-            / "snap_limited_utility_allowance_tn.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-tn"
+                / "sources"
+                / "slices"
+                / "tenncare"
+                / "post-eligibility"
+                / "current-effective"
+                / "snap_limited_utility_allowance_tn.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -5839,16 +6261,19 @@ cases:
             case.source_id
             == "Tennessee SNAP telephone utility allowance under TennCare ABD Manual 125.020 section 3.d.ii.1.c.iii"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-tn"
-            / "sources"
-            / "slices"
-            / "tenncare"
-            / "post-eligibility"
-            / "current-effective"
-            / "snap_individual_utility_allowance_tn.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-tn"
+                / "sources"
+                / "slices"
+                / "tenncare"
+                / "post-eligibility"
+                / "current-effective"
+                / "snap_individual_utility_allowance_tn.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -5875,22 +6300,24 @@ cases:
             case.source_id
             == "Tennessee SNAP child support deduction election under SNAP Policy Manual Chapter 23.L"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-tn"
-            / "sources"
-            / "slices"
-            / "tdhs"
-            / "snap"
-            / "current-effective"
-            / "snap_state_uses_child_support_deduction_tn.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-tn"
+                / "sources"
+                / "slices"
+                / "tdhs"
+                / "snap"
+                / "current-effective"
+                / "snap_state_uses_child_support_deduction_tn.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
         assert (
-            case.policyengine_rac_var_hint
-            == "snap_state_uses_child_support_deduction"
+            case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
         )
 
     def test_repo_us_snap_tn_self_employment_expense_option_refresh_manifest_loads_expected_case(
@@ -5903,10 +6330,7 @@ cases:
             / "us_snap_tn_self_employment_expense_option_refresh.yaml"
         )
 
-        assert (
-            manifest.name
-            == "Tennessee SNAP self-employment expense option refresh"
-        )
+        assert manifest.name == "Tennessee SNAP self-employment expense option refresh"
         assert manifest.mode == "repo-augmented"
         assert len(manifest.cases) == 1
         assert manifest.gates.min_policyengine_pass_rate == 1.0
@@ -5917,16 +6341,19 @@ cases:
             case.source_id
             == "Tennessee SNAP self-employment expense option under TDHS SNAP Income Policy 24.14"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-tn"
-            / "sources"
-            / "slices"
-            / "tdhs"
-            / "snap"
-            / "current-effective"
-            / "snap_self_employment_expense_based_deduction_applies_tn.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-tn"
+                / "sources"
+                / "slices"
+                / "tdhs"
+                / "snap"
+                / "current-effective"
+                / "snap_self_employment_expense_based_deduction_applies_tn.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -5945,10 +6372,7 @@ cases:
             / "us_snap_ca_self_employment_expense_option_refresh.yaml"
         )
 
-        assert (
-            manifest.name
-            == "California SNAP self-employment expense option refresh"
-        )
+        assert manifest.name == "California SNAP self-employment expense option refresh"
         assert manifest.mode == "repo-augmented"
         assert len(manifest.cases) == 1
         assert manifest.gates.min_policyengine_pass_rate == 1.0
@@ -5959,16 +6383,19 @@ cases:
             case.source_id
             == "California CalFresh self-employment expense choice under MPP 63-503.413"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-ca"
-            / "sources"
-            / "slices"
-            / "cdss"
-            / "calfresh"
-            / "current-effective"
-            / "snap_self_employment_expense_based_deduction_applies_ca.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-ca"
+                / "sources"
+                / "slices"
+                / "cdss"
+                / "calfresh"
+                / "current-effective"
+                / "snap_self_employment_expense_based_deduction_applies_ca.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -5998,22 +6425,24 @@ cases:
             case.source_id
             == "California CalFresh child support exclusion under MPP 63-502.2(p)"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-ca"
-            / "sources"
-            / "slices"
-            / "cdss"
-            / "calfresh"
-            / "current-effective"
-            / "snap_state_uses_child_support_deduction_ca.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-ca"
+                / "sources"
+                / "slices"
+                / "cdss"
+                / "calfresh"
+                / "current-effective"
+                / "snap_state_uses_child_support_deduction_ca.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
         assert (
-            case.policyengine_rac_var_hint
-            == "snap_state_uses_child_support_deduction"
+            case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
         )
 
     def test_repo_us_snap_co_self_employment_expense_option_refresh_manifest_loads_expected_case(
@@ -6037,16 +6466,19 @@ cases:
             case.source_id
             == "Colorado SNAP self-employment expense deduction rule under 10 CCR 2506-1 section 4.403.11(B)-(C)(3)"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-co"
-            / "sources"
-            / "slices"
-            / "cdhs"
-            / "snap"
-            / "current-effective"
-            / "snap_self_employment_expense_based_deduction_applies_co.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-co"
+                / "sources"
+                / "slices"
+                / "cdhs"
+                / "snap"
+                / "current-effective"
+                / "snap_self_employment_expense_based_deduction_applies_co.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -6076,22 +6508,24 @@ cases:
             case.source_id
             == "Colorado SNAP child support exclusion under 10 CCR 2506-1 section 4.407.5"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-co"
-            / "sources"
-            / "slices"
-            / "cdhs"
-            / "snap"
-            / "current-effective"
-            / "snap_state_uses_child_support_deduction_co.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-co"
+                / "sources"
+                / "slices"
+                / "cdhs"
+                / "snap"
+                / "current-effective"
+                / "snap_state_uses_child_support_deduction_co.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
         assert (
-            case.policyengine_rac_var_hint
-            == "snap_state_uses_child_support_deduction"
+            case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
         )
 
     def test_repo_us_snap_ny_individual_utility_allowance_refresh_manifest_loads_expected_case(
@@ -6115,16 +6549,19 @@ cases:
             case.source_id
             == "New York SNAP telephone utility allowance under OTDA LDSS-5006 effective October 1, 2025"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-ny"
-            / "sources"
-            / "slices"
-            / "otda"
-            / "snap"
-            / "current-effective"
-            / "snap_individual_utility_allowance_ny.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-ny"
+                / "sources"
+                / "slices"
+                / "otda"
+                / "snap"
+                / "current-effective"
+                / "snap_individual_utility_allowance_ny.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -6151,22 +6588,24 @@ cases:
             case.source_id
             == "New York SNAP child support deduction election under OTDA SNAP Source Book section 13.G.2"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-ny"
-            / "sources"
-            / "slices"
-            / "otda"
-            / "snap"
-            / "current-effective"
-            / "snap_state_uses_child_support_deduction_ny.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-ny"
+                / "sources"
+                / "slices"
+                / "otda"
+                / "snap"
+                / "current-effective"
+                / "snap_state_uses_child_support_deduction_ny.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
         assert (
-            case.policyengine_rac_var_hint
-            == "snap_state_uses_child_support_deduction"
+            case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
         )
 
     def test_repo_us_snap_nc_child_support_deduction_option_refresh_manifest_loads_expected_case(
@@ -6179,7 +6618,10 @@ cases:
             / "us_snap_nc_child_support_deduction_option_refresh.yaml"
         )
 
-        assert manifest.name == "North Carolina SNAP child support deduction option refresh"
+        assert (
+            manifest.name
+            == "North Carolina SNAP child support deduction option refresh"
+        )
         assert manifest.mode == "repo-augmented"
         assert len(manifest.cases) == 1
         assert manifest.gates.min_policyengine_pass_rate == 1.0
@@ -6190,23 +6632,25 @@ cases:
             case.source_id
             == "North Carolina SNAP child support deduction election under FNS 340 section 340.19"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-nc"
-            / "sources"
-            / "slices"
-            / "ncdhhs"
-            / "fns"
-            / "340"
-            / "current-effective"
-            / "snap_state_uses_child_support_deduction_nc.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-nc"
+                / "sources"
+                / "slices"
+                / "ncdhhs"
+                / "fns"
+                / "340"
+                / "current-effective"
+                / "snap_state_uses_child_support_deduction_nc.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
         assert (
-            case.policyengine_rac_var_hint
-            == "snap_state_uses_child_support_deduction"
+            case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
         )
 
     def test_repo_us_snap_nc_self_employment_expense_option_refresh_manifest_loads_expected_case(
@@ -6233,17 +6677,20 @@ cases:
             case.source_id
             == "North Carolina SNAP self-employment expense option under FNS 315 section 315.28"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-nc"
-            / "sources"
-            / "slices"
-            / "ncdhhs"
-            / "fns"
-            / "315"
-            / "current-effective"
-            / "snap_self_employment_expense_based_deduction_applies_nc.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-nc"
+                / "sources"
+                / "slices"
+                / "ncdhhs"
+                / "fns"
+                / "315"
+                / "current-effective"
+                / "snap_self_employment_expense_based_deduction_applies_nc.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -6273,16 +6720,19 @@ cases:
             case.source_id
             == "New York SNAP self-employment expense treatment under OTDA SNAP Source Book section 13.H"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-ny"
-            / "sources"
-            / "slices"
-            / "otda"
-            / "snap"
-            / "current-effective"
-            / "snap_self_employment_expense_based_deduction_applies_ny.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-ny"
+                / "sources"
+                / "slices"
+                / "otda"
+                / "snap"
+                / "current-effective"
+                / "snap_self_employment_expense_based_deduction_applies_ny.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -6296,7 +6746,9 @@ cases:
     ):
         repo_root = Path(__file__).resolve().parents[1]
         manifest = load_eval_suite_manifest(
-            repo_root / "benchmarks" / "us_snap_ny_standard_utility_allowance_refresh.yaml"
+            repo_root
+            / "benchmarks"
+            / "us_snap_ny_standard_utility_allowance_refresh.yaml"
         )
 
         assert manifest.name == "New York SNAP standard utility allowance refresh"
@@ -6310,16 +6762,19 @@ cases:
             case.source_id
             == "New York SNAP standard utility allowance under OTDA LDSS-5006 effective October 1, 2025"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-ny"
-            / "sources"
-            / "slices"
-            / "otda"
-            / "snap"
-            / "current-effective"
-            / "snap_standard_utility_allowance_ny.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-ny"
+                / "sources"
+                / "slices"
+                / "otda"
+                / "snap"
+                / "current-effective"
+                / "snap_standard_utility_allowance_ny.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -6330,7 +6785,9 @@ cases:
     ):
         repo_root = Path(__file__).resolve().parents[1]
         manifest = load_eval_suite_manifest(
-            repo_root / "benchmarks" / "us_snap_ny_limited_utility_allowance_refresh.yaml"
+            repo_root
+            / "benchmarks"
+            / "us_snap_ny_limited_utility_allowance_refresh.yaml"
         )
 
         assert manifest.name == "New York SNAP limited utility allowance refresh"
@@ -6344,16 +6801,19 @@ cases:
             case.source_id
             == "New York SNAP limited utility allowance under OTDA LDSS-5006 effective October 1, 2025"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-ny"
-            / "sources"
-            / "slices"
-            / "otda"
-            / "snap"
-            / "current-effective"
-            / "snap_limited_utility_allowance_ny.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-ny"
+                / "sources"
+                / "slices"
+                / "otda"
+                / "snap"
+                / "current-effective"
+                / "snap_limited_utility_allowance_ny.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -6364,7 +6824,9 @@ cases:
     ):
         repo_root = Path(__file__).resolve().parents[1]
         manifest = load_eval_suite_manifest(
-            repo_root / "benchmarks" / "us_snap_tx_standard_utility_allowance_refresh.yaml"
+            repo_root
+            / "benchmarks"
+            / "us_snap_tx_standard_utility_allowance_refresh.yaml"
         )
 
         assert manifest.name == "Texas SNAP standard utility allowance refresh"
@@ -6404,7 +6866,9 @@ cases:
     ):
         repo_root = Path(__file__).resolve().parents[1]
         manifest = load_eval_suite_manifest(
-            repo_root / "benchmarks" / "us_snap_tx_limited_utility_allowance_refresh.yaml"
+            repo_root
+            / "benchmarks"
+            / "us_snap_tx_limited_utility_allowance_refresh.yaml"
         )
 
         assert manifest.name == "Texas SNAP limited utility allowance refresh"
@@ -6521,7 +6985,9 @@ cases:
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
-        assert case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
+        assert (
+            case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
+        )
 
     def test_repo_us_snap_tx_self_employment_expense_option_refresh_manifest_loads_expected_case(
         self,
@@ -6564,7 +7030,10 @@ cases:
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
-        assert case.policyengine_rac_var_hint == "snap_self_employment_expense_based_deduction_applies"
+        assert (
+            case.policyengine_rac_var_hint
+            == "snap_self_employment_expense_based_deduction_applies"
+        )
 
     def test_repo_us_snap_tx_state_using_standard_utility_allowance_refresh_manifest_loads_expected_case(
         self,
@@ -6576,7 +7045,9 @@ cases:
             / "us_snap_tx_state_using_standard_utility_allowance_refresh.yaml"
         )
 
-        assert manifest.name == "Texas SNAP state using standard utility allowance refresh"
+        assert (
+            manifest.name == "Texas SNAP state using standard utility allowance refresh"
+        )
         assert manifest.mode == "repo-augmented"
         assert len(manifest.cases) == 1
         assert manifest.gates.min_policyengine_pass_rate == 1.0
@@ -6637,20 +7108,25 @@ cases:
             case.source_id
             == "Florida SNAP child support deduction election under ESS Program Policy Manual 2610.0410"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-fl"
-            / "sources"
-            / "slices"
-            / "myflfamilies"
-            / "ess"
-            / "current-effective"
-            / "snap_state_uses_child_support_deduction_fl.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-fl"
+                / "sources"
+                / "slices"
+                / "myflfamilies"
+                / "ess"
+                / "current-effective"
+                / "snap_state_uses_child_support_deduction_fl.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
-        assert case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
+        assert (
+            case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
+        )
 
     def test_repo_us_snap_fl_self_employment_expense_option_refresh_manifest_loads_expected_case(
         self,
@@ -6673,20 +7149,26 @@ cases:
             case.source_id
             == "Florida SNAP self-employment expense option under ESS Program Policy Manual 1810.0302"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-fl"
-            / "sources"
-            / "slices"
-            / "myflfamilies"
-            / "ess"
-            / "current-effective"
-            / "snap_self_employment_expense_based_deduction_applies_fl.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-fl"
+                / "sources"
+                / "slices"
+                / "myflfamilies"
+                / "ess"
+                / "current-effective"
+                / "snap_self_employment_expense_based_deduction_applies_fl.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
-        assert case.policyengine_rac_var_hint == "snap_self_employment_expense_based_deduction_applies"
+        assert (
+            case.policyengine_rac_var_hint
+            == "snap_self_employment_expense_based_deduction_applies"
+        )
 
     def test_repo_us_snap_md_child_support_deduction_option_refresh_manifest_loads_expected_case(
         self,
@@ -6709,20 +7191,25 @@ cases:
             case.source_id
             == "Maryland SNAP child support deduction election under SNAP Manual Section 408 Verification"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-md"
-            / "sources"
-            / "slices"
-            / "dhs"
-            / "snap"
-            / "current-effective"
-            / "snap_state_uses_child_support_deduction_md.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-md"
+                / "sources"
+                / "slices"
+                / "dhs"
+                / "snap"
+                / "current-effective"
+                / "snap_state_uses_child_support_deduction_md.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
-        assert case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
+        assert (
+            case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
+        )
 
     def test_repo_us_snap_md_self_employment_simplified_deduction_rate_refresh_manifest_loads_expected_case(
         self,
@@ -6748,16 +7235,19 @@ cases:
             case.source_id
             == "Maryland SNAP self-employment simplified deduction rate under SNAP Manual Section 104 Self-employed Households"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-md"
-            / "sources"
-            / "slices"
-            / "dhs"
-            / "snap"
-            / "current-effective"
-            / "snap_self_employment_simplified_deduction_rate_md.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-md"
+                / "sources"
+                / "slices"
+                / "dhs"
+                / "snap"
+                / "current-effective"
+                / "snap_self_employment_simplified_deduction_rate_md.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -6787,20 +7277,25 @@ cases:
             case.source_id
             == "Georgia SNAP child support deduction election under DFCS SNAP Manual 3035 Verification"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-ga"
-            / "sources"
-            / "slices"
-            / "dfcs"
-            / "snap"
-            / "current-effective"
-            / "snap_state_uses_child_support_deduction_ga.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-ga"
+                / "sources"
+                / "slices"
+                / "dfcs"
+                / "snap"
+                / "current-effective"
+                / "snap_state_uses_child_support_deduction_ga.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
-        assert case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
+        assert (
+            case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
+        )
 
     def test_repo_us_snap_ga_self_employment_expense_option_refresh_manifest_loads_expected_case(
         self,
@@ -6823,16 +7318,19 @@ cases:
             case.source_id
             == "Georgia SNAP self-employment expense option under DFCS SNAP Manual 3425 Self-Employment Income"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-ga"
-            / "sources"
-            / "slices"
-            / "dfcs"
-            / "snap"
-            / "current-effective"
-            / "snap_self_employment_expense_based_deduction_applies_ga.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-ga"
+                / "sources"
+                / "slices"
+                / "dfcs"
+                / "snap"
+                / "current-effective"
+                / "snap_self_employment_expense_based_deduction_applies_ga.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -6851,10 +7349,7 @@ cases:
             / "us_snap_tx_standard_medical_expense_deduction_refresh.yaml"
         )
 
-        assert (
-            manifest.name
-            == "Texas SNAP standard medical expense deduction refresh"
-        )
+        assert manifest.name == "Texas SNAP standard medical expense deduction refresh"
         assert manifest.mode == "repo-augmented"
         assert len(manifest.cases) == 1
         assert manifest.gates.min_policyengine_pass_rate == 1.0
@@ -6888,8 +7383,7 @@ cases:
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
         assert (
-            case.policyengine_rac_var_hint
-            == "snap_standard_medical_expense_deduction"
+            case.policyengine_rac_var_hint == "snap_standard_medical_expense_deduction"
         )
 
     def test_repo_us_snap_tx_homeless_shelter_deduction_available_refresh_manifest_loads_expected_case(
@@ -6930,7 +7424,10 @@ cases:
             case.metadata_file
             == tx_target_root / "snap_homeless_shelter_deduction_available_tx.meta.yaml"
         )
-        assert case.section_eid == "sec_bulletin_25_15_section_2_homeless_shelter_deduction"
+        assert (
+            case.section_eid
+            == "sec_bulletin_25_15_section_2_homeless_shelter_deduction"
+        )
         assert case.section_eids == []
         assert case.allow_context == []
         assert case.oracle == "policyengine"
@@ -6973,7 +7470,8 @@ cases:
         assert case.akn_file is None
         assert (
             case.metadata_file
-            == tx_target_root / "snap_tanf_non_cash_gross_income_limit_fpg_ratio_tx.meta.yaml"
+            == tx_target_root
+            / "snap_tanf_non_cash_gross_income_limit_fpg_ratio_tx.meta.yaml"
         )
         assert case.section_eid == "sec_b_471"
         assert case.section_eids == []
@@ -7051,16 +7549,19 @@ cases:
             case.source_id
             == "Georgia SNAP self-employment simplified deduction rate under DFCS SNAP Manual 3425 Self-Employment Income"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-ga"
-            / "sources"
-            / "slices"
-            / "dfcs"
-            / "snap"
-            / "current-effective"
-            / "snap_self_employment_simplified_deduction_rate_ga.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-ga"
+                / "sources"
+                / "slices"
+                / "dfcs"
+                / "snap"
+                / "current-effective"
+                / "snap_self_employment_simplified_deduction_rate_ga.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -7093,20 +7594,25 @@ cases:
             case.source_id
             == "South Carolina SNAP child support deduction under SNAP Manual Vol 65 section 12.7"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-sc"
-            / "sources"
-            / "slices"
-            / "scdss"
-            / "snap"
-            / "current-effective"
-            / "snap_state_uses_child_support_deduction_sc.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-sc"
+                / "sources"
+                / "slices"
+                / "scdss"
+                / "snap"
+                / "current-effective"
+                / "snap_state_uses_child_support_deduction_sc.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
-        assert case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
+        assert (
+            case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
+        )
 
     def test_repo_us_snap_sc_self_employment_expense_option_refresh_manifest_loads_expected_case(
         self,
@@ -7132,16 +7638,19 @@ cases:
             case.source_id
             == "South Carolina SNAP self-employment expense option under SNAP Manual Vol 65 section 11.4(3)"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-sc"
-            / "sources"
-            / "slices"
-            / "scdss"
-            / "snap"
-            / "current-effective"
-            / "snap_self_employment_expense_based_deduction_applies_sc.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-sc"
+                / "sources"
+                / "slices"
+                / "scdss"
+                / "snap"
+                / "current-effective"
+                / "snap_self_employment_expense_based_deduction_applies_sc.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -7174,16 +7683,19 @@ cases:
             case.source_id
             == "South Carolina SNAP self-employment simplified deduction rate under SNAP Manual Vol 65 section 11.4(3)"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-sc"
-            / "sources"
-            / "slices"
-            / "scdss"
-            / "snap"
-            / "current-effective"
-            / "snap_self_employment_simplified_deduction_rate_sc.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-sc"
+                / "sources"
+                / "slices"
+                / "scdss"
+                / "snap"
+                / "current-effective"
+                / "snap_self_employment_simplified_deduction_rate_sc.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -7213,20 +7725,25 @@ cases:
             case.source_id
             == "Alabama SNAP child support deduction under DHR Food Assistance Program Points of Eligibility Manual Appendix I section E"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-al"
-            / "sources"
-            / "slices"
-            / "aldhr"
-            / "poe"
-            / "current-effective"
-            / "snap_state_uses_child_support_deduction_al.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-al"
+                / "sources"
+                / "slices"
+                / "aldhr"
+                / "poe"
+                / "current-effective"
+                / "snap_state_uses_child_support_deduction_al.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
-        assert case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
+        assert (
+            case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
+        )
 
     def test_repo_us_snap_al_self_employment_expense_option_refresh_manifest_loads_expected_case(
         self,
@@ -7249,16 +7766,19 @@ cases:
             case.source_id
             == "Alabama SNAP self-employment expense option under DHR Food Assistance Program Points of Eligibility Manual Chapter 11 section D"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-al"
-            / "sources"
-            / "slices"
-            / "aldhr"
-            / "poe"
-            / "current-effective"
-            / "snap_self_employment_expense_based_deduction_applies_al.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-al"
+                / "sources"
+                / "slices"
+                / "aldhr"
+                / "poe"
+                / "current-effective"
+                / "snap_self_employment_expense_based_deduction_applies_al.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -7291,16 +7811,19 @@ cases:
             case.source_id
             == "Alabama SNAP self-employment simplified deduction rate under DHR Food Assistance Program Points of Eligibility Manual Chapter 11 section 1100"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-al"
-            / "sources"
-            / "slices"
-            / "aldhr"
-            / "poe"
-            / "current-effective"
-            / "snap_self_employment_simplified_deduction_rate_al.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-al"
+                / "sources"
+                / "slices"
+                / "aldhr"
+                / "poe"
+                / "current-effective"
+                / "snap_self_employment_simplified_deduction_rate_al.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -7330,20 +7853,25 @@ cases:
             case.source_id
             == "Arkansas SNAP child support deduction under DHS SNAP Certification Manual section 6550 Child Support Deductions"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-ar"
-            / "sources"
-            / "slices"
-            / "ardhs"
-            / "snap"
-            / "current-effective"
-            / "snap_state_uses_child_support_deduction_ar.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-ar"
+                / "sources"
+                / "slices"
+                / "ardhs"
+                / "snap"
+                / "current-effective"
+                / "snap_state_uses_child_support_deduction_ar.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
-        assert case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
+        assert (
+            case.policyengine_rac_var_hint == "snap_state_uses_child_support_deduction"
+        )
 
     def test_repo_us_snap_ar_self_employment_expense_option_refresh_manifest_loads_expected_case(
         self,
@@ -7366,16 +7894,19 @@ cases:
             case.source_id
             == "Arkansas SNAP self-employment expense option under DHS SNAP Certification Manual section 5663 Costs of Producing Self-Employment Income"
         )
-        assert case.source_file == (
-            repo_root.parent
-            / "rac-us-ar"
-            / "sources"
-            / "slices"
-            / "ardhs"
-            / "snap"
-            / "current-effective"
-            / "snap_self_employment_expense_based_deduction_applies_ar.txt"
-        ).resolve()
+        assert (
+            case.source_file
+            == (
+                repo_root.parent
+                / "rac-us-ar"
+                / "sources"
+                / "slices"
+                / "ardhs"
+                / "snap"
+                / "current-effective"
+                / "snap_self_employment_expense_based_deduction_applies_ar.txt"
+            ).resolve()
+        )
         assert case.allow_context == []
         assert case.oracle == "policyengine"
         assert case.policyengine_country == "auto"
@@ -7459,7 +7990,9 @@ class TestRepoAugmentedContext:
         repo_root = tmp_path / "repos"
         rac_root = repo_root / "rac"
         rac_root.mkdir(parents=True)
-        context_file = repo_root / "rac-us" / "statute" / "26" / "32" / "b" / "2" / "A.rac"
+        context_file = (
+            repo_root / "rac-us" / "statute" / "26" / "32" / "b" / "2" / "A.rac"
+        )
         context_file.parent.mkdir(parents=True)
         context_file.write_text("status: encoded\n")
 
@@ -7527,7 +8060,9 @@ class TestRepoAugmentedContext:
         copied = workspace.root / manifest["context_files"][0]["workspace_path"]
         assert copied.exists()
 
-    def test_prepare_eval_workspace_materializes_source_metadata_sidecar(self, tmp_path):
+    def test_prepare_eval_workspace_materializes_source_metadata_sidecar(
+        self, tmp_path
+    ):
         repo_root = tmp_path / "repos"
         policy_repo = repo_root / "rac-us-tn"
         policy_repo.mkdir(parents=True)
@@ -7691,7 +8226,12 @@ class TestRepoAugmentedContext:
         rac_root = repo_root / "rac"
         rac_root.mkdir(parents=True)
         external_file = (
-            repo_root / "rac-us-co" / "regulation" / "9-CCR-2503-6" / "3.606.1" / "F.rac"
+            repo_root
+            / "rac-us-co"
+            / "regulation"
+            / "9-CCR-2503-6"
+            / "3.606.1"
+            / "F.rac"
         )
         external_file.parent.mkdir(parents=True, exist_ok=True)
         external_file.write_text(
@@ -7724,14 +8264,35 @@ class TestRepoAugmentedContext:
             "import target `regulation/9-CCR-2503-6/3.606.1/F`"
         ) in prompt
         assert "do not wrap import targets in quotes" in prompt
-        assert "use the listed import target rather than the `./context/...` inspection path" in prompt
-        assert "do not guess contradictory `.rac.test` expectations for those imported values" in prompt
-        assert "keep `.rac.test` inputs and expected outputs consistent with the rows visible in that imported file" in prompt
-        assert "Do not invent degenerate placeholder rows like `number_of_children_in_assistance_unit: 0` plus `number_of_caretakers_in_assistance_unit: 0`" in prompt
-        assert "Do not assert an exact zero imported standard, grant, or threshold unless that exact imported row is visible in the copied chart file" in prompt
-        assert "Do not use a `0 children / 0 caretakers` household as the primary threshold test" in prompt
+        assert (
+            "use the listed import target rather than the `./context/...` inspection path"
+            in prompt
+        )
+        assert (
+            "do not guess contradictory `.rac.test` expectations for those imported values"
+            in prompt
+        )
+        assert (
+            "keep `.rac.test` inputs and expected outputs consistent with the rows visible in that imported file"
+            in prompt
+        )
+        assert (
+            "Do not invent degenerate placeholder rows like `number_of_children_in_assistance_unit: 0` plus `number_of_caretakers_in_assistance_unit: 0`"
+            in prompt
+        )
+        assert (
+            "Do not assert an exact zero imported standard, grant, or threshold unless that exact imported row is visible in the copied chart file"
+            in prompt
+        )
+        assert (
+            "Do not use a `0 children / 0 caretakers` household as the primary threshold test"
+            in prompt
+        )
         assert "Wrong (`.rac.test` guesses a degenerate chart row):" in prompt
-        assert "Right (`.rac.test` uses a visible chart row like one child / no caretaker):" in prompt
+        assert (
+            "Right (`.rac.test` uses a visible chart row like one child / no caretaker):"
+            in prompt
+        )
 
     def test_hydrate_eval_root_copies_context_into_import_tree(self, tmp_path):
         repo_root = tmp_path / "repos"
@@ -7760,7 +8321,9 @@ class TestRepoAugmentedContext:
         eval_root = tmp_path / "eval-root"
         _hydrate_eval_root(eval_root, workspace)
 
-        assert (eval_root / "statute" / "26" / "24" / "c.rac").read_text() == "status: stub\n"
+        assert (
+            eval_root / "statute" / "26" / "24" / "c.rac"
+        ).read_text() == "status: stub\n"
 
     def test_prepare_eval_workspace_expands_transitive_context_imports(self, tmp_path):
         repo_root = tmp_path / "repos"
@@ -7825,10 +8388,14 @@ class TestRepoAugmentedContext:
 
         eval_root = tmp_path / "eval-root"
         _hydrate_eval_root(eval_root, workspace)
-        assert (eval_root / "26" / "24" / "c" / "2.rac").read_text() == "status: encoded\n"
+        assert (
+            eval_root / "26" / "24" / "c" / "2.rac"
+        ).read_text() == "status: encoded\n"
         assert (eval_root / "26" / "152" / "c.rac").read_text() == "status: encoded\n"
 
-    def test_repo_augmented_context_resolves_statute_prefixed_dependencies(self, tmp_path):
+    def test_repo_augmented_context_resolves_statute_prefixed_dependencies(
+        self, tmp_path
+    ):
         repo_root = tmp_path / "repos"
         rac_root = repo_root / "rac"
         rac_root.mkdir(parents=True)
@@ -7930,18 +8497,23 @@ class TestUnexpectedAccessDetection:
 
 
 class TestSourceEval:
-    def test_run_source_eval_uses_explicit_context_without_statute_lookup(self, tmp_path):
+    def test_run_source_eval_uses_explicit_context_without_statute_lookup(
+        self, tmp_path
+    ):
         rac_root = tmp_path / "rac"
         rac_root.mkdir()
         context_file = tmp_path / "examples" / "piecewise.rac"
         context_file.parent.mkdir(parents=True)
         context_file.write_text("status: encoded\n")
 
-        with patch(
-            "autorac.harness.evals._run_prompt_eval",
-        ) as mock_prompt_eval, patch(
-            "autorac.harness.evals.evaluate_artifact",
-        ) as mock_evaluate_artifact:
+        with (
+            patch(
+                "autorac.harness.evals._run_prompt_eval",
+            ) as mock_prompt_eval,
+            patch(
+                "autorac.harness.evals.evaluate_artifact",
+            ) as mock_evaluate_artifact,
+        ):
             mock_prompt_eval.return_value.text = (
                 "=== FILE: 9-CCR-2503-6-3.606.1-F.rac ===\n"
                 '"""\nF. Determining Eligibility ...\n"""\n'
@@ -7989,15 +8561,20 @@ class TestSourceEval:
         assert ".rac.test" in prompt
         assert "=== FILE:" in prompt
 
-    def test_run_source_eval_passes_oracle_settings_to_evaluate_artifact(self, tmp_path):
+    def test_run_source_eval_passes_oracle_settings_to_evaluate_artifact(
+        self, tmp_path
+    ):
         rac_root = tmp_path / "rac"
         rac_root.mkdir()
 
-        with patch(
-            "autorac.harness.evals._run_prompt_eval",
-        ) as mock_prompt_eval, patch(
-            "autorac.harness.evals.evaluate_artifact",
-        ) as mock_evaluate_artifact:
+        with (
+            patch(
+                "autorac.harness.evals._run_prompt_eval",
+            ) as mock_prompt_eval,
+            patch(
+                "autorac.harness.evals.evaluate_artifact",
+            ) as mock_evaluate_artifact,
+        ):
             mock_prompt_eval.return_value.text = (
                 "=== FILE: uksi-2006-965-regulation-2.rac ===\n"
                 '"""\nhttps://www.legislation.gov.uk/uksi/2006/965/regulation/2\n"""\n'
@@ -8029,9 +8606,7 @@ class TestSourceEval:
             )
 
         assert mock_evaluate_artifact.call_args.kwargs["oracle"] == "policyengine"
-        assert (
-            mock_evaluate_artifact.call_args.kwargs["policyengine_country"] == "uk"
-        )
+        assert mock_evaluate_artifact.call_args.kwargs["policyengine_country"] == "uk"
 
     def test_run_source_eval_passes_policyengine_rac_var_hint_to_evaluate_artifact(
         self, tmp_path
@@ -8039,11 +8614,14 @@ class TestSourceEval:
         rac_root = tmp_path / "rac"
         rac_root.mkdir()
 
-        with patch(
-            "autorac.harness.evals._run_prompt_eval",
-        ) as mock_prompt_eval, patch(
-            "autorac.harness.evals.evaluate_artifact",
-        ) as mock_evaluate_artifact:
+        with (
+            patch(
+                "autorac.harness.evals._run_prompt_eval",
+            ) as mock_prompt_eval,
+            patch(
+                "autorac.harness.evals.evaluate_artifact",
+            ) as mock_evaluate_artifact,
+        ):
             mock_prompt_eval.return_value.text = (
                 "=== FILE: uksi-2013-376-regulation-36-3-single-under-25.rac ===\n"
                 '"""\n317.82\n"""\n'
@@ -8117,7 +8695,10 @@ class TestSourceEval:
             "each case must assert `uc_standard_allowance_single_claimant_aged_under_25` directly in `output:`"
             in prompt
         )
-        assert "prefer the oracle's direct component facts over inverted household proxy inputs" in prompt
+        assert (
+            "prefer the oracle's direct component facts over inverted household proxy inputs"
+            in prompt
+        )
         assert (
             "preserve that as a person-level fact instead of turning it into a whole-household bar"
             in prompt
@@ -8172,17 +8753,19 @@ class TestSourceEval:
             "should set `snap_state_using_standard_utility_allowance` to `false`, not `true`"
             in prompt
         )
-        assert "do not invent placeholder literals like `OTHER`, `NONE`, or `UNKNOWN`" in prompt
         assert (
-            "should use a valid non-telephone category like `SUA` or `BUA`"
+            "do not invent placeholder literals like `OTHER`, `NONE`, or `UNKNOWN`"
             in prompt
         )
+        assert "should use a valid non-telephone category like `SUA` or `BUA`" in prompt
 
     def test_build_eval_prompt_includes_sets_source_metadata_guidance(self, tmp_path):
         runner = parse_runner_spec("openai:gpt-5.4")
         source_path = tmp_path / "snap_standard_utility_allowance_tn.txt"
         source_path.write_text("The SUA is $451, effective October 1, 2025.")
-        source_path.with_name("snap_standard_utility_allowance_tn.meta.yaml").write_text(
+        source_path.with_name(
+            "snap_standard_utility_allowance_tn.meta.yaml"
+        ).write_text(
             "version: 1\n"
             "source_backing:\n"
             "  kind: akn_section\n"
@@ -8219,8 +8802,14 @@ class TestSourceEval:
         assert "relation: sets" not in prompt
         assert '"relation": "sets"' in prompt
         assert '"source_backing"' in prompt
-        assert "setting the effective jurisdiction-specific value for that delegated slot" in prompt
-        assert "derived extraction from the listed authoritative AKN section or sections" in prompt
+        assert (
+            "setting the effective jurisdiction-specific value for that delegated slot"
+            in prompt
+        )
+        assert (
+            "derived extraction from the listed authoritative AKN section or sections"
+            in prompt
+        )
         assert "cfr/7/273.9/d/6/iii#snap_standard_utility_allowance" in prompt
         assert "...#*_applies` or `...#*_uses_*" in prompt
         assert (
@@ -8270,7 +8859,10 @@ class TestSourceEval:
             runner_backend="openai",
         )
 
-        assert "For a single fixed-amount source slice, a base case is sufficient." in prompt
+        assert (
+            "For a single fixed-amount source slice, a base case is sufficient."
+            in prompt
+        )
         assert (
             "For a one-row fixed-amount slice with `period: Year`, a base case is sufficient; do not synthesize an `effective_date_boundary` test."
             in prompt
@@ -8289,7 +8881,9 @@ class TestSourceEval:
             is False
         )
 
-    def test_normalize_nonannual_test_period_value_converts_iso_week_to_effective_date(self):
+    def test_normalize_nonannual_test_period_value_converts_iso_week_to_effective_date(
+        self,
+    ):
         assert (
             _normalize_nonannual_test_period_value("2025-W13", date(2025, 3, 21))
             == "2025-03-21"

--- a/tests/test_orchestrator_context.py
+++ b/tests/test_orchestrator_context.py
@@ -356,7 +356,7 @@ class TestCliUsageParsing:
         payload = json.dumps(
             {
                 "type": "result",
-                "result": 'status: encoded\n\ncredit:\n    from 1998-01-01: 1000\n',
+                "result": "status: encoded\n\ncredit:\n    from 1998-01-01: 1000\n",
                 "is_error": False,
                 "total_cost_usd": 0.123,
                 "usage": {
@@ -390,14 +390,16 @@ class TestCliUsageParsing:
                 {
                     "type": "reasoning",
                     "id": "rs_1",
-                    "summary": [{"type": "summary_text", "text": "Need one file only."}],
+                    "summary": [
+                        {"type": "summary_text", "text": "Need one file only."}
+                    ],
                 },
                 {
                     "type": "message",
                     "content": [
                         {
                             "type": "output_text",
-                            "text": 'status: encoded\n\ncredit:\n    from 1998-01-01: 1000\n',
+                            "text": "status: encoded\n\ncredit:\n    from 1998-01-01: 1000\n",
                         }
                     ],
                 },
@@ -447,7 +449,7 @@ class TestCliUsageParsing:
             agent_type="encoder",
             prompt="Encode 26 USC 24(a)",
             phase=Phase.ENCODING,
-            result='status: encoded\n\ncredit:\n    from 1998-01-01: 1000\n',
+            result="status: encoded\n\ncredit:\n    from 1998-01-01: 1000\n",
         )
 
         wrote = openai_orchestrator._materialize_agent_artifact(agent_run, expected)
@@ -509,7 +511,9 @@ class TestPathResolution:
     ):
         monkeypatch.setattr(
             "autorac.harness.orchestrator.find_citation_text",
-            lambda citation, xml_root: "(a) Allowance of credit. Exact subsection text.",
+            lambda citation, xml_root: (
+                "(a) Allowance of credit. Exact subsection text."
+            ),
         )
 
         result = openai_orchestrator._fetch_statute_text("26 USC 24(a)")
@@ -851,7 +855,9 @@ class TestAggregatorWaveInEncoding:
             if compile_calls == 1:
                 return SimpleNamespace(
                     passed=False,
-                    issues=["Compilation failed: line 6, col 18: unexpected token: IDENT"],
+                    issues=[
+                        "Compilation failed: line 6, col 18: unexpected token: IDENT"
+                    ],
                     raw_output=None,
                     error="unexpected token",
                 )
@@ -892,9 +898,8 @@ class TestAggregatorWaveInEncoding:
 class TestOutputPathInference:
     def test_find_statute_root_for_temp_output_path(self, cli_orchestrator):
         output_path = Path("/tmp/autorac-openai-irc24-reencode-v5/26/24")
-        assert (
-            cli_orchestrator._find_statute_root(output_path)
-            == Path("/tmp/autorac-openai-irc24-reencode-v5")
+        assert cli_orchestrator._find_statute_root(output_path) == Path(
+            "/tmp/autorac-openai-irc24-reencode-v5"
         )
 
 
@@ -1020,7 +1025,9 @@ class TestProvenanceLogging:
         cli_orchestrator._log_agent_run("prov-reasoning", agent_run)
 
         events = cli_orchestrator.encoding_db.get_session_events("prov-reasoning")
-        reasoning_event = [e for e in events if e.event_type == "provenance_reasoning"][0]
+        reasoning_event = [e for e in events if e.event_type == "provenance_reasoning"][
+            0
+        ]
         assert reasoning_event.content.startswith("Need to align subsection (a)")
         assert reasoning_event.metadata["provider"] == "openai"
         assert reasoning_event.metadata["backend"] == "codex-cli"

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,48 @@
+"""Smoke tests for the TOML-backed pricing rate loader."""
+
+from __future__ import annotations
+
+from autorac.harness.pricing import (
+    ModelPricing,
+    PricingRates,
+    _load_pricing_rates,
+    get_model_pricing,
+    get_pricing_rates,
+)
+
+
+def test_pricing_rates_load_has_expected_shape():
+    rates = get_pricing_rates()
+    assert isinstance(rates, PricingRates)
+    assert rates.version >= 1
+    assert rates.effective_date  # non-empty string
+    assert rates.models, "pricing_rates.toml should declare at least one model"
+
+    for name, pricing in rates.models.items():
+        assert isinstance(name, str) and name
+        assert isinstance(pricing, ModelPricing)
+        assert pricing.input_per_million >= 0.0
+        assert pricing.output_per_million >= 0.0
+        assert pricing.cache_read_per_million >= 0.0
+        assert pricing.cache_create_per_million >= 0.0
+
+
+def test_known_models_resolve_via_public_api():
+    # The public API must keep working after the TOML extraction.
+    opus = get_model_pricing("opus")
+    assert opus is not None
+    assert opus.input_per_million > 0
+
+    # Prefix matching is part of the existing contract.
+    extended = get_model_pricing("claude-opus-4-6-some-variant")
+    assert extended is not None
+
+
+def test_load_pricing_rates_is_reparseable():
+    # _load_pricing_rates bypasses the cache, so calling twice must still work
+    # and produce structurally identical output.
+    first = _load_pricing_rates()
+    second = _load_pricing_rates()
+    assert first.version == second.version
+    assert first.effective_date == second.effective_date
+    assert set(first.models) == set(second.models)

--- a/tests/test_resolve_externals.py
+++ b/tests/test_resolve_externals.py
@@ -202,7 +202,9 @@ class TestResolveExternalDependencies:
         self, orchestrator, dir_21
     ):
         """Resolver should not clobber an existing file just because a variable is missing."""
-        (dir_21 / "a.rac").write_text("x:\n    imports:\n        - 26/21/b#missing_var\n")
+        (dir_21 / "a.rac").write_text(
+            "x:\n    imports:\n        - 26/21/b#missing_var\n"
+        )
         existing_target = dir_21 / "b.rac"
         existing_target.write_text(
             "# 26 USC 21(b)\nstatus: encoded\nexisting_var:\n    entity: TaxUnit\n"

--- a/tests/test_snap_queue_runner.py
+++ b/tests/test_snap_queue_runner.py
@@ -41,9 +41,7 @@ def test_sha256_paths_ignores_file_names(tmp_path):
     assert left_digest == right_digest
 
 
-def test_iter_manifest_queue_candidates_includes_federal_rac_us(
-    tmp_path, monkeypatch
-):
+def test_iter_manifest_queue_candidates_includes_federal_rac_us(tmp_path, monkeypatch):
     module = load_queue_runner_module()
     autorac_root = tmp_path / "autorac"
     benchmarks = autorac_root / "benchmarks"
@@ -217,7 +215,9 @@ def test_reconcile_stale_running_items_marks_ready_orphan_done(tmp_path):
     assert changed is True
     assert data["items"][0]["status"] == "done"
     assert data["items"][0]["source_tracking_version"] == module.SOURCE_TRACKING_VERSION
-    assert data["items"][0]["note"] == "closed fully ready after orphaned eval completed"
+    assert (
+        data["items"][0]["note"] == "closed fully ready after orphaned eval completed"
+    )
     assert data["event_log"][0]["message"] == (
         "snap_demo was left in `running`, but its output is ready; marked done."
     )

--- a/tests/test_supabase_sync.py
+++ b/tests/test_supabase_sync.py
@@ -30,18 +30,14 @@ from autorac.supabase_sync import (
 class TestGetSupabaseClient:
     def test_missing_url(self):
         with patch.dict(os.environ, {}, clear=True):
-            with pytest.raises(
-                ValueError, match="Missing Supabase write credentials"
-            ):
+            with pytest.raises(ValueError, match="Missing Supabase write credentials"):
                 get_supabase_client()
 
     def test_missing_key(self):
         with patch.dict(
             os.environ, {"RAC_SUPABASE_URL": "https://example.supabase.co"}, clear=True
         ):
-            with pytest.raises(
-                ValueError, match="Missing Supabase write credentials"
-            ):
+            with pytest.raises(ValueError, match="Missing Supabase write credentials"):
                 get_supabase_client()
 
     def test_with_secret_key(self):
@@ -85,9 +81,7 @@ class TestGetSupabaseClient:
             },
             clear=True,
         ):
-            with pytest.raises(
-                ValueError, match="Missing Supabase write credentials"
-            ):
+            with pytest.raises(ValueError, match="Missing Supabase write credentials"):
                 get_supabase_client()
 
 

--- a/tests/test_validator_pipeline.py
+++ b/tests/test_validator_pipeline.py
@@ -3638,13 +3638,16 @@ assessed_income_period_10_2_a_satisfied:
         assert any("Carve-out logic inverted" in issue for issue in issues)
 
     def test_reviewer_no_json_in_output(self, pipeline, temp_rac_file):
-        """Reviewer handles response without JSON."""
+        """Reviewer handles response without JSON via structured parse-failure result."""
         with patch("autorac.harness.validator_pipeline.run_claude_code") as mock_claude:
             mock_claude.return_value = ("No JSON here, just text", 0)
             result = pipeline._run_reviewer("rac-reviewer", temp_rac_file)
             assert result.passed is False
             assert result.score is None
-            assert any("error" in issue.lower() for issue in result.issues)
+            # New behavior: structured reviewer_parse_failed tag + detail message
+            assert "reviewer_parse_failed" in result.issues
+            assert result.error is not None
+            assert "reviewer_parse_failed" in result.error
 
     def test_reviewer_parses_fenced_generalist_json(self, pipeline, temp_rac_file):
         with patch("autorac.harness.validator_pipeline.run_claude_code") as mock_claude:

--- a/tests/test_validator_pipeline.py
+++ b/tests/test_validator_pipeline.py
@@ -105,8 +105,14 @@ def test_generalist_reviewer_prompt_allows_justified_entity_not_supported_fallba
 
 def test_generalist_reviewer_prompt_allows_editorial_omission_and_unavailable_subject_to_imports():
     assert "editorial omission or dotted ellipsis" in GENERALIST_REVIEWER_PROMPT
-    assert "top-level `status: deferred` fallback is acceptable" in GENERALIST_REVIEWER_PROMPT
-    assert "paragraph-specific local inputs can be acceptable" in GENERALIST_REVIEWER_PROMPT
+    assert (
+        "top-level `status: deferred` fallback is acceptable"
+        in GENERALIST_REVIEWER_PROMPT
+    )
+    assert (
+        "paragraph-specific local inputs can be acceptable"
+        in GENERALIST_REVIEWER_PROMPT
+    )
     assert "Prefer imports when available" in GENERALIST_REVIEWER_PROMPT
 
 
@@ -139,16 +145,20 @@ class TestRunClaudeCode:
             assert code == 1
 
     def test_prefers_codex_when_env_requests_it(self):
-        with patch.dict(
-            "os.environ",
-            {"AUTORAC_REVIEWER_CLI": "codex"},
-            clear=False,
-        ), patch(
-            "autorac.harness.validator_pipeline._run_codex_reviewer_cli",
-            return_value=('{"passed": true}', 0),
-        ) as mock_codex, patch(
-            "autorac.harness.validator_pipeline._run_subprocess_with_idle_timeout"
-        ) as mock_run:
+        with (
+            patch.dict(
+                "os.environ",
+                {"AUTORAC_REVIEWER_CLI": "codex"},
+                clear=False,
+            ),
+            patch(
+                "autorac.harness.validator_pipeline._run_codex_reviewer_cli",
+                return_value=('{"passed": true}', 0),
+            ) as mock_codex,
+            patch(
+                "autorac.harness.validator_pipeline._run_subprocess_with_idle_timeout"
+            ) as mock_run,
+        ):
             output, code = run_claude_code("test")
 
         assert output == '{"passed": true}'
@@ -157,11 +167,14 @@ class TestRunClaudeCode:
         mock_run.assert_not_called()
 
     def test_handles_missing_cli(self):
-        with patch(
-            "autorac.harness.validator_pipeline._run_subprocess_with_idle_timeout"
-        ) as mock_run, patch(
-            "autorac.harness.validator_pipeline._run_codex_reviewer_cli",
-            return_value=("Reviewer CLIs not found (missing claude and codex)", 1),
+        with (
+            patch(
+                "autorac.harness.validator_pipeline._run_subprocess_with_idle_timeout"
+            ) as mock_run,
+            patch(
+                "autorac.harness.validator_pipeline._run_codex_reviewer_cli",
+                return_value=("Reviewer CLIs not found (missing claude and codex)", 1),
+            ),
         ):
             mock_run.side_effect = [FileNotFoundError()]
             output, code = run_claude_code("test")
@@ -169,12 +182,18 @@ class TestRunClaudeCode:
             assert code == 1
 
     def test_falls_back_to_codex_when_claude_missing(self):
-        with patch(
-            "autorac.harness.validator_pipeline._run_subprocess_with_idle_timeout"
-        ) as mock_run, patch(
-            "autorac.harness.validator_pipeline._run_codex_reviewer_cli",
-            return_value=('{"score": 8.0, "passed": true, "issues": [], "reasoning": "ok"}', 0),
-        ) as mock_codex:
+        with (
+            patch(
+                "autorac.harness.validator_pipeline._run_subprocess_with_idle_timeout"
+            ) as mock_run,
+            patch(
+                "autorac.harness.validator_pipeline._run_codex_reviewer_cli",
+                return_value=(
+                    '{"score": 8.0, "passed": true, "issues": [], "reasoning": "ok"}',
+                    0,
+                ),
+            ) as mock_codex,
+        ):
             mock_run.side_effect = [FileNotFoundError()]
             output, code = run_claude_code("test prompt", cwd=Path("/tmp"))
             assert '"score": 8.0' in output
@@ -196,11 +215,14 @@ class TestRunClaudeCode:
             def kill(self):
                 self.returncode = -9
 
-        with patch.dict(
-            "os.environ",
-            {"AUTORAC_REVIEWER_CLAUDE_IDLE_TIMEOUT_SECONDS": "0"},
-            clear=False,
-        ), patch("autorac.harness.validator_pipeline.subprocess.Popen", FakePopen):
+        with (
+            patch.dict(
+                "os.environ",
+                {"AUTORAC_REVIEWER_CLAUDE_IDLE_TIMEOUT_SECONDS": "0"},
+                clear=False,
+            ),
+            patch("autorac.harness.validator_pipeline.subprocess.Popen", FakePopen),
+        ):
             output, code = run_claude_code("test prompt", timeout=5)
 
         assert "Timeout after 0s" in output
@@ -227,7 +249,9 @@ class TestRunPeSubprocessDetailed:
         ) as mock_run:
             mock_run.return_value = Mock(output="RESULT:123\n", returncode=0)
 
-            result = pipeline._run_pe_subprocess_detailed("print('RESULT:123')", "python")
+            result = pipeline._run_pe_subprocess_detailed(
+                "print('RESULT:123')", "python"
+            )
 
         assert result.returncode == 0
         assert result.stdout == "RESULT:123\n"
@@ -241,7 +265,9 @@ class TestRunPeSubprocessDetailed:
         ) as mock_run:
             mock_run.side_effect = subprocess.TimeoutExpired(cmd="python", timeout=120)
 
-            result = pipeline._run_pe_subprocess_detailed("print('RESULT:123')", "python")
+            result = pipeline._run_pe_subprocess_detailed(
+                "print('RESULT:123')", "python"
+            )
 
         assert result.returncode == 124
         assert result.stderr == "Timeout after 120s"
@@ -299,11 +325,14 @@ class TestRunPeSubprocessDetailed:
             def kill(self):
                 self.returncode = -9
 
-        with patch.dict(
-            "os.environ",
-            {"AUTORAC_REVIEWER_CODEX_IDLE_TIMEOUT_SECONDS": "0"},
-            clear=False,
-        ), patch("autorac.harness.validator_pipeline.subprocess.Popen", FakePopen):
+        with (
+            patch.dict(
+                "os.environ",
+                {"AUTORAC_REVIEWER_CODEX_IDLE_TIMEOUT_SECONDS": "0"},
+                clear=False,
+            ),
+            patch("autorac.harness.validator_pipeline.subprocess.Popen", FakePopen),
+        ):
             output, code = _run_codex_reviewer_cli("test prompt", timeout=5)
 
         assert "Timeout after 5s" in output
@@ -463,7 +492,9 @@ Both legally obligated and informal child support payments are treated as income
         assert 7.0 not in numbers
         assert 2025.0 not in numbers
 
-    def test_ignores_bulletin_dates_month_periods_and_statewide_restatements_for_grounding(self):
+    def test_ignores_bulletin_dates_month_periods_and_statewide_restatements_for_grounding(
+        self,
+    ):
         numbers = extract_numbers_from_text(
             """
 Texas SNAP telephone standard under MEPD and TW Bulletin 25-15 section 2
@@ -882,7 +913,9 @@ Households with at least one person age 60 or older or disabled: $4,500
         assert 3000.0 in occurrences
         assert 4500.0 in occurrences
 
-    def test_allows_table_label_age_values_for_grounding_without_requiring_scalars(self):
+    def test_allows_table_label_age_values_for_grounding_without_requiring_scalars(
+        self,
+    ):
         numbers = extract_numbers_from_text(
             """
 Table 5: Maximum Asset Limits
@@ -2334,7 +2367,9 @@ size_6_or_more_amount:
 
     def test_ci_allows_schedule_index_helper_scalars(self, pipeline):
         """CI should ignore helper constants that only name schedule row indices."""
-        rac_file = pipeline.rac_us_path / "us" / "snap_standard_deduction_helper_indices.rac"
+        rac_file = (
+            pipeline.rac_us_path / "us" / "snap_standard_deduction_helper_indices.rac"
+        )
         rac_file.parent.mkdir(parents=True, exist_ok=True)
         rac_file.write_text(
             '''
@@ -2417,11 +2452,15 @@ size_6_or_more_amount:
             result = pipeline._run_ci(rac_file)
 
         assert result.passed is True
-        assert not any("missing from source" in issue.lower() for issue in result.issues)
+        assert not any(
+            "missing from source" in issue.lower() for issue in result.issues
+        )
 
     def test_ci_allows_size_segment_schedule_index_literals(self, pipeline):
         """CI should allow schedule-row indices on helpers that contain `_size_`."""
-        rac_file = pipeline.rac_us_path / "us" / "snap_standard_deduction_segment_leaf.rac"
+        rac_file = (
+            pipeline.rac_us_path / "us" / "snap_standard_deduction_segment_leaf.rac"
+        )
         rac_file.parent.mkdir(parents=True, exist_ok=True)
         rac_file.write_text(
             '''
@@ -2501,7 +2540,7 @@ size_6_or_more_amount:
 
     def test_extract_grounding_values_ignores_worded_schedule_index_helpers(self):
         values = extract_grounding_values(
-            '''
+            """
 north_carolina_sua_unit_size_four:
     entity: SnapUnit
     period: Month
@@ -2519,7 +2558,7 @@ north_carolina_sua_unit_size_five_or_more_threshold:
     period: Month
     dtype: Count
     from 2025-01-01: 5
-'''
+"""
         )
 
         assert not any(raw == "4" and value == 4.0 for _, raw, value in values)
@@ -2527,7 +2566,7 @@ north_carolina_sua_unit_size_five_or_more_threshold:
 
     def test_extract_grounding_values_ignores_row_number_schedule_index_helpers(self):
         values = extract_grounding_values(
-            '''
+            """
 nc_tua_unit_size_row_4:
     entity: SnapUnit
     period: Month
@@ -2539,15 +2578,17 @@ nc_tua_unit_size_row_5_or_more_threshold:
     period: Month
     dtype: Count
     from 2025-01-01: 5
-'''
+"""
         )
 
         assert not any(raw == "4" and value == 4.0 for _, raw, value in values)
         assert any(raw == "5" and value == 5.0 for _, raw, value in values)
 
-    def test_extract_grounding_values_ignores_person_worded_schedule_index_helpers(self):
+    def test_extract_grounding_values_ignores_person_worded_schedule_index_helpers(
+        self,
+    ):
         values = extract_grounding_values(
-            '''
+            """
 north_carolina_snap_tua_four_person_unit_size:
     entity: SnapUnit
     period: Month
@@ -2559,7 +2600,7 @@ north_carolina_snap_tua_five_or_more_threshold:
     period: Month
     dtype: Count
     from 2025-01-01: 5
-'''
+"""
         )
 
         assert not any(raw == "4" and value == 4.0 for _, raw, value in values)
@@ -2718,7 +2759,9 @@ assessed_amount_deemed_increase:
         result = pipeline._run_ci(rac_file)
 
         assert result.passed is False
-        assert any("Function-style variable reference" in issue for issue in result.issues)
+        assert any(
+            "Function-style variable reference" in issue for issue in result.issues
+        )
 
     def test_ci_allows_numeric_age_threshold_scalars(self, pipeline):
         """CI should allow substantive age thresholds represented as named scalars."""
@@ -2809,7 +2852,9 @@ qualifying_young_person_4A_1_b:
             result = pipeline._run_ci(rac_file)
 
         assert result.passed is False
-        assert any("Branch-specific output name missing" in issue for issue in result.issues)
+        assert any(
+            "Branch-specific output name missing" in issue for issue in result.issues
+        )
 
     def test_ci_requires_import_for_resolved_defined_term(self, pipeline):
         """CI should fail when a known defined term is modeled locally instead of imported."""
@@ -2885,7 +2930,9 @@ savings_credit_condition:
             ]
             result = pipeline._run_ci(rac_file)
 
-        assert not any("Defined term import missing" in issue for issue in result.issues)
+        assert not any(
+            "Defined term import missing" in issue for issue in result.issues
+        )
 
     def test_ci_requires_import_for_resolved_canonical_concept(self, pipeline):
         """CI should fail when a unique nearby canonical concept exists but is modeled locally."""
@@ -2907,7 +2954,9 @@ is_individual_responsibility_contract:
 '''
         )
 
-        rac_file = pipeline.rac_us_path / "regulation" / "9-CCR-2503-6" / "3.609.1" / "A.rac"
+        rac_file = (
+            pipeline.rac_us_path / "regulation" / "9-CCR-2503-6" / "3.609.1" / "A.rac"
+        )
         rac_file.parent.mkdir(parents=True, exist_ok=True)
         rac_file.write_text(
             '''
@@ -2940,8 +2989,12 @@ individual_responsibility_contract_requirement_satisfied:
             result = pipeline._run_ci(rac_file)
 
         assert result.passed is False
-        assert any("Canonical concept import missing" in issue for issue in result.issues)
-        assert any("individual responsibility contract" in issue for issue in result.issues)
+        assert any(
+            "Canonical concept import missing" in issue for issue in result.issues
+        )
+        assert any(
+            "individual responsibility contract" in issue for issue in result.issues
+        )
 
     def test_ci_allows_import_for_resolved_canonical_concept(self, pipeline):
         """CI should allow a uniquely resolved nearby canonical concept import."""
@@ -2963,7 +3016,9 @@ is_individual_responsibility_contract:
 '''
         )
 
-        rac_file = pipeline.rac_us_path / "regulation" / "9-CCR-2503-6" / "3.609.1" / "A.rac"
+        rac_file = (
+            pipeline.rac_us_path / "regulation" / "9-CCR-2503-6" / "3.609.1" / "A.rac"
+        )
         rac_file.parent.mkdir(parents=True, exist_ok=True)
         rac_file.write_text(
             '''
@@ -2999,7 +3054,9 @@ individual_responsibility_contract_requirement_satisfied:
             ]
             result = pipeline._run_ci(rac_file)
 
-        assert not any("Canonical concept import missing" in issue for issue in result.issues)
+        assert not any(
+            "Canonical concept import missing" in issue for issue in result.issues
+        )
 
     def test_ci_rejects_promoted_stub_when_source_is_ingested(self, pipeline):
         """CI should reject a committed stub once the official source snapshot exists."""
@@ -3052,11 +3109,12 @@ is_assistance_unit:
 
         assert result.passed is False
         assert any(
-            "Promoted RAC stub with ingested source" in issue
-            for issue in result.issues
+            "Promoted RAC stub with ingested source" in issue for issue in result.issues
         )
 
-    def test_ci_rejects_imported_stub_dependency_when_source_is_ingested(self, pipeline):
+    def test_ci_rejects_imported_stub_dependency_when_source_is_ingested(
+        self, pipeline
+    ):
         """CI should reject downstream imports that still point at a promoted stub."""
         target = pipeline.rac_us_path / "statute" / "crs" / "26-2-703" / "2.5.rac"
         target.parent.mkdir(parents=True, exist_ok=True)
@@ -3090,7 +3148,9 @@ is_assistance_unit:
         source_file.parent.mkdir(parents=True, exist_ok=True)
         source_file.write_text("<html>official statute source</html>")
 
-        rac_file = pipeline.rac_us_path / "regulation" / "9-CCR-2503-6" / "3.606.1" / "J.rac"
+        rac_file = (
+            pipeline.rac_us_path / "regulation" / "9-CCR-2503-6" / "3.606.1" / "J.rac"
+        )
         rac_file.parent.mkdir(parents=True, exist_ok=True)
         rac_file.write_text(
             '''
@@ -3132,9 +3192,13 @@ grant_amount_for_assistance_unit:
             for issue in result.issues
         )
 
-    def test_ci_does_not_force_import_for_low_confidence_one_word_concept(self, pipeline):
+    def test_ci_does_not_force_import_for_low_confidence_one_word_concept(
+        self, pipeline
+    ):
         """Generic one-word concepts like `income` should not become required imports."""
-        concept_file = pipeline.rac_us_path / "statute" / "crs" / "26-2-703" / "10.5.rac"
+        concept_file = (
+            pipeline.rac_us_path / "statute" / "crs" / "26-2-703" / "10.5.rac"
+        )
         concept_file.parent.mkdir(parents=True, exist_ok=True)
         concept_file.write_text(
             '''
@@ -3152,7 +3216,9 @@ is_income:
 '''
         )
 
-        rac_file = pipeline.rac_us_path / "regulation" / "9-CCR-2503-6" / "3.605.2" / "X.rac"
+        rac_file = (
+            pipeline.rac_us_path / "regulation" / "9-CCR-2503-6" / "3.605.2" / "X.rac"
+        )
         rac_file.parent.mkdir(parents=True, exist_ok=True)
         rac_file.write_text(
             '''
@@ -3184,9 +3250,13 @@ income_is_considered_for_eligibility:
             ]
             result = pipeline._run_ci(rac_file)
 
-        assert not any("Canonical concept import missing" in issue for issue in result.issues)
+        assert not any(
+            "Canonical concept import missing" in issue for issue in result.issues
+        )
 
-    def test_ci_runs_test_runner_from_flattened_import_workspace(self, pipeline, tmp_path):
+    def test_ci_runs_test_runner_from_flattened_import_workspace(
+        self, pipeline, tmp_path
+    ):
         runner_root = tmp_path / "case" / "codex-gpt-5.4"
         source_dir = runner_root / "source"
         external_dir = runner_root / "external"
@@ -3255,7 +3325,9 @@ grant_standard_for_assistance_unit:
                 )
             raise AssertionError(f"Unexpected subprocess command: {cmd}")
 
-        with patch("autorac.harness.validator_pipeline.subprocess.run", side_effect=fake_run):
+        with patch(
+            "autorac.harness.validator_pipeline.subprocess.run", side_effect=fake_run
+        ):
             result = pipeline._run_ci(rac_file)
 
         assert result.passed is True
@@ -3375,7 +3447,9 @@ snap_state_uses_child_support_deduction:
 '''
         )
 
-        manifest_dir = case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        manifest_dir = (
+            case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        )
         manifest_dir.mkdir(parents=True, exist_ok=True)
         (manifest_dir / "context-manifest.json").write_text(
             json.dumps(
@@ -3471,11 +3545,15 @@ shared_eligibility_flag:
         assert pipeline._infer_title_from_rac_path(rac_file) == "26"
 
     def test_infer_title_from_rac_path_skips_non_statute_eval_layout(self, pipeline):
-        rac_file = pipeline.rac_us_path / "claude-opus" / "source" / "9-CCR-2503-6-3.606.1.rac"
+        rac_file = (
+            pipeline.rac_us_path / "claude-opus" / "source" / "9-CCR-2503-6-3.606.1.rac"
+        )
         assert pipeline._infer_title_from_rac_path(rac_file) is None
 
     def test_ci_skips_cross_statute_rule_for_non_statute_eval_layout(self, pipeline):
-        rac_file = pipeline.rac_us_path / "claude-opus" / "source" / "9-CCR-2503-6-3.606.1.rac"
+        rac_file = (
+            pipeline.rac_us_path / "claude-opus" / "source" / "9-CCR-2503-6-3.606.1.rac"
+        )
         rac_file.parent.mkdir(parents=True, exist_ok=True)
         rac_file.write_text(
             '''
@@ -3583,9 +3661,10 @@ class TestRunReviewer:
             # Verify oracle context was included in prompt
             call_prompt = mock_claude.call_args[0][0]
             assert "POLICYENGINE" in call_prompt
-            assert result.prompt_sha256 == hashlib.sha256(
-                call_prompt.encode("utf-8")
-            ).hexdigest()
+            assert (
+                result.prompt_sha256
+                == hashlib.sha256(call_prompt.encode("utf-8")).hexdigest()
+            )
 
     def test_reviewer_includes_review_context_and_companion_test(
         self, pipeline, temp_rac_file
@@ -3609,7 +3688,9 @@ class TestRunReviewer:
             assert "File: benchmark artifact (.rac)" in call_prompt
             assert str(temp_rac_file) not in call_prompt
 
-    def test_ci_flags_except_where_carve_outs_treated_as_satisfied(self, pipeline, temp_rac_file):
+    def test_ci_flags_except_where_carve_outs_treated_as_satisfied(
+        self, pipeline, temp_rac_file
+    ):
         temp_rac_file.write_text(
             '''"""
 10. The circumstances prescribed are that except where sub-paragraph (b) applies,
@@ -3710,7 +3791,10 @@ assessed_income_period_10_2_a_satisfied:
             assert "senior statutory-fidelity reviewer" in call_prompt
             assert "No semantic compression" in call_prompt
             assert "atomic source slice or branch leaf" in call_prompt
-            assert "Only place substantive statutory-fidelity defects in `blocking_issues`" in call_prompt
+            assert (
+                "Only place substantive statutory-fidelity defects in `blocking_issues`"
+                in call_prompt
+            )
 
     def test_generalist_reviewer_separates_blocking_and_non_blocking_issues(
         self, pipeline, temp_rac_file
@@ -3814,7 +3898,9 @@ class TestFindPePython:
             if python_path == str(env_python):
                 return Mock(stdout="ok", stderr="", returncode=0)
             if python_path == sys.executable:
-                pytest.fail("current interpreter should not be checked before env override")
+                pytest.fail(
+                    "current interpreter should not be checked before env override"
+                )
             return Mock(stdout="", stderr="error", returncode=1)
 
         with patch("autorac.harness.validator_pipeline.subprocess.run") as mock_run:
@@ -3898,12 +3984,16 @@ class TestFindPePython:
 
         with patch("autorac.harness.validator_pipeline.subprocess.run") as mock_run:
             mock_run.side_effect = mock_run_side_effect
-            with patch("autorac.harness.validator_pipeline.Path.home", return_value=tmp_path):
+            with patch(
+                "autorac.harness.validator_pipeline.Path.home", return_value=tmp_path
+            ):
                 result = pipeline._find_pe_python()
 
         assert result == str(worktree_python)
 
-    def test_worktree_venv_preferred_over_policyengine_checkout(self, pipeline, tmp_path):
+    def test_worktree_venv_preferred_over_policyengine_checkout(
+        self, pipeline, tmp_path
+    ):
         worktree_python = (
             tmp_path
             / "worktrees"
@@ -3913,12 +4003,7 @@ class TestFindPePython:
             / "python"
         )
         checkout_python = (
-            tmp_path
-            / "PolicyEngine"
-            / "policyengine-us"
-            / ".venv"
-            / "bin"
-            / "python"
+            tmp_path / "PolicyEngine" / "policyengine-us" / ".venv" / "bin" / "python"
         )
         worktree_python.parent.mkdir(parents=True)
         checkout_python.parent.mkdir(parents=True)
@@ -3930,12 +4015,16 @@ class TestFindPePython:
             if python_path == str(worktree_python):
                 return Mock(stdout="ok", stderr="", returncode=0)
             if python_path == str(checkout_python):
-                pytest.fail("worktree venv should be preferred over PolicyEngine checkout")
+                pytest.fail(
+                    "worktree venv should be preferred over PolicyEngine checkout"
+                )
             return Mock(stdout="", stderr="error", returncode=1)
 
         with patch("autorac.harness.validator_pipeline.subprocess.run") as mock_run:
             mock_run.side_effect = mock_run_side_effect
-            with patch("autorac.harness.validator_pipeline.Path.home", return_value=tmp_path):
+            with patch(
+                "autorac.harness.validator_pipeline.Path.home", return_value=tmp_path
+            ):
                 result = pipeline._find_pe_python()
 
         assert result == str(worktree_python)
@@ -4139,9 +4228,7 @@ eitc:
             with patch.object(
                 pipeline,
                 "_run_pe_subprocess_detailed",
-                return_value=OracleSubprocessResult(
-                    returncode=1, stderr="boom"
-                ),
+                return_value=OracleSubprocessResult(returncode=1, stderr="boom"),
             ):
                 result = pipeline._run_policyengine(rac_file)
                 assert any("failed" in issue.lower() for issue in result.issues)
@@ -4308,9 +4395,7 @@ source_row_amount:
         assert result.score == 1.0
         assert "uc_standard_allowance" in mock_run.call_args[0][0]
 
-    def test_pe_uk_prefers_nested_input_period_and_quotes_year_keys(
-        self, temp_dirs
-    ):
+    def test_pe_uk_prefers_nested_input_period_and_quotes_year_keys(self, temp_dirs):
         rac_us, rac_dir = temp_dirs
         pipeline = ValidatorPipeline(
             rac_us_path=rac_us,
@@ -4361,9 +4446,7 @@ regulation_80A_2_b_ii_applicable_annual_limit:
         assert "'2025': 30" in scenario_script
         assert "int('2025')" in scenario_script
 
-    def test_pe_uk_skips_zero_oracle_cases_for_table_row_amount_slices(
-        self, temp_dirs
-    ):
+    def test_pe_uk_skips_zero_oracle_cases_for_table_row_amount_slices(self, temp_dirs):
         rac_us, rac_dir = temp_dirs
         pipeline = ValidatorPipeline(
             rac_us_path=rac_us,
@@ -4400,9 +4483,7 @@ uc_standard_allowance_single_claimant_aged_under_25:
 
         assert result.score is None
         assert mock_run.call_count == 0
-        assert any(
-            "row-specific zero case" in issue.lower() for issue in result.issues
-        )
+        assert any("row-specific zero case" in issue.lower() for issue in result.issues)
 
     def test_pe_no_expected(self, pipeline, temp_dirs):
         """Tests without expected values are skipped."""
@@ -5081,7 +5162,10 @@ class TestGetPeVariableMap:
             mapping["snap_tanf_non_cash_gross_income_limit_fpg_ratio"]
             == "snap_tanf_non_cash_gross_income_limit_fpg_ratio"
         )
-        assert mapping["snap_tanf_non_cash_asset_limit"] == "snap_tanf_non_cash_asset_limit"
+        assert (
+            mapping["snap_tanf_non_cash_asset_limit"]
+            == "snap_tanf_non_cash_asset_limit"
+        )
         assert (
             mapping["snap_child_support_deduction"]
             == "snap_child_support_gross_income_deduction"
@@ -5093,16 +5177,37 @@ class TestGetPeVariableMap:
 
     def test_uk_child_benefit_leaf_mapping(self, pipeline):
         mapping = pipeline._get_pe_variable_map("uk")
-        assert mapping["child_benefit_enhanced_rate_amount"] == "child_benefit_respective_amount"
-        assert mapping["child_benefit_enhanced_weekly_rate"] == "child_benefit_respective_amount"
-        assert mapping["child_benefit_regulation_2_1_a_amount"] == "child_benefit_respective_amount"
+        assert (
+            mapping["child_benefit_enhanced_rate_amount"]
+            == "child_benefit_respective_amount"
+        )
+        assert (
+            mapping["child_benefit_enhanced_weekly_rate"]
+            == "child_benefit_respective_amount"
+        )
+        assert (
+            mapping["child_benefit_regulation_2_1_a_amount"]
+            == "child_benefit_respective_amount"
+        )
         assert mapping["child_benefit_reg2_1_a"] == "child_benefit_respective_amount"
         assert mapping["child_benefit_weekly_rate"] == "child_benefit_respective_amount"
-        assert mapping["uk_child_benefit_other_child_weekly_rate"] == "child_benefit_respective_amount"
+        assert (
+            mapping["uk_child_benefit_other_child_weekly_rate"]
+            == "child_benefit_respective_amount"
+        )
         assert mapping["child_benefit_reg2_1_b"] == "child_benefit_respective_amount"
-        assert mapping["child_benefit_weekly_rate_other_case"] == "child_benefit_respective_amount"
-        assert mapping["standard_minimum_guarantee_couple_weekly_rate"] == "standard_minimum_guarantee"
-        assert mapping["standard_minimum_guarantee_single_weekly_rate"] == "standard_minimum_guarantee"
+        assert (
+            mapping["child_benefit_weekly_rate_other_case"]
+            == "child_benefit_respective_amount"
+        )
+        assert (
+            mapping["standard_minimum_guarantee_couple_weekly_rate"]
+            == "standard_minimum_guarantee"
+        )
+        assert (
+            mapping["standard_minimum_guarantee_single_weekly_rate"]
+            == "standard_minimum_guarantee"
+        )
 
     def test_pe_monthly_vars(self, pipeline):
         assert "snap" in pipeline._PE_MONTHLY_VARS
@@ -5112,7 +5217,9 @@ class TestGetPeVariableMap:
         assert "snap_standard_utility_allowance" in pipeline._PE_MONTHLY_VARS
         assert "snap_limited_utility_allowance" in pipeline._PE_MONTHLY_VARS
         assert "snap_individual_utility_allowance" in pipeline._PE_MONTHLY_VARS
-        assert "snap_state_using_standard_utility_allowance" in pipeline._PE_MONTHLY_VARS
+        assert (
+            "snap_state_using_standard_utility_allowance" in pipeline._PE_MONTHLY_VARS
+        )
         assert "meets_snap_asset_test" in pipeline._PE_MONTHLY_VARS
         assert "meets_snap_gross_income_test" in pipeline._PE_MONTHLY_VARS
         assert "meets_snap_net_income_test" in pipeline._PE_MONTHLY_VARS
@@ -5304,9 +5411,7 @@ class TestGetPeVariableMap:
 
         assert "'snap_earned_income': {'2022-01': 0}" in script
 
-    def test_build_pe_us_script_maps_snap_net_income_pre_shelter_inputs(
-        self, pipeline
-    ):
+    def test_build_pe_us_script_maps_snap_net_income_pre_shelter_inputs(self, pipeline):
         script = pipeline._build_pe_us_scenario_script(
             "snap_net_income_pre_shelter",
             {
@@ -5327,9 +5432,7 @@ class TestGetPeVariableMap:
         assert "'snap_child_support_deduction': {'2022-01': 20}" in script
         assert "'snap_excess_medical_expense_deduction': {'2022-01': 30}" in script
 
-    def test_build_pe_us_script_maps_direct_pre_shelter_income_synonym(
-        self, pipeline
-    ):
+    def test_build_pe_us_script_maps_direct_pre_shelter_income_synonym(self, pipeline):
         script = pipeline._build_pe_us_scenario_script(
             "snap_net_income_pre_shelter",
             {
@@ -5341,9 +5444,7 @@ class TestGetPeVariableMap:
 
         assert "'snap_net_income_pre_shelter': {'2024-01': 50}" in script
 
-    def test_build_pe_us_script_maps_long_pre_shelter_income_synonym(
-        self, pipeline
-    ):
+    def test_build_pe_us_script_maps_long_pre_shelter_income_synonym(self, pipeline):
         script = pipeline._build_pe_us_scenario_script(
             "snap_net_income_pre_shelter",
             {
@@ -5369,9 +5470,7 @@ class TestGetPeVariableMap:
 
         assert "'snap_net_income_pre_shelter': {'2024-01': 300}" in script
 
-    def test_build_pe_us_script_maps_short_pre_shelter_income_synonym(
-        self, pipeline
-    ):
+    def test_build_pe_us_script_maps_short_pre_shelter_income_synonym(self, pipeline):
         script = pipeline._build_pe_us_scenario_script(
             "snap_net_income_pre_shelter",
             {
@@ -5396,7 +5495,10 @@ class TestGetPeVariableMap:
             "2022",
         )
 
-        assert "'child0': {'age': {'2022': 8}, 'is_tax_unit_dependent': {'2022': True}}" in script
+        assert (
+            "'child0': {'age': {'2022': 8}, 'is_tax_unit_dependent': {'2022': True}}"
+            in script
+        )
         assert "'spm_unit_pre_subsidy_childcare_expenses': {'2022': 600}" in script
 
     def test_build_pe_us_script_annualizes_direct_pre_shelter_dependent_care_deduction(
@@ -5411,7 +5513,10 @@ class TestGetPeVariableMap:
             "2022",
         )
 
-        assert "'child0': {'age': {'2022': 8}, 'is_tax_unit_dependent': {'2022': True}}" in script
+        assert (
+            "'child0': {'age': {'2022': 8}, 'is_tax_unit_dependent': {'2022': True}}"
+            in script
+        )
         assert "'spm_unit_pre_subsidy_childcare_expenses': {'2022': 120}" in script
 
     def test_build_pe_us_script_derives_snap_earned_income_for_pre_shelter_path(
@@ -5504,7 +5609,10 @@ class TestGetPeVariableMap:
 
         assert "CountryTaxBenefitSystem" in script
         assert "system.parameters('2026-01')" in script
-        assert "float(params.gov.usda.snap.income.deductions.self_employment.rate['MD'])" in script
+        assert (
+            "float(params.gov.usda.snap.income.deductions.self_employment.rate['MD'])"
+            in script
+        )
 
     def test_build_pe_us_script_maps_snap_self_employment_simplified_deduction_rate_for_explicit_state(
         self, pipeline
@@ -5515,7 +5623,10 @@ class TestGetPeVariableMap:
             "2026",
         )
 
-        assert "float(params.gov.usda.snap.income.deductions.self_employment.rate['OH'])" in script
+        assert (
+            "float(params.gov.usda.snap.income.deductions.self_employment.rate['OH'])"
+            in script
+        )
 
     def test_build_pe_us_script_maps_snap_standard_medical_expense_deduction(
         self, pipeline
@@ -5593,7 +5704,9 @@ snap_state_uses_child_support_deduction:
 """
         )
 
-        manifest_dir = case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        manifest_dir = (
+            case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        )
         manifest_dir.mkdir(parents=True, exist_ok=True)
         (manifest_dir / "context-manifest.json").write_text(
             json.dumps(
@@ -5647,7 +5760,9 @@ snap_individual_utility_allowance:
 """
         )
 
-        manifest_dir = case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        manifest_dir = (
+            case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        )
         manifest_dir.mkdir(parents=True, exist_ok=True)
         (manifest_dir / "context-manifest.json").write_text(
             json.dumps(
@@ -5669,9 +5784,7 @@ snap_individual_utility_allowance:
             with patch.object(
                 pipeline,
                 "_run_pe_subprocess_detailed",
-                return_value=OracleSubprocessResult(
-                    returncode=0, stdout="RESULT:62\n"
-                ),
+                return_value=OracleSubprocessResult(returncode=0, stdout="RESULT:62\n"),
             ) as mock_run:
                 result = pipeline._run_policyengine(rac_file)
 
@@ -5701,7 +5814,9 @@ snap_self_employment_expense_based_deduction_applies:
 """
         )
 
-        manifest_dir = case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        manifest_dir = (
+            case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        )
         manifest_dir.mkdir(parents=True, exist_ok=True)
         (manifest_dir / "context-manifest.json").write_text(
             json.dumps(
@@ -5753,7 +5868,9 @@ snap_self_employment_simplified_deduction_rate:
 """
         )
 
-        manifest_dir = case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        manifest_dir = (
+            case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        )
         manifest_dir.mkdir(parents=True, exist_ok=True)
         (manifest_dir / "context-manifest.json").write_text(
             json.dumps(
@@ -5805,7 +5922,9 @@ snap_standard_medical_expense_deduction:
 """
         )
 
-        manifest_dir = case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        manifest_dir = (
+            case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        )
         manifest_dir.mkdir(parents=True, exist_ok=True)
         (manifest_dir / "context-manifest.json").write_text(
             json.dumps(
@@ -5857,7 +5976,9 @@ snap_homeless_shelter_deduction_available:
 """
         )
 
-        manifest_dir = case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        manifest_dir = (
+            case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        )
         manifest_dir.mkdir(parents=True, exist_ok=True)
         (manifest_dir / "context-manifest.json").write_text(
             json.dumps(
@@ -5909,7 +6030,9 @@ snap_tanf_non_cash_gross_income_limit_fpg_ratio:
 """
         )
 
-        manifest_dir = case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        manifest_dir = (
+            case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        )
         manifest_dir.mkdir(parents=True, exist_ok=True)
         (manifest_dir / "context-manifest.json").write_text(
             json.dumps(
@@ -5961,7 +6084,9 @@ snap_tanf_non_cash_asset_limit:
 """
         )
 
-        manifest_dir = case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        manifest_dir = (
+            case_root / "_eval_workspaces" / "openai-gpt-5.4" / "leaf" / "workspace"
+        )
         manifest_dir.mkdir(parents=True, exist_ok=True)
         (manifest_dir / "context-manifest.json").write_text(
             json.dumps(
@@ -6407,9 +6532,7 @@ class TestBuildPeScenarioScript:
         assert "else:" in script
         assert "val = float(monthly[target_index]) * 12 / 52" in script
 
-    def test_uk_child_benefit_other_case_false_targets_eldest_person(
-        self, pipeline
-    ):
+    def test_uk_child_benefit_other_case_false_targets_eldest_person(self, pipeline):
         script = pipeline._build_pe_scenario_script(
             "child_benefit_respective_amount",
             {
@@ -6423,9 +6546,7 @@ class TestBuildPeScenarioScript:
         )
         assert "target_index = 0" in script
 
-    def test_uk_child_benefit_other_case_alias_uses_other_child_branch(
-        self, pipeline
-    ):
+    def test_uk_child_benefit_other_case_alias_uses_other_child_branch(self, pipeline):
         script = pipeline._build_pe_scenario_script(
             "child_benefit_respective_amount",
             {
@@ -6461,9 +6582,7 @@ class TestBuildPeScenarioScript:
             in script
         )
 
-    def test_uk_child_benefit_weekly_rate_b_uses_other_child_branch(
-        self, pipeline
-    ):
+    def test_uk_child_benefit_weekly_rate_b_uses_other_child_branch(self, pipeline):
         script = pipeline._build_pe_scenario_script(
             "child_benefit_respective_amount",
             {
@@ -6480,9 +6599,7 @@ class TestBuildPeScenarioScript:
             in script
         )
 
-    def test_uk_child_benefit_not_child_or_qyp_false_uses_adult_target(
-        self, pipeline
-    ):
+    def test_uk_child_benefit_not_child_or_qyp_false_uses_adult_target(self, pipeline):
         script = pipeline._build_pe_scenario_script(
             "child_benefit_respective_amount",
             {
@@ -6535,9 +6652,7 @@ class TestBuildPeScenarioScript:
         assert "weekly = float(annual[0]) / 52" in script
         assert "if scenario_is_couple:" in script
 
-    def test_uk_pension_credit_single_leaf_script_zeros_couple_branch(
-        self, pipeline
-    ):
+    def test_uk_pension_credit_single_leaf_script_zeros_couple_branch(self, pipeline):
         script = pipeline._build_pe_scenario_script(
             "standard_minimum_guarantee",
             {
@@ -6589,9 +6704,7 @@ class TestBuildPeScenarioScript:
         assert "if scenario_is_couple:" in script
         assert "val = weekly" in script
 
-    def test_uk_pension_credit_suffix_a_alias_builds_couple_branch(
-        self, pipeline
-    ):
+    def test_uk_pension_credit_suffix_a_alias_builds_couple_branch(self, pipeline):
         script = pipeline._build_pe_scenario_script(
             "standard_minimum_guarantee",
             {
@@ -6607,9 +6720,7 @@ class TestBuildPeScenarioScript:
         assert "if scenario_is_couple:" in script
         assert "val = 0.0" in script
 
-    def test_uk_pension_credit_suffix_b_alias_builds_single_branch(
-        self, pipeline
-    ):
+    def test_uk_pension_credit_suffix_b_alias_builds_single_branch(self, pipeline):
         script = pipeline._build_pe_scenario_script(
             "standard_minimum_guarantee",
             {
@@ -6737,9 +6848,7 @@ class TestBuildPeScenarioScript:
         assert "'child'" in script
         assert "is_single = True" in script
 
-    def test_uk_benefit_cap_80a_2_b_ii_not_single_claimant_zeros_branch(
-        self, pipeline
-    ):
+    def test_uk_benefit_cap_80a_2_b_ii_not_single_claimant_zeros_branch(self, pipeline):
         script = pipeline._build_pe_scenario_script(
             "benefit_cap",
             {
@@ -6756,9 +6865,7 @@ class TestBuildPeScenarioScript:
         assert "is_single = False" in script
         assert "if is_single and in_london and has_child:" in script
 
-    def test_uk_benefit_cap_80a_2_d_script_supports_household_inputs(
-        self, pipeline
-    ):
+    def test_uk_benefit_cap_80a_2_d_script_supports_household_inputs(self, pipeline):
         script = pipeline._build_pe_scenario_script(
             "benefit_cap",
             {
@@ -6819,9 +6926,7 @@ class TestBuildPeScenarioScript:
         assert "'child'" not in script
         assert "if is_single and not in_london and not has_child:" in script
 
-    def test_uk_benefit_cap_explicit_inputs_override_leaf_heuristics(
-        self, pipeline
-    ):
+    def test_uk_benefit_cap_explicit_inputs_override_leaf_heuristics(self, pipeline):
         script = pipeline._build_pe_scenario_script(
             "benefit_cap",
             {
@@ -6839,9 +6944,7 @@ class TestBuildPeScenarioScript:
         assert "'spouse'" in script
         assert "'child'" in script
 
-    def test_uk_benefit_cap_negated_child_helper_false_means_no_child(
-        self, pipeline
-    ):
+    def test_uk_benefit_cap_negated_child_helper_false_means_no_child(self, pipeline):
         script = pipeline._build_pe_scenario_script(
             "benefit_cap",
             {
@@ -6899,9 +7002,7 @@ class TestBuildPeScenarioScript:
         assert "has_child = False" in script
         assert "if is_single and in_london and not has_child:" in script
 
-    def test_uk_benefit_cap_residency_keys_do_not_imply_joint_claimants(
-        self, pipeline
-    ):
+    def test_uk_benefit_cap_residency_keys_do_not_imply_joint_claimants(self, pipeline):
         script = pipeline._build_pe_scenario_script(
             "benefit_cap",
             {
@@ -6935,9 +7036,7 @@ class TestIsPeTestMappable:
         assert mappable is False
         assert "internal parameter" in reason.lower()
 
-    def test_us_snap_min_allotment_with_renamed_tfp_cost_is_unmappable(
-        self, pipeline
-    ):
+    def test_us_snap_min_allotment_with_renamed_tfp_cost_is_unmappable(self, pipeline):
         mappable, reason = pipeline._is_pe_test_mappable(
             "us",
             "snap_min_allotment",
@@ -7123,9 +7222,7 @@ class TestIsPeTestMappable:
         assert mappable is False
         assert "take-up" in reason.lower()
 
-    def test_uk_child_benefit_non_child_or_qyp_subject_is_unmappable(
-        self, pipeline
-    ):
+    def test_uk_child_benefit_non_child_or_qyp_subject_is_unmappable(self, pipeline):
         mappable, reason = pipeline._is_pe_test_mappable(
             "uk",
             "child_benefit_other_child_weekly_rate",
@@ -7242,8 +7339,14 @@ class TestIsPeTestMappable:
 
 class TestResolvePeVariable:
     def test_resolves_direct_us_snap_variable_names(self, pipeline):
-        assert pipeline._resolve_pe_variable("us", "snap_normal_allotment") == "snap_normal_allotment"
-        assert pipeline._resolve_pe_variable("us", "snap_expected_contribution") == "snap_expected_contribution"
+        assert (
+            pipeline._resolve_pe_variable("us", "snap_normal_allotment")
+            == "snap_normal_allotment"
+        )
+        assert (
+            pipeline._resolve_pe_variable("us", "snap_expected_contribution")
+            == "snap_expected_contribution"
+        )
         assert (
             pipeline._resolve_pe_variable("us", "snap_earned_income_deduction")
             == "snap_earned_income_deduction"
@@ -7252,14 +7355,33 @@ class TestResolvePeVariable:
             pipeline._resolve_pe_variable("us", "snap_net_income_pre_shelter")
             == "snap_net_income_pre_shelter"
         )
-        assert pipeline._resolve_pe_variable("us", "snap_min_allotment") == "snap_min_allotment"
-        assert pipeline._resolve_pe_variable("us", "snap_net_income") == "snap_net_income"
-        assert pipeline._resolve_pe_variable("us", "meets_snap_asset_test") == "meets_snap_asset_test"
-        assert pipeline._resolve_pe_variable("us", "meets_snap_gross_income_test") == "meets_snap_gross_income_test"
-        assert pipeline._resolve_pe_variable("us", "meets_snap_net_income_test") == "meets_snap_net_income_test"
-        assert pipeline._resolve_pe_variable("us", "is_snap_eligible") == "is_snap_eligible"
+        assert (
+            pipeline._resolve_pe_variable("us", "snap_min_allotment")
+            == "snap_min_allotment"
+        )
+        assert (
+            pipeline._resolve_pe_variable("us", "snap_net_income") == "snap_net_income"
+        )
+        assert (
+            pipeline._resolve_pe_variable("us", "meets_snap_asset_test")
+            == "meets_snap_asset_test"
+        )
+        assert (
+            pipeline._resolve_pe_variable("us", "meets_snap_gross_income_test")
+            == "meets_snap_gross_income_test"
+        )
+        assert (
+            pipeline._resolve_pe_variable("us", "meets_snap_net_income_test")
+            == "meets_snap_net_income_test"
+        )
+        assert (
+            pipeline._resolve_pe_variable("us", "is_snap_eligible")
+            == "is_snap_eligible"
+        )
 
-    def test_resolves_uk_child_benefit_enhanced_rate_family_by_substring(self, pipeline):
+    def test_resolves_uk_child_benefit_enhanced_rate_family_by_substring(
+        self, pipeline
+    ):
         assert (
             pipeline._resolve_pe_variable(
                 "uk", "child_benefit_enhanced_rate_paragraph_1_a"
@@ -7281,7 +7403,9 @@ class TestResolvePeVariable:
 
     def test_resolves_uk_child_benefit_other_child_weekly_rate(self, pipeline):
         assert (
-            pipeline._resolve_pe_variable("uk", "uk_child_benefit_other_child_weekly_rate")
+            pipeline._resolve_pe_variable(
+                "uk", "uk_child_benefit_other_child_weekly_rate"
+            )
             == "child_benefit_respective_amount"
         )
 
@@ -7319,7 +7443,9 @@ class TestResolvePeVariable:
         self, pipeline
     ):
         assert (
-            pipeline._resolve_pe_variable("uk", "standard_minimum_guarantee_couple_weekly_rate")
+            pipeline._resolve_pe_variable(
+                "uk", "standard_minimum_guarantee_couple_weekly_rate"
+            )
             == "standard_minimum_guarantee"
         )
 
@@ -7327,7 +7453,9 @@ class TestResolvePeVariable:
         self, pipeline
     ):
         assert (
-            pipeline._resolve_pe_variable("uk", "standard_minimum_guarantee_single_weekly_rate")
+            pipeline._resolve_pe_variable(
+                "uk", "standard_minimum_guarantee_single_weekly_rate"
+            )
             == "standard_minimum_guarantee"
         )
 
@@ -7389,7 +7517,9 @@ class TestResolvePeVariable:
 
     def test_resolves_uk_pc_disabled_child_addition_amount(self, pipeline):
         assert (
-            pipeline._resolve_pe_variable("uk", "pc_disabled_child_addition_weekly_rate")
+            pipeline._resolve_pe_variable(
+                "uk", "pc_disabled_child_addition_weekly_rate"
+            )
             == "child_minimum_guarantee_addition"
         )
 
@@ -7428,7 +7558,10 @@ class TestResolvePeVariable:
         )
 
     def test_resolves_uk_benefit_cap_80a_2_b_amount(self, pipeline):
-        assert pipeline._resolve_pe_variable("uk", "benefit_cap_80A_2_b_amount") == "benefit_cap"
+        assert (
+            pipeline._resolve_pe_variable("uk", "benefit_cap_80A_2_b_amount")
+            == "benefit_cap"
+        )
 
     def test_resolves_uk_benefit_cap_relevant_amount_80a_2_d(self, pipeline):
         assert (
@@ -7444,9 +7577,7 @@ class TestResolvePeVariable:
             == "benefit_cap"
         )
 
-    def test_resolves_uk_benefit_cap_relevant_amount_without_prefix(
-        self, pipeline
-    ):
+    def test_resolves_uk_benefit_cap_relevant_amount_without_prefix(self, pipeline):
         assert (
             pipeline._resolve_pe_variable("uk", "relevant_amount_80A_2_b_ii")
             == "benefit_cap"
@@ -7496,9 +7627,7 @@ class TestResolvePeVariable:
 
     def test_resolves_uk_uc_work_allowance_with_housing_amount(self, pipeline):
         assert (
-            pipeline._resolve_pe_variable(
-                "uk", "uc_work_allowance_with_housing_amount"
-            )
+            pipeline._resolve_pe_variable("uk", "uc_work_allowance_with_housing_amount")
             == "uc_work_allowance"
         )
 
@@ -7512,7 +7641,9 @@ class TestResolvePeVariable:
 
     def test_resolves_uk_uc_non_dep_deduction_amount(self, pipeline):
         assert (
-            pipeline._resolve_pe_variable("uk", "uc_individual_non_dep_deduction_amount")
+            pipeline._resolve_pe_variable(
+                "uk", "uc_individual_non_dep_deduction_amount"
+            )
             == "uc_individual_non_dep_deduction"
         )
 
@@ -7642,7 +7773,10 @@ class TestBuildPeUkAdditionalScenarios:
             rac_var="pc_severe_disability_addition_one_eligible_adult_weekly_rate",
         )
 
-        assert "sim.calculate('severe_disability_minimum_guarantee_addition', int('2025'))" in script
+        assert (
+            "sim.calculate('severe_disability_minimum_guarantee_addition', int('2025'))"
+            in script
+        )
         assert "'attendance_allowance': {'2025': 1}" in script
         assert "'members': ['adult']" in script
         assert "val = float(annual[0]) / 52" in script
@@ -7659,8 +7793,14 @@ class TestBuildPeUkAdditionalScenarios:
             rac_var="pc_severe_disability_addition_two_eligible_adults_weekly_rate",
         )
 
-        assert "sim.calculate('severe_disability_minimum_guarantee_addition', int('2025'))" in script
-        assert "'spouse': {'age': {'2025': 70}, 'attendance_allowance': {'2025': 1}}" in script
+        assert (
+            "sim.calculate('severe_disability_minimum_guarantee_addition', int('2025'))"
+            in script
+        )
+        assert (
+            "'spouse': {'age': {'2025': 70}, 'attendance_allowance': {'2025': 1}}"
+            in script
+        )
         assert "'members': ['adult', 'spouse']" in script
 
     def test_uk_pc_carer_addition_script_builds_carer_case(self, pipeline):
@@ -7673,7 +7813,9 @@ class TestBuildPeUkAdditionalScenarios:
             rac_var="pc_carer_addition_weekly_rate",
         )
 
-        assert "sim.calculate('carer_minimum_guarantee_addition', int('2025'))" in script
+        assert (
+            "sim.calculate('carer_minimum_guarantee_addition', int('2025'))" in script
+        )
         assert "'carers_allowance': {'2025': 1}" in script
         assert "val = float(annual[0]) / 52" in script
 
@@ -7687,7 +7829,10 @@ class TestBuildPeUkAdditionalScenarios:
             rac_var="pc_child_addition_weekly_rate",
         )
 
-        assert "target_sim.calculate('child_minimum_guarantee_addition', int('2025'))" in script
+        assert (
+            "target_sim.calculate('child_minimum_guarantee_addition', int('2025'))"
+            in script
+        )
         assert "'child': {'age': {'2025': 10}}" in script
         assert "val = float(target_annual[0]) / 52" in script
 
@@ -7702,7 +7847,10 @@ class TestBuildPeUkAdditionalScenarios:
         )
 
         assert "'dla': {'2025': 1}" in script
-        assert "base_annual = base_sim.calculate('child_minimum_guarantee_addition', int('2025'))" in script
+        assert (
+            "base_annual = base_sim.calculate('child_minimum_guarantee_addition', int('2025'))"
+            in script
+        )
         assert "val = (float(target_annual[0]) - float(base_annual[0])) / 52" in script
 
     def test_uk_pc_severely_disabled_child_addition_script_subtracts_base_case(
@@ -7732,7 +7880,10 @@ class TestBuildPeUkAdditionalScenarios:
             rac_var="uc_disabled_child_element_amount",
         )
 
-        assert "sim.calculate('uc_individual_disabled_child_element', int('2025'))" in script
+        assert (
+            "sim.calculate('uc_individual_disabled_child_element', int('2025'))"
+            in script
+        )
         assert "'is_disabled_for_benefits': {'2025': True}" in script
         assert "'members': ['child']" in script
         assert "val = float(annual[0]) / 12" in script
@@ -7795,7 +7946,10 @@ class TestBuildPeUkAdditionalScenarios:
             rac_var="uc_maximum_childcare_element_one_child_amount",
         )
 
-        assert "sim.calculate('uc_maximum_childcare_element_amount', int('2025'))" in script
+        assert (
+            "sim.calculate('uc_maximum_childcare_element_amount', int('2025'))"
+            in script
+        )
         assert "'uc_childcare_element_eligible_children': {'2025': 1}" in script
         assert "val = float(annual[0]) / 12" in script
 
@@ -7811,13 +7965,14 @@ class TestBuildPeUkAdditionalScenarios:
             rac_var="uc_maximum_childcare_element_two_or_more_children_amount",
         )
 
-        assert "sim.calculate('uc_maximum_childcare_element_amount', int('2025'))" in script
+        assert (
+            "sim.calculate('uc_maximum_childcare_element_amount', int('2025'))"
+            in script
+        )
         assert "'uc_childcare_element_eligible_children': {'2025': 2}" in script
         assert "val = float(annual[0]) / 12" in script
 
-    def test_uk_uc_non_dep_deduction_script_builds_liable_adult_case(
-        self, pipeline
-    ):
+    def test_uk_uc_non_dep_deduction_script_builds_liable_adult_case(self, pipeline):
         script = pipeline._build_pe_scenario_script(
             "uc_individual_non_dep_deduction",
             {"period": "2025-04-01"},
@@ -7862,9 +8017,7 @@ class TestBuildPeUkAdditionalScenarios:
         assert "'weekly_hours': {'2025': 30}" in script
         assert "'is_disabled_for_benefits': {'2025': True}" in script
 
-    def test_uk_wtc_severely_disabled_element_script_builds_severe_case(
-        self, pipeline
-    ):
+    def test_uk_wtc_severely_disabled_element_script_builds_severe_case(self, pipeline):
         script = pipeline._build_pe_scenario_script(
             "WTC_severely_disabled_element",
             {"period": "2025-04-06"},


### PR DESCRIPTION
Concrete fixes from a stack-wide review. Architectural decisions deliberately deferred for Max's input.

## Fixes

1. **Pricing rates → TOML** (`src/autorac/harness/pricing.py`, `pricing_rates.toml`)
   Model pricing was hardcoded at Feb 2026 rates. Extracted to `pricing_rates.toml` with `version` and `effective_date` fields. Public API unchanged; internal data source swapped. `tests/test_pricing.py` covers shape + loading.

2. **Prompt versioning** (`src/autorac/prompts/encoder.py`, `reviewers.py`)
   Added `__version__` constants and `docs/prompt-versioning.md` covering policy (why, when to bump, interaction with encoding DB).

3. **TODO hygiene** (`src/autorac/harness/encoder_harness.py`, `CHANGELOG.md`)
   Resolved `# TODO: Implement formula` site: tagged as `# TODO(#issue-needed): …` and added a tracked-TODOs section to CHANGELOG.md.

4. **Defensive reviewer-output parsing** (`src/autorac/harness/validator_pipeline.py`)
   Added module logger. `_run_reviewer` now catches JSON parse failures explicitly and returns a structured `reviewer_parse_failed` `ValidationResult` with a `WARNING` log (raw output truncated to 500 chars) rather than letting the generic `except Exception` swallow detail.

5. **26 USC 1 validation-report banner**
   Added a prominent "STATUS: OUTDATED (as of 2026-04-16)" banner noting the report predates the live oracle pipeline. Content unchanged pending a live-oracle refresh.

## Explicitly NOT done (architectural — need decisions)

- **Split cli.py** (3,463 LOC). Needs preferred subcommand structure.
- **Full 26 USC 1 validation refresh** via live oracles. Hours of compute; flag-only.
- **Parser consolidation with rac** — separate repo, separate call.

## Tests

- Pre-existing failures on origin/main: 6 (5 in test_validator_pipeline, 1 in test_evals).
- Failures introduced by this PR: 0 (all pre-existing failures verified with git stash).
- New passing tests: test_pricing.py (3 tests) + updated assertions in test_validator_pipeline.py::TestRunReviewer::test_reviewer_no_json_in_output and test_encoder_harness.py::TestEncode::test_returns_fallback_on_cli_failure.

Generated with Claude Code.
