### PR TITLE
Assign 170p zero-branch factual inputs

### DIFF
--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -4433,6 +4433,12 @@ def _append_nonitemizer_charitable_deduction_zero_test_if_missing(
   input:
     {input_prefix}filing_status: 0
     {input_prefix}{itemization_input}: false
+    {input_prefix}contribution_made_in_cash_during_taxable_year: false
+    {input_prefix}contribution_to_organization_described_in_section_170_b_1_A: false
+    {input_prefix}contribution_to_organization_described_in_section_509_a_3: false
+    {input_prefix}contribution_for_establishment_or_maintenance_of_donor_advised_fund: false
+    {input_prefix}payment_amount: 0
+    {input_prefix}contribution_amount: 0
 {amount_input_line.rstrip()}
   output:
     {deduction_target}: 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3040,6 +3040,11 @@ rules:
             in test_content
         )
         assert (
+            "us:statutes/26/170/p#input.contribution_made_in_cash_during_taxable_year: false"
+            in test_content
+        )
+        assert "us:statutes/26/170/p#input.payment_amount: 0" in test_content
+        assert (
             "us:statutes/26/170/p#nonitemizer_charitable_deduction: 0" in test_content
         )
         run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
@@ -4406,6 +4411,11 @@ rules:
             "us:statutes/26/170/p#input.individual_does_not_elect_to_itemize_deductions_for_taxable_year: false"
             in test_content
         )
+        assert (
+            "us:statutes/26/170/p#input.contribution_for_establishment_or_maintenance_of_donor_advised_fund: false"
+            in test_content
+        )
+        assert "us:statutes/26/170/p#input.contribution_amount: 0" in test_content
         assert (
             "us:statutes/26/170/p#input.nonitemizer_section_170_deduction_determined_for_eligible_cash_contributions_without_regard_to_subsections_b_1_G_ii_b_1_I_and_d_1: 500"
             in test_content


### PR DESCRIPTION
## Summary
- assign all known local 170(p) factual inputs in the deterministic itemizer-zero companion test
- keep the generated zero branch explicit while satisfying proof-required test input checks

## Tests
- uv run pytest tests/test_cli.py -k "auto_repairs_generated_zero_branch_tests or zero_branch_tests_handles_nonitemizer_charitable_deduction"
- uv run ruff format src/axiom_encode/cli.py tests/test_cli.py && uv run ruff check src/axiom_encode/cli.py tests/test_cli.py