### PR TITLE
Narrow surviving-spouse filing-status validation

### DIFF
--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -764,8 +764,19 @@ _SCHEDULE_SIZE_CAP_RESTATEMENT_PATTERN = re.compile(
 )
 _SCHEDULE_INDEX_NAME_PATTERN = r"[A-Za-z_]\w*_size(?:_[A-Za-z_]\w*)*"
 _STRUCTURAL_ENUM_INDEX_NAME_PATTERN = r"(?:filing_status|tax_filing_status)"
-_US_TAX_SURVIVING_SPOUSE_TEXT_PATTERN = re.compile(
-    r"(?:^|[^A-Za-z0-9])(?:surviving[\s_-]+spouse|qualifying[\s_-]+widow(?:er)?)\b",
+_US_TAX_JOINT_SURVIVING_SPOUSE_GROUP_TEXT_PATTERN = re.compile(
+    r"(?:"
+    r"(?:joint(?:[\s_-]+return)?|married[\s_-]+filing[\s_-]+jointly)"
+    r"\s*(?:/|,|\bor\b|\band\b)\s*"
+    r"(?:surviving[\s_-]+spouse|qualifying[\s_-]+widow(?:er)?)"
+    r"|"
+    r"(?:surviving[\s_-]+spouse|qualifying[\s_-]+widow(?:er)?)"
+    r"\s*(?:/|,|\bor\b|\band\b)\s*"
+    r"(?:joint(?:[\s_-]+return)?|married[\s_-]+filing[\s_-]+jointly)"
+    r"|"
+    r"(?:surviving[\s_-]+spouse|qualifying[\s_-]+widow(?:er)?)"
+    r"\s+with\s+joint(?:[\s_-]+return)?"
+    r")",
     flags=re.IGNORECASE,
 )
 _US_TAX_FILING_STATUS_NAME_PATTERN = re.compile(
@@ -3266,7 +3277,9 @@ def _rulespec_rule_formulas(payload: dict[str, Any]) -> list[tuple[str, str, str
 def find_tax_filing_status_surviving_spouse_issues(content: str) -> list[str]:
     """Flag filing-status branches that omit surviving spouse when source groups it."""
     payload = _rulespec_payload(content)
-    if payload is None or not _US_TAX_SURVIVING_SPOUSE_TEXT_PATTERN.search(content):
+    if payload is None or not _US_TAX_JOINT_SURVIVING_SPOUSE_GROUP_TEXT_PATTERN.search(
+        content
+    ):
         return []
 
     issues: list[str] = []
@@ -3433,9 +3446,9 @@ def _filing_status_surviving_spouse_branch_issue(
                 "surviving spouse with joint return."
             )
 
-    if _filing_status_has_code_comparison(formula, 1) and not (
+    if _filing_status_has_code_equality(formula, 1) and not (
         _filing_status_has_grouped_joint_surviving_spouse_condition(formula)
-        or _filing_status_has_code_comparison(formula, 4)
+        or _filing_status_has_code_equality(formula, 4)
     ):
         return (
             "Filing status branch missing surviving spouse: "
@@ -3514,11 +3527,11 @@ def _normalize_branch_result(result: str) -> str:
     return re.sub(r"\s+", "", result.strip().rstrip(",")).lower()
 
 
-def _filing_status_has_code_comparison(formula: str, code: int) -> bool:
+def _filing_status_has_code_equality(formula: str, code: int) -> bool:
     return bool(
         re.search(
-            rf"\b{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\s*(?:==|!=|>=|>|<=|<)\s*{code}\b"
-            rf"|\b{code}\s*(?:==|!=|>=|>|<=|<)\s*{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\b",
+            rf"\b{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\s*==\s*{code}\b"
+            rf"|\b{code}\s*==\s*{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\b",
             formula,
             flags=re.IGNORECASE,
         )

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6295,6 +6295,28 @@ rules:
     assert any("different result" in issue for issue in issues)
 
 
+def test_filing_status_branch_allows_joint_return_exclusion_without_surviving_spouse():
+    content = """format: rulespec/v1
+module:
+  summary: The source mentions surviving spouse elsewhere, but this rule excludes joint returns from the unmarried individual exception.
+rules:
+  - name: unmarried_individual_filing_exception
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          taxpayer_is_individual
+          and filing_status != 1
+          and filing_status != 2
+          and gross_income <= standard_deduction
+"""
+
+    assert find_tax_filing_status_surviving_spouse_issues(content) == []
+
+
 def test_filing_status_branch_rejects_unrelated_surviving_spouse_code():
     content = """format: rulespec/v1
 module:


### PR DESCRIPTION
## Summary
- require explicit joint/surviving-spouse grouping before enforcing status-code 4 parity
- treat equality branches as branch handling, not every inequality/exclusion comparison
- add a regression for 26 USC 6012-style filing exceptions where surviving spouse is mentioned elsewhere in the source but the rule only excludes joint returns

## Tests
- uv run pytest tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_rulespec_validation.py::test_filing_status_branch_allows_joint_return_exclusion_without_surviving_spouse tests/test_rulespec_validation.py::test_filing_status_branch_rejects_missing_surviving_spouse_code tests/test_rulespec_validation.py::test_filing_status_branch_allows_surviving_spouse_code tests/test_rulespec_validation.py::test_filing_status_branch_rejects_comparison_surviving_spouse_different_result
- uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py