### PR TITLE
Auto-repair generic zero branch tests

### DIFF
--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3805,6 +3805,7 @@ def _append_generated_zero_branch_tests_if_missing(
     test_file: Path,
     repo_path: Path,
     relative_output: Path,
+    issues: list[str] | None = None,
 ) -> list[str]:
     repaired: list[str] = []
     if _append_snap_zero_allotment_test_if_missing(
@@ -3865,7 +3866,117 @@ def _append_generated_zero_branch_tests_if_missing(
         relative_output=relative_output,
     ):
         repaired.append("itemizer_zero_nonitemizer_charitable_deduction")
+    repaired.extend(
+        _append_generic_zero_branch_tests_if_missing(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=repo_path,
+            relative_output=relative_output,
+            issues=issues or [],
+        )
+    )
     return repaired
+
+
+def _append_generic_zero_branch_tests_if_missing(
+    *,
+    rules_file: Path,
+    test_file: Path,
+    repo_path: Path,
+    relative_output: Path,
+    issues: list[str],
+) -> list[str]:
+    """Append deterministic zero-output tests named by validator issues."""
+    if not issues or not test_file.exists() or not rules_file.exists():
+        return []
+    output_names = _zero_branch_output_names_from_issues(issues)
+    if not output_names:
+        return []
+
+    try:
+        rules_content = rules_file.read_text()
+        rules_payload = yaml.safe_load(rules_content) or {}
+        test_payload = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    if not isinstance(rules_payload, dict) or not isinstance(test_payload, list):
+        return []
+
+    rules = rules_payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+    rule_names = {
+        str(rule.get("name") or "").strip()
+        for rule in rules
+        if isinstance(rule, dict) and str(rule.get("name") or "").strip()
+    }
+    target_base = (
+        f"{_repo_jurisdiction_prefix(repo_path)}:"
+        f"{_relative_rulespec_import_target(relative_output)}"
+    )
+    factual_inputs = _local_factual_input_names_from_rules_content(rules_content)
+    input_defaults = {
+        f"{target_base}#input.{input_name}": _default_generated_test_input_value(
+            input_name,
+            rules_payload=rules_payload,
+        )
+        for input_name in sorted(factual_inputs)
+    }
+
+    repaired: list[str] = []
+    existing_case_names = {
+        str(test_case.get("name") or "").strip()
+        for test_case in test_payload
+        if isinstance(test_case, dict)
+    }
+    for output_name in output_names:
+        if output_name not in rule_names:
+            continue
+        target = f"{target_base}#{output_name}"
+        if _has_zero_output_test(test_payload, target):
+            continue
+        case_name = f"auto_zero_{_safe_test_name(output_name)}"
+        if case_name in existing_case_names:
+            continue
+        test_payload.append(
+            {
+                "name": case_name,
+                "period": {
+                    "period_kind": "tax_year",
+                    "start": "2026-01-01",
+                    "end": "2026-12-31",
+                },
+                "input": dict(input_defaults),
+                "output": {target: 0},
+            }
+        )
+        existing_case_names.add(case_name)
+        repaired.append(case_name)
+
+    if not repaired:
+        return []
+    test_file.write_text(
+        yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
+    )
+    return repaired
+
+
+def _zero_branch_output_names_from_issues(issues: list[str]) -> list[str]:
+    output_names: list[str] = []
+    seen: set[str] = set()
+    for issue in issues:
+        match = re.search(
+            r"Zero branch test coverage missing:\s*`(?P<name>[^`]+)`",
+            str(issue),
+        )
+        if not match:
+            continue
+        name = match["name"].strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        output_names.append(name)
+    return output_names
 
 
 def _append_snap_zero_allotment_test_if_missing(
@@ -5064,6 +5175,7 @@ def _try_repair_generated_zero_branch_tests_for_apply(
         test_file=test_file,
         repo_path=policy_repo_path,
         relative_output=relative_output,
+        issues=issues,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3053,6 +3053,106 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_auto_repairs_generic_zero_branch_test(self, capsys, tmp_path):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path / "out" / "codex-test-model" / "statutes" / "26" / "213.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: lodging_treated_as_medical_care
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          lodging_not_lavish_or_extravagant
+          and lodging_away_from_home_primarily_for_and_essential_to_medical_care
+  - name: lodging_medical_care_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if lodging_treated_as_medical_care:
+              min(lodging_amount_paid, lodging_medical_care_nightly_cap * lodging_nights * lodging_individuals)
+          else:
+              0
+"""
+        )
+        test_file = output_file.with_name("213.test.yaml")
+        test_file.write_text(
+            """- name: qualifying_lodging_positive
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/213#input.lodging_not_lavish_or_extravagant: true
+    us:statutes/26/213#input.lodging_away_from_home_primarily_for_and_essential_to_medical_care: true
+    us:statutes/26/213#input.lodging_amount_paid: 300
+    us:statutes/26/213#input.lodging_medical_care_nightly_cap: 50
+    us:statutes/26/213#input.lodging_nights: 2
+    us:statutes/26/213#input.lodging_individuals: 2
+  output:
+    us:statutes/26/213#lodging_medical_care_amount: 200
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/26/213.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "statutes/26/213.yaml: ci: "
+                            "Zero branch test coverage missing: "
+                            "`lodging_medical_care_amount` has a formula branch "
+                            "that returns 0."
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert (
+            "apply=auto_repaired_zero_branch_tests:"
+            "auto_zero_lodging_medical_care_amount"
+        ) in output
+        assert mock_overlay.call_count == 2
+        mock_apply.assert_called_once()
+        test_content = test_file.read_text()
+        assert "auto_zero_lodging_medical_care_amount" in test_content
+        assert (
+            "us:statutes/26/213#input.lodging_not_lavish_or_extravagant: false"
+            in test_content
+        )
+        assert "us:statutes/26/213#lodging_medical_care_amount: 0" in test_content
+
     def test_encode_apply_auto_repairs_missing_test_input_assignments(
         self, capsys, tmp_path
     ):


### PR DESCRIPTION
## Summary
- add a generic apply-time repair for validator-reported missing zero-branch tests
- append deterministic auto_zero_<rule> companion cases with all local factual inputs defaulted
- add a regression test based on the 26 USC 213 lodging zero branch that failed during encoding

## Checks
- uv run pytest tests/test_cli.py::TestCmdEncode::test_encode_apply_auto_repairs_generated_zero_branch_tests tests/test_cli.py::TestCmdEncode::test_encode_apply_auto_repairs_generic_zero_branch_test tests/test_cli.py::TestCmdEncode::test_encode_apply_auto_repairs_missing_test_input_assignments
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py