### PR TITLE
Prefer current RuleSpec repo during validation

### DIFF
--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -5244,17 +5244,17 @@ def _candidate_rulespec_repo_roots(
         else:
             candidates.append(expanded / repo_name)
 
-    env_roots = os.environ.get("AXIOM_RULESPEC_REPO_ROOTS", "")
-    for raw_root in env_roots.split(os.pathsep):
-        if raw_root.strip():
-            add(Path(raw_root.strip()))
-
     if policy_repo_path is not None:
         policy_root = Path(policy_repo_path).resolve()
         add(policy_root)
         add(policy_root.parent / repo_name)
         add(policy_root / "_axiom" / repo_name)
         add(policy_root.parent / "_axiom" / repo_name)
+
+    env_roots = os.environ.get("AXIOM_RULESPEC_REPO_ROOTS", "")
+    for raw_root in env_roots.split(os.pathsep):
+        if raw_root.strip():
+            add(Path(raw_root.strip()))
 
     cwd = Path.cwd()
     add(cwd / repo_name)

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5208,6 +5208,58 @@ rules:
     assert issue is None
 
 
+def test_rulespec_test_reference_prefers_current_repo_over_stale_env_root(
+    monkeypatch,
+    tmp_path,
+):
+    stale_repo = tmp_path / "canonical" / "rulespec-us"
+    stale_file = stale_repo / "regulations" / "7-cfr" / "273" / "10.yaml"
+    stale_file.parent.mkdir(parents=True)
+    stale_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: snap_monthly_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: snap_net_income
+"""
+    )
+
+    current_repo = tmp_path / "workspace" / "rulespec-us"
+    current_file = current_repo / "regulations" / "7-cfr" / "273" / "10.yaml"
+    current_file.parent.mkdir(parents=True)
+    current_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: snap_monthly_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if household_size <= 2: snap_minimum_benefit else: snap_net_income
+"""
+    )
+    monkeypatch.setenv("AXIOM_RULESPEC_REPO_ROOTS", str(stale_repo))
+
+    issue = validator_pipeline._rulespec_absolute_test_reference_issue(
+        "us:regulations/7-cfr/273/10#input.household_size",
+        label="input",
+        policy_repo_path=current_repo,
+        allow_input_slots=True,
+        allow_relations=False,
+        allow_outputs=False,
+    )
+
+    assert issue is None
+
+
 def test_rulespec_ci_rejects_scale_tables_encoded_as_match_literals(tmp_path):
     if not AXIOM_RULES_ENGINE_BINARY.exists():
         pytest.skip("local axiom-rules-engine binary is not built")


### PR DESCRIPTION
## Summary
- Prefer the current policy repo before env-provided canonical RuleSpec roots when resolving absolute RuleSpec references.
- Add a regression for CI validating a PR file while `AXIOM_RULESPEC_REPO_ROOTS` points at stale `rulespec-us@main`.

## Validation
- `uv run pytest tests/test_rulespec_validation.py -q -k stale_env_root`
- `AXIOM_RULESPEC_REPO_ROOTS=/tmp/rulespec-ci-repro/rulespec-us uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/rulespec-us/regulations/7-cfr/273/10.yaml --skip-reviewers`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run pytest tests/test_rulespec_validation.py tests/test_evals.py`