### PR TITLE
Guard lower-entity caps before aggregation

### DIFF
--- a/changelog.d/entity-limited-aggregation.added.md
+++ b/changelog.d/entity-limited-aggregation.added.md
@@ -1,0 +1,1 @@
+Add generic encoder guidance and validation for applying lower-entity limits before aggregating broad relations.

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3261,16 +3261,8 @@ _RELATION_AMOUNT_AGGREGATE_CALL_PATTERN = re.compile(
     r"(?P<relation>[A-Za-z_][A-Za-z0-9_]*)(?P<tail>[^)]*)\)",
     flags=re.IGNORECASE | re.DOTALL,
 )
-_ENTITY_LIMITED_HELPER_NAME_PATTERN = re.compile(
-    r"(?:^|_|\b)(?:limit|limited|limitation|cap|capped|ceiling|maximum|"
-    r"minimum|not_exceed|lesser|greater|reduc(?:e|ed|tion)|net_of)"
-    r"(?:_|\b|$)",
-    flags=re.IGNORECASE,
-)
 _ENTITY_LIMIT_IMPLEMENTATION_PATTERN = re.compile(
-    r"\bmin\s*\(|\bif\b[^\n:]*[<>]=?|(?:^|_|\b)(?:limit|limited|limitation|"
-    r"cap|capped|ceiling|maximum|not_exceed|lesser|threshold|base|"
-    r"reduc(?:e|ed|tion)|net_of)(?:_|\b|$)",
+    r"\bmin\s*\(|\bif\b[^\n:]*[<>]=?",
     flags=re.IGNORECASE,
 )
 _LIMITING_FUNCTION_CALL_PATTERN = re.compile(
@@ -5927,19 +5919,15 @@ def _aggregate_uses_pre_limited_amount(
     tail: str,
     *,
     formula_by_name: dict[str, str],
-    source_text: str,
 ) -> bool:
     amount_arg = _aggregate_amount_argument(function_name, tail)
     helper_formula = formula_by_name.get(amount_arg)
     if helper_formula is None:
         return False
-    return bool(
-        _ENTITY_LIMITED_HELPER_NAME_PATTERN.search(amount_arg)
-        and _formula_or_referenced_helpers_implement_entity_limit(
-            helper_formula,
-            formula_by_name=formula_by_name,
-            current_name=amount_arg,
-        )
+    return _formula_or_referenced_helpers_implement_entity_limit(
+        helper_formula,
+        formula_by_name=formula_by_name,
+        current_name=amount_arg,
     )
 
 
@@ -5947,7 +5935,6 @@ def _uncapped_broad_relation_aggregates_in_formula(
     formula: str,
     *,
     formula_by_name: dict[str, str],
-    source_text: str,
 ) -> set[str]:
     relations: set[str] = set()
     for match in _RELATION_AMOUNT_AGGREGATE_CALL_PATTERN.finditer(formula):
@@ -5958,7 +5945,6 @@ def _uncapped_broad_relation_aggregates_in_formula(
             match.group("function"),
             match.group("tail") or "",
             formula_by_name=formula_by_name,
-            source_text=source_text,
         ):
             continue
         relations.add(relation_name)
@@ -6045,7 +6031,6 @@ def _limited_aggregate_relations_in_formula(
     *,
     aggregate_relations_by_name: dict[str, set[str]],
     formula_by_name: dict[str, str],
-    source_text: str,
 ) -> set[str]:
     relations: set[str] = set()
     for expression in _formula_limiting_expressions(formula):
@@ -6053,7 +6038,6 @@ def _limited_aggregate_relations_in_formula(
             _uncapped_broad_relation_aggregates_in_formula(
                 expression,
                 formula_by_name=formula_by_name,
-                source_text=source_text,
             )
         )
         relations.update(
@@ -6246,7 +6230,6 @@ def find_entity_limited_aggregation_order_issues(content: str) -> list[str]:
             relations := _uncapped_broad_relation_aggregates_in_formula(
                 formula,
                 formula_by_name=formula_by_name,
-                source_text=source_text,
             )
         )
     }
@@ -6272,7 +6255,6 @@ def find_entity_limited_aggregation_order_issues(content: str) -> list[str]:
             formula,
             aggregate_relations_by_name=aggregate_relations_by_name,
             formula_by_name=formula_by_name,
-            source_text=scoped_source_text,
         )
         scoped_entity_detail = ", ".join(sorted(scoped_entity_terms)[:4])
         for relation_name in sorted(relations):

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3261,8 +3261,8 @@ _RELATION_AMOUNT_AGGREGATE_CALL_PATTERN = re.compile(
     r"(?P<relation>[A-Za-z_][A-Za-z0-9_]*)(?P<tail>[^)]*)\)",
     flags=re.IGNORECASE | re.DOTALL,
 )
-_ENTITY_LIMIT_IMPLEMENTATION_PATTERN = re.compile(
-    r"\bmin\s*\(|\bif\b[^\n:]*[<>]=?",
+_MIN_FUNCTION_CALL_PATTERN = re.compile(
+    r"\bmin\s*\(",
     flags=re.IGNORECASE,
 )
 _LIMITING_FUNCTION_CALL_PATTERN = re.compile(
@@ -3274,16 +3274,36 @@ _LIMITING_CONDITIONAL_PATTERN = re.compile(
     flags=re.IGNORECASE,
 )
 _FORMULA_LIMIT_COMPARISON_PATTERN = re.compile(r"[<>]=?")
+_SOURCE_RELEVANT_COMPARISON_PATTERN = re.compile(
+    r"(?P<left>[^<>=:\n]+?)\s*(?P<op><=|>=|<|>)\s*(?P<right>[^<>=:\n]+)"
+)
+_NEGATED_IDENTIFIER_PATTERN = re.compile(
+    r"\bnot\s+([A-Za-z_][A-Za-z0-9_]*)\b",
+    flags=re.IGNORECASE,
+)
 _SOURCE_LIMIT_SEGMENT_SPLIT_PATTERN = re.compile(r"(?<=[.;])\s+|\n\s*\n+")
+_SOURCE_LIMIT_CLAUSE_SPLIT_PATTERN = re.compile(
+    r"\s*(?:,\s+and\s+|;\s*(?:and\s+)?|"
+    r"\s+and\s+(?=(?:each|every|per|for\s+each|the|a|an)\s+"
+    r"(?:household|tax\s+unit|filing\s+unit|family|individual|person|"
+    r"member|members|taxpayer|employee|claimant|applicant|child|children|"
+    r"dependent|spouse)\b))"
+)
 _LIMITATION_PHRASE_PATTERN = re.compile(
     r"\b(?:limited\s+to|shall\s+not\s+exceed|may\s+not\s+exceed|"
     r"not\s+exceed|lesser\s+of|greater\s+of|reduced\s+by)\b",
     flags=re.IGNORECASE,
 )
 _AGGREGATE_UNIT_SUBJECT_PATTERN = re.compile(
+    r"(?:"
     r"\b(?:household|tax\s+unit|filing\s+unit|family)\b(?!\s+members?\b)"
     r"[\s\S]{0,80}\b(?:benefit|amount|allotment|allowance|credit|"
-    r"deduction|tax|maximum|cap|ceiling)\b",
+    r"deduction|tax|maximum|cap|ceiling)\b"
+    r"|"
+    r"\b(?:benefit|amount|allotment|allowance|credit|deduction|tax|maximum|"
+    r"cap|ceiling)\b[\s\S]{0,80}\b(?:for|of|in)\s+(?:a\s+|an\s+|the\s+)?"
+    r"(?:household|tax\s+unit|filing\s+unit|family)\b(?!\s+members?\b)"
+    r")",
     flags=re.IGNORECASE,
 )
 _LOWER_ENTITY_CONTEXTUAL_AMOUNT_PATTERN = re.compile(
@@ -3296,9 +3316,147 @@ _ANAPHORIC_AMOUNT_PATTERN = re.compile(
     r"\b(?:such|that|the)\s+amount\b",
     flags=re.IGNORECASE,
 )
+_LIMIT_RELEVANCE_WORD_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9_]*")
+_LIMIT_RELEVANCE_TOKEN_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "any",
+        "apply",
+        "applies",
+        "applicant",
+        "are",
+        "be",
+        "benefit",
+        "by",
+        "can",
+        "cap",
+        "capped",
+        "ceiling",
+        "child",
+        "children",
+        "claimant",
+        "credit",
+        "deduction",
+        "dependent",
+        "did",
+        "do",
+        "does",
+        "each",
+        "employee",
+        "exceed",
+        "exceeds",
+        "family",
+        "filing",
+        "for",
+        "from",
+        "greater",
+        "had",
+        "has",
+        "have",
+        "household",
+        "if",
+        "in",
+        "individual",
+        "into",
+        "is",
+        "lesser",
+        "limit",
+        "limitation",
+        "limited",
+        "limits",
+        "maximum",
+        "may",
+        "member",
+        "members",
+        "minimum",
+        "must",
+        "not",
+        "of",
+        "on",
+        "only",
+        "or",
+        "per",
+        "person",
+        "reduced",
+        "reduction",
+        "shall",
+        "spouse",
+        "such",
+        "tax",
+        "taxpayer",
+        "that",
+        "the",
+        "to",
+        "unit",
+        "unless",
+        "was",
+        "were",
+        "with",
+    }
+)
+_LIMIT_RELEVANCE_PHRASE_STOPWORDS = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "any",
+        "are",
+        "be",
+        "by",
+        "can",
+        "did",
+        "do",
+        "does",
+        "each",
+        "for",
+        "from",
+        "had",
+        "has",
+        "have",
+        "if",
+        "in",
+        "into",
+        "is",
+        "may",
+        "must",
+        "not",
+        "of",
+        "on",
+        "only",
+        "or",
+        "per",
+        "shall",
+        "such",
+        "that",
+        "the",
+        "to",
+        "unless",
+        "was",
+        "were",
+        "with",
+    }
+)
 _CONDITIONAL_SOURCE_LIMITATION_PATTERN = re.compile(
     r"\b(?:except\s+that|only\s+if|shall\s+not\s+apply|does\s+not\s+apply|unless)\b",
     flags=re.IGNORECASE,
+)
+_FILTER_LIMITATION_PHRASE_PATTERN = re.compile(
+    r"\b(?:only\s+if|shall\s+not\s+apply|does\s+not\s+apply|unless)\b",
+    flags=re.IGNORECASE,
+)
+_FILTER_NEGATION_SOURCE_PATTERN = re.compile(
+    r"\b(?:not|unless|ineligible|ineligibility|disqualified|excluded)\b",
+    flags=re.IGNORECASE,
+)
+_FILTER_NEGATION_IDENTIFIER_WORDS = frozenset(
+    {
+        "disqualified",
+        "excluded",
+        "ineligible",
+        "not",
+    }
 )
 _LIMITATION_ON_SUBJECT_PATTERN = re.compile(
     r"\blimitation\s+on\s+(?:the\s+)?([A-Za-z][A-Za-z\s-]{2,80}?)"
@@ -5907,11 +6065,468 @@ def _source_supports_structural_relation_container(
     )
 
 
+@dataclass(frozen=True)
+class _SourceLimitPair:
+    tokens: frozenset[str]
+    phrases: frozenset[str]
+    amount_tokens: frozenset[str]
+    amount_phrases: frozenset[str]
+    cap_tokens: frozenset[str]
+    cap_phrases: frozenset[str]
+    has_standalone_reduction: bool = False
+
+
+@dataclass(frozen=True)
+class _SourceLimitRelevance:
+    tokens: frozenset[str]
+    phrases: frozenset[str]
+    amount_tokens: frozenset[str]
+    amount_phrases: frozenset[str]
+    cap_tokens: frozenset[str]
+    cap_phrases: frozenset[str]
+    filter_tokens: frozenset[str]
+    filter_phrases: frozenset[str]
+    has_standalone_reduction: bool
+    filter_allows_negated_identifiers: bool
+    limit_pairs: tuple[_SourceLimitPair, ...]
+
+
+def _limit_relevance_tokens(text: str) -> set[str]:
+    tokens: set[str] = set()
+    for raw_word in _LIMIT_RELEVANCE_WORD_PATTERN.findall(text):
+        for token in raw_word.lower().split("_"):
+            if len(token) < 3 or token in _LIMIT_RELEVANCE_TOKEN_STOPWORDS:
+                continue
+            tokens.add(token)
+    return tokens
+
+
+def _limit_relevance_phrase_words(text: str) -> list[str]:
+    words: list[str] = []
+    for raw_word in _LIMIT_RELEVANCE_WORD_PATTERN.findall(text):
+        for token in raw_word.lower().split("_"):
+            if len(token) < 3 or token in _LIMIT_RELEVANCE_PHRASE_STOPWORDS:
+                continue
+            words.append(token)
+    return words
+
+
+def _limit_relevance_phrases(text: str) -> set[str]:
+    phrases: set[str] = set()
+    phrase_words = _limit_relevance_phrase_words(text)
+    for ngram_size in range(2, 5):
+        for index in range(0, len(phrase_words) - ngram_size + 1):
+            phrases.add("_".join(phrase_words[index : index + ngram_size]))
+    return phrases
+
+
+def _phrase_is_amount_side(
+    phrase: str,
+    *,
+    amount_words: set[str],
+    amount_phrases: set[str],
+) -> bool:
+    phrase_words = set(phrase.split("_"))
+    return phrase_words <= amount_words or any(
+        amount_phrase in phrase for amount_phrase in amount_phrases
+    )
+
+
+_LESSER_GREATER_OF_PATTERN = re.compile(
+    r"\b(?:lesser|greater)\s+of\b",
+    flags=re.IGNORECASE,
+)
+
+
+def _source_limit_lesser_greater_operands(
+    text: str,
+    *,
+    already_after_phrase: bool = False,
+) -> tuple[str, str] | None:
+    operand_text = text
+    if not already_after_phrase:
+        match = _LESSER_GREATER_OF_PATTERN.search(text)
+        if match is None:
+            return None
+        operand_text = text[match.end() :]
+    operand_text = re.sub(r"^\s*(?:the\s+)?", "", operand_text.strip(), flags=re.I)
+    parts = re.split(r"\s+(?:and|or)\s+", operand_text, maxsplit=1, flags=re.I)
+    if len(parts) < 2:
+        return None
+    return parts[0].strip(" ,.;:"), parts[1].strip(" ,.;:")
+
+
+def _source_limit_pair(
+    *,
+    segment_text: str,
+    amount_text: str,
+    cap_text: str,
+    has_standalone_reduction: bool = False,
+) -> _SourceLimitPair | None:
+    amount_tokens = _limit_relevance_tokens(amount_text)
+    amount_phrases = _limit_relevance_phrases(amount_text)
+    cap_tokens = _limit_relevance_tokens(cap_text) - amount_tokens
+    cap_phrases = {
+        phrase
+        for phrase in _limit_relevance_phrases(cap_text)
+        if not _phrase_is_amount_side(
+            phrase,
+            amount_words=amount_tokens,
+            amount_phrases=amount_phrases,
+        )
+    }
+    if (not amount_tokens and not amount_phrases) or (
+        not cap_tokens and not cap_phrases
+    ):
+        return None
+    return _SourceLimitPair(
+        tokens=frozenset(_limit_relevance_tokens(segment_text)),
+        phrases=frozenset(_limit_relevance_phrases(segment_text)),
+        amount_tokens=frozenset(amount_tokens),
+        amount_phrases=frozenset(amount_phrases),
+        cap_tokens=frozenset(cap_tokens),
+        cap_phrases=frozenset(cap_phrases),
+        has_standalone_reduction=has_standalone_reduction,
+    )
+
+
+def _operand_matches_amount_side(
+    operand_text: str,
+    *,
+    amount_tokens: set[str],
+    amount_phrases: set[str],
+) -> bool:
+    if not amount_tokens and not amount_phrases:
+        return False
+    operand_tokens = _limit_relevance_tokens(operand_text)
+    operand_phrases = _limit_relevance_phrases(operand_text)
+    return bool(
+        operand_tokens & amount_tokens
+        or operand_phrases & amount_phrases
+        or any(
+            _phrase_is_amount_side(
+                phrase,
+                amount_words=amount_tokens,
+                amount_phrases=amount_phrases,
+            )
+            for phrase in operand_phrases
+        )
+    )
+
+
+def _source_limit_pairs_from_segment(segment: str) -> list[_SourceLimitPair]:
+    match = _LIMITATION_PHRASE_PATTERN.search(segment)
+    if match is None:
+        return []
+    has_standalone_reduction = bool(
+        re.fullmatch(r"reduced\s+by", match.group(0), flags=re.I)
+    )
+    amount_side_text = _source_limit_amount_side_text(segment)
+    operands = _source_limit_lesser_greater_operands(
+        segment[match.end() :],
+        already_after_phrase=bool(
+            re.fullmatch(r"(?:lesser|greater)\s+of", match.group(0), flags=re.I)
+        ),
+    )
+    candidate_texts: list[tuple[str, str]]
+    if operands is None:
+        candidate_texts = [(amount_side_text, _source_limit_cap_side_text(segment))]
+    else:
+        left_operand, right_operand = operands
+        amount_side_tokens = _limit_relevance_tokens(amount_side_text)
+        amount_side_phrases = _limit_relevance_phrases(amount_side_text)
+        left_matches_amount = _operand_matches_amount_side(
+            left_operand,
+            amount_tokens=amount_side_tokens,
+            amount_phrases=amount_side_phrases,
+        )
+        right_matches_amount = _operand_matches_amount_side(
+            right_operand,
+            amount_tokens=amount_side_tokens,
+            amount_phrases=amount_side_phrases,
+        )
+        if left_matches_amount and not right_matches_amount:
+            candidate_texts = [(f"{amount_side_text} {left_operand}", right_operand)]
+        elif right_matches_amount and not left_matches_amount:
+            candidate_texts = [(f"{amount_side_text} {right_operand}", left_operand)]
+        else:
+            candidate_texts = [
+                (f"{amount_side_text} {left_operand}", right_operand),
+                (f"{amount_side_text} {right_operand}", left_operand),
+            ]
+    pairs: list[_SourceLimitPair] = []
+    seen: set[tuple[frozenset[str], frozenset[str], frozenset[str], frozenset[str]]] = (
+        set()
+    )
+    for amount_text, cap_text in candidate_texts:
+        pair = _source_limit_pair(
+            segment_text=segment,
+            amount_text=amount_text,
+            cap_text=cap_text,
+            has_standalone_reduction=has_standalone_reduction,
+        )
+        if pair is None:
+            continue
+        key = (
+            pair.amount_tokens,
+            pair.amount_phrases,
+            pair.cap_tokens,
+            pair.cap_phrases,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        pairs.append(pair)
+    return pairs
+
+
+def _source_filter_allows_negated_identifiers(
+    phrase_text: str,
+    filter_side_text: str,
+) -> bool:
+    return bool(
+        _FILTER_NEGATION_SOURCE_PATTERN.search(f"{phrase_text} {filter_side_text}")
+    )
+
+
+def _source_limit_relevance(source_text: str) -> _SourceLimitRelevance:
+    tokens: set[str] = set()
+    phrases: set[str] = set()
+    amount_tokens: set[str] = set()
+    amount_phrases: set[str] = set()
+    cap_tokens: set[str] = set()
+    cap_phrases: set[str] = set()
+    filter_tokens: set[str] = set()
+    filter_phrases: set[str] = set()
+    limit_pairs: list[_SourceLimitPair] = []
+    has_standalone_reduction = False
+    filter_allows_negated_identifiers = False
+    for segment, _terms in _source_lower_entity_limitation_records(source_text):
+        tokens.update(_limit_relevance_tokens(segment))
+        phrases.update(_limit_relevance_phrases(segment))
+        limitation_match = _LIMITATION_PHRASE_PATTERN.search(segment)
+        filter_match = _FILTER_LIMITATION_PHRASE_PATTERN.search(segment)
+        if filter_match is not None and limitation_match is None:
+            amount_side_text = segment[: filter_match.start()]
+            amount_tokens.update(_limit_relevance_tokens(amount_side_text))
+            amount_phrases.update(_limit_relevance_phrases(amount_side_text))
+            filter_side_text = segment[filter_match.end() :]
+            filter_tokens.update(_limit_relevance_tokens(filter_side_text))
+            filter_phrases.update(_limit_relevance_phrases(filter_side_text))
+            filter_allows_negated_identifiers = (
+                filter_allows_negated_identifiers
+                or _source_filter_allows_negated_identifiers(
+                    filter_match.group(0),
+                    filter_side_text,
+                )
+            )
+            continue
+        segment_pairs = _source_limit_pairs_from_segment(segment)
+        limit_pairs.extend(segment_pairs)
+        for pair in segment_pairs:
+            amount_tokens.update(pair.amount_tokens)
+            amount_phrases.update(pair.amount_phrases)
+            cap_tokens.update(pair.cap_tokens)
+            cap_phrases.update(pair.cap_phrases)
+            has_standalone_reduction = (
+                has_standalone_reduction or pair.has_standalone_reduction
+            )
+    return _SourceLimitRelevance(
+        tokens=frozenset(tokens),
+        phrases=frozenset(phrases),
+        amount_tokens=frozenset(amount_tokens),
+        amount_phrases=frozenset(amount_phrases),
+        cap_tokens=frozenset(cap_tokens),
+        cap_phrases=frozenset(cap_phrases),
+        filter_tokens=frozenset(filter_tokens),
+        filter_phrases=frozenset(filter_phrases),
+        has_standalone_reduction=has_standalone_reduction,
+        filter_allows_negated_identifiers=filter_allows_negated_identifiers,
+        limit_pairs=tuple(limit_pairs),
+    )
+
+
+def _source_limit_cap_side_text(segment: str) -> str:
+    match = _LIMITATION_PHRASE_PATTERN.search(segment)
+    if match is None:
+        return segment
+    tail = segment[match.end() :]
+    operands = _source_limit_lesser_greater_operands(
+        tail,
+        already_after_phrase=bool(
+            re.fullmatch(r"(?:lesser|greater)\s+of", match.group(0), flags=re.I)
+        ),
+    )
+    return operands[1] if operands is not None else tail
+
+
+def _source_limit_amount_side_text(segment: str) -> str:
+    match = _LIMITATION_PHRASE_PATTERN.search(segment)
+    return segment[: match.start()] if match else ""
+
+
+def _source_limit_lesser_greater_amount_side_text(segment: str) -> str:
+    match = _LIMITATION_PHRASE_PATTERN.search(segment)
+    if match is None:
+        return ""
+    operands = _source_limit_lesser_greater_operands(
+        segment[match.end() :],
+        already_after_phrase=bool(
+            re.fullmatch(r"(?:lesser|greater)\s+of", match.group(0), flags=re.I)
+        ),
+    )
+    return operands[0] if operands is not None else ""
+
+
+def _text_matches_source_cap_relevance(
+    text: str,
+    source_limit_relevance: _SourceLimitRelevance | _SourceLimitPair,
+) -> bool:
+    if not source_limit_relevance.cap_tokens and not source_limit_relevance.cap_phrases:
+        return False
+    identifiers = {
+        raw_word.lower() for raw_word in _LIMIT_RELEVANCE_WORD_PATTERN.findall(text)
+    }
+    if any(
+        _identifier_matches_source_cap_phrase(
+            identifier,
+            source_limit_relevance.cap_phrases,
+        )
+        for identifier in identifiers
+        if "_" in identifier
+    ):
+        return True
+    if any("_" in identifier for identifier in identifiers):
+        return False
+    return bool(_limit_relevance_tokens(text) & source_limit_relevance.cap_tokens)
+
+
+def _text_matches_source_amount_relevance(
+    text: str,
+    source_limit_relevance: _SourceLimitRelevance | _SourceLimitPair,
+) -> bool:
+    if (
+        not source_limit_relevance.amount_tokens
+        and not source_limit_relevance.amount_phrases
+    ):
+        return False
+    identifiers = {
+        raw_word.lower() for raw_word in _LIMIT_RELEVANCE_WORD_PATTERN.findall(text)
+    }
+    if any(
+        identifier in source_limit_relevance.amount_phrases
+        for identifier in identifiers
+        if "_" in identifier
+    ):
+        return True
+    return bool(_limit_relevance_tokens(text) & source_limit_relevance.amount_tokens)
+
+
+def _text_matches_source_filter_relevance(
+    text: str,
+    source_limit_relevance: _SourceLimitRelevance,
+) -> bool:
+    if (
+        not source_limit_relevance.filter_tokens
+        and not source_limit_relevance.filter_phrases
+    ):
+        return False
+    if (
+        _expression_has_negated_filter_identifier(text)
+        and not source_limit_relevance.filter_allows_negated_identifiers
+    ):
+        return False
+    identifiers = {
+        raw_word.lower() for raw_word in _LIMIT_RELEVANCE_WORD_PATTERN.findall(text)
+    }
+    if any(
+        _identifier_matches_source_filter_phrase(
+            identifier,
+            source_limit_relevance.filter_phrases,
+        )
+        for identifier in identifiers
+        if "_" in identifier
+    ):
+        return True
+    return bool(_limit_relevance_tokens(text) & source_limit_relevance.filter_tokens)
+
+
+def _identifier_has_negated_filter(identifier: str) -> bool:
+    return bool(set(identifier.lower().split("_")) & _FILTER_NEGATION_IDENTIFIER_WORDS)
+
+
+def _expression_has_negated_filter_identifier(expression: str) -> bool:
+    if _NEGATED_IDENTIFIER_PATTERN.search(expression):
+        return True
+    return any(
+        _identifier_has_negated_filter(raw_word)
+        for raw_word in _LIMIT_RELEVANCE_WORD_PATTERN.findall(expression)
+    )
+
+
+def _identifier_matches_source_cap_phrase(
+    identifier: str,
+    cap_phrases: frozenset[str],
+) -> bool:
+    if identifier in cap_phrases:
+        return True
+    for suffix in (
+        "_amount",
+        "_cap",
+        "_ceiling",
+        "_limit",
+        "_limitation",
+        "_maximum",
+        "_value",
+    ):
+        if identifier.endswith(suffix) and identifier[: -len(suffix)] in cap_phrases:
+            return True
+    return False
+
+
+def _identifier_matches_source_filter_phrase(
+    identifier: str,
+    filter_phrases: frozenset[str],
+) -> bool:
+    if identifier in filter_phrases:
+        return True
+    identifier_words = [
+        word
+        for word in identifier.split("_")
+        if word and word not in _LIMIT_RELEVANCE_PHRASE_STOPWORDS
+    ]
+    normalized_identifier = "_".join(identifier_words)
+    return any(
+        phrase in normalized_identifier
+        or set(phrase.split("_")) <= set(identifier_words)
+        for phrase in filter_phrases
+    )
+
+
+def _aggregate_tail_arguments(tail: str) -> list[str]:
+    tail_after_relation = re.sub(r"^\s*,\s*", "", tail, count=1)
+    return [
+        argument.strip()
+        for argument in _split_top_level_call_arguments(tail_after_relation)
+        if argument.strip()
+    ]
+
+
 def _aggregate_amount_argument(function_name: str, tail: str) -> str:
     if function_name.lower() == "sum_where":
-        parts = [part.strip() for part in tail.lstrip(",").split(",", 2)]
+        parts = _aggregate_tail_arguments(tail)
         return parts[0] if parts else ""
+    if function_name.lower() == "sum":
+        field_match = re.match(r"\s*\.\s*([A-Za-z_][A-Za-z0-9_]*)", tail)
+        return field_match.group(1) if field_match else ""
     return ""
+
+
+def _aggregate_predicate_argument(function_name: str, tail: str) -> str:
+    if function_name.lower() != "sum_where":
+        return ""
+    parts = _aggregate_tail_arguments(tail)
+    return parts[1] if len(parts) >= 2 else ""
 
 
 def _aggregate_uses_pre_limited_amount(
@@ -5919,7 +6534,16 @@ def _aggregate_uses_pre_limited_amount(
     tail: str,
     *,
     formula_by_name: dict[str, str],
+    source_limit_relevance: _SourceLimitRelevance,
 ) -> bool:
+    predicate_arg = _aggregate_predicate_argument(function_name, tail)
+    if predicate_arg and _expression_or_referenced_helpers_match_source_filter(
+        predicate_arg,
+        formula_by_name=formula_by_name,
+        source_limit_relevance=source_limit_relevance,
+        seen=set(),
+    ):
+        return True
     amount_arg = _aggregate_amount_argument(function_name, tail)
     helper_formula = formula_by_name.get(amount_arg)
     if helper_formula is None:
@@ -5928,6 +6552,27 @@ def _aggregate_uses_pre_limited_amount(
         helper_formula,
         formula_by_name=formula_by_name,
         current_name=amount_arg,
+        source_limit_relevance=source_limit_relevance,
+    )
+
+
+def _aggregate_amount_matches_source_limit(
+    function_name: str,
+    tail: str,
+    *,
+    formula_by_name: dict[str, str],
+    source_limit_relevance: _SourceLimitRelevance,
+) -> bool:
+    amount_arg = _aggregate_amount_argument(function_name, tail)
+    if _text_matches_source_amount_relevance(amount_arg, source_limit_relevance):
+        return True
+    helper_formula = formula_by_name.get(amount_arg)
+    return bool(
+        helper_formula is not None
+        and _text_matches_source_amount_relevance(
+            helper_formula,
+            source_limit_relevance,
+        )
     )
 
 
@@ -5935,18 +6580,34 @@ def _uncapped_broad_relation_aggregates_in_formula(
     formula: str,
     *,
     formula_by_name: dict[str, str],
+    source_limit_relevance: _SourceLimitRelevance,
+    require_source_amount_match: bool = False,
 ) -> set[str]:
     relations: set[str] = set()
     for match in _RELATION_AMOUNT_AGGREGATE_CALL_PATTERN.finditer(formula):
         relation_name = match.group("relation")
         if not _BROAD_STRUCTURAL_RELATION_PATTERN.search(relation_name):
             continue
+        function_name = match.group("function")
+        tail = match.group("tail") or ""
         if _aggregate_uses_pre_limited_amount(
-            match.group("function"),
-            match.group("tail") or "",
+            function_name,
+            tail,
             formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
         ):
             continue
+        if require_source_amount_match and not _text_matches_source_amount_relevance(
+            _aggregate_amount_argument(function_name, tail),
+            source_limit_relevance,
+        ):
+            if not _aggregate_amount_matches_source_limit(
+                function_name,
+                tail,
+                formula_by_name=formula_by_name,
+                source_limit_relevance=source_limit_relevance,
+            ):
+                continue
         relations.add(relation_name)
     return relations
 
@@ -6002,17 +6663,390 @@ def _formula_limiting_expressions(formula: str) -> list[str]:
     return expressions
 
 
+def _formula_min_limit_side_expressions(formula: str) -> list[str]:
+    expressions: list[str] = []
+    for arguments in _formula_min_argument_sets(formula):
+        expressions.extend(arguments)
+    return expressions
+
+
+def _formula_min_argument_sets(formula: str) -> list[list[str]]:
+    argument_sets: list[list[str]] = []
+    for match in _MIN_FUNCTION_CALL_PATTERN.finditer(formula):
+        open_index = match.end() - 1
+        depth = 0
+        for index in range(open_index, len(formula)):
+            char = formula[index]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    arguments = _split_top_level_call_arguments(
+                        formula[open_index + 1 : index]
+                    )
+                    argument_sets.append([argument.strip() for argument in arguments])
+                    break
+    return argument_sets
+
+
+def _formula_has_source_relevant_comparison(
+    formula: str,
+    *,
+    formula_by_name: dict[str, str],
+    source_limit_relevance: _SourceLimitRelevance | _SourceLimitPair,
+    seen: set[str],
+) -> bool:
+    return bool(
+        _FORMULA_LIMIT_COMPARISON_PATTERN.search(formula)
+        and _expression_or_referenced_helpers_match_source_amount(
+            formula,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=seen,
+        )
+        and _expression_or_referenced_helpers_match_source_cap(
+            formula,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=seen,
+        )
+    )
+
+
+def _clean_comparison_operand(operand: str) -> str:
+    return re.sub(
+        r"^\s*(?:if|elif|return)\s+",
+        "",
+        operand.strip().strip("() "),
+        flags=re.I,
+    ).strip()
+
+
+def _source_relevant_comparison_direction(
+    expression: str,
+    *,
+    formula_by_name: dict[str, str],
+    source_limit_relevance: _SourceLimitRelevance | _SourceLimitPair,
+    seen: set[str],
+) -> str | None:
+    for match in _SOURCE_RELEVANT_COMPARISON_PATTERN.finditer(expression):
+        left = _clean_comparison_operand(match.group("left"))
+        right = _clean_comparison_operand(match.group("right"))
+        op = match.group("op")
+        left_amount = _expression_or_referenced_helpers_match_source_amount(
+            left,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=seen,
+        )
+        right_amount = _expression_or_referenced_helpers_match_source_amount(
+            right,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=seen,
+        )
+        left_cap = _expression_or_referenced_helpers_match_source_cap(
+            left,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=seen,
+        )
+        right_cap = _expression_or_referenced_helpers_match_source_cap(
+            right,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=seen,
+        )
+        if left_amount and right_cap:
+            return "amount_gt_cap" if op in {">", ">="} else "amount_lt_cap"
+        if left_cap and right_amount:
+            return "amount_gt_cap" if op in {"<", "<="} else "amount_lt_cap"
+
+    for match in _NEGATED_IDENTIFIER_PATTERN.finditer(expression):
+        identifier = match.group(1)
+        if identifier in seen:
+            continue
+        helper_formula = formula_by_name.get(identifier)
+        if helper_formula is None:
+            continue
+        visited = set(seen)
+        visited.add(identifier)
+        direction = _source_relevant_comparison_direction(
+            helper_formula,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=visited,
+        )
+        if direction == "amount_gt_cap":
+            return "amount_lt_cap"
+        if direction == "amount_lt_cap":
+            return "amount_gt_cap"
+
+    for identifier in _formula_local_identifiers(expression):
+        if identifier in seen:
+            continue
+        helper_formula = formula_by_name.get(identifier)
+        if helper_formula is None:
+            continue
+        visited = set(seen)
+        visited.add(identifier)
+        direction = _source_relevant_comparison_direction(
+            helper_formula,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=visited,
+        )
+        if direction is not None:
+            return direction
+    return None
+
+
+def _expression_or_referenced_helpers_match_source_filter(
+    expression: str,
+    *,
+    formula_by_name: dict[str, str],
+    source_limit_relevance: _SourceLimitRelevance,
+    seen: set[str],
+) -> bool:
+    if _text_matches_source_filter_relevance(expression, source_limit_relevance):
+        return True
+    for identifier in _formula_local_identifiers(expression):
+        if identifier in seen:
+            continue
+        helper_formula = formula_by_name.get(identifier)
+        if helper_formula is None:
+            continue
+        visited = set(seen)
+        visited.add(identifier)
+        if _expression_or_referenced_helpers_match_source_filter(
+            helper_formula,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=visited,
+        ):
+            return True
+    return False
+
+
+def _expression_or_referenced_helpers_match_source_amount(
+    expression: str,
+    *,
+    formula_by_name: dict[str, str],
+    source_limit_relevance: _SourceLimitRelevance | _SourceLimitPair,
+    seen: set[str],
+) -> bool:
+    if _text_matches_source_amount_relevance(expression, source_limit_relevance):
+        return True
+    for identifier in _formula_local_identifiers(expression):
+        if identifier in seen:
+            continue
+        helper_formula = formula_by_name.get(identifier)
+        if helper_formula is None:
+            continue
+        visited = set(seen)
+        visited.add(identifier)
+        if _expression_or_referenced_helpers_match_source_amount(
+            helper_formula,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=visited,
+        ):
+            return True
+    return False
+
+
+def _expression_or_referenced_helpers_match_source_cap(
+    expression: str,
+    *,
+    formula_by_name: dict[str, str],
+    source_limit_relevance: _SourceLimitRelevance | _SourceLimitPair,
+    seen: set[str],
+) -> bool:
+    if _text_matches_source_cap_relevance(expression, source_limit_relevance):
+        return True
+    for identifier in _formula_local_identifiers(expression):
+        if identifier in seen:
+            continue
+        helper_formula = formula_by_name.get(identifier)
+        if helper_formula is None:
+            continue
+        visited = set(seen)
+        visited.add(identifier)
+        if _expression_or_referenced_helpers_match_source_cap(
+            helper_formula,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=visited,
+        ):
+            return True
+    return False
+
+
+def _conditional_branch_texts(
+    formula: str, condition_match: re.Match[str]
+) -> list[str]:
+    body = formula[condition_match.end() :]
+    else_match = re.search(r"(?m)^\s*else\s*:\s*", body)
+    if else_match is None:
+        return [body.strip()]
+    return [
+        body[: else_match.start()].strip(),
+        body[else_match.end() :].strip(),
+    ]
+
+
+def _conditional_implements_source_relevant_limit(
+    formula: str,
+    condition_match: re.Match[str],
+    *,
+    formula_by_name: dict[str, str],
+    source_limit_relevance: _SourceLimitRelevance,
+    seen: set[str],
+) -> bool:
+    branch_texts = _conditional_branch_texts(formula, condition_match)
+    if len(branch_texts) < 2:
+        return False
+    then_branch, else_branch = branch_texts[0], branch_texts[1]
+    direction = _source_relevant_comparison_direction(
+        condition_match.group("condition"),
+        formula_by_name=formula_by_name,
+        source_limit_relevance=source_limit_relevance,
+        seen=seen,
+    )
+    if direction is None:
+        return False
+    then_matches_amount = _expression_or_referenced_helpers_match_source_amount(
+        then_branch,
+        formula_by_name=formula_by_name,
+        source_limit_relevance=source_limit_relevance,
+        seen=seen,
+    )
+    else_matches_amount = _expression_or_referenced_helpers_match_source_amount(
+        else_branch,
+        formula_by_name=formula_by_name,
+        source_limit_relevance=source_limit_relevance,
+        seen=seen,
+    )
+    then_matches_cap = _expression_or_referenced_helpers_match_source_cap(
+        then_branch,
+        formula_by_name=formula_by_name,
+        source_limit_relevance=source_limit_relevance,
+        seen=seen,
+    )
+    else_matches_cap = _expression_or_referenced_helpers_match_source_cap(
+        else_branch,
+        formula_by_name=formula_by_name,
+        source_limit_relevance=source_limit_relevance,
+        seen=seen,
+    )
+    if direction == "amount_gt_cap":
+        return then_matches_cap and else_matches_amount
+    return then_matches_amount and else_matches_cap
+
+
+def _min_arguments_implement_source_limit(
+    arguments: list[str],
+    *,
+    formula_by_name: dict[str, str],
+    source_limit_relevance: _SourceLimitRelevance,
+    seen: set[str],
+) -> bool:
+    amount_indexes = {
+        index
+        for index, argument in enumerate(arguments)
+        if _expression_or_referenced_helpers_match_source_amount(
+            argument,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=seen,
+        )
+    }
+    cap_indexes = {
+        index
+        for index, argument in enumerate(arguments)
+        if _expression_or_referenced_helpers_match_source_cap(
+            argument,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=seen,
+        )
+    }
+    return any(
+        amount_index != cap_index
+        for amount_index in amount_indexes
+        for cap_index in cap_indexes
+    )
+
+
+def _formula_has_source_relevant_reduction(
+    formula: str,
+    *,
+    formula_by_name: dict[str, str],
+    source_limit_relevance: _SourceLimitRelevance,
+    seen: set[str],
+) -> bool:
+    return bool(
+        source_limit_relevance.has_standalone_reduction
+        and "-" in formula
+        and _expression_or_referenced_helpers_match_source_amount(
+            formula,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=seen,
+        )
+        and _expression_or_referenced_helpers_match_source_cap(
+            formula,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=seen,
+        )
+    )
+
+
 def _formula_or_referenced_helpers_implement_entity_limit(
     formula: str,
     *,
     formula_by_name: dict[str, str],
     current_name: str,
+    source_limit_relevance: _SourceLimitRelevance,
     seen: set[str] | None = None,
 ) -> bool:
-    if _ENTITY_LIMIT_IMPLEMENTATION_PATTERN.search(formula):
-        return True
     visited = set(seen or set())
     visited.add(current_name)
+    for arguments in _formula_min_argument_sets(formula):
+        if _min_arguments_implement_source_limit(
+            arguments,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=visited,
+        ):
+            return True
+    for match in _LIMITING_CONDITIONAL_PATTERN.finditer(formula):
+        if _conditional_implements_source_relevant_limit(
+            formula,
+            match,
+            formula_by_name=formula_by_name,
+            source_limit_relevance=source_limit_relevance,
+            seen=visited,
+        ):
+            return True
+    if _formula_has_source_relevant_reduction(
+        formula,
+        formula_by_name=formula_by_name,
+        source_limit_relevance=source_limit_relevance,
+        seen=visited,
+    ):
+        return True
+    if not _LIMITING_CONDITIONAL_PATTERN.search(
+        formula
+    ) and _formula_has_source_relevant_comparison(
+        formula,
+        formula_by_name=formula_by_name,
+        source_limit_relevance=source_limit_relevance,
+        seen=visited,
+    ):
+        return True
     for identifier in _formula_local_identifiers(formula):
         if identifier in visited or identifier not in formula_by_name:
             continue
@@ -6020,6 +7054,7 @@ def _formula_or_referenced_helpers_implement_entity_limit(
             formula_by_name[identifier],
             formula_by_name=formula_by_name,
             current_name=identifier,
+            source_limit_relevance=source_limit_relevance,
             seen=visited,
         ):
             return True
@@ -6031,6 +7066,7 @@ def _limited_aggregate_relations_in_formula(
     *,
     aggregate_relations_by_name: dict[str, set[str]],
     formula_by_name: dict[str, str],
+    source_limit_relevance: _SourceLimitRelevance,
 ) -> set[str]:
     relations: set[str] = set()
     for expression in _formula_limiting_expressions(formula):
@@ -6038,6 +7074,8 @@ def _limited_aggregate_relations_in_formula(
             _uncapped_broad_relation_aggregates_in_formula(
                 expression,
                 formula_by_name=formula_by_name,
+                source_limit_relevance=source_limit_relevance,
+                require_source_amount_match=True,
             )
         )
         relations.update(
@@ -6052,29 +7090,59 @@ def _limited_aggregate_relations_in_formula(
 
 def _source_lower_entity_limitation_terms(source_text: str) -> set[str]:
     terms: set[str] = set()
+    for _segment, segment_terms in _source_lower_entity_limitation_records(source_text):
+        terms.update(segment_terms)
+    return terms
+
+
+def _source_lower_entity_limitation_records(
+    source_text: str,
+) -> list[tuple[str, set[str]]]:
+    records: list[tuple[str, set[str]]] = []
     previous_lower_terms: set[str] = set()
-    for segment in _SOURCE_LIMIT_SEGMENT_SPLIT_PATTERN.split(source_text):
-        if not segment.strip():
-            continue
-        segment_lower_terms = _source_lower_entity_terms_before_limitation(segment)
-        if not _SOURCE_LIMITATION_PATTERN.search(segment):
-            if _LOWER_ENTITY_CONTEXTUAL_AMOUNT_PATTERN.search(segment):
+    previous_context_segment = ""
+    for raw_segment in _SOURCE_LIMIT_SEGMENT_SPLIT_PATTERN.split(source_text):
+        for segment in _source_limit_clauses(raw_segment):
+            if not segment.strip():
+                continue
+            segment_lower_terms = _source_lower_entity_terms_before_limitation(segment)
+            if not _SOURCE_LIMITATION_PATTERN.search(segment):
+                if _LOWER_ENTITY_CONTEXTUAL_AMOUNT_PATTERN.search(segment):
+                    previous_lower_terms = segment_lower_terms
+                    previous_context_segment = segment
+                continue
+            if _source_limitation_subject_is_aggregate_unit(segment):
+                previous_lower_terms = set()
+                previous_context_segment = ""
+                continue
+            if segment_lower_terms:
+                records.append((segment, segment_lower_terms))
                 previous_lower_terms = segment_lower_terms
-            continue
-        if segment_lower_terms:
-            terms.update(segment_lower_terms)
-            previous_lower_terms = segment_lower_terms
-            continue
-        if previous_lower_terms and _ANAPHORIC_AMOUNT_PATTERN.search(segment):
-            terms.update(previous_lower_terms)
-            continue
-        if not _source_limitation_subject_is_aggregate_unit(segment):
+                previous_context_segment = segment
+                continue
+            if previous_lower_terms and _ANAPHORIC_AMOUNT_PATTERN.search(segment):
+                records.append(
+                    (
+                        f"{previous_context_segment} {segment}".strip(),
+                        previous_lower_terms,
+                    )
+                )
+                continue
             later_terms = {
                 match.group(0).lower()
                 for match in _LOWER_ENTITY_LIMITED_SOURCE_PATTERN.finditer(segment)
             }
-            terms.update(later_terms)
-    return terms
+            if later_terms:
+                records.append((segment, later_terms))
+    return records
+
+
+def _source_limit_clauses(segment: str) -> list[str]:
+    clauses = [
+        clause.strip(" ,;")
+        for clause in _SOURCE_LIMIT_CLAUSE_SPLIT_PATTERN.split(segment)
+    ]
+    return [clause for clause in clauses if clause]
 
 
 def _source_lower_entity_terms_before_limitation(segment: str) -> set[str]:
@@ -6210,10 +7278,14 @@ def find_entity_limited_aggregation_order_issues(content: str) -> list[str]:
     source_entity_terms = (
         _source_lower_entity_limitation_terms(source_text) if source_text else set()
     )
+    source_limit_relevance = (
+        _source_limit_relevance(source_text) if source_text else None
+    )
     if (
         not source_text
         or not _SOURCE_LIMITATION_PATTERN.search(source_text)
         or not source_entity_terms
+        or source_limit_relevance is None
     ):
         return []
 
@@ -6230,6 +7302,8 @@ def find_entity_limited_aggregation_order_issues(content: str) -> list[str]:
             relations := _uncapped_broad_relation_aggregates_in_formula(
                 formula,
                 formula_by_name=formula_by_name,
+                source_limit_relevance=source_limit_relevance,
+                require_source_amount_match=True,
             )
         )
     }
@@ -6251,10 +7325,20 @@ def find_entity_limited_aggregation_order_issues(content: str) -> list[str]:
             continue
         if not scoped_entity_terms:
             continue
+        scoped_limit_relevance = _source_limit_relevance(scoped_source_text)
         relations = _limited_aggregate_relations_in_formula(
             formula,
             aggregate_relations_by_name=aggregate_relations_by_name,
             formula_by_name=formula_by_name,
+            source_limit_relevance=scoped_limit_relevance,
+        )
+        relations.update(
+            _uncapped_broad_relation_aggregates_in_formula(
+                formula,
+                formula_by_name=formula_by_name,
+                source_limit_relevance=scoped_limit_relevance,
+                require_source_amount_match=True,
+            )
         )
         scoped_entity_detail = ", ".join(sorted(scoped_entity_terms)[:4])
         for relation_name in sorted(relations):

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3251,6 +3251,27 @@ _SOURCE_LIMITATION_PATTERN = re.compile(
     r"only\s+if|shall\s+not\s+apply|does\s+not\s+apply|unless)\b",
     flags=re.IGNORECASE,
 )
+_LOWER_ENTITY_LIMITED_SOURCE_PATTERN = re.compile(
+    r"\b(?:individual|person|member|members|taxpayer|employee|claimant|applicant|"
+    r"child|children|dependent|spouse)\b",
+    flags=re.IGNORECASE,
+)
+_RELATION_AMOUNT_AGGREGATE_CALL_PATTERN = re.compile(
+    r"\b(?P<function>sum|sum_where)\s*\(\s*"
+    r"(?P<relation>[A-Za-z_][A-Za-z0-9_]*)(?P<tail>[^)]*)\)",
+    flags=re.IGNORECASE | re.DOTALL,
+)
+_ENTITY_LIMITED_HELPER_NAME_PATTERN = re.compile(
+    r"(?:^|_|\b)(?:limit|limited|limitation|cap|capped|ceiling|maximum|"
+    r"minimum|not_exceed|lesser|greater|reduc(?:e|ed|tion)|net_of)"
+    r"(?:_|\b|$)",
+    flags=re.IGNORECASE,
+)
+_LIMITING_FUNCTION_CALL_PATTERN = re.compile(
+    r"\b(?:min|max)\s*\(",
+    flags=re.IGNORECASE,
+)
+_SOURCE_LIMIT_SEGMENT_SPLIT_PATTERN = re.compile(r"(?<=[.;])\s+|\n\s*\n+")
 _CONDITIONAL_SOURCE_LIMITATION_PATTERN = re.compile(
     r"\b(?:except\s+that|only\s+if|shall\s+not\s+apply|does\s+not\s+apply|unless)\b",
     flags=re.IGNORECASE,
@@ -5862,6 +5883,142 @@ def _source_supports_structural_relation_container(
     )
 
 
+def _aggregate_amount_argument(function_name: str, tail: str) -> str:
+    if function_name.lower() == "sum_where":
+        parts = [part.strip() for part in tail.lstrip(",").split(",", 2)]
+        return parts[0] if parts else ""
+    return ""
+
+
+def _aggregate_uses_pre_limited_amount(
+    function_name: str,
+    tail: str,
+    *,
+    formula_by_name: dict[str, str],
+    source_text: str,
+) -> bool:
+    amount_arg = _aggregate_amount_argument(function_name, tail)
+    helper_formula = formula_by_name.get(amount_arg)
+    if helper_formula is None:
+        return False
+    return bool(
+        _ENTITY_LIMITED_HELPER_NAME_PATTERN.search(amount_arg)
+        and _formula_or_referenced_helpers_implement_limitation(
+            helper_formula,
+            formula_by_name=formula_by_name,
+            current_name=amount_arg,
+            source_text=source_text,
+        )
+    )
+
+
+def _uncapped_broad_relation_aggregates_in_formula(
+    formula: str,
+    *,
+    formula_by_name: dict[str, str],
+    source_text: str,
+) -> set[str]:
+    relations: set[str] = set()
+    for match in _RELATION_AMOUNT_AGGREGATE_CALL_PATTERN.finditer(formula):
+        relation_name = match.group("relation")
+        if not _BROAD_STRUCTURAL_RELATION_PATTERN.search(relation_name):
+            continue
+        if _aggregate_uses_pre_limited_amount(
+            match.group("function"),
+            match.group("tail") or "",
+            formula_by_name=formula_by_name,
+            source_text=source_text,
+        ):
+            continue
+        relations.add(relation_name)
+    return relations
+
+
+def _aggregate_relations_referenced_by_formula(
+    formula: str,
+    *,
+    aggregate_relations_by_name: dict[str, set[str]],
+    formula_by_name: dict[str, str],
+    seen: set[str] | None = None,
+) -> set[str]:
+    relations: set[str] = set()
+    visited = set(seen or set())
+    for identifier in _formula_local_identifiers(formula):
+        if identifier in visited:
+            continue
+        if identifier in aggregate_relations_by_name:
+            relations.update(aggregate_relations_by_name[identifier])
+        helper_formula = formula_by_name.get(identifier)
+        if helper_formula is None:
+            continue
+        visited.add(identifier)
+        relations.update(
+            _aggregate_relations_referenced_by_formula(
+                helper_formula,
+                aggregate_relations_by_name=aggregate_relations_by_name,
+                formula_by_name=formula_by_name,
+                seen=visited,
+            )
+        )
+    return relations
+
+
+def _formula_limiting_expressions(formula: str) -> list[str]:
+    expressions: list[str] = []
+    for match in _LIMITING_FUNCTION_CALL_PATTERN.finditer(formula):
+        start = match.start()
+        open_index = match.end() - 1
+        depth = 0
+        for index in range(open_index, len(formula)):
+            char = formula[index]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    expressions.append(formula[start : index + 1])
+                    break
+    return expressions
+
+
+def _limited_aggregate_relations_in_formula(
+    formula: str,
+    *,
+    aggregate_relations_by_name: dict[str, set[str]],
+    formula_by_name: dict[str, str],
+    source_text: str,
+) -> set[str]:
+    relations: set[str] = set()
+    for expression in _formula_limiting_expressions(formula):
+        relations.update(
+            _uncapped_broad_relation_aggregates_in_formula(
+                expression,
+                formula_by_name=formula_by_name,
+                source_text=source_text,
+            )
+        )
+        relations.update(
+            _aggregate_relations_referenced_by_formula(
+                expression,
+                aggregate_relations_by_name=aggregate_relations_by_name,
+                formula_by_name=formula_by_name,
+            )
+        )
+    return relations
+
+
+def _source_lower_entity_limitation_terms(source_text: str) -> set[str]:
+    terms: set[str] = set()
+    for segment in _SOURCE_LIMIT_SEGMENT_SPLIT_PATTERN.split(source_text):
+        if not _SOURCE_LIMITATION_PATTERN.search(segment):
+            continue
+        terms.update(
+            match.group(0).lower()
+            for match in _LOWER_ENTITY_LIMITED_SOURCE_PATTERN.finditer(segment)
+        )
+    return terms
+
+
 def find_relation_aggregate_syntax_issues(content: str) -> list[str]:
     """Reject relation aggregation forms that the runtime does not support."""
     payload = _rulespec_payload(content)
@@ -5962,6 +6119,85 @@ def find_role_limited_relation_scope_issues(content: str) -> list[str]:
                 "a relation/fact scoped to the exact roles counted by the source; "
                 "do not count every member of a broader container unless the "
                 "source says every member counts."
+            )
+    return issues
+
+
+def find_entity_limited_aggregation_order_issues(content: str) -> list[str]:
+    """Flag lower-entity caps applied after aggregating a broad relation."""
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+
+    source_text = extract_embedded_source_text(
+        content
+    ) or _extract_source_verification_text(content)
+    source_entity_terms = (
+        _source_lower_entity_limitation_terms(source_text) if source_text else set()
+    )
+    if (
+        not source_text
+        or not _SOURCE_LIMITATION_PATTERN.search(source_text)
+        or not source_entity_terms
+    ):
+        return []
+
+    formula_records = _rulespec_rule_formula_records(payload)
+    formula_by_name = {
+        name: formula
+        for name, kind, formula, _source in formula_records
+        if kind == "derived"
+    }
+    aggregate_relations_by_name = {
+        name: relations
+        for name, formula in formula_by_name.items()
+        if (
+            relations := _uncapped_broad_relation_aggregates_in_formula(
+                formula,
+                formula_by_name=formula_by_name,
+                source_text=source_text,
+            )
+        )
+    }
+    if not aggregate_relations_by_name:
+        return []
+
+    dtype_by_name = _rulespec_rule_dtype_by_name(payload)
+    entity_detail = ", ".join(sorted(source_entity_terms)[:4])
+    issues: list[str] = []
+    reported: set[tuple[str, str]] = set()
+    for name, kind, formula, rule_source in formula_records:
+        if kind != "derived":
+            continue
+        if dtype_by_name.get(name) in {"judgment", "boolean", "bool", "count"}:
+            continue
+        scoped_source_text = _source_text_for_rule_source(source_text, rule_source)
+        scoped_entity_terms = _source_lower_entity_limitation_terms(scoped_source_text)
+        if not _SOURCE_LIMITATION_PATTERN.search(scoped_source_text):
+            continue
+        if not scoped_entity_terms:
+            continue
+        relations = _limited_aggregate_relations_in_formula(
+            formula,
+            aggregate_relations_by_name=aggregate_relations_by_name,
+            formula_by_name=formula_by_name,
+            source_text=scoped_source_text,
+        )
+        scoped_entity_detail = ", ".join(sorted(scoped_entity_terms)[:4])
+        for relation_name in sorted(relations):
+            key = (name, relation_name)
+            if key in reported:
+                continue
+            reported.add(key)
+            issues.append(
+                "Entity-limited aggregation order: "
+                f"`{name}` applies a limitation/cap/reduction to an aggregate "
+                f"over `{relation_name}`, while the source text states "
+                "lower-entity legal subject(s) "
+                f"({scoped_entity_detail or entity_detail}). Apply the "
+                "limit at the source-stated lower entity first, then aggregate; "
+                "do not aggregate before capping unless the source says the cap "
+                "applies to the aggregate unit."
             )
     return issues
 
@@ -10809,6 +11045,7 @@ class ValidatorPipeline:
         )
         issues.extend(find_relation_aggregate_syntax_issues(content))
         issues.extend(find_role_limited_relation_scope_issues(content))
+        issues.extend(find_entity_limited_aggregation_order_issues(content))
         issues.extend(find_source_limitation_application_issues(content))
         issues.extend(find_partial_extent_zeroing_issues(content))
         issues.extend(find_broad_application_passthrough_issues(content))

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3267,11 +3267,43 @@ _ENTITY_LIMITED_HELPER_NAME_PATTERN = re.compile(
     r"(?:_|\b|$)",
     flags=re.IGNORECASE,
 )
+_ENTITY_LIMIT_IMPLEMENTATION_PATTERN = re.compile(
+    r"\bmin\s*\(|\bif\b[^\n:]*[<>]=?|(?:^|_|\b)(?:limit|limited|limitation|"
+    r"cap|capped|ceiling|maximum|not_exceed|lesser|threshold|base|"
+    r"reduc(?:e|ed|tion)|net_of)(?:_|\b|$)",
+    flags=re.IGNORECASE,
+)
 _LIMITING_FUNCTION_CALL_PATTERN = re.compile(
     r"\b(?:min|max)\s*\(",
     flags=re.IGNORECASE,
 )
+_LIMITING_CONDITIONAL_PATTERN = re.compile(
+    r"\bif\s+(?P<condition>[^\n:]+?)\s*:",
+    flags=re.IGNORECASE,
+)
+_FORMULA_LIMIT_COMPARISON_PATTERN = re.compile(r"[<>]=?")
 _SOURCE_LIMIT_SEGMENT_SPLIT_PATTERN = re.compile(r"(?<=[.;])\s+|\n\s*\n+")
+_LIMITATION_PHRASE_PATTERN = re.compile(
+    r"\b(?:limited\s+to|shall\s+not\s+exceed|may\s+not\s+exceed|"
+    r"not\s+exceed|lesser\s+of|greater\s+of|reduced\s+by)\b",
+    flags=re.IGNORECASE,
+)
+_AGGREGATE_UNIT_SUBJECT_PATTERN = re.compile(
+    r"\b(?:household|tax\s+unit|filing\s+unit|family)\b(?!\s+members?\b)"
+    r"[\s\S]{0,80}\b(?:benefit|amount|allotment|allowance|credit|"
+    r"deduction|tax|maximum|cap|ceiling)\b",
+    flags=re.IGNORECASE,
+)
+_LOWER_ENTITY_CONTEXTUAL_AMOUNT_PATTERN = re.compile(
+    r"\b(?:for\s+each|each|per)\s+"
+    r"(?:individual|person|member|members|taxpayer|employee|claimant|"
+    r"applicant|child|children|dependent|spouse)\b",
+    flags=re.IGNORECASE,
+)
+_ANAPHORIC_AMOUNT_PATTERN = re.compile(
+    r"\b(?:such|that|the)\s+amount\b",
+    flags=re.IGNORECASE,
+)
 _CONDITIONAL_SOURCE_LIMITATION_PATTERN = re.compile(
     r"\b(?:except\s+that|only\s+if|shall\s+not\s+apply|does\s+not\s+apply|unless)\b",
     flags=re.IGNORECASE,
@@ -5903,11 +5935,10 @@ def _aggregate_uses_pre_limited_amount(
         return False
     return bool(
         _ENTITY_LIMITED_HELPER_NAME_PATTERN.search(amount_arg)
-        and _formula_or_referenced_helpers_implement_limitation(
+        and _formula_or_referenced_helpers_implement_entity_limit(
             helper_formula,
             formula_by_name=formula_by_name,
             current_name=amount_arg,
-            source_text=source_text,
         )
     )
 
@@ -5978,7 +6009,35 @@ def _formula_limiting_expressions(formula: str) -> list[str]:
                 if depth == 0:
                     expressions.append(formula[start : index + 1])
                     break
+    for match in _LIMITING_CONDITIONAL_PATTERN.finditer(formula):
+        condition = match.group("condition")
+        if _FORMULA_LIMIT_COMPARISON_PATTERN.search(condition):
+            expressions.append(condition)
     return expressions
+
+
+def _formula_or_referenced_helpers_implement_entity_limit(
+    formula: str,
+    *,
+    formula_by_name: dict[str, str],
+    current_name: str,
+    seen: set[str] | None = None,
+) -> bool:
+    if _ENTITY_LIMIT_IMPLEMENTATION_PATTERN.search(formula):
+        return True
+    visited = set(seen or set())
+    visited.add(current_name)
+    for identifier in _formula_local_identifiers(formula):
+        if identifier in visited or identifier not in formula_by_name:
+            continue
+        if _formula_or_referenced_helpers_implement_entity_limit(
+            formula_by_name[identifier],
+            formula_by_name=formula_by_name,
+            current_name=identifier,
+            seen=visited,
+        ):
+            return True
+    return False
 
 
 def _limited_aggregate_relations_in_formula(
@@ -6009,14 +6068,46 @@ def _limited_aggregate_relations_in_formula(
 
 def _source_lower_entity_limitation_terms(source_text: str) -> set[str]:
     terms: set[str] = set()
+    previous_lower_terms: set[str] = set()
     for segment in _SOURCE_LIMIT_SEGMENT_SPLIT_PATTERN.split(source_text):
-        if not _SOURCE_LIMITATION_PATTERN.search(segment):
+        if not segment.strip():
             continue
-        terms.update(
-            match.group(0).lower()
-            for match in _LOWER_ENTITY_LIMITED_SOURCE_PATTERN.finditer(segment)
-        )
+        segment_lower_terms = _source_lower_entity_terms_before_limitation(segment)
+        if not _SOURCE_LIMITATION_PATTERN.search(segment):
+            if _LOWER_ENTITY_CONTEXTUAL_AMOUNT_PATTERN.search(segment):
+                previous_lower_terms = segment_lower_terms
+            continue
+        if segment_lower_terms:
+            terms.update(segment_lower_terms)
+            previous_lower_terms = segment_lower_terms
+            continue
+        if previous_lower_terms and _ANAPHORIC_AMOUNT_PATTERN.search(segment):
+            terms.update(previous_lower_terms)
+            continue
+        if not _source_limitation_subject_is_aggregate_unit(segment):
+            later_terms = {
+                match.group(0).lower()
+                for match in _LOWER_ENTITY_LIMITED_SOURCE_PATTERN.finditer(segment)
+            }
+            terms.update(later_terms)
     return terms
+
+
+def _source_lower_entity_terms_before_limitation(segment: str) -> set[str]:
+    match = _LIMITATION_PHRASE_PATTERN.search(segment)
+    search_text = segment[: match.start()] if match else segment
+    return {
+        term_match.group(0).lower()
+        for term_match in _LOWER_ENTITY_LIMITED_SOURCE_PATTERN.finditer(search_text)
+    }
+
+
+def _source_limitation_subject_is_aggregate_unit(segment: str) -> bool:
+    match = _LIMITATION_PHRASE_PATTERN.search(segment)
+    if match is None:
+        return False
+    subject = segment[max(0, match.start() - 120) : match.start()]
+    return bool(_AGGREGATE_UNIT_SUBJECT_PATTERN.search(subject))
 
 
 def find_relation_aggregate_syntax_issues(content: str) -> list[str]:

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -9,6 +9,13 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   that scope directly. If the same source also states member/person predicates
   that feed that test, encode those predicates only as support for the
   source-stated unit-level output.
+- When the source applies a cap, threshold, ceiling, reduction, "not exceed",
+  "lesser/greater of", or coordination rule to the amount of an individual,
+  person, member, taxpayer, employee, claimant, child, dependent, or spouse,
+  apply that limit at the source-stated lower entity before aggregating to a
+  household, unit, filing-unit, tax-unit, or family output. Do not sum a broad
+  relation and then cap the aggregate unless the source says the cap applies to
+  that aggregate unit.
 - Do not create a roll-up, top-level program output, or connection merely
   because downstream consumers want it, sibling/state files patched it, or the
   program conventionally has such a concept. The output must be directly

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -442,6 +442,8 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "RuleSpec YAML" in prompt
     assert "=== FILE: tn-snap-standard-utility-allowance.yaml ===" in prompt
     assert "=== FILE: tn-snap-standard-utility-allowance.test.yaml ===" in prompt
+    assert "apply that limit at the source-stated lower entity" in prompt
+    assert "then cap the aggregate" in prompt
     assert "Do not narrate your plan" in prompt
     assert "snap_standard_utility_allowance" in prompt
     assert "Do not use bare year periods like `2024`" in prompt

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -10679,8 +10679,8 @@ rules:
     issues = find_entity_limited_aggregation_order_issues(content)
 
     assert any("Entity-limited aggregation order" in issue for issue in issues)
-    assert "tax_unit_covered_wages_after_base_limit" in issues[0]
-    assert "member_of_tax_unit" in issues[0]
+    assert any("tax_unit_covered_wages_after_base_limit" in issue for issue in issues)
+    assert any("member_of_tax_unit" in issue for issue in issues)
 
 
 def test_entity_limited_aggregation_order_accepts_per_entity_limited_sum():
@@ -10713,6 +10713,546 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: sum_where(member_of_tax_unit, employee_wages_after_annual_base_limit, employee_counts_for_tax_unit)
+"""
+
+    assert find_entity_limited_aggregation_order_issues(content) == []
+
+
+def test_entity_limited_aggregation_order_accepts_reversed_per_entity_minimum():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_wages_after_annual_base_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(annual_base - wages_already_paid_to_employee, covered_wages)
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum_where(member_of_tax_unit, employee_wages_after_annual_base_limit, employee_counts_for_tax_unit)
+"""
+
+    assert find_entity_limited_aggregation_order_issues(content) == []
+
+
+def test_entity_limited_aggregation_order_rejects_missing_entity_cap_before_sum():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum(member_of_tax_unit.covered_wages)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_tax_unit" in issues[0]
+
+
+def test_entity_limited_aggregation_order_rejects_sum_where_with_spaced_comma():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum_where(member_of_tax_unit , covered_wages, employee_counts_for_tax_unit)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_tax_unit" in issues[0]
+
+
+def test_entity_limited_aggregation_order_rejects_unrelated_helper_minimum():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_wages_after_annual_base_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(covered_wages, unrelated_program_cap)
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum_where(member_of_tax_unit, employee_wages_after_annual_base_limit, employee_counts_for_tax_unit)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_tax_unit" in issues[0]
+
+
+def test_entity_limited_aggregation_order_rejects_lesser_of_amount_with_unrelated_cap():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages are limited to the lesser of covered wages
+    and annual base.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_wages_after_annual_base_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(covered_wages, unrelated_program_cap)
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum_where(member_of_tax_unit, employee_wages_after_annual_base_limit, employee_counts_for_tax_unit)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_tax_unit" in issues[0]
+
+
+def test_entity_limited_aggregation_order_rejects_generic_lesser_of_subject_with_unrelated_cap():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, the employee benefit is limited to the lesser of covered
+    wages and annual base.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_wages_after_annual_base_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(covered_wages, unrelated_program_cap)
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum_where(member_of_tax_unit, employee_wages_after_annual_base_limit, employee_counts_for_tax_unit)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_tax_unit" in issues[0]
+
+
+def test_entity_limited_aggregation_order_accepts_generic_lesser_of_entity_limit():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, the employee benefit is limited to the lesser of covered
+    wages and annual base.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_wages_after_annual_base_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(covered_wages, annual_base)
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum_where(member_of_tax_unit, employee_wages_after_annual_base_limit, employee_counts_for_tax_unit)
+"""
+
+    assert find_entity_limited_aggregation_order_issues(content) == []
+
+
+def test_entity_limited_aggregation_order_rejects_cap_applied_to_wrong_amount():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_wages_after_annual_base_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(other_income, annual_base)
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum_where(member_of_tax_unit, employee_wages_after_annual_base_limit, employee_counts_for_tax_unit)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_tax_unit" in issues[0]
+
+
+def test_entity_limited_aggregation_order_accepts_predicate_factored_helper():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_wages_exceed_base
+    kind: derived
+    entity: Person
+    dtype: Boolean
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: covered_wages > annual_base
+  - name: employee_covered_wages
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if employee_wages_exceed_base:
+              annual_base
+          else:
+              covered_wages
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(sum_where(member_of_tax_unit, employee_covered_wages, employee_counts_for_tax_unit), tax_unit_maximum)
+"""
+
+    assert find_entity_limited_aggregation_order_issues(content) == []
+
+
+def test_entity_limited_aggregation_order_rejects_predicate_without_capping_branch():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_wages_above_base_kept
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if covered_wages > annual_base:
+              covered_wages
+          else:
+              0
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum_where(member_of_tax_unit, employee_wages_above_base_kept, employee_counts_for_tax_unit)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_tax_unit" in issues[0]
+
+
+def test_entity_limited_aggregation_order_rejects_unrelated_predicate_with_cap_branch():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_wages_after_annual_base_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if covered_wages > unrelated_program_cap:
+              annual_base
+          else:
+              covered_wages
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum_where(member_of_tax_unit, employee_wages_after_annual_base_limit, employee_counts_for_tax_unit)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_tax_unit" in issues[0]
+
+
+def test_entity_limited_aggregation_order_rejects_swapped_conditional_branches():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_wages_after_annual_base_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if covered_wages > annual_base:
+              covered_wages
+          else:
+              annual_base
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum_where(member_of_tax_unit, employee_wages_after_annual_base_limit, employee_counts_for_tax_unit)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_tax_unit" in issues[0]
+
+
+def test_entity_limited_aggregation_order_accepts_only_if_sum_where_predicate():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each child, the allowance applies only if the child is eligible.
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      predicate: member_of_household
+      arity: 2
+  - name: household_child_allowance
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum_where(member_of_household, child_allowance, child_is_eligible)
+"""
+
+    assert find_entity_limited_aggregation_order_issues(content) == []
+
+
+def test_entity_limited_aggregation_order_rejects_only_if_without_predicate():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each child, the allowance applies only if the child is eligible.
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      predicate: member_of_household
+      arity: 2
+  - name: household_child_allowance
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum(member_of_household.child_allowance)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_household" in issues[0]
+
+
+def test_entity_limited_aggregation_order_accepts_standalone_per_entity_reduction():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages are reduced by excluded wages.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_covered_wages
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: covered_wages - excluded_wages
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum_where(member_of_tax_unit, employee_covered_wages, employee_counts_for_tax_unit)
 """
 
     assert find_entity_limited_aggregation_order_issues(content) == []
@@ -10806,6 +11346,58 @@ rules:
     assert find_entity_limited_aggregation_order_issues(content) == []
 
 
+def test_entity_limited_aggregation_order_accepts_unit_cap_with_member_condition():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    The household benefit for a household with an elderly member shall not
+    exceed the household maximum.
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      predicate: member_of_household
+      arity: 2
+  - name: household_benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(sum(member_of_household.member_allowance), household_maximum)
+"""
+
+    assert find_entity_limited_aggregation_order_issues(content) == []
+
+
+def test_entity_limited_aggregation_order_accepts_unit_cap_with_prefixed_amount():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    The maximum allotment for a household with an elderly member shall not
+    exceed the household maximum.
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      predicate: member_of_household
+      arity: 2
+  - name: household_benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(sum(member_of_household.member_allotment), household_maximum)
+"""
+
+    assert find_entity_limited_aggregation_order_issues(content) == []
+
+
 def test_entity_limited_aggregation_order_accepts_unrelated_limit_and_sum():
     content = """format: rulespec/v1
 module:
@@ -10859,6 +11451,61 @@ rules:
 
     assert any("Entity-limited aggregation order" in issue for issue in issues)
     assert "member_of_household" in issues[0]
+
+
+def test_entity_limited_aggregation_order_rejects_same_sentence_mixed_caps():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    The household benefit shall not exceed the household maximum, and each
+    household member amount shall not exceed the member maximum.
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      predicate: member_of_household
+      arity: 2
+  - name: household_benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(sum(member_of_household.member_amount), household_maximum)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_household" in issues[0]
+
+
+def test_entity_limited_aggregation_order_accepts_cap_side_unrelated_aggregate():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: tax_unit_annual_base_adjustment
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum(member_of_tax_unit.annual_base_adjustment)
+"""
+
+    assert find_entity_limited_aggregation_order_issues(content) == []
 
 
 def test_entity_limited_aggregation_order_rejects_conditional_aggregate_cap():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -10718,6 +10718,42 @@ rules:
     assert find_entity_limited_aggregation_order_issues(content) == []
 
 
+def test_entity_limited_aggregation_order_accepts_semantic_limited_helper_name():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+    The tax unit amount shall not exceed the tax unit maximum.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_covered_wages
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(covered_wages, annual_base - wages_already_paid_to_employee)
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(sum_where(member_of_tax_unit, employee_covered_wages, employee_counts_for_tax_unit), tax_unit_maximum)
+"""
+
+    assert find_entity_limited_aggregation_order_issues(content) == []
+
+
 def test_entity_limited_aggregation_order_accepts_source_stated_unit_cap():
     content = """format: rulespec/v1
 module:
@@ -10908,6 +10944,44 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: covered_wages
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(sum_where(member_of_tax_unit, employee_wages_after_annual_base_limit, employee_counts_for_tax_unit), annual_base)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_tax_unit" in issues[0]
+
+
+def test_entity_limited_aggregation_order_rejects_identifier_only_limited_helper():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_wages_after_annual_base_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: covered_wages + annual_base_adjustment
   - name: tax_unit_covered_wages
     kind: derived
     entity: TaxUnit

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -10744,6 +10744,32 @@ rules:
     assert find_entity_limited_aggregation_order_issues(content) == []
 
 
+def test_entity_limited_aggregation_order_accepts_unit_cap_with_member_context():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    The household benefit shall not exceed the maximum allotment for a
+    household of the same size, based on the number of household members.
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      predicate: member_of_household
+      arity: 2
+  - name: household_benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(sum(member_of_household.member_allowance), household_maximum)
+"""
+
+    assert find_entity_limited_aggregation_order_issues(content) == []
+
+
 def test_entity_limited_aggregation_order_accepts_unrelated_limit_and_sum():
     content = """format: rulespec/v1
 module:
@@ -10799,6 +10825,68 @@ rules:
     assert "member_of_household" in issues[0]
 
 
+def test_entity_limited_aggregation_order_rejects_conditional_aggregate_cap():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if sum(member_of_tax_unit.covered_wages) > annual_base:
+              annual_base
+          else:
+              sum(member_of_tax_unit.covered_wages)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_tax_unit" in issues[0]
+
+
+def test_entity_limited_aggregation_order_rejects_adjacent_such_amount_cap():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    The amount for each employee is covered wages. Such amount shall not exceed
+    the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(sum(member_of_tax_unit.covered_wages), annual_base)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "employee" in issues[0]
+
+
 def test_entity_limited_aggregation_order_rejects_misleading_limited_helper_name():
     content = """format: rulespec/v1
 module:
@@ -10820,6 +10908,44 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: covered_wages
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(sum_where(member_of_tax_unit, employee_wages_after_annual_base_limit, employee_counts_for_tax_unit), annual_base)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_tax_unit" in issues[0]
+
+
+def test_entity_limited_aggregation_order_rejects_floor_only_limited_helper():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_wages_after_annual_base_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(0, covered_wages)
   - name: tax_unit_covered_wages
     kind: derived
     entity: TaxUnit

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -34,6 +34,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_deferred_output_issues,
     find_deprecated_source_url_issues,
     find_empty_rules_module_issues,
+    find_entity_limited_aggregation_order_issues,
     find_exception_test_coverage_issues,
     find_filtered_entity_dependency_issues,
     find_formula_absolute_reference_issues,
@@ -10610,6 +10611,230 @@ rules:
 """
 
     assert find_role_limited_relation_scope_issues(content) == []
+
+
+def test_entity_limited_aggregation_order_rejects_cap_after_relation_sum():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(sum(member_of_tax_unit.covered_wages), annual_base - wages_already_paid_to_employee)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "tax_unit_covered_wages" in issues[0]
+    assert "member_of_tax_unit" in issues[0]
+    assert "employee" in issues[0]
+
+
+def test_entity_limited_aggregation_order_rejects_limit_on_aggregate_helper():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: raw_tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum(member_of_tax_unit.covered_wages)
+  - name: tax_unit_covered_wages_after_base_limit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(raw_tax_unit_covered_wages, annual_base - wages_already_paid_to_employee)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "tax_unit_covered_wages_after_base_limit" in issues[0]
+    assert "member_of_tax_unit" in issues[0]
+
+
+def test_entity_limited_aggregation_order_accepts_per_entity_limited_sum():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_wages_after_annual_base_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(covered_wages, annual_base - wages_already_paid_to_employee)
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum_where(member_of_tax_unit, employee_wages_after_annual_base_limit, employee_counts_for_tax_unit)
+"""
+
+    assert find_entity_limited_aggregation_order_issues(content) == []
+
+
+def test_entity_limited_aggregation_order_accepts_source_stated_unit_cap():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Each household member has a monthly allowance. The household benefit shall
+    not exceed the household maximum.
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      predicate: member_of_household
+      arity: 2
+  - name: household_benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(sum(member_of_household.member_allowance), household_maximum)
+"""
+
+    assert find_entity_limited_aggregation_order_issues(content) == []
+
+
+def test_entity_limited_aggregation_order_accepts_unrelated_limit_and_sum():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the employee cap.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_wages_and_other_tax_unit_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(covered_wages, employee_cap) + sum(member_of_tax_unit.other_income)
+"""
+
+    assert find_entity_limited_aggregation_order_issues(content) == []
+
+
+def test_entity_limited_aggregation_order_rejects_mixed_entity_and_unit_caps():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Each household member amount shall not exceed the member maximum. The
+    household benefit shall not exceed the household maximum.
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      predicate: member_of_household
+      arity: 2
+  - name: household_benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(sum(member_of_household.member_amount), household_maximum)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_household" in issues[0]
+
+
+def test_entity_limited_aggregation_order_rejects_misleading_limited_helper_name():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, covered wages taken into account for the employee shall
+    not exceed the annual base reduced by wages already paid to the employee.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: employee_wages_after_annual_base_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: covered_wages
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(sum_where(member_of_tax_unit, employee_wages_after_annual_base_limit, employee_counts_for_tax_unit), annual_base)
+"""
+
+    issues = find_entity_limited_aggregation_order_issues(content)
+
+    assert any("Entity-limited aggregation order" in issue for issue in issues)
+    assert "member_of_tax_unit" in issues[0]
 
 
 def test_source_limitation_application_rejects_final_amount_without_limit():


### PR DESCRIPTION
## Summary
- add policy-neutral encoder guidance to apply source-stated lower-entity caps before aggregating broad relations
- add a RuleSpec validation check for aggregate-before-cap formulas over broad structural relations
- cover simple aggregate caps, aggregate helper caps, mixed entity/unit caps, unrelated caps, and misleading limited-helper names

## Tests
- `uv run ruff check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py tests/test_rulespec_validation.py`
- `uv run --extra dev pytest tests/test_evals.py::test_build_eval_prompt_targets_rulespec_yaml tests/test_rulespec_validation.py::test_entity_limited_aggregation_order_rejects_cap_after_relation_sum tests/test_rulespec_validation.py::test_entity_limited_aggregation_order_rejects_limit_on_aggregate_helper tests/test_rulespec_validation.py::test_entity_limited_aggregation_order_accepts_per_entity_limited_sum tests/test_rulespec_validation.py::test_entity_limited_aggregation_order_accepts_source_stated_unit_cap tests/test_rulespec_validation.py::test_entity_limited_aggregation_order_accepts_unrelated_limit_and_sum tests/test_rulespec_validation.py::test_entity_limited_aggregation_order_rejects_mixed_entity_and_unit_caps tests/test_rulespec_validation.py::test_entity_limited_aggregation_order_rejects_misleading_limited_helper_name -q`
- `uv run --extra dev pytest tests/test_rulespec_validation.py -q -k 'not test_rulespec_compile_ci_and_grounding'`\n\nNote: the full local `tests/test_rulespec_validation.py` run still hits an existing machine-dependent `test_rulespec_compile_ci_and_grounding` failure when the local `axiom-rules-engine` binary exists; it reports a filtered entity dependency issue for the test fixture `SnapUnit`, unrelated to this change.