### PR TITLE
Handle prefixed zero-branch validation issues

### DIFF
--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3795,7 +3795,7 @@ def _safe_test_name(value: str) -> str:
 
 def _only_pending_zero_branch_coverage_issues(issues: list[str]) -> bool:
     return bool(issues) and all(
-        issue.startswith("Zero branch test coverage missing: ") for issue in issues
+        "Zero branch test coverage missing: " in issue for issue in issues
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3005,6 +3005,7 @@ rules:
                     (
                         False,
                         [
+                            "statutes/26/170/p.yaml: ci: "
                             "Zero branch test coverage missing: "
                             "`nonitemizer_charitable_deduction` has a formula branch "
                             "that returns 0."


### PR DESCRIPTION
## Summary
- treat prefixed overlay validation messages as zero-branch-only issues
- regression test the real `statutes/...: ci: Zero branch...` shape so generated auto-repair runs before apply blocks

## Tests
- uv run pytest tests/test_cli.py -k "auto_repairs_generated_zero_branch_tests or repair_zero_branch_tests"
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
