### PR TITLE
Classify section 224 PolicyEngine oracle coverage

### DIFF
--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -8266,6 +8266,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 163(h)(4)(A) passenger-vehicle-loan-interest outputs are source-specific statutory predicates not exposed as one-to-one PolicyEngine variables.
 
+  - legal_id_prefix: us:statutes/26/224#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 224 qualified-tips deduction outputs are new statutory caps, phaseouts, eligibility predicates, and formula intermediates that PolicyEngine does not yet expose as one-to-one variables.
+
   - legal_id_prefix: us:statutes/26/1402/a#
     country: us
     program: tax

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1498,6 +1498,12 @@ def test_policyengine_registry_is_legal_id_keyed():
         ).match_type
         == "prefix"
     )
+    qualified_tips_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/224#qualified_tips_deduction",
+        country="us",
+    )
+    assert qualified_tips_mapping.mapping_type == "not_comparable"
+    assert qualified_tips_mapping.match_type == "prefix"
     self_employment_tax_deduction_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/164/f#self_employment_tax_deduction",
         country="us",


### PR DESCRIPTION
## Summary
- classify 26 USC 224 statutory outputs as PolicyEngine not_comparable until PE exposes matching variables
- add a registry regression for the section 224 prefix

## Tests
- uv run ruff check src tests
- uv run ruff format --check src tests
- uv run pytest tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tax --limit 20 --fail-on-unmapped --fail-on-untested-comparable