### PR TITLE
Recognize shorter nonitemizer itemization input

### DIFF
--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -4388,11 +4388,17 @@ def _append_nonitemizer_charitable_deduction_zero_test_if_missing(
         return False
 
     rules_content = rules_file.read_text()
-    if (
-        "name: nonitemizer_charitable_deduction" not in rules_content
-        or "individual_does_not_elect_to_itemize_deductions_for_taxable_year"
-        not in rules_content
+    if "name: nonitemizer_charitable_deduction" not in rules_content:
+        return False
+    itemization_input = None
+    for candidate in (
+        "individual_does_not_elect_to_itemize_deductions_for_taxable_year",
+        "individual_does_not_elect_to_itemize_deductions",
     ):
+        if candidate in rules_content:
+            itemization_input = candidate
+            break
+    if itemization_input is None:
         return False
 
     target_base = (
@@ -4413,6 +4419,12 @@ def _append_nonitemizer_charitable_deduction_zero_test_if_missing(
         return False
 
     input_prefix = f"{target_base}#input."
+    amount_input = "nonitemizer_section_170_deduction_determined_for_eligible_cash_contributions_without_regard_to_subsections_b_1_G_ii_b_1_I_and_d_1"
+    amount_input_line = (
+        f"    {input_prefix}{amount_input}: 500\n"
+        if amount_input in rules_content
+        else ""
+    )
     case = f"""- name: {case_name}
   period:
     period_kind: tax_year
@@ -4420,8 +4432,8 @@ def _append_nonitemizer_charitable_deduction_zero_test_if_missing(
     end: '2026-12-31'
   input:
     {input_prefix}filing_status: 0
-    {input_prefix}individual_does_not_elect_to_itemize_deductions_for_taxable_year: false
-    {input_prefix}nonitemizer_section_170_deduction_determined_for_eligible_cash_contributions_without_regard_to_subsections_b_1_G_ii_b_1_I_and_d_1: 500
+    {input_prefix}{itemization_input}: false
+{amount_input_line.rstrip()}
   output:
     {deduction_target}: 0
 """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2974,7 +2974,7 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: |-
-          if individual_does_not_elect_to_itemize_deductions_for_taxable_year:
+          if individual_does_not_elect_to_itemize_deductions:
               nonitemizer_section_170_deduction_determined_for_eligible_cash_contributions_without_regard_to_subsections_b_1_G_ii_b_1_I_and_d_1
           else:
               0
@@ -2988,7 +2988,7 @@ rules:
     start: '2026-01-01'
     end: '2026-12-31'
   input:
-    us:statutes/26/170/p#input.individual_does_not_elect_to_itemize_deductions_for_taxable_year: true
+    us:statutes/26/170/p#input.individual_does_not_elect_to_itemize_deductions: true
     us:statutes/26/170/p#input.nonitemizer_section_170_deduction_determined_for_eligible_cash_contributions_without_regard_to_subsections_b_1_G_ii_b_1_I_and_d_1: 500
   output:
     us:statutes/26/170/p#nonitemizer_charitable_deduction: 500
@@ -3036,7 +3036,7 @@ rules:
         test_content = test_file.read_text()
         assert "itemizer_zero_nonitemizer_charitable_deduction" in test_content
         assert (
-            "us:statutes/26/170/p#input.individual_does_not_elect_to_itemize_deductions_for_taxable_year: false"
+            "us:statutes/26/170/p#input.individual_does_not_elect_to_itemize_deductions: false"
             in test_content
         )
         assert (


### PR DESCRIPTION
## Summary
- allow 26 USC 170(p) zero-branch generated test repair to recognize both itemization input spellings
- omit the long section-170 amount input unless the generated formula actually references it
- cover the shorter generated input spelling in encode apply auto-repair tests

## Tests
- uv run pytest tests/test_cli.py -k "auto_repairs_generated_zero_branch_tests or zero_branch_tests_handles_nonitemizer_charitable_deduction"
- uv run ruff format src/axiom_encode/cli.py tests/test_cli.py && uv run ruff check src/axiom_encode/cli.py tests/test_cli.py