### PR TITLE
Retry evals that return no RuleSpec artifact

### DIFF
--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -12814,6 +12814,8 @@ def cmd_eval(args):
         print(
             f"  tokens in={result.input_tokens} out={result.output_tokens} cache_read={result.cache_read_tokens} reasoning_out={result.reasoning_output_tokens}"
         )
+        if getattr(result, "retry_count", 0):
+            print(f"  retry_count={result.retry_count}")
         print(f"  retrieved_files={len(result.retrieved_files)}")
         if result.unexpected_accesses:
             print(f"  unexpected_accesses={len(result.unexpected_accesses)}")
@@ -12935,6 +12937,7 @@ def _serialize_eval_result(result) -> dict:
         "success": getattr(result, "success", None),
         "error": getattr(result, "error", None),
         "generation_prompt_sha256": getattr(result, "generation_prompt_sha256", None),
+        "retry_count": getattr(result, "retry_count", 0),
         "metrics": getattr(result, "metrics", None),
     }
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -106,6 +106,11 @@ _CONDITIONAL_AMOUNT_SLICE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _LOCAL_IMPORT_ROOT_TOKENS = {"legislation", "statutes", "regulation"}
+_CODEX_DEFAULT_TIMEOUT_SECONDS = 600
+_CODEX_DEFAULT_IDLE_TIMEOUT_SECONDS = 300
+_CODEX_LONG_SOURCE_CHAR_THRESHOLD = 40_000
+_CODEX_LONG_SOURCE_TIMEOUT_SECONDS = 1800
+_CODEX_LONG_SOURCE_IDLE_TIMEOUT_SECONDS = 900
 
 
 def _matching_numeric_occurrence_count(
@@ -494,6 +499,16 @@ def _combine_retry_response(
             *retry.unexpected_accesses,
         ],
         error=retry.error,
+    )
+
+
+def _response_allows_empty_artifact_retry(response: EvalPromptResponse) -> bool:
+    """Return true when a missing artifact should get one forced retry."""
+    if response.error is None:
+        return True
+    return (
+        not response.text.strip()
+        and "timed out" in response.error.lower()
     )
 
 
@@ -2437,7 +2452,7 @@ def _run_prompt_eval_with_empty_artifact_retry(
         workspace_root=workspace.root,
         policyengine_rule_hint=policyengine_rule_hint,
     )
-    if wrote_artifact or response.error is not None:
+    if wrote_artifact or not _response_allows_empty_artifact_retry(response):
         return response, wrote_artifact, 0
 
     retry_prompt = _build_empty_artifact_retry_prompt(
@@ -5362,7 +5377,9 @@ def _run_codex_prompt_eval(
     prompt: str,
 ) -> EvalPromptResponse:
     """Run prompt-only eval via Codex CLI."""
-    codex_idle_timeout_seconds = 300
+    codex_timeout_seconds, codex_idle_timeout_seconds = _codex_prompt_timeouts(
+        workspace
+    )
     last_message_file = workspace.root / ".codex-last-message.txt"
     if last_message_file.exists():
         last_message_file.unlink()
@@ -5388,6 +5405,7 @@ def _run_codex_prompt_eval(
     start = time.time()
     terminated_after_output = False
     timed_out = False
+    timeout_reason = None
     with (
         tempfile.NamedTemporaryFile(mode="w+", delete=False) as stdout_file,
         tempfile.NamedTemporaryFile(mode="w+", delete=False) as stderr_file,
@@ -5405,12 +5423,17 @@ def _run_codex_prompt_eval(
             terminated_after_output = _wait_for_codex_process(
                 process,
                 last_message_file=last_message_file,
-                timeout=600,
+                timeout=codex_timeout_seconds,
                 heartbeat_paths=[stdout_path, stderr_path],
                 max_idle_seconds=codex_idle_timeout_seconds,
             )
-        except subprocess.TimeoutExpired:
+        except subprocess.TimeoutExpired as exc:
             timed_out = True
+            timeout_reason = (
+                "idle"
+                if exc.timeout == codex_idle_timeout_seconds
+                else "wall"
+            )
             process.kill()
             process.wait()
 
@@ -5488,11 +5511,29 @@ def _run_codex_prompt_eval(
             "provider": "openai",
             "backend": "codex-exec",
             "model": runner.model,
+            "timed_out": timed_out,
+            "timeout_reason": timeout_reason,
+            "timeout_seconds": codex_timeout_seconds,
+            "idle_timeout_seconds": codex_idle_timeout_seconds,
             "events": events,
         },
         unexpected_accesses=unexpected_accesses,
         error=error,
     )
+
+
+def _codex_prompt_timeouts(workspace: EvalWorkspace) -> tuple[int, int]:
+    """Return wall and idle timeouts for a Codex eval workspace."""
+    try:
+        source_length = len(workspace.source_text_file.read_text())
+    except OSError:
+        source_length = 0
+    if source_length >= _CODEX_LONG_SOURCE_CHAR_THRESHOLD:
+        return (
+            _CODEX_LONG_SOURCE_TIMEOUT_SECONDS,
+            _CODEX_LONG_SOURCE_IDLE_TIMEOUT_SECONDS,
+        )
+    return (_CODEX_DEFAULT_TIMEOUT_SECONDS, _CODEX_DEFAULT_IDLE_TIMEOUT_SECONDS)
 
 
 def _wait_for_codex_process(

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -484,7 +484,9 @@ def _combine_retry_response(
         estimated_cost_usd=_sum_optional_float(
             initial.estimated_cost_usd, retry.estimated_cost_usd
         ),
-        actual_cost_usd=_sum_optional_float(initial.actual_cost_usd, retry.actual_cost_usd),
+        actual_cost_usd=_sum_optional_float(
+            initial.actual_cost_usd, retry.actual_cost_usd
+        ),
         trace={
             "retry_count": 1,
             "retry_reason": "empty_rulespec_artifact",
@@ -506,10 +508,7 @@ def _response_allows_empty_artifact_retry(response: EvalPromptResponse) -> bool:
     """Return true when a missing artifact should get one forced retry."""
     if response.error is None:
         return True
-    return (
-        not response.text.strip()
-        and "timed out" in response.error.lower()
-    )
+    return not response.text.strip() and "timed out" in response.error.lower()
 
 
 def load_eval_suite_manifest(path: Path) -> EvalSuiteManifest:
@@ -5430,9 +5429,7 @@ def _run_codex_prompt_eval(
         except subprocess.TimeoutExpired as exc:
             timed_out = True
             timeout_reason = (
-                "idle"
-                if exc.timeout == codex_idle_timeout_seconds
-                else "wall"
+                "idle" if exc.timeout == codex_idle_timeout_seconds else "wall"
             )
             process.kill()
             process.wait()

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -257,6 +257,7 @@ class EvalResult:
     unexpected_accesses: list[str]
     metrics: EvalArtifactMetrics | None
     generation_prompt_sha256: str | None = None
+    retry_count: int = 0
 
     def to_dict(self) -> dict:
         data = asdict(self)
@@ -437,6 +438,63 @@ def _sha256_text(text: str | None) -> str | None:
     if text is None:
         return None
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _sum_optional_float(left: float | None, right: float | None) -> float | None:
+    if left is None and right is None:
+        return None
+    return (left or 0.0) + (right or 0.0)
+
+
+def _sum_token_usage(
+    left: TokenUsage | None,
+    right: TokenUsage | None,
+) -> TokenUsage | None:
+    if left is None and right is None:
+        return None
+    return TokenUsage(
+        input_tokens=(left.input_tokens if left else 0)
+        + (right.input_tokens if right else 0),
+        output_tokens=(left.output_tokens if left else 0)
+        + (right.output_tokens if right else 0),
+        cache_read_tokens=(left.cache_read_tokens if left else 0)
+        + (right.cache_read_tokens if right else 0),
+        cache_creation_tokens=(left.cache_creation_tokens if left else 0)
+        + (right.cache_creation_tokens if right else 0),
+        reasoning_output_tokens=(left.reasoning_output_tokens if left else 0)
+        + (right.reasoning_output_tokens if right else 0),
+    )
+
+
+def _combine_retry_response(
+    initial: EvalPromptResponse,
+    retry: EvalPromptResponse,
+    retry_prompt: str,
+) -> EvalPromptResponse:
+    """Return the retry response while preserving aggregate accounting."""
+    return EvalPromptResponse(
+        text=retry.text,
+        duration_ms=initial.duration_ms + retry.duration_ms,
+        tokens=_sum_token_usage(initial.tokens, retry.tokens),
+        estimated_cost_usd=_sum_optional_float(
+            initial.estimated_cost_usd, retry.estimated_cost_usd
+        ),
+        actual_cost_usd=_sum_optional_float(initial.actual_cost_usd, retry.actual_cost_usd),
+        trace={
+            "retry_count": 1,
+            "retry_reason": "empty_rulespec_artifact",
+            "retry_prompt_sha256": _sha256_text(retry_prompt),
+            "attempts": [
+                {"attempt": 0, "trace": initial.trace or {}},
+                {"attempt": 1, "trace": retry.trace or {}},
+            ],
+        },
+        unexpected_accesses=[
+            *initial.unexpected_accesses,
+            *retry.unexpected_accesses,
+        ],
+        error=retry.error,
+    )
 
 
 def load_eval_suite_manifest(path: Path) -> EvalSuiteManifest:
@@ -978,6 +1036,7 @@ def _eval_result_from_payload(payload: dict) -> EvalResult:
         retrieved_files=list(payload.get("retrieved_files") or []),
         unexpected_accesses=list(payload.get("unexpected_accesses") or []),
         metrics=metrics,
+        retry_count=int(payload.get("retry_count", 0) or 0),
     )
 
 
@@ -2328,6 +2387,79 @@ def _relative_rulespec_source_path(path: Path) -> Path | None:
     return None
 
 
+def _build_empty_artifact_retry_prompt(
+    original_prompt: str,
+    target_file_name: str,
+    include_tests: bool,
+) -> str:
+    """Build the one-shot repair prompt for narrative-only eval responses."""
+    output_contract = (
+        f"Return exactly this two-file bundle and nothing else, beginning with "
+        f"`=== FILE: {target_file_name} ===`."
+        if include_tests
+        else (
+            f"Return only raw RuleSpec YAML for `{target_file_name}` beginning "
+            "with `format: rulespec/v1`."
+        )
+    )
+    return f"""The previous response did not contain a RuleSpec artifact, so the harness could not parse or write `{target_file_name}`.
+
+Emit the artifact now.
+- Do not narrate your plan.
+- Do not explain what you will do.
+- Do not include markdown prose, analysis, or file-write confirmations.
+- {output_contract}
+
+Use the same source, context, schema, and validation constraints from the original task below.
+
+=== BEGIN ORIGINAL TASK ===
+{original_prompt}
+=== END ORIGINAL TASK ===
+"""
+
+
+def _run_prompt_eval_with_empty_artifact_retry(
+    runner: EvalRunnerSpec,
+    workspace: EvalWorkspace,
+    prompt: str,
+    output_file: Path,
+    source_text: str,
+    target_file_name: str,
+    include_tests: bool,
+    policyengine_rule_hint: str | None = None,
+) -> tuple[EvalPromptResponse, bool, int]:
+    """Run an eval and retry once if no RuleSpec artifact can be materialized."""
+    response = _run_prompt_eval(runner, workspace, prompt)
+    wrote_artifact = _materialize_eval_artifact(
+        response.text,
+        output_file,
+        source_text=source_text,
+        workspace_root=workspace.root,
+        policyengine_rule_hint=policyengine_rule_hint,
+    )
+    if wrote_artifact or response.error is not None:
+        return response, wrote_artifact, 0
+
+    retry_prompt = _build_empty_artifact_retry_prompt(
+        prompt,
+        target_file_name=target_file_name,
+        include_tests=include_tests,
+    )
+    retry_response = _run_prompt_eval(runner, workspace, retry_prompt)
+    retry_wrote_artifact = _materialize_eval_artifact(
+        retry_response.text,
+        output_file,
+        source_text=source_text,
+        workspace_root=workspace.root,
+        policyengine_rule_hint=policyengine_rule_hint,
+    )
+    return (
+        _combine_retry_response(response, retry_response, retry_prompt),
+        retry_wrote_artifact,
+        1,
+    )
+
+
 def _run_single_eval(
     citation: str,
     runner: EvalRunnerSpec,
@@ -2383,14 +2515,16 @@ def _run_single_eval(
         runner_backend=runner.backend,
     )
     generation_prompt_sha256 = _sha256_text(prompt)
-    response = _run_prompt_eval(runner, workspace, prompt)
     output_file = Path(output_root) / runner.name / relative_output
     output_file.parent.mkdir(parents=True, exist_ok=True)
-    wrote_artifact = _materialize_eval_artifact(
-        response.text,
-        output_file,
+    response, wrote_artifact, retry_count = _run_prompt_eval_with_empty_artifact_retry(
+        runner=runner,
+        workspace=workspace,
+        prompt=prompt,
+        output_file=output_file,
         source_text=source_text,
-        workspace_root=workspace.root,
+        target_file_name=relative_output.name,
+        include_tests=include_tests,
     )
     if wrote_artifact:
         eval_root = Path(output_root) / runner.name
@@ -2438,6 +2572,7 @@ def _run_single_eval(
         retrieved_files=[item.source_path for item in workspace.context_files],
         unexpected_accesses=response.unexpected_accesses,
         metrics=metrics,
+        retry_count=retry_count,
     )
     emit_eval_result(result, response.trace)
     return result
@@ -2492,14 +2627,16 @@ def _run_single_source_eval(
         policyengine_rule_hint=policyengine_rule_hint,
     )
     generation_prompt_sha256 = _sha256_text(prompt)
-    response = _run_prompt_eval(runner, workspace, prompt)
     output_file = Path(output_root) / runner.name / relative_output
     output_file.parent.mkdir(parents=True, exist_ok=True)
-    wrote_artifact = _materialize_eval_artifact(
-        response.text,
-        output_file,
+    response, wrote_artifact, retry_count = _run_prompt_eval_with_empty_artifact_retry(
+        runner=runner,
+        workspace=workspace,
+        prompt=prompt,
+        output_file=output_file,
         source_text=source_text,
-        workspace_root=workspace.root,
+        target_file_name=relative_output.name,
+        include_tests=True,
         policyengine_rule_hint=policyengine_rule_hint,
     )
     if wrote_artifact:
@@ -2551,6 +2688,7 @@ def _run_single_source_eval(
         retrieved_files=[item.source_path for item in workspace.context_files],
         unexpected_accesses=response.unexpected_accesses,
         metrics=metrics,
+        retry_count=retry_count,
     )
     emit_eval_result(result, response.trace)
     return result
@@ -2932,6 +3070,8 @@ Preferred principal output:
     return f"""You are participating in an encoding eval for {citation}.
 
 Author the output in Axiom RuleSpec YAML.
+Do not narrate your plan or describe what you will do before emitting the artifact.
+The response must begin with the requested RuleSpec artifact, not with prose.
 
 Primary legal authority:
 - `./source.txt` contains the complete source text for this target source unit.

--- a/src/axiom_encode/harness/observability.py
+++ b/src/axiom_encode/harness/observability.py
@@ -288,6 +288,7 @@ def emit_eval_result(result: Any, trace_payload: Mapping[str, Any] | None) -> No
             "axiom_encode.unexpected_access_count": len(
                 getattr(result, "unexpected_accesses", []) or []
             ),
+            "axiom_encode.retry_count": getattr(result, "retry_count", 0),
             "axiom_encode.compile_pass": getattr(metrics, "compile_pass", None),
             "axiom_encode.ci_pass": getattr(metrics, "ci_pass", None),
             "axiom_encode.grounded_numeric_count": getattr(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -14,6 +14,7 @@ import yaml
 from axiom_encode.harness.evals import (
     EvalArtifactMetrics,
     EvalContextFile,
+    EvalPromptResponse,
     EvalReadinessGates,
     EvalResult,
     EvalSuiteCase,
@@ -440,6 +441,7 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "RuleSpec YAML" in prompt
     assert "=== FILE: tn-snap-standard-utility-allowance.yaml ===" in prompt
     assert "=== FILE: tn-snap-standard-utility-allowance.test.yaml ===" in prompt
+    assert "Do not narrate your plan" in prompt
     assert "snap_standard_utility_allowance" in prompt
     assert "Do not use bare year periods like `2024`" in prompt
     assert "never use `period_kind: calendar_year`" in prompt
@@ -773,6 +775,92 @@ rules:
     assert output_file.read_text().startswith("format: rulespec/v1")
 
 
+def test_run_source_eval_retries_once_when_first_response_has_no_rulespec(tmp_path):
+    policy_repo_root = tmp_path / "axiom-rules-engine"
+    policy_repo_root.mkdir()
+    first_response = EvalPromptResponse(
+        text="I'm going to encode a compact source-faithful slice.",
+        duration_ms=10,
+        trace={"attempt": "initial"},
+    )
+    second_response = EvalPromptResponse(
+        text=(
+            "=== FILE: sample.yaml ===\n"
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  summary: source states 451.\n"
+            "rules: []\n"
+            "=== FILE: sample.test.yaml ===\n"
+            "[]\n"
+        ),
+        duration_ms=20,
+        trace={"attempt": "retry"},
+    )
+
+    with (
+        patch(
+            "axiom_encode.harness.evals._run_prompt_eval",
+            side_effect=[first_response, second_response],
+        ) as mock_prompt_eval,
+        patch("axiom_encode.harness.evals.evaluate_artifact", return_value=None),
+    ):
+        [result] = run_source_eval(
+            source_id="sample",
+            source_text="source states 451.",
+            runner_specs=["codex:gpt-5.4"],
+            output_root=tmp_path / "out",
+            policy_path=policy_repo_root,
+            mode="cold",
+        )
+
+    assert result.success is True
+    assert result.retry_count == 1
+    assert result.duration_ms == 30
+    assert Path(result.output_file).exists()
+    assert mock_prompt_eval.call_count == 2
+    retry_prompt = mock_prompt_eval.call_args_list[1].args[2]
+    assert "previous response did not contain a RuleSpec artifact" in retry_prompt
+    assert "Do not narrate your plan" in retry_prompt
+
+
+def test_run_source_eval_does_not_retry_when_first_response_writes_rulespec(tmp_path):
+    policy_repo_root = tmp_path / "axiom-rules-engine"
+    policy_repo_root.mkdir()
+    response = EvalPromptResponse(
+        text=(
+            "=== FILE: sample.yaml ===\n"
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  summary: source states 451.\n"
+            "rules: []\n"
+            "=== FILE: sample.test.yaml ===\n"
+            "[]\n"
+        ),
+        duration_ms=10,
+        trace={"attempt": "initial"},
+    )
+
+    with (
+        patch(
+            "axiom_encode.harness.evals._run_prompt_eval",
+            return_value=response,
+        ) as mock_prompt_eval,
+        patch("axiom_encode.harness.evals.evaluate_artifact", return_value=None),
+    ):
+        [result] = run_source_eval(
+            source_id="sample",
+            source_text="source states 451.",
+            runner_specs=["codex:gpt-5.4"],
+            output_root=tmp_path / "out",
+            policy_path=policy_repo_root,
+            mode="cold",
+        )
+
+    assert result.success is True
+    assert result.retry_count == 0
+    assert mock_prompt_eval.call_count == 1
+
+
 def test_eval_result_payload_round_trips_prompt_digests():
     result = EvalResult(
         citation="snap_test",
@@ -795,6 +883,7 @@ def test_eval_result_payload_round_trips_prompt_digests():
         actual_cost_usd=None,
         retrieved_files=["/tmp/context.yaml"],
         unexpected_accesses=[],
+        retry_count=1,
         metrics=EvalArtifactMetrics(
             compile_pass=True,
             compile_issues=[],
@@ -821,6 +910,7 @@ def test_eval_result_payload_round_trips_prompt_digests():
     restored = _eval_result_from_payload(result.to_dict())
 
     assert restored.generation_prompt_sha256 == "generation-digest"
+    assert restored.retry_count == 1
     assert restored.metrics is not None
     assert restored.metrics.generalist_review_prompt_sha256 == "review-digest"
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -23,6 +23,7 @@ from axiom_encode.harness.evals import (
     GroundingMetric,
     _build_eval_prompt,
     _clean_generated_file_content,
+    _codex_prompt_timeouts,
     _command_looks_out_of_bounds,
     _context_file_executable_surfaces,
     _eval_result_from_payload,
@@ -821,6 +822,81 @@ def test_run_source_eval_retries_once_when_first_response_has_no_rulespec(tmp_pa
     retry_prompt = mock_prompt_eval.call_args_list[1].args[2]
     assert "previous response did not contain a RuleSpec artifact" in retry_prompt
     assert "Do not narrate your plan" in retry_prompt
+
+
+def test_run_source_eval_retries_once_when_first_response_times_out(tmp_path):
+    policy_repo_root = tmp_path / "axiom-rules-engine"
+    policy_repo_root.mkdir()
+    first_response = EvalPromptResponse(
+        text="",
+        duration_ms=300000,
+        trace={"timed_out": True, "timeout_reason": "idle"},
+        error="Codex eval timed out",
+    )
+    second_response = EvalPromptResponse(
+        text=(
+            "=== FILE: sample.yaml ===\n"
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  summary: source states 451.\n"
+            "rules: []\n"
+            "=== FILE: sample.test.yaml ===\n"
+            "[]\n"
+        ),
+        duration_ms=20,
+        trace={"attempt": "retry"},
+    )
+
+    with (
+        patch(
+            "axiom_encode.harness.evals._run_prompt_eval",
+            side_effect=[first_response, second_response],
+        ) as mock_prompt_eval,
+        patch("axiom_encode.harness.evals.evaluate_artifact", return_value=None),
+    ):
+        [result] = run_source_eval(
+            source_id="sample",
+            source_text="source states 451.",
+            runner_specs=["codex:gpt-5.4"],
+            output_root=tmp_path / "out",
+            policy_path=policy_repo_root,
+            mode="cold",
+        )
+
+    assert result.success is True
+    assert result.retry_count == 1
+    assert result.error is None
+    assert result.duration_ms == 300020
+    assert Path(result.output_file).exists()
+    assert mock_prompt_eval.call_count == 2
+
+
+def test_codex_prompt_timeouts_use_default_for_short_source(tmp_path):
+    workspace = prepare_eval_workspace(
+        citation="us/statute/7/2012",
+        runner=parse_runner_spec("codex:gpt-5.4"),
+        output_root=tmp_path / "out",
+        source_text="short source",
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        mode="cold",
+        extra_context_paths=[],
+    )
+
+    assert _codex_prompt_timeouts(workspace) == (600, 300)
+
+
+def test_codex_prompt_timeouts_use_long_limits_for_large_source(tmp_path):
+    workspace = prepare_eval_workspace(
+        citation="us/statute/7/2014",
+        runner=parse_runner_spec("codex:gpt-5.4"),
+        output_root=tmp_path / "out",
+        source_text="x" * 40000,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        mode="cold",
+        extra_context_paths=[],
+    )
+
+    assert _codex_prompt_timeouts(workspace) == (1800, 900)
 
 
 def test_run_source_eval_does_not_retry_when_first_response_writes_rulespec(tmp_path):


### PR DESCRIPTION
## Summary
- add an explicit prompt contract forbidding planning narration before RuleSpec output
- retry evals once when the first response cannot be materialized into a RuleSpec artifact, including timeout/no-text attempts
- raise Codex wall/idle timeouts for large eval sources so 40KB+ source bodies get 1800s wall / 900s idle limits instead of 600s / 300s
- persist and expose retry_count in eval results, CLI output, traces, and observability attributes
- add timeout metadata to Codex traces for silent-run diagnosis

Fixes #89.

## Tests
- uv run pytest tests/test_evals.py
- uv run pytest tests/test_observability.py
- uv run ruff check src/axiom_encode/harness/evals.py src/axiom_encode/cli.py src/axiom_encode/harness/observability.py tests/test_evals.py
- git diff --check

## Live retest note
The May 21 retest artifacts showed us/statute/7/2014 source.txt at 48,776 bytes and us/statute/26/163 source.txt at 52,941 bytes. This PR now treats both as large sources by using a 40,000-character threshold. I have not rerun the full 15-30 minute live cold encodes after this latest timeout patch.