### PR TITLE
Allow focused ECPS tax-unit comparisons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ build/
 *.db
 .DS_Store
 .coverage
+.axiom/
 hook_debug.log
 artifacts/eval-suites/

--- a/changelog.d/ecps-tax-unit-id.added.md
+++ b/changelog.d/ecps-tax-unit-id.added.md
@@ -1,0 +1,1 @@
+Allow ECPS federal tax oracle runs to target explicit tax-unit IDs for focused residual debugging.

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -369,6 +369,17 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         ),
     )
     parser.add_argument(
+        "--tax-unit-id",
+        type=int,
+        action="append",
+        default=None,
+        dest="tax_unit_ids",
+        help=(
+            "Compare a specific ECPS tax_unit_id. Repeat to compare multiple "
+            "known residual cases; when provided this bypasses --sample-size."
+        ),
+    )
+    parser.add_argument(
         "--positive-ctc-only",
         action="store_true",
         help="Restrict to ECPS tax units with positive PolicyEngine CTC",
@@ -438,6 +449,7 @@ def main(args: argparse.Namespace) -> int:
         data_folder=args.data_folder,
         tolerance=args.tolerance,
         relative_tolerance=args.relative_tolerance,
+        tax_unit_ids=tuple(args.tax_unit_ids or ()),
         allow_policyengine_us_version=args.allow_policyengine_us_version,
         allow_uncertified_policyengine_data=args.allow_uncertified_policyengine_data,
     )
@@ -466,6 +478,7 @@ def compare_tax_ecps(
     data_folder: Path,
     tolerance: float,
     relative_tolerance: float,
+    tax_unit_ids: tuple[int, ...] = (),
     allow_policyengine_us_version: bool = False,
     allow_uncertified_policyengine_data: bool = False,
 ) -> TaxComparisonReport:
@@ -486,6 +499,7 @@ def compare_tax_ecps(
         year=year,
         sample_size=sample_size,
         positive_ctc_only=positive_ctc_only,
+        tax_unit_ids=tax_unit_ids,
         data_folder=data_folder,
         allow_uncertified_policyengine_data=allow_uncertified_policyengine_data,
     )
@@ -561,6 +575,7 @@ def load_policyengine_tax_data(
     sample_size: int,
     positive_ctc_only: bool,
     data_folder: Path,
+    tax_unit_ids: tuple[int, ...] = (),
     allow_uncertified_policyengine_data: bool = False,
 ) -> dict[str, Any]:
     if allow_uncertified_policyengine_data:
@@ -596,12 +611,13 @@ def load_policyengine_tax_data(
     person_outputs = sim.output_dataset.data.person[
         ["person_id", *PE_PERSON_VARIABLES]
     ].copy()
-    mask = np.asarray(raw_tax_units["tax_unit_weight"]) > 0
-    if positive_ctc_only:
-        mask &= np.asarray(tax_units["ctc"]) > 0
-    indices = np.flatnonzero(mask)
-    if sample_size > 0:
-        indices = indices[:sample_size]
+    indices = select_tax_unit_indices(
+        raw_tax_units=raw_tax_units,
+        tax_units=tax_units,
+        sample_size=sample_size,
+        positive_ctc_only=positive_ctc_only,
+        tax_unit_ids=tax_unit_ids,
+    )
     selected = raw_tax_units.iloc[indices].copy()
     selected = selected.merge(
         tax_unit_outputs,
@@ -625,6 +641,51 @@ def load_policyengine_tax_data(
         "tax_unit_ids": [int(value) for value in selected["tax_unit_id"]],
         "person_ids": [int(value) for value in selected_persons["person_id"]],
     }
+
+
+def select_tax_unit_indices(
+    *,
+    raw_tax_units: Any,
+    tax_units: Any,
+    sample_size: int,
+    positive_ctc_only: bool,
+    tax_unit_ids: tuple[int, ...] = (),
+) -> Any:
+    """Select ECPS tax-unit row indices for oracle comparison."""
+    mask = np.asarray(raw_tax_units["tax_unit_weight"]) > 0
+    if positive_ctc_only:
+        mask &= np.asarray(tax_units["ctc"]) > 0
+    if not tax_unit_ids:
+        indices = np.flatnonzero(mask)
+        if sample_size > 0:
+            indices = indices[:sample_size]
+        return indices
+
+    requested_ids = tuple(dict.fromkeys(int(value) for value in tax_unit_ids))
+    raw_ids = np.asarray(raw_tax_units["tax_unit_id"], dtype=int)
+    index_by_id = {int(tax_unit_id): index for index, tax_unit_id in enumerate(raw_ids)}
+    selected: list[int] = []
+    missing: list[int] = []
+    filtered: list[int] = []
+    for tax_unit_id in requested_ids:
+        index = index_by_id.get(tax_unit_id)
+        if index is None:
+            missing.append(tax_unit_id)
+        elif not bool(mask[index]):
+            filtered.append(tax_unit_id)
+        else:
+            selected.append(index)
+    if missing:
+        raise SystemExit(
+            "Requested ECPS tax_unit_id not found: "
+            + ", ".join(str(value) for value in missing)
+        )
+    if filtered:
+        raise SystemExit(
+            "Requested ECPS tax_unit_id is not eligible for this comparison: "
+            + ", ".join(str(value) for value in filtered)
+        )
+    return np.asarray(selected, dtype=int)
 
 
 def _install_policyengine_data_certification_override() -> None:

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -59,6 +59,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     project_tax_unit_inputs,
     project_tax_unit_person_contexts,
     require_policyengine_versions,
+    select_tax_unit_indices,
     taxable_oasdi_wages_by_person_id,
     uses_joint_ctc_phaseout_threshold,
     valid_child_ssn_type,
@@ -1000,7 +1001,58 @@ def test_tax_ecps_parser_documents_full_sample_size():
     sample_size_help = next(
         action.help for action in parser._actions if action.dest == "sample_size"
     )
+    tax_unit_id_help = next(
+        action.help for action in parser._actions if action.dest == "tax_unit_ids"
+    )
     assert "0 compares all eligible tax units" in sample_size_help
+    assert "bypasses --sample-size" in tax_unit_id_help
+
+
+def test_select_tax_unit_indices_can_target_known_residuals():
+    pd = pytest.importorskip("pandas")
+    raw_tax_units = pd.DataFrame(
+        [
+            {"tax_unit_id": 10, "tax_unit_weight": 1},
+            {"tax_unit_id": 2976, "tax_unit_weight": 1},
+            {"tax_unit_id": 42, "tax_unit_weight": 0},
+        ]
+    )
+    tax_units = pd.DataFrame(
+        [
+            {"ctc": 0},
+            {"ctc": 10},
+            {"ctc": 10},
+        ]
+    )
+
+    indices = select_tax_unit_indices(
+        raw_tax_units=raw_tax_units,
+        tax_units=tax_units,
+        sample_size=1,
+        positive_ctc_only=False,
+        tax_unit_ids=(2976,),
+    )
+
+    assert indices.tolist() == [1]
+
+
+def test_select_tax_unit_indices_rejects_filtered_requested_case():
+    pd = pytest.importorskip("pandas")
+    raw_tax_units = pd.DataFrame(
+        [
+            {"tax_unit_id": 2976, "tax_unit_weight": 1},
+        ]
+    )
+    tax_units = pd.DataFrame([{"ctc": 0}])
+
+    with pytest.raises(SystemExit, match="not eligible"):
+        select_tax_unit_indices(
+            raw_tax_units=raw_tax_units,
+            tax_units=tax_units,
+            sample_size=0,
+            positive_ctc_only=True,
+            tax_unit_ids=(2976,),
+        )
 
 
 def test_compare_outputs_reports_max_relative_diff_for_large_float_noise():


### PR DESCRIPTION
## Summary
- add `--tax-unit-id` to `tax-ecps-compare` so ECPS oracle runs can target known residual cases directly
- preserve existing sample-size behavior when no explicit tax-unit IDs are provided
- ignore local `.axiom/` PolicyEngine dataset caches created by oracle runs

## Focused SECA/EITC reproduction
This command now compares only `tax_unit_2976` from rulespec-us#48:

```bash
uv run --python 3.14 --extra dev \
  --with policyengine==4.4.4 \
  --with policyengine-core==3.26.0 \
  --with policyengine-us==1.705.1 \
  axiom-encode tax-ecps-compare \
  --root /Users/maxghenis/TheAxiomFoundation \
  --rulespec-root /Users/maxghenis/TheAxiomFoundation/rulespec-us \
  --axiom-rules-engine-path /tmp/axiom-rules-engine-main \
  --surface eitc \
  --tax-unit-id 2976 \
  --sample-size 0 \
  --allow-policyengine-us-version \
  --allow-uncertified-policyengine-data \
  --json
```

Observed focused mismatch:
- `eitc_earned_income`: Axiom `1,106,080.66`, PolicyEngine `1,134,631.00`, diff `-28,550.34`
- `eitc_reduction`: Axiom `83,235.16`, PolicyEngine `85,411.56`, diff `-2,176.41`

## Checks
- `uv run ruff check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py`
- `uv run ruff format --check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py`
- `uv run --extra dev pytest tests/test_policyengine_ecps_tax.py -q`
- `git diff --check`
