### PR TITLE
Use PolicyEngine tax unit roles in EITC oracle

### DIFF
--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -263,6 +263,9 @@ PE_PERSON_VARIABLES = tuple(
             "employer_medicare_tax",
             "employer_social_security_tax",
             "irs_employment_income",
+            "is_tax_unit_head",
+            "is_tax_unit_head_or_spouse",
+            "is_tax_unit_spouse",
             "payroll_tax_gross_wages",
         }
     )
@@ -1221,14 +1224,8 @@ def project_capital_gain_definition_inputs(
 def project_eitc_tax_unit_inputs(row: Any, persons: list[Any]) -> dict[str, Any]:
     filing_status = str(row["filing_status"])
     filing_status_numeric = filing_status_code(filing_status)
-    contexts = project_tax_unit_person_contexts(persons)
-    head_index, spouse_index = tax_unit_head_spouse_indices(persons)
-    filer_indices = {index for index in (head_index, spouse_index) if index is not None}
-    filer_contexts = [
-        context for index, context in enumerate(contexts) if index in filer_indices
-    ]
-    spouse_has_required_ssn = spouse_index is not None and valid_child_ssn_type(
-        str(persons[spouse_index].get("ssn_card_type", ""))
+    filer_meets_id_requirements = filer_meets_eitc_identification_requirements(
+        persons,
     )
     return {
         "filing_status": filing_status_numeric,
@@ -1239,11 +1236,8 @@ def project_eitc_tax_unit_inputs(row: Any, persons: list[Any]) -> dict[str, Any]
         ),
         "childless_taxpayer_principal_place_of_abode_in_united_states_more_than_half_year": True,
         "childless_taxpayer_or_spouse_age_eligible_for_eitc": any(
-            context.is_head or context.is_spouse
-            for context in filer_contexts
-            if context.is_head or context.is_spouse
-        )
-        and any(25 <= money(persons[index]["age"]) < 65 for index in filer_indices),
+            25 <= money(person["age"]) < 65 for person in persons
+        ),
         "taxpayer_is_dependent_for_section_151_to_another_taxpayer": False,
         "taxpayer_is_qualifying_child_of_another_taxpayer": False,
         "taxpayer_claims_section_911_benefits": False,
@@ -1258,11 +1252,11 @@ def project_eitc_tax_unit_inputs(row: Any, persons: list[Any]) -> dict[str, Any]
         "taxable_year_closed_by_reason_of_taxpayer_death": False,
         "eitc_disallowance_period_applies": False,
         "prior_deficiency_denial_without_required_eligibility_information": False,
-        "taxpayer_includes_required_social_security_number_on_return": any(
-            context.filer_has_valid_child_ctc_ssn for context in contexts
+        "taxpayer_includes_required_social_security_number_on_return": (
+            filer_meets_id_requirements
         ),
         "spouse_includes_required_social_security_number_on_return": (
-            spouse_has_required_ssn
+            filer_meets_id_requirements
         ),
     }
 
@@ -1534,6 +1528,26 @@ def project_tax_unit_person_contexts(
 
 
 def tax_unit_head_spouse_indices(persons: list[Any]) -> tuple[int | None, int | None]:
+    has_explicit_tax_unit_roles = any(
+        "is_tax_unit_head" in person or "is_tax_unit_spouse" in person
+        for person in persons
+    )
+    if has_explicit_tax_unit_roles:
+        head_indices = [
+            index
+            for index, person in enumerate(persons)
+            if bool_value(person.get("is_tax_unit_head", False))
+        ]
+        spouse_indices = [
+            index
+            for index, person in enumerate(persons)
+            if bool_value(person.get("is_tax_unit_spouse", False))
+        ]
+        return (
+            head_indices[0] if head_indices else None,
+            spouse_indices[0] if spouse_indices else None,
+        )
+
     adult_indices = [
         index for index, person in enumerate(persons) if money(person["age"]) >= 18
     ]
@@ -1553,6 +1567,25 @@ def tax_unit_head_spouse_indices(persons: list[Any]) -> tuple[int | None, int | 
         else None
     )
     return head_index, spouse_index
+
+
+def filer_meets_eitc_identification_requirements(persons: list[Any]) -> bool:
+    has_explicit_head_or_spouse = any(
+        "is_tax_unit_head_or_spouse" in person for person in persons
+    )
+    if has_explicit_head_or_spouse:
+        return not any(
+            bool_value(person.get("is_tax_unit_head_or_spouse", False))
+            and not valid_child_ssn_type(str(person.get("ssn_card_type", "")))
+            for person in persons
+        )
+
+    head_index, spouse_index = tax_unit_head_spouse_indices(persons)
+    filer_indices = [index for index in (head_index, spouse_index) if index is not None]
+    return all(
+        valid_child_ssn_type(str(persons[index].get("ssn_card_type", "")))
+        for index in filer_indices
+    )
 
 
 def run_axiom_program(

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -393,6 +393,87 @@ def test_eitc_projection_uses_ecps_income_and_demographic_inputs():
     }
 
 
+def test_eitc_projection_matches_policyengine_age_and_identification_edges():
+    row = {
+        "filing_status": "SEPARATE",
+        "adjusted_gross_income": -15_000,
+    }
+    persons = [
+        {
+            "age": 66,
+            "ssn_card_type": "CITIZEN",
+            "is_tax_unit_head": True,
+            "is_tax_unit_spouse": False,
+            "is_tax_unit_head_or_spouse": True,
+            "is_separated": True,
+            "employment_income_before_lsr": 0,
+            "self_employment_income_before_lsr": 0,
+            "sstb_self_employment_income_before_lsr": 0,
+        },
+        {
+            "age": 34,
+            "ssn_card_type": "CITIZEN",
+            "is_tax_unit_head": False,
+            "is_tax_unit_spouse": False,
+            "is_tax_unit_head_or_spouse": False,
+            "employment_income_before_lsr": 22_000,
+            "self_employment_income_before_lsr": 5_000,
+            "sstb_self_employment_income_before_lsr": 0,
+        },
+    ]
+
+    projected = project_eitc_tax_unit_inputs(row=row, persons=persons)
+    contexts = project_tax_unit_person_contexts(persons)
+
+    assert projected["childless_taxpayer_or_spouse_age_eligible_for_eitc"] is True
+    assert (
+        projected["taxpayer_includes_required_social_security_number_on_return"] is True
+    )
+    assert (
+        projected["spouse_includes_required_social_security_number_on_return"] is True
+    )
+    assert (
+        project_section_32_c_2_tax_unit_inputs(
+            persons=persons,
+            contexts=contexts,
+        )[
+            "wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income"
+        ]
+        == 0
+    )
+
+
+def test_eitc_projection_treats_tax_units_without_explicit_filers_as_id_eligible():
+    row = {
+        "filing_status": "HEAD_OF_HOUSEHOLD",
+        "adjusted_gross_income": 0,
+    }
+    persons = [
+        {
+            "age": 16,
+            "ssn_card_type": "CITIZEN",
+            "is_tax_unit_head": False,
+            "is_tax_unit_spouse": False,
+            "is_tax_unit_head_or_spouse": False,
+            "employment_income_before_lsr": 0,
+            "self_employment_income_before_lsr": 0,
+            "sstb_self_employment_income_before_lsr": 0,
+        }
+    ]
+
+    projected = project_eitc_tax_unit_inputs(row=row, persons=persons)
+    context = project_tax_unit_person_contexts(persons)[0]
+
+    assert (
+        projected["taxpayer_includes_required_social_security_number_on_return"] is True
+    )
+    assert (
+        projected["spouse_includes_required_social_security_number_on_return"] is True
+    )
+    assert context.is_tax_unit_dependent is True
+    assert context.qualifying_child_under_section_152_c is True
+
+
 def test_eitc_projection_sends_self_employment_to_section_1402_not_earned_income():
     row = {"filing_status": "SINGLE"}
     persons = [


### PR DESCRIPTION
## Summary

Publishes the local FIIT oracle harness patch Pavel called out in Slack so the EITC comparison is reproducible from `axiom-encode` main instead of relying on a dirty checkout.

- pulls PolicyEngine tax-unit role variables (`is_tax_unit_head`, `is_tax_unit_spouse`, `is_tax_unit_head_or_spouse`) into the ECPS person projection
- uses those explicit roles when reconstructing filer/spouse indices and EITC SSN identification inputs
- aligns the EITC childless age edge with PolicyEngine's tax-unit-level behavior for the harness projection
- adds focused regression tests for the age/identification edges that caused the sampled EITC mismatches

## Validation

- `uv run --extra dev python -m pytest tests/test_policyengine_ecps_tax.py` -> 49 passed, 8 skipped
- `uv run --extra dev ruff check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py` -> passed
- 100-tax-unit all-surface FIIT smoke using pinned PE stack and clean `rulespec-us`: 2,720 compared values, 16 mismatches, all remaining mismatches are known OASDI base-year drift; EITC outputs have 0 mismatches

## Notes

The worktree still produced an untracked `.axiom/` runtime directory during the smoke run; it is intentionally not included in this PR.
