### PR TITLE
Strengthen RuleSpec generation validation

### DIFF
--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -625,6 +625,15 @@ def main():
         ),
     )
     encode_parser.add_argument(
+        "--source-id",
+        default=None,
+        help=(
+            "Optional canonical RuleSpec source identifier to write while reading "
+            "the requested corpus citation as source text. Use when a corpus "
+            "page backs a logical policy file."
+        ),
+    )
+    encode_parser.add_argument(
         "--output",
         type=Path,
         default=Path("/tmp/axiom-encode-encodings"),
@@ -2689,17 +2698,37 @@ def cmd_encode(args):
         print(f"Policy repo not found: {policy_repo_path}")
         sys.exit(1)
 
-    results = run_model_eval(
-        citations=[args.citation],
-        runner_specs=[runner],
-        output_root=args.output,
-        policy_path=policy_repo_path,
-        runtime_axiom_rules_path=axiom_rules_path,
-        corpus_path=corpus_path,
-        mode=args.mode,
-        extra_context_paths=[Path(path) for path in args.allow_context],
-        include_tests=True,
-    )
+    source_id = getattr(args, "source_id", None)
+    source_unit = None
+    if source_id:
+        source_unit = resolve_corpus_source_unit(args.citation, corpus_path)
+        results = run_source_eval(
+            source_id=source_id,
+            source_text=source_unit.body,
+            runner_specs=[runner],
+            output_root=args.output,
+            policy_path=policy_repo_path,
+            source_metadata_payload={
+                "corpus_citation_path": source_unit.citation_path,
+                "corpus_source": source_unit.source,
+                "requested_source": source_unit.requested,
+            },
+            runtime_axiom_rules_path=axiom_rules_path,
+            mode=args.mode,
+            extra_context_paths=[Path(path) for path in args.allow_context],
+        )
+    else:
+        results = run_model_eval(
+            citations=[args.citation],
+            runner_specs=[runner],
+            output_root=args.output,
+            policy_path=policy_repo_path,
+            runtime_axiom_rules_path=axiom_rules_path,
+            corpus_path=corpus_path,
+            mode=args.mode,
+            extra_context_paths=[Path(path) for path in args.allow_context],
+            include_tests=True,
+        )
 
     result = results[0]
     print(f"Output root: {args.output}")
@@ -2708,6 +2737,9 @@ def cmd_encode(args):
     print(f"Policy repo: {policy_repo_path}")
     print(f"Runner: {runner}")
     print(f"Mode: {args.mode}")
+    if source_unit is not None:
+        print(f"Corpus source: {source_unit.citation_path} ({source_unit.source})")
+        print(f"RuleSpec source id: {source_id}")
     print()
     print(f"{result.citation} [{result.runner}]")
     apply_requested = getattr(args, "apply", False) is True

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2617,6 +2617,14 @@ Import and context rules:
 - Copied context listings include exported symbols as `import_target#name`; use
   those exact references in `imports:` and proof atoms when composing from context.
 - In formulas, reference imported exports by their bare local rule name after adding an `imports:` entry; never write an absolute `us:...#rule_name` reference inside a formula.
+- When source text cites a section or subsection and a copied context file for
+  that citation is listed, import and use the listed exported symbol from that
+  context instead of creating a local `section_...` or `subsection_...`
+  placeholder. For example, if a source references a deduction allowed by
+  section 163(a) and context lists `us:statutes/26/163/a#interest_deduction`,
+  import that exact export and use `interest_deduction`; a local fact such as
+  `section_163_a_deduction_attributable_to_section_163_h_4_A_exception` is
+  invalid.
 - If this target is an aggregate parent provision and copied child-fragment files
   already encode subparagraphs, import those child outputs and compose them.
   Do not redefine the child parameters, helper rules, or copied executable

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1600,7 +1600,23 @@ def _parenthetical_marker_context_is_structural(text: str, marker_start: int) ->
     previous = prefix.rstrip()[-1:] if prefix.rstrip() else ""
     if previous == ")":
         return False
-    return _NONSTRUCTURAL_PARENTHETICAL_REFERENCE_PREFIX.search(prefix) is None
+    if _NONSTRUCTURAL_PARENTHETICAL_REFERENCE_PREFIX.search(prefix):
+        return False
+    return not _parenthetical_marker_is_in_reference_list(prefix)
+
+
+def _parenthetical_marker_is_in_reference_list(prefix: str) -> bool:
+    segment = re.split(r"(?:[.;]\s+|\n+)", prefix)[-1]
+    if not re.search(
+        r"\b(?:paragraph|subparagraph|clause|subclause|section|subsection|"
+        r"chapter|title|part|item|sentence|regulation)\b",
+        segment,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    if not re.search(r"\([A-Za-z0-9]+\)", segment):
+        return False
+    return re.search(r"(?:,\s*|\b(?:or|and)\s+)$", segment) is not None
 
 
 def _sibling_parenthetical_marker_pattern(

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2886,6 +2886,12 @@ RuleSpec requirements:
 - Do not create derived `dtype: Boolean` helper rules with logical formulas. Use `dtype: Judgment` for derived legal predicates, or leave simple local facts as factual `{target_ref_prefix + "#input.<fact>" if target_ref_prefix else "<jurisdiction>:<path>#input.<fact>"}` keys consumed by formulas and tests.
 - Use `unit: USD`, `unit: GBP`, or another explicit unit for money outputs when the source states a currency.
 - Put each rule's formulas under `versions: - effective_from: 'YYYY-MM-DD'` and `formula: |-`.
+- Do not encode legal effective dates as `dtype: String` parameters or date
+  literal formulas such as `2025-01-01`. Axiom formulas have no date literal type.
+  Use `effective_from` metadata for version timing, or use a
+  source-stated boolean predicate such as
+  `taxable_year_begins_after_2024_and_before_2029` when a date window is a
+  runtime condition.
 - Do not emit more than one `versions:` entry for `kind: derived`; the runtime does not yet support period-selecting versioned formulas. Use a single source-faithful conditional formula when the provision itself defines a temporal branch, or encode only the currently applicable provision after resolving the source context.
 - Formula strings use Axiom formula syntax: `if condition: value else: other`, `==` for equality, `and`/`or` for booleans, decimal ratios for percentages, and no Python inline ternary syntax.
 - Supported scalar functions are `min(...)`, `max(...)`, `floor(x)`, and `ceil(x)`. Do not use Python-only functions such as `round(...)`; express nearest-multiple rounding as `floor((x / multiple) + 0.5) * multiple` for nonnegative amounts.
@@ -2922,6 +2928,10 @@ RuleSpec requirements:
 - Use concrete ISO calendar dates like `2025-03-21` for day-level tests; do not use ISO week strings like `2025-W13`.
 - Any substantive numeric literal in a formula must either appear in `./source.txt` or be one of -1, 0, 1, 2, or 3.
 - Every substantive numeric occurrence in `./source.txt` must be represented by a named scalar definition in RuleSpec when it is a legal amount, rate, threshold, cap, or limit.
+- If you encode a substantive numeric literal, `module.summary` or the rule's proof excerpt
+  must include the exact source phrase containing that number. Do not omit a
+  subsection, table row, or clause that grounds an encoded
+  numeric amount, rate, threshold, cap, or limit.
 - Represent every substantive source amount, rate, threshold, cap, or limit as a named `parameter` rule, then reference that parameter from derived formulas.
 - If the same numeric value appears twice in materially different legal roles, including separate numbered exceptions or subparagraphs, give those roles distinct named scalars; otherwise reuse that named scalar everywhere the rule compares against or computes with that number.
 - Adjacent bracket thresholds repeated as both an upper bound and the next bracket's lower bound are separate source-stated legal roles; define distinct semantic scalars for those occurrences and use them in the branch conditions.

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2845,6 +2845,16 @@ RuleSpec requirements:
 - Do not emit more than one `versions:` entry for `kind: derived`; the runtime does not yet support period-selecting versioned formulas. Use a single source-faithful conditional formula when the provision itself defines a temporal branch, or encode only the currently applicable provision after resolving the source context.
 - Formula strings use Axiom formula syntax: `if condition: value else: other`, `==` for equality, `and`/`or` for booleans, decimal ratios for percentages, and no Python inline ternary syntax.
 - Supported scalar functions are `min(...)`, `max(...)`, `floor(x)`, and `ceil(x)`. Do not use Python-only functions such as `round(...)`; express nearest-multiple rounding as `floor((x / multiple) + 0.5) * multiple` for nonnegative amounts.
+- US tax `filing_status` is a structural enum: 0 single, 1 joint return,
+  2 married filing separately, 3 head of household, and 4 surviving spouse /
+  qualifying widow(er). Never encode US tax filing status as string literals
+  such as `"married_filing_jointly"` or as separate boolean facts such as
+  `married_filing_jointly`, `head_of_household`, or `surviving_spouse`.
+  Formulas and tests must use the numeric `filing_status` enum input directly,
+  e.g. `match filing_status: 1 => joint_amount; 4 => joint_amount; ...`, and
+  `.test.yaml` should assign `#input.filing_status: 1` or `4`. If the source
+  groups surviving spouse with joint return, every branch or match that handles
+  status 1 must also handle status 4 in that same branch with the same result.
 - Supported relation aggregators are `len(relation)`,
   `count_where(relation, predicate_fact)`, `sum(relation.amount_fact)`, and
   `sum_where(relation, amount_fact_or_derived, predicate_fact)`. Do not write

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2864,6 +2864,12 @@ RuleSpec requirements:
   concept, not as the current-year value. For IRC section 63(c)(5), use a name
   like `dependent_basic_standard_deduction_statutory_limit`, not
   `dependent_standard_deduction_limit`.
+- When the source rounds an inflation or cost-of-living increase, round the
+  increase before adding it to the base amount unless the source explicitly
+  says to round the final total. Companion tests must assert the rounded
+  increase plus the base, not the unrounded total. For example, with base
+  15750, adjustment 0.1, and a next-lower $50 multiple, the increase is 1550
+  and the total is 17300, not 17325.
 - Do not invent new entities, periods, or dtypes.
 - Allowed `entity:` values are {", ".join(f"`{entity}`" for entity in SUPPORTED_EVAL_ENTITIES)}.
 - Allowed `period:` values are {", ".join(f"`{period}`" for period in SUPPORTED_EVAL_PERIODS)}.

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2915,6 +2915,10 @@ RuleSpec requirements:
 - Use chained `if condition: value else: other_value` expressions; do not use YAML-style `if:` / `then:` / `else:` blocks.
 - Do not append a multiline conditional directly onto another expression, and do not use inline assignment syntax like `:=` inside formula blocks.
 - For `dtype: Rate`, encode percentages as decimal ratios like `0.60` or `0.40`, never as `%` literals.
+- Do not simplify source-stated ratios or fractions into new decimal literals.
+  If the source states `20/200`, encode grounded numerator and denominator
+  parameters and compare with `20 / 200` or with those named parameters; do not
+  emit an ungrounded decimal such as `0.10`.
 - Use concrete ISO calendar dates like `2025-03-21` for day-level tests; do not use ISO week strings like `2025-W13`.
 - Any substantive numeric literal in a formula must either appear in `./source.txt` or be one of -1, 0, 1, 2, or 3.
 - Every substantive numeric occurrence in `./source.txt` must be represented by a named scalar definition in RuleSpec when it is a legal amount, rate, threshold, cap, or limit.

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1588,9 +1588,12 @@ def _slice_legal_text_by_parenthetical_fragment(
     return text[start:end]
 
 
+_NONSTRUCTURAL_PARENTHETICAL_REFERENCE_LABEL = (
+    r"(?:paragraphs?|subparagraphs?|clauses?|subclauses?|sections?|"
+    r"subsections?|chapters?|titles?|parts?|items?|sentences?|regulations?)"
+)
 _NONSTRUCTURAL_PARENTHETICAL_REFERENCE_PREFIX = re.compile(
-    r"\b(?:paragraph|subparagraph|clause|subclause|section|subsection|"
-    r"chapter|title|part|item|sentence|regulation)\s+$",
+    rf"\b{_NONSTRUCTURAL_PARENTHETICAL_REFERENCE_LABEL}\s+$",
     re.IGNORECASE,
 )
 
@@ -1608,8 +1611,7 @@ def _parenthetical_marker_context_is_structural(text: str, marker_start: int) ->
 def _parenthetical_marker_is_in_reference_list(prefix: str) -> bool:
     segment = re.split(r"(?:[.;]\s+|\n+)", prefix)[-1]
     if not re.search(
-        r"\b(?:paragraph|subparagraph|clause|subclause|section|subsection|"
-        r"chapter|title|part|item|sentence|regulation)\b",
+        rf"\b{_NONSTRUCTURAL_PARENTHETICAL_REFERENCE_LABEL}\b",
         segment,
         flags=re.IGNORECASE,
     ):
@@ -2850,6 +2852,13 @@ RuleSpec requirements:
   current-year authority already provides the applicable inflation-adjusted
   parameter. Import the current-year authority unless the task is to encode the
   inflation adjustment formula itself.
+- If a copied current-year authority exports the same concept or output name
+  that the requested statute formula would otherwise create, do not emit a
+  local executable duplicate with that name. Import and use the current-year
+  authority's output, keeping only statute-specific conditions or non-executable
+  `source_relation` records in the statute file. For IRC section 63(c)(5), if
+  Rev. Proc. context already exports `dependent_standard_deduction_limit`, do
+  not recreate it in the statute file.
 - Do not invent new entities, periods, or dtypes.
 - Allowed `entity:` values are {", ".join(f"`{entity}`" for entity in SUPPORTED_EVAL_ENTITIES)}.
 - Allowed `period:` values are {", ".join(f"`{period}`" for period in SUPPORTED_EVAL_PERIODS)}.

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2859,6 +2859,11 @@ RuleSpec requirements:
   `source_relation` records in the statute file. For IRC section 63(c)(5), if
   Rev. Proc. context already exports `dependent_standard_deduction_limit`, do
   not recreate it in the statute file.
+- When the statute states pre-inflation base dollars that a current-year
+  authority adjusts, any local statute output must be named as a statutory/base
+  concept, not as the current-year value. For IRC section 63(c)(5), use a name
+  like `dependent_basic_standard_deduction_statutory_limit`, not
+  `dependent_standard_deduction_limit`.
 - Do not invent new entities, periods, or dtypes.
 - Allowed `entity:` values are {", ".join(f"`{entity}`" for entity in SUPPORTED_EVAL_ENTITIES)}.
 - Allowed `period:` values are {", ".join(f"`{period}`" for period in SUPPORTED_EVAL_PERIODS)}.

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3642,9 +3642,12 @@ def _final_expression_has_zero_floor(expression: str) -> bool:
     compact = re.sub(r"\s+", "", expression).lower()
     if re.match(r"^max\(0(?:\.0+)?,", compact):
         return True
-    return any(
-        _NONNEGATIVE_REDUCTION_FORMULA_PATTERN.search(inner_expression)
-        for inner_expression in _zero_floor_argument_expressions(expression)
+    without_zero_floor_calls = _expression_without_zero_floor_calls(expression)
+    return not _NONNEGATIVE_REDUCTION_FORMULA_PATTERN.search(
+        without_zero_floor_calls
+    ) and any(
+        _NONNEGATIVE_REDUCTION_FORMULA_PATTERN.search(argument)
+        for argument in _zero_floor_argument_expressions(expression)
     )
 
 
@@ -3656,6 +3659,26 @@ _ZERO_FLOOR_CALL_PATTERN = re.compile(
 
 def _zero_floor_argument_expressions(expression: str) -> list[str]:
     argument_expressions: list[str] = []
+    for _start, _end, argument in _zero_floor_call_spans(expression):
+        argument_expressions.append(argument)
+    return argument_expressions
+
+
+def _expression_without_zero_floor_calls(expression: str) -> str:
+    chunks: list[str] = []
+    last_end = 0
+    for start, end, _argument in _zero_floor_call_spans(expression):
+        if start < last_end:
+            continue
+        chunks.append(expression[last_end:start])
+        chunks.append(" zero_floor_result ")
+        last_end = end
+    chunks.append(expression[last_end:])
+    return "".join(chunks)
+
+
+def _zero_floor_call_spans(expression: str) -> list[tuple[int, int, str]]:
+    spans: list[tuple[int, int, str]] = []
     for match in _ZERO_FLOOR_CALL_PATTERN.finditer(expression):
         depth = 1
         index = match.end()
@@ -3666,10 +3689,12 @@ def _zero_floor_argument_expressions(expression: str) -> list[str]:
             elif char == ")":
                 depth -= 1
                 if depth == 0:
-                    argument_expressions.append(expression[match.end() : index])
+                    spans.append(
+                        (match.start(), index + 1, expression[match.end() : index])
+                    )
                     break
             index += 1
-    return argument_expressions
+    return spans
 
 
 def find_zero_branch_test_coverage_issues(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -788,6 +788,9 @@ _ZERO_FLOOR_REDUCTION_ARGUMENT_PATTERN = re.compile(
     r"(?:^|_)(?:income|contribution|reduction)(?:_|\b)",
     flags=re.IGNORECASE,
 )
+_FORMULA_ISO_DATE_LITERAL_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_])\d{4}-\d{2}-\d{2}(?![A-Za-z0-9_])"
+)
 _ZERO_AMOUNT_BRANCH_PATTERN = re.compile(
     r"(?:\bif\b[\s\S]{0,500}:\s*0(?:\.0+)?(?:\s+else\s*:|\s*$))"
     r"|(?:\belse\s*:\s*0(?:\.0+)?(?:\s|$))"
@@ -3598,6 +3601,45 @@ def find_nonnegative_amount_reduction_issues(content: str) -> list[str]:
                 "maximum amount but does not floor the result at zero. Benefit, "
                 "allotment, credit, deduction, allowance, and subsidy outputs must "
                 "use `max(0, ...)` before downstream minimums or eligibility branches."
+            )
+    return issues
+
+
+def find_formula_date_literal_issues(content: str) -> list[str]:
+    """Flag ISO date literals in executable formulas."""
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    issues: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() not in {"parameter", "derived"}:
+            continue
+        name = str(rule.get("name") or "").strip()
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            match = _FORMULA_ISO_DATE_LITERAL_PATTERN.search(formula)
+            if match is None:
+                continue
+            issues.append(
+                "Formula date literal unsupported: "
+                f"`{name}` uses `{match.group(0)}` inside an executable formula. "
+                "Axiom formula syntax has no date literal type; encode effective "
+                "windows with `effective_from` metadata or source-stated boolean "
+                "predicates such as `taxable_year_begins_after_2024_and_before_2029`."
             )
     return issues
 
@@ -7606,6 +7648,7 @@ class ValidatorPipeline:
         issues.extend(find_source_condition_coverage_issues(content))
         issues.extend(find_tax_filing_status_enum_representation_issues(content))
         issues.extend(find_tax_filing_status_surviving_spouse_issues(content))
+        issues.extend(find_formula_date_literal_issues(content))
         issues.extend(find_nonnegative_amount_reduction_issues(content))
         issues.extend(find_relation_aggregate_syntax_issues(content))
         issues.extend(find_role_limited_relation_scope_issues(content))

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3249,6 +3249,76 @@ def find_tax_filing_status_surviving_spouse_issues(content: str) -> list[str]:
     return issues
 
 
+_FILING_STATUS_STRING_VALUE_PATTERN = re.compile(
+    rf"\b{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\s*(?:==|!=)\s*['\"][^'\"]+['\"]"
+    rf"|['\"][^'\"]+['\"]\s*(?:==|!=)\s*{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}",
+    flags=re.IGNORECASE,
+)
+_FILING_STATUS_NAMED_VALUE_PATTERN = re.compile(
+    rf"\b{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\s*(?:==|!=)\s*"
+    r"(?:single|joint|joint_return|married_filing_jointly|married_filing_separately|"
+    r"separate|head_of_household|surviving_spouse|qualifying_widow(?:er)?)\b",
+    flags=re.IGNORECASE,
+)
+_FILING_STATUS_MATCH_NAMED_ARM_PATTERN = re.compile(
+    r"^\s*(?:single|joint|joint_return|married_filing_jointly|"
+    r"married_filing_separately|separate|head_of_household|surviving_spouse|"
+    r"qualifying_widow(?:er)?)\s*=>",
+    flags=re.IGNORECASE | re.MULTILINE,
+)
+
+
+def find_tax_filing_status_enum_representation_issues(content: str) -> list[str]:
+    """Reject string/boolean encodings of the structural US filing-status enum."""
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+
+    issues: list[str] = []
+    for name, kind, formula in _rulespec_rule_formulas(payload):
+        if kind != "derived" or not _US_TAX_FILING_STATUS_NAME_PATTERN.search(formula):
+            continue
+        if (
+            _FILING_STATUS_STRING_VALUE_PATTERN.search(formula)
+            or _FILING_STATUS_NAMED_VALUE_PATTERN.search(formula)
+            or _FILING_STATUS_MATCH_NAMED_ARM_PATTERN.search(formula)
+        ):
+            issues.append(
+                "Filing status must use numeric enum: "
+                f"`{name}` compares `filing_status` to string/named status values. "
+                "Use numeric codes directly: 0 single, 1 joint return, 2 married "
+                "filing separately, 3 head of household, 4 surviving spouse / "
+                "qualifying widow(er)."
+            )
+    return issues
+
+
+def find_tax_filing_status_test_input_issues(test_cases: Any) -> list[str]:
+    """Reject nonnumeric `#input.filing_status` test assignments."""
+    if not isinstance(test_cases, list):
+        return []
+
+    issues: list[str] = []
+    for test_case in test_cases:
+        if not isinstance(test_case, dict):
+            continue
+        test_name = str(test_case.get("name") or "<unnamed>").strip() or "<unnamed>"
+        inputs = test_case.get("input")
+        if not isinstance(inputs, dict):
+            continue
+        for key, value in inputs.items():
+            if _test_reference_fragment(key) != "input.filing_status":
+                continue
+            if isinstance(value, bool) or value not in {0, 1, 2, 3, 4}:
+                issues.append(
+                    "Filing status test input must use numeric enum: "
+                    f"`{test_name}` assigns `{key}: {value}`. Use 0 single, "
+                    "1 joint return, 2 married filing separately, 3 head of "
+                    "household, or 4 surviving spouse / qualifying widow(er)."
+                )
+    return issues
+
+
 def _filing_status_surviving_spouse_branch_issue(
     rule_name: str,
     formula: str,
@@ -7334,6 +7404,7 @@ class ValidatorPipeline:
         issues.extend(find_upstream_placement_issues(content, rules_file=rules_file))
         issues.extend(find_source_verification_issues(content))
         issues.extend(find_source_condition_coverage_issues(content))
+        issues.extend(find_tax_filing_status_enum_representation_issues(content))
         issues.extend(find_tax_filing_status_surviving_spouse_issues(content))
         issues.extend(find_nonnegative_amount_reduction_issues(content))
         issues.extend(find_relation_aggregate_syntax_issues(content))
@@ -7422,6 +7493,7 @@ class ValidatorPipeline:
                             )
                         )
                     issues.extend(find_test_input_assignment_issues(content, payload))
+                    issues.extend(find_tax_filing_status_test_input_issues(payload))
                     issues.extend(find_exception_test_coverage_issues(content, payload))
                     issues.extend(
                         find_zero_branch_test_coverage_issues(content, payload)

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -7440,10 +7440,10 @@ class ValidatorPipeline:
             parameter_outputs: list[str] = []
             for output_name in output_map:
                 output_key = str(output_name)
-                if output_key in derived_by_key:
-                    derived_outputs.append(output_key)
-                elif output_key in parameter_by_key:
+                if output_key in parameter_by_key:
                     parameter_outputs.append(output_key)
+                elif output_key in derived_by_key:
+                    derived_outputs.append(output_key)
                 else:
                     if _RULESPEC_ABSOLUTE_REFERENCE.match(output_key):
                         resolution_issue = _rulespec_absolute_test_reference_issue(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3254,16 +3254,18 @@ _FILING_STATUS_STRING_VALUE_PATTERN = re.compile(
     rf"|['\"][^'\"]+['\"]\s*(?:==|!=)\s*{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}",
     flags=re.IGNORECASE,
 )
+_FILING_STATUS_NAMED_VALUE_ALTERNATIVES = (
+    r"single|joint|joint_return|married_filing_jointly|"
+    r"married_filing_separately|separate|head_of_household|surviving_spouse|"
+    r"qualifying_widow(?:er)?"
+)
 _FILING_STATUS_NAMED_VALUE_PATTERN = re.compile(
     rf"\b{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\s*(?:==|!=)\s*"
-    r"(?:single|joint|joint_return|married_filing_jointly|married_filing_separately|"
-    r"separate|head_of_household|surviving_spouse|qualifying_widow(?:er)?)\b",
+    rf"(?:{_FILING_STATUS_NAMED_VALUE_ALTERNATIVES})\b",
     flags=re.IGNORECASE,
 )
 _FILING_STATUS_MATCH_NAMED_ARM_PATTERN = re.compile(
-    r"^\s*(?:single|joint|joint_return|married_filing_jointly|"
-    r"married_filing_separately|separate|head_of_household|surviving_spouse|"
-    r"qualifying_widow(?:er)?)\s*=>",
+    rf"^\s*['\"]?(?:{_FILING_STATUS_NAMED_VALUE_ALTERNATIVES})['\"]?\s*=>",
     flags=re.IGNORECASE | re.MULTILINE,
 )
 
@@ -3346,6 +3348,29 @@ def _filing_status_surviving_spouse_branch_issue(
     if match_blocks:
         return None
 
+    conditional_results = _filing_status_conditional_branch_results(formula)
+    if conditional_results:
+        if 1 in conditional_results and 4 not in conditional_results:
+            return (
+                "Filing status branch missing surviving spouse: "
+                f"`{rule_name}` handles joint-return status code 1 while this source "
+                "mentions surviving spouse or qualifying widow(er), but the formula "
+                "does not handle status code 4 in the same filing-status branch. "
+                "Include code 4 when the source groups surviving spouse with joint "
+                "return, or encode a separate explicit branch."
+            )
+        if (
+            1 in conditional_results
+            and 4 in conditional_results
+            and (conditional_results[1] != conditional_results[4])
+        ):
+            return (
+                "Filing status branch routes surviving spouse to a different result: "
+                f"`{rule_name}` handles joint-return status code 1 and surviving-spouse "
+                "status code 4 with different branch results, but this source groups "
+                "surviving spouse with joint return."
+            )
+
     if _filing_status_has_code_comparison(formula, 1) and not (
         _filing_status_has_grouped_joint_surviving_spouse_condition(formula)
         or _filing_status_has_code_comparison(formula, 4)
@@ -3386,6 +3411,41 @@ def _filing_status_match_blocks(formula: str) -> list[dict[int, str]]:
                 arms[int(branch_match.group(1))] = branch_match.group(2)
         blocks.append(arms)
     return blocks
+
+
+def _filing_status_conditional_branch_results(formula: str) -> dict[int, set[str]]:
+    results: dict[int, set[str]] = {}
+    for raw_line in formula.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        branch = re.match(r"^(?:if|elif)\s+(.+?)\s*:\s*(.+)$", line)
+        if branch is None:
+            continue
+        condition = branch.group(1)
+        expression = re.split(
+            r"\s+else\s*:",
+            branch.group(2).strip(),
+            maxsplit=1,
+            flags=re.IGNORECASE,
+        )[0].strip()
+        if not expression:
+            continue
+        for code in _filing_status_equality_codes_in_condition(condition):
+            results.setdefault(code, set()).add(_normalize_branch_result(expression))
+    return results
+
+
+def _filing_status_equality_codes_in_condition(condition: str) -> set[int]:
+    codes: set[int] = set()
+    for pattern in (
+        rf"\b{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\s*==\s*(\d+)\b",
+        rf"\b(\d+)\s*==\s*{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\b",
+    ):
+        for match in re.finditer(pattern, condition, flags=re.IGNORECASE):
+            with contextlib.suppress(ValueError):
+                codes.add(int(match.group(1)))
+    return codes
 
 
 def _normalize_branch_result(result: str) -> str:
@@ -3497,13 +3557,29 @@ def _formula_result_expressions(formula: str) -> list[str]:
         line = raw_line.strip()
         if not line:
             continue
+        inline_conditional = re.match(
+            r"^(?:if\b.+?|elif\b.+?)\s*:\s*(.+?)\s+else\s*:\s*(.+)$",
+            line,
+            flags=re.IGNORECASE,
+        )
+        if inline_conditional is not None:
+            expressions.append(inline_conditional.group(1).strip())
+            expressions.append(inline_conditional.group(2).strip())
+            continue
         match_arm = re.match(r"^(?:\d+|default|otherwise|_)\s*=>\s*(.+)$", line)
         if match_arm is not None:
             expressions.append(match_arm.group(1).strip())
             continue
         branch = re.match(r"^(?:if\b.+|elif\b.+|else)\s*:\s*(.+)$", line)
         if branch is not None:
-            expressions.append(branch.group(1).strip())
+            expression = re.split(
+                r"\s+else\s*:",
+                branch.group(1).strip(),
+                maxsplit=1,
+                flags=re.IGNORECASE,
+            )[0].strip()
+            if expression:
+                expressions.append(expression)
     if not expressions and formula.strip():
         expressions.append(formula.strip())
     return expressions

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3299,12 +3299,14 @@ def _filing_status_match_has_named_arms(formula: str) -> bool:
     lines = formula.splitlines()
     for index, line in enumerate(lines):
         match = re.match(
-            rf"^(\s*)match\s+{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\s*:\s*$",
+            rf"^(\s*)match\s+{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\s*:\s*(.*)$",
             line,
             flags=re.IGNORECASE,
         )
         if match is None:
             continue
+        if _match_fragment_has_named_arm(match.group(2)):
+            return True
         base_indent = len(match.group(1))
         for branch_line in lines[index + 1 :]:
             if not branch_line.strip():
@@ -3312,9 +3314,17 @@ def _filing_status_match_has_named_arms(formula: str) -> bool:
             branch_indent = len(branch_line) - len(branch_line.lstrip())
             if branch_indent <= base_indent:
                 break
-            if _FILING_STATUS_MATCH_NAMED_ARM_PATTERN.match(branch_line):
+            if _match_fragment_has_named_arm(branch_line):
                 return True
     return False
+
+
+def _match_fragment_has_named_arm(fragment: str) -> bool:
+    return any(
+        _FILING_STATUS_MATCH_NAMED_ARM_PATTERN.match(part)
+        for part in re.split(r";", fragment)
+        if part.strip()
+    )
 
 
 def find_tax_filing_status_test_input_issues(test_cases: Any) -> list[str]:
@@ -3630,7 +3640,36 @@ def _split_inline_conditional_result_expressions(expression: str) -> list[str]:
 
 def _final_expression_has_zero_floor(expression: str) -> bool:
     compact = re.sub(r"\s+", "", expression).lower()
-    return bool(re.match(r"^max\(0(?:\.0+)?,", compact))
+    if re.match(r"^max\(0(?:\.0+)?,", compact):
+        return True
+    return any(
+        _NONNEGATIVE_REDUCTION_FORMULA_PATTERN.search(inner_expression)
+        for inner_expression in _zero_floor_argument_expressions(expression)
+    )
+
+
+_ZERO_FLOOR_CALL_PATTERN = re.compile(
+    r"\bmax\s*\(\s*0(?:\.0+)?\s*,",
+    flags=re.IGNORECASE,
+)
+
+
+def _zero_floor_argument_expressions(expression: str) -> list[str]:
+    argument_expressions: list[str] = []
+    for match in _ZERO_FLOOR_CALL_PATTERN.finditer(expression):
+        depth = 1
+        index = match.end()
+        while index < len(expression):
+            char = expression[index]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    argument_expressions.append(expression[match.end() : index])
+                    break
+            index += 1
+    return argument_expressions
 
 
 def find_zero_branch_test_coverage_issues(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3639,9 +3639,6 @@ def _split_inline_conditional_result_expressions(expression: str) -> list[str]:
 
 
 def _final_expression_has_zero_floor(expression: str) -> bool:
-    compact = re.sub(r"\s+", "", expression).lower()
-    if re.match(r"^max\(0(?:\.0+)?,", compact):
-        return True
     without_zero_floor_calls = _expression_without_zero_floor_calls(expression)
     return not _NONNEGATIVE_REDUCTION_FORMULA_PATTERN.search(
         without_zero_floor_calls

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -774,7 +774,7 @@ _NONNEGATIVE_REDUCTION_AMOUNT_NAME_PATTERN = re.compile(
     flags=re.IGNORECASE,
 )
 _NONNEGATIVE_REDUCTION_FORMULA_PATTERN = re.compile(
-    r"\b[A-Za-z_][A-Za-z0-9_]*(?:max(?:imum)?|maximum)[A-Za-z0-9_]*\b"
+    r"\b(?=[A-Za-z_][A-Za-z0-9_]*\b)(?=[A-Za-z0-9_]*max)[A-Za-z_][A-Za-z0-9_]*\b"
     r"[\s\S]{0,180}-[\s\S]{0,220}"
     r"(?:^|_)(?:income|contribution|reduction)(?:_|\b)",
     flags=re.IGNORECASE,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3283,7 +3283,7 @@ def find_tax_filing_status_enum_representation_issues(content: str) -> list[str]
         if (
             _FILING_STATUS_STRING_VALUE_PATTERN.search(formula)
             or _FILING_STATUS_NAMED_VALUE_PATTERN.search(formula)
-            or _FILING_STATUS_MATCH_NAMED_ARM_PATTERN.search(formula)
+            or _filing_status_match_has_named_arms(formula)
         ):
             issues.append(
                 "Filing status must use numeric enum: "
@@ -3293,6 +3293,28 @@ def find_tax_filing_status_enum_representation_issues(content: str) -> list[str]
                 "qualifying widow(er)."
             )
     return issues
+
+
+def _filing_status_match_has_named_arms(formula: str) -> bool:
+    lines = formula.splitlines()
+    for index, line in enumerate(lines):
+        match = re.match(
+            rf"^(\s*)match\s+{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\s*:\s*$",
+            line,
+            flags=re.IGNORECASE,
+        )
+        if match is None:
+            continue
+        base_indent = len(match.group(1))
+        for branch_line in lines[index + 1 :]:
+            if not branch_line.strip():
+                continue
+            branch_indent = len(branch_line) - len(branch_line.lstrip())
+            if branch_indent <= base_indent:
+                break
+            if _FILING_STATUS_MATCH_NAMED_ARM_PATTERN.match(branch_line):
+                return True
+    return False
 
 
 def find_tax_filing_status_test_input_issues(test_cases: Any) -> list[str]:
@@ -3557,32 +3579,53 @@ def _formula_result_expressions(formula: str) -> list[str]:
         line = raw_line.strip()
         if not line:
             continue
-        inline_conditional = re.match(
-            r"^(?:if\b.+?|elif\b.+?)\s*:\s*(.+?)\s+else\s*:\s*(.+)$",
-            line,
-            flags=re.IGNORECASE,
-        )
+        inline_conditional = _INLINE_CONDITIONAL_RESULT_PATTERN.match(line)
         if inline_conditional is not None:
-            expressions.append(inline_conditional.group(1).strip())
-            expressions.append(inline_conditional.group(2).strip())
+            expressions.extend(_split_inline_conditional_result_expressions(line))
             continue
         match_arm = re.match(r"^(?:\d+|default|otherwise|_)\s*=>\s*(.+)$", line)
         if match_arm is not None:
-            expressions.append(match_arm.group(1).strip())
+            expressions.extend(
+                _split_inline_conditional_result_expressions(match_arm.group(1))
+            )
             continue
         branch = re.match(r"^(?:if\b.+|elif\b.+|else)\s*:\s*(.+)$", line)
         if branch is not None:
-            expression = re.split(
-                r"\s+else\s*:",
-                branch.group(1).strip(),
-                maxsplit=1,
-                flags=re.IGNORECASE,
-            )[0].strip()
-            if expression:
-                expressions.append(expression)
+            expression = _branch_result_expression(branch.group(1).strip())
+            expressions.extend(_split_inline_conditional_result_expressions(expression))
     if not expressions and formula.strip():
         expressions.append(formula.strip())
     return expressions
+
+
+_INLINE_CONDITIONAL_RESULT_PATTERN = re.compile(
+    r"^(?:if\b.+?|elif\b.+?)\s*:\s*(.+?)\s+else\s*:\s*(.+)$",
+    flags=re.IGNORECASE,
+)
+
+
+def _branch_result_expression(branch_tail: str) -> str:
+    if _INLINE_CONDITIONAL_RESULT_PATTERN.match(branch_tail):
+        return branch_tail
+    return re.split(
+        r"\s+else\s*:",
+        branch_tail,
+        maxsplit=1,
+        flags=re.IGNORECASE,
+    )[0].strip()
+
+
+def _split_inline_conditional_result_expressions(expression: str) -> list[str]:
+    expression = expression.strip()
+    if not expression:
+        return []
+    inline_conditional = _INLINE_CONDITIONAL_RESULT_PATTERN.match(expression)
+    if inline_conditional is None:
+        return [expression]
+    return [
+        *(_split_inline_conditional_result_expressions(inline_conditional.group(1))),
+        *(_split_inline_conditional_result_expressions(inline_conditional.group(2))),
+    ]
 
 
 def _final_expression_has_zero_floor(expression: str) -> bool:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -780,7 +780,9 @@ _NONNEGATIVE_REDUCTION_FORMULA_PATTERN = re.compile(
     flags=re.IGNORECASE,
 )
 _ZERO_AMOUNT_BRANCH_PATTERN = re.compile(
-    r"\bif\b[\s\S]{0,500}:\s*0(?:\.0+)?\s+else\s*:",
+    r"(?:\bif\b[\s\S]{0,500}:\s*0(?:\.0+)?(?:\s+else\s*:|\s*$))"
+    r"|(?:\belse\s*:\s*0(?:\.0+)?(?:\s|$))"
+    r"|(?:=>\s*0(?:\.0+)?(?:\s|$))",
     flags=re.IGNORECASE,
 )
 _CARDINAL_WORD_VALUES = {
@@ -3241,16 +3243,112 @@ def find_tax_filing_status_surviving_spouse_issues(content: str) -> list[str]:
     for name, kind, formula in _rulespec_rule_formulas(payload):
         if kind != "derived" or not _US_TAX_FILING_STATUS_NAME_PATTERN.search(formula):
             continue
-        codes = _filing_status_codes_in_formula(formula)
-        if 1 in codes and 4 not in codes:
-            issues.append(
-                "Filing status branch missing surviving spouse: "
-                f"`{name}` handles joint-return status code 1 while this source "
-                "mentions surviving spouse or qualifying widow(er), but the formula "
-                "does not handle status code 4. Include code 4 when the source groups "
-                "surviving spouse with joint return, or encode a separate explicit branch."
-            )
+        branch_issue = _filing_status_surviving_spouse_branch_issue(name, formula)
+        if branch_issue is not None:
+            issues.append(branch_issue)
     return issues
+
+
+def _filing_status_surviving_spouse_branch_issue(
+    rule_name: str,
+    formula: str,
+) -> str | None:
+    match_blocks = _filing_status_match_blocks(formula)
+    for arms in match_blocks:
+        if 1 not in arms:
+            continue
+        if 4 not in arms:
+            return (
+                "Filing status branch missing surviving spouse: "
+                f"`{rule_name}` handles joint-return status code 1 while this source "
+                "mentions surviving spouse or qualifying widow(er), but the formula "
+                "does not handle status code 4 in the same filing-status branch. "
+                "Include code 4 when the source groups surviving spouse with joint "
+                "return, or encode a separate explicit branch."
+            )
+        if _normalize_branch_result(arms[1]) != _normalize_branch_result(arms[4]):
+            return (
+                "Filing status branch routes surviving spouse to a different result: "
+                f"`{rule_name}` handles joint-return status code 1 and surviving-spouse "
+                "status code 4 with different branch results, but this source groups "
+                "surviving spouse with joint return."
+            )
+    if match_blocks:
+        return None
+
+    if _filing_status_has_code_comparison(formula, 1) and not (
+        _filing_status_has_grouped_joint_surviving_spouse_condition(formula)
+        or _filing_status_has_code_comparison(formula, 4)
+    ):
+        return (
+            "Filing status branch missing surviving spouse: "
+            f"`{rule_name}` handles joint-return status code 1 while this source "
+            "mentions surviving spouse or qualifying widow(er), but the formula "
+            "does not handle status code 4. Include code 4 when the source groups "
+            "surviving spouse with joint return, or encode a separate explicit branch."
+        )
+    return None
+
+
+def _filing_status_match_blocks(formula: str) -> list[dict[int, str]]:
+    blocks: list[dict[int, str]] = []
+    lines = formula.splitlines()
+    for index, line in enumerate(lines):
+        match = re.match(
+            rf"^(\s*)match\s+{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\s*:\s*$",
+            line,
+            flags=re.IGNORECASE,
+        )
+        if match is None:
+            continue
+        base_indent = len(match.group(1))
+        arms: dict[int, str] = {}
+        for branch_line in lines[index + 1 :]:
+            if not branch_line.strip():
+                continue
+            branch_indent = len(branch_line) - len(branch_line.lstrip())
+            if branch_indent <= base_indent:
+                break
+            branch_match = re.match(r"^\s*(\d+)\s*=>\s*(.+?)\s*$", branch_line)
+            if branch_match is None:
+                continue
+            with contextlib.suppress(ValueError):
+                arms[int(branch_match.group(1))] = branch_match.group(2)
+        blocks.append(arms)
+    return blocks
+
+
+def _normalize_branch_result(result: str) -> str:
+    return re.sub(r"\s+", "", result.strip().rstrip(",")).lower()
+
+
+def _filing_status_has_code_comparison(formula: str, code: int) -> bool:
+    return bool(
+        re.search(
+            rf"\b{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\s*(?:==|!=|>=|>|<=|<)\s*{code}\b"
+            rf"|\b{code}\s*(?:==|!=|>=|>|<=|<)\s*{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\b",
+            formula,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _filing_status_has_grouped_joint_surviving_spouse_condition(formula: str) -> bool:
+    compact = re.sub(r"\s+", "", formula).lower()
+    for name in ("filing_status", "tax_filing_status"):
+        if re.search(rf"\b{name}in[\[\(\{{]1,4[\]\)\}}]", compact):
+            return True
+        if re.search(rf"\b{name}in[\[\(\{{]4,1[\]\)\}}]", compact):
+            return True
+        if f"{name}==1or{name}==4" in compact:
+            return True
+        if f"{name}==4or{name}==1" in compact:
+            return True
+        if f"1=={name}or4=={name}" in compact:
+            return True
+        if f"4=={name}or1=={name}" in compact:
+            return True
+    return False
 
 
 def _filing_status_codes_in_formula(formula: str) -> set[int]:
@@ -3268,9 +3366,8 @@ def _filing_status_codes_in_formula(formula: str) -> set[int]:
         normalized,
         flags=re.IGNORECASE,
     ):
-        for match in re.finditer(r"\b(\d+)\s*=>", normalized):
-            with contextlib.suppress(ValueError):
-                codes.add(int(match.group(1)))
+        for block in _filing_status_match_blocks(formula):
+            codes.update(block)
     return codes
 
 
@@ -3305,10 +3402,14 @@ def find_nonnegative_amount_reduction_issues(content: str) -> list[str]:
             formula = version.get("formula")
             if not isinstance(formula, str):
                 continue
-            compact = re.sub(r"\s+", "", formula).lower()
-            if "max(0" in compact or "max(0.0" in compact:
-                continue
-            if not _NONNEGATIVE_REDUCTION_FORMULA_PATTERN.search(formula):
+            result_expressions = _formula_result_expressions(formula)
+            unfloored_expressions = [
+                expression
+                for expression in result_expressions
+                if _NONNEGATIVE_REDUCTION_FORMULA_PATTERN.search(expression)
+                and not _final_expression_has_zero_floor(expression)
+            ]
+            if not unfloored_expressions:
                 continue
             issues.append(
                 "Nonnegative amount reduction missing floor: "
@@ -3318,6 +3419,29 @@ def find_nonnegative_amount_reduction_issues(content: str) -> list[str]:
                 "use `max(0, ...)` before downstream minimums or eligibility branches."
             )
     return issues
+
+
+def _formula_result_expressions(formula: str) -> list[str]:
+    expressions: list[str] = []
+    for raw_line in formula.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        match_arm = re.match(r"^(?:\d+|default|otherwise|_)\s*=>\s*(.+)$", line)
+        if match_arm is not None:
+            expressions.append(match_arm.group(1).strip())
+            continue
+        branch = re.match(r"^(?:if\b.+|elif\b.+|else)\s*:\s*(.+)$", line)
+        if branch is not None:
+            expressions.append(branch.group(1).strip())
+    if not expressions and formula.strip():
+        expressions.append(formula.strip())
+    return expressions
+
+
+def _final_expression_has_zero_floor(expression: str) -> bool:
+    compact = re.sub(r"\s+", "", expression).lower()
+    return bool(re.match(r"^max\(0(?:\.0+)?,", compact))
 
 
 def find_zero_branch_test_coverage_issues(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -7826,6 +7826,14 @@ class ValidatorPipeline:
 
     def _extract_import_paths(self, content: str) -> list[str]:
         """Extract import file references from an imports block."""
+        return [
+            item.split("#", 1)[0].strip()
+            for item in self._extract_import_items(content)
+            if item.split("#", 1)[0].strip()
+        ]
+
+    def _extract_import_items(self, content: str) -> list[str]:
+        """Extract raw import items from an imports block."""
         paths: list[str] = []
         in_imports = False
         imports_indent = 0
@@ -7856,9 +7864,9 @@ class ValidatorPipeline:
                 if not mapping_match:
                     continue
                 item = mapping_match.group(2).strip()
-            import_target = item.split("#", 1)[0].strip()
-            if import_target:
-                paths.append(import_target)
+            item = item.strip().strip("\"'")
+            if item:
+                paths.append(item)
 
         return paths
 
@@ -7945,10 +7953,7 @@ class ValidatorPipeline:
             return []
         current_section = self._infer_section_from_rulespec_path(rulespec_file)
 
-        imports = {
-            self._normalize_rulespec_import_path(import_path)
-            for import_path in self._extract_import_paths(content)
-        }
+        import_items = self._extract_import_items(content)
         issues: list[str] = []
         seen: set[tuple[str, str]] = set()
         for block in self._extract_definition_blocks(content):
@@ -7964,7 +7969,12 @@ class ValidatorPipeline:
                 )
                 if not import_base:
                     continue
-                if self._imports_cover_path(imports, import_base):
+                if self._imports_cover_placeholder_identifier(
+                    import_items,
+                    import_base,
+                    identifier,
+                    rulespec_file=rulespec_file,
+                ):
                     continue
                 key = (str(block["name"]), identifier)
                 if key in seen:
@@ -7977,6 +7987,44 @@ class ValidatorPipeline:
                     f"`{import_base}` instead of creating a local cross-reference input."
                 )
         return issues
+
+    def _imports_cover_placeholder_identifier(
+        self,
+        import_items: list[str],
+        expected_path: str,
+        identifier: str,
+        *,
+        rulespec_file: Path,
+    ) -> bool:
+        """Return whether an import covers a cross-reference placeholder symbol."""
+        expected = expected_path.strip("/")
+        for import_item in import_items:
+            normalized = self._normalize_rulespec_import_path(import_item)
+            if not self._imports_cover_path({normalized}, expected):
+                continue
+
+            fragment = self._import_item_fragment(import_item)
+            if fragment == identifier:
+                return True
+
+            import_file = _resolve_rulespec_import_file_static(
+                import_item,
+                rules_file=rulespec_file,
+                policy_repo_path=self.policy_repo_path,
+            )
+            if import_file is None:
+                continue
+            with contextlib.suppress(OSError):
+                if identifier in self._extract_defined_symbols(import_file.read_text()):
+                    return True
+        return False
+
+    def _import_item_fragment(self, import_item: str) -> str | None:
+        """Return the imported symbol fragment for an import item, if any."""
+        if "#" not in import_item:
+            return None
+        fragment = import_item.split("#", 1)[1].strip().strip("\"'")
+        return fragment or None
 
     def _normalize_rulespec_import_path(self, import_path: str) -> str:
         """Normalize a RuleSpec import path for repository-local comparison."""

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -761,6 +761,28 @@ _SCHEDULE_SIZE_CAP_RESTATEMENT_PATTERN = re.compile(
 )
 _SCHEDULE_INDEX_NAME_PATTERN = r"[A-Za-z_]\w*_size(?:_[A-Za-z_]\w*)*"
 _STRUCTURAL_ENUM_INDEX_NAME_PATTERN = r"(?:filing_status|tax_filing_status)"
+_US_TAX_SURVIVING_SPOUSE_TEXT_PATTERN = re.compile(
+    r"(?:^|[^A-Za-z0-9])(?:surviving[\s_-]+spouse|qualifying[\s_-]+widow(?:er)?)\b",
+    flags=re.IGNORECASE,
+)
+_US_TAX_FILING_STATUS_NAME_PATTERN = re.compile(
+    rf"\b{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\b",
+    flags=re.IGNORECASE,
+)
+_NONNEGATIVE_REDUCTION_AMOUNT_NAME_PATTERN = re.compile(
+    r"(?:^|_)(?:allotment|benefit|credit|deduction|allowance|subsidy)(?:_|$)",
+    flags=re.IGNORECASE,
+)
+_NONNEGATIVE_REDUCTION_FORMULA_PATTERN = re.compile(
+    r"\b[A-Za-z_][A-Za-z0-9_]*(?:max(?:imum)?|maximum)[A-Za-z0-9_]*\b"
+    r"[\s\S]{0,180}-[\s\S]{0,220}"
+    r"(?:^|_)(?:income|contribution|reduction)(?:_|\b)",
+    flags=re.IGNORECASE,
+)
+_ZERO_AMOUNT_BRANCH_PATTERN = re.compile(
+    r"\bif\b[\s\S]{0,500}:\s*0(?:\.0+)?\s+else\s*:",
+    flags=re.IGNORECASE,
+)
 _CARDINAL_WORD_VALUES = {
     "zero": 0.0,
     "one": 1.0,
@@ -3207,6 +3229,240 @@ def _rulespec_rule_formulas(payload: dict[str, Any]) -> list[tuple[str, str, str
         (name, kind, formula)
         for name, kind, formula, _source in _rulespec_rule_formula_records(payload)
     ]
+
+
+def find_tax_filing_status_surviving_spouse_issues(content: str) -> list[str]:
+    """Flag filing-status branches that omit surviving spouse when source groups it."""
+    payload = _rulespec_payload(content)
+    if payload is None or not _US_TAX_SURVIVING_SPOUSE_TEXT_PATTERN.search(content):
+        return []
+
+    issues: list[str] = []
+    for name, kind, formula in _rulespec_rule_formulas(payload):
+        if kind != "derived" or not _US_TAX_FILING_STATUS_NAME_PATTERN.search(formula):
+            continue
+        codes = _filing_status_codes_in_formula(formula)
+        if 1 in codes and 4 not in codes:
+            issues.append(
+                "Filing status branch missing surviving spouse: "
+                f"`{name}` handles joint-return status code 1 while this source "
+                "mentions surviving spouse or qualifying widow(er), but the formula "
+                "does not handle status code 4. Include code 4 when the source groups "
+                "surviving spouse with joint return, or encode a separate explicit branch."
+            )
+    return issues
+
+
+def _filing_status_codes_in_formula(formula: str) -> set[int]:
+    codes: set[int] = set()
+    normalized = re.sub(r"\s+", " ", formula)
+    for match in re.finditer(
+        rf"\b{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\s*(?:==|!=|>=|>|<=|<)\s*(\d+)\b",
+        normalized,
+        flags=re.IGNORECASE,
+    ):
+        with contextlib.suppress(ValueError):
+            codes.add(int(match.group(1)))
+    if re.search(
+        rf"\bmatch\s+{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\s*:",
+        normalized,
+        flags=re.IGNORECASE,
+    ):
+        for match in re.finditer(r"\b(\d+)\s*=>", normalized):
+            with contextlib.suppress(ValueError):
+                codes.add(int(match.group(1)))
+    return codes
+
+
+def find_nonnegative_amount_reduction_issues(content: str) -> list[str]:
+    """Flag benefit-style reductions that can fall below zero."""
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    issues: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "derived":
+            continue
+        dtype = str(rule.get("dtype") or "").strip().lower()
+        if dtype not in {"money", "currency", "decimal", "integer", "number"}:
+            continue
+        name = str(rule.get("name") or "").strip()
+        if not _NONNEGATIVE_REDUCTION_AMOUNT_NAME_PATTERN.search(name):
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            compact = re.sub(r"\s+", "", formula).lower()
+            if "max(0" in compact or "max(0.0" in compact:
+                continue
+            if not _NONNEGATIVE_REDUCTION_FORMULA_PATTERN.search(formula):
+                continue
+            issues.append(
+                "Nonnegative amount reduction missing floor: "
+                f"`{name}` subtracts an income/contribution-style reduction from a "
+                "maximum amount but does not floor the result at zero. Benefit, "
+                "allotment, credit, deduction, allowance, and subsidy outputs must "
+                "use `max(0, ...)` before downstream minimums or eligibility branches."
+            )
+    return issues
+
+
+def find_zero_branch_test_coverage_issues(
+    content: str,
+    test_cases: Any,
+) -> list[str]:
+    """Require a companion assertion for source-stated zero amount branches."""
+    if not isinstance(test_cases, list):
+        return []
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    issues: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "derived":
+            continue
+        dtype = str(rule.get("dtype") or "").strip().lower()
+        if dtype in {"judgment", "boolean", "bool"}:
+            continue
+        name = str(rule.get("name") or "").strip()
+        if not name:
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        if not any(
+            isinstance(version, dict)
+            and isinstance(version.get("formula"), str)
+            and _ZERO_AMOUNT_BRANCH_PATTERN.search(version["formula"])
+            for version in versions
+        ):
+            continue
+        if _has_zero_output_test(test_cases, name):
+            continue
+        issues.append(
+            "Zero branch test coverage missing: "
+            f"`{name}` has a formula branch that returns 0, but no companion test "
+            "asserts that output is zero. Add a case that exercises the zero branch "
+            "rather than only above-threshold positive cases."
+        )
+    return issues
+
+
+def _has_zero_output_test(test_cases: list[Any], rule_name: str) -> bool:
+    for test_case in test_cases:
+        if not isinstance(test_case, dict):
+            continue
+        outputs = test_case.get("output")
+        if not isinstance(outputs, dict):
+            continue
+        for key, value in outputs.items():
+            if _test_reference_fragment(key) == rule_name and _is_zero_expected_value(
+                value
+            ):
+                return True
+    return False
+
+
+def _is_zero_expected_value(value: Any) -> bool:
+    if isinstance(value, bool) or value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return float(value) == 0.0
+    if isinstance(value, str):
+        with contextlib.suppress(ValueError):
+            return float(value.strip()) == 0.0
+    if isinstance(value, dict):
+        raw_value = value.get("value")
+        if isinstance(raw_value, dict):
+            return _is_zero_expected_value(raw_value.get("value"))
+        return _is_zero_expected_value(raw_value)
+    return False
+
+
+def find_proof_import_hash_consistency_issues(
+    content: str,
+    *,
+    rules_file: Path,
+    policy_repo_path: Path | None = None,
+) -> list[str]:
+    """Validate proof import hashes against resolved RuleSpec source files."""
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    issues: list[str] = []
+    current_file = Path(rules_file).resolve()
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        rule_name = str(rule.get("name") or "<unknown>").strip() or "<unknown>"
+        proof = _rule_proof_payload(rule)
+        atoms = proof.get("atoms") if isinstance(proof, dict) else None
+        if not isinstance(atoms, list):
+            continue
+        for atom_index, atom in enumerate(atoms):
+            if not isinstance(atom, dict) or not isinstance(atom.get("import"), dict):
+                continue
+            raw_import = atom["import"]
+            target = str(raw_import.get("target") or "").strip()
+            hash_value = str(raw_import.get("hash") or "").strip()
+            target_ref = _parse_rulespec_target(target)
+            if target_ref is None:
+                continue
+            target_file = _resolve_rulespec_target_file(
+                target_ref,
+                policy_repo_path or _rulespec_repo_root(current_file),
+            )
+            if target_file is None or not target_file.exists():
+                continue
+            expected_hash = (
+                "sha256:local"
+                if target_file.resolve() == current_file
+                else f"sha256:{_file_sha256(target_file)}"
+            )
+            if hash_value == expected_hash:
+                continue
+            issues.append(
+                "Proof import hash mismatch: "
+                f"`{rule_name}` proof atom {atom_index} imports `{target}` with "
+                f"`hash: {hash_value or '<missing>'}`, expected `{expected_hash}`."
+            )
+    return issues
+
+
+def _rule_proof_payload(rule: dict[str, Any]) -> dict[str, Any] | None:
+    metadata = rule.get("metadata")
+    if isinstance(metadata, dict) and isinstance(metadata.get("proof"), dict):
+        return metadata["proof"]
+    proof = rule.get("proof")
+    return proof if isinstance(proof, dict) else None
+
+
+def _file_sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
 def _rulespec_data_relation_names(payload: dict[str, Any]) -> set[str]:
@@ -6672,6 +6928,7 @@ class ValidatorPipeline:
             text=True,
             timeout=60,
             cwd=str(self.axiom_rules_path) if self.axiom_rules_path.exists() else None,
+            env=self._rulespec_compile_env(),
         )
         if result.returncode != 0:
             detail = result.stderr.strip() or result.stdout.strip()
@@ -6953,11 +7210,20 @@ class ValidatorPipeline:
         issues.extend(find_upstream_placement_issues(content, rules_file=rules_file))
         issues.extend(find_source_verification_issues(content))
         issues.extend(find_source_condition_coverage_issues(content))
+        issues.extend(find_tax_filing_status_surviving_spouse_issues(content))
+        issues.extend(find_nonnegative_amount_reduction_issues(content))
         issues.extend(find_relation_aggregate_syntax_issues(content))
         issues.extend(find_role_limited_relation_scope_issues(content))
         issues.extend(find_source_limitation_application_issues(content))
         issues.extend(find_broad_application_passthrough_issues(content))
         issues.extend(find_formula_absolute_reference_issues(content))
+        issues.extend(
+            find_proof_import_hash_consistency_issues(
+                content,
+                rules_file=rules_file,
+                policy_repo_path=self.policy_repo_path,
+            )
+        )
         issues.extend(
             find_copied_cross_reference_source_issues(
                 content,
@@ -7033,6 +7299,9 @@ class ValidatorPipeline:
                         )
                     issues.extend(find_test_input_assignment_issues(content, payload))
                     issues.extend(find_exception_test_coverage_issues(content, payload))
+                    issues.extend(
+                        find_zero_branch_test_coverage_issues(content, payload)
+                    )
                     if len(issues) == pre_test_issue_count:
                         issues.extend(
                             self._run_rulespec_test_cases(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -782,6 +782,12 @@ _NONNEGATIVE_REDUCTION_FORMULA_PATTERN = re.compile(
     r"(?:^|_)(?:income|contribution|reduction)(?:_|\b)",
     flags=re.IGNORECASE,
 )
+_ZERO_FLOOR_REDUCTION_ARGUMENT_PATTERN = re.compile(
+    r"\b[A-Za-z_][A-Za-z0-9_]*\b"
+    r"[\s\S]{0,180}-[\s\S]{0,220}"
+    r"(?:^|_)(?:income|contribution|reduction)(?:_|\b)",
+    flags=re.IGNORECASE,
+)
 _ZERO_AMOUNT_BRANCH_PATTERN = re.compile(
     r"(?:\bif\b[\s\S]{0,500}:\s*0(?:\.0+)?(?:\s+else\s*:|\s*$))"
     r"|(?:\belse\s*:\s*0(?:\.0+)?(?:\s|$))"
@@ -3657,6 +3663,7 @@ def _final_expression_has_zero_floor(expression: str) -> bool:
         without_zero_floor_calls
     ) and any(
         _NONNEGATIVE_REDUCTION_FORMULA_PATTERN.search(argument)
+        or _ZERO_FLOOR_REDUCTION_ARGUMENT_PATTERN.search(argument)
         for argument in _zero_floor_argument_expressions(expression)
     )
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -559,6 +559,9 @@ GROUNDING_FORMULA_NUMBER_PATTERN = re.compile(
 SOURCE_TEXT_NUMBER_PATTERN = re.compile(
     r"(?:^|(?<=[\s$£€(\[,]))(-?(?:[\d,]+(?:\.\d+)?|\.\d+))\b"
 )
+SOURCE_TEXT_RATIO_NUMBER_PATTERN = re.compile(
+    r"(?<![\w.])(\d{1,3})\s*/\s*(\d{1,3})(?![\w/])"
+)
 _UNICODE_FRACTION_VALUES = {
     "¼": 0.25,
     "½": 0.5,
@@ -1537,6 +1540,16 @@ def _iter_normalized_special_numeric_matches(
     for match in _SUBPOUND_MONEY_PATTERN.finditer(text):
         with contextlib.suppress(ValueError):
             matches.append((match.span(), float(match.group(1).replace(",", "")) / 100))
+
+    for match in SOURCE_TEXT_RATIO_NUMBER_PATTERN.finditer(text):
+        for group_index in (1, 2):
+            with contextlib.suppress(ValueError):
+                matches.append(
+                    (
+                        match.span(),
+                        float(match.group(group_index).replace(",", "")),
+                    )
+                )
 
     for match in re.finditer(r"(?<=[=+])\s*(-?[\d,]+(?:\.\d+)?)\b", text):
         with contextlib.suppress(ValueError):

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -336,6 +336,12 @@ Hard requirements:
   qualifying widow(er). If the source groups surviving spouse with joint return,
   every filing-status branch or match that handles status 1 must also handle
   status 4 in that same branch.
+- Never encode US tax filing status as string literals such as
+  `"married_filing_jointly"` or as separate boolean facts such as
+  `married_filing_jointly`, `head_of_household`, or `surviving_spouse`.
+  Formulas and tests must use the numeric `filing_status` enum input directly,
+  e.g. `match filing_status: 1 => joint_amount; 4 => joint_amount; ...` and
+  `.test.yaml` should assign `#input.filing_status: 1` or `4`.
 - Every substantive numeric occurrence in `./source.txt` must be represented by
   a named scalar definition when it is a legal amount, rate, threshold, cap, or
   limit.

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -177,6 +177,11 @@ Hard requirements:
   `source_relation` records in the statute file. For IRC section 63(c)(5), if
   Rev. Proc. context already exports `dependent_standard_deduction_limit`, do
   not recreate it in the statute file.
+- When the statute states pre-inflation base dollars that a current-year
+  authority adjusts, any local statute output must be named as a statutory/base
+  concept, not as the current-year value. For IRC section 63(c)(5), use a name
+  like `dependent_basic_standard_deduction_statutory_limit`, not
+  `dependent_standard_deduction_limit`.
 - Use `kind: source_relation` for non-executable legal/provenance edges such as
   `restates`, `sets`, `amends`, `implements`, `delegates`, `defines`, or
   `cites`. It must include `source_relation.type` and

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -24,7 +24,8 @@ Hard requirements:
   do not put imported RuleSpec targets under `source:`. Import proof atoms must
   include `import.target`, `import.output`, and `import.hash` with a listed
   `sha256:` hash; if no `sha256:` hash is provided, do not emit an import proof
-  atom.
+  atom. When the imported proof target is in the same RuleSpec file, use
+  `hash: sha256:local` instead of the file's current content hash.
 - Proof atom `kind` must be one of: `amount`, `condition`, `definition`,
   `default`, `effective_period`, `exception`, `formula`, `import`, `ordering`,
   `parameter`, `parameter_table`, `predicate`, `table_cell`, or `unit`.
@@ -304,6 +305,10 @@ Hard requirements:
   `ceil(x)`. Do not use Python-only functions such as `round(...)`; express
   nearest-multiple rounding as `floor((x / multiple) + 0.5) * multiple` for
   nonnegative amounts.
+- Benefit, allotment, credit, deduction, allowance, and subsidy formulas must
+  never emit negative money. When subtracting an income, contribution, or other
+  reduction from a maximum amount, floor the result with `max(0, ...)` before
+  applying downstream minimum-benefit or issuance branches.
 - Supported relation aggregators are `len(relation)`,
   `count_where(relation, predicate_fact)`, `sum(relation.amount_fact)`, and
   `sum_where(relation, amount_fact_or_derived, predicate_fact)`. Do not write
@@ -326,6 +331,11 @@ Hard requirements:
   compact `not A and not B` line.
 - Formula strings reference indexed parameter tables with `table_name[index_expr]`.
 - Every substantive numeric literal must be grounded in the supplied source text unless it is -1, 0, 1, 2, or 3.
+- US tax `filing_status` is a structural enum: 0 single, 1 joint return,
+  2 married filing separately, 3 head of household, and 4 surviving spouse /
+  qualifying widow(er). If the source groups surviving spouse with joint return,
+  every filing-status branch or match that handles status 1 must also handle
+  status 4 in that same branch.
 - Every substantive numeric occurrence in `./source.txt` must be represented by
   a named scalar definition when it is a legal amount, rate, threshold, cap, or
   limit.
@@ -345,7 +355,9 @@ Hard requirements:
      defaults. If a test asserts an indexed `parameter` table output directly,
      the test must assign every `indexed_by` key as `#input.<key>`; otherwise
      assert the derived lookup output instead of the raw table. In ordinary
-     end-to-end tests, do not output raw indexed parameter tables at all.
+     end-to-end tests, do not output raw indexed parameter tables at all. If a
+     local amount formula has a branch returning 0, include a companion case that
+     asserts that local output is 0.
      For imported modules, only assign imported `#input` or `#relation` keys
      that exist in the current imported RuleSpec context. Do not preserve stale
      imported test inputs from copied files. Do not stub imported derived

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -170,6 +170,13 @@ Hard requirements:
   current-year authority already provides the applicable inflation-adjusted
   parameter. Import the current-year authority unless the task is to encode the
   inflation adjustment formula itself.
+- If a copied current-year authority exports the same concept or output name
+  that the requested statute formula would otherwise create, do not emit a
+  local executable duplicate with that name. Import and use the current-year
+  authority's output, keeping only statute-specific conditions or non-executable
+  `source_relation` records in the statute file. For IRC section 63(c)(5), if
+  Rev. Proc. context already exports `dependent_standard_deduction_limit`, do
+  not recreate it in the statute file.
 - Use `kind: source_relation` for non-executable legal/provenance edges such as
   `restates`, `sets`, `amends`, `implements`, `delegates`, `defines`, or
   `cites`. It must include `source_relation.type` and

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -182,6 +182,12 @@ Hard requirements:
   concept, not as the current-year value. For IRC section 63(c)(5), use a name
   like `dependent_basic_standard_deduction_statutory_limit`, not
   `dependent_standard_deduction_limit`.
+- When the source rounds an inflation or cost-of-living increase, round the
+  increase before adding it to the base amount unless the source explicitly
+  says to round the final total. Companion tests must assert the rounded
+  increase plus the base, not the unrounded total. For example, with base
+  15750, adjustment 0.1, and a next-lower $50 multiple, the increase is 1550
+  and the total is 17300, not 17325.
 - Use `kind: source_relation` for non-executable legal/provenance edges such as
   `restates`, `sets`, `amends`, `implements`, `delegates`, `defines`, or
   `cites`. It must include `source_relation.type` and

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -313,6 +313,12 @@ Hard requirements:
   state-residency input unless the provision itself is encoding a residency
   eligibility test.
 - Put formulas under `versions: - effective_from: 'YYYY-MM-DD'` and `formula: |-`.
+- Do not encode legal effective dates as `dtype: String` parameters or date
+  literal formulas such as `2025-01-01`. Axiom formulas have no date literal type.
+  Use `effective_from` metadata for version timing, or use a
+  source-stated boolean predicate such as
+  `taxable_year_begins_after_2024_and_before_2029` when a date window is a
+  runtime condition.
 - Do not emit more than one `versions:` entry for `kind: derived`; the runtime
   does not yet support period-selecting versioned formulas. Use a single
   source-faithful conditional formula when the provision itself defines a
@@ -349,6 +355,10 @@ Hard requirements:
   compact `not A and not B` line.
 - Formula strings reference indexed parameter tables with `table_name[index_expr]`.
 - Every substantive numeric literal must be grounded in the supplied source text unless it is -1, 0, 1, 2, or 3.
+- If you encode a substantive numeric literal, `module.summary` or the rule's proof excerpt
+  must include the exact source phrase containing that number. Do not omit a
+  subsection, table row, or clause that grounds an encoded
+  numeric amount, rate, threshold, cap, or limit.
 - US tax `filing_status` is a structural enum: 0 single, 1 joint return,
   2 married filing separately, 3 head of household, and 4 surviving spouse /
   qualifying widow(er). If the source groups surviving spouse with joint return,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2548,6 +2548,7 @@ class TestCmdEncode:
         policy_repo_path.mkdir(exist_ok=True)
         args = MagicMock()
         args.citation = overrides.get("citation", "26 USC 1(j)(2)")
+        args.source_id = overrides.get("source_id", None)
         args.output = overrides.get("output", tmp_path / "out")
         args.model = overrides.get("model", "test-model")
         args.backend = overrides.get("backend", "codex")
@@ -2558,6 +2559,8 @@ class TestCmdEncode:
         args.allow_context = overrides.get("allow_context", [])
         args.db = overrides.get("db", tmp_path / "encodings.db")
         args.sync = overrides.get("sync", True)
+        args.apply = overrides.get("apply", False)
+        args.apply_target_only = overrides.get("apply_target_only", False)
         return args
 
     def _make_eval_result(self, success=True):
@@ -2602,6 +2605,60 @@ class TestCmdEncode:
         assert (
             mock_run.call_args.kwargs["runtime_axiom_rules_path"]
             == args.axiom_rules_path
+        )
+
+    def test_encode_with_source_id_uses_corpus_source_unit(self, capsys, tmp_path):
+        args = self._make_args(
+            tmp_path,
+            citation="us/guidance/irs/rev-proc-2025-32/page-18",
+            source_id="us/policies/irs/rev-proc-2025-32/standard-deduction",
+            sync=False,
+        )
+        result = self._make_eval_result(True)
+        result.citation = args.source_id
+
+        with (
+            patch(
+                "axiom_encode.cli.resolve_corpus_source_unit",
+                return_value=SimpleNamespace(
+                    body="standard deduction source text",
+                    citation_path="us/guidance/irs/rev-proc-2025-32/page-18",
+                    source="local",
+                    requested="us/guidance/irs/rev-proc-2025-32/page-18",
+                ),
+            ) as mock_resolve,
+            patch(
+                "axiom_encode.cli.run_source_eval", return_value=[result]
+            ) as mock_run_source,
+            patch("axiom_encode.cli.run_model_eval") as mock_run_model,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        mock_resolve.assert_called_once_with(args.citation, args.corpus_path)
+        mock_run_model.assert_not_called()
+        assert mock_run_source.call_args.kwargs["source_id"] == args.source_id
+        assert (
+            mock_run_source.call_args.kwargs["source_text"]
+            == "standard deduction source text"
+        )
+        assert mock_run_source.call_args.kwargs["runner_specs"] == ["codex:test-model"]
+        assert mock_run_source.call_args.kwargs["policy_path"] == args.policy_repo_path
+        assert (
+            mock_run_source.call_args.kwargs["runtime_axiom_rules_path"]
+            == args.axiom_rules_path
+        )
+        assert mock_run_source.call_args.kwargs["source_metadata_payload"] == {
+            "corpus_citation_path": "us/guidance/irs/rev-proc-2025-32/page-18",
+            "corpus_source": "local",
+            "requested_source": "us/guidance/irs/rev-proc-2025-32/page-18",
+        }
+        output = capsys.readouterr().out
+        assert (
+            "RuleSpec source id: us/policies/irs/rev-proc-2025-32/standard-deduction"
+            in output
         )
 
     def test_encode_with_errors(self, capsys, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ All external dependencies are mocked.
 
 import json
 import os
+import subprocess
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
@@ -2005,6 +2006,112 @@ rules:
         assert exc_info.value.code == 0
         output = json.loads(capsys.readouterr().out)
         assert output["success"] is True
+
+    def test_executes_companion_tests_passes_rulespec_env_to_engine(
+        self, capsys, monkeypatch, tmp_path
+    ):
+        repo = tmp_path / "workspace" / "rulespec-us"
+        rules_file = repo / "statutes/1/1.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2024-01-01'
+        formula: income + 1
+"""
+        )
+        rules_file.with_name("1.test.yaml").write_text(
+            """- name: computes_benefit
+  period: 2026-01
+  input:
+    us:statutes/1/1#input.income: 5
+  output:
+    us:statutes/1/1#benefit: 6
+"""
+        )
+        stale_repo = tmp_path / "stale-rulespec-us"
+        stale_repo.mkdir()
+        monkeypatch.setenv("AXIOM_RULESPEC_REPO_ROOTS", str(stale_repo))
+
+        engine_root = tmp_path / "axiom-rules-engine"
+        binary = engine_root / "target/debug/axiom-rules-engine"
+        captured_envs: list[dict[str, str] | None] = []
+
+        def fake_binary(self):
+            return binary
+
+        def fake_run(cmd, **kwargs):
+            captured_envs.append(kwargs.get("env"))
+            if "compile" in cmd:
+                output_path = Path(cmd[cmd.index("--output") + 1])
+                output_path.write_text(
+                    json.dumps(
+                        {
+                            "program": {
+                                "parameters": [],
+                                "derived": [
+                                    {
+                                        "id": "us:statutes/1/1#benefit",
+                                        "name": "benefit",
+                                    }
+                                ],
+                            }
+                        }
+                    )
+                )
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if "run-compiled" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout=json.dumps(
+                        {
+                            "results": [
+                                {
+                                    "outputs": {
+                                        "us:statutes/1/1#benefit": {
+                                            "kind": "scalar",
+                                            "value": {"kind": "integer", "value": 6},
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ),
+                    stderr="",
+                )
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        args = MagicMock()
+        args.root = repo
+        args.paths = []
+        args.json = True
+        args.axiom_rules_path = engine_root
+
+        monkeypatch.setattr(
+            "axiom_encode.harness.validator_pipeline.ValidatorPipeline._axiom_rules_binary",
+            fake_binary,
+        )
+        monkeypatch.setattr("axiom_encode.cli.subprocess.run", fake_run)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_test(args)
+
+        assert exc_info.value.code == 0
+        assert json.loads(capsys.readouterr().out)["success"] is True
+        assert len(captured_envs) == 2
+        for env in captured_envs:
+            assert env is not None
+            roots = env["AXIOM_RULESPEC_REPO_ROOTS"].split(os.pathsep)
+            assert roots[:2] == [str(repo.resolve()), str(repo.resolve().parent)]
+            assert str(stale_repo) in roots
 
     def test_discovery_skips_axiom_dependency_tree(self, tmp_path):
         root = tmp_path / "workspace"

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -19,6 +19,7 @@ from axiom_encode.harness.backends import (
     EncoderRequest,
     EncoderResponse,
 )
+from axiom_encode.prompts import ENCODER_PROMPT, get_encoder_prompt
 
 
 @pytest.fixture(autouse=True)
@@ -58,6 +59,25 @@ class TestEncoderBackendInterface:
         assert resp.success
         assert "eitc" in resp.rulespec_content
         assert resp.duration_ms == 1500
+
+
+def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
+    prompt = get_encoder_prompt(
+        citation="26 USC 63(c)(5)",
+        output_path="statutes/26/63/c/5.yaml",
+        corpus_citation_path="us/statute/26/63",
+    )
+
+    assert "dependent_basic_standard_deduction_statutory_limit" in ENCODER_PROMPT
+    assert "dependent_standard_deduction_limit" in ENCODER_PROMPT
+    assert "round the" in ENCODER_PROMPT
+    assert "increase before adding it to the base amount" in ENCODER_PROMPT
+    assert "17300, not 17325" in ENCODER_PROMPT
+    assert "dependent_basic_standard_deduction_statutory_limit" in prompt
+    assert "dependent_standard_deduction_limit" in prompt
+    assert "round the" in prompt
+    assert "increase before adding it to the base amount" in prompt
+    assert "17300, not 17325" in prompt
 
 
 class TestClaudeCodeBackend:

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -73,11 +73,15 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "round the" in ENCODER_PROMPT
     assert "increase before adding it to the base amount" in ENCODER_PROMPT
     assert "17300, not 17325" in ENCODER_PROMPT
+    assert "Axiom formulas have no date literal type" in ENCODER_PROMPT
+    assert "module.summary` or the rule's proof excerpt" in ENCODER_PROMPT
     assert "dependent_basic_standard_deduction_statutory_limit" in prompt
     assert "dependent_standard_deduction_limit" in prompt
     assert "round the" in prompt
     assert "increase before adding it to the base amount" in prompt
     assert "17300, not 17325" in prompt
+    assert "Axiom formulas have no date literal type" in prompt
+    assert "module.summary` or the rule's proof excerpt" in prompt
 
 
 class TestClaudeCodeBackend:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3598,6 +3598,9 @@ rules:
         assert "same concept or output name" in prompt
         assert "dependent_standard_deduction_limit" in prompt
         assert "dependent_basic_standard_deduction_statutory_limit" in prompt
+        assert "round the" in prompt
+        assert "increase before adding it to the base amount" in prompt
+        assert "17300, not 17325" in prompt
         assert "says a value is determined `in accordance with section X`" in prompt
         assert "do not invent `import` statements or `imports:` blocks" in prompt
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3366,10 +3366,14 @@ class TestEvalPrompt:
             "Do not invent `dtype: String` variables just to restate the effective date"
             in prompt
         )
+        assert "Axiom formulas have no date literal type" in prompt
+        assert "taxable_year_begins_after_2024_and_before_2029" in prompt
         assert (
             "Do not decompose legal dates into numeric `year`, `month`, or `day` scalar variables"
             in prompt
         )
+        assert "module.summary` or the rule's proof excerpt" in prompt
+        assert "exact source phrase containing that number" in prompt
         assert "`==` for equality" in prompt
 
     def test_prepare_eval_workspace_injects_resolved_defined_term_stub(self, tmp_path):

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3356,6 +3356,8 @@ class TestEvalPrompt:
             "reuse that named scalar everywhere the rule compares against or computes with that number"
             in prompt
         )
+        assert "Do not simplify source-stated ratios or fractions" in prompt
+        assert "ungrounded decimal such as `0.10`" in prompt
         assert (
             'If `./source.txt` says someone is "aged 18 or over", "under 25"' in prompt
         )

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -205,6 +205,43 @@ class TestCorpusSourceResolution:
         assert source.body.startswith("(5) Limitation on basic standard deduction")
         assert "paragraph (2)(B)" not in source.body
 
+    def test_nested_slicing_ignores_plural_parenthetical_cross_reference_list(
+        self, tmp_path
+    ):
+        corpus_path = tmp_path / "axiom-corpus"
+        provisions_dir = (
+            corpus_path / "data" / "corpus" / "provisions" / "us" / "statute"
+        )
+        provisions_dir.mkdir(parents=True)
+        (provisions_dir / "2026-01-01.jsonl").write_text(
+            json.dumps(
+                {
+                    "citation_path": "us/statute/26/63",
+                    "body": (
+                        "(c) Standard deduction "
+                        "(4) Adjustments for inflation Each dollar amount "
+                        "contained in paragraphs (2)(B), (2)(C), or (5) or "
+                        "subsection (f) shall be increased. "
+                        "(5) Limitation on basic standard deduction in the case "
+                        "of certain dependents In the case of an individual with "
+                        "respect to whom a deduction under section 151 is "
+                        "allowable to another taxpayer, the basic standard "
+                        "deduction shall not exceed the greater of— (A) $500, "
+                        "or (B) the sum of $250 and earned income. "
+                        "(6) Certain individuals not eligible."
+                    ),
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        source = resolve_corpus_source_unit("26 USC 63(c)(5)", corpus_path)
+
+        assert source.citation_path == "us/statute/26/63"
+        assert source.body.startswith("(5) Limitation on basic standard deduction")
+        assert "paragraphs (2)(B)" not in source.body
+
     def test_build_prompt_requires_resolved_corpus_locator(self, tmp_path):
         workspace = prepare_eval_workspace(
             citation="26 USC 3101(a)",
@@ -3558,6 +3595,8 @@ rules:
             "emit the upstream import instead of restating the concept locally"
             in prompt
         )
+        assert "same concept or output name" in prompt
+        assert "dependent_standard_deduction_limit" in prompt
         assert "says a value is determined `in accordance with section X`" in prompt
         assert "do not invent `import` statements or `imports:` blocks" in prompt
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3597,6 +3597,7 @@ rules:
         )
         assert "same concept or output name" in prompt
         assert "dependent_standard_deduction_limit" in prompt
+        assert "dependent_basic_standard_deduction_statutory_limit" in prompt
         assert "says a value is determined `in accordance with section X`" in prompt
         assert "do not invent `import` statements or `imports:` blocks" in prompt
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -170,6 +170,41 @@ class TestCorpusSourceResolution:
         assert source.citation_path == "us/statute/7/2015"
         assert source.body == "(C) Student exemption states 20 hours."
 
+    def test_nested_slicing_ignores_parenthetical_cross_reference_list(self, tmp_path):
+        corpus_path = tmp_path / "axiom-corpus"
+        provisions_dir = (
+            corpus_path / "data" / "corpus" / "provisions" / "us" / "statute"
+        )
+        provisions_dir.mkdir(parents=True)
+        (provisions_dir / "2026-01-01.jsonl").write_text(
+            json.dumps(
+                {
+                    "citation_path": "us/statute/26/63",
+                    "body": (
+                        "(c) Standard deduction "
+                        "(4) Adjustments for inflation Each dollar amount "
+                        "contained in paragraph (2)(B), (2)(C), or (5) or "
+                        "subsection (f) shall be increased. "
+                        "(5) Limitation on basic standard deduction in the case "
+                        "of certain dependents In the case of an individual with "
+                        "respect to whom a deduction under section 151 is "
+                        "allowable to another taxpayer, the basic standard "
+                        "deduction shall not exceed the greater of— (A) $500, "
+                        "or (B) the sum of $250 and earned income. "
+                        "(6) Certain individuals not eligible."
+                    ),
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        source = resolve_corpus_source_unit("26 USC 63(c)(5)", corpus_path)
+
+        assert source.citation_path == "us/statute/26/63"
+        assert source.body.startswith("(5) Limitation on basic standard deduction")
+        assert "paragraph (2)(B)" not in source.body
+
     def test_build_prompt_requires_resolved_corpus_locator(self, tmp_path):
         workspace = prepare_eval_workspace(
             citation="26 USC 3101(a)",

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -2302,6 +2302,8 @@ class TestEvalPrompt:
         assert "only one entity type" in prompt
         assert "Do not assert relation-child outputs" in prompt
         assert "Do not use bare year periods like `2024`" in prompt
+        assert "Never encode US tax filing status as string literals" in prompt
+        assert "`#input.filing_status: 1` or `4`" in prompt
 
     def test_build_eval_prompt_for_broad_application_clause_discourages_passthrough_outputs(
         self, tmp_path

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -4763,6 +4763,12 @@ class TestRepoAugmentedContext:
             "In formulas, reference imported exports by their bare local rule name"
             in prompt
         )
+        assert "import and use the listed exported symbol from that" in prompt
+        assert "context instead of creating a local `section_...`" in prompt
+        assert (
+            "`section_163_a_deduction_attributable_to_section_163_h_4_A_exception`"
+            in prompt
+        )
         assert (
             "never write an absolute `us:...#rule_name` reference inside a formula"
             in prompt

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -24,6 +24,7 @@ from axiom_encode.harness.validator_pipeline import (
     extract_embedded_source_text,
     extract_grounding_values,
     extract_named_scalar_occurrences,
+    extract_numbers_from_text,
     extract_numeric_occurrences_from_text,
     find_aggregate_exception_predicate_issues,
     find_broad_application_passthrough_issues,
@@ -2819,6 +2820,26 @@ rules:
     )
 
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
+def test_rulespec_grounding_accepts_slash_separated_source_measure_denominator():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/63
+rules:
+  - name: blindness_central_visual_acuity_denominator
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '200'
+"""
+
+    source_text = "Central visual acuity does not exceed 20/200."
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert {20.0, 200.0}.issubset(extract_numbers_from_text(source_text))
 
 
 def test_rulespec_rejects_legacy_source_url_metadata():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5245,6 +5245,92 @@ def test_rulespec_ci_rejects_mixed_derived_output_entities(tmp_path):
     ]
 
 
+def test_rulespec_ci_allows_scalar_parameters_with_entity_outputs(
+    tmp_path, monkeypatch
+):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=tmp_path / "missing-rules-engine",
+        enable_oracles=False,
+    )
+    compiled_payload = {
+        "program": {
+            "derived": [
+                {
+                    "name": "aged_additional_amount_age_threshold",
+                    "id": "us:statutes/26/63/f#aged_additional_amount_age_threshold",
+                    "entity": "Scalar",
+                },
+                {
+                    "name": "blind_under_subsection_f",
+                    "id": "us:statutes/26/63/f#blind_under_subsection_f",
+                    "entity": "Person",
+                },
+            ],
+            "parameters": [
+                {
+                    "name": "aged_additional_amount_age_threshold",
+                    "id": "us:statutes/26/63/f#aged_additional_amount_age_threshold",
+                    "versions": [
+                        {
+                            "effective_from": "2026-01-01",
+                            "values": {
+                                "0": {
+                                    "kind": "integer",
+                                    "value": "65",
+                                }
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+    }
+    cases = [
+        {
+            "name": "person_output_with_scalar_parameters",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "input": {},
+            "output": {
+                "us:statutes/26/63/f#aged_additional_amount_age_threshold": 65,
+                "us:statutes/26/63/f#blind_under_subsection_f": "holds",
+            },
+        }
+    ]
+
+    monkeypatch.setattr(
+        pipeline,
+        "_axiom_rules_binary",
+        lambda: tmp_path / "missing-rules-engine",
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "_run_rulespec_derived_test_case",
+        lambda **_kwargs: (
+            {
+                "us:statutes/26/63/f#blind_under_subsection_f": {
+                    "kind": "judgment",
+                    "outcome": "holds",
+                }
+            },
+            [],
+        ),
+    )
+
+    issues = pipeline._run_rulespec_test_cases(
+        rules_file=tmp_path / "statutes/26/63/f.yaml",
+        compiled_path=tmp_path / "compiled.json",
+        compiled_payload=compiled_payload,
+        cases=cases,
+    )
+
+    assert issues == []
+
+
 def test_rulespec_ci_rejects_computed_imported_outputs_as_inputs(tmp_path):
     pipeline = ValidatorPipeline(
         policy_repo_path=tmp_path,

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5998,6 +5998,48 @@ rules:
     )
 
 
+def test_nonnegative_amount_reduction_rejects_unfloored_maximum_name_without_prefix():
+    content = """format: rulespec/v1
+rules:
+  - name: monthly_benefit_amount
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          maximum_benefit - income_reduction
+"""
+
+    issues = find_nonnegative_amount_reduction_issues(content)
+
+    assert any(
+        "Nonnegative amount reduction missing floor" in issue for issue in issues
+    )
+
+
+def test_nonnegative_amount_reduction_rejects_unfloored_max_name_without_prefix():
+    content = """format: rulespec/v1
+rules:
+  - name: monthly_benefit_amount
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          max_benefit - income_reduction
+"""
+
+    issues = find_nonnegative_amount_reduction_issues(content)
+
+    assert any(
+        "Nonnegative amount reduction missing floor" in issue for issue in issues
+    )
+
+
 def test_nonnegative_amount_reduction_allows_zero_floor():
     content = """format: rulespec/v1
 rules:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6236,6 +6236,23 @@ rules:
     assert find_nonnegative_amount_reduction_issues(content) == []
 
 
+def test_nonnegative_amount_reduction_allows_zero_floor_for_limit_minus_reduction():
+    content = """format: rulespec/v1
+rules:
+  - name: qualified_passenger_vehicle_interest_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, passenger_vehicle_interest_after_dollar_limit - passenger_vehicle_interest_phaseout_reduction)
+"""
+
+    assert find_nonnegative_amount_reduction_issues(content) == []
+
+
 def test_nonnegative_amount_reduction_allows_zero_branch_with_floored_else():
     content = """format: rulespec/v1
 rules:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5786,6 +5786,28 @@ rules:
     assert any("Filing status must use numeric enum" in issue for issue in issues)
 
 
+def test_filing_status_enum_rejects_quoted_named_match_arm():
+    content = """format: rulespec/v1
+rules:
+  - name: basic_standard_deduction_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          match filing_status:
+              "married_filing_jointly" => standard_deduction_joint
+              "surviving_spouse" => standard_deduction_joint
+              "single" => standard_deduction_single
+"""
+
+    issues = find_tax_filing_status_enum_representation_issues(content)
+
+    assert any("Filing status must use numeric enum" in issue for issue in issues)
+
+
 def test_filing_status_test_input_rejects_string_value():
     test_cases = [
         {
@@ -5868,6 +5890,29 @@ rules:
     assert any("different result" in issue for issue in issues)
 
 
+def test_filing_status_branch_rejects_comparison_surviving_spouse_different_result():
+    content = """format: rulespec/v1
+module:
+  summary: The basic standard deduction is doubled for a joint return or surviving spouse.
+rules:
+  - name: basic_standard_deduction_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if filing_status == 1: standard_deduction_joint else:
+          if filing_status == 4: standard_deduction_single else:
+          standard_deduction_single
+"""
+
+    issues = find_tax_filing_status_surviving_spouse_issues(content)
+
+    assert any("different result" in issue for issue in issues)
+
+
 def test_filing_status_branch_rejects_unrelated_surviving_spouse_code():
     content = """format: rulespec/v1
 module:
@@ -5927,6 +5972,23 @@ rules:
       - effective_from: '2025-10-01'
         formula: |-
           max(0, snap_maximum_allotment_for_household_size - ceil(snap_net_monthly_income * snap_allotment_net_income_reduction_rate))
+"""
+
+    assert find_nonnegative_amount_reduction_issues(content) == []
+
+
+def test_nonnegative_amount_reduction_allows_zero_branch_with_floored_else():
+    content = """format: rulespec/v1
+rules:
+  - name: snap_calculated_monthly_allotment_before_minimums
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if ineligible: 0 else: max(0, snap_maximum_allotment_for_household_size - ceil(snap_net_monthly_income * snap_allotment_net_income_reduction_rate))
 """
 
     assert find_nonnegative_amount_reduction_issues(content) == []

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6087,6 +6087,27 @@ rules:
     )
 
 
+def test_nonnegative_amount_reduction_rejects_unfloored_sibling_after_leading_zero_floor():
+    content = """format: rulespec/v1
+rules:
+  - name: snap_calculated_monthly_allotment_before_minimums
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          max(0, snap_maximum_allotment_for_household_size - snap_net_monthly_income_reduction) + (snap_maximum_allotment_for_household_size - snap_net_monthly_income_reduction)
+"""
+
+    issues = find_nonnegative_amount_reduction_issues(content)
+
+    assert any(
+        "Nonnegative amount reduction missing floor" in issue for issue in issues
+    )
+
+
 def test_nonnegative_amount_reduction_rejects_intermediate_zero_floor():
     content = """format: rulespec/v1
 rules:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -45,7 +45,9 @@ from axiom_encode.harness.validator_pipeline import (
     find_source_condition_coverage_issues,
     find_source_limitation_application_issues,
     find_source_verification_issues,
+    find_tax_filing_status_enum_representation_issues,
     find_tax_filing_status_surviving_spouse_issues,
+    find_tax_filing_status_test_input_issues,
     find_test_input_assignment_issues,
     find_ungrounded_numeric_issues,
     find_upstream_placement_issues,
@@ -5739,6 +5741,81 @@ rules:
     issues = find_tax_filing_status_surviving_spouse_issues(content)
 
     assert any("status code 4" in issue for issue in issues)
+
+
+def test_filing_status_enum_rejects_string_formula():
+    content = """format: rulespec/v1
+rules:
+  - name: basic_standard_deduction_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if filing_status == "married_filing_jointly": standard_deduction_joint else:
+          if filing_status == "surviving_spouse": standard_deduction_joint else:
+          standard_deduction_single
+"""
+
+    issues = find_tax_filing_status_enum_representation_issues(content)
+
+    assert any("Filing status must use numeric enum" in issue for issue in issues)
+
+
+def test_filing_status_enum_rejects_named_match_arm():
+    content = """format: rulespec/v1
+rules:
+  - name: basic_standard_deduction_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          match filing_status:
+              married_filing_jointly => standard_deduction_joint
+              surviving_spouse => standard_deduction_joint
+              single => standard_deduction_single
+"""
+
+    issues = find_tax_filing_status_enum_representation_issues(content)
+
+    assert any("Filing status must use numeric enum" in issue for issue in issues)
+
+
+def test_filing_status_test_input_rejects_string_value():
+    test_cases = [
+        {
+            "name": "joint_status_string",
+            "input": {
+                "us:policies/irs/rev-proc-2025-32/standard-deduction#input.filing_status": "married_filing_jointly"
+            },
+            "output": {},
+        }
+    ]
+
+    issues = find_tax_filing_status_test_input_issues(test_cases)
+
+    assert any(
+        "Filing status test input must use numeric enum" in issue for issue in issues
+    )
+
+
+def test_filing_status_test_input_allows_numeric_value():
+    test_cases = [
+        {
+            "name": "joint_status_code",
+            "input": {
+                "us:policies/irs/rev-proc-2025-32/standard-deduction#input.filing_status": 1
+            },
+            "output": {},
+        }
+    ]
+
+    assert find_tax_filing_status_test_input_issues(test_cases) == []
 
 
 def test_filing_status_branch_allows_surviving_spouse_code():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -32,6 +33,8 @@ from axiom_encode.harness.validator_pipeline import (
     find_formula_absolute_reference_issues,
     find_missing_derived_companion_output_issues,
     find_missing_same_section_subsection_import_issues,
+    find_nonnegative_amount_reduction_issues,
+    find_proof_import_hash_consistency_issues,
     find_relation_aggregate_syntax_issues,
     find_role_limited_relation_scope_issues,
     find_rule_name_path_suffix_issues,
@@ -41,10 +44,12 @@ from axiom_encode.harness.validator_pipeline import (
     find_source_condition_coverage_issues,
     find_source_limitation_application_issues,
     find_source_verification_issues,
+    find_tax_filing_status_surviving_spouse_issues,
     find_test_input_assignment_issues,
     find_ungrounded_numeric_issues,
     find_upstream_placement_issues,
     find_versioned_derived_formula_issues,
+    find_zero_branch_test_coverage_issues,
 )
 from axiom_encode.oracles.policyengine.registry import (
     PolicyEngineMapping,
@@ -74,6 +79,74 @@ def test_rulespec_compile_env_exposes_policy_repo_roots(monkeypatch, tmp_path):
     )
     assert roots[:2] == [str(policy_repo), str(repo_parent)]
     assert str(existing_root) in roots
+
+
+def test_rulespec_validation_run_compiled_uses_current_repo_env(monkeypatch, tmp_path):
+    repo_parent = tmp_path / "repos"
+    policy_repo = repo_parent / "rulespec-us"
+    policy_repo.mkdir(parents=True)
+    stale_root = tmp_path / "stale-rulespec-us"
+    stale_root.mkdir()
+    monkeypatch.setenv("AXIOM_RULESPEC_REPO_ROOTS", str(stale_root))
+
+    pipeline = ValidatorPipeline(
+        policy_repo_path=policy_repo,
+        axiom_rules_path=repo_parent / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+    captured_env: dict[str, str] | None = None
+
+    def fake_run(cmd, **kwargs):
+        nonlocal captured_env
+        captured_env = kwargs.get("env")
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=json.dumps(
+                {
+                    "results": [
+                        {
+                            "outputs": {
+                                "us:statutes/1/1#benefit": {
+                                    "kind": "scalar",
+                                    "id": "us:statutes/1/1#benefit",
+                                    "value": {"kind": "integer", "value": 6},
+                                }
+                            }
+                        }
+                    ]
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(validator_pipeline.subprocess, "run", fake_run)
+
+    outputs, issues = pipeline._run_rulespec_derived_test_case(
+        binary=tmp_path / "engine",
+        compiled_path=tmp_path / "compiled.json",
+        case={"input": {}},
+        case_name="computes_benefit",
+        case_index=0,
+        period={
+            "period_kind": "month",
+            "start": "2026-01-01",
+            "end": "2026-01-31",
+        },
+        output_names=["us:statutes/1/1#benefit"],
+        derived_by_key={"us:statutes/1/1#benefit": {"entity": "Household"}},
+        require_legal_input_keys=False,
+        legal_ids_by_friendly_name={},
+        module_target=None,
+    )
+
+    assert issues == []
+    assert outputs is not None
+    assert outputs["us:statutes/1/1#benefit"]["value"]["value"] == 6
+    assert captured_env is not None
+    roots = captured_env["AXIOM_RULESPEC_REPO_ROOTS"].split(os.pathsep)
+    assert roots[:2] == [str(policy_repo), str(repo_parent)]
+    assert str(stale_root) in roots
 
 
 def test_cross_statute_definition_import_check_uses_cited_title_and_existing_targets(
@@ -3111,6 +3184,77 @@ rules:
     assert any("Proof import hash invalid" in issue for issue in issues)
 
 
+def test_proof_import_hash_consistency_rejects_same_file_content_hash(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes/26/22.yaml"
+    rules_file.parent.mkdir(parents=True)
+    content = """format: rulespec/v1
+rules:
+  - name: section_22_aged_individual
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/22#section_22_age_threshold
+              output: section_22_age_threshold
+              hash: sha256:abc123
+    versions:
+      - effective_from: '2026-01-01'
+        formula: age >= section_22_age_threshold
+"""
+    rules_file.write_text(content)
+
+    issues = find_proof_import_hash_consistency_issues(
+        content,
+        rules_file=rules_file,
+        policy_repo_path=repo,
+    )
+
+    assert any("expected `sha256:local`" in issue for issue in issues)
+
+
+def test_proof_import_hash_consistency_accepts_same_file_local_hash(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes/26/22.yaml"
+    rules_file.parent.mkdir(parents=True)
+    content = """format: rulespec/v1
+rules:
+  - name: section_22_aged_individual
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/22#section_22_age_threshold
+              output: section_22_age_threshold
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: age >= section_22_age_threshold
+"""
+    rules_file.write_text(content)
+
+    assert (
+        find_proof_import_hash_consistency_issues(
+            content,
+            rules_file=rules_file,
+            policy_repo_path=repo,
+        )
+        == []
+    )
+
+
 def test_rulespec_grounding_accepts_source_leading_decimal():
     content = """format: rulespec/v1
 rules:
@@ -5492,6 +5636,141 @@ rules:
     )
 
     assert issues == []
+
+
+def test_filing_status_branch_rejects_missing_surviving_spouse_code():
+    content = """format: rulespec/v1
+module:
+  summary: The basic standard deduction is doubled for a joint return or surviving spouse.
+rules:
+  - name: basic_standard_deduction_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          match filing_status:
+              1 => standard_deduction_joint
+              2 => standard_deduction_separate
+              3 => standard_deduction_head_of_household
+              0 => standard_deduction_single
+"""
+
+    issues = find_tax_filing_status_surviving_spouse_issues(content)
+
+    assert any("status code 4" in issue for issue in issues)
+
+
+def test_filing_status_branch_allows_surviving_spouse_code():
+    content = """format: rulespec/v1
+module:
+  summary: The basic standard deduction is doubled for a joint return or surviving spouse.
+rules:
+  - name: basic_standard_deduction_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          match filing_status:
+              1 => standard_deduction_joint
+              4 => standard_deduction_joint
+              2 => standard_deduction_separate
+              3 => standard_deduction_head_of_household
+              0 => standard_deduction_single
+"""
+
+    assert find_tax_filing_status_surviving_spouse_issues(content) == []
+
+
+def test_nonnegative_amount_reduction_rejects_unfloored_allotment():
+    content = """format: rulespec/v1
+rules:
+  - name: snap_calculated_monthly_allotment_before_minimums
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_maximum_allotment_for_household_size - ceil(snap_net_monthly_income * snap_allotment_net_income_reduction_rate)
+"""
+
+    issues = find_nonnegative_amount_reduction_issues(content)
+
+    assert any(
+        "Nonnegative amount reduction missing floor" in issue for issue in issues
+    )
+
+
+def test_nonnegative_amount_reduction_allows_zero_floor():
+    content = """format: rulespec/v1
+rules:
+  - name: snap_calculated_monthly_allotment_before_minimums
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          max(0, snap_maximum_allotment_for_household_size - ceil(snap_net_monthly_income * snap_allotment_net_income_reduction_rate))
+"""
+
+    assert find_nonnegative_amount_reduction_issues(content) == []
+
+
+def test_zero_branch_test_coverage_rejects_untested_zero_output():
+    content = """format: rulespec/v1
+rules:
+  - name: snap_monthly_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if household_initial_month and snap_amount < snap_minimum_issuance: 0 else: snap_amount
+"""
+    cases = [
+        {
+            "name": "above_threshold_initial_month",
+            "output": {"us:regulations/7-cfr/273/10#snap_monthly_allotment": 90},
+        }
+    ]
+
+    issues = find_zero_branch_test_coverage_issues(content, cases)
+
+    assert any("Zero branch test coverage missing" in issue for issue in issues)
+
+
+def test_zero_branch_test_coverage_allows_zero_output_case():
+    content = """format: rulespec/v1
+rules:
+  - name: snap_monthly_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if household_initial_month and snap_amount < snap_minimum_issuance: 0 else: snap_amount
+"""
+    cases = [
+        {
+            "name": "below_threshold_initial_month",
+            "output": {"us:regulations/7-cfr/273/10#snap_monthly_allotment": 0},
+        }
+    ]
+
+    assert find_zero_branch_test_coverage_issues(content, cases) == []
 
 
 def test_source_condition_coverage_rejects_cost_availability_as_only_exclusions():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5808,6 +5808,25 @@ rules:
     assert any("Filing status must use numeric enum" in issue for issue in issues)
 
 
+def test_filing_status_enum_allows_named_arms_in_unrelated_match_block():
+    content = """format: rulespec/v1
+rules:
+  - name: household_type_adjusted_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          match household_type:
+              single => if filing_status == 1: joint_household_amount else: single_household_amount
+              family => family_household_amount
+"""
+
+    assert find_tax_filing_status_enum_representation_issues(content) == []
+
+
 def test_filing_status_test_input_rejects_string_value():
     test_cases = [
         {
@@ -5989,6 +6008,23 @@ rules:
       - effective_from: '2025-10-01'
         formula: |-
           if ineligible: 0 else: max(0, snap_maximum_allotment_for_household_size - ceil(snap_net_monthly_income * snap_allotment_net_income_reduction_rate))
+"""
+
+    assert find_nonnegative_amount_reduction_issues(content) == []
+
+
+def test_nonnegative_amount_reduction_allows_nested_inline_zero_branch_with_floored_inner_else():
+    content = """format: rulespec/v1
+rules:
+  - name: snap_calculated_monthly_allotment_before_minimums
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if ineligible: 0 else: if has_utility_cost: max(0, snap_maximum_allotment_for_household_size - ceil(snap_net_monthly_income * snap_allotment_net_income_reduction_rate)) else: 0
 """
 
     assert find_nonnegative_amount_reduction_issues(content) == []

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 import subprocess
@@ -3255,6 +3256,83 @@ rules:
     )
 
 
+def test_proof_import_hash_consistency_accepts_external_file_hash(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    current_file = repo / "statutes/26/22.yaml"
+    target_file = repo / "statutes/26/1.yaml"
+    current_file.parent.mkdir(parents=True)
+    target_file.write_text("format: rulespec/v1\nrules: []\n")
+    target_hash = target_file.read_bytes()
+    import_hash = hashlib.sha256(target_hash).hexdigest()
+    content = f"""format: rulespec/v1
+rules:
+  - name: section_22_aged_individual
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/1#section_1_tax
+              output: section_1_tax
+              hash: sha256:{import_hash}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: section_1_tax > 0
+"""
+    current_file.write_text(content)
+
+    assert (
+        find_proof_import_hash_consistency_issues(
+            content,
+            rules_file=current_file,
+            policy_repo_path=repo,
+        )
+        == []
+    )
+
+
+def test_proof_import_hash_consistency_rejects_external_file_hash_mismatch(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    current_file = repo / "statutes/26/22.yaml"
+    target_file = repo / "statutes/26/1.yaml"
+    current_file.parent.mkdir(parents=True)
+    target_file.write_text("format: rulespec/v1\nrules: []\n")
+    content = """format: rulespec/v1
+rules:
+  - name: section_22_aged_individual
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/1#section_1_tax
+              output: section_1_tax
+              hash: sha256:abc123
+    versions:
+      - effective_from: '2026-01-01'
+        formula: section_1_tax > 0
+"""
+    current_file.write_text(content)
+
+    issues = find_proof_import_hash_consistency_issues(
+        content,
+        rules_file=current_file,
+        policy_repo_path=repo,
+    )
+
+    assert any("Proof import hash mismatch" in issue for issue in issues)
+
+
 def test_rulespec_grounding_accepts_source_leading_decimal():
     content = """format: rulespec/v1
 rules:
@@ -5687,6 +5765,58 @@ rules:
     assert find_tax_filing_status_surviving_spouse_issues(content) == []
 
 
+def test_filing_status_branch_rejects_surviving_spouse_different_result():
+    content = """format: rulespec/v1
+module:
+  summary: The basic standard deduction is doubled for a joint return or surviving spouse.
+rules:
+  - name: basic_standard_deduction_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          match filing_status:
+              1 => standard_deduction_joint
+              4 => standard_deduction_single
+              2 => standard_deduction_separate
+              3 => standard_deduction_head_of_household
+              0 => standard_deduction_single
+"""
+
+    issues = find_tax_filing_status_surviving_spouse_issues(content)
+
+    assert any("different result" in issue for issue in issues)
+
+
+def test_filing_status_branch_rejects_unrelated_surviving_spouse_code():
+    content = """format: rulespec/v1
+module:
+  summary: The basic standard deduction is doubled for a joint return or surviving spouse.
+rules:
+  - name: basic_standard_deduction_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          match filing_status:
+              1 => standard_deduction_joint
+              2 => standard_deduction_separate
+              0 => standard_deduction_single
+          match unrelated_enum:
+              4 => unrelated_result
+"""
+
+    issues = find_tax_filing_status_surviving_spouse_issues(content)
+
+    assert any("status code 4" in issue for issue in issues)
+
+
 def test_nonnegative_amount_reduction_rejects_unfloored_allotment():
     content = """format: rulespec/v1
 rules:
@@ -5723,6 +5853,27 @@ rules:
 """
 
     assert find_nonnegative_amount_reduction_issues(content) == []
+
+
+def test_nonnegative_amount_reduction_rejects_intermediate_zero_floor():
+    content = """format: rulespec/v1
+rules:
+  - name: snap_calculated_monthly_allotment_before_minimums
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_maximum_allotment_for_household_size - max(0, ceil(snap_net_monthly_income * snap_allotment_net_income_reduction_rate))
+"""
+
+    issues = find_nonnegative_amount_reduction_issues(content)
+
+    assert any(
+        "Nonnegative amount reduction missing floor" in issue for issue in issues
+    )
 
 
 def test_zero_branch_test_coverage_rejects_untested_zero_output():
@@ -5771,6 +5922,58 @@ rules:
     ]
 
     assert find_zero_branch_test_coverage_issues(content, cases) == []
+
+
+def test_zero_branch_test_coverage_rejects_untested_else_zero_output():
+    content = """format: rulespec/v1
+rules:
+  - name: refundable_credit_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if credit_eligible: tentative_credit else: 0
+"""
+    cases = [
+        {
+            "name": "eligible_credit",
+            "output": {"us:statutes/26/24#refundable_credit_amount": 500},
+        }
+    ]
+
+    issues = find_zero_branch_test_coverage_issues(content, cases)
+
+    assert any("Zero branch test coverage missing" in issue for issue in issues)
+
+
+def test_zero_branch_test_coverage_rejects_untested_match_zero_output():
+    content = """format: rulespec/v1
+rules:
+  - name: benefit_amount
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          match eligibility_status:
+              0 => 0
+              1 => maximum_benefit
+"""
+    cases = [
+        {
+            "name": "eligible_benefit",
+            "output": {"us:regulations/example#benefit_amount": 100},
+        }
+    ]
+
+    issues = find_zero_branch_test_coverage_issues(content, cases)
+
+    assert any("Zero branch test coverage missing" in issue for issue in issues)
 
 
 def test_source_condition_coverage_rejects_cost_availability_as_only_exclusions():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -33,6 +33,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_deprecated_source_url_issues,
     find_exception_test_coverage_issues,
     find_formula_absolute_reference_issues,
+    find_formula_date_literal_issues,
     find_missing_derived_companion_output_issues,
     find_missing_same_section_subsection_import_issues,
     find_nonnegative_amount_reduction_issues,
@@ -6251,6 +6252,26 @@ rules:
 """
 
     assert find_nonnegative_amount_reduction_issues(content) == []
+
+
+def test_formula_date_literal_rejects_iso_dates_in_formulas():
+    content = """format: rulespec/v1
+rules:
+  - name: passenger_vehicle_loan_interest_period_start
+    kind: parameter
+    dtype: String
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          2025-01-01
+"""
+
+    issues = find_formula_date_literal_issues(content)
+
+    assert any("Formula date literal unsupported" in issue for issue in issues)
+    assert any(
+        "taxable_year_begins_after_2024_and_before_2029" in issue for issue in issues
+    )
 
 
 def test_nonnegative_amount_reduction_allows_zero_branch_with_floored_else():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6066,6 +6066,27 @@ rules:
     assert find_nonnegative_amount_reduction_issues(content) == []
 
 
+def test_nonnegative_amount_reduction_rejects_unfloored_sibling_next_to_zero_floor():
+    content = """format: rulespec/v1
+rules:
+  - name: snap_calculated_monthly_allotment_before_minimums
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          min(snap_maximum_allotment_for_household_size - snap_net_monthly_income_reduction, max(0, snap_maximum_allotment_for_household_size - snap_net_monthly_income_reduction))
+"""
+
+    issues = find_nonnegative_amount_reduction_issues(content)
+
+    assert any(
+        "Nonnegative amount reduction missing floor" in issue for issue in issues
+    )
+
+
 def test_nonnegative_amount_reduction_rejects_intermediate_zero_floor():
     content = """format: rulespec/v1
 rules:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5808,6 +5808,25 @@ rules:
     assert any("Filing status must use numeric enum" in issue for issue in issues)
 
 
+def test_filing_status_enum_rejects_inline_named_match_arm():
+    content = """format: rulespec/v1
+rules:
+  - name: basic_standard_deduction_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          match filing_status: married_filing_jointly => standard_deduction_joint; surviving_spouse => standard_deduction_joint; single => standard_deduction_single
+"""
+
+    issues = find_tax_filing_status_enum_representation_issues(content)
+
+    assert any("Filing status must use numeric enum" in issue for issue in issues)
+
+
 def test_filing_status_enum_allows_named_arms_in_unrelated_match_block():
     content = """format: rulespec/v1
 rules:
@@ -6025,6 +6044,23 @@ rules:
       - effective_from: '2025-10-01'
         formula: |-
           if ineligible: 0 else: if has_utility_cost: max(0, snap_maximum_allotment_for_household_size - ceil(snap_net_monthly_income * snap_allotment_net_income_reduction_rate)) else: 0
+"""
+
+    assert find_nonnegative_amount_reduction_issues(content) == []
+
+
+def test_nonnegative_amount_reduction_allows_downstream_min_wrapper_after_zero_floor():
+    content = """format: rulespec/v1
+rules:
+  - name: snap_calculated_monthly_allotment_before_minimums
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          min(snap_maximum_allotment_for_household_size, max(0, snap_maximum_allotment_for_household_size - ceil(snap_net_monthly_income * snap_allotment_net_income_reduction_rate)))
 """
 
     assert find_nonnegative_amount_reduction_issues(content) == []

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -4315,7 +4315,22 @@ rules:
 def test_cross_reference_exception_placeholder_allows_covering_import(tmp_path):
     repo = tmp_path / "rulespec-us"
     rules_file = repo / "statutes" / "7" / "2014" / "a.yaml"
+    imported_file = repo / "statutes" / "7" / "2015" / "b.yaml"
     rules_file.parent.mkdir(parents=True)
+    imported_file.parent.mkdir(parents=True)
+    imported_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: section_2015_b_exception_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: household_is_subject_to_section_2015_b_exception
+"""
+    )
     rules_file.write_text(
         """format: rulespec/v1
 module:
@@ -4343,6 +4358,63 @@ rules:
     )
 
     assert pipeline._check_cross_reference_exception_placeholders(rules_file) == []
+
+
+def test_cross_reference_placeholder_rejects_covering_import_without_export(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "63.yaml"
+    imported_file = repo / "statutes" / "26" / "163" / "a.yaml"
+    rules_file.parent.mkdir(parents=True)
+    imported_file.parent.mkdir(parents=True)
+    imported_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: interest_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: interest_paid_or_accrued_on_indebtedness
+"""
+    )
+    rules_file.write_text(
+        """format: rulespec/v1
+imports:
+  - us:statutes/26/163/a#interest_deduction
+module:
+  summary: |-
+    Except as provided in subsection (b), taxable income subtracts so much of
+    the deduction allowed by section 163(a) as is attributable to the exception
+    under section 163(h)(4)(A).
+rules:
+  - name: subsection_b_deductions_for_nonitemizer
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          standard_deduction
+          + section_163_a_deduction_attributable_to_section_163_h_4_A_exception
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_cross_reference_exception_placeholders(rules_file)
+
+    assert len(issues) == 1
+    assert "Cross-reference placeholder" in issues[0]
+    assert "interest_deduction" not in issues[0]
+    assert "section_163_a_deduction_attributable" in issues[0]
 
 
 def test_cross_reference_placeholder_allows_deeper_import_for_semantic_tail(


### PR DESCRIPTION
## Summary
- pass the current-root RuleSpec env through validation run-compiled calls
- add CI-enforced mocked coverage for companion test engine env propagation
- add validation and prompt guidance for filing-status surviving-spouse branches, nonnegative benefit-style reductions, zero-branch tests, and proof import hash consistency

## Tests
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run pytest tests/test_cli.py tests/test_rulespec_validation.py tests/test_evals.py -q