### PR TITLE
Skip limitation check for judgment rules

### DIFF
--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -4380,6 +4380,7 @@ def find_source_limitation_application_issues(content: str) -> list[str]:
         return []
 
     formula_records = _rulespec_rule_formula_records(payload)
+    dtype_by_name = _rulespec_rule_dtype_by_name(payload)
     formula_by_name = {
         name: formula
         for name, kind, formula, _source in formula_records
@@ -4388,6 +4389,8 @@ def find_source_limitation_application_issues(content: str) -> list[str]:
     issues: list[str] = []
     for name, kind, formula, rule_source in formula_records:
         if kind != "derived":
+            continue
+        if dtype_by_name.get(name) in {"judgment", "boolean", "bool"}:
             continue
         if not _FINAL_AMOUNT_NAME_PATTERN.search(name):
             continue
@@ -4417,6 +4420,21 @@ def find_source_limitation_application_issues(content: str) -> list[str]:
             "compose it into the final exported amount."
         )
     return issues
+
+
+def _rulespec_rule_dtype_by_name(payload: dict[str, Any]) -> dict[str, str]:
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return {}
+    dtype_by_name: dict[str, str] = {}
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            continue
+        name = str(rule.get("name") or f"rules[{index}]").strip()
+        dtype = str(rule.get("dtype") or "").strip().lower()
+        if name and dtype:
+            dtype_by_name[name] = dtype
+    return dtype_by_name
 
 
 def _formula_or_referenced_helpers_implement_limitation(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6927,6 +6927,27 @@ rules:
     assert "standard_deduction" in issues[0]
 
 
+def test_source_limitation_application_ignores_judgment_predicates():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    A deduction is allowed subject to a limitation. An applicable taxpayer
+    means a taxpayer whose active qualified business income is at least $1,000.
+rules:
+  - name: applicable_taxpayer_for_minimum_active_qbi_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: example
+    versions:
+      - effective_from: '2026-01-01'
+        formula: active_qbi >= active_qbi_threshold
+"""
+
+    assert find_source_limitation_application_issues(content) == []
+
+
 def test_source_limitation_application_accepts_final_amount_with_limit_helper():
     content = """format: rulespec/v1
 module:


### PR DESCRIPTION
## Summary
- keep source-limitation validation scoped to final amount-style derived outputs
- skip boolean/Judgment predicates whose names happen to contain amount words like deduction
- add a regression using the 26 USC 199A applicable-taxpayer predicate shape

## Validation
- uv run pytest tests/test_rulespec_validation.py::test_source_limitation_application_rejects_final_amount_without_limit tests/test_rulespec_validation.py::test_source_limitation_application_ignores_judgment_predicates tests/test_rulespec_validation.py::test_source_limitation_application_accepts_final_amount_with_limit_helper tests/test_rulespec_validation.py::test_source_limitation_application_accepts_indirect_limited_helper tests/test_rulespec_validation.py::test_source_limitation_application_accepts_transitive_limited_helper
- uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py