### PR TITLE
Repair generated source table band parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.93"
+version = "0.2.94"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.93"
+__version__ = "0.2.94"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -70,6 +70,7 @@ from .validator_pipeline import (
     find_ungrounded_numeric_issues,
     find_unused_modifier_parameter_issues,
     numeric_value_is_grounded,
+    repair_source_table_band_scalar_parameters,
 )
 
 EvalMode = Literal["cold", "repo-augmented"]
@@ -3357,6 +3358,7 @@ RuleSpec requirements:
   semantic date-window predicate in formulas and tests.
 - Do not emit more than one `versions:` entry for `kind: derived`; the runtime does not yet support period-selecting versioned formulas. Use a single source-faithful conditional formula when the provision itself defines a temporal branch, or encode only the currently applicable provision after resolving the source context.
 - Formula strings use Axiom formula syntax: `if condition: value else: other`, `==` for equality, `and`/`or` for booleans, decimal ratios for percentages, and no Python inline ternary syntax.
+  Do not write `else if` or `elif`; chain branches as `if condition: value else: if next_condition: next_value else: fallback`.
 - Supported scalar functions are `min(...)`, `max(...)`, `floor(x)`, and `ceil(x)`. Do not use Python-only functions such as `round(...)`; express nearest-multiple rounding as `floor((x / multiple) + 0.5) * multiple` for nonnegative amounts.
 - Benefit, allotment, credit, deduction, allowance, and subsidy formulas must never emit negative money. When subtracting an income, contribution, or other reduction from a maximum amount, floor the result with `max(0, ...)` before applying downstream minimum-benefit or issuance branches. When a nonnegative credit, deduction, allowance, subsidy, or benefit is a percentage of `min(income, cap)` or similar, floor the income base at zero: use `rate * min(max(0, earned_income), cap)`, not `rate * min(earned_income, cap)`.
 - Outputs named `taxable_income` or ending in `_taxable_income` must also never be negative. Wrap the final selected branch at zero, including both sides of conditionals: use `if condition: max(0, branch_a) else: max(0, branch_b)`, not `if condition: branch_a else: branch_b`.
@@ -3421,11 +3423,11 @@ RuleSpec requirements:
 - Formula strings must use bare identifiers only. If an imported rule is listed
   as `us:statutes/...#example_rule`, add that exact target to `imports:` but
   reference `example_rule` inside formula text.
-- Axiom conditionals are expression syntax, not YAML syntax. Money/scalar formulas may use `if condition: value else: other`; do not use Python ternary syntax.
+- Axiom conditionals are expression syntax, not YAML syntax. Money/scalar formulas may use `if condition: value else: other`; do not use Python ternary syntax, `else if`, or `elif`.
 - `dtype: Judgment` formulas must not use `if ... else ...`. Write them as boolean expressions using `and`, `or`, `not`, comparisons, and parentheses. For example, encode `if exempt: net_ok else: net_ok and gross_ok` as `net_ok and (exempt or gross_ok)`.
 - When using negated conjuncts, write them as a multiline formula with each `not <predicate>` term on its own line joined by `and`, rather than one compact `not A and not B` line.
 - Do not use Python inline ternaries like `x if cond else y`.
-- Use chained `if condition: value else: other_value` expressions; do not use YAML-style `if:` / `then:` / `else:` blocks.
+- Use chained `if condition: value else: other_value` expressions; do not use YAML-style `if:` / `then:` / `else:` blocks, `else if`, or `elif`.
 - Do not append a multiline conditional directly onto another expression, and do not use inline assignment syntax like `:=` inside formula blocks.
 - For `dtype: Rate`, encode percentages as decimal ratios like `0.60` or `0.40`, never as `%` literals.
 - Do not simplify source-stated ratios or fractions into new decimal literals.
@@ -5860,11 +5862,17 @@ def _normalize_main_eval_content(
     *,
     target_path: Path,
     single_amount_table_slice: bool,
+    source_text: str | None = None,
 ) -> str:
     """Normalize generated main artifacts according to their format."""
     if target_path.suffix not in {".yaml", ".yml"}:
         raise ValueError("RuleSpec artifacts must use .yaml or .yml paths")
-    return _normalize_rulespec_content(content)
+    normalized = _normalize_rulespec_content(content)
+    normalized, _repaired_rules = repair_source_table_band_scalar_parameters(
+        normalized,
+        source_text=source_text,
+    )
+    return normalized
 
 
 def _extract_generated_file_bundle(llm_response: str) -> dict[str, str]:
@@ -6640,6 +6648,7 @@ def _materialize_eval_artifact(
                         content,
                         target_path=target_path,
                         single_amount_table_slice=single_amount_table_slice,
+                        source_text=source_text,
                     )
                 except ValueError:
                     continue
@@ -6683,6 +6692,7 @@ def _materialize_eval_artifact(
             rulespec_content,
             target_path=expected_path,
             single_amount_table_slice=single_amount_table_slice,
+            source_text=source_text,
         )
     except ValueError:
         return False
@@ -6712,6 +6722,7 @@ def _materialize_workspace_artifacts(
             main_content,
             target_path=expected_path,
             single_amount_table_slice=single_amount_table_slice,
+            source_text=source_text,
         )
     except ValueError:
         return False

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1257,9 +1257,11 @@ def extract_grounding_values(content: str) -> list[tuple[int, str, float]]:
             and isinstance(payload.get("rules"), list)
         ):
             values: list[tuple[int, str, float]] = []
+            selector_table_keys = _rulespec_index_selector_keys(payload["rules"])
             for rule in payload["rules"]:
                 if not isinstance(rule, dict):
                     continue
+                rule_name = str(rule.get("name") or "").strip()
                 versions = rule.get("versions")
                 if not isinstance(versions, list):
                     continue
@@ -1274,7 +1276,17 @@ def extract_grounding_values(content: str) -> list[tuple[int, str, float]]:
                         if value not in GROUNDING_ALLOWED_VALUES:
                             values.append((1, str(formula), value))
                     elif isinstance(formula, str):
-                        values.extend(_extract_formula_grounding_values(1, formula))
+                        values.extend(
+                            _extract_formula_grounding_values(
+                                1,
+                                formula,
+                                structural_selector_keys=(
+                                    selector_table_keys.get(rule_name)
+                                    if _is_structural_selector_rule(rule)
+                                    else None
+                                ),
+                            )
+                        )
                     table_values = version.get("values")
                     if isinstance(table_values, dict):
                         for table_value in table_values.values():
@@ -1302,7 +1314,9 @@ def _numeric_rule_value(value: Any) -> tuple[str, float] | None:
 
 
 def _extract_formula_grounding_values(
-    line_number: int, formula_text: str
+    line_number: int,
+    formula_text: str,
+    structural_selector_keys: set[str] | None = None,
 ) -> list[tuple[int, str, float]]:
     """Extract numeric literals from a formula expression or formula line."""
     cleaned = formula_text.split("#", 1)[0]
@@ -1319,11 +1333,68 @@ def _extract_formula_grounding_values(
             continue
         if _is_structural_enum_index_literal(cleaned, raw):
             continue
+        if _is_structural_selector_result_literal(
+            cleaned,
+            raw,
+            structural_selector_keys,
+        ):
+            continue
         with contextlib.suppress(ValueError):
             value = float(raw)
             if value not in GROUNDING_ALLOWED_VALUES:
                 values.append((line_number, raw, value))
     return values
+
+
+def _is_structural_selector_rule(rule: dict[str, Any]) -> bool:
+    if str(rule.get("dtype") or "").strip().lower() != "integer":
+        return False
+    name = str(rule.get("name") or "").strip().lower()
+    return bool(re.search(r"(?:^|_)(?:band|bracket|tier|index)(?:_|$)", name))
+
+
+def _rulespec_index_selector_keys(rules: list[Any]) -> dict[str, set[str]]:
+    selector_keys: dict[str, set[str]] = {}
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "parameter":
+            continue
+        index_names = _rulespec_indexed_by_names(rule.get("indexed_by"))
+        if len(index_names) != 1:
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        table_keys: set[str] = set()
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            table_values = version.get("values")
+            if not isinstance(table_values, dict):
+                continue
+            for key in table_values:
+                normalized_key = _structural_integer_key(key)
+                if normalized_key is not None:
+                    table_keys.add(normalized_key)
+        if table_keys:
+            selector_name = next(iter(index_names))
+            selector_keys.setdefault(selector_name, set()).update(table_keys)
+    return selector_keys
+
+
+def _structural_integer_key(value: Any) -> str | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    if isinstance(value, str) and re.fullmatch(r"-?\d+(?:\.0+)?", value.strip()):
+        numeric_value = float(value.strip())
+        if numeric_value.is_integer():
+            return str(int(numeric_value))
+    return None
 
 
 def _is_half_up_rounding_expression(expression: str) -> bool:
@@ -1361,6 +1432,29 @@ def _is_structural_table_key_literal(expression: str, literal: str) -> bool:
             rf"\[[ \t]*{re.escape(literal)}[ \t]*\]",
             expression,
         )
+    )
+
+
+def _is_structural_selector_result_literal(
+    expression: str,
+    literal: str,
+    selector_keys: set[str] | None,
+) -> bool:
+    """Return true when an integer is only a generated table selector key."""
+    if not selector_keys or literal in _EMBEDDED_SCALAR_ALLOWED_VALUES:
+        return False
+    if not re.fullmatch(r"\d+(?:\.0+)?", literal):
+        return False
+    with contextlib.suppress(ValueError):
+        numeric_value = float(literal)
+        if not numeric_value.is_integer() or not (0 <= int(numeric_value) <= 20):
+            return False
+        if str(int(numeric_value)) not in selector_keys:
+            return False
+    normalized = re.sub(r"\s+", " ", expression)
+    return bool(
+        re.search(rf":\s*{re.escape(literal)}\s+(?:else\b|$)", normalized)
+        or re.search(rf"(?:^|\s)else\s*:\s*{re.escape(literal)}\s*$", normalized)
     )
 
 
@@ -2405,10 +2499,219 @@ def _is_source_table_structural_scalar_name(name: str) -> bool:
     )
 
 
+def repair_source_table_band_scalar_parameters(
+    content: str,
+    *,
+    source_text: str | None = None,
+) -> tuple[str, list[str]]:
+    """Inline generated structural table band bounds and remove public scalars."""
+    payload = _rulespec_payload(content)
+    table_source_text = source_text or extract_embedded_source_text(content)
+    if (
+        payload is None
+        or payload.get("format") != "rulespec/v1"
+        or not _source_text_looks_like_table(table_source_text)
+    ):
+        return content, []
+
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return content, []
+
+    bound_values: dict[str, str] = {}
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "parameter":
+            continue
+        if rule.get("indexed_by") is not None:
+            continue
+        name = str(rule.get("name") or "").strip()
+        if not _is_source_table_structural_bound_parameter_name(name):
+            continue
+        value = _single_version_numeric_formula(rule)
+        if value is not None:
+            bound_values[name] = value
+
+    if not bound_values:
+        return content, []
+
+    referenced_bounds: set[str] = set()
+    changed_rules: set[str] = set()
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        rule_name = str(rule.get("name") or "<unknown>").strip() or "<unknown>"
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            formula_bounds = {
+                name
+                for name in bound_values
+                if _formula_references_identifier(formula, name)
+            }
+            if not formula_bounds:
+                continue
+            repaired = _inline_formula_identifiers(
+                formula,
+                {
+                    name: value
+                    for name, value in bound_values.items()
+                    if name in formula_bounds
+                },
+            )
+            repaired = _repair_else_if_formula(repaired)
+            if _formula_has_unsupported_chained_conditional(repaired):
+                continue
+            referenced_bounds.update(formula_bounds)
+            if repaired != formula:
+                version["formula"] = repaired
+                changed_rules.add(rule_name)
+
+    if not referenced_bounds:
+        return content, []
+
+    payload["rules"] = [
+        rule
+        for rule in rules
+        if not (
+            isinstance(rule, dict)
+            and str(rule.get("name") or "").strip() in referenced_bounds
+        )
+    ]
+
+    repaired_content = yaml.safe_dump(payload, sort_keys=False).strip() + "\n"
+    return repaired_content, sorted(changed_rules | referenced_bounds)
+
+
+def _is_source_table_structural_bound_parameter_name(name: str) -> bool:
+    normalized = name.strip().lower()
+    if not normalized:
+        return False
+    has_index = re.search(r"(?:^|_)(?:row|band|bracket)_\d+(?:_|$)", normalized)
+    has_bound_word = re.search(
+        r"(?:^|_)(?:lower|upper)(?:_bound|_threshold|_limit)?(?:_|$)",
+        normalized,
+    )
+    has_structural_noun = re.search(
+        r"(?:^|_)(?:bound|threshold|limit)(?:_|$)", normalized
+    )
+    return bool(has_index and has_bound_word and has_structural_noun)
+
+
+def _single_version_numeric_formula(rule: dict[str, Any]) -> str | None:
+    versions = rule.get("versions")
+    if not isinstance(versions, list) or len(versions) != 1:
+        return None
+    version = versions[0]
+    if not isinstance(version, dict):
+        return None
+    formula = version.get("formula")
+    if isinstance(formula, bool):
+        return None
+    if isinstance(formula, int):
+        return str(formula)
+    if isinstance(formula, float):
+        return str(formula)
+    if isinstance(formula, str) and re.fullmatch(r"-?\d+(?:\.\d+)?", formula.strip()):
+        return formula.strip()
+    return None
+
+
+def _inline_formula_identifiers(
+    formula: str,
+    replacements: dict[str, str],
+) -> str:
+    repaired = formula
+    for name in sorted(replacements, key=len, reverse=True):
+        repaired = re.sub(
+            rf"(?<![A-Za-z0-9_]){re.escape(name)}(?![A-Za-z0-9_])",
+            replacements[name],
+            repaired,
+        )
+    return repaired
+
+
+def _formula_references_identifier(formula: str, identifier: str) -> bool:
+    return (
+        re.search(
+            rf"(?<![A-Za-z0-9_]){re.escape(identifier)}(?![A-Za-z0-9_])",
+            formula,
+        )
+        is not None
+    )
+
+
+def _repair_else_if_formula(formula: str) -> str:
+    branches = _parse_multiline_else_if_formula(formula)
+    if branches is None:
+        return formula
+
+    tail = branches[-1][1]
+    for condition, result in reversed(branches[:-1]):
+        tail = f"if {condition}: {result} else: {tail}"
+    return tail
+
+
+def _parse_multiline_else_if_formula(
+    formula: str,
+) -> list[tuple[str | None, str]] | None:
+    lines = [line.rstrip() for line in formula.strip().splitlines() if line.strip()]
+    if len(lines) < 4:
+        return None
+
+    branches: list[tuple[str | None, str]] = []
+    index = 0
+    while index < len(lines):
+        header = lines[index].strip()
+        if_match = re.fullmatch(r"(?:if|elif|else\s+if)\s+(.+):", header)
+        if if_match is not None:
+            if index + 1 >= len(lines):
+                return None
+            result = lines[index + 1].strip()
+            if not result or re.match(r"(?:if|elif|else\b)", result):
+                return None
+            branches.append((if_match.group(1).strip(), result))
+            index += 2
+            continue
+        if header == "else:":
+            if index + 1 >= len(lines):
+                return None
+            result = lines[index + 1].strip()
+            if not result or re.match(r"(?:if|elif|else\b)", result):
+                return None
+            branches.append((None, result))
+            index += 2
+            break
+        return None
+
+    if index != len(lines):
+        return None
+    if len(branches) < 2 or branches[-1][0] is not None:
+        return None
+    if not any(condition is not None for condition, _result in branches):
+        return None
+    return branches
+
+
+def _formula_has_unsupported_chained_conditional(formula: str) -> bool:
+    return bool(re.search(r"(?:^|\s)(?:elif|else\s+if)\b", formula))
+
+
 def _source_text_looks_like_table(source_text: str) -> bool:
     return bool(
         re.search(r"\btable\b", source_text, flags=re.IGNORECASE)
         or source_text.count("|") >= 6
+        or (
+            re.search(r"\bschedule\b", source_text, flags=re.IGNORECASE)
+            and source_text.count("|") >= 2
+        )
     )
 
 
@@ -8857,8 +9160,9 @@ def find_test_input_assignment_issues(
         if not rule_name:
             continue
         if str(rule.get("kind") or "").strip().lower() == "parameter":
-            symbol_inputs[rule_name] = _indexed_by_input_names(rule.get("indexed_by"))
-            symbol_dependencies[rule_name] = set()
+            index_names = _indexed_by_input_names(rule.get("indexed_by"))
+            symbol_inputs[rule_name] = index_names - defined_symbols - imported_symbols
+            symbol_dependencies[rule_name] = index_names & defined_symbols
             continue
         if str(rule.get("kind") or "").strip().lower() != "derived":
             continue

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -537,6 +537,8 @@ Hard requirements:
   temporal branch, or encode only the currently applicable provision after
   resolving the source context.
 - Formula strings use Axiom formula syntax: `if condition: value else: other`, `==`, `and`, and `or`.
+  Do not write `else if` or `elif`; chain branches as
+  `if condition: value else: if next_condition: next_value else: fallback`.
 - Supported scalar functions are `min(...)`, `max(...)`, `floor(x)`, and
   `ceil(x)`. Do not use Python-only functions such as `round(...)`; express
   nearest-multiple rounding as `floor((x / multiple) + 0.5) * multiple` for
@@ -582,7 +584,7 @@ Hard requirements:
   reference `example_rule` inside formula text.
 - Axiom conditionals are expression syntax, not YAML syntax. Money/scalar
   formulas may use `if condition: value else: other`; do not use Python ternary
-  syntax.
+  syntax, `else if`, or `elif`.
 - `dtype: Judgment` formulas must not use `if ... else ...`. Write them as
   boolean expressions using `and`, `or`, `not`, comparisons, and parentheses.
   For example, encode `if exempt: net_ok else: net_ok and gross_ok` as

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -77,6 +77,7 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
         in ENCODER_PROMPT
     )
     assert "overrides preservation of existing local input names" in ENCODER_PROMPT
+    assert "Do not write `else if` or `elif`" in ENCODER_PROMPT
     assert "module.summary` or the rule's proof excerpt" in ENCODER_PROMPT
     assert "Importing an adjacent upstream output only as proof" in ENCODER_PROMPT
     assert "does not satisfy the dependency" in ENCODER_PROMPT

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -788,6 +788,64 @@ rules:
     assert output_file.read_text().startswith("format: rulespec/v1")
 
 
+def test_materialize_eval_artifact_repairs_source_table_band_scalars(tmp_path):
+    output_file = tmp_path / "runner" / "statutes" / "26" / "3241" / "b.yaml"
+    llm_response = """=== FILE: b.yaml ===
+format: rulespec/v1
+module:
+  summary: Section defines applicable percentages by benefits ratio.
+rules:
+  - name: average_account_benefits_ratio_lower_bound_band_0
+    kind: parameter
+    dtype: Float
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2.5
+  - name: average_account_benefits_ratio_upper_bound_band_0
+    kind: parameter
+    dtype: Float
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3.0
+  - name: average_account_benefits_ratio_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if average_account_benefits_ratio < average_account_benefits_ratio_lower_bound_band_0:
+            -1
+          elif average_account_benefits_ratio < average_account_benefits_ratio_upper_bound_band_0:
+            0
+          else:
+            1
+  - name: applicable_percentage_3201_by_average_account_benefits_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_band
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          0: 0.049
+          1: 0
+"""
+
+    wrote = _materialize_eval_artifact(
+        llm_response,
+        output_file,
+        source_text="Tax rate schedule | Average account benefits ratio | 2.5 | 3.0",
+    )
+
+    assert wrote is True
+    content = output_file.read_text()
+    assert "average_account_benefits_ratio_lower_bound_band_0" not in content
+    assert "average_account_benefits_ratio < 2.5" in content
+    assert "elif" not in content
+    assert "else if" not in content
+
+
 def test_run_source_eval_retries_once_when_first_response_has_no_rulespec(tmp_path):
     policy_repo_root = tmp_path / "axiom-rules-engine"
     policy_repo_root.mkdir()
@@ -2863,6 +2921,7 @@ class TestEvalPrompt:
         assert (
             "Use chained `if condition: value else: other_value` expressions" in prompt
         )
+        assert "Do not write `else if` or `elif`" in prompt
         assert "do not inline that cross-reference's mechanics into this file" in prompt
         assert (
             "additional_standard_deduction_entitlement_count_under_subsection_f"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -77,6 +77,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_zero_branch_test_coverage_issues,
     repair_current_year_final_amount_tables,
     repair_nonnegative_amount_reductions,
+    repair_source_table_band_scalar_parameters,
 )
 from axiom_encode.oracles.policyengine.registry import (
     PolicyEngineMapping,
@@ -3271,6 +3272,66 @@ rules:
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
 
 
+def test_rulespec_grounding_allows_generated_band_selector_keys():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3241
+rules:
+  - name: average_account_benefits_ratio_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if ratio < 2.5: 0 else: if ratio < 3.0: 4 else: 10
+  - name: rate_by_average_account_benefits_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_band
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          0: 0
+          4: 1
+          10: 2
+"""
+
+    source_text = (
+        "The table includes average account benefits ratio cutoffs 2.5 and 3.0."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
+def test_rulespec_grounding_rejects_ungrounded_index_like_integer_outputs():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/example/index
+rules:
+  - name: cost_of_living_index
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if eligible: 10 else: 0
+"""
+
+    issues = find_ungrounded_numeric_issues(
+        content,
+        source_text="The source describes eligibility but does not state the index value.",
+    )
+
+    assert len(issues) == 1
+    assert "10" in issues[0]
+
+
 def test_rulespec_grounding_accepts_slash_separated_source_measure_denominator():
     content = """format: rulespec/v1
 module:
@@ -4259,6 +4320,53 @@ rules:
             },
             "output": {
                 "us:statutes/26/32#credit_rate": 0.34,
+            },
+        },
+    ]
+
+    assert find_test_input_assignment_issues(content, test_cases) == []
+
+
+def test_test_input_assignment_treats_local_indexed_by_selector_as_dependency():
+    content = """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: income_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: if income < 100: 0 else: 4
+  - name: rate_by_income_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: income_band
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          0: 0.1
+          4: 0.2
+  - name: rate
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: rate_by_income_band[income_band]
+"""
+    test_cases = [
+        {
+            "name": "low_income",
+            "input": {
+                "us:statutes/example#input.income": 50,
+            },
+            "output": {
+                "us:statutes/example#rate": 0.1,
             },
         },
     ]
@@ -7750,6 +7858,110 @@ rules:
     assert "Source table row/band scalar parameters" in issues[0]
     assert "average_account_benefits_ratio_lower_bound_band_0" in issues[0]
     assert "structural bounds inline" in issues[0]
+
+
+def test_repair_source_table_band_bound_scalars_inlines_selector_bounds():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Tax rate schedule | Average account benefits ratio | Applicable percentage
+    | At least | But less than | Section 3201(b) |
+    | .............. | 2.5 | 4.9 |
+    | 2.5 | 3.0 | 4.9 |
+rules:
+  - name: average_account_benefits_ratio_lower_bound_band_0
+    kind: parameter
+    dtype: Decimal
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2.5
+  - name: average_account_benefits_ratio_upper_bound_band_0
+    kind: parameter
+    dtype: Decimal
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3.0
+  - name: average_account_benefits_ratio_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if average_account_benefits_ratio < average_account_benefits_ratio_lower_bound_band_0:
+            -1
+          else if average_account_benefits_ratio < average_account_benefits_ratio_upper_bound_band_0:
+            0
+          else:
+            1
+  - name: applicable_percentage_3201_by_average_account_benefits_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_band
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          0: 0.049
+          1: 0
+"""
+
+    repaired, repaired_rules = repair_source_table_band_scalar_parameters(content)
+
+    assert "average_account_benefits_ratio_lower_bound_band_0" not in repaired
+    assert "average_account_benefits_ratio_upper_bound_band_0" not in repaired
+    assert "average_account_benefits_ratio < 2.5" in repaired
+    assert "< 3.0" in repaired
+    assert "else if" not in repaired
+    assert "average_account_benefits_ratio_band" in repaired_rules
+    assert find_source_table_row_scalar_parameter_issues(repaired) == []
+
+
+def test_repair_source_table_band_bound_scalars_uses_external_table_text():
+    content = """format: rulespec/v1
+module:
+  summary: Section defines applicable percentages by benefits ratio.
+rules:
+  - name: ratio_lower_bound_band_0
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2.5
+  - name: ratio_upper_bound_band_0
+    kind: parameter
+    dtype: Decimal
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3.0
+  - name: ratio_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if ratio < ratio_lower_bound_band_0:
+            -1
+          elif ratio < ratio_upper_bound_band_0:
+            0
+          else:
+            1
+"""
+
+    repaired, _repaired_rules = repair_source_table_band_scalar_parameters(
+        content,
+        source_text="Tax rate schedule | Average account benefits ratio | 2.5 | 3.0",
+    )
+
+    assert "ratio_lower_bound_band_0" not in repaired
+    assert "ratio < 2.5" in repaired
+    assert "elif" not in repaired
 
 
 def test_source_table_row_scalar_parameters_allows_indexed_table():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.93"
+version = "0.2.94"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- inline generated source-table band bound scalars during eval artifact normalization and remove those public scalar rules
- repair multiline else-if selector formulas into supported nested Axiom conditional syntax
- allow generated band selector keys in grounding and treat local indexed_by selectors as dependencies
- add prompt guardrails for else-if/elif and bump axiom-encode to 0.2.94 for generated-artifact provenance

## Verification
- uv run python -m pytest tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_statutory_base_naming_guidance tests/test_rulespec_validation.py -k 'not test_rulespec_compile_ci_and_grounding' tests/test_evals.py
- uv run ruff check src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/harness/evals.py src/axiom_encode/prompts/encoder.py src/axiom_encode/__init__.py tests/test_rulespec_validation.py tests/test_evals.py tests/test_encoder_backend.py
- uv run axiom-encode validate /tmp/axiom-encode-3241b-repaired-policy/rulespec-us/statutes/26/3241/b.yaml --skip-reviewers

Note: tests/test_rulespec_validation.py::test_rulespec_compile_ci_and_grounding fails locally on origin/main too because the local rules-engine binary now enforces a SnapUnit relation dependency in that old fixture.