### PR TITLE
Repair section 86 zero-branch encoding apply

### DIFF
--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5113,6 +5113,24 @@ def _validate_generated_encoding_in_policy_overlay(
         for _ in range(10):
             if all(validation.all_passed for _, validation in validations):
                 return True, [], supplemental_files
+            mixed_scalar_repairs = _repair_mixed_scalar_output_tests(
+                rules_file=overlay_target,
+                test_file=_rulespec_test_path(overlay_target),
+                repo_path=overlay_repo,
+                relative_output=relative_output,
+            )
+            if mixed_scalar_repairs:
+                test_path = _rulespec_test_path(overlay_target)
+                supplemental_files[test_path.relative_to(overlay_repo)] = (
+                    test_path.read_text()
+                )
+                validations = _validate_overlay_files(
+                    pipeline,
+                    dependent_pipeline=dependent_pipeline,
+                    overlay_target=overlay_target,
+                    dependents=dependents,
+                )
+                continue
             changed_tests = _complete_missing_dependent_test_inputs(
                 overlay_repo=overlay_repo,
                 relative_output=relative_output,
@@ -5137,6 +5155,99 @@ def _validate_generated_encoding_in_policy_overlay(
                         f"{relative_file}: {validator_result.validator_name}: {validator_result.error}"
                     )
         return False, issues, {}
+
+
+def _repair_mixed_scalar_output_tests(
+    *,
+    rules_file: Path,
+    test_file: Path,
+    repo_path: Path,
+    relative_output: Path,
+) -> list[str]:
+    """Split scalar parameter outputs out of mixed entity companion tests."""
+    if not test_file.exists():
+        return []
+    try:
+        rules_document = yaml.safe_load(rules_file.read_text()) or {}
+        test_cases = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(rules_document, dict) or not isinstance(test_cases, list):
+        return []
+
+    target_base = (
+        f"{_repo_jurisdiction_prefix(repo_path)}:"
+        f"{_relative_rulespec_import_target(relative_output)}"
+    )
+    scalar_outputs: set[str] = set()
+    for rule in rules_document.get("rules") or []:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "parameter":
+            continue
+        name = str(rule.get("name") or "").strip()
+        if name:
+            scalar_outputs.add(f"{target_base}#{name}")
+    if not scalar_outputs:
+        return []
+
+    repaired_cases: list[object] = []
+    repaired_names: list[str] = []
+    existing_names = {
+        str(case.get("name") or "")
+        for case in test_cases
+        if isinstance(case, dict)
+    }
+    for case in test_cases:
+        if not isinstance(case, dict):
+            repaired_cases.append(case)
+            continue
+        output = case.get("output")
+        if not isinstance(output, dict):
+            repaired_cases.append(case)
+            continue
+        scalar_items = {
+            key: value for key, value in output.items() if str(key) in scalar_outputs
+        }
+        if not scalar_items or len(scalar_items) == len(output):
+            repaired_cases.append(case)
+            continue
+
+        entity_items = {
+            key: value for key, value in output.items() if str(key) not in scalar_outputs
+        }
+        repaired_case = dict(case)
+        repaired_case["output"] = entity_items
+        repaired_cases.append(repaired_case)
+
+        case_name = str(case.get("name") or "case").strip() or "case"
+        scalar_case_name = _unique_test_case_name(
+            f"{case_name}_scalar_outputs",
+            existing_names,
+        )
+        existing_names.add(scalar_case_name)
+        scalar_case = {
+            "name": scalar_case_name,
+            "period": case.get("period"),
+            "input": case.get("input", {}),
+            "output": scalar_items,
+        }
+        repaired_cases.append(scalar_case)
+        repaired_names.append(case_name)
+
+    if not repaired_names:
+        return []
+    test_file.write_text(yaml.safe_dump(repaired_cases, sort_keys=False))
+    return repaired_names
+
+
+def _unique_test_case_name(base: str, existing_names: set[str]) -> str:
+    if base not in existing_names:
+        return base
+    index = 2
+    while f"{base}_{index}" in existing_names:
+        index += 1
+    return f"{base}_{index}"
 
 
 def _validate_overlay_files(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3743,6 +3743,13 @@ def _append_generated_zero_branch_tests_if_missing(
         repaired.append(
             "post_2026_no_able_contributions_zero_savers_credit_gross_contributions"
         )
+    if _append_section_86_zero_initial_inclusion_test_if_missing(
+        rules_file=rules_file,
+        test_file=test_file,
+        repo_path=repo_path,
+        relative_output=relative_output,
+    ):
+        repaired.append("single_taxpayer_below_base_zero_social_security_inclusion")
     if _append_limitation_period_zero_overpayment_test_if_missing(
         rules_file=rules_file,
         test_file=test_file,
@@ -4051,6 +4058,69 @@ def _append_savers_credit_zero_gross_contributions_test_if_missing(
     {target_base}#savers_credit_qualified_retirement_savings_contributions: 0
     {target_base}#savers_credit_contributions_taken_into_account: 0
     {target_base}#savers_credit: 0
+"""
+    separator = "" if test_content.endswith("\n") else "\n"
+    test_file.write_text(f"{test_content}{separator}{case}")
+    return True
+
+
+def _append_section_86_zero_initial_inclusion_test_if_missing(
+    *,
+    rules_file: Path,
+    test_file: Path,
+    repo_path: Path,
+    relative_output: Path,
+) -> bool:
+    """Append a generated proof case for 26 USC 86's below-base zero branch."""
+    if not test_file.exists():
+        return False
+
+    rules_content = rules_file.read_text()
+    if (
+        "name: social_security_benefits_includible_under_paragraph_1"
+        not in rules_content
+        or "name: taxpayer_described_in_subsection_b" not in rules_content
+        or "name: social_security_base_amount" not in rules_content
+    ):
+        return False
+
+    target_base = (
+        f"{_repo_jurisdiction_prefix(repo_path)}:"
+        f"{_relative_rulespec_import_target(relative_output)}"
+    )
+    inclusion_target = (
+        f"{target_base}#social_security_benefits_includible_under_paragraph_1"
+    )
+    try:
+        test_payload = yaml.safe_load(test_file.read_text()) or []
+    except yaml.YAMLError:
+        test_payload = []
+    if _has_zero_output_test(test_payload, inclusion_target):
+        return False
+
+    test_content = test_file.read_text()
+    case_name = "single_taxpayer_below_base_zero_social_security_inclusion"
+    if case_name in test_content:
+        return False
+
+    input_prefix = f"{target_base}#input."
+    case = f"""- name: {case_name}
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    {input_prefix}filing_status: 0
+    {input_prefix}married_as_of_close_of_taxable_year_and_does_not_live_apart_from_spouse_at_all_times: false
+    {input_prefix}adjusted_gross_income_determined_without_section_86_85c_135_137_221_911_931_933: 10000
+    {input_prefix}tax_exempt_interest_received_or_accrued: 0
+    {input_prefix}gross_social_security_benefits_received: 10000
+    {input_prefix}workers_compensation_benefits_substituted_for_social_security_benefits: 0
+    {input_prefix}social_security_benefit_repayments_made_during_taxable_year: 0
+  output:
+    {target_base}#social_security_combined_income_excess: 0
+    {inclusion_target}: 0
+    {target_base}#social_security_benefits_includible_before_lump_sum_limit: 0
 """
     separator = "" if test_content.endswith("\n") else "\n"
     test_file.write_text(f"{test_content}{separator}{case}")

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -13,6 +13,7 @@ Self-contained -- no external plugin dependencies.
 
 import argparse
 import contextlib
+import copy
 import csv
 import hashlib
 import hmac
@@ -5228,8 +5229,8 @@ def _repair_mixed_scalar_output_tests(
         existing_names.add(scalar_case_name)
         scalar_case = {
             "name": scalar_case_name,
-            "period": case.get("period"),
-            "input": case.get("input", {}),
+            "period": copy.deepcopy(case.get("period")),
+            "input": copy.deepcopy(case.get("input", {})),
             "output": scalar_items,
         }
         repaired_cases.append(scalar_case)

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5195,9 +5195,7 @@ def _repair_mixed_scalar_output_tests(
     repaired_cases: list[object] = []
     repaired_names: list[str] = []
     existing_names = {
-        str(case.get("name") or "")
-        for case in test_cases
-        if isinstance(case, dict)
+        str(case.get("name") or "") for case in test_cases if isinstance(case, dict)
     }
     for case in test_cases:
         if not isinstance(case, dict):
@@ -5215,7 +5213,9 @@ def _repair_mixed_scalar_output_tests(
             continue
 
         entity_items = {
-            key: value for key, value in output.items() if str(key) not in scalar_outputs
+            key: value
+            for key, value in output.items()
+            if str(key) not in scalar_outputs
         }
         repaired_case = dict(case)
         repaired_case["output"] = entity_items

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3811,7 +3811,9 @@ def _replace_indented_block_text_once(content: str, old: str, new: str) -> str:
                 for new_line in new.splitlines()
             ]
             return "".join(
-                content_lines[:start] + replacement + content_lines[start + len(old_lines) :]
+                content_lines[:start]
+                + replacement
+                + content_lines[start + len(old_lines) :]
             )
     return content
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -813,6 +813,35 @@ mappings:
     candidate_priority: P4
     rationale: Axiom's current 1401 slice includes self-employment tax components at the section boundary; PE's self_employment_tax excludes additional_medicare_tax and applies 1402 taxable-income rules.
 
+  - legal_id: us:statutes/26/1402/a#self_employment_tax_equivalent_deduction_fraction
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.ald.misc.employer_share
+    period: year
+    comparison: rate
+    rationale: Same section 1402(a)(12)(B) one-half factor used in PE to compute the employer-share deduction from net earnings.
+
+  - legal_id: us:statutes/26/164/f#self_employment_tax_deduction_fraction
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.ald.self_employment_tax.percent_deductible
+    period: year
+    comparison: rate
+    rationale: Same section 164(f)(1) one-half deduction fraction, stored in PE as an above-the-line deduction parameter.
+
+  - legal_id: us:statutes/26/164/f#self_employment_tax_deduction
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: self_employment_tax_ald
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same above-the-line deduction for one-half of self-employment taxes for supported individual cases.
+
   - legal_id: us:statutes/26/3101/a#oasdi_wage_tax_rate
     country: us
     program: tax
@@ -1604,6 +1633,121 @@ mappings:
     unit: USD
     comparison: money
     rationale: Same federal taxable income after exemptions and taxable-income deductions.
+
+  - legal_id: us:statutes/26/86#social_security_one_half_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.social_security.taxability.combined_income_ss_fraction
+    period: year
+    comparison: rate
+    rationale: Same section 86 one-half rate used for provisional income and base-tier inclusion.
+
+  - legal_id: us:statutes/26/86#social_security_additional_inclusion_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.social_security.taxability.rate.additional.excess
+    period: year
+    comparison: rate
+    rationale: Same section 86(a)(2)(A)(i) 85 percent additional inclusion rate.
+
+  - legal_id: us:statutes/26/86#social_security_base_amount_other
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.social_security.taxability.threshold.base.main
+    parameter_key: SINGLE
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same section 86(c)(1)(A) base amount for non-joint filers represented by PE's single-filer table cell.
+
+  - legal_id: us:statutes/26/86#social_security_base_amount_joint
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.social_security.taxability.threshold.base.main
+    parameter_key: JOINT
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same section 86(c)(1)(B) joint-return base amount.
+
+  - legal_id: us:statutes/26/86#social_security_base_amount_married_separate_not_apart
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.social_security.taxability.threshold.base.separate_cohabitating
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same section 86(c)(1)(C) zero base amount for married separate filers who did not live apart.
+
+  - legal_id: us:statutes/26/86#social_security_adjusted_base_amount_other
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.social_security.taxability.threshold.adjusted_base.main
+    parameter_key: SINGLE
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same section 86(c)(2)(A) adjusted base amount for non-joint filers represented by PE's single-filer table cell.
+
+  - legal_id: us:statutes/26/86#social_security_adjusted_base_amount_joint
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.social_security.taxability.threshold.adjusted_base.main
+    parameter_key: JOINT
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same section 86(c)(2)(B) joint-return adjusted base amount.
+
+  - legal_id: us:statutes/26/86#social_security_adjusted_base_amount_married_separate_not_apart
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.social_security.taxability.threshold.adjusted_base.separate_cohabitating
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same section 86(c)(2)(C) zero adjusted base amount for married separate filers who did not live apart.
+
+  - legal_id: us:statutes/26/86#social_security_provisional_income
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: tax_unit_combined_income_for_social_security_taxability
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same section 86(b)(1) provisional income concept for supported current-law cases.
+
+  - legal_id: us:statutes/26/86#social_security_excess_over_base_amount
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: tax_unit_ss_combined_income_excess
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same excess of section 86 provisional income over the applicable base amount.
+
+  - legal_id: us:statutes/26/86#social_security_benefits_included_in_gross_income
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: tax_unit_taxable_social_security
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same section 86 taxable Social Security amount included in federal gross income.
 
   - legal_id: us:policies/irs/rev-proc-2025-32/alternative-minimum-tax#amt_exemption_joint
     country: us
@@ -3989,6 +4133,18 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 163(h)(4)(A) passenger-vehicle-loan-interest outputs are source-specific statutory predicates not exposed as one-to-one PolicyEngine variables.
 
+  - legal_id_prefix: us:statutes/26/1402/a#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 1402(a) net-earnings-from-self-employment intermediates use statutory trade-or-business gross income, deduction, partnership, and paragraph (12) components that PE folds into taxable_self_employment_income unless an exact mapping overrides this prefix.
+
+  - legal_id_prefix: us:statutes/26/164/f#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 164(f) self-employment-tax deduction intermediates are source-specific assembly outputs unless an exact PolicyEngine mapping overrides this prefix.
+
   - legal_id_prefix: us:statutes/26/21#
     country: us
     program: tax
@@ -4042,6 +4198,12 @@ prefixes:
     program: tax
     mapping_type: not_comparable
     rationale: Section 63(f) aged-or-blind additional-standard-deduction outputs are statutory parameters and predicates unless an exact PolicyEngine mapping overrides this prefix.
+
+  - legal_id_prefix: us:statutes/26/86#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 86 Social Security taxability outputs are statutory thresholds, predicates, and lump-sum or repayment intermediates unless an exact PolicyEngine mapping overrides this prefix.
 
   - legal_id_prefix: us:statutes/26/6401#
     country: us

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3164,6 +3164,9 @@ rules:
             relative_output=Path("statutes/26/164/f.yaml"),
         )
 
+        repaired_content = test_file.read_text()
+        assert "&id" not in repaired_content
+        assert "*id" not in repaired_content
         cases = yaml.safe_load(test_file.read_text())
         assert repaired == ["zero_liability_individual"]
         assert cases == [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,7 @@ from axiom_encode.cli import (
     _find_rulespec_dependents,
     _has_zero_output_test,
     _insert_false_input_default,
+    _repair_mixed_scalar_output_tests,
     _rewrite_gpt_runner_backend,
     _sha256_file,
     _sign_applied_encoding_manifest,
@@ -3116,6 +3117,78 @@ class TestCmdEncode:
             "encode_request",
             "encode_result",
             "encode_outcome",
+        ]
+
+    def test_mixed_scalar_output_test_repair_splits_parameter_outputs(self, tmp_path):
+        policy_repo = tmp_path / "rulespec-us"
+        rules_file = policy_repo / "statutes/26/164/f.yaml"
+        test_file = policy_repo / "statutes/26/164/f.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: self_employment_tax_deduction_fraction
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 1 / 2
+  - name: self_employment_tax_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: self_employment_tax * self_employment_tax_deduction_fraction
+"""
+        )
+        test_file.write_text(
+            """- name: zero_liability_individual
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/164/f#input.self_employment_tax: 0
+  output:
+    us:statutes/26/164/f#self_employment_tax_deduction_fraction: 0.5
+    us:statutes/26/164/f#self_employment_tax_deduction: 0
+"""
+        )
+
+        repaired = _repair_mixed_scalar_output_tests(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=policy_repo,
+            relative_output=Path("statutes/26/164/f.yaml"),
+        )
+
+        cases = yaml.safe_load(test_file.read_text())
+        assert repaired == ["zero_liability_individual"]
+        assert cases == [
+            {
+                "name": "zero_liability_individual",
+                "period": {
+                    "period_kind": "tax_year",
+                    "start": "2026-01-01",
+                    "end": "2026-12-31",
+                },
+                "input": {"us:statutes/26/164/f#input.self_employment_tax": 0},
+                "output": {"us:statutes/26/164/f#self_employment_tax_deduction": 0},
+            },
+            {
+                "name": "zero_liability_individual_scalar_outputs",
+                "period": {
+                    "period_kind": "tax_year",
+                    "start": "2026-01-01",
+                    "end": "2026-12-31",
+                },
+                "input": {"us:statutes/26/164/f#input.self_employment_tax": 0},
+                "output": {
+                    "us:statutes/26/164/f#self_employment_tax_deduction_fraction": 0.5
+                },
+            },
         ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3915,6 +3915,175 @@ rules:
         assert "us:statutes/26/25B#input.able_account_contributions: 0" in test_content
         assert "us:statutes/26/25B#savers_credit_gross_contributions: 0" in test_content
 
+    def test_repair_zero_branch_tests_handles_section_86_below_base_amount(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "statutes/26/86.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+rules:
+  - name: initial_social_security_inclusion_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          1 / 2
+
+  - name: social_security_base_amount_default
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          25000
+
+  - name: social_security_modified_adjusted_gross_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          adjusted_gross_income_determined_without_section_86_85c_135_137_221_911_931_933
+          + tax_exempt_interest_received_or_accrued
+
+  - name: social_security_benefits_received
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(
+              0,
+              gross_social_security_benefits_received
+              + workers_compensation_benefits_substituted_for_social_security_benefits
+              - social_security_benefit_repayments_made_during_taxable_year
+          )
+
+  - name: social_security_base_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          social_security_base_amount_default
+
+  - name: social_security_combined_income_excess
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          max(
+              0,
+              social_security_modified_adjusted_gross_income
+              + initial_social_security_inclusion_rate * social_security_benefits_received
+              - social_security_base_amount
+          )
+
+  - name: taxpayer_described_in_subsection_b
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          social_security_modified_adjusted_gross_income
+          + initial_social_security_inclusion_rate * social_security_benefits_received
+          > social_security_base_amount
+
+  - name: social_security_benefits_includible_under_paragraph_1
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if taxpayer_described_in_subsection_b:
+              min(
+                  initial_social_security_inclusion_rate * social_security_benefits_received,
+                  initial_social_security_inclusion_rate * social_security_combined_income_excess
+              )
+          else:
+              0
+"""
+        )
+        test_file = policy_repo / "statutes/26/86.test.yaml"
+        test_file.write_text(
+            """- name: existing_positive_case
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/86#input.adjusted_gross_income_determined_without_section_86_85c_135_137_221_911_931_933: 30000
+    us:statutes/26/86#input.tax_exempt_interest_received_or_accrued: 0
+    us:statutes/26/86#input.gross_social_security_benefits_received: 12000
+    us:statutes/26/86#input.workers_compensation_benefits_substituted_for_social_security_benefits: 0
+    us:statutes/26/86#input.social_security_benefit_repayments_made_during_taxable_year: 0
+  output:
+    us:statutes/26/86#social_security_benefits_includible_under_paragraph_1: 5500
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("statutes/26/86.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_zero_branch_tests(args)
+
+        test_content = test_file.read_text()
+        assert "single_taxpayer_below_base_zero_social_security_inclusion" in test_content
+        assert (
+            "us:statutes/26/86#input.adjusted_gross_income_determined_without_section_86_85c_135_137_221_911_931_933: 10000"
+            in test_content
+        )
+        assert (
+            "us:statutes/26/86#input.lump_sum_social_security_benefits_attributable_to_prior_taxable_years"
+            not in test_content
+        )
+        assert (
+            "us:statutes/26/86#social_security_benefits_includible_under_paragraph_1: 0"
+            in test_content
+        )
+        assert (
+            "us:statutes/26/86#social_security_benefits_includible_before_lump_sum_limit: 0"
+            in test_content
+        )
+
     def test_repair_zero_branch_tests_handles_limitation_period_overpayment(
         self, tmp_path
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3673,7 +3673,9 @@ rules:
         test_content = test_file.read_text()
         assert "low_income_nonitemizer_zero_taxable_income" in test_content
         assert "us:statutes/26/63#taxable_income: 0" in test_content
-        assert "taxable_income_for_individual_who_does_not_itemize: -" not in test_content
+        assert (
+            "taxable_income_for_individual_who_does_not_itemize: -" not in test_content
+        )
         assert "taxable_income_general_rule: -" not in test_content
 
     def test_repair_zero_branch_tests_writes_signed_manifest(self, tmp_path):
@@ -4142,7 +4144,9 @@ rules:
             cmd_repair_zero_branch_tests(args)
 
         test_content = test_file.read_text()
-        assert "single_taxpayer_below_base_zero_social_security_inclusion" in test_content
+        assert (
+            "single_taxpayer_below_base_zero_social_security_inclusion" in test_content
+        )
         assert (
             "us:statutes/26/86#input.adjusted_gross_income_determined_without_section_86_85c_135_137_221_911_931_933: 10000"
             in test_content
@@ -4245,9 +4249,7 @@ rules:
             }
         ]
 
-        assert (
-            _has_zero_output_test(cases, "us:statutes/26/63#taxable_income") is False
-        )
+        assert _has_zero_output_test(cases, "us:statutes/26/63#taxable_income") is False
         assert _has_zero_output_test(cases, "us:statutes/26/1#taxable_income") is True
 
     def test_repair_tax_filing_status_branches_writes_signed_manifest(self, tmp_path):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1484,6 +1484,45 @@ def test_policyengine_registry_is_legal_id_keyed():
         ).mapping_type
         == "not_comparable"
     )
+    assert (
+        registry.mapping_for_legal_id(
+            "us:statutes/26/1402/a#self_employment_tax_equivalent_deduction_fraction",
+            country="us",
+        ).policyengine_parameter
+        == "gov.irs.ald.misc.employer_share"
+    )
+    assert (
+        registry.mapping_for_legal_id(
+            "us:statutes/26/1402/a#net_earnings_from_self_employment",
+            country="us",
+        ).match_type
+        == "prefix"
+    )
+    self_employment_tax_deduction_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/164/f#self_employment_tax_deduction",
+        country="us",
+    )
+    assert self_employment_tax_deduction_mapping.mapping_type == "direct_variable"
+    assert (
+        self_employment_tax_deduction_mapping.policyengine_variable
+        == "self_employment_tax_ald"
+    )
+    social_security_taxable_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/86#social_security_benefits_included_in_gross_income",
+        country="us",
+    )
+    assert social_security_taxable_mapping.mapping_type == "direct_variable"
+    assert (
+        social_security_taxable_mapping.policyengine_variable
+        == "tax_unit_taxable_social_security"
+    )
+    assert (
+        registry.mapping_for_legal_id(
+            "us:statutes/26/86#social_security_base_amount_joint",
+            country="us",
+        ).policyengine_parameter
+        == "gov.irs.social_security.taxability.threshold.base.main"
+    )
     savers_credit_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/25B#savers_credit",
         country="us",


### PR DESCRIPTION
## Summary
- repairs mixed scalar-output tests during signed apply
- avoids YAML anchors in split generated tests
- handles section 86 zero-branch test repair deterministically

## Verification
- `uv run --frozen pytest -q tests/test_cli.py::TestCmdEncode::test_mixed_scalar_output_test_repair_splits_parameter_outputs tests/test_cli.py::TestApplyDependencyValidation::test_repair_zero_branch_tests_handles_section_86_below_base_amount`
- `uv run --frozen ruff check src/axiom_encode/cli.py tests/test_cli.py`