### PR TITLE
Pin PolicyEngine core for ECPS tax oracle

### DIFF
--- a/changelog.d/ecps-policyengine-core-pin.fixed.md
+++ b/changelog.d/ecps-policyengine-core-pin.fixed.md
@@ -1,0 +1,1 @@
+Require the ECPS tax oracle's pinned `policyengine-core` version so released PolicyEngine baselines remain reproducible.

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -27,6 +27,7 @@ except ImportError:  # pragma: no cover - exercised only without optional oracle
 
 
 POLICYENGINE_VERSION = "4.4.4"
+POLICYENGINE_CORE_VERSION = "3.26.0"
 POLICYENGINE_US_VERSION = "1.691.3"
 DATASET = "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5"
 
@@ -1981,6 +1982,7 @@ def require_policyengine_versions(
 ) -> None:
     try:
         policyengine_version = version("policyengine")
+        policyengine_core_version = version("policyengine-core")
         policyengine_us_version = version("policyengine-us")
     except PackageNotFoundError as exc:
         raise SystemExit(policyengine_install_message()) from exc
@@ -1988,6 +1990,11 @@ def require_policyengine_versions(
         raise SystemExit(
             f"policyengine=={POLICYENGINE_VERSION} required; found "
             f"{policyengine_version}. {policyengine_install_message()}"
+        )
+    if policyengine_core_version != POLICYENGINE_CORE_VERSION:
+        raise SystemExit(
+            f"policyengine-core=={POLICYENGINE_CORE_VERSION} required; found "
+            f"{policyengine_core_version}. {policyengine_install_message()}"
         )
     if (
         policyengine_us_version != POLICYENGINE_US_VERSION
@@ -2001,8 +2008,10 @@ def require_policyengine_versions(
 
 def policyengine_install_message() -> str:
     return (
-        "Run with: uv run --with policyengine==4.4.4 "
-        "--with policyengine-us==1.691.3 axiom-encode tax-ecps-compare"
+        f"Run with: uv run --with policyengine=={POLICYENGINE_VERSION} "
+        f"--with policyengine-core=={POLICYENGINE_CORE_VERSION} "
+        f"--with policyengine-us=={POLICYENGINE_US_VERSION} "
+        "axiom-encode tax-ecps-compare"
     )
 
 

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -13,6 +13,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     OASDI_WAGE_BASE_BASE,
     OASDI_WAGE_BASE_EXCLUSION_OUTPUT,
     OASDI_WAGE_BASE_PROGRAM_PATH,
+    POLICYENGINE_CORE_VERSION,
     POLICYENGINE_VERSION,
     SECTION_32_C_2_BASE,
     SECTION_112_BASE,
@@ -1278,6 +1279,8 @@ def test_policyengine_version_guard_rejects_unpinned_us_version(monkeypatch):
     def fake_version(package):
         if package == "policyengine":
             return POLICYENGINE_VERSION
+        if package == "policyengine-core":
+            return POLICYENGINE_CORE_VERSION
         if package == "policyengine-us":
             return "999.0.0"
         raise AssertionError(package)
@@ -1288,10 +1291,28 @@ def test_policyengine_version_guard_rejects_unpinned_us_version(monkeypatch):
         require_policyengine_versions()
 
 
+def test_policyengine_version_guard_rejects_unpinned_core_version(monkeypatch):
+    def fake_version(package):
+        if package == "policyengine":
+            return POLICYENGINE_VERSION
+        if package == "policyengine-core":
+            return "999.0.0"
+        if package == "policyengine-us":
+            return "1.691.3"
+        raise AssertionError(package)
+
+    monkeypatch.setattr(ecps_tax, "version", fake_version)
+
+    with pytest.raises(SystemExit, match="policyengine-core=="):
+        require_policyengine_versions()
+
+
 def test_policyengine_version_guard_allows_local_us_override(monkeypatch):
     def fake_version(package):
         if package == "policyengine":
             return POLICYENGINE_VERSION
+        if package == "policyengine-core":
+            return POLICYENGINE_CORE_VERSION
         if package == "policyengine-us":
             return "999.0.0"
         raise AssertionError(package)


### PR DESCRIPTION
## Summary
- add a pinned `policyengine-core` baseline for `tax-ecps-compare`
- fail fast with the exact install command when the resolver selects a different core version
- cover the guard with a regression test

## Context
While validating the payroll ECPS oracle against PolicyEngine/policyengine-us#8374, `uv run --with policyengine==4.4.4 --with policyengine-us==1.691.3 ...` selected `policyengine-core==3.26.11` and failed while importing released `policyengine-us==1.691.3` before any Axiom code ran. Pinning core to `3.26.0` made the released baseline and PR checkout comparisons run.

## Verification
- `uv run --extra dev python -m pytest tests/test_policyengine_ecps_tax.py -q -k "policyengine_version_guard"`
- `uv run --extra dev python -m pytest tests/test_policyengine_ecps_tax.py -q`
- `uv run ruff format --check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py`
- `uv run ruff check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py`