### PR TITLE
Include self-employment sources in EITC ECPS projection

### DIFF
--- a/changelog.d/ecps-eitc-self-employment.fixed.md
+++ b/changelog.d/ecps-eitc-self-employment.fixed.md
@@ -1,0 +1,1 @@
+Include farm operations and partnership self-employment income in the EITC ECPS projection.

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -183,6 +183,10 @@ CAPITAL_GAINS_DEFINITION_OUTPUTS = {
     },
 }
 EITC_OUTPUTS = {
+    "eitc_earned_income": {
+        "axiom": f"{SECTION_32_C_2_BASE}#earned_income",
+        "pe": "eitc_earned_income",
+    },
     "eitc_child_count": {
         "axiom": f"{EITC_BASE}#eitc_child_count",
         "pe": "eitc_child_count",
@@ -252,6 +256,7 @@ PE_TAX_UNIT_VARIABLES = tuple(
             "ctc_qualifying_children",
             "eitc_child_count",
             "eitc_demographic_eligible",
+            "eitc_earned_income",
             "eitc_eligible",
             "eitc_investment_income_eligible",
             "eitc_maximum",
@@ -1363,13 +1368,21 @@ def project_section_1402_a_tax_unit_inputs(
     self_employment_income = sum(
         money(person.get("self_employment_income_before_lsr", 0))
         + money(person.get("sstb_self_employment_income_before_lsr", 0))
+        + money(person.get("farm_operations_income", 0))
+        for person, context in zip(persons, contexts, strict=True)
+        if context.is_head or context.is_spouse
+    )
+    partnership_self_employment_income = sum(
+        money(person.get("partnership_se_income", 0))
         for person, context in zip(persons, contexts, strict=True)
         if context.is_head or context.is_spouse
     )
     return {
         "self_employment_trade_or_business_gross_income": self_employment_income,
         "self_employment_trade_or_business_deductions": 0,
-        "partnership_section_702_a_8_income_or_loss": 0,
+        "partnership_section_702_a_8_income_or_loss": (
+            partnership_self_employment_income
+        ),
     }
 
 
@@ -1800,8 +1813,10 @@ def compare_outputs(
             "taxable income rather than using PolicyEngine taxable income as "
             "an Axiom input.",
             "EITC projections supply ECPS wage and self-employment leaf facts "
+            "including farm operations and partnership self-employment income "
             "to Sections 32(c)(2) and 1402(a); Section 32 earned income is "
-            "computed by Axiom rather than passed in as a PolicyEngine output.",
+            "computed by Axiom and compared as an output rather than passed in "
+            "from PolicyEngine.",
         ],
     )
 

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -615,6 +615,8 @@ def test_eitc_projection_sends_self_employment_to_section_1402_not_earned_income
             "employment_income_before_lsr": 18_000,
             "self_employment_income_before_lsr": 2_500,
             "sstb_self_employment_income_before_lsr": 0,
+            "farm_operations_income": 300,
+            "partnership_se_income": 450,
         },
         {
             "age": 35,
@@ -622,6 +624,8 @@ def test_eitc_projection_sends_self_employment_to_section_1402_not_earned_income
             "employment_income_before_lsr": 5_000,
             "self_employment_income_before_lsr": 0,
             "sstb_self_employment_income_before_lsr": 750,
+            "farm_operations_income": 0,
+            "partnership_se_income": -50,
         },
         {
             "age": 8,
@@ -629,6 +633,8 @@ def test_eitc_projection_sends_self_employment_to_section_1402_not_earned_income
             "employment_income_before_lsr": 1_000,
             "self_employment_income_before_lsr": 9_999,
             "sstb_self_employment_income_before_lsr": 9_999,
+            "farm_operations_income": 9_999,
+            "partnership_se_income": 9_999,
         },
     ]
     contexts = project_tax_unit_person_contexts(persons)
@@ -648,9 +654,9 @@ def test_eitc_projection_sends_self_employment_to_section_1402_not_earned_income
         persons=persons,
         contexts=contexts,
     ) == {
-        "self_employment_trade_or_business_gross_income": 3_250,
+        "self_employment_trade_or_business_gross_income": 3_550,
         "self_employment_trade_or_business_deductions": 0,
-        "partnership_section_702_a_8_income_or_loss": 0,
+        "partnership_section_702_a_8_income_or_loss": 400,
     }
     assert project_section_164_f_tax_unit_inputs() == {
         "taxpayer_is_individual": True,
@@ -662,7 +668,7 @@ def test_eitc_projection_sends_self_employment_to_section_1402_not_earned_income
     ) == {
         "international_social_security_agreement_under_section_233_in_effect": False,
         "filing_status": 0,
-        "self_employment_income": 3001.375,
+        "self_employment_income": 3647.825,
         "wages_taken_into_account_for_additional_medicare_tax": 0,
     }
 


### PR DESCRIPTION
## Summary

- include ECPS farm operations income and partnership self-employment income in the EITC Section 1402(a) projection
- compare Axiom Section 32(c)(2) earned income directly against PolicyEngine `eitc_earned_income` as an output-only oracle value
- add coverage so dependent farm/partnership values are not pulled into the filer self-employment projection

## Validation

- `uv run ruff check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py`
- `uv run --extra dev pytest tests/test_policyengine_ecps_tax.py -q`
- EITC-only ECPS 1,000-unit sample with policyengine.py 4.4.4 / PE-US 1.705.1:
  - before: 10,000 compared values, 54 mismatches (`eitc_phased_in`: 34, `eitc_reduction`: 20)
  - after: existing final-output residual falls to 6 `eitc_reduction` mismatches; new output-only `eitc_earned_income` comparison exposes 56 upstream earned-income mismatches
- all-surface FIIT ECPS 1,000-unit sample after this change: 28,380 compared values, 63 mismatches (`ctc_phaseout_amount`: 1, `eitc_earned_income`: 56, `eitc_reduction`: 6)

## Residual

The remaining EITC earned-income residual is tracked in TheAxiomFoundation/rulespec-us#48. It appears to be the generated Section 1401/164(f) self-employment tax deduction path, especially OASDI wage-base coordination, not the ECPS farm/partnership projection.