### PR TITLE
Classify section 225 PolicyEngine oracle coverage

### DIFF
--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -8272,6 +8272,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 224 qualified-tips deduction outputs are new statutory caps, phaseouts, eligibility predicates, and formula intermediates that PolicyEngine does not yet expose as one-to-one variables.
 
+  - legal_id_prefix: us:statutes/26/225#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 225 qualified-overtime deduction outputs are new statutory caps, phaseouts, eligibility predicates, and formula intermediates that PolicyEngine does not yet expose as one-to-one variables.
+
   - legal_id_prefix: us:statutes/26/1402/a#
     country: us
     program: tax

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1504,6 +1504,12 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
     assert qualified_tips_mapping.mapping_type == "not_comparable"
     assert qualified_tips_mapping.match_type == "prefix"
+    qualified_overtime_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/225#qualified_overtime_deduction",
+        country="us",
+    )
+    assert qualified_overtime_mapping.mapping_type == "not_comparable"
+    assert qualified_overtime_mapping.match_type == "prefix"
     self_employment_tax_deduction_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/164/f#self_employment_tax_deduction",
         country="us",


### PR DESCRIPTION
## Summary
- classify 26 USC 225 statutory outputs as PolicyEngine not_comparable until PE exposes matching variables
- add a registry regression for the section 225 prefix

## Tests
- uv run ruff check src tests
- uv run ruff format --check src tests
- uv run pytest tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tax --limit 40 --fail-on-unmapped --fail-on-untested-comparable