### PR TITLE
Fix deferred blocked_by target quality

### DIFF
--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -120,6 +120,23 @@ def _matching_numeric_occurrence_count(
     )
 
 
+def _is_empty_nonassertable_artifact(content: str) -> bool:
+    """Return true for intentionally non-executable artifacts with no rules."""
+    try:
+        payload = yaml.safe_load(content)
+    except (ValueError, yaml.YAMLError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    module = payload.get("module")
+    status = (
+        str(module.get("status", "")).strip()
+        if isinstance(module, dict)
+        else str(payload.get("status", "")).strip()
+    )
+    return status in {"deferred", "entity_not_supported"} and not payload.get("rules")
+
+
 @dataclass(frozen=True)
 class EvalRunnerSpec:
     """How to invoke a model in an eval."""
@@ -2129,6 +2146,8 @@ def evaluate_artifact(
     source_numeric_occurrences = Counter(
         extract_numeric_occurrences_from_text(numeric_validation_source_text or "")
     )
+    if _is_empty_nonassertable_artifact(content):
+        source_numeric_occurrences = Counter()
     named_scalar_occurrences = Counter(
         item.value for item in extract_named_scalar_occurrences(content)
     )
@@ -3037,10 +3056,14 @@ RuleSpec requirements:
   surface and still encode independent source-backed outputs that do not require
   the unavailable dependency. For each omitted/deferred executable output in a
   mixed provision, add `module.deferred_outputs[]` with absolute RuleSpec
-  targets for `output` and every `blocked_by` dependency, a plain-language
-  `reason`, and `source_values` entries for any source-stated local parameters
-  retained only for that deferred output. Do not create tests for deferred
-  outputs. If a source-grounded overriding rule makes the
+  targets for `output`, a plain-language `reason`, and `source_values` entries
+  for any source-stated local parameters retained only for that deferred output.
+  Only include `blocked_by` entries when you know the exact RuleSpec output with
+  a `#rule_fragment`. Do not list bare legal provisions, corpus paths, statute
+  sections, or guessed pseudo-targets in `blocked_by`; for example,
+  `us:statutes/us-ca/17000` is invalid. If the exact upstream RuleSpec output is
+  unknown, omit `blocked_by` and name the legal dependency in `reason`. Do not create
+  tests for deferred outputs. If a source-grounded overriding rule makes the
   unavailable branch zero or unreachable for the encoded effective period,
   encode that overriding branch instead of deferring the whole module. If that
   section is present in repo context, import it and use its exported output
@@ -3205,7 +3228,9 @@ RuleSpec requirements:
   affected formula, or defer that affected output until the upstream branch
   condition can be encoded/imported. If you defer the affected output, list the
   deferred output under `module.deferred_outputs[]` and list the absolute target
-  for the retained modifier parameter under that record's `source_values`.
+  for the retained modifier parameter under that record's `source_values`. Include
+  `blocked_by` only for exact upstream RuleSpec outputs with `#rule_fragment`;
+  otherwise explain the unknown blocker in `reason`.
   Do not solve this by deleting the affected numeric output while leaving the
   modifier parameter stranded.
 - Supported relation aggregators are `len(relation)`,
@@ -3270,7 +3295,7 @@ RuleSpec requirements:
 - Do not create named `parameter` rules for structural table row labels, household-size row indexes, or branch numbers unless the source actually sets that value as a legal amount, rate, threshold, cap, or limit; use those structural comparisons inline instead.
 - If the source cannot be represented faithfully with the supported schema, emit `module.status: deferred` or `module.status: entity_not_supported` with `rules: []`; do not invent unsupported ontology.
 - Never emit `rules: []` without an explicit non-executable `module.status`. If the source has operative text, encode at least one source-backed rule instead of silently returning an empty module.
-- For deferred or entity-not-supported artifacts, leave the companion `.test.yaml` empty and do not create assertions against deferred symbols.
+- For deferred or entity-not-supported artifacts, leave the companion `.test.yaml` empty. Do not create tests for deferred outputs or assertions against deferred symbols.
 - If metadata or context names an absolute canonical target that this source `sets`, `amends`, `implements`, or `restates`, add a separate `kind: source_relation` record with `source_relation.type` and `source_relation.target`. Do not put source graph edges in executable rule metadata.
 - Preserve existing or copied `kind: source_relation` records unless `./source.txt` proves the legal/provenance edge is wrong.
 - For state-set standards, allowances, thresholds, or options implementing federal delegation, include `source_relation.value` pointing to the local executable RuleSpec output and `source_relation.basis.delegation` when context identifies the upstream delegated slot.
@@ -3656,7 +3681,9 @@ issues are gone. If a copied import no longer resolves in the clean repo
 context, remove that import and defer the affected executable surface instead of
 preserving a dirty-tree dependency. For deferred executable surfaces, record
 exact provenance under `module.deferred_outputs[]` with absolute `output`,
-`blocked_by`, and `source_values` targets as applicable:
+`source_values`, and exact `blocked_by` targets as applicable. If an exact
+upstream RuleSpec output is unknown, omit `blocked_by` and explain the legal
+dependency in `reason` instead of inventing a bare provision target:
 {lines}
 """.format(lines="\n".join(issue_lines))
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3852,20 +3852,28 @@ def find_deferred_output_issues(content: str) -> list[str]:
             issues.append(f"{label}.reason is required.")
 
         blocked_by = record.get("blocked_by")
-        if not isinstance(blocked_by, list) or not blocked_by:
+        if blocked_by is not None and not isinstance(blocked_by, list):
             issues.append(
-                f"{label}.blocked_by must list the absolute RuleSpec targets "
-                "that prevent executable lowering."
+                f"{label}.blocked_by must be a list of absolute RuleSpec "
+                "targets when exact blockers are known."
             )
-            continue
-        for blocker in blocked_by:
-            blocker_text = str(blocker or "").strip()
-            blocker_ref = _parse_rulespec_target(blocker_text) if blocker_text else None
-            if blocker_ref is None or blocker_ref.symbol is None:
-                issues.append(
-                    f"{label}.blocked_by entry `{blocker_text}` must be an "
-                    "absolute RuleSpec target with a rule fragment."
+        elif isinstance(blocked_by, list):
+            for blocker in blocked_by:
+                blocker_text = str(blocker or "").strip()
+                blocker_ref = (
+                    _parse_rulespec_target(blocker_text) if blocker_text else None
                 )
+                if blocker_ref is None or blocker_ref.symbol is None:
+                    issues.append(
+                        f"{label}.blocked_by entry `{blocker_text}` must be an "
+                        "absolute RuleSpec target with a rule fragment."
+                    )
+                elif _target_path_embeds_jurisdiction(blocker_ref):
+                    issues.append(
+                        f"{label}.blocked_by entry `{blocker_text}` embeds a "
+                        "jurisdiction in the path; use the target jurisdiction "
+                        "prefix instead."
+                    )
 
         source_values = record.get("source_values")
         if source_values is not None:
@@ -8344,6 +8352,18 @@ def _parse_rulespec_target(target: str) -> _RuleSpecTargetRef | None:
         repo_name=f"rulespec-{prefix}",
         relative_path=relative_path,
         symbol=symbol.strip() if symbol and symbol.strip() else None,
+    )
+
+
+def _target_path_embeds_jurisdiction(target_ref: _RuleSpecTargetRef) -> bool:
+    """Return whether a RuleSpec path repeats a jurisdiction after the kind."""
+    parts = target_ref.relative_path.with_suffix("").parts
+    if len(parts) < 2 or parts[0] not in {"policies", "regulations", "statutes"}:
+        return False
+    embedded = parts[1]
+    return (
+        embedded == target_ref.prefix
+        or re.match(r"^[a-z]{2}-[a-z0-9_-]+$", embedded) is not None
     )
 
 

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -239,10 +239,14 @@ Hard requirements:
   surface and still encode independent source-backed outputs that do not require
   the unavailable dependency. For each omitted/deferred executable output in a
   mixed provision, add `module.deferred_outputs[]` with absolute RuleSpec
-  targets for `output` and every `blocked_by` dependency, a plain-language
-  `reason`, and `source_values` entries for any source-stated local parameters
-  retained only for that deferred output. Do not create tests for deferred
-  outputs. If a source-grounded overriding rule makes the
+  targets for `output`, a plain-language `reason`, and `source_values` entries
+  for any source-stated local parameters retained only for that deferred output.
+  Only include `blocked_by` entries when you know the exact RuleSpec output with
+  a `#rule_fragment`. Do not list bare legal provisions, corpus paths, statute
+  sections, or guessed pseudo-targets in `blocked_by`; for example,
+  `us:statutes/us-ca/17000` is invalid. If the exact upstream RuleSpec output is
+  unknown, omit `blocked_by` and name the legal dependency in `reason`. Do not create
+  tests for deferred outputs. If a source-grounded overriding rule makes the
   unavailable branch zero or unreachable for the encoded effective period,
   encode that overriding branch instead of deferring the whole module. If that
   section is present in repo context, import it and use its exported output
@@ -584,7 +588,9 @@ Hard requirements:
   affected formula, or defer that affected output until the upstream branch
   condition can be encoded/imported. If you defer the affected output, list the
   deferred output under `module.deferred_outputs[]` and list the absolute target
-  for the retained modifier parameter under that record's `source_values`.
+  for the retained modifier parameter under that record's `source_values`. Include
+  `blocked_by` only for exact upstream RuleSpec outputs with `#rule_fragment`;
+  otherwise explain the unknown blocker in `reason`.
   Do not solve this by deleting the affected numeric output while leaving the
   modifier parameter stranded.
 - Every substantive numeric occurrence in `./source.txt` must be represented by

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -89,6 +89,12 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "arity: 2" in ENCODER_PROMPT
     assert "source_relation: member_of_household" in ENCODER_PROMPT
     assert "formula: snap_member_eligible" in ENCODER_PROMPT
+    assert (
+        "Only include `blocked_by` entries when you know the exact RuleSpec output"
+        in ENCODER_PROMPT
+    )
+    assert "Do not list bare legal provisions" in ENCODER_PROMPT
+    assert "us:statutes/us-ca/17000" in ENCODER_PROMPT
     assert "round the" in prompt
     assert "increase before adding it to the base amount" in prompt
     assert "17300, not 17325" in prompt
@@ -107,6 +113,12 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "arity: 2" in prompt
     assert "source_relation: member_of_household" in prompt
     assert "formula: snap_member_eligible" in prompt
+    assert (
+        "Only include `blocked_by` entries when you know the exact RuleSpec output"
+        in prompt
+    )
+    assert "Do not list bare legal provisions" in prompt
+    assert "us:statutes/us-ca/17000" in prompt
 
 
 class TestClaudeCodeBackend:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -467,6 +467,12 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "modifier parameter stranded" in prompt
     assert "module.deferred_outputs[]" in prompt
     assert "source_values" in prompt
+    assert (
+        "Only include `blocked_by` entries when you know the exact RuleSpec output"
+        in prompt
+    )
+    assert "Do not list bare legal provisions" in prompt
+    assert "us:statutes/us-ca/17000" in prompt
     assert "imported test inputs from copied files" in prompt
     assert "Do not stub imported derived" in prompt
     assert "never assign prohibited derived" in prompt
@@ -1218,6 +1224,50 @@ rules:
                 source_text=(
                     "(a) Households in which each member receives qualifying public assistance shall be eligible.\n\n"
                     "(e) The unrelated standard deduction is 8.31 percent, $144, and $246."
+                ),
+            )
+
+        assert metrics.ci_pass
+        assert metrics.source_numeric_occurrence_count == 0
+        assert metrics.numeric_occurrence_issues == []
+
+    def test_numeric_occurrence_check_skips_empty_deferred_artifact(self, tmp_path):
+        rulespec_file = tmp_path / "statutes" / "wic" / "18901" / "5.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  status: deferred
+  source_verification:
+    corpus_citation_path: us-ca/statute/wic/18901.5
+  summary: |-
+    The department shall establish a program under 7 U.S.C. Sec. 2014(a). Categorical eligibility applies to households receiving or eligible to receive cash assistance under Part 5 (commencing with Section 17000), or food assistance under Chapter 10.1 (commencing with Section 18930).
+  deferred_outputs:
+    - output: us-ca:statutes/wic/18901/5#individual_categorically_eligible_for_calfresh
+      reason: Requires upstream rules under Part 5 commencing with Section 17000 and Chapter 10.1 commencing with Section 18930, but no exact RuleSpec outputs were available in context.
+rules: []
+"""
+        )
+
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline, "_run_compile_check", return_value=compile_result
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=tmp_path,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text=(
+                    "The department shall establish a program under 7 U.S.C. Sec. "
+                    "2014(a). Categorical eligibility applies to households "
+                    "receiving or eligible to receive cash assistance under Part "
+                    "5 (commencing with Section 17000), or food assistance under "
+                    "Chapter 10.1 (commencing with Section 18930)."
                 ),
             )
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -8695,6 +8695,38 @@ rules: []
     ]
 
 
+def test_deferred_output_allows_unknown_blockers_in_reason_without_blocked_by():
+    content = """format: rulespec/v1
+module:
+  deferred_outputs:
+    - output: us-ca:statutes/wic/18901/5#calfresh_categorical_eligibility
+      reason: Requires California General Assistance rules under WIC 17000 and SNAP categorical eligibility rules under WIC 18930, but no exact RuleSpec outputs were available in context.
+rules: []
+"""
+
+    assert find_deferred_output_issues(content) == []
+
+
+def test_deferred_output_rejects_embedded_jurisdiction_blocker_path():
+    content = """format: rulespec/v1
+module:
+  deferred_outputs:
+    - output: us-ca:statutes/wic/18901/5#calfresh_categorical_eligibility
+      reason: Missing upstream eligibility rules.
+      blocked_by:
+        - us:statutes/us-ca/17000#general_assistance_eligibility
+rules: []
+"""
+
+    issues = find_deferred_output_issues(content)
+
+    assert issues == [
+        "module.deferred_outputs[0].blocked_by entry "
+        "`us:statutes/us-ca/17000#general_assistance_eligibility` embeds a "
+        "jurisdiction in the path; use the target jurisdiction prefix instead."
+    ]
+
+
 def test_unused_modifier_parameter_ignores_judgment_names_with_amount_word():
     content = """format: rulespec/v1
 rules:


### PR DESCRIPTION
## Summary

- Tightens encoder and eval prompts so deferred output `blocked_by` entries are emitted only for exact RuleSpec outputs with `#rule_fragment`.
- Allows deferred outputs to omit `blocked_by` when upstream legal dependencies are known but exact RuleSpec outputs are not.
- Keeps malformed blockers invalid, including bare targets without fragments and pseudo-targets that embed a jurisdiction in the path such as `us:statutes/us-ca/...`.
- Skips numeric occurrence requirements for fully deferred, non-executable artifacts with `rules: []`.

Fixes #83.

## TDD / validation

- Added failing-first regression tests for omitted unknown blockers, embedded-jurisdiction blockers, prompt guidance, and empty deferred artifact numeric-occurrence handling.
- `uv run pytest tests/test_rulespec_validation.py tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_statutory_base_naming_guidance tests/test_evals.py::test_build_eval_prompt_targets_rulespec_yaml tests/test_evals.py::TestEvaluateArtifact::test_numeric_occurrence_check_skips_empty_deferred_artifact tests/test_evals.py::TestEvaluateArtifact::test_numeric_occurrence_check_uses_embedded_operating_excerpt`
- `uv run ruff check src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_rulespec_validation.py tests/test_encoder_backend.py tests/test_evals.py`
- `uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_rulespec_validation.py tests/test_encoder_backend.py tests/test_evals.py`
- `git diff --check`

## Real encoding runs

- Repro: `uv run axiom-encode encode us-ca/statute/wic/18901.5 --backend codex --mode cold ...`
  - Result: `success=True`, `compile=yes`, `ci=yes`.
  - Generated deferred output omitted `blocked_by` and put the unknown WIC 17000 / WIC 18930 dependencies in `reason`.
  - No `us:statutes/us-ca/...` or `us:statutes/us/...` malformed blockers were emitted.
- Additional start check: `uv run axiom-encode encode us/statute/7/2014/a --backend codex --mode cold ...`
  - Result: no malformed `blocked_by`; run failed for unrelated generated-test input-assignment issues on relation row facts.
