### PR TITLE
Use rule-local evidence for source-scope validation

### DIFF
--- a/changelog.d/source-scope-rule-local-validation.fixed.md
+++ b/changelog.d/source-scope-rule-local-validation.fixed.md
@@ -1,0 +1,1 @@
+Strengthened source-scope validation to use rule-local proof excerpts before module summaries, catch definite person/member subjects encoded at unit scope, flag clear unrelated unit-to-unit mismatches, and recognize additional state-manual source wording.

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3268,22 +3268,48 @@ _FINAL_AMOUNT_NAME_PATTERN = re.compile(
     flags=re.IGNORECASE,
 )
 _UNIT_SCOPED_ENTITY_NAMES = {"household", "snapunit", "taxunit", "family", "spmunit"}
+_UNIT_SCOPED_ENTITY_LABELS = {
+    "household": "Household",
+    "snapunit": "SnapUnit",
+    "taxunit": "TaxUnit",
+    "family": "Family",
+    "spmunit": "SPMUnit",
+}
+_UNIT_ENTITY_EQUIVALENCE_SETS = (frozenset({"household", "snapunit"}),)
 _PERSON_SCOPE_SOURCE_PATTERN = re.compile(
-    r"\b(?:no|any|each|every|all)\s+"
-    r"(?:individual|person|(?:household\s+)?member|taxpayer|claimant|child)\b"
+    r"\b(?:no|any|each|every|all|a|an|the|that|such)\s+"
+    r"(?:individual|person|(?:household\s+|family\s+)?member|taxpayer|claimant|child|"
+    r"(?:sponsored\s+)?alien|qualified\s+alien|applicant|recipient|"
+    r"participant|client|case\s+member)\b"
     r"[\s\S]{0,180}\b(?:eligible|ineligible|disqualif|excluded?|participat)",
     flags=re.IGNORECASE,
 )
-_HOUSEHOLD_SCOPE_SOURCE_PATTERN = re.compile(
-    r"\bhousehold\b(?!\s+member\b)[\s\S]{0,180}"
-    r"\b(?:eligible|eligibility|test|requirement|resources?|income)\b",
+_UNIT_SCOPE_SOURCE_PATTERN = re.compile(
+    r"\b(?:household\b(?!\s+member\b)|snap\s+unit|food\s+assistance\s+unit|"
+    r"assistance\s+unit|tax\s+unit|filing\s+unit|family\b(?!\s+member\b)|"
+    r"spm\s+unit)\b"
+    r"[\s\S]{0,180}\b"
+    r"(?:eligible|eligibility|test|requirement|resources?|income|standard|"
+    r"benefit|allotment)\b",
     flags=re.IGNORECASE,
+)
+_UNIT_SOURCE_ENTITY_PATTERNS = (
+    ("household", re.compile(r"\bhousehold\b(?!\s+member\b)", flags=re.IGNORECASE)),
+    (
+        "snapunit",
+        re.compile(r"\b(?:snap|food\s+assistance)\s+unit\b", flags=re.IGNORECASE),
+    ),
+    ("taxunit", re.compile(r"\b(?:tax|filing)\s+unit\b", flags=re.IGNORECASE)),
+    ("family", re.compile(r"\bfamily\b(?!\s+member\b)", flags=re.IGNORECASE)),
+    ("spmunit", re.compile(r"\bspm\s+unit\b", flags=re.IGNORECASE)),
 )
 _HOUSEHOLD_MEMBER_MIXED_SCOPE_PATTERN = re.compile(
     r"\bhousehold\b(?!\s+member\b)[\s\S]{0,180}"
     r"\b(?:each|every|all)\s+(?:household\s+)?member\b",
     flags=re.IGNORECASE,
 )
+_SOURCE_SCOPE_PERSON = "person"
+_SOURCE_SCOPE_UNIT = "unit"
 
 
 def _rulespec_payload(content: str) -> dict[str, Any] | None:
@@ -3366,6 +3392,92 @@ def find_empty_rules_module_issues(content: str) -> list[str]:
     ]
 
 
+def _classify_source_scope(text: str) -> str | None:
+    """Return a clear source scope, or None when the text is mixed/vague."""
+    person_scoped = _PERSON_SCOPE_SOURCE_PATTERN.search(text) is not None
+    unit_scoped = _UNIT_SCOPE_SOURCE_PATTERN.search(text) is not None
+    if _HOUSEHOLD_MEMBER_MIXED_SCOPE_PATTERN.search(text):
+        return None
+    if person_scoped == unit_scoped:
+        return None
+    return _SOURCE_SCOPE_PERSON if person_scoped else _SOURCE_SCOPE_UNIT
+
+
+def _classify_source_unit_entity(text: str) -> str | None:
+    """Return a clear unit entity from source text, or None when generic/mixed."""
+    matches = {
+        entity
+        for entity, pattern in _UNIT_SOURCE_ENTITY_PATTERNS
+        if pattern.search(text)
+    }
+    if len(matches) != 1:
+        return None
+    return next(iter(matches))
+
+
+def _unit_entities_are_equivalent(left: str, right: str) -> bool:
+    if left == right:
+        return True
+    return any(
+        {left, right} <= entity_set for entity_set in _UNIT_ENTITY_EQUIVALENCE_SETS
+    )
+
+
+def _rule_proof_source_excerpts(rule: dict[str, Any]) -> list[str]:
+    metadata = rule.get("metadata")
+    if not isinstance(metadata, dict):
+        return []
+    proof = metadata.get("proof")
+    if not isinstance(proof, dict):
+        return []
+    atoms = proof.get("atoms")
+    if not isinstance(atoms, list):
+        return []
+
+    excerpts: list[str] = []
+    for atom in atoms:
+        if not isinstance(atom, dict):
+            continue
+        source = atom.get("source")
+        if not isinstance(source, dict):
+            continue
+        excerpt = source.get("excerpt")
+        if isinstance(excerpt, str) and excerpt.strip():
+            excerpts.append(excerpt.strip())
+    return excerpts
+
+
+def _rule_source_scope(
+    rule: dict[str, Any],
+    fallback_source_text: str,
+) -> tuple[str, str | None] | None:
+    source_texts = _rule_proof_source_excerpts(rule)
+    if not source_texts and fallback_source_text:
+        source_texts = [fallback_source_text]
+
+    classifications = [
+        (
+            scope,
+            _classify_source_unit_entity(text) if scope == _SOURCE_SCOPE_UNIT else None,
+        )
+        for text in source_texts
+        if (scope := _classify_source_scope(text)) is not None
+    ]
+    scopes = {scope for scope, _unit_entity in classifications}
+    if len(scopes) != 1:
+        return None
+    scope = next(iter(scopes))
+    unit_entities = {
+        unit_entity
+        for _scope, unit_entity in classifications
+        if unit_entity is not None
+    }
+    if len(unit_entities) > 1:
+        return None
+    source_unit_entity = next(iter(unit_entities), None)
+    return scope, source_unit_entity
+
+
 def find_source_scope_consistency_issues(content: str) -> list[str]:
     """Flag obvious mismatches between source legal subject and rule entity.
 
@@ -3376,15 +3488,6 @@ def find_source_scope_consistency_issues(content: str) -> list[str]:
     if payload is None:
         return []
     source_text = extract_embedded_source_text(content)
-    if not source_text:
-        return []
-
-    person_scoped = _PERSON_SCOPE_SOURCE_PATTERN.search(source_text) is not None
-    household_scoped = _HOUSEHOLD_SCOPE_SOURCE_PATTERN.search(source_text) is not None
-    if _HOUSEHOLD_MEMBER_MIXED_SCOPE_PATTERN.search(source_text):
-        return []
-    if person_scoped == household_scoped:
-        return []
 
     rules = payload.get("rules")
     if not isinstance(rules, list):
@@ -3399,7 +3502,14 @@ def find_source_scope_consistency_issues(content: str) -> list[str]:
         name = str(rule.get("name") or "").strip()
         entity = str(rule.get("entity") or "").strip()
         normalized_entity = entity.lower()
-        if person_scoped and normalized_entity in _UNIT_SCOPED_ENTITY_NAMES:
+        source_scope_record = _rule_source_scope(rule, source_text)
+        if source_scope_record is None:
+            continue
+        source_scope, source_unit_entity = source_scope_record
+        if (
+            source_scope == _SOURCE_SCOPE_PERSON
+            and normalized_entity in _UNIT_SCOPED_ENTITY_NAMES
+        ):
             issues.append(
                 "Source scope mismatch: "
                 f"`{name}` is declared on `{entity}`, but the embedded source "
@@ -3407,13 +3517,26 @@ def find_source_scope_consistency_issues(content: str) -> list[str]:
                 "disqualification. Encode the rule at the person/member scope "
                 "or cite source text that states the unit-level test."
             )
-        elif household_scoped and normalized_entity == "person":
+        elif source_scope == _SOURCE_SCOPE_UNIT and normalized_entity == "person":
             issues.append(
                 "Source scope mismatch: "
                 f"`{name}` is declared on `Person`, but the embedded source "
                 "states a household/unit-scoped test. Encode the rule at the "
                 "source-stated unit scope or cite source text that states the "
                 "person-level test."
+            )
+        elif (
+            source_scope == _SOURCE_SCOPE_UNIT
+            and source_unit_entity is not None
+            and normalized_entity in _UNIT_SCOPED_ENTITY_NAMES
+            and not _unit_entities_are_equivalent(normalized_entity, source_unit_entity)
+        ):
+            issues.append(
+                "Source scope mismatch: "
+                f"`{name}` is declared on `{entity}`, but the embedded source "
+                f"states a `{_UNIT_SCOPED_ENTITY_LABELS[source_unit_entity]}` "
+                "unit-scoped test. Encode the rule at the source-stated unit "
+                "scope or cite source text that states the declared unit scope."
             )
     return issues
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7995,6 +7995,156 @@ rules:
     ]
 
 
+def test_source_scope_consistency_allows_household_source_as_snapunit_rule():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Household resources are tested against the applicable resource limit for
+    household eligibility.
+rules:
+  - name: snap_unit_resource_eligible
+    kind: derived
+    entity: SnapUnit
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.8
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          snap_unit_resources <= resource_limit
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_rejects_taxunit_source_as_household_rule():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    The tax unit income must be below the eligibility standard.
+rules:
+  - name: household_tax_unit_income_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Year
+    source: tax manual
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          household_income <= tax_unit_income_standard
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `household_tax_unit_income_eligible` is "
+        "declared on `Household`, but the embedded source states a `TaxUnit` "
+        "unit-scoped test. Encode the rule at the source-stated unit scope or "
+        "cite source text that states the declared unit scope."
+    ]
+
+
+def test_source_scope_consistency_accepts_matching_snapunit_source():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    The SNAP unit income is tested against the applicable standard.
+rules:
+  - name: snap_unit_income_eligible
+    kind: derived
+    entity: SnapUnit
+    dtype: Judgment
+    period: Month
+    source: state manual
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          snap_unit_income <= snap_unit_income_standard
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_does_not_treat_family_member_as_family_unit():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    A qualifying family member is eligible for food assistance.
+rules:
+  - name: qualifying_family_member_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: state manual
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          is_qualifying_family_member
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_recognizes_state_manual_person_wording():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    An applicant who fails to cooperate with identity verification is not
+    eligible for food assistance.
+rules:
+  - name: household_identity_verification_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: state manual
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          all_applicants_cooperated_with_identity_verification
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `household_identity_verification_eligible` "
+        "is declared on `Household`, but the embedded source states an "
+        "individual/person/member-scoped eligibility or disqualification. "
+        "Encode the rule at the person/member scope or cite source text that "
+        "states the unit-level test."
+    ]
+
+
+def test_source_scope_consistency_recognizes_state_manual_unit_wording():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    The assistance unit income must be below the eligibility standard.
+rules:
+  - name: applicant_income_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: state manual
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          applicant_income <= eligibility_standard
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `applicant_income_eligible` is declared on "
+        "`Person`, but the embedded source states a household/unit-scoped test. "
+        "Encode the rule at the source-stated unit scope or cite source text "
+        "that states the person-level test."
+    ]
+
+
 def test_source_scope_consistency_does_not_guess_mixed_source_scope():
     content = """format: rulespec/v1
 module:
@@ -8015,6 +8165,156 @@ rules:
 """
 
     assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_uses_rule_proof_excerpt_before_mixed_summary():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Household eligibility depends on income, resources, and whether each
+    household member satisfies several person-level disqualification rules.
+rules:
+  - name: snap_sponsored_alien_verification_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.4(c)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              excerpt: "Until the alien provides information or verification necessary to carry out the provisions of paragraph (c)(2), the sponsored alien is ineligible."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          all_members_have_sponsor_information
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `snap_sponsored_alien_verification_eligible` "
+        "is declared on `Household`, but the embedded source states an "
+        "individual/person/member-scoped eligibility or disqualification. "
+        "Encode the rule at the person/member scope or cite source text that "
+        "states the unit-level test."
+    ]
+
+
+def test_source_scope_consistency_rejects_definite_person_subject_at_unit_scope():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Until the alien provides information or verification necessary to carry out
+    the provisions of paragraph (c)(2), the sponsored alien is ineligible.
+rules:
+  - name: sponsored_alien_ineligible_while_verification_missing
+    kind: derived
+    entity: SnapUnit
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.4(c)(5)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          not sponsored_alien_provided_verification
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: "
+        "`sponsored_alien_ineligible_while_verification_missing` is declared "
+        "on `SnapUnit`, but the embedded source states an "
+        "individual/person/member-scoped eligibility or disqualification. "
+        "Encode the rule at the person/member scope or cite source text that "
+        "states the unit-level test."
+    ]
+
+
+def test_source_scope_consistency_skips_rule_with_mixed_proof_excerpt():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Household eligibility depends on each household member meeting an
+    individual condition.
+rules:
+  - name: snap_member_condition_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: mixed source
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              excerpt: "Household eligibility depends on each household member meeting an individual condition."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          all_member_conditions_met
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_checks_each_rule_independently():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Household eligibility depends on resources and member-level alien status.
+rules:
+  - name: snap_member_alien_status_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.4
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              excerpt: "No person is eligible to participate in the Program unless that person meets a listed citizenship or alien status condition."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          member_has_eligible_alien_status
+  - name: snap_sponsored_alien_verification_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.4(c)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              excerpt: "Until the alien provides information or verification necessary to carry out paragraph (c)(2), the sponsored alien is ineligible."
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          all_sponsored_aliens_provided_verification
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `snap_sponsored_alien_verification_eligible` "
+        "is declared on `Household`, but the embedded source states an "
+        "individual/person/member-scoped eligibility or disqualification. "
+        "Encode the rule at the person/member scope or cite source text that "
+        "states the unit-level test."
+    ]
 
 
 def test_filing_status_local_input_allows_imported_formula():
@@ -8316,6 +8616,26 @@ rules: []
         "source_values" in issue and "absolute RuleSpec target" in issue
         for issue in issues
     )
+
+
+def test_deferred_output_rejects_absolute_blocker_without_rule_fragment():
+    content = """format: rulespec/v1
+module:
+  deferred_outputs:
+    - output: us:regulations/7-cfr/273/4#qualified_alien_eligible_to_receive_snap_benefits
+      reason: Missing upstream INA withholding-of-removal rule.
+      blocked_by:
+        - us:statutes/us/241/b/3
+rules: []
+"""
+
+    issues = find_deferred_output_issues(content)
+
+    assert issues == [
+        "module.deferred_outputs[0].blocked_by entry "
+        "`us:statutes/us/241/b/3` must be an absolute RuleSpec target with a "
+        "rule fragment."
+    ]
 
 
 def test_unused_modifier_parameter_ignores_judgment_names_with_amount_word():


### PR DESCRIPTION
## Summary
- Strengthens source-scope validation to classify each rule from its own proof excerpts before falling back to module summary text.
- Expands person-scope wording for definite person subjects such as sponsored alien, qualified alien, applicant, recipient, participant, client, case member, and family member.
- Adds unit-to-unit checks for clear source mentions of Household, SnapUnit, TaxUnit, Family, and SPMUnit, but treats Household and SnapUnit as equivalent for this guard so we do not overfit the validator to one modeling distinction.
- Keeps generic, ambiguous, or mixed excerpts unflagged, and adds a multi-rule regression test so one bad rule can be reported without rejecting a whole mixed-quality file.
- Adds an exact regression showing the existing deferred-output validator catches the 273.4-style invalid blocked_by target without a rule fragment.
- Adds a false-positive regression so person-level “family member” wording is not treated as a Family-unit rule.

This still does not claim to solve all encode quality. The 273.4 smoke failure was already caught by CI validation; this PR keeps that guard covered but does not try to make every generated 273.4 artifact pass end to end.

Closes #78.

## Tests
- Initially confirmed the new source-scope tests failed before implementation, including the now-allowed Household-source/SnapUnit-entity case before adding explicit equivalence.
- `uv run pytest` focused source-scope/deferred-output tests: 15 passed.
- `uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `git diff --check`
