### PR TITLE
Prefer corpus text for source verification

### DIFF
--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3106,7 +3106,7 @@ def find_source_verification_issues(
             )
         )
 
-    source_text = extract_embedded_source_text(content) or _source_verification_text(
+    source_text = _source_verification_text(
         citation_paths=citation_paths,
         source_label=source_label,
         source_texts=source_texts,
@@ -3522,8 +3522,13 @@ def find_tax_filing_status_local_input_issues(
             inputs = test_case.get("input")
             if not isinstance(inputs, dict):
                 continue
-            for key in inputs:
+            for key, value in inputs.items():
                 fragment = _test_reference_fragment(key)
+                if (
+                    fragment == "input.filing_status"
+                    and _is_numeric_filing_status_fixture(value)
+                ):
+                    continue
                 if fragment not in {"input.filing_status", "input.tax_filing_status"}:
                     continue
                 issues.append(
@@ -3878,7 +3883,7 @@ def _match_fragment_has_named_arm(fragment: str) -> bool:
 
 
 def find_tax_filing_status_test_input_issues(test_cases: Any) -> list[str]:
-    """Reject `#input.filing_status` test assignments."""
+    """Reject non-enum `#input.filing_status` and local alias test assignments."""
     if not isinstance(test_cases, list):
         return []
 
@@ -3890,11 +3895,13 @@ def find_tax_filing_status_test_input_issues(test_cases: Any) -> list[str]:
         inputs = test_case.get("input")
         if not isinstance(inputs, dict):
             continue
-        for key in inputs:
-            if _test_reference_fragment(key) not in {
-                "input.filing_status",
-                "input.tax_filing_status",
-            }:
+        for key, value in inputs.items():
+            fragment = _test_reference_fragment(key)
+            if fragment == "input.filing_status" and _is_numeric_filing_status_fixture(
+                value
+            ):
+                continue
+            if fragment not in {"input.filing_status", "input.tax_filing_status"}:
                 continue
             issues.append(
                 "Filing status is a derived legal classification, not a factual "
@@ -3902,6 +3909,17 @@ def find_tax_filing_status_test_input_issues(test_cases: Any) -> list[str]:
                 f"`{key}`. Set the upstream filing-status leaf facts instead."
             )
     return issues
+
+
+def _is_numeric_filing_status_fixture(value: Any) -> bool:
+    numeric = _numeric_rule_value(value)
+    if numeric is None:
+        return False
+    _, number = numeric
+    with contextlib.suppress(TypeError, ValueError):
+        numeric_int = int(number)
+        return number == numeric_int and 0 <= numeric_int <= 4
+    return False
 
 
 def _filing_status_surviving_spouse_branch_issue(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2177,6 +2177,17 @@ rules:
             return binary
 
         def fake_run(cmd, **kwargs):
+            if (
+                len(cmd) >= 6
+                and cmd[:3] == ["git", "-C", str(repo)]
+                and cmd[3:] == ["remote", "get-url", "origin"]
+            ):
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout="https://github.com/TheAxiomFoundation/rulespec-us.git\n",
+                    stderr="",
+                )
             captured_envs.append(kwargs.get("env"))
             if "compile" in cmd:
                 output_path = Path(cmd[cmd.index("--output") + 1])

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -72,7 +72,10 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "increase before adding it to the base amount" in ENCODER_PROMPT
     assert "17300, not 17325" in ENCODER_PROMPT
     assert "Axiom formulas have no date literal type" in ENCODER_PROMPT
-    assert "Never use `post_YYYY`, `pre_YYYY`, `after_YYYY`, `before_YYYY`" in ENCODER_PROMPT
+    assert (
+        "Never use `post_YYYY`, `pre_YYYY`, `after_YYYY`, `before_YYYY`"
+        in ENCODER_PROMPT
+    )
     assert "overrides preservation of existing local input names" in ENCODER_PROMPT
     assert "module.summary` or the rule's proof excerpt" in ENCODER_PROMPT
     assert "Importing an adjacent upstream output only as proof" in ENCODER_PROMPT

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7678,6 +7678,36 @@ rules:
     assert issues == []
 
 
+def test_source_verification_prefers_corpus_source_over_module_summary():
+    content = """format: rulespec/v1
+module:
+  summary: The summary intentionally omits the exact official dollar amount.
+  source_verification:
+    corpus_citation_path: us/guidance/example/page-1
+    values:
+      official_amount: 140200
+rules:
+  - name: official_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '140200'
+"""
+
+    issues = find_source_verification_issues(
+        content,
+        source_texts={
+            "us/guidance/example/page-1": (
+                "Joint Returns or Surviving Spouses $140,200"
+            )
+        },
+    )
+
+    assert issues == []
+
+
 def test_source_verification_accepts_decimal_rate_values_as_percentages():
     content = """format: rulespec/v1
 module:
@@ -8222,7 +8252,7 @@ rules:
     assert find_unused_modifier_parameter_issues(content) == []
 
 
-def test_filing_status_local_input_rejects_numeric_test_assignment():
+def test_filing_status_local_input_allows_numeric_test_fixture():
     content = """format: rulespec/v1
 rules:
   - name: filing_status_sensitive_amount
@@ -8244,7 +8274,9 @@ rules:
 
     issues = find_tax_filing_status_local_input_issues(content, test_cases)
 
-    assert any("assigns filing status as a local input" in issue for issue in issues)
+    assert not any(
+        "assigns filing status as a local input" in issue for issue in issues
+    )
 
 
 def test_filing_status_test_input_rejects_string_value():
@@ -8265,12 +8297,28 @@ def test_filing_status_test_input_rejects_string_value():
     )
 
 
-def test_filing_status_test_input_rejects_numeric_value():
+def test_filing_status_test_input_allows_numeric_enum_fixture():
     test_cases = [
         {
             "name": "joint_status_code",
             "input": {
                 "us:policies/irs/rev-proc-2025-32/standard-deduction#input.filing_status": 1
+            },
+            "output": {},
+        }
+    ]
+
+    issues = find_tax_filing_status_test_input_issues(test_cases)
+
+    assert issues == []
+
+
+def test_filing_status_test_input_rejects_out_of_range_numeric_value():
+    test_cases = [
+        {
+            "name": "bad_status_code",
+            "input": {
+                "us:policies/irs/rev-proc-2025-32/standard-deduction#input.filing_status": 9
             },
             "output": {},
         }


### PR DESCRIPTION
## Summary
- validate `source_verification.values` against the declared corpus source text instead of `module.summary`
- add a regression test where the module summary omits a value present in the source page
- allow companion tests to assign numeric `#input.filing_status` enum fixtures (`0` through `4`) while still rejecting local aliases, string labels, formulas, and out-of-range values
- fix two current-main CI hygiene failures: stale ruff formatting in `tests/test_encoder_backend.py` and a `cmd_test` subprocess mock missing `git remote get-url origin`

## Tests
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_rulespec_validation.py -k "source_verification or filing_status"`
- `AXIOM_CORPUS_REPO=/Users/maxghenis/ssa-worktree/axiom-corpus uv run --project /Users/maxghenis/ssa-worktree/axiom-encode axiom-encode validate /Users/maxghenis/ssa-worktree/rulespec-us/policies/irs/rev-proc-2025-32/alternative-minimum-tax.yaml --skip-reviewers --json`
- `uvx ruff check src/ tests/`
- `uvx ruff format --check src/ tests/`

This fixes the source-verification failure and the existing numeric filing-status companion-test blocker observed while validating TheAxiomFoundation/rulespec-us#40. The filing-status blocker is tracked in TheAxiomFoundation/rulespec-us#41.
