### PR TITLE
Map 213 tax outputs for PolicyEngine coverage

### DIFF
--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -8316,6 +8316,15 @@ mappings:
     comparison: money
     rationale: Same statutory active-QBI threshold for the deduction floor.
 
+  - legal_id: us:statutes/26/213#medical_expense_agi_floor_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.deductions.itemized.medical.floor
+    period: year
+    comparison: rate
+    rationale: Same statutory percentage of adjusted gross income that floors deductible medical-care expenses.
+
 prefixes:
   - legal_id_prefix: us-co:regulations/10-ccr-2506-1/
     country: us
@@ -8436,6 +8445,12 @@ prefixes:
     program: tax
     mapping_type: not_comparable
     rationale: Section 199A provision-level QBI outputs use source-specific threshold bases, trade-or-business, cooperative, floor, phase-in, and taxable-income-limit intermediates that PolicyEngine folds into qualified_business_income_deduction/qbid_amount or stores as annual parameter surfaces unless an exact mapping overrides this prefix.
+
+  - legal_id_prefix: us:statutes/26/213#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 213 provision-level medical-care outputs include source-specific lodging, medicine-or-drug, long-term-care, decedent, cosmetic-surgery, section 21 exclusion, and expense assembly surfaces that PolicyEngine folds into itemized_medical_expenses/medical_expense_deduction unless an exact mapping overrides this prefix.
 
   - legal_id_prefix: us:statutes/26/1411#
     country: us

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1565,6 +1565,22 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
     assert qbi_formula_mapping.mapping_type == "not_comparable"
     assert qbi_formula_mapping.match_type == "prefix"
+    medical_floor_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/213#medical_expense_agi_floor_rate",
+        country="us",
+    )
+    assert medical_floor_mapping.mapping_type == "parameter_value"
+    assert (
+        medical_floor_mapping.policyengine_parameter
+        == "gov.irs.deductions.itemized.medical.floor"
+    )
+    assert medical_floor_mapping.match_type == "exact"
+    medical_formula_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/213#medical_care_deduction",
+        country="us",
+    )
+    assert medical_formula_mapping.mapping_type == "not_comparable"
+    assert medical_formula_mapping.match_type == "prefix"
     self_employment_tax_deduction_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/164/f#self_employment_tax_deduction",
         country="us",


### PR DESCRIPTION
## Summary
- map 26 USC 213 medical-expense AGI floor to the exact PolicyEngine itemized medical floor parameter
- classify the remaining provision-level 213 outputs as source-specific/not-comparable unless an exact override is added
- add registry assertions for the exact mapping and prefix fallback

## Tests
- uv run pytest tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed
- uv run ruff check tests/test_rulespec_validation.py
- uv run ruff format --check tests/test_rulespec_validation.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tax --limit 100 --fail-on-unmapped --fail-on-untested-comparable