### PR TITLE
Teach encoder about derived relations

### DIFF
--- a/changelog.d/derived-relation-encoder.added.md
+++ b/changelog.d/derived-relation-encoder.added.md
@@ -1,0 +1,1 @@
+Added encoder prompt and validation/oracle allow-list support for `kind: derived_relation` filtered membership rules.

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -8334,7 +8334,7 @@ def _rulespec_module_source_paths(payload: dict[str, object]) -> list[str]:
 
 def _parsed_rule_requires_generated_source_proof(rule: dict[str, object]) -> bool:
     kind = str(rule.get("kind") or "").strip()
-    if kind not in {"parameter", "derived"}:
+    if kind not in {"parameter", "derived", "derived_relation"}:
         return False
     versions = rule.get("versions")
     if not isinstance(versions, list) or not versions:

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2953,9 +2953,10 @@ RuleSpec requirements:
 - Use `kind: derived_relation` when the source defines a derived legal
   membership concept by filtering a source relation through a predicate. Keep
   the membership predicate as an ordinary source-backed rule, then define the
-  filtered entity with `source_relation`, `member_relation`, `slot_entities`,
-  and a `versions[].formula` that names the predicate. Otherwise stay on
-  `kind: derived` for ordinary entity-scoped outputs.
+  filtered entity under `derived_relation:` with `arity`, `source_relation`,
+  `entity`, `member_relation`, `slot_entities`, and a `versions[].formula` that
+  names the predicate. Otherwise stay on `kind: derived` for ordinary
+  entity-scoped outputs.
 {SOURCE_SCOPE_PROTOCOL}
 - If `./source.txt` is a broad application, furnishing, administrative duty, or purpose clause without a computable policy condition, preserve it in `module.summary` but do not create an executable derived output just to paraphrase it. Encode only the concrete conditions, exceptions, parameters, and relations that affect computation.
 - Do not create an output for administrative clauses like "assistance shall be furnished to all eligible households who make application." Unless the source defines a calculable benefit, amount, condition, or exception, keep that text documentary in `module.summary`.
@@ -3377,10 +3378,12 @@ rules:
           and not member_is_excluded_student
   - name: snap_unit
     kind: derived_relation
-    entity: SnapUnit
-    source_relation: member_of_household
-    member_relation: members
-    slot_entities: [Person]
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
     source: 7 CFR 273.1(a)
     versions:
       - effective_from: '2026-01-01'
@@ -4591,9 +4594,13 @@ def _context_file_executable_surfaces(source_path: str) -> dict[str, dict[str, o
                     effective_dates.append(
                         str(version.get("effective_from") or "").strip()
                     )
+        derived_relation = rule.get("derived_relation")
+        relation_entity = ""
+        if kind == "derived_relation" and isinstance(derived_relation, dict):
+            relation_entity = str(derived_relation.get("entity") or "").strip()
         surfaces[name] = {
             "kind": kind,
-            "entity": str(rule.get("entity") or "").strip(),
+            "entity": relation_entity or str(rule.get("entity") or "").strip(),
             "dtype": str(rule.get("dtype") or "").strip(),
             "period": str(rule.get("period") or "").strip(),
             "unit": str(rule.get("unit") or "").strip(),

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2928,7 +2928,8 @@ RuleSpec requirements:
 - Do not emit `source_url`; RuleSpec source verification reads `corpus.provisions`, not raw PDFs or web pages.
 {corpus_rulespec_requirement.rstrip()}
 - Include `module.proof_validation.required: true` and add
-  `metadata.proof.atoms` to every `parameter` and `derived` rule. Each atom
+  `metadata.proof.atoms` to every `parameter`, `derived`, and
+  `derived_relation` rule. Each atom
   must point to the corpus source, an accepted claim, or an explicit imported
   RuleSpec export supporting that rule's formula/value.
 - For imported proof support, put `import:` at the proof atom top level
@@ -2943,12 +2944,18 @@ RuleSpec requirements:
   `parameter`, `parameter_table`, `predicate`, `table_cell`, or `unit`.
 - Use `rules:` as a list of rule objects. The filepath is the ID; do not add an `id:` field.
 - Do not invent schema keys like `namespace:`, `parameter`, `variable`, or `rule:`.
-- Rule kinds are `parameter`, `derived`, `data_relation`, or `source_relation`. Use `parameter` for named source scalars, `derived` for entity-scoped outputs, `data_relation` for runtime predicates, and `source_relation` for non-executable legal/provenance edges.
+- Rule kinds are `parameter`, `derived`, `derived_relation`, `data_relation`, or `source_relation`. Use `parameter` for named source scalars, `derived` for entity-scoped outputs, `derived_relation` when source text defines a filtered legal membership relation, `data_relation` for runtime predicates, and `source_relation` for non-executable legal/provenance edges.
 - A `kind: table_cell` proof atom must include `source.table.header`, `source.table.row`, and `source.table.column`. A `kind: parameter_table` proof atom with `source.table` must include `source.table.header`, `source.table.row_key`, and `source.table.column_key`; header-only `parameter_table` proof atoms are invalid. Example: `source: {{table: {{header: "credit percentage table", row_key: "qualifying_child_count", column_key: "credit_percentage"}}}}`. If you cannot identify table coordinates, use a direct proof kind such as `amount`, `parameter`, or `formula` instead of `table_cell` or `parameter_table`.
-- Every executable `parameter` and `derived` rule must include a `source:`
+- Every executable `parameter`, `derived`, and `derived_relation` rule must include a `source:`
   field with the legal citation/span that directly supports that rule. Keep
   `source:` short and local to the rule; use `module.source_verification` for
   the corpus locator.
+- Use `kind: derived_relation` when the source defines a derived legal
+  membership concept by filtering a source relation through a predicate. Keep
+  the membership predicate as an ordinary source-backed rule, then define the
+  filtered entity with `source_relation`, `member_relation`, `slot_entities`,
+  and a `versions[].formula` that names the predicate. Otherwise stay on
+  `kind: derived` for ordinary entity-scoped outputs.
 {SOURCE_SCOPE_PROTOCOL}
 - If `./source.txt` is a broad application, furnishing, administrative duty, or purpose clause without a computable policy condition, preserve it in `module.summary` but do not create an executable derived output just to paraphrase it. Encode only the concrete conditions, exceptions, parameters, and relations that affect computation.
 - Do not create an output for administrative clauses like "assistance shall be furnished to all eligible households who make application." Unless the source defines a calculable benefit, amount, condition, or exception, keep that text documentary in `module.summary`.
@@ -3352,6 +3359,32 @@ rules:
       - effective_from: '2024-01-01'
         formula: |-
           if example_condition: example_amount else: 0
+```
+
+Derived membership shape:
+```yaml
+rules:
+  - name: snap_member_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(a)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          member_has_required_status
+          and not member_is_excluded_student
+  - name: snap_unit
+    kind: derived_relation
+    entity: SnapUnit
+    source_relation: member_of_household
+    member_relation: members
+    slot_entities: [Person]
+    source: 7 CFR 273.1(a)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: snap_member_eligible
 ```
 
 {output_rules}
@@ -4545,7 +4578,7 @@ def _context_file_executable_surfaces(source_path: str) -> dict[str, dict[str, o
         if not isinstance(rule, dict):
             continue
         kind = str(rule.get("kind") or "").strip().lower()
-        if kind not in {"parameter", "derived", "data_relation"}:
+        if kind not in {"parameter", "derived", "derived_relation", "data_relation"}:
             continue
         name = str(rule.get("name") or "").strip()
         if not name:

--- a/src/axiom_encode/harness/proof_validator.py
+++ b/src/axiom_encode/harness/proof_validator.py
@@ -45,7 +45,7 @@ PROOF_ATOM_KINDS = frozenset(
         "unit",
     }
 )
-POLICY_RULE_KINDS = frozenset({"derived", "parameter"})
+POLICY_RULE_KINDS = frozenset({"derived", "derived_relation", "parameter"})
 
 
 def find_rulespec_proof_issues(content: str) -> list[str]:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3309,7 +3309,7 @@ _UNIT_SOURCE_ENTITY_PATTERNS = (
 )
 _HOUSEHOLD_MEMBER_MIXED_SCOPE_PATTERN = re.compile(
     r"\bhousehold\b(?!\s+member\b)[\s\S]{0,180}"
-    r"\b(?:each|every|all)\s+(?:household\s+)?member\b",
+    r"\b(?:each|every|all|no)\s+(?:household\s+)?member\b",
     flags=re.IGNORECASE,
 )
 _SOURCE_SCOPE_PERSON = "person"

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2814,7 +2814,11 @@ def _rulespec_executable_index_for_roots(
 def _is_executable_rulespec_rule(rule: Any) -> bool:
     if not isinstance(rule, dict):
         return False
-    return str(rule.get("kind") or "").strip().lower() in {"parameter", "derived"}
+    return str(rule.get("kind") or "").strip().lower() in {
+        "parameter",
+        "derived",
+        "derived_relation",
+    }
 
 
 def _has_module_source_locator(payload: dict[str, Any]) -> bool:
@@ -4927,7 +4931,11 @@ def find_formula_date_literal_issues(content: str) -> list[str]:
     for rule in rules:
         if not isinstance(rule, dict):
             continue
-        if str(rule.get("kind") or "").strip().lower() not in {"parameter", "derived"}:
+        if str(rule.get("kind") or "").strip().lower() not in {
+            "parameter",
+            "derived",
+            "derived_relation",
+        }:
             continue
         name = str(rule.get("name") or "").strip()
         versions = rule.get("versions")
@@ -6248,7 +6256,7 @@ def _rule_formula_numeric_values_by_name_for_child_source(
     for name, kind, formula, source, rule in _rulespec_rule_formula_rule_records(
         payload
     ):
-        if kind not in {"parameter", "derived"}:
+        if kind not in {"parameter", "derived", "derived_relation"}:
             continue
         context = "\n".join(
             [

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -11,7 +11,7 @@ import yaml
 
 from .registry import PolicyEngineMapping, load_policyengine_registry
 
-EXECUTABLE_RULE_KINDS = {"parameter", "derived"}
+EXECUTABLE_RULE_KINDS = {"parameter", "derived", "derived_relation"}
 ORACLE_COVERAGE_STATUSES = {"comparable", "known_not_comparable", "unmapped"}
 
 

--- a/src/axiom_encode/oracles/policyengine/snap_readiness.py
+++ b/src/axiom_encode/oracles/policyengine/snap_readiness.py
@@ -12,7 +12,7 @@ import yaml
 
 from .ecps_snap import JURISDICTION_CONFIGS
 
-EXECUTABLE_RULE_KINDS = {"parameter", "derived"}
+EXECUTABLE_RULE_KINDS = {"parameter", "derived", "derived_relation"}
 SNAP_MARKERS = (
     "snap",
     "supplemental nutrition assistance",

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -19,7 +19,8 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   defines that collapsed test. Keep process simplifications out of RuleSpec
   source encodings.
 - Before finalizing, compare the source's legal subject nouns and proof excerpts
-  against every executable `parameter` and `derived` rule's `entity:`. If the
+  against every executable `parameter`, `derived`, and `derived_relation`
+  rule's `entity:`. If the
   scope does not match the source, rename/re-scope the rule, defer the blocked
   output, or leave the phrase documentary; do not bridge the mismatch with an
   opaque local fact or a made-up household/tax-unit proxy."""
@@ -67,7 +68,7 @@ Hard requirements:
 - Do not emit `source_url`; RuleSpec validation reads normalized corpus provisions,
   not raw PDFs or web pages.
 - Use `rules:` as a list of rule objects.
-- Every executable `parameter` and `derived` rule must include a `source:`
+- Every executable `parameter`, `derived`, and `derived_relation` rule must include a `source:`
   field with the legal citation/span that directly supports that rule. Keep
   `source:` short and local to the rule; use `module.source_verification` for
   the corpus locator.
@@ -77,6 +78,12 @@ Hard requirements:
   age band, or another row key. Do not encode those cells as `match` arms or
   numeric literals inside a derived formula.
 - Use `kind: derived` for entity-scoped outputs.
+- Use `kind: derived_relation` when the source defines a derived legal
+  membership concept by filtering a source relation through a predicate. Keep
+  the membership predicate as an ordinary source-backed rule, then define the
+  filtered entity with `source_relation`, `member_relation`, `slot_entities`,
+  and a `versions[].formula` that names the predicate. Otherwise stay on
+  `kind: derived` for ordinary entity-scoped outputs.
 """
     + SOURCE_SCOPE_PROTOCOL
     + """
@@ -673,6 +680,31 @@ rules:
     versions:
       - effective_from: '2025-10-01'
         formula: example_amount_by_household_size[household_size]
+
+Derived membership shape:
+
+rules:
+  - name: snap_member_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(a)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          member_has_required_status
+          and not member_is_excluded_student
+  - name: snap_unit
+    kind: derived_relation
+    entity: SnapUnit
+    source_relation: member_of_household
+    member_relation: members
+    slot_entities: [Person]
+    source: 7 CFR 273.1(a)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: snap_member_eligible
 """
 )
 

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -81,9 +81,10 @@ Hard requirements:
 - Use `kind: derived_relation` when the source defines a derived legal
   membership concept by filtering a source relation through a predicate. Keep
   the membership predicate as an ordinary source-backed rule, then define the
-  filtered entity with `source_relation`, `member_relation`, `slot_entities`,
-  and a `versions[].formula` that names the predicate. Otherwise stay on
-  `kind: derived` for ordinary entity-scoped outputs.
+  filtered entity under `derived_relation:` with `arity`, `source_relation`,
+  `entity`, `member_relation`, `slot_entities`, and a `versions[].formula` that
+  names the predicate. Otherwise stay on `kind: derived` for ordinary
+  entity-scoped outputs.
 """
     + SOURCE_SCOPE_PROTOCOL
     + """
@@ -697,10 +698,12 @@ rules:
           and not member_is_excluded_student
   - name: snap_unit
     kind: derived_relation
-    entity: SnapUnit
-    source_relation: member_of_household
-    member_relation: members
-    slot_entities: [Person]
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
     source: 7 CFR 273.1(a)
     versions:
       - effective_from: '2026-01-01'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7750,10 +7750,12 @@ module:
 rules:
   - name: snap_unit
     kind: derived_relation
-    entity: SnapUnit
-    source_relation: member_of_household
-    member_relation: members
-    slot_entities: [Person]
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
     source: 7 CFR 273.1(a)
     versions:
       - effective_from: '2026-01-01'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,7 @@ from axiom_encode.cli import (
     _has_zero_output_test,
     _insert_false_input_default,
     _local_factual_input_names_from_rules_content,
+    _repair_missing_source_proof_atoms,
     _repair_mixed_scalar_output_tests,
     _repair_section_151_imports,
     _repair_section_151_temporal_fact_names,
@@ -7738,6 +7739,34 @@ rules:
         assert [applied_file["path"] for applied_file in payload["applied_files"]] == [
             "statutes/26/3101/b/2.yaml",
         ]
+
+    def test_repair_missing_source_proofs_treats_derived_relation_as_executable(
+        self,
+    ):
+        content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/7/273/1
+rules:
+  - name: snap_unit
+    kind: derived_relation
+    entity: SnapUnit
+    source_relation: member_of_household
+    member_relation: members
+    slot_entities: [Person]
+    source: 7 CFR 273.1(a)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: snap_member_eligible
+"""
+
+        repaired, repaired_rules = _repair_missing_source_proof_atoms(content)
+
+        assert repaired_rules == ["snap_unit"]
+        assert "metadata:\n      proof:\n        atoms:" in repaired
+        assert "kind: formula" in repaired
+        assert "corpus_citation_path: us/regulation/7/273/1" in repaired
+        assert "span: '7 CFR 273.1(a)'" in repaired
 
     def test_repair_missing_source_proofs_allows_pending_tax_branch_repair(
         self, tmp_path

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -84,6 +84,9 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "Never drop the jurisdiction prefix" in ENCODER_PROMPT
     assert "listed under invalid copied local inputs" in ENCODER_PROMPT
     assert "do not preserve, rename, or recreate" in ENCODER_PROMPT
+    assert "kind: derived_relation" in ENCODER_PROMPT
+    assert "source_relation: member_of_household" in ENCODER_PROMPT
+    assert "formula: snap_member_eligible" in ENCODER_PROMPT
     assert "round the" in prompt
     assert "increase before adding it to the base amount" in prompt
     assert "17300, not 17325" in prompt
@@ -97,6 +100,9 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "Never drop the jurisdiction prefix" in prompt
     assert "listed under invalid copied local inputs" in prompt
     assert "do not preserve, rename, or recreate" in prompt
+    assert "kind: derived_relation" in prompt
+    assert "source_relation: member_of_household" in prompt
+    assert "formula: snap_member_eligible" in prompt
 
 
 class TestClaudeCodeBackend:

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -85,6 +85,8 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "listed under invalid copied local inputs" in ENCODER_PROMPT
     assert "do not preserve, rename, or recreate" in ENCODER_PROMPT
     assert "kind: derived_relation" in ENCODER_PROMPT
+    assert "derived_relation:" in ENCODER_PROMPT
+    assert "arity: 2" in ENCODER_PROMPT
     assert "source_relation: member_of_household" in ENCODER_PROMPT
     assert "formula: snap_member_eligible" in ENCODER_PROMPT
     assert "round the" in prompt
@@ -101,6 +103,8 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "listed under invalid copied local inputs" in prompt
     assert "do not preserve, rename, or recreate" in prompt
     assert "kind: derived_relation" in prompt
+    assert "derived_relation:" in prompt
+    assert "arity: 2" in prompt
     assert "source_relation: member_of_household" in prompt
     assert "formula: snap_member_eligible" in prompt
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -504,6 +504,8 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "row_key" in prompt
     assert "column_key" in prompt
     assert "kind: derived_relation" in prompt
+    assert "derived_relation:" in prompt
+    assert "arity: 2" in prompt
     assert "source_relation: member_of_household" in prompt
     assert "formula: snap_member_eligible" in prompt
     assert (
@@ -519,10 +521,12 @@ def test_context_file_surfaces_include_derived_relation(tmp_path):
 rules:
   - name: snap_unit
     kind: derived_relation
-    entity: SnapUnit
-    source_relation: member_of_household
-    member_relation: members
-    slot_entities: [Person]
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
     versions:
       - effective_from: '2026-01-01'
         formula: snap_member_eligible

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -23,6 +23,7 @@ from axiom_encode.harness.evals import (
     _build_eval_prompt,
     _clean_generated_file_content,
     _command_looks_out_of_bounds,
+    _context_file_executable_surfaces,
     _eval_result_from_payload,
     _hydrate_eval_root,
     _is_single_amount_table_slice,
@@ -502,10 +503,36 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "header-only `parameter_table` proof atoms are invalid" in prompt
     assert "row_key" in prompt
     assert "column_key" in prompt
+    assert "kind: derived_relation" in prompt
+    assert "source_relation: member_of_household" in prompt
+    assert "formula: snap_member_eligible" in prompt
     assert (
         "Adjacent bracket thresholds repeated as both an upper bound and the next"
         in prompt
     )
+
+
+def test_context_file_surfaces_include_derived_relation(tmp_path):
+    context_file = tmp_path / "snap_unit.yaml"
+    context_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: snap_unit
+    kind: derived_relation
+    entity: SnapUnit
+    source_relation: member_of_household
+    member_relation: members
+    slot_entities: [Person]
+    versions:
+      - effective_from: '2026-01-01'
+        formula: snap_member_eligible
+"""
+    )
+
+    surfaces = _context_file_executable_surfaces(str(context_file))
+
+    assert surfaces["snap_unit"]["kind"] == "derived_relation"
+    assert surfaces["snap_unit"]["entity"] == "SnapUnit"
 
 
 def test_build_eval_prompt_lists_existing_target_surfaces(tmp_path):

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -118,6 +118,30 @@ rules:
     assert report["untested_comparable"] == 1
 
 
+def test_policyengine_coverage_counts_derived_relation_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "regulations/7-cfr/273/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: snap_unit
+    kind: derived_relation
+    entity: SnapUnit
+    source_relation: member_of_household
+    member_relation: members
+    slot_entities: [Person]
+    versions:
+      - effective_from: '2026-01-01'
+        formula: snap_member_eligible
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="snap")
+
+    assert report["total_outputs"] == 1
+    assert report["items"][0]["legal_id"] == "us:regulations/7-cfr/273/1#snap_unit"
+    assert report["items"][0]["kind"] == "derived_relation"
+
+
 def test_policyengine_coverage_classifies_tax_parameter_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3101/a.yaml",

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -125,10 +125,12 @@ def test_policyengine_coverage_counts_derived_relation_outputs(tmp_path):
 rules:
   - name: snap_unit
     kind: derived_relation
-    entity: SnapUnit
-    source_relation: member_of_household
-    member_relation: members
-    slot_entities: [Person]
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
     versions:
       - effective_from: '2026-01-01'
         formula: snap_member_eligible

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -319,10 +319,12 @@ module:
 rules:
   - name: snap_unit
     kind: derived_relation
-    entity: SnapUnit
-    source_relation: member_of_household
-    member_relation: members
-    slot_entities: [Person]
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
     versions:
       - effective_from: '2026-01-01'
         formula: snap_member_eligible
@@ -9176,10 +9178,12 @@ def test_formula_date_literal_rejects_iso_dates_in_derived_relation_formulas():
 rules:
   - name: snap_unit
     kind: derived_relation
-    entity: SnapUnit
-    source_relation: member_of_household
-    member_relation: members
-    slot_entities: [Person]
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
     versions:
       - effective_from: '2026-01-01'
         formula: |-

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -310,6 +310,32 @@ rules:
     ]
 
 
+def test_rule_source_metadata_rejects_derived_relation_without_rule_source():
+    content = """format: rulespec/v1
+module:
+  summary: Household members who meet the eligibility tests form the SNAP unit.
+  source_verification:
+    corpus_citation_path: us/regulation/7/273/1
+rules:
+  - name: snap_unit
+    kind: derived_relation
+    entity: SnapUnit
+    source_relation: member_of_household
+    member_relation: members
+    slot_entities: [Person]
+    versions:
+      - effective_from: '2026-01-01'
+        formula: snap_member_eligible
+"""
+
+    issues = find_rule_source_metadata_issues(content)
+
+    assert issues == [
+        "Rule source metadata required: `snap_unit` is an executable rule "
+        "and must include `source:` with the legal citation/span supporting it."
+    ]
+
+
 def test_rule_source_metadata_rejects_missing_module_source_locator():
     content = """format: rulespec/v1
 module:
@@ -9143,6 +9169,26 @@ rules:
     assert any(
         "taxable_year_begins_after_termination_date" in issue for issue in issues
     )
+
+
+def test_formula_date_literal_rejects_iso_dates_in_derived_relation_formulas():
+    content = """format: rulespec/v1
+rules:
+  - name: snap_unit
+    kind: derived_relation
+    entity: SnapUnit
+    source_relation: member_of_household
+    member_relation: members
+    slot_entities: [Person]
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          member_entry_date >= 2025-01-01
+"""
+
+    issues = find_formula_date_literal_issues(content)
+
+    assert any("Formula date literal unsupported" in issue for issue in issues)
 
 
 def test_temporal_value_fact_name_rejects_year_embedded_taxable_year_input():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -8292,6 +8292,35 @@ rules:
     assert find_source_scope_consistency_issues(content) == []
 
 
+def test_source_scope_consistency_skips_no_household_member_counterfactual_cap():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    No household shall receive more benefits than it would have received if no
+    household member was rendered ineligible.
+rules:
+  - name: household_benefit_after_ineligible_member_cap
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: state statute
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              excerpt: "No household shall receive more benefits than it would have received if no household member was rendered ineligible."
+    versions:
+      - effective_from: '1998-09-01'
+        formula: min(benefit_calculated_under_section, benefit_if_no_member_ineligible)
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
 def test_source_scope_consistency_checks_each_rule_independently():
     content = """format: rulespec/v1
 module:

--- a/tests/test_snap_readiness.py
+++ b/tests/test_snap_readiness.py
@@ -17,6 +17,31 @@ def _write_rulespec(
 ):
     path = repo / relative
     path.parent.mkdir(parents=True, exist_ok=True)
+    if kind == "derived_relation":
+        body = (
+            f"  - name: {rule_name}\n"
+            "    kind: derived_relation\n"
+            "    derived_relation:\n"
+            "      arity: 2\n"
+            "      source_relation: member_of_household\n"
+            "      entity: SnapUnit\n"
+            "      member_relation: members\n"
+            "      slot_entities: [Person, Household]\n"
+            "    versions:\n"
+            "      - effective_from: '2025-10-01'\n"
+            "        formula: snap_member_eligible\n"
+        )
+    else:
+        body = (
+            f"  - name: {rule_name}\n"
+            f"    kind: {kind}\n"
+            "    entity: Household\n"
+            "    dtype: Judgment\n"
+            "    period: Month\n"
+            "    versions:\n"
+            "      - effective_from: '2025-10-01'\n"
+            "        formula: true\n"
+        )
     path.write_text(
         "format: rulespec/v1\n"
         "module:\n"
@@ -24,14 +49,7 @@ def _write_rulespec(
         "  source_verification:\n"
         "    corpus_citation_path: us-tn/regulation/demo/snap\n"
         "rules:\n"
-        f"  - name: {rule_name}\n"
-        f"    kind: {kind}\n"
-        "    entity: Household\n"
-        "    dtype: Judgment\n"
-        "    period: Month\n"
-        "    versions:\n"
-        "      - effective_from: '2025-10-01'\n"
-        "        formula: true\n"
+        f"{body}"
     )
     return path
 

--- a/tests/test_snap_readiness.py
+++ b/tests/test_snap_readiness.py
@@ -8,7 +8,13 @@ from axiom_encode.oracles.policyengine.snap_readiness import (
 )
 
 
-def _write_rulespec(repo: Path, relative: str, *, rule_name: str = "snap_eligible"):
+def _write_rulespec(
+    repo: Path,
+    relative: str,
+    *,
+    rule_name: str = "snap_eligible",
+    kind: str = "derived",
+):
     path = repo / relative
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -19,7 +25,7 @@ def _write_rulespec(repo: Path, relative: str, *, rule_name: str = "snap_eligibl
         "    corpus_citation_path: us-tn/regulation/demo/snap\n"
         "rules:\n"
         f"  - name: {rule_name}\n"
-        "    kind: derived\n"
+        f"    kind: {kind}\n"
         "    entity: Household\n"
         "    dtype: Judgment\n"
         "    period: Month\n"
@@ -92,6 +98,24 @@ def test_snap_readiness_reports_ecps_ready_for_configured_program_module(tmp_pat
     assert colorado["policyengine_ecps_configured"] is True
     assert colorado["program_module_exists"] is True
     assert colorado["executable_outputs"] == 1
+
+
+def test_snap_readiness_counts_derived_relation_outputs(tmp_path):
+    root = tmp_path / "workspace"
+    corpus_root = root / "axiom-corpus"
+    repo = root / "rulespec-us-co"
+    _write_rulespec(
+        repo,
+        "policies/cdhs/snap/fy-2026-benefit-calculation.yaml",
+        rule_name="snap_unit",
+        kind="derived_relation",
+    )
+    _write_corpus_provision(corpus_root, "us-co/regulation/demo/snap")
+
+    report = build_snap_readiness_report(root, corpus_root=corpus_root)
+
+    by_jurisdiction = {item["jurisdiction"]: item for item in report["items"]}
+    assert by_jurisdiction["us-co"]["executable_outputs"] == 1
 
 
 def test_snap_readiness_flags_rules_without_policyengine_config(tmp_path):


### PR DESCRIPTION
## Summary
- Adds `derived_relation` to encoder/eval prompt guidance with a SNAP filtered-membership example using the nested engine schema under `derived_relation:`.
- Allows `derived_relation` through encode-side executable-rule allow-lists used by source proof repair, proof validation, source metadata checks, date-literal checks, context surface extraction, PolicyEngine coverage, and SNAP readiness.
- Keeps companion-test guidance focused on ordinary `parameter` and `derived` outputs, so we do not force direct relation-output assertions.
- Surfaces the nested derived-relation entity in copied-context executable surfaces so prompts can see `SnapUnit` correctly.
- Loosens one source-scope validator false positive found during real encoding: household-level counterfactual caps that mention `no household member` are treated as mixed scope rather than person-only scope.

This is intentionally a draft while TheAxiomFoundation/axiom-rules-engine#41 is still open. The encoder-side pieces are locally tested against that engine branch, but merge should wait until the engine contract lands.

Closes #80 once the engine dependency is merged and end-to-end validation is confirmed.

## Real encoding runs
- Passed: `uv run axiom-encode encode us-ca/statute/wic/18914.5 --backend codex --mode cold --output /private/tmp/axiom-encode-real-18914-5 --corpus-path /Users/pavelmakarchuk/axiom-corpus --axiom-rules-engine-path /Users/pavelmakarchuk/axiom-rules-engine --policy-repo-path /Users/pavelmakarchuk/rulespec-us-ca --db /private/tmp/axiom-encode-real-18914-5.db --no-sync`
  - Result: `success=True`, `compile=yes`, `ci=yes`, output `/private/tmp/axiom-encode-real-18914-5/codex-gpt-5.5/statutes/wic/18914/5.yaml`.
  - The model encoded this source as ordinary person-scoped derived rules, not `derived_relation`; that is reasonable for this source.
- Failed after generation, as expected from existing quality checks: `uv run axiom-encode encode us-ca/statute/wic/18901.7 --backend codex --mode cold --output /private/tmp/axiom-encode-real-18901-7-patched --corpus-path /Users/pavelmakarchuk/axiom-corpus --axiom-rules-engine-path /Users/pavelmakarchuk/axiom-rules-engine --policy-repo-path /Users/pavelmakarchuk/rulespec-us-ca --db /private/tmp/axiom-encode-real-18901-7-patched.db --no-sync`
  - Result: `compile=yes`, `ci=no`.
  - The first run exposed the source-scope false positive fixed here. After that fix, the remaining failure is the existing partial-exemption validator: the model collapsed `to the extent allowable by federal law` into a zero-out rule.

## Tests
- `/Users/pavelmakarchuk/axiom-rules-engine/target/debug/axiom-rules-engine compile --program /private/tmp/derived_relation_engine_compile.yaml --output /private/tmp/derived_relation_engine_compile.json` against local axiom-rules-engine#41 branch
- `uv run pytest tests/test_encoder_backend.py tests/test_policyengine_coverage.py tests/test_snap_readiness.py`
- `uv run pytest tests/test_cli.py -k derived_relation`
- `uv run pytest tests/test_evals.py::test_build_eval_prompt_targets_rulespec_yaml tests/test_evals.py::test_context_file_surfaces_include_derived_relation tests/test_evals.py::TestSourceEval::test_build_eval_prompt_includes_sets_source_metadata_guidance tests/test_rulespec_validation.py::test_rule_source_metadata_rejects_derived_relation_without_rule_source tests/test_rulespec_validation.py::test_formula_date_literal_rejects_iso_dates_in_derived_relation_formulas tests/test_rulespec_validation.py::test_source_scope_consistency_skips_no_household_member_counterfactual_cap`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `git diff --check`
