### PR TITLE
Map 170p tax outputs as not comparable

### DIFF
--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -8278,6 +8278,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 225 qualified-overtime deduction outputs are new statutory caps, phaseouts, eligibility predicates, and formula intermediates that PolicyEngine does not yet expose as one-to-one variables.
 
+  - legal_id_prefix: us:statutes/26/170/p#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 170(p) nonitemizer charitable-deduction outputs are new statutory caps, eligibility predicates, relation aggregates, and formula intermediates that PolicyEngine does not yet expose as one-to-one variables.
+
   - legal_id_prefix: us:statutes/26/1402/a#
     country: us
     program: tax

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1510,6 +1510,12 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
     assert qualified_overtime_mapping.mapping_type == "not_comparable"
     assert qualified_overtime_mapping.match_type == "prefix"
+    nonitemizer_charitable_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/170/p#nonitemizer_charitable_deduction",
+        country="us",
+    )
+    assert nonitemizer_charitable_mapping.mapping_type == "not_comparable"
+    assert nonitemizer_charitable_mapping.match_type == "prefix"
     self_employment_tax_deduction_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/164/f#self_employment_tax_deduction",
         country="us",


### PR DESCRIPTION
## Summary
- classify Section 170(p) generated tax outputs as intentionally not comparable with PolicyEngine
- add registry coverage for the 170(p) prefix mapping

## Validation
- uv run pytest tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed
- uv run ruff check tests/test_rulespec_validation.py
- uv run ruff format --check tests/test_rulespec_validation.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tax --limit 50 --fail-on-unmapped --fail-on-untested-comparable