### PR TITLE
Repair tax status component command and classify SSA outputs

### DIFF
--- a/changelog.d/encoder-version-0.2.93.changed.md
+++ b/changelog.d/encoder-version-0.2.93.changed.md
@@ -1,0 +1,1 @@
+Pinned encoder provenance at version 0.2.93 after recent encoder-affecting changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.92"
+version = "0.2.93"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.92"
+__version__ = "0.2.93"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -6536,6 +6536,23 @@ def cmd_repair_tax_status_components(args):
         path: (path.read_text() if path.exists() else None)
         for path in extra_file_contents
     }
+    preexisting_test_targets = [test_file] if test_file.exists() else []
+    preexisting_test_targets.extend(
+        path
+        for path in extra_file_contents
+        if path.name.endswith(".test.yaml") and path.exists()
+    )
+    preexisting_test_targets.extend(
+        path for path in related_151_test_files if path.exists()
+    )
+    preexisting_test_targets = _unique_paths(preexisting_test_targets)
+    preexisting_test_issues = set(
+        _companion_test_issues(
+            test_files=preexisting_test_targets,
+            repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+        )
+    )
 
     rules_file.write_text(repaired_content)
     if (
@@ -6589,13 +6606,16 @@ def cmd_repair_tax_status_components(args):
         repo_path=repo_path,
         axiom_rules_path=axiom_rules_path,
     )
-    if test_issues:
+    new_test_issues = [
+        issue for issue in test_issues if issue not in preexisting_test_issues
+    ]
+    if new_test_issues:
         rules_file.write_text(original_content)
         if original_test_content is not None:
             test_file.write_text(original_test_content)
         _restore_original_files(original_extra_contents)
         print("Repair failed companion tests; restored original RuleSpec file.")
-        for issue in test_issues:
+        for issue in new_test_issues:
             print(f"- {issue}")
         sys.exit(1)
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1121,6 +1121,246 @@ mappings:
     comparison: money
     rationale: Same final section 230 Social Security contribution-and-benefit base, stored in PolicyEngine as the Social Security payroll cap parameter.
 
+  - legal_id: us:policies/ssa/pia-bend-points/2026#base_year_first_pia_bend_point
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not compute the 2026 SSA PIA bend point automatic determination from the underlying base-year values.
+
+  - legal_id: us:policies/ssa/pia-bend-points/2026#base_year_second_pia_bend_point
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not compute the 2026 SSA PIA bend point automatic determination from the underlying base-year values.
+
+  - legal_id: us:policies/ssa/pia-bend-points/2026#pia_base_year_average_wage_index
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the wage-index inputs used by the 2026 SSA PIA bend point automatic determination.
+
+  - legal_id: us:policies/ssa/pia-bend-points/2026#pia_computation_year_average_wage_index
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the wage-index inputs used by the 2026 SSA PIA bend point automatic determination.
+
+  - legal_id: us:policies/ssa/pia-bend-points/2026#pia_bend_point_rounding_multiple
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the rounding parameter used by the 2026 SSA PIA bend point automatic determination.
+
+  - legal_id: us:policies/ssa/pia-bend-points/2026#first_pia_bend_point
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine ages or stores Social Security benefit parameters rather than computing this 2026 SSA PIA bend point determination as an oracle-comparable formula.
+
+  - legal_id: us:policies/ssa/pia-bend-points/2026#second_pia_bend_point
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine ages or stores Social Security benefit parameters rather than computing this 2026 SSA PIA bend point determination as an oracle-comparable formula.
+
+  - legal_id: us:policies/ssa/quarter-of-coverage/2026#base_year_quarter_of_coverage_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not compute the 2026 SSA quarter-of-coverage automatic determination from the underlying base-year values.
+
+  - legal_id: us:policies/ssa/quarter-of-coverage/2026#quarter_of_coverage_base_year_average_wage_index
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the wage-index inputs used by the 2026 SSA quarter-of-coverage automatic determination.
+
+  - legal_id: us:policies/ssa/quarter-of-coverage/2026#quarter_of_coverage_computation_year_average_wage_index
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the wage-index inputs used by the 2026 SSA quarter-of-coverage automatic determination.
+
+  - legal_id: us:policies/ssa/quarter-of-coverage/2026#prior_year_quarter_of_coverage_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores the final quarter-of-coverage amount, not the prior-year floor intermediate separately.
+
+  - legal_id: us:policies/ssa/quarter-of-coverage/2026#quarter_of_coverage_rounding_multiple
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the rounding parameter used by the 2026 SSA quarter-of-coverage automatic determination.
+
+  - legal_id: us:policies/ssa/quarter-of-coverage/2026#wage_indexed_quarter_of_coverage_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores the final quarter-of-coverage amount, not the wage-indexed pre-floor computation separately.
+
+  - legal_id: us:policies/ssa/quarter-of-coverage/2026#quarter_of_coverage_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores or ages the quarter-of-coverage amount rather than computing this 2026 SSA automatic determination as an oracle-comparable formula.
+
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#lower_base_year_monthly_exempt_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not compute the 2026 SSA retirement earnings test automatic determination from the underlying base-year values.
+
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#higher_base_year_monthly_exempt_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not compute the 2026 SSA retirement earnings test automatic determination from the underlying base-year values.
+
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#lower_base_year_average_wage_index
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the wage-index inputs used by the 2026 SSA retirement earnings test automatic determination.
+
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#higher_base_year_average_wage_index
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the wage-index inputs used by the 2026 SSA retirement earnings test automatic determination.
+
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#retirement_earnings_test_computation_year_average_wage_index
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the wage-index inputs used by the 2026 SSA retirement earnings test automatic determination.
+
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#retirement_earnings_test_rounding_multiple
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the rounding parameter used by the 2026 SSA retirement earnings test automatic determination.
+
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#prior_year_lower_monthly_exempt_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores the final retirement earnings test exempt amounts, not the prior-year floor intermediates separately.
+
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#prior_year_higher_monthly_exempt_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores the final retirement earnings test exempt amounts, not the prior-year floor intermediates separately.
+
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#wage_indexed_lower_monthly_exempt_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores the final retirement earnings test exempt amounts, not the wage-indexed pre-floor computation separately.
+
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#wage_indexed_higher_monthly_exempt_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores the final retirement earnings test exempt amounts, not the wage-indexed pre-floor computation separately.
+
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#retirement_earnings_test_lower_monthly_exempt_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores or ages the retirement earnings test exempt amounts rather than computing this 2026 SSA automatic determination as an oracle-comparable formula.
+
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#retirement_earnings_test_lower_annual_exempt_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores or ages the retirement earnings test exempt amounts rather than computing this 2026 SSA automatic determination as an oracle-comparable formula.
+
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#retirement_earnings_test_higher_monthly_exempt_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores or ages the retirement earnings test exempt amounts rather than computing this 2026 SSA automatic determination as an oracle-comparable formula.
+
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#retirement_earnings_test_higher_annual_exempt_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores or ages the retirement earnings test exempt amounts rather than computing this 2026 SSA automatic determination as an oracle-comparable formula.
+
+  - legal_id: us:policies/ssa/substantial-gainful-activity/2026#blind_base_year_sga_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not compute the 2026 SSA substantial gainful activity automatic determination from the underlying base-year values.
+
+  - legal_id: us:policies/ssa/substantial-gainful-activity/2026#blind_base_year_average_wage_index
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the wage-index inputs used by the 2026 SSA substantial gainful activity automatic determination.
+
+  - legal_id: us:policies/ssa/substantial-gainful-activity/2026#non_blind_disabled_base_year_sga_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not compute the 2026 SSA substantial gainful activity automatic determination from the underlying base-year values.
+
+  - legal_id: us:policies/ssa/substantial-gainful-activity/2026#non_blind_disabled_base_year_average_wage_index
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the wage-index inputs used by the 2026 SSA substantial gainful activity automatic determination.
+
+  - legal_id: us:policies/ssa/substantial-gainful-activity/2026#substantial_gainful_activity_computation_year_average_wage_index
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the wage-index inputs used by the 2026 SSA substantial gainful activity automatic determination.
+
+  - legal_id: us:policies/ssa/substantial-gainful-activity/2026#substantial_gainful_activity_rounding_multiple
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the rounding parameter used by the 2026 SSA substantial gainful activity automatic determination.
+
+  - legal_id: us:policies/ssa/substantial-gainful-activity/2026#prior_year_blind_sga_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores the final substantial gainful activity amounts, not the prior-year floor intermediates separately.
+
+  - legal_id: us:policies/ssa/substantial-gainful-activity/2026#prior_year_non_blind_disabled_sga_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores the final substantial gainful activity amounts, not the prior-year floor intermediates separately.
+
+  - legal_id: us:policies/ssa/substantial-gainful-activity/2026#wage_indexed_blind_sga_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores the final substantial gainful activity amounts, not the wage-indexed pre-floor computation separately.
+
+  - legal_id: us:policies/ssa/substantial-gainful-activity/2026#wage_indexed_non_blind_disabled_sga_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores the final substantial gainful activity amounts, not the wage-indexed pre-floor computation separately.
+
+  - legal_id: us:policies/ssa/substantial-gainful-activity/2026#substantial_gainful_activity_blind_monthly_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores or ages substantial gainful activity amounts rather than computing this 2026 SSA automatic determination as an oracle-comparable formula.
+
+  - legal_id: us:policies/ssa/substantial-gainful-activity/2026#substantial_gainful_activity_non_blind_disabled_monthly_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores or ages substantial gainful activity amounts rather than computing this 2026 SSA automatic determination as an oracle-comparable formula.
+
   - legal_id: us:statutes/26/45A/a#base_year_1993_indian_employment_costs
     country: us
     program: tax

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6046,6 +6046,90 @@ rules:
             "policies/irs/rev-proc-2025-32/standard-deduction.test.yaml",
         ]
 
+    def test_repair_tax_status_components_allows_preexisting_test_failures(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "policies/irs/rev-proc-2025-32/standard-deduction.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: additional_standard_deduction_for_aged_or_blind
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if individual_is_unmarried_and_not_surviving_spouse: higher_amount else: regular_amount
+"""
+        )
+        test_file = target.with_name("standard-deduction.test.yaml")
+        test_file.write_text(
+            """- name: legacy_companion_shape
+  input:
+    us:policies/irs/rev-proc-2025-32/standard-deduction#input.filing_status: 3
+    us:policies/irs/rev-proc-2025-32/standard-deduction#input.individual_is_unmarried_and_not_surviving_spouse: true
+  output:
+    us:policies/irs/rev-proc-2025-32/standard-deduction#additional_standard_deduction_for_aged_or_blind: 2050
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("policies/irs/rev-proc-2025-32/standard-deduction.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+        preexisting_issue = (
+            "policies/irs/rev-proc-2025-32/standard-deduction.test.yaml :: "
+            "legacy_companion_shape: unknown executable output "
+            "us:policies/irs/rev-proc-2025-32/standard-deduction"
+            "#additional_standard_deduction_for_aged_or_blind"
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                assert "individual_is_unmarried" not in target.read_text()
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._companion_test_issues",
+                side_effect=[[preexisting_issue], [preexisting_issue]],
+            ) as companion_tests,
+            patch(
+                "axiom_encode.cli._ensure_no_unmanifested_preexisting_rulespec_changes"
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_tax_status_components(args)
+
+        assert companion_tests.call_count == 2
+        assert (
+            "individual_is_unmarried_and_not_surviving_spouse" not in target.read_text()
+        )
+        assert (
+            "input.individual_is_unmarried_and_not_surviving_spouse"
+            not in test_file.read_text()
+        )
+
     def test_repair_tax_status_temporal_rewrite_only_updates_formulas(self):
         content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.92"
+version = "0.2.93"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- allow deterministic tax-status-component repairs when companion-test failures are pre-existing and unchanged
- classify the new SSA automatic-determination outputs for PolicyEngine oracle coverage
- bump axiom-encode version metadata to 0.2.93 after recent encoder-affecting changes
- add a regression test for unchanged pre-existing companion-test failures

## Tests
- uv run --extra dev python -m pytest tests/test_cli.py -q -k "tax_status_components or apply_version_provenance"
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run --project /Users/maxghenis/ssa-worktree/axiom-encode-bump-0.2.93 axiom-encode oracle-coverage --root /Users/maxghenis/ssa-worktree --json