### PR TITLE
Bump axiom-encode version to 0.2.87

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.86"
+version = "0.2.87"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.86"
+__version__ = "0.2.87"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.86"
+version = "0.2.87"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Bumps axiom-encode from `0.2.86` to `0.2.87` after the latest encoder-affecting changes. This unblocks signed RuleSpec apply/repair commands that require all encoder changes to be behind a committed version bump.

## Validation

- `uv lock --check`
- `uv run python -c "import axiom_encode; print(axiom_encode.__version__)"`
- `uv run python -c "from pathlib import Path; from axiom_encode.cli import _require_axiom_encode_version_provenance; print(_require_axiom_encode_version_provenance(Path('.'))['version'])"`
