### PR TITLE
Repair source table minmax bounds

### DIFF
--- a/changelog.d/source-table-band-minmax.fixed.md
+++ b/changelog.d/source-table-band-minmax.fixed.md
@@ -1,0 +1,1 @@
+Repair generated source-table interval bounds named with adjacent band min/max suffixes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.94"
+version = "0.2.95"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.94"
+__version__ = "0.2.95"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -5875,6 +5875,97 @@ def _normalize_main_eval_content(
     return normalized
 
 
+def _rulespec_rule_names(content: str) -> set[str]:
+    try:
+        payload = yaml.safe_load(content)
+    except (yaml.YAMLError, ValueError):
+        return set()
+    if not isinstance(payload, dict):
+        return set()
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return set()
+    names: set[str] = set()
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        name = str(rule.get("name") or "").strip()
+        if name:
+            names.add(name)
+    return names
+
+
+def _removed_rulespec_rule_names(original: str, normalized: str) -> set[str]:
+    return _rulespec_rule_names(original) - _rulespec_rule_names(normalized)
+
+
+def _indexed_parameter_rule_names(content: str) -> set[str]:
+    try:
+        payload = yaml.safe_load(content)
+    except (yaml.YAMLError, ValueError):
+        return set()
+    if not isinstance(payload, dict):
+        return set()
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return set()
+    names: set[str] = set()
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "parameter":
+            continue
+        if rule.get("indexed_by") is None:
+            continue
+        name = str(rule.get("name") or "").strip()
+        if name:
+            names.add(name)
+    return names
+
+
+def _strip_test_outputs_for_rule_names(
+    content: str,
+    *,
+    rule_names: set[str],
+) -> str:
+    if not rule_names:
+        return content
+    try:
+        cases = yaml.safe_load(content)
+    except (yaml.YAMLError, ValueError):
+        return content
+    if not isinstance(cases, list):
+        return content
+
+    changed = False
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        output = case.get("output")
+        if not isinstance(output, dict):
+            continue
+        filtered = {
+            key: value
+            for key, value in output.items()
+            if _rulespec_output_key_name(key) not in rule_names
+        }
+        if len(filtered) != len(output):
+            case["output"] = filtered
+            changed = True
+
+    if not changed:
+        return content
+    return yaml.safe_dump(cases, sort_keys=False).strip() + "\n"
+
+
+def _rulespec_output_key_name(key: object) -> str | None:
+    if not isinstance(key, str):
+        return None
+    if "#" in key:
+        return key.rsplit("#", 1)[1].strip() or None
+    return key.strip() or None
+
+
 def _extract_generated_file_bundle(llm_response: str) -> dict[str, str]:
     """Extract a small multi-file bundle emitted by eval backends."""
     if not llm_response or "=== FILE:" not in llm_response:
@@ -6634,6 +6725,27 @@ def _materialize_eval_artifact(
         bundle_by_candidate_name = {
             Path(file_name).name: content for file_name, content in bundle.items()
         }
+        normalized_main_content: str | None = None
+        stripped_test_output_names: set[str] = set()
+        raw_main_content = bundle_by_candidate_name.get(expected_path.name)
+        if raw_main_content is not None:
+            try:
+                normalized_main_content = _normalize_main_eval_content(
+                    raw_main_content,
+                    target_path=expected_path,
+                    single_amount_table_slice=single_amount_table_slice,
+                    source_text=source_text,
+                )
+                stripped_test_output_names = _removed_rulespec_rule_names(
+                    raw_main_content,
+                    normalized_main_content,
+                )
+                stripped_test_output_names.update(
+                    _indexed_parameter_rule_names(normalized_main_content)
+                )
+            except ValueError:
+                normalized_main_content = None
+                stripped_test_output_names = set()
         for file_name, content in bundle.items():
             candidate_name = Path(file_name).name
             if candidate_name == expected_path.name:
@@ -6643,40 +6755,32 @@ def _materialize_eval_artifact(
             else:
                 continue
             if target_path == expected_path:
-                try:
-                    content = _normalize_main_eval_content(
-                        content,
-                        target_path=target_path,
-                        single_amount_table_slice=single_amount_table_slice,
-                        source_text=source_text,
-                    )
-                except ValueError:
+                if normalized_main_content is None:
                     continue
+                content = normalized_main_content
             elif target_path == expected_test_path:
                 if single_amount_table_slice:
                     content = _normalize_single_amount_row_test_content(
                         content,
-                        rulespec_content=bundle_by_candidate_name.get(
-                            expected_path.name
-                        ),
+                        rulespec_content=normalized_main_content or raw_main_content,
                         source_text=source_text,
                     )
                 else:
                     content = _normalize_test_periods_to_effective_dates(
                         content,
-                        rulespec_content=bundle_by_candidate_name.get(
-                            expected_path.name
-                        ),
+                        rulespec_content=normalized_main_content or raw_main_content,
                         source_text=source_text,
                     )
                     content = _complete_oracle_hint_test_outputs(
                         content,
-                        rulespec_content=bundle_by_candidate_name.get(
-                            expected_path.name
-                        ),
+                        rulespec_content=normalized_main_content or raw_main_content,
                         policyengine_rule_hint=policyengine_rule_hint,
                         rulespec_path=expected_path,
                     )
+                content = _strip_test_outputs_for_rule_names(
+                    content,
+                    rule_names=stripped_test_output_names,
+                )
             target_path.parent.mkdir(parents=True, exist_ok=True)
             target_path.write_text(content)
             if target_path == expected_path:
@@ -6716,16 +6820,21 @@ def _materialize_workspace_artifacts(
     if not workspace_main.exists():
         return False
 
-    main_content = workspace_main.read_text()
+    raw_main_content = workspace_main.read_text()
     try:
         main_content = _normalize_main_eval_content(
-            main_content,
+            raw_main_content,
             target_path=expected_path,
             single_amount_table_slice=single_amount_table_slice,
             source_text=source_text,
         )
     except ValueError:
         return False
+    stripped_test_output_names = _removed_rulespec_rule_names(
+        raw_main_content,
+        main_content,
+    )
+    stripped_test_output_names.update(_indexed_parameter_rule_names(main_content))
 
     expected_path.parent.mkdir(parents=True, exist_ok=True)
     expected_path.write_text(main_content)
@@ -6750,6 +6859,10 @@ def _materialize_workspace_artifacts(
                 policyengine_rule_hint=policyengine_rule_hint,
                 rulespec_path=expected_path,
             )
+        test_content = _strip_test_outputs_for_rule_names(
+            test_content,
+            rule_names=stripped_test_output_names,
+        )
         expected_test_path.write_text(test_content)
 
     return True

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2602,7 +2602,16 @@ def _is_source_table_structural_bound_parameter_name(name: str) -> bool:
     has_structural_noun = re.search(
         r"(?:^|_)(?:bound|threshold|limit)(?:_|$)", normalized
     )
-    return bool(has_index and has_bound_word and has_structural_noun)
+    has_adjacent_min_max = re.search(
+        r"(?:^|_)(?:row|band|bracket)_\d+_(?:min|max|minimum|maximum)(?:_|$)",
+        normalized,
+    ) or re.search(
+        r"(?:^|_)(?:min|max|minimum|maximum)_(?:row|band|bracket)_\d+(?:_|$)",
+        normalized,
+    )
+    return bool(
+        has_index and ((has_bound_word and has_structural_noun) or has_adjacent_min_max)
+    )
 
 
 def _single_version_numeric_formula(rule: dict[str, Any]) -> str | None:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -830,6 +830,20 @@ rules:
         values:
           0: 0.049
           1: 0
+=== FILE: b.test.yaml ===
+- name: selector_band
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.75
+  output:
+    us:statutes/26/3241/b#average_account_benefits_ratio_lower_bound_band_0: 2.5
+    us:statutes/26/3241/b#applicable_percentage_3201_by_average_account_benefits_ratio_band:
+      0: 0.049
+      1: 0
+    us:statutes/26/3241/b#average_account_benefits_ratio_band: 0
 """
 
     wrote = _materialize_eval_artifact(
@@ -844,6 +858,13 @@ rules:
     assert "average_account_benefits_ratio < 2.5" in content
     assert "elif" not in content
     assert "else if" not in content
+    test_content = output_file.with_name("b.test.yaml").read_text()
+    assert "average_account_benefits_ratio_lower_bound_band_0" not in test_content
+    assert (
+        "applicable_percentage_3201_by_average_account_benefits_ratio_band"
+        not in test_content
+    )
+    assert "average_account_benefits_ratio_band" in test_content
 
 
 def test_run_source_eval_retries_once_when_first_response_has_no_rulespec(tmp_path):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7921,6 +7921,65 @@ rules:
     assert find_source_table_row_scalar_parameter_issues(repaired) == []
 
 
+def test_repair_source_table_band_bound_scalars_inlines_adjacent_min_max():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Tax rate schedule | Average account benefits ratio | Applicable percentage
+    | At least | But less than | Section 3201(b) |
+    | .............. | 2.5 | 4.9 |
+    | 2.5 | 3.0 | 4.9 |
+rules:
+  - name: average_account_benefits_ratio_band_1_max
+    kind: parameter
+    dtype: Decimal
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2.5
+  - name: average_account_benefits_ratio_band_2_min
+    kind: parameter
+    dtype: Decimal
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2.5
+  - name: average_account_benefits_ratio_band_2_max
+    kind: parameter
+    dtype: Decimal
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3.0
+  - name: average_account_benefits_ratio_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if average_account_benefits_ratio < average_account_benefits_ratio_band_1_max:
+            1
+          else: if average_account_benefits_ratio < average_account_benefits_ratio_band_2_max and average_account_benefits_ratio >= average_account_benefits_ratio_band_2_min:
+            2
+          else:
+            3
+"""
+
+    repaired, repaired_rules = repair_source_table_band_scalar_parameters(content)
+
+    assert "average_account_benefits_ratio_band_1_max" not in repaired
+    assert "average_account_benefits_ratio_band_2_min" not in repaired
+    assert "average_account_benefits_ratio_band_2_max" not in repaired
+    assert "average_account_benefits_ratio < 2.5" in repaired
+    assert "< 3.0" in repaired
+    assert ">= 2.5" in repaired
+    assert "average_account_benefits_ratio_band" in repaired_rules
+    assert find_source_table_row_scalar_parameter_issues(repaired) == []
+
+
 def test_repair_source_table_band_bound_scalars_uses_external_table_text():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.94"
+version = "0.2.95"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair generated source-table bounds named with adjacent `band_N_min/max` or `row_N_min/max` forms
- strip companion test outputs for removed structural bounds and indexed parameter tables during materialization
- bump axiom-encode to 0.2.95

## Validation
- `uv run --extra dev python -m pytest tests/test_rulespec_validation.py -k source_table_band tests/test_evals.py::test_materialize_eval_artifact_repairs_source_table_band_scalars`
- `uv run --extra dev python -m pytest tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_statutory_base_naming_guidance tests/test_rulespec_validation.py -k 'not test_rulespec_compile_ci_and_grounding' tests/test_evals.py`\n- `uv run --extra dev ruff check src/ tests/`\n- `uv run --extra dev ruff format --check src/ tests/`\n- reproduced the failed 26 USC 3241(b) response into `/tmp/rulespec-us` and ran `uv run axiom-encode validate /tmp/rulespec-us/statutes/26/3241/b.yaml --skip-reviewers`