### PR TITLE
Tighten concept registry review items

### DIFF
--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -41,6 +41,7 @@ from .concepts import (
     load_concept_registry,
     validate_generated_against_registry,
 )
+from .concepts.jurisdiction import jurisdiction_prefix as _repo_jurisdiction_prefix
 from .constants import DEFAULT_OPENAI_MODEL
 from .harness.encoding_db import (
     EncodingDB,
@@ -5624,15 +5625,6 @@ def _find_rulespec_dependents(
 
 def _relative_rulespec_import_target(relative_output: Path) -> str:
     return relative_output.with_suffix("").as_posix()
-
-
-def _repo_jurisdiction_prefix(policy_repo_path: Path) -> str:
-    name = policy_repo_path.name
-    if name.startswith("rulespec-"):
-        return name.removeprefix("rulespec-")
-    if name.startswith("rules-"):
-        return name.removeprefix("rules-")
-    return name
 
 
 def _rulespec_file_imports_target(

--- a/src/axiom_encode/concepts/__init__.py
+++ b/src/axiom_encode/concepts/__init__.py
@@ -5,6 +5,18 @@ variable names across encoder runs. The registry maps a canonical concept id
 to one approved variable name plus a producer anchor; the validator refuses
 to apply generated RuleSpec that uses a blocked synonym or conflicts with a
 registered canonical.
+
+Cross-jurisdiction semantics
+----------------------------
+Anchors carry a jurisdiction prefix: `us:` for federal, `us-co:`, `us-ny:`,
+etc. for state RuleSpec. A registered canonical's `producer_anchor` is the
+single approved location of its producer rule, regardless of where consumers
+live. So a state policy in `us-co:policies/...` that consumes a federal
+concept must reference it as `us:regulations/7-cfr/.../#snap_total_gross_income`
+— anchoring it under `us-co:` triggers `anchored_ref_miss`. State-only
+concepts (no federal counterpart) get a `us-co:` / `us-ny:` `producer_anchor`
+and are state-canonical. Concepts marked `producer_missing: true` allow the
+canonical name in consumers while the producer is encoded in a follow-up.
 """
 
 from .audit import (

--- a/src/axiom_encode/concepts/audit.py
+++ b/src/axiom_encode/concepts/audit.py
@@ -15,6 +15,7 @@ from typing import Iterable
 
 import yaml
 
+from .jurisdiction import jurisdiction_prefix
 from .registry import ConceptRegistry
 
 IDENT_RE = re.compile(r"\b([a-z][a-z0-9_]*)\b")
@@ -203,15 +204,12 @@ def audit_corpus(
     # Canonical-name conflicts: registered canonical produced under a different anchor
     for canonical, concept in registry.canonical_to_concept.items():
         producer_sites = graph.producers.get(canonical, [])
-        if (
-            not producer_sites
-            or concept.producer_anchor is None
-            or concept.producer_missing
-        ):
+        if not producer_sites or not concept.has_producer:
             continue
         bad = [(a, p) for a, p in producer_sites if a != concept.producer_anchor]
         if not bad:
             continue
+        bad_anchors = ", ".join(sorted({a for a, _ in bad}))
         findings.append(
             DriftFinding(
                 kind="canonical_conflict",
@@ -219,7 +217,7 @@ def audit_corpus(
                 anchor=concept.producer_anchor,
                 site_paths=tuple(p for _, p in bad),
                 detail=(
-                    f"{canonical} produced under {[a for a, _ in bad]} but registry "
+                    f"{canonical} produced under {bad_anchors} but registry "
                     f"expects {concept.producer_anchor}"
                 ),
             )
@@ -232,16 +230,7 @@ def _anchor_for(path: Path, root: Path) -> str:
     rel = path.relative_to(root).with_suffix("")
     if rel.name.endswith(".test"):
         rel = rel.with_name(rel.name[:-5])
-    return f"{_jurisdiction_prefix(root)}:{rel.as_posix()}"
-
-
-def _jurisdiction_prefix(root: Path) -> str:
-    name = root.name
-    if name.startswith("rulespec-"):
-        return name.removeprefix("rulespec-")
-    if name.startswith("rules-"):
-        return name.removeprefix("rules-")
-    return name
+    return f"{jurisdiction_prefix(root)}:{rel.as_posix()}"
 
 
 def _similar(a: str, b: str) -> bool:

--- a/src/axiom_encode/concepts/jurisdiction.py
+++ b/src/axiom_encode/concepts/jurisdiction.py
@@ -1,0 +1,20 @@
+"""Map a rules/rulespec repo path to its jurisdiction anchor prefix.
+
+Repo names are encoded as `rulespec-<jurisdiction>` or `rules-<jurisdiction>`
+(e.g. `rules-us-co`, `rulespec-us-ny`, `rulespec-uk`). The jurisdiction
+prefix is the suffix after the repo-kind prefix and is used as the anchor
+scheme in `<jurisdiction>:<path>#<name>` RuleSpec references.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def jurisdiction_prefix(repo_path: Path) -> str:
+    name = repo_path.name
+    if name.startswith("rulespec-"):
+        return name.removeprefix("rulespec-")
+    if name.startswith("rules-"):
+        return name.removeprefix("rules-")
+    return name

--- a/src/axiom_encode/concepts/validator.py
+++ b/src/axiom_encode/concepts/validator.py
@@ -24,7 +24,7 @@ ANCHORED_REF_RE = re.compile(
 
 @dataclass(frozen=True)
 class CanonicalNameViolation:
-    kind: str  # "blocked_synonym" | "canonical_conflict" | "anchored_ref_miss"
+    kind: str  # "blocked_synonym" | "canonical_conflict" | "anchored_ref_miss" | "parse_error"
     name: str
     where: str  # file:rule or file:anchored-ref
     concept_id: str | None
@@ -54,8 +54,17 @@ def validate_generated_against_registry(
         text = path.read_text()
         try:
             doc = yaml.safe_load(text)
-        except Exception:
+        except Exception as exc:
             doc = None
+            violations.append(
+                CanonicalNameViolation(
+                    kind="parse_error",
+                    name="",
+                    where=str(path),
+                    concept_id=None,
+                    detail=f"YAML did not parse, validator cannot scan rules: {exc}",
+                )
+            )
 
         # 1. Anchored-ref scan: catch any `us:file#name` whose name is a blocked synonym,
         #    or whose name is a registered canonical but referenced under the wrong anchor.
@@ -76,9 +85,8 @@ def validate_generated_against_registry(
             canonical = registry.lookup_canonical(name)
             if (
                 canonical is not None
-                and canonical.producer_anchor is not None
+                and canonical.has_producer
                 and canonical.producer_anchor != anchor
-                and not canonical.producer_missing
             ):
                 violations.append(
                     CanonicalNameViolation(
@@ -120,9 +128,8 @@ def validate_generated_against_registry(
                 if (
                     canonical is not None
                     and apply_anchor is not None
-                    and canonical.producer_anchor is not None
+                    and canonical.has_producer
                     and canonical.producer_anchor != apply_anchor
-                    and not canonical.producer_missing
                     and not path.name.endswith(".test.yaml")
                 ):
                     violations.append(

--- a/tests/test_concepts_cli.py
+++ b/tests/test_concepts_cli.py
@@ -146,3 +146,44 @@ def test_concepts_audit_cli_runs_and_emits_json(tmp_path: Path):
     payload = json.loads(result.stdout)
     assert "findings" in payload
     assert payload["count"] == 0
+
+
+def test_concepts_audit_cli_surfaces_blocked_synonym(tmp_path: Path):
+    """Real-content smoke test: the CLI must surface a blocked-synonym finding
+    with the expected structure when the corpus actually contains drift."""
+    root = tmp_path / "rulespec-us"
+    drift = root / "policies/example.yaml"
+    drift.parent.mkdir(parents=True)
+    drift.write_text(
+        textwrap.dedent(
+            """
+            format: rulespec/v1
+            rules:
+              - name: example_rule
+                kind: derived
+                versions:
+                  - effective_from: '2025-10-01'
+                    formula: snap_gross_monthly_income
+            """
+        )
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "axiom_encode.cli",
+            "concepts-audit",
+            "--roots",
+            str(root),
+            "--name-prefix",
+            "snap_",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    payload = json.loads(result.stdout)
+    assert payload["count"] >= 1
+    blocked = [f for f in payload["findings"] if f["kind"] == "blocked_synonym"]
+    assert any(f["name"] == "snap_gross_monthly_income" for f in blocked), payload

--- a/tests/test_concepts_registry.py
+++ b/tests/test_concepts_registry.py
@@ -217,6 +217,28 @@ def test_validator_flags_consumer_anchored_ref_to_canonical_wrong_anchor(
     )
 
 
+def test_validator_flags_unparseable_yaml_explicitly(tmp_path: Path):
+    """If a generated YAML doesn't parse, the validator must emit a parse_error
+    violation so the apply hook still refuses — silent skip would let a
+    drifting rule through whenever the rest of the file is malformed."""
+    registry = load_concept_registry()
+    bad = _write(
+        tmp_path,
+        "broken.yaml",
+        """
+        format: rulespec/v1
+        rules:
+          - name: snap_total_gross_income
+            kind: parameter
+            versions:
+              - effective_from: '2025-10-01'
+                formula: "0
+        """,
+    )
+    violations = validate_generated_against_registry([bad], registry)
+    assert any(v.kind == "parse_error" for v in violations)
+
+
 def test_validator_flags_canonical_under_wrong_anchor(tmp_path: Path):
     registry = load_concept_registry()
     wrong = _write(
@@ -312,6 +334,36 @@ def test_audit_name_prefix_filters_blocked_synonyms(tmp_path: Path):
 
     findings = audit_corpus([root], registry, name_prefixes=("ny_snap_",))
     assert findings == []
+
+
+def test_audit_suppresses_missing_producer_for_producer_missing_canonical(
+    tmp_path: Path,
+):
+    """A registered canonical with producer_missing: true must not surface as
+    missing_producer in the audit, since the registry already approves its
+    use ahead of the encoder back-filling the producer rule."""
+    registry = load_concept_registry()
+    root = tmp_path / "rulespec-us"
+    path = root / "policies/example.yaml"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        textwrap.dedent(
+            """
+            format: rulespec/v1
+            rules:
+              - name: example_rule
+                kind: derived
+                versions:
+                  - effective_from: '2025-10-01'
+                    formula: snap_countable_earned_income
+            """
+        )
+    )
+    findings = audit_corpus([root], registry, name_prefixes=("snap_",))
+    assert not any(
+        f.kind == "missing_producer" and f.name == "snap_countable_earned_income"
+        for f in findings
+    ), findings
 
 
 def test_audit_scans_uppercase_path_anchored_refs(tmp_path: Path):


### PR DESCRIPTION
## Summary
Follow-up cleanup to #41 addressing self-review items before relying on the registry in production:

- **Dedupe** the rules/rulespec → jurisdiction-prefix helper into `concepts/jurisdiction.py` so audit and cli share one implementation.
- **Use `Concept.has_producer`** in the validator and audit conflict checks, expressing the `producer_anchor`/`producer_missing` invariant in one place instead of three.
- **Emit a `parse_error` violation** when generated YAML fails to parse, so the apply hook refuses instead of silently skipping rule-level checks.
- **Render `canonical_conflict` audit details** with a sorted joined anchor list instead of Python `repr`.
- **Document cross-jurisdiction anchor semantics** in the package docstring — a federal canonical anchored at `us:...` consumed under `us-co:...` is `anchored_ref_miss`, state-canonical concepts live under `us-co:`/`us-ny:`.
- **Add audit test** for `producer_missing` canonical suppression (previously only covered on the validator side).
- **Add CLI smoke test** that exercises a real `blocked_synonym` finding (previous test only ran against an empty corpus).

## Test plan
- [x] `pytest tests/test_concepts_registry.py tests/test_concepts_cli.py` — 25 pass (up from 22).
- [x] `pytest --ignore=tests/test_evals.py` — 534 pass, 35 skipped, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)