### PR TITLE
Add source-scope validation

### DIFF
--- a/changelog.d/source-scope-protocol.added.md
+++ b/changelog.d/source-scope-protocol.added.md
@@ -1,0 +1,1 @@
+Added source-scope prompt guardrails so encoder outputs stay at the legal subject/entity level stated by the source and avoid downstream-only roll-ups.

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -29,6 +29,7 @@ from axiom_encode.concepts.registry import (
     load_concept_registry,
 )
 from axiom_encode.constants import DEFAULT_OPENAI_MODEL
+from axiom_encode.prompts.encoder import SOURCE_SCOPE_PROTOCOL
 from axiom_encode.repo_routing import canonical_rulespec_repo_name
 from axiom_encode.statute import (
     CitationParts,
@@ -2948,6 +2949,7 @@ RuleSpec requirements:
   field with the legal citation/span that directly supports that rule. Keep
   `source:` short and local to the rule; use `module.source_verification` for
   the corpus locator.
+{SOURCE_SCOPE_PROTOCOL}
 - If `./source.txt` is a broad application, furnishing, administrative duty, or purpose clause without a computable policy condition, preserve it in `module.summary` but do not create an executable derived output just to paraphrase it. Encode only the concrete conditions, exceptions, parameters, and relations that affect computation.
 - Do not create an output for administrative clauses like "assistance shall be furnished to all eligible households who make application." Unless the source defines a calculable benefit, amount, condition, or exception, keep that text documentary in `module.summary`.
 - Do not encode a pure pass-through rule whose formula is only one local fact. If the source only names a preexisting fact without changing it, reference the upstream rule when available or leave the phrase documentary.

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3267,6 +3267,23 @@ _FINAL_AMOUNT_NAME_PATTERN = re.compile(
     r"(?:^|_)(?:amount|benefit|deduction|credit|tax|allotment|allowance)$",
     flags=re.IGNORECASE,
 )
+_UNIT_SCOPED_ENTITY_NAMES = {"household", "snapunit", "taxunit", "family", "spmunit"}
+_PERSON_SCOPE_SOURCE_PATTERN = re.compile(
+    r"\b(?:no|any|each|every|all)\s+"
+    r"(?:individual|person|(?:household\s+)?member|taxpayer|claimant|child)\b"
+    r"[\s\S]{0,180}\b(?:eligible|ineligible|disqualif|excluded?|participat)",
+    flags=re.IGNORECASE,
+)
+_HOUSEHOLD_SCOPE_SOURCE_PATTERN = re.compile(
+    r"\bhousehold\b(?!\s+member\b)[\s\S]{0,180}"
+    r"\b(?:eligible|eligibility|test|requirement|resources?|income)\b",
+    flags=re.IGNORECASE,
+)
+_HOUSEHOLD_MEMBER_MIXED_SCOPE_PATTERN = re.compile(
+    r"\bhousehold\b(?!\s+member\b)[\s\S]{0,180}"
+    r"\b(?:each|every|all)\s+(?:household\s+)?member\b",
+    flags=re.IGNORECASE,
+)
 
 
 def _rulespec_payload(content: str) -> dict[str, Any] | None:
@@ -3347,6 +3364,58 @@ def find_empty_rules_module_issues(content: str) -> list[str]:
         "If the source is executable, encode at least one source-backed rule; "
         "do not silently apply an empty module."
     ]
+
+
+def find_source_scope_consistency_issues(content: str) -> list[str]:
+    """Flag obvious mismatches between source legal subject and rule entity.
+
+    This is intentionally conservative: if the source appears mixed or vague,
+    it returns no issue rather than guessing a legal scope.
+    """
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+    source_text = extract_embedded_source_text(content)
+    if not source_text:
+        return []
+
+    person_scoped = _PERSON_SCOPE_SOURCE_PATTERN.search(source_text) is not None
+    household_scoped = _HOUSEHOLD_SCOPE_SOURCE_PATTERN.search(source_text) is not None
+    if _HOUSEHOLD_MEMBER_MIXED_SCOPE_PATTERN.search(source_text):
+        return []
+    if person_scoped == household_scoped:
+        return []
+
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+    issues: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        kind = str(rule.get("kind") or "").strip().lower()
+        if kind != "derived":
+            continue
+        name = str(rule.get("name") or "").strip()
+        entity = str(rule.get("entity") or "").strip()
+        normalized_entity = entity.lower()
+        if person_scoped and normalized_entity in _UNIT_SCOPED_ENTITY_NAMES:
+            issues.append(
+                "Source scope mismatch: "
+                f"`{name}` is declared on `{entity}`, but the embedded source "
+                "states an individual/person/member-scoped eligibility or "
+                "disqualification. Encode the rule at the person/member scope "
+                "or cite source text that states the unit-level test."
+            )
+        elif household_scoped and normalized_entity == "person":
+            issues.append(
+                "Source scope mismatch: "
+                f"`{name}` is declared on `Person`, but the embedded source "
+                "states a household/unit-scoped test. Encode the rule at the "
+                "source-stated unit scope or cite source text that states the "
+                "person-level test."
+            )
+    return issues
 
 
 def find_tax_filing_status_surviving_spouse_issues(content: str) -> list[str]:
@@ -10240,6 +10309,7 @@ class ValidatorPipeline:
         issues.extend(find_upstream_placement_issues(content, rules_file=rules_file))
         issues.extend(find_source_verification_issues(content))
         issues.extend(find_source_condition_coverage_issues(content))
+        issues.extend(find_source_scope_consistency_issues(content))
         issues.extend(find_helper_only_definition_issues(content))
         issues.extend(find_deferred_output_issues(content))
         issues.extend(find_tax_status_component_local_input_issues(content))

--- a/src/axiom_encode/prompts/__init__.py
+++ b/src/axiom_encode/prompts/__init__.py
@@ -5,9 +5,14 @@ All prompts are self-contained -- no dependency on external plugins.
 The public prompt surface is RuleSpec-only.
 """
 
-from .encoder import ENCODER_PROMPT, get_encoder_prompt
+from .encoder import (
+    ENCODER_PROMPT,
+    SOURCE_SCOPE_PROTOCOL,
+    get_encoder_prompt,
+)
 
 __all__ = [
     "ENCODER_PROMPT",
+    "SOURCE_SCOPE_PROTOCOL",
     "get_encoder_prompt",
 ]

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -24,7 +24,8 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   output, or leave the phrase documentary; do not bridge the mismatch with an
   opaque local fact or a made-up household/tax-unit proxy."""
 
-ENCODER_PROMPT = """# Axiom RuleSpec Encoder
+ENCODER_PROMPT = (
+    """# Axiom RuleSpec Encoder
 
 Encode only the supplied legal source text into Axiom RuleSpec YAML.
 
@@ -76,7 +77,9 @@ Hard requirements:
   age band, or another row key. Do not encode those cells as `match` arms or
   numeric literals inside a derived formula.
 - Use `kind: derived` for entity-scoped outputs.
-""" + SOURCE_SCOPE_PROTOCOL + """
+"""
+    + SOURCE_SCOPE_PROTOCOL
+    + """
 - If source text is a broad application, furnishing, administrative duty, or
   purpose clause without a computable policy condition, preserve it in
   `module.summary` but do not create an executable derived output just to
@@ -671,6 +674,7 @@ rules:
       - effective_from: '2025-10-01'
         formula: example_amount_by_household_size[household_size]
 """
+)
 
 
 def get_encoder_prompt(

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1,5 +1,29 @@
 """RuleSpec encoder prompt used by generic backend adapters."""
 
+SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
+- Match each executable rule's `entity:` to the legal subject stated by the
+  supplied source text. If the source states an individual, member, taxpayer,
+  claimant, or child disqualification, encode that person-scoped rule as such;
+  do not promote it to a household, unit, or top-level eligibility boolean.
+- If the source states a household, unit, filing-unit, or tax-unit test, encode
+  that scope directly. If the same source also states member/person predicates
+  that feed that test, encode those predicates only as support for the
+  source-stated unit-level output.
+- Do not create a roll-up, top-level program output, or connection merely
+  because downstream consumers want it, sibling/state files patched it, or the
+  program conventionally has such a concept. The output must be directly
+  supported by the supplied source text, an explicit imported RuleSpec export,
+  or an accepted source claim listed in `module.source_claims`.
+- Downstream convenience booleans that collapse a legal process into one
+  answer are not federal/source outputs unless the supplied source text itself
+  defines that collapsed test. Keep process simplifications out of RuleSpec
+  source encodings.
+- Before finalizing, compare the source's legal subject nouns and proof excerpts
+  against every executable `parameter` and `derived` rule's `entity:`. If the
+  scope does not match the source, rename/re-scope the rule, defer the blocked
+  output, or leave the phrase documentary; do not bridge the mismatch with an
+  opaque local fact or a made-up household/tax-unit proxy."""
+
 ENCODER_PROMPT = """# Axiom RuleSpec Encoder
 
 Encode only the supplied legal source text into Axiom RuleSpec YAML.
@@ -52,6 +76,7 @@ Hard requirements:
   age band, or another row key. Do not encode those cells as `match` arms or
   numeric literals inside a derived formula.
 - Use `kind: derived` for entity-scoped outputs.
+""" + SOURCE_SCOPE_PROTOCOL + """
 - If source text is a broad application, furnishing, administrative duty, or
   purpose clause without a computable policy condition, preserve it in
   `module.summary` but do not create an executable derived output just to

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -55,6 +55,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_source_claim_reference_issues,
     find_source_condition_coverage_issues,
     find_source_limitation_application_issues,
+    find_source_scope_consistency_issues,
     find_source_verification_issues,
     find_tax_filing_status_enum_representation_issues,
     find_tax_filing_status_local_input_issues,
@@ -7911,6 +7912,109 @@ rules: []
 """
 
     assert find_empty_rules_module_issues(content) == []
+
+
+def test_source_scope_consistency_rejects_person_source_as_household_rule():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    No individual who refuses to provide a required Social Security number
+    shall be eligible to participate as a member of any household.
+rules:
+  - name: snap_ssn_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.6
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          count_where(member_of_household, member_has_provided_ssn) == len(member_of_household)
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `snap_ssn_eligible` is declared on "
+        "`Household`, but the embedded source states an "
+        "individual/person/member-scoped eligibility or disqualification. "
+        "Encode the rule at the person/member scope or cite source text that "
+        "states the unit-level test."
+    ]
+
+
+def test_source_scope_consistency_accepts_person_source_as_person_rule():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    No individual who refuses to provide a required Social Security number
+    shall be eligible to participate as a member of any household.
+rules:
+  - name: snap_member_ssn_requirement_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.6
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          member_has_provided_ssn
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_rejects_household_source_as_person_rule():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Household resources are tested against the applicable resource limit for
+    household eligibility.
+rules:
+  - name: snap_member_resource_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.8
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          member_resources <= resource_limit
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `snap_member_resource_eligible` is declared on "
+        "`Person`, but the embedded source states a household/unit-scoped test. "
+        "Encode the rule at the source-stated unit scope or cite source text "
+        "that states the person-level test."
+    ]
+
+
+def test_source_scope_consistency_does_not_guess_mixed_source_scope():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Household eligibility depends on each household member meeting an
+    individual condition.
+rules:
+  - name: snap_member_condition_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: mixed source
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          member_condition_met
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
 
 
 def test_filing_status_local_input_allows_imported_formula():


### PR DESCRIPTION
## Summary
- Adds conservative source-scope guidance for encoder/eval prompts: encode the legal subject actually stated by the source, and do not invent downstream convenience roll-ups.
- Adds functional RuleSpec validation for obvious source-scope/entity mismatches.
- Keeps ambiguous or mixed source text unflagged so the validator does not guess connections that the law does not state.

After the issue comment update, this PR no longer treats the SNAP examples as missing federal household outputs. It focuses on preventing the encoder from promoting person/member disqualifications into household/unit rules, or demoting household tests into person rules, unless the cited source supports that scope.

## Tests
- Added validator tests that reject a person/member-scoped source encoded as `Household`.
- Added validator tests that accept the same source encoded as `Person`.
- Added validator tests that reject a household-scoped source encoded as `Person`.
- Added validator tests that leave mixed/ambiguous household-member text alone.
- Removed prompt-presence tests because they only checked wording, not behavior.

## Verification
- TDD proof: applying the new functional test to `main` fails before implementation with `ImportError: cannot import name find_source_scope_consistency_issues`.
- `uv run pytest tests/test_rulespec_validation.py::test_source_scope_consistency_rejects_person_source_as_household_rule tests/test_rulespec_validation.py::test_source_scope_consistency_accepts_person_source_as_person_rule tests/test_rulespec_validation.py::test_source_scope_consistency_rejects_household_source_as_person_rule tests/test_rulespec_validation.py::test_source_scope_consistency_does_not_guess_mixed_source_scope tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_statutory_base_naming_guidance tests/test_evals.py::TestEvalPrompt::test_build_eval_prompt_includes_rulespec_schema_guardrails`
- `uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py tests/test_encoder_backend.py tests/test_evals.py`
- `git diff --check`