### PR TITLE
Guard person-scoped rate bases

### DIFF
--- a/changelog.d/person-scoped-rate-base.fixed.md
+++ b/changelog.d/person-scoped-rate-base.fixed.md
@@ -1,0 +1,1 @@
+Reject unit-level rate-base formulas when the source states a person-scoped legal base.

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3245,6 +3245,26 @@ _ROLE_LIMITED_SOURCE_PATTERN = re.compile(
     r"\b(?:taxpayer|spouse|claimant|applicant|child|children|dependent|individual)\b",
     flags=re.IGNORECASE,
 )
+_PERSON_SCOPED_RATE_BASE_SOURCE_PATTERN = re.compile(
+    r"\b(?:"
+    r"(?:for|with\s+respect\s+to)\s+(?:each|every|any|the)\s+"
+    r"(?:individual|person|member|employee|claimant|applicant|child|children|"
+    r"dependent|spouse)"
+    r"|(?:each|every|any|the)\s+"
+    r"(?:individual|person|member|employee|claimant|applicant|child|children|"
+    r"dependent|spouse)"
+    r"|of\s+(?:each|every|any|the)\s+"
+    r"(?:individual|person|member|employee|claimant|applicant|child|children|"
+    r"dependent|spouse)"
+    r")\b[\s\S]{0,260}\b(?:amount|allowance|base|benefit|compensation|"
+    r"contribution|credit|deduction|earnings?|income|tax|wages?)\b",
+    flags=re.IGNORECASE,
+)
+_RATE_IDENTIFIER_MULTIPLICATION_PATTERN = re.compile(
+    r"\b[A-Za-z_][A-Za-z0-9_]*(?:_rate|_percentage|_percent)\b\s*\*"
+    r"|\*\s*\b[A-Za-z_][A-Za-z0-9_]*(?:_rate|_percentage|_percent)\b",
+    flags=re.IGNORECASE,
+)
 _SOURCE_LIMITATION_PATTERN = re.compile(
     r"\b(?:limitation|limited\s+to|shall\s+not\s+exceed|may\s+not\s+exceed|"
     r"not\s+exceed|lesser\s+of|greater\s+of|reduced\s+by|except\s+that|"
@@ -3756,6 +3776,82 @@ def find_source_scope_consistency_issues(content: str) -> list[str]:
                 "unit-scoped test. Encode the rule at the source-stated unit "
                 "scope or cite source text that states the declared unit scope."
             )
+    return issues
+
+
+def _formula_or_referenced_helpers_use_relation_aggregate(
+    formula: str,
+    *,
+    formula_by_name: dict[str, str],
+    seen: set[str] | None = None,
+) -> bool:
+    if _RELATION_AGGREGATE_PATTERN.search(formula):
+        return True
+    visited = set(seen or set())
+    for identifier in _formula_local_identifiers(formula):
+        if identifier in visited:
+            continue
+        helper_formula = formula_by_name.get(identifier)
+        if helper_formula is None:
+            continue
+        visited.add(identifier)
+        if _formula_or_referenced_helpers_use_relation_aggregate(
+            helper_formula,
+            formula_by_name=formula_by_name,
+            seen=visited,
+        ):
+            return True
+    return False
+
+
+def find_person_scoped_rate_base_unit_issues(content: str) -> list[str]:
+    """Flag unit-level rate * base formulas for person-scoped legal bases."""
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+    source_text = extract_embedded_source_text(content)
+    if not source_text:
+        source_text = _extract_source_verification_text(content)
+    if not source_text:
+        return []
+
+    formula_records = _rulespec_rule_formula_rule_records(payload)
+    formula_by_name = {
+        name: formula
+        for name, kind, formula, _source, _rule in formula_records
+        if kind == "derived"
+    }
+    dtype_by_name = _rulespec_rule_dtype_by_name(payload)
+    issues: list[str] = []
+    for name, kind, formula, rule_source, rule in formula_records:
+        if kind != "derived":
+            continue
+        if not _RATE_IDENTIFIER_MULTIPLICATION_PATTERN.search(formula):
+            continue
+        entity = str(rule.get("entity") or "").strip()
+        if entity.lower() not in _UNIT_SCOPED_ENTITY_NAMES:
+            continue
+        if dtype_by_name.get(name) not in {"money", "decimal", "rate"}:
+            continue
+        scoped_source_text = " ".join(_rule_proof_source_excerpts(rule))
+        if not scoped_source_text:
+            scoped_source_text = _source_text_for_rule_source(source_text, rule_source)
+        if not _PERSON_SCOPED_RATE_BASE_SOURCE_PATTERN.search(scoped_source_text):
+            continue
+        if _formula_or_referenced_helpers_use_relation_aggregate(
+            formula,
+            formula_by_name=formula_by_name,
+        ):
+            continue
+        issues.append(
+            "Person-scoped rate base at unit scope: "
+            f"`{name}` is declared on `{entity}` and multiplies a base by a "
+            "rate, but the source text states the amount or tax for each/every "
+            "individual, person, member, employee, or similar lower-entity "
+            "subject. Encode the rate-applied amount at that lower entity "
+            "first, then aggregate through an explicit relation; do not "
+            "multiply a unit-level placeholder or aggregate base by the rate."
+        )
     return issues
 
 
@@ -12180,6 +12276,7 @@ class ValidatorPipeline:
         issues.extend(find_source_condition_coverage_issues(content))
         issues.extend(find_filtered_entity_dependency_issues(content))
         issues.extend(find_source_scope_consistency_issues(content))
+        issues.extend(find_person_scoped_rate_base_unit_issues(content))
         issues.extend(find_helper_only_definition_issues(content))
         issues.extend(find_deferred_output_issues(content))
         issues.extend(

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -16,6 +16,14 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   household, unit, filing-unit, tax-unit, or family output. Do not sum a broad
   relation and then cap the aggregate unless the source says the cap applies to
   that aggregate unit.
+- When a tax, credit, deduction, contribution, or other amount is computed as a
+  rate or percentage of a legal base stated for each/every individual, person,
+  member, employee, claimant, child, dependent, or spouse, compute that base and
+  the rate-applied result at the source-stated lower entity before any unit
+  roll-up. A household, filing-unit, tax-unit, or family output may aggregate
+  those lower-entity results through an explicit relation; it must not multiply
+  a unit-level placeholder or aggregate base by the rate unless the source
+  defines the base on that unit.
 - Do not create a roll-up, top-level program output, or connection merely
   because downstream consumers want it, sibling/state files patched it, or the
   program conventionally has such a concept. The output must be directly

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -81,6 +81,8 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "Importing an adjacent upstream output only as proof" in ENCODER_PROMPT
     assert "does not satisfy the dependency" in ENCODER_PROMPT
     assert "is not an executable dependency" in ENCODER_PROMPT
+    assert "rate-applied result at the source-stated lower entity" in ENCODER_PROMPT
+    assert "unit-level placeholder or aggregate base by the rate" in ENCODER_PROMPT
     assert "Never drop the jurisdiction prefix" in ENCODER_PROMPT
     assert "listed under invalid copied local inputs" in ENCODER_PROMPT
     assert "do not preserve, rename, or recreate" in ENCODER_PROMPT
@@ -114,6 +116,8 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "Importing an adjacent upstream output only as proof" in prompt
     assert "does not satisfy the dependency" in prompt
     assert "is not an executable dependency" in prompt
+    assert "rate-applied result at the source-stated lower entity" in prompt
+    assert "unit-level placeholder or aggregate base by the rate" in prompt
     assert "Never drop the jurisdiction prefix" in prompt
     assert "listed under invalid copied local inputs" in prompt
     assert "do not preserve, rename, or recreate" in prompt

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -444,6 +444,8 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "=== FILE: tn-snap-standard-utility-allowance.test.yaml ===" in prompt
     assert "apply that limit at the source-stated lower entity" in prompt
     assert "then cap the aggregate" in prompt
+    assert "rate-applied result at the source-stated lower entity" in prompt
+    assert "unit-level placeholder or aggregate base by the rate" in prompt
     assert "Do not narrate your plan" in prompt
     assert "snap_standard_utility_allowance" in prompt
     assert "Do not use bare year periods like `2024`" in prompt

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -47,6 +47,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_missing_same_section_subsection_import_issues,
     find_nonnegative_amount_reduction_issues,
     find_partial_extent_zeroing_issues,
+    find_person_scoped_rate_base_unit_issues,
     find_proof_import_hash_consistency_issues,
     find_proof_import_reference_issues,
     find_relation_aggregate_syntax_issues,
@@ -8404,6 +8405,81 @@ rules:
 """
 
     assert find_source_scope_consistency_issues(content) == []
+
+
+def test_person_scoped_rate_base_unit_rejects_unit_level_rate_base():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    In addition to other taxes, there shall be imposed for each taxable year, on
+    the self-employment income of every individual, a tax equal to 12.4 percent
+    of the amount of the self-employment income for such taxable year.
+rules:
+  - name: self_employment_oasdi_tax_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.124
+  - name: self_employment_oasdi_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 1401(a)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: taxable_self_employment_income_for_section_1401 * self_employment_oasdi_tax_rate
+"""
+
+    issues = find_person_scoped_rate_base_unit_issues(content)
+
+    assert any("Person-scoped rate base at unit scope" in issue for issue in issues)
+    assert "self_employment_oasdi_tax" in issues[0]
+    assert "TaxUnit" in issues[0]
+
+
+def test_person_scoped_rate_base_unit_accepts_relation_rollup():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    For each employee, a payroll contribution is 6.2 percent of taxable wages.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: payroll_contribution_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.062
+  - name: employee_payroll_contribution
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: payroll contribution rule
+    versions:
+      - effective_from: '2026-01-01'
+        formula: taxable_wages * payroll_contribution_rate
+  - name: tax_unit_payroll_contribution
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: payroll contribution rule
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum_where(member_of_tax_unit, employee_payroll_contribution, employee_has_taxable_wages)
+"""
+
+    assert find_person_scoped_rate_base_unit_issues(content) == []
 
 
 def test_source_scope_consistency_checks_each_rule_independently():


### PR DESCRIPTION
## Summary
- teach the encoder prompt to apply rate-based amounts at the source-stated lower entity before unit roll-up
- add a conservative validator for unit-level `rate * base` formulas when source text states a person/member/employee/individual legal base
- cover both the prompt surfaces and the SECA-style bad shape that motivated rulespec-us#48

## SECA check
Running the new validator against the current generated `rulespec-us/statutes/26/1401.yaml` flags the existing unit-level rate-base shape for:
- `self_employment_oasdi_tax`
- `self_employment_hospital_insurance_tax`

This is encoder-side only; it does not edit rulespec-us artifacts directly.

## Checks
- `uv run ruff check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py tests/test_evals.py tests/test_encoder_backend.py`
- `uv run ruff format --check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py tests/test_evals.py tests/test_encoder_backend.py`
- `uv run --extra dev pytest tests/test_rulespec_validation.py::test_person_scoped_rate_base_unit_rejects_unit_level_rate_base tests/test_rulespec_validation.py::test_person_scoped_rate_base_unit_accepts_relation_rollup tests/test_evals.py::test_build_eval_prompt_targets_rulespec_yaml tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_statutory_base_naming_guidance -q`
- `uv run --extra dev pytest tests/test_rulespec_validation.py -q -k 'not test_rulespec_compile_ci_and_grounding'`
- `uv run --extra dev pytest tests/test_evals.py::test_build_eval_prompt_targets_rulespec_yaml tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_statutory_base_naming_guidance -q`
- `git diff --check`

Note: a full local `uv run --extra dev pytest tests/test_rulespec_validation.py -q` run had one unrelated local-environment failure in `test_rulespec_compile_ci_and_grounding` because this machine has `/Users/maxghenis/TheAxiomFoundation/axiom-rules-engine`; that fixture fails on a pre-existing SnapUnit declaration guard. The remaining validation tests passed with that binary-sensitive test deselected (`372 passed, 1 deselected`).
