### PR TITLE
Repeat generated test input repairs

### DIFF
--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5054,17 +5054,21 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
-                repaired_test_cases = (
-                    _try_repair_generated_test_input_assignments_for_apply(
-                        result,
-                        output_root=args.output,
-                        policy_repo_path=policy_repo_path,
-                        issues=apply_issues,
+                repaired_input_cases: list[str] = []
+                while not can_apply:
+                    repaired_test_cases = (
+                        _try_repair_generated_test_input_assignments_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            issues=apply_issues,
+                        )
                     )
-                )
-                if repaired_test_cases:
+                    if not repaired_test_cases:
+                        break
+                    repaired_input_cases.extend(repaired_test_cases)
                     outcome["auto_repaired_test_input_assignments"] = (
-                        repaired_test_cases
+                        repaired_input_cases
                     )
                     print(
                         "  apply=auto_repaired_test_input_assignments:"
@@ -5082,6 +5086,10 @@ def cmd_encode(args):
                         )
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
+                if repaired_input_cases:
+                    outcome["auto_repaired_test_input_assignments"] = (
+                        repaired_input_cases
+                    )
             if not can_apply:
                 detail = (
                     apply_issues[0]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3255,6 +3255,115 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_repeats_missing_test_input_assignment_repairs(
+        self, capsys, tmp_path
+    ):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path / "out" / "codex-test-model" / "statutes" / "26" / "6012.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: filing_requirement
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          gross_income > taxable_income
+"""
+        )
+        test_file = output_file.with_name("6012.test.yaml")
+        test_file.write_text(
+            """- name: first_case
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/6012#input.gross_income: 1
+  output:
+    us:statutes/26/6012#filing_requirement: holds
+- name: second_case
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/6012#input.gross_income: 2
+  output:
+    us:statutes/26/6012#filing_requirement: holds
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/26/6012.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "statutes/26/6012.yaml: ci: "
+                            "Test input assignment missing: `first_case` does not "
+                            "assign #input.taxable_income. Every test for a "
+                            "proof-required RuleSpec module must set all local "
+                            "factual inputs, including false facts, so tests "
+                            "cannot pass through implicit defaults."
+                        ],
+                        {},
+                    ),
+                    (
+                        False,
+                        [
+                            "statutes/26/6012.yaml: ci: "
+                            "Test input assignment missing: `second_case` does not "
+                            "assign #input.taxable_income. Every test for a "
+                            "proof-required RuleSpec module must set all local "
+                            "factual inputs, including false facts, so tests "
+                            "cannot pass through implicit defaults."
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert "apply=auto_repaired_test_input_assignments:first_case" in output
+        assert "apply=auto_repaired_test_input_assignments:second_case" in output
+        assert mock_overlay.call_count == 3
+        mock_apply.assert_called_once()
+        test_content = test_file.read_text()
+        assert test_content.count("us:statutes/26/6012#input.taxable_income: 0") == 2
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_test_input_assignments"] == [
+            "first_case",
+            "second_case",
+        ]
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_allows_overlay_to_rescue_failed_standalone_validation(
         self, capsys, tmp_path
     ):


### PR DESCRIPTION
## Summary
- repeat apply-time missing-test-input repairs until overlay validation stops reporting them
- keep the accumulated repaired case list in the encoding outcome
- add a regression where validation reveals missing inputs one case at a time

## Tests
- uv run pytest tests/test_cli.py::TestCmdEncode::test_encode_apply_auto_repairs_missing_test_input_assignments tests/test_cli.py::TestCmdEncode::test_encode_apply_repeats_missing_test_input_assignment_repairs
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py