### PR TITLE
Use current RuleSpec roots in test runner

### DIFF
--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1381,6 +1381,7 @@ def cmd_test(args):
         enable_oracles=False,
     )
     binary = pipeline._axiom_rules_binary()
+    rulespec_env = pipeline._rulespec_compile_env()
 
     failures: list[dict[str, str | None]] = []
     case_count = 0
@@ -1393,6 +1394,7 @@ def cmd_test(args):
                 test_file,
                 binary=binary,
                 axiom_rules_path=Path(axiom_rules_path),
+                env=rulespec_env,
                 tmp_path=tmp_path,
                 compiled_cache=compiled_cache,
             )
@@ -1494,6 +1496,7 @@ def _execute_rulespec_test_file(
     *,
     binary: Path,
     axiom_rules_path: Path,
+    env: dict[str, str],
     tmp_path: Path,
     compiled_cache: dict[Path, tuple[Path, dict]],
 ) -> dict:
@@ -1529,6 +1532,7 @@ def _execute_rulespec_test_file(
             text=True,
             timeout=60,
             cwd=str(axiom_rules_path) if axiom_rules_path.exists() else None,
+            env=env,
         )
         if result.returncode != 0:
             return {
@@ -1571,6 +1575,7 @@ def _execute_rulespec_test_file(
                     compiled_path=compiled_path,
                     binary=binary,
                     axiom_rules_path=axiom_rules_path,
+                    env=env,
                     parameter_by_id=parameter_by_id,
                     derived_ids=derived_ids,
                 )
@@ -1605,6 +1610,7 @@ def _execute_rulespec_test_case(
     compiled_path: Path,
     binary: Path,
     axiom_rules_path: Path,
+    env: dict[str, str],
     parameter_by_id: dict[str, dict],
     derived_ids: set[str],
 ) -> list[dict[str, str | None]]:
@@ -1733,6 +1739,7 @@ def _execute_rulespec_test_case(
         text=True,
         timeout=60,
         cwd=str(axiom_rules_path) if axiom_rules_path.exists() else None,
+        env=env,
     )
     if result.returncode != 0:
         failures.append(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1933,6 +1933,79 @@ rules:
         assert output["success"] is False
         assert "expected 16" in output["failures"][0]["message"]
 
+    def test_executes_companion_tests_prefers_current_repo_over_env_root(
+        self, capsys, monkeypatch, tmp_path
+    ):
+        stale_repo = tmp_path / "canonical" / "rulespec-us"
+        stale_child = stale_repo / "statutes/1/child.yaml"
+        stale_child.parent.mkdir(parents=True)
+        stale_child.write_text(
+            """format: rulespec/v1
+rules:
+  - name: child_benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2024-01-01'
+        formula: stale_income + 1
+"""
+        )
+
+        repo = tmp_path / "workspace" / "rulespec-us"
+        child = repo / "statutes/1/child.yaml"
+        child.parent.mkdir(parents=True)
+        child.write_text(
+            """format: rulespec/v1
+rules:
+  - name: child_benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2024-01-01'
+        formula: current_income + 1
+"""
+        )
+        parent = repo / "statutes/1/parent.yaml"
+        parent.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/1/child
+rules:
+  - name: total_benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2024-01-01'
+        formula: child_benefit + 1
+"""
+        )
+        parent.with_name("parent.test.yaml").write_text(
+            """- name: imported_current_child_input
+  period: 2026-01
+  input:
+    us:statutes/1/child#input.current_income: 5
+  output:
+    us:statutes/1/parent#total_benefit: 7
+"""
+        )
+        monkeypatch.setenv("AXIOM_RULESPEC_REPO_ROOTS", str(stale_repo))
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_test(self._args(repo, json_output=True))
+
+        assert exc_info.value.code == 0
+        output = json.loads(capsys.readouterr().out)
+        assert output["success"] is True
+
     def test_discovery_skips_axiom_dependency_tree(self, tmp_path):
         root = tmp_path / "workspace"
         valid_test = root / "statutes/1/1.test.yaml"


### PR DESCRIPTION
## Summary
- Pass the RuleSpec compile environment into `axiom-encode test` compile and execution subprocesses.
- Add an end-to-end companion-test regression where a stale `AXIOM_RULESPEC_REPO_ROOTS` checkout would otherwise shadow the current repo import.

## Validation
- `uv run pytest tests/test_cli.py -q -k 'prefers_current_repo_over_env_root or executes_companion_tests_success_json'`
- `AXIOM_RULESPEC_REPO_ROOTS=/tmp/rulespec-ci-repro/rulespec-us uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/rulespec-us --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine statutes regulations policies`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run pytest tests/test_cli.py tests/test_rulespec_validation.py tests/test_evals.py`