### PR TITLE
Map 6012 tax outputs for PolicyEngine coverage

### DIFF
--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -8452,6 +8452,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 213 provision-level medical-care outputs include source-specific lodging, medicine-or-drug, long-term-care, decedent, cosmetic-surgery, section 21 exclusion, and expense assembly surfaces that PolicyEngine folds into itemized_medical_expenses/medical_expense_deduction unless an exact mapping overrides this prefix.
 
+  - legal_id_prefix: us:statutes/26/6012#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 6012 provision-level filing-requirement outputs include 2018-2025 return exceptions, estate/trust filing thresholds, gross-income adjustments, and tax-exempt-interest reporting amounts that PolicyEngine folds into broader filer variables or does not expose as one-to-one federal tax outputs unless an exact mapping overrides this prefix.
+
   - legal_id_prefix: us:statutes/26/1411#
     country: us
     program: tax

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1581,6 +1581,12 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
     assert medical_formula_mapping.mapping_type == "not_comparable"
     assert medical_formula_mapping.match_type == "prefix"
+    filing_requirement_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/6012#individual_income_tax_return_required_under_2018_2025_rule",
+        country="us",
+    )
+    assert filing_requirement_mapping.mapping_type == "not_comparable"
+    assert filing_requirement_mapping.match_type == "prefix"
     self_employment_tax_deduction_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/164/f#self_employment_tax_deduction",
         country="us",


### PR DESCRIPTION
## Summary
- classify 26 USC 6012 provision-level filing requirement outputs as known not-comparable to PolicyEngine unless exact overrides are added later
- add registry coverage for the 6012 prefix mapping

## Tests
- uv run pytest tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed
- uv run ruff check tests/test_rulespec_validation.py
- uv run ruff format --check tests/test_rulespec_validation.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tax --limit 100 --fail-on-unmapped --fail-on-untested-comparable