### PR TITLE
Catch FICA wage-base gaps in ECPS oracle

### DIFF
--- a/changelog.d/ecps-fica-wages.fixed.md
+++ b/changelog.d/ecps-fica-wages.fixed.md
@@ -1,0 +1,1 @@
+Derive ECPS payroll FICA wages from employment-income and Section 125 deduction leaves instead of PolicyEngine payroll-tax gross wages, allowing the oracle to catch retirement-deferral wage-base bugs.

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -52,6 +52,15 @@ OASDI_WAGE_BASE_EXCLUSION_OUTPUT = (
     f"{OASDI_WAGE_BASE_BASE}#oasdi_wage_base_excess_excluded_remuneration"
 )
 AXIOM_3121_TAXABLE_OASDI_WAGES = "axiom_3121_taxable_oasdi_wages"
+FICA_EMPLOYMENT_INCOME_COLUMNS = (
+    "employment_income_before_lsr",
+    "employment_income",
+    "payroll_tax_gross_wages",
+)
+FICA_PRE_TAX_CONTRIBUTION_COLUMNS = (
+    "pre_tax_health_insurance_premiums",
+    "health_savings_account_payroll_contributions",
+)
 CAPITAL_GAINS_PROGRAM_PATH = Path("statutes/26/1/h.yaml")
 CAPITAL_GAINS_BASE = "us:statutes/26/1/h"
 EITC_PROGRAM_PATH = Path("statutes/26/32.yaml")
@@ -978,7 +987,11 @@ def build_payroll_request(
         wages = (
             oasdi_taxable_wages[person_id]
             if oasdi_taxable_wages is not None
-            else money(person[wage_input])
+            else (
+                project_fica_wages(person)
+                if wage_input == "payroll_tax_gross_wages"
+                else money(person[wage_input])
+            )
         )
         inputs.append(
             input_record(
@@ -1111,7 +1124,7 @@ def project_oasdi_wage_base_inputs(
             contribution_base
         ),
         "remuneration_paid_to_individual_by_employer_with_respect_to_employment": (
-            money(person["payroll_tax_gross_wages"])
+            project_fica_wages(person)
         ),
     }
 
@@ -1138,9 +1151,26 @@ def taxable_oasdi_wages_by_person_id(
             raise ValueError(
                 f"Axiom 3121 wage-base output missing for {person_entity_id(person_id)}."
             )
-        gross_wages = money(persons.iloc[index]["payroll_tax_gross_wages"])
+        gross_wages = project_fica_wages(persons.iloc[index])
         values[person_id] = max(0.0, gross_wages - exclusion)
     return values
+
+
+def project_fica_wages(person: Any) -> float:
+    """Project IRC 3121(a) FICA wages from ECPS leaf inputs.
+
+    PolicyEngine's payroll tax gross wages are the output being tested here, so
+    use them only as a compatibility fallback for hand-built unit fixtures. ECPS
+    rows should supply gross employment income plus Section 125 deduction leaves.
+    Traditional 401(k) and 403(b) deferrals reduce income-tax wages, but not
+    FICA wages.
+    """
+    gross_wages = first_available_money(person, FICA_EMPLOYMENT_INCOME_COLUMNS)
+    fica_pre_tax_contributions = sum(
+        money(row_value(person, column, 0))
+        for column in FICA_PRE_TAX_CONTRIBUTION_COLUMNS
+    )
+    return max(0.0, gross_wages - fica_pre_tax_contributions)
 
 
 def payroll_surface_uses_axiom_3121(surface: str) -> bool:
@@ -1732,6 +1762,11 @@ def compare_outputs(
             "from PolicyEngine. The section 230 contribution-and-benefit base "
             "is resolved by running the encoded SSA automatic-determination "
             "RuleSpec before section 3121(a)(1).",
+            "Payroll projections derive FICA wages from ECPS employment-income "
+            "and Section 125 health/HSA payroll-deduction leaves instead of "
+            "feeding Axiom from PolicyEngine payroll_tax_gross_wages. "
+            "Traditional 401(k) and 403(b) elective deferrals are deliberately "
+            "not subtracted from the FICA wage base.",
             "Capital-gain-definition projections compare Section 1(h) net and "
             "adjusted net capital gain from ECPS raw capital-gain, dividend, "
             "investment-income-election, and unrecaptured-section-1250 fields. "
@@ -1885,6 +1920,32 @@ def money(value: Any) -> float:
     except TypeError:
         pass
     return float(value)
+
+
+def first_available_money(row: Any, columns: tuple[str, ...]) -> float:
+    for column in columns:
+        value = row_value(row, column, None)
+        if value is None:
+            continue
+        try:
+            if np is not None and np.isnan(value):
+                continue
+        except TypeError:
+            pass
+        return money(value)
+    return 0.0
+
+
+def row_value(row: Any, column: str, default: Any = None) -> Any:
+    try:
+        if column in row:
+            return row[column]
+    except TypeError:
+        pass
+    getter = getattr(row, "get", None)
+    if callable(getter):
+        return getter(column, default)
+    return default
 
 
 def bool_value(value: Any) -> bool:

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -40,6 +40,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     project_eitc_person_inputs,
     project_eitc_relevant_investment_income,
     project_eitc_tax_unit_inputs,
+    project_fica_wages,
     project_oasdi_wage_base_inputs,
     project_section_32_c_2_tax_unit_inputs,
     project_section_112_tax_unit_inputs,
@@ -946,6 +947,40 @@ def test_contribution_and_benefit_base_requires_axiom_result():
         contribution_and_benefit_base_from_results([], year=2026)
 
 
+def test_fica_wage_projection_does_not_subtract_retirement_deferrals():
+    projected = project_fica_wages(
+        {
+            "employment_income_before_lsr": 106_706,
+            "traditional_401k_contributions": 6_006,
+            "traditional_403b_contributions": 1_000,
+            "pre_tax_health_insurance_premiums": 5_606,
+            "health_savings_account_payroll_contributions": 6_750,
+            "payroll_tax_gross_wages": 94_344,
+        }
+    )
+
+    assert projected == 94_350
+
+
+def test_fica_wage_projection_falls_back_to_payroll_wages_for_unit_fixtures():
+    assert project_fica_wages({"payroll_tax_gross_wages": 80_000}) == 80_000
+
+
+def test_fica_wage_projection_skips_missing_gross_income_leaves():
+    np = pytest.importorskip("numpy")
+
+    assert (
+        project_fica_wages(
+            {
+                "employment_income_before_lsr": np.nan,
+                "employment_income": 100_000,
+                "pre_tax_health_insurance_premiums": 2_000,
+            }
+        )
+        == 98_000
+    )
+
+
 def test_oasdi_wage_base_projection_uses_gross_wages_and_official_base():
     projected = project_oasdi_wage_base_inputs(
         {"payroll_tax_gross_wages": 200_000},
@@ -975,7 +1010,19 @@ def test_oasdi_wage_base_projection_uses_gross_wages_and_official_base():
 def test_build_oasdi_wage_base_request_uses_3121_inputs():
     pd = pytest.importorskip("pandas")
     pe_data = {
-        "persons": pd.DataFrame([{"person_id": 7, "payroll_tax_gross_wages": 200_000}]),
+        "persons": pd.DataFrame(
+            [
+                {
+                    "person_id": 7,
+                    "employment_income_before_lsr": 106_706,
+                    "traditional_401k_contributions": 6_006,
+                    "traditional_403b_contributions": 1_000,
+                    "pre_tax_health_insurance_premiums": 5_606,
+                    "health_savings_account_payroll_contributions": 6_750,
+                    "payroll_tax_gross_wages": 94_344,
+                }
+            ]
+        ),
         "person_ids": [7],
     }
 
@@ -1009,8 +1056,38 @@ def test_build_oasdi_wage_base_request_uses_3121_inputs():
         input_values[
             f"{OASDI_WAGE_BASE_BASE}#input.remuneration_paid_to_individual_by_employer_with_respect_to_employment"
         ]
-        == "200000.0"
+        == "94350.0"
     )
+
+
+def test_build_medicare_payroll_request_uses_projected_fica_wages():
+    pd = pytest.importorskip("pandas")
+    pe_data = {
+        "persons": pd.DataFrame(
+            [
+                {
+                    "person_id": 7,
+                    "employment_income_before_lsr": 106_706,
+                    "traditional_401k_contributions": 6_006,
+                    "pre_tax_health_insurance_premiums": 5_606,
+                    "health_savings_account_payroll_contributions": 6_750,
+                    "payroll_tax_gross_wages": 94_344,
+                }
+            ]
+        ),
+        "person_ids": [7],
+    }
+
+    request = build_payroll_request(
+        pe_data=pe_data,
+        year=2026,
+        surface="employee-medicare",
+    )
+
+    input_values = {
+        item["name"]: item["value"]["value"] for item in request["dataset"]["inputs"]
+    }
+    assert input_values["us:statutes/26/3101/b/1#input.wages"] == "94350.0"
 
 
 def test_taxable_oasdi_wages_come_from_axiom_3121_results():


### PR DESCRIPTION
## Summary
- project ECPS FICA wages from gross employment income and Section 125 health/HSA payroll deductions instead of feeding Axiom from PolicyEngine `payroll_tax_gross_wages`
- feed the projected FICA wages into Medicare payroll and Section 3121 OASDI wage-base requests
- add regression coverage for #8374-style retirement deferrals, missing gross-income leaves, and Medicare request inputs

## Verification
- `uv run --extra dev python -m pytest tests/test_policyengine_ecps_tax.py -q -k "fica_wage or oasdi_wage_base or medicare_payroll or oasdi_payroll or compare_oasdi_stage"`
- `uv run --extra dev python -m pytest tests/test_policyengine_ecps_tax.py -q`
- `uv run ruff format --check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py`
- `uv run ruff check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py`
- `uv run --with policyengine==4.4.4 --with policyengine-us==1.691.3 --with policyengine-core==3.26.0 --with pandas --with numpy axiom-encode tax-ecps-compare --root /Users/maxghenis/TheAxiomFoundation --surface employee-medicare --sample-size 25 --json` surfaced 10 Medicare mismatches out of 50 compared person values, as expected when Axiom no longer receives PE's payroll-tax gross wage output as its wage input.

Note: the same live compare fails at import time without pinning `policyengine-core==3.26.0` because the resolver otherwise selects `policyengine-core==3.26.11`, which rejects `self_employment_income` for mixed computation modes before Axiom code runs.