### PR TITLE
Tighten SnapUnit derived relation prompt

### DIFF
--- a/changelog.d/snapunit-derived-relation-prompt.fixed.md
+++ b/changelog.d/snapunit-derived-relation-prompt.fixed.md
@@ -1,0 +1,1 @@
+Tightened derived-relation prompt guidance so filtered entities such as `SnapUnit` are only used when the source defines membership and the file declares or imports the derived relation.

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2969,13 +2969,21 @@ RuleSpec requirements:
   field with the legal citation/span that directly supports that rule. Keep
   `source:` short and local to the rule; use `module.source_verification` for
   the corpus locator.
-- Use `kind: derived_relation` when the source defines a derived legal
-  membership concept by filtering a source relation through a predicate. Keep
-  the membership predicate as an ordinary source-backed rule, then define the
-  filtered entity under `derived_relation:` with `arity`, `source_relation`,
+- Use `kind: derived_relation` only when the source text explicitly defines
+  membership in a derived legal unit by filtering a source relation through a
+  stated predicate. "This source is about SNAP" is not enough. If the source
+  uses an existing structural entity such as `Household`, `TaxUnit`, or
+  `Person`, and merely references a program-specific concept without defining
+  who belongs to it, stay on the source-stated structural entity.
+- Keep the membership predicate as an ordinary source-backed rule, then define
+  the filtered entity under `derived_relation:` with `arity`, `source_relation`,
   `entity`, `member_relation`, `slot_entities`, and a `versions[].formula` that
-  names the predicate. Otherwise stay on `kind: derived` for ordinary
-  entity-scoped outputs.
+  names the predicate.
+- Any rule that uses `entity: <filtered-entity>` such as `SnapUnit`, a MAGI
+  household, or a qualifying-child set requires the same file to either declare
+  that entity with a `kind: derived_relation` rule or import a RuleSpec file
+  that declares it. Filtered entities have no structural existence without that
+  dependency.
 {SOURCE_SCOPE_PROTOCOL}
 - If `./source.txt` is a broad application, furnishing, administrative duty, or purpose clause without a computable policy condition, preserve it in `module.summary` but do not create an executable derived output just to paraphrase it. Encode only the concrete conditions, exceptions, parameters, and relations that affect computation.
 - Do not create an output for administrative clauses like "assistance shall be furnished to all eligible households who make application." Unless the source defines a calculable benefit, amount, condition, or exception, keep that text documentary in `module.summary`.
@@ -3376,7 +3384,7 @@ rules:
           451
   - name: example_output
     kind: derived
-    entity: SnapUnit
+    entity: Household
     dtype: Money
     period: Month
     unit: USD

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3280,6 +3280,9 @@ _UNIT_SCOPED_ENTITY_LABELS = {
     "spmunit": "SPMUnit",
 }
 _UNIT_ENTITY_EQUIVALENCE_SETS = (frozenset({"household", "snapunit"}),)
+_FILTERED_ENTITY_DECLARATION_IMPORTS = {
+    "SnapUnit": frozenset({"snap_unit"}),
+}
 _PERSON_SCOPE_SOURCE_PATTERN = re.compile(
     r"\b(?:no|any|each|every|all|a|an|the|that|such)\s+"
     r"(?:individual|person|(?:household\s+|family\s+)?member|taxpayer|claimant|child|"
@@ -3542,6 +3545,62 @@ def find_source_scope_consistency_issues(content: str) -> list[str]:
                 "unit-scoped test. Encode the rule at the source-stated unit "
                 "scope or cite source text that states the declared unit scope."
             )
+    return issues
+
+
+def find_filtered_entity_dependency_issues(content: str) -> list[str]:
+    """Reject rules scoped to filtered entities without a declaration/import."""
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    declared_entities: set[str] = set()
+    filtered_entity_rules: list[tuple[str, str]] = []
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            continue
+        name = str(rule.get("name") or f"rules[{index}]").strip()
+        kind = str(rule.get("kind") or "").strip().lower()
+        if kind == "derived_relation":
+            derived_relation = rule.get("derived_relation")
+            if isinstance(derived_relation, dict):
+                entity = str(derived_relation.get("entity") or "").strip()
+                if entity in _FILTERED_ENTITY_DECLARATION_IMPORTS:
+                    declared_entities.add(entity)
+            continue
+        entity = str(rule.get("entity") or "").strip()
+        if entity in _FILTERED_ENTITY_DECLARATION_IMPORTS:
+            filtered_entity_rules.append((name, entity))
+
+    if not filtered_entity_rules:
+        return []
+
+    imported_symbols = _rulespec_import_fragment_names(payload.get("imports"))
+    imported_entities = {
+        entity
+        for entity, symbols in _FILTERED_ENTITY_DECLARATION_IMPORTS.items()
+        if imported_symbols & symbols
+    }
+    available_entities = declared_entities | imported_entities
+
+    issues: list[str] = []
+    for name, entity in filtered_entity_rules:
+        if entity in available_entities:
+            continue
+        required_symbols = ", ".join(
+            f"`{symbol}`"
+            for symbol in sorted(_FILTERED_ENTITY_DECLARATION_IMPORTS[entity])
+        )
+        issues.append(
+            "Filtered entity dependency missing: "
+            f"`{name}` uses `entity: {entity}`, but this RuleSpec file does "
+            f"not declare `{entity}` with a `kind: derived_relation` rule or "
+            f"import its declaring relation ({required_symbols})."
+        )
     return issues
 
 
@@ -10460,6 +10519,7 @@ class ValidatorPipeline:
         issues.extend(find_upstream_placement_issues(content, rules_file=rules_file))
         issues.extend(find_source_verification_issues(content))
         issues.extend(find_source_condition_coverage_issues(content))
+        issues.extend(find_filtered_entity_dependency_issues(content))
         issues.extend(find_source_scope_consistency_issues(content))
         issues.extend(find_helper_only_definition_issues(content))
         issues.extend(find_deferred_output_issues(content))

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -78,13 +78,21 @@ Hard requirements:
   age band, or another row key. Do not encode those cells as `match` arms or
   numeric literals inside a derived formula.
 - Use `kind: derived` for entity-scoped outputs.
-- Use `kind: derived_relation` when the source defines a derived legal
-  membership concept by filtering a source relation through a predicate. Keep
-  the membership predicate as an ordinary source-backed rule, then define the
-  filtered entity under `derived_relation:` with `arity`, `source_relation`,
+- Use `kind: derived_relation` only when the source text explicitly defines
+  membership in a derived legal unit by filtering a source relation through a
+  stated predicate. "This source is about SNAP" is not enough. If the source
+  uses an existing structural entity such as `Household`, `TaxUnit`, or
+  `Person`, and merely references a program-specific concept without defining
+  who belongs to it, stay on the source-stated structural entity.
+- Keep the membership predicate as an ordinary source-backed rule, then define
+  the filtered entity under `derived_relation:` with `arity`, `source_relation`,
   `entity`, `member_relation`, `slot_entities`, and a `versions[].formula` that
-  names the predicate. Otherwise stay on `kind: derived` for ordinary
-  entity-scoped outputs.
+  names the predicate.
+- Any rule that uses `entity: <filtered-entity>` such as `SnapUnit`, a MAGI
+  household, or a qualifying-child set requires the same file to either declare
+  that entity with a `kind: derived_relation` rule or import a RuleSpec file
+  that declares it. Filtered entities have no structural existence without that
+  dependency.
 """
     + SOURCE_SCOPE_PROTOCOL
     + """

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -89,6 +89,15 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "arity: 2" in ENCODER_PROMPT
     assert "source_relation: member_of_household" in ENCODER_PROMPT
     assert "formula: snap_member_eligible" in ENCODER_PROMPT
+    assert "explicitly defines" in ENCODER_PROMPT
+    assert "membership in a derived legal unit" in ENCODER_PROMPT
+    assert '"This source is about SNAP" is not enough' in ENCODER_PROMPT
+    assert "stay on the source-stated structural entity" in ENCODER_PROMPT
+    assert "Any rule that uses `entity: <filtered-entity>`" in ENCODER_PROMPT
+    assert "declare" in ENCODER_PROMPT
+    assert "that entity with a `kind: derived_relation` rule" in ENCODER_PROMPT
+    assert "import a RuleSpec file" in ENCODER_PROMPT
+    assert "that declares it" in ENCODER_PROMPT
     assert (
         "Only include `blocked_by` entries when you know the exact RuleSpec output"
         in ENCODER_PROMPT
@@ -113,6 +122,15 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "arity: 2" in prompt
     assert "source_relation: member_of_household" in prompt
     assert "formula: snap_member_eligible" in prompt
+    assert "explicitly defines" in prompt
+    assert "membership in a derived legal unit" in prompt
+    assert '"This source is about SNAP" is not enough' in prompt
+    assert "stay on the source-stated structural entity" in prompt
+    assert "Any rule that uses `entity: <filtered-entity>`" in prompt
+    assert "declare" in prompt
+    assert "that entity with a `kind: derived_relation` rule" in prompt
+    assert "import a RuleSpec file" in prompt
+    assert "that declares it" in prompt
     assert (
         "Only include `blocked_by` entries when you know the exact RuleSpec output"
         in prompt

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -514,6 +514,16 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "arity: 2" in prompt
     assert "source_relation: member_of_household" in prompt
     assert "formula: snap_member_eligible" in prompt
+    assert "explicitly defines" in prompt
+    assert "membership in a derived legal unit" in prompt
+    assert '"This source is about SNAP" is not enough' in prompt
+    assert "stay on the source-stated structural entity" in prompt
+    assert "Any rule that uses `entity: <filtered-entity>`" in prompt
+    assert "declare" in prompt
+    assert "that entity with a `kind: derived_relation` rule" in prompt
+    assert "import a RuleSpec file" in prompt
+    assert "that declares it" in prompt
+    assert "example_output\n    kind: derived\n    entity: Household" in prompt
     assert (
         "Adjacent bracket thresholds repeated as both an upper bound and the next"
         in prompt

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -35,6 +35,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_deprecated_source_url_issues,
     find_empty_rules_module_issues,
     find_exception_test_coverage_issues,
+    find_filtered_entity_dependency_issues,
     find_formula_absolute_reference_issues,
     find_formula_date_literal_issues,
     find_helper_only_definition_issues,
@@ -7970,6 +7971,88 @@ rules:
         "Encode the rule at the person/member scope or cite source text that "
         "states the unit-level test."
     ]
+
+
+def test_filtered_entity_dependency_rejects_snapunit_without_relation():
+    content = """format: rulespec/v1
+rules:
+  - name: household_entitled_to_expedited_service
+    kind: derived
+    entity: SnapUnit
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.2
+    versions:
+      - effective_from: '2026-01-01'
+        formula: expedited_service_conditions_met
+"""
+
+    issues = find_filtered_entity_dependency_issues(content)
+
+    assert issues == [
+        "Filtered entity dependency missing: "
+        "`household_entitled_to_expedited_service` uses `entity: SnapUnit`, "
+        "but this RuleSpec file does not declare `SnapUnit` with a "
+        "`kind: derived_relation` rule or import its declaring relation "
+        "(`snap_unit`)."
+    ]
+
+
+def test_filtered_entity_dependency_allows_local_snapunit_relation():
+    content = """format: rulespec/v1
+rules:
+  - name: household_member_eligible_for_snap_unit
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.1(a)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: household_member_meets_snap_unit_rules
+  - name: snap_unit
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
+    source: 7 CFR 273.1(a)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: household_member_eligible_for_snap_unit
+  - name: snap_unit_entitled_to_expedited_service
+    kind: derived
+    entity: SnapUnit
+    dtype: Judgment
+    period: Month
+    source: synthetic source
+    versions:
+      - effective_from: '2026-01-01'
+        formula: expedited_service_conditions_met
+"""
+
+    assert find_filtered_entity_dependency_issues(content) == []
+
+
+def test_filtered_entity_dependency_allows_imported_snapunit_relation():
+    content = """format: rulespec/v1
+imports:
+  - us:regulations/7-cfr/273/1#snap_unit
+rules:
+  - name: snap_unit_entitled_to_expedited_service
+    kind: derived
+    entity: SnapUnit
+    dtype: Judgment
+    period: Month
+    source: synthetic source
+    versions:
+      - effective_from: '2026-01-01'
+        formula: expedited_service_conditions_met
+"""
+
+    assert find_filtered_entity_dependency_issues(content) == []
 
 
 def test_source_scope_consistency_accepts_person_source_as_person_rule():


### PR DESCRIPTION
## Summary
- tighten derived_relation trigger language so SNAP context alone is not enough to use filtered entities
- require filtered entities such as SnapUnit to be declared via derived_relation or imported
- add validator coverage that rejects orphan SnapUnit-scoped rules without a local or imported snap_unit relation
- change the eval prompt generic derived example from SnapUnit to Household to avoid modeling an orphan filtered entity

Closes #85

## Tests
- uv run pytest tests/test_rulespec_validation.py tests/test_encoder_backend.py tests/test_evals.py
- uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_encoder_backend.py tests/test_evals.py