### PR TITLE
Auto-repair generated zero-branch tests

### DIFF
--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3858,6 +3858,13 @@ def _append_generated_zero_branch_tests_if_missing(
         relative_output=relative_output,
     ):
         repaired.append("low_income_nonitemizer_zero_taxable_income")
+    if _append_nonitemizer_charitable_deduction_zero_test_if_missing(
+        rules_file=rules_file,
+        test_file=test_file,
+        repo_path=repo_path,
+        relative_output=relative_output,
+    ):
+        repaired.append("itemizer_zero_nonitemizer_charitable_deduction")
     return repaired
 
 
@@ -4369,6 +4376,60 @@ def _append_taxable_income_zero_floor_test_if_missing(
     return True
 
 
+def _append_nonitemizer_charitable_deduction_zero_test_if_missing(
+    *,
+    rules_file: Path,
+    test_file: Path,
+    repo_path: Path,
+    relative_output: Path,
+) -> bool:
+    """Append a generated proof case for 26 USC 170(p)'s itemizer exclusion."""
+    if not test_file.exists():
+        return False
+
+    rules_content = rules_file.read_text()
+    if (
+        "name: nonitemizer_charitable_deduction" not in rules_content
+        or "individual_does_not_elect_to_itemize_deductions_for_taxable_year"
+        not in rules_content
+    ):
+        return False
+
+    target_base = (
+        f"{_repo_jurisdiction_prefix(repo_path)}:"
+        f"{_relative_rulespec_import_target(relative_output)}"
+    )
+    deduction_target = f"{target_base}#nonitemizer_charitable_deduction"
+    try:
+        test_payload = yaml.safe_load(test_file.read_text()) or []
+    except yaml.YAMLError:
+        test_payload = []
+    if _has_zero_output_test(test_payload, deduction_target):
+        return False
+
+    test_content = test_file.read_text()
+    case_name = "itemizer_zero_nonitemizer_charitable_deduction"
+    if case_name in test_content:
+        return False
+
+    input_prefix = f"{target_base}#input."
+    case = f"""- name: {case_name}
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    {input_prefix}filing_status: 0
+    {input_prefix}individual_does_not_elect_to_itemize_deductions_for_taxable_year: false
+    {input_prefix}nonitemizer_section_170_deduction_determined_for_eligible_cash_contributions_without_regard_to_subsections_b_1_G_ii_b_1_I_and_d_1: 500
+  output:
+    {deduction_target}: 0
+"""
+    separator = "" if test_content.endswith("\n") else "\n"
+    test_file.write_text(f"{test_content}{separator}{case}")
+    return True
+
+
 def _has_zero_output_test(test_cases: object, target: str) -> bool:
     if not isinstance(test_cases, list):
         return False
@@ -4782,6 +4843,31 @@ def cmd_encode(args):
             )
             outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_test_cases = _try_repair_generated_zero_branch_tests_for_apply(
+                    result,
+                    output_root=args.output,
+                    policy_repo_path=policy_repo_path,
+                    issues=apply_issues,
+                )
+                if repaired_test_cases:
+                    outcome["auto_repaired_zero_branch_tests"] = repaired_test_cases
+                    print(
+                        "  apply=auto_repaired_zero_branch_tests:"
+                        + ",".join(repaired_test_cases)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 detail = (
                     apply_issues[0]
                     if apply_issues
@@ -4847,6 +4933,34 @@ def _can_attempt_apply(result) -> bool:
         "Generated RuleSpec failed compile validation",
         "Generated RuleSpec failed CI validation",
     }
+
+
+def _try_repair_generated_zero_branch_tests_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+    issues: list[str],
+) -> list[str]:
+    """Append deterministic generated zero-branch tests before applying."""
+    if not _only_pending_zero_branch_coverage_issues(issues):
+        return []
+
+    try:
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    test_file = _rulespec_test_path(rules_file)
+    return _append_generated_zero_branch_tests_if_missing(
+        rules_file=rules_file,
+        test_file=test_file,
+        repo_path=policy_repo_path,
+        relative_output=relative_output,
+    )
 
 
 def _relative_generated_output_path(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2953,6 +2953,101 @@ class TestCmdEncode:
             "encode_issue",
         ]
 
+    def test_encode_apply_auto_repairs_generated_zero_branch_tests(
+        self, capsys, tmp_path
+    ):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(True)
+        output_file = (
+            tmp_path / "out" / "codex-test-model" / "statutes" / "26" / "170" / "p.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: nonitemizer_charitable_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if individual_does_not_elect_to_itemize_deductions_for_taxable_year:
+              nonitemizer_section_170_deduction_determined_for_eligible_cash_contributions_without_regard_to_subsections_b_1_G_ii_b_1_I_and_d_1
+          else:
+              0
+"""
+        )
+        test_file = output_file.with_name("p.test.yaml")
+        test_file.write_text(
+            """- name: positive_nonitemizer_case
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/170/p#input.individual_does_not_elect_to_itemize_deductions_for_taxable_year: true
+    us:statutes/26/170/p#input.nonitemizer_section_170_deduction_determined_for_eligible_cash_contributions_without_regard_to_subsections_b_1_G_ii_b_1_I_and_d_1: 500
+  output:
+    us:statutes/26/170/p#nonitemizer_charitable_deduction: 500
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/26/170/p.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "Zero branch test coverage missing: "
+                            "`nonitemizer_charitable_deduction` has a formula branch "
+                            "that returns 0."
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert (
+            "apply=auto_repaired_zero_branch_tests:"
+            "itemizer_zero_nonitemizer_charitable_deduction"
+        ) in output
+        assert "outcome=apply_applied final_success=True" in output
+        assert mock_overlay.call_count == 2
+        mock_apply.assert_called_once()
+        test_content = test_file.read_text()
+        assert "itemizer_zero_nonitemizer_charitable_deduction" in test_content
+        assert (
+            "us:statutes/26/170/p#input.individual_does_not_elect_to_itemize_deductions_for_taxable_year: false"
+            in test_content
+        )
+        assert (
+            "us:statutes/26/170/p#nonitemizer_charitable_deduction: 0" in test_content
+        )
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_zero_branch_tests"] == [
+            "itemizer_zero_nonitemizer_charitable_deduction"
+        ]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_allows_overlay_to_rescue_failed_standalone_validation(
         self, capsys, tmp_path
     ):
@@ -4238,6 +4333,93 @@ rules:
         assert (
             "us:statutes/26/6401#limitation_period_overpayment_part: 0" in test_content
         )
+
+    def test_repair_zero_branch_tests_handles_nonitemizer_charitable_deduction(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "statutes/26/170/p.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+rules:
+  - name: nonitemizer_charitable_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if individual_does_not_elect_to_itemize_deductions_for_taxable_year:
+              nonitemizer_section_170_deduction_determined_for_eligible_cash_contributions_without_regard_to_subsections_b_1_G_ii_b_1_I_and_d_1
+          else:
+              0
+"""
+        )
+        test_file = policy_repo / "statutes/26/170/p.test.yaml"
+        test_file.write_text(
+            """- name: positive_nonitemizer_case
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/170/p#input.individual_does_not_elect_to_itemize_deductions_for_taxable_year: true
+    us:statutes/26/170/p#input.nonitemizer_section_170_deduction_determined_for_eligible_cash_contributions_without_regard_to_subsections_b_1_G_ii_b_1_I_and_d_1: 500
+  output:
+    us:statutes/26/170/p#nonitemizer_charitable_deduction: 500
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("statutes/26/170/p.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_zero_branch_tests(args)
+
+        test_content = test_file.read_text()
+        assert "itemizer_zero_nonitemizer_charitable_deduction" in test_content
+        assert (
+            "us:statutes/26/170/p#input.individual_does_not_elect_to_itemize_deductions_for_taxable_year: false"
+            in test_content
+        )
+        assert (
+            "us:statutes/26/170/p#input.nonitemizer_section_170_deduction_determined_for_eligible_cash_contributions_without_regard_to_subsections_b_1_G_ii_b_1_I_and_d_1: 500"
+            in test_content
+        )
+        assert (
+            "us:statutes/26/170/p#nonitemizer_charitable_deduction: 0" in test_content
+        )
+        manifest = policy_repo / ".axiom/encoding-manifests/statutes/26/170/p.json"
+        payload = json.loads(manifest.read_text())
+        assert payload["backend"] == "deterministic"
+        assert payload["model"] == "zero-branch-test-v1"
+        assert [applied_file["path"] for applied_file in payload["applied_files"]] == [
+            "statutes/26/170/p.yaml",
+            "statutes/26/170/p.test.yaml",
+        ]
 
     def test_has_zero_output_test_requires_exact_legal_id(self):
         cases = [


### PR DESCRIPTION
## Summary
- append deterministic 26 USC 170(p) zero-branch companion tests
- let encode --apply retry overlay validation after generated zero-branch-only repairs
- cover both direct repair and encode apply auto-repair flows

## Tests
- uv run pytest tests/test_cli.py
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py