### PR TITLE
Bump encoder version after section 151 guard

### DIFF
--- a/changelog.d/section-151-related-test-guard.fixed.md
+++ b/changelog.d/section-151-related-test-guard.fixed.md
@@ -1,0 +1,1 @@
+Require section 151 related-test repairs to be generated from a versioned encoder commit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.91"
+version = "0.2.92"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.91"
+__version__ = "0.2.92"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.91"
+version = "0.2.92"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- bump axiom-encode to 0.2.92 after the section 151 related-test guard change
- add a towncrier fragment for the guard/versioning fix

## Why
The apply provenance guard refuses to generate signed RuleSpec when encoder-affecting files changed after the latest version bump. This makes the merged guard commit usable for generated RuleSpec manifests without weakening that protection.

## Validation
- uv run ruff check src/axiom_encode/__init__.py
- uv run ruff format --check src/axiom_encode/__init__.py
- .venv/bin/python -m towncrier build --draft --version 0.0.0
