### PR TITLE
Update ECPS tax projection for refreshed RuleSpecs

### DIFF
--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -72,6 +72,7 @@ SECTION_152_C_BASE = "us:statutes/26/152/c"
 SECTION_164_F_BASE = "us:statutes/26/164/f"
 SECTION_1401_BASE = "us:statutes/26/1401"
 SECTION_1402_A_BASE = "us:statutes/26/1402/a"
+SECTION_7703_BASE = "us:statutes/26/7703"
 
 
 def contribution_and_benefit_base_program_path(year: int) -> Path:
@@ -700,10 +701,10 @@ def build_ctc_request(*, pe_data: dict[str, Any], year: int) -> dict[str, Any]:
             )
         inputs.append(
             input_record(
-                f"{CTC_H_BASE}#input.filing_status_is_joint_return",
+                f"{CTC_H_BASE}#input.filing_status",
                 entity_id,
                 interval,
-                uses_joint_ctc_phaseout_threshold(str(row["filing_status"])),
+                filing_status_code(str(row["filing_status"])),
             )
         )
         tax_unit_persons = persons_by_tax_unit.get(tax_unit_id, [])
@@ -858,6 +859,15 @@ def build_eitc_request(*, pe_data: dict[str, Any], year: int) -> dict[str, Any]:
         ).items():
             inputs.append(
                 input_record(f"{EITC_BASE}#input.{name}", entity_id, interval, value)
+            )
+        for name, value in project_section_7703_tax_unit_inputs(row=row).items():
+            inputs.append(
+                input_record(
+                    f"{SECTION_7703_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
             )
         for name, value in project_section_32_c_2_tax_unit_inputs(
             persons=tax_unit_persons,
@@ -1183,34 +1193,36 @@ def payroll_surface_uses_axiom_3121(surface: str) -> bool:
 
 
 def project_tax_unit_inputs(row: Any) -> dict[str, Any]:
+    filing_status = str(row["filing_status"])
     return {
         "adjusted_gross_income": money(row["adjusted_gross_income"]),
-        "amount_excluded_from_gross_income_under_section_911": 0,
-        "amount_excluded_from_gross_income_under_section_931": 0,
-        "amount_excluded_from_gross_income_under_section_933": 0,
-        "filing_status": filing_status_code(str(row["filing_status"])),
-        "taxable_year_begins_after_2017": True,
+        "ctc_foreign_earned_income_exclusion_adjustment": 0,
+        "ctc_possession_income_exclusion_adjustment": 0,
+        "ctc_puerto_rico_income_exclusion_adjustment": 0,
+        "ctc_phaseout_joint_threshold_applies": (
+            uses_joint_ctc_phaseout_threshold(filing_status)
+        ),
+        "ctc_phaseout_separate_threshold_applies": (
+            filing_status_code(filing_status) == 2
+        ),
+        "ctc_subsection_h_special_rules_apply": True,
         "taxpayer_identification_number_issued_after_return_due_date": False,
         "taxable_year_months": 12,
         "taxable_year_closed_by_reason_of_taxpayer_death": False,
         "ctc_fraud_disallowance_period_applies": False,
         "ctc_reckless_or_intentional_disregard_disallowance_period_applies": False,
         "prior_deficiency_denial_without_required_eligibility_information": False,
-        "aggregate_advance_payments_under_section_7527A": 0,
+        "ctc_advance_payments_received": 0,
     }
 
 
 def project_standard_deduction_inputs(row: Any, persons: list[Any]) -> dict[str, Any]:
-    filing_status = str(row["filing_status"])
     return {
-        "filing_status": filing_status_code(filing_status),
+        "filing_status": filing_status_code(str(row["filing_status"])),
         "may_be_claimed_as_dependent_by_another_taxpayer": False,
         "earned_income": 0,
         "additional_standard_deduction_entitlement_count_under_subsection_f": (
             additional_standard_deduction_entitlement_count(persons)
-        ),
-        "individual_is_unmarried_and_not_surviving_spouse": (
-            individual_is_unmarried_and_not_surviving_spouse(filing_status)
         ),
     }
 
@@ -1274,7 +1286,6 @@ def project_eitc_tax_unit_inputs(row: Any, persons: list[Any]) -> dict[str, Any]
         "taxpayer_claims_section_911_benefits": False,
         "taxpayer_is_nonresident_alien_for_any_portion_of_year": False,
         "taxpayer_treated_as_resident_by_section_6013_g_or_h_election": False,
-        "taxpayer_is_married_under_section_7703_a": filing_status_numeric in {1, 2},
         "satisfies_eitc_separated_spouse_rules": (
             filing_status_numeric == 2
             and any(bool_value(person.get("is_separated", False)) for person in persons)
@@ -1289,6 +1300,20 @@ def project_eitc_tax_unit_inputs(row: Any, persons: list[Any]) -> dict[str, Any]
         "spouse_includes_required_social_security_number_on_return": (
             filer_meets_id_requirements
         ),
+    }
+
+
+def project_section_7703_tax_unit_inputs(*, row: Any) -> dict[str, Any]:
+    filing_status_numeric = filing_status_code(str(row["filing_status"]))
+    return {
+        "spouse_dies_during_taxable_year": False,
+        "taxpayer_married_at_time_of_spouse_death": False,
+        "taxpayer_married_at_close_of_taxable_year": filing_status_numeric in {1, 2},
+        "legally_separated_under_decree_of_divorce_or_separate_maintenance": False,
+        "taxpayer_files_separate_return": filing_status_numeric == 2,
+        "taxpayer_maintains_household_as_home": False,
+        "taxpayer_household_cost_fraction_furnished": 0,
+        "spouse_not_member_of_household_final_month_count": 0,
     }
 
 
@@ -1405,7 +1430,7 @@ def project_eitc_person_inputs(
         "qualifying_child_name_age_and_tin_included_on_return": (
             context.has_valid_child_ssn
         ),
-        "qualifying_child_is_married_at_close_of_taxable_year": False,
+        "qualifying_child_marital_status_requires_section_151_entitlement": False,
         "taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e": (
             context.is_tax_unit_dependent
         ),
@@ -1432,12 +1457,14 @@ def project_section_152_c_person_inputs(
         "individual_is_student": bool_value(
             person.get("is_full_time_college_student", False)
         ),
-        "individual_filed_joint_return_with_spouse_other_than_only_for_claim_of_refund": False,
+        "individual_own_support_fraction_provided_by_individual": 0,
+        "filing_status": 0,
+        "return_filed_only_for_claim_of_refund": False,
         "individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers": False,
         "parents_of_individual_may_claim_individual_but_no_parent_claims": False,
         "taxpayer_is_parent_of_individual": context.is_tax_unit_dependent,
         "taxpayer_adjusted_gross_income_higher_than_highest_parent_adjusted_gross_income": False,
-        "parents_claiming_child_do_not_file_joint_return_together": False,
+        "parents_filing_status": 1,
         "child_resided_with_taxpayer_parent_for_longest_period": False,
         "child_resided_with_both_parents_same_amount_of_time_and_taxpayer_parent_has_highest_adjusted_gross_income": False,
         "no_parent_of_individual_is_a_claiming_taxpayer": False,
@@ -1470,12 +1497,10 @@ def project_ctc_person_inputs(
     age = money(person["age"])
     return {
         "age": age,
-        "qualifying_child_under_section_152_c": (
+        "ctc_child_satisfies_dependency_rules": (
             context.qualifying_child_under_section_152_c
         ),
-        "allowed_deduction_under_section_151_for_child": (
-            context.is_tax_unit_dependent
-        ),
+        "ctc_child_deduction_allowed": context.is_tax_unit_dependent,
         "certain_noncitizen_exception_applies": False,
         "ctc_child_missing_identification": bool(
             context.qualifying_child_described_in_subsection_c
@@ -1494,8 +1519,8 @@ def project_ctc_h_person_inputs(
 ) -> dict[str, Any]:
     context = context or project_tax_unit_person_contexts([person])[0]
     return {
-        "dependent_under_section_152": context.is_tax_unit_dependent,
-        "qualifying_child_described_in_subsection_c": (
+        "ctc_person_satisfies_dependency_rules": context.is_tax_unit_dependent,
+        "ctc_child_satisfies_subsection_c": (
             context.qualifying_child_described_in_subsection_c
         ),
         "noncitizen_exception_to_other_dependent_credit_under_subsection_h": False,

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -704,7 +704,7 @@ def build_ctc_request(*, pe_data: dict[str, Any], year: int) -> dict[str, Any]:
                 f"{CTC_H_BASE}#input.filing_status",
                 entity_id,
                 interval,
-                filing_status_code(str(row["filing_status"])),
+                ctc_h_filing_status_code(str(row["filing_status"])),
             )
         )
         tax_unit_persons = persons_by_tax_unit.get(tax_unit_id, [])
@@ -1919,6 +1919,12 @@ def filing_status_code(value: str) -> int:
     if normalized not in FILING_STATUS_CODES:
         raise ValueError(f"unsupported filing status: {value}")
     return FILING_STATUS_CODES[normalized]
+
+
+def ctc_h_filing_status_code(value: str) -> int:
+    if uses_joint_ctc_phaseout_threshold(value):
+        return filing_status_code("JOINT")
+    return filing_status_code(value)
 
 
 def uses_joint_ctc_phaseout_threshold(value: str) -> bool:

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -21,6 +21,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     SECTION_164_F_BASE,
     SECTION_1401_BASE,
     SECTION_1402_A_BASE,
+    SECTION_7703_BASE,
     additional_standard_deduction_entitlement_count,
     build_capital_gain_definitions_request,
     build_contribution_and_benefit_base_request,
@@ -49,6 +50,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     project_section_164_f_tax_unit_inputs,
     project_section_1401_tax_unit_inputs,
     project_section_1402_a_tax_unit_inputs,
+    project_section_7703_tax_unit_inputs,
     project_standard_deduction_inputs,
     project_tax_unit_inputs,
     project_tax_unit_person_contexts,
@@ -109,8 +111,8 @@ def test_ctc_person_projection_marks_under_17_valid_ssn_child():
     projected = project_ctc_person_inputs({"age": 16, "ssn_card_type": "CITIZEN"})
 
     assert projected["age"] == 16
-    assert projected["qualifying_child_under_section_152_c"] is True
-    assert projected["allowed_deduction_under_section_151_for_child"] is True
+    assert projected["ctc_child_satisfies_dependency_rules"] is True
+    assert projected["ctc_child_deduction_allowed"] is True
     assert projected["ctc_child_missing_identification"] is False
     assert projected["qualifying_child_tin_included_on_return"] is True
 
@@ -121,10 +123,10 @@ def test_ctc_person_projection_marks_under_17_missing_ssn_child():
         {"age": 9, "ssn_card_type": "NONE"}
     )
 
-    assert projected["qualifying_child_under_section_152_c"] is True
+    assert projected["ctc_child_satisfies_dependency_rules"] is True
     assert projected["ctc_child_missing_identification"] is True
     assert projected["qualifying_child_tin_included_on_return"] is False
-    assert subsection_h_projected["dependent_under_section_152"] is True
+    assert subsection_h_projected["ctc_person_satisfies_dependency_rules"] is True
     assert (
         subsection_h_projected["qualifying_child_ssn_is_valid_for_subsection_h"]
         is False
@@ -137,9 +139,9 @@ def test_ctc_person_projection_treats_single_adult_as_tax_unit_head():
         {"age": 18, "ssn_card_type": "CITIZEN"}
     )
 
-    assert projected["qualifying_child_under_section_152_c"] is False
-    assert projected["allowed_deduction_under_section_151_for_child"] is False
-    assert subsection_h_projected["dependent_under_section_152"] is False
+    assert projected["ctc_child_satisfies_dependency_rules"] is False
+    assert projected["ctc_child_deduction_allowed"] is False
+    assert subsection_h_projected["ctc_person_satisfies_dependency_rules"] is False
 
 
 def test_tax_unit_person_contexts_project_head_spouse_and_dependents():
@@ -240,9 +242,11 @@ def test_tax_unit_projection_uses_boundary_inputs_without_ctc_outputs():
     )
 
     assert projected["adjusted_gross_income"] == 123_456
-    assert projected["filing_status"] == 3
-    assert projected["aggregate_advance_payments_under_section_7527A"] == 0
-    assert "ctc" not in projected
+    assert projected["ctc_phaseout_joint_threshold_applies"] is False
+    assert projected["ctc_phaseout_separate_threshold_applies"] is False
+    assert projected["ctc_subsection_h_special_rules_apply"] is True
+    assert projected["ctc_advance_payments_received"] == 0
+    assert "ctc_before_advance_payments" not in projected
 
 
 @pytest.mark.parametrize(
@@ -289,7 +293,7 @@ def test_standard_deduction_projection_uses_leaf_age_and_blind_inputs():
         projected["additional_standard_deduction_entitlement_count_under_subsection_f"]
         == 2
     )
-    assert projected["individual_is_unmarried_and_not_surviving_spouse"] is True
+    assert "individual_is_unmarried_and_not_surviving_spouse" not in projected
 
 
 def test_capital_gain_definition_projection_uses_ecps_leaf_inputs():
@@ -364,6 +368,17 @@ def test_eitc_projection_uses_ecps_income_and_demographic_inputs():
     assert (
         projected["taxpayer_includes_required_social_security_number_on_return"] is True
     )
+    assert "taxpayer_is_married_under_section_7703_a" not in projected
+    assert project_section_7703_tax_unit_inputs(row=row) == {
+        "spouse_dies_during_taxable_year": False,
+        "taxpayer_married_at_time_of_spouse_death": False,
+        "taxpayer_married_at_close_of_taxable_year": False,
+        "legally_separated_under_decree_of_divorce_or_separate_maintenance": False,
+        "taxpayer_files_separate_return": False,
+        "taxpayer_maintains_household_as_home": False,
+        "taxpayer_household_cost_fraction_furnished": 0,
+        "spouse_not_member_of_household_final_month_count": 0,
+    }
 
     contexts = project_tax_unit_person_contexts(persons)
     earned_income_inputs = project_section_32_c_2_tax_unit_inputs(
@@ -433,6 +448,16 @@ def test_eitc_projection_matches_policyengine_age_and_identification_edges():
     )
     assert (
         projected["spouse_includes_required_social_security_number_on_return"] is True
+    )
+    assert (
+        project_section_7703_tax_unit_inputs(row=row)[
+            "taxpayer_married_at_close_of_taxable_year"
+        ]
+        is True
+    )
+    assert (
+        project_section_7703_tax_unit_inputs(row=row)["taxpayer_files_separate_return"]
+        is True
     )
     assert (
         project_section_32_c_2_tax_unit_inputs(
@@ -562,7 +587,7 @@ def test_eitc_person_projection_marks_valid_minor_child():
     assert projected == {
         "qualifying_child_principal_place_of_abode_is_in_united_states": True,
         "qualifying_child_name_age_and_tin_included_on_return": True,
-        "qualifying_child_is_married_at_close_of_taxable_year": False,
+        "qualifying_child_marital_status_requires_section_151_entitlement": False,
         "taxpayer_entitled_to_section_151_deduction_for_child_or_would_be_but_for_section_152_e": True,
     }
 
@@ -595,6 +620,10 @@ def test_section_152_c_projection_uses_leaf_child_facts():
     assert projected["individual_is_younger_than_taxpayer"] is True
     assert projected["individual_age_at_close_of_calendar_year"] == 20
     assert projected["individual_is_student"] is True
+    assert projected["individual_own_support_fraction_provided_by_individual"] == 0
+    assert projected["filing_status"] == 0
+    assert projected["return_filed_only_for_claim_of_refund"] is False
+    assert projected["parents_filing_status"] == 1
     assert (
         projected[
             "individual_may_be_claimed_as_qualifying_child_by_two_or_more_taxpayers"
@@ -736,6 +765,12 @@ def test_build_eitc_request_uses_structural_child_relation_and_component_outputs
     assert (
         input_values[
             f"{SECTION_1401_BASE}#input.international_social_security_agreement_under_section_233_in_effect"
+        ]
+        is False
+    )
+    assert (
+        input_values[
+            f"{SECTION_7703_BASE}#input.taxpayer_married_at_close_of_taxable_year"
         ]
         is False
     )

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -6,6 +6,8 @@ import axiom_encode.oracles.policyengine.ecps_tax as ecps_tax
 from axiom_encode.oracles.policyengine.ecps_tax import (
     CAPITAL_GAINS_BASE,
     CAPITAL_GAINS_DEFINITION_OUTPUTS,
+    CTC_BASE,
+    CTC_H_BASE,
     EITC_BASE,
     EITC_OUTPUTS,
     EMPLOYEE_OASDI_BASE,
@@ -25,6 +27,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     additional_standard_deduction_entitlement_count,
     build_capital_gain_definitions_request,
     build_contribution_and_benefit_base_request,
+    build_ctc_request,
     build_eitc_request,
     build_oasdi_wage_base_request,
     build_payroll_request,
@@ -234,6 +237,90 @@ def test_tax_unit_person_contexts_handle_minor_only_tax_unit_without_filer_ssn()
     assert context.qualifying_child_described_in_subsection_c is True
     assert context.filer_has_valid_child_ctc_ssn is False
     assert projected["taxpayer_or_spouse_ssn_is_valid_for_subsection_h"] is False
+
+
+def test_build_ctc_request_uses_refreshed_rulespec_input_contract():
+    pd = pytest.importorskip("pandas")
+    pe_data = {
+        "tax_units": pd.DataFrame(
+            [
+                {
+                    "tax_unit_id": 1,
+                    "filing_status": "JOINT",
+                    "adjusted_gross_income": 125_000,
+                }
+            ]
+        ),
+        "persons": pd.DataFrame(
+            [
+                {
+                    "person_id": 7,
+                    "person_tax_unit_id": 1,
+                    "age": 39,
+                    "ssn_card_type": "CITIZEN",
+                },
+                {
+                    "person_id": 8,
+                    "person_tax_unit_id": 1,
+                    "age": 9,
+                    "ssn_card_type": "CITIZEN",
+                },
+            ]
+        ),
+        "tax_unit_ids": [1],
+    }
+
+    request = build_ctc_request(pe_data=pe_data, year=2026)
+
+    inputs = request["dataset"]["inputs"]
+    input_names = {item["name"] for item in inputs}
+    input_values = {
+        (item["name"], item["entity_id"]): item["value"]["value"] for item in inputs
+    }
+    tax_unit_id = "tax_unit_1"
+    child_id = "tax_unit_1_person_1"
+    assert input_values[(f"{CTC_H_BASE}#input.filing_status", tax_unit_id)] == 1
+    assert (
+        input_values[
+            (
+                f"{CTC_BASE}#input.ctc_phaseout_joint_threshold_applies",
+                tax_unit_id,
+            )
+        ]
+        is True
+    )
+    assert (
+        input_values[(f"{CTC_BASE}#input.ctc_advance_payments_received", tax_unit_id)]
+        == 0
+    )
+    assert (
+        input_values[
+            (f"{CTC_BASE}#input.ctc_child_satisfies_dependency_rules", child_id)
+        ]
+        is True
+    )
+    assert (
+        input_values[(f"{CTC_BASE}#input.ctc_child_deduction_allowed", child_id)]
+        is True
+    )
+    assert (
+        input_values[
+            (f"{CTC_H_BASE}#input.ctc_person_satisfies_dependency_rules", child_id)
+        ]
+        is True
+    )
+    assert (
+        input_values[(f"{CTC_H_BASE}#input.ctc_child_satisfies_subsection_c", child_id)]
+        is True
+    )
+    assert f"{CTC_BASE}#input.filing_status" not in input_names
+    assert f"{CTC_H_BASE}#input.filing_status_is_joint_return" not in input_names
+    assert (
+        f"{CTC_BASE}#input.aggregate_advance_payments_under_section_7527A"
+        not in input_names
+    )
+    assert f"{CTC_BASE}#input.qualifying_child_under_section_152_c" not in input_names
+    assert f"{CTC_H_BASE}#input.dependent_under_section_152" not in input_names
 
 
 def test_tax_unit_projection_uses_boundary_inputs_without_ctc_outputs():

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -35,6 +35,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     contribution_and_benefit_base_from_results,
     contribution_and_benefit_base_output,
     contribution_and_benefit_base_program_path,
+    ctc_h_filing_status_code,
     filing_status_code,
     individual_is_unmarried_and_not_surviving_spouse,
     output_number,
@@ -108,6 +109,22 @@ def test_valid_child_ssn_type_maps_policyengine_enum(value, expected):
 )
 def test_uses_joint_ctc_phaseout_threshold_matches_policyengine(value, expected):
     assert uses_joint_ctc_phaseout_threshold(value) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("JOINT", 1),
+        ("SURVIVING_SPOUSE", 1),
+        ("SINGLE", 0),
+        ("SEPARATE", 2),
+        ("HEAD_OF_HOUSEHOLD", 3),
+    ],
+)
+def test_ctc_h_filing_status_code_matches_policyengine_phaseout_threshold(
+    value, expected
+):
+    assert ctc_h_filing_status_code(value) == expected
 
 
 def test_ctc_person_projection_marks_under_17_valid_ssn_child():
@@ -239,14 +256,15 @@ def test_tax_unit_person_contexts_handle_minor_only_tax_unit_without_filer_ssn()
     assert projected["taxpayer_or_spouse_ssn_is_valid_for_subsection_h"] is False
 
 
-def test_build_ctc_request_uses_refreshed_rulespec_input_contract():
+@pytest.mark.parametrize("filing_status", ["JOINT", "SURVIVING_SPOUSE"])
+def test_build_ctc_request_uses_refreshed_rulespec_input_contract(filing_status):
     pd = pytest.importorskip("pandas")
     pe_data = {
         "tax_units": pd.DataFrame(
             [
                 {
                     "tax_unit_id": 1,
-                    "filing_status": "JOINT",
+                    "filing_status": filing_status,
                     "adjusted_gross_income": 125_000,
                 }
             ]


### PR DESCRIPTION
## Summary
- updates the ECPS tax oracle input projection for refreshed RuleSpec input names from rulespec-us #46
- sends section 7703 inputs for EITC married-status derivation instead of old direct 32 inputs
- adds builder-level CTC request regression coverage for the refreshed input names and removed old names

## Verification
- `uv run ruff check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py`
- `uv run --extra dev pytest tests/test_policyengine_ecps_tax.py -q` (63 passed)
- ECPS smoke against current rulespec-us main and policyengine-us 1.705.1: 292 compared values, 0 mismatches
