### PR TITLE
Repair generated selector auto tests

### DIFF
--- a/changelog.d/generated-selector-tests.fixed.md
+++ b/changelog.d/generated-selector-tests.fixed.md
@@ -1,0 +1,1 @@
+Use indexed table keys when auto-adding generated selector companion tests and drop unreferenced structural source-table bounds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.95"
+version = "0.2.96"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.95"
+__version__ = "0.2.96"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -9143,7 +9143,10 @@ def _append_generated_derived_output_tests_if_missing(
                 },
                 "input": dict(input_defaults),
                 "output": {
-                    target: _default_generated_test_output_value(rule),
+                    target: _default_generated_test_output_value(
+                        rule,
+                        rules_payload=rules_payload,
+                    ),
                 },
             }
         )
@@ -9176,8 +9179,19 @@ def _missing_derived_output_targets_from_issues(issues: list[str]) -> list[str]:
     return targets
 
 
-def _default_generated_test_output_value(rule: dict[str, object]) -> object:
+def _default_generated_test_output_value(
+    rule: dict[str, object],
+    *,
+    rules_payload: dict[str, object] | None = None,
+) -> object:
     dtype = str(rule.get("dtype") or "").strip().lower()
+    if dtype in {"integer", "int"}:
+        selector_value = _default_generated_selector_output_value(
+            rule,
+            rules_payload=rules_payload,
+        )
+        if selector_value is not None:
+            return selector_value
     if dtype == "judgment":
         return "not_holds"
     if dtype in {"boolean", "bool"}:
@@ -9185,6 +9199,52 @@ def _default_generated_test_output_value(rule: dict[str, object]) -> object:
     if dtype in {"list", "array"}:
         return []
     return 0
+
+
+def _default_generated_selector_output_value(
+    rule: dict[str, object],
+    *,
+    rules_payload: dict[str, object] | None,
+) -> int | None:
+    selector_name = str(rule.get("name") or "").strip()
+    if not selector_name or not isinstance(rules_payload, dict):
+        return None
+    table_keys: list[int] = []
+    rules = rules_payload.get("rules")
+    if not isinstance(rules, list):
+        return None
+    for candidate in rules:
+        if not isinstance(candidate, dict):
+            continue
+        if str(candidate.get("kind") or "").strip().lower() != "parameter":
+            continue
+        if str(candidate.get("indexed_by") or "").strip() != selector_name:
+            continue
+        versions = candidate.get("versions")
+        if not isinstance(versions, list):
+            continue
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            values = version.get("values")
+            if not isinstance(values, dict):
+                continue
+            table_keys.extend(
+                key
+                for raw_key in values
+                if (key := _integer_table_key(raw_key)) is not None
+            )
+    return min(table_keys) if table_keys else None
+
+
+def _integer_table_key(raw_key: object) -> int | None:
+    if isinstance(raw_key, bool):
+        return None
+    if isinstance(raw_key, int):
+        return raw_key
+    if isinstance(raw_key, str) and re.fullmatch(r"-?\d+", raw_key.strip()):
+        return int(raw_key.strip())
+    return None
 
 
 def _remove_generated_import_output_input_placeholders(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2577,17 +2577,18 @@ def repair_source_table_band_scalar_parameters(
     if not referenced_bounds:
         return content, []
 
+    removed_bounds = set(bound_values)
     payload["rules"] = [
         rule
         for rule in rules
         if not (
             isinstance(rule, dict)
-            and str(rule.get("name") or "").strip() in referenced_bounds
+            and str(rule.get("name") or "").strip() in removed_bounds
         )
     ]
 
     repaired_content = yaml.safe_dump(payload, sort_keys=False).strip() + "\n"
-    return repaired_content, sorted(changed_rules | referenced_bounds)
+    return repaired_content, sorted(changed_rules | removed_bounds)
 
 
 def _is_source_table_structural_bound_parameter_name(name: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,7 @@ from axiom_encode import __version__ as AXIOM_ENCODE_TEST_VERSION
 from axiom_encode.cli import (
     APPLIED_ENCODING_MANIFEST_SCHEMA,
     APPLIED_ENCODING_SIGNING_KEY_ENV,
+    _append_generated_derived_output_tests_if_missing,
     _apply_generated_encoding_result,
     _complete_missing_imported_test_inputs,
     _default_generated_test_input_value,
@@ -3679,6 +3680,51 @@ rules:
         ]
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
+
+    def test_derived_output_test_repair_uses_indexed_selector_key(self, tmp_path):
+        repo_path = tmp_path / "rulespec-us"
+        rules_file = repo_path / "statutes" / "26" / "3241" / "b.yaml"
+        test_file = repo_path / "statutes" / "26" / "3241" / "b.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: average_account_benefits_ratio_bracket
+    kind: derived
+    dtype: Integer
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 'if average_account_benefits_ratio < 2.5: 1 else: 2'
+  - name: applicable_percentage_by_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_bracket
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          1: 0.221
+          2: 0.181
+"""
+        )
+        test_file.write_text("[]\n")
+
+        repaired = _append_generated_derived_output_tests_if_missing(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=repo_path,
+            relative_output=Path("statutes/26/3241/b.yaml"),
+            issues=[
+                "Derived rule missing companion output coverage: "
+                "`us:statutes/26/3241/b#average_account_benefits_ratio_bracket` "
+                "is not asserted by the companion `.test.yaml` file."
+            ],
+        )
+
+        assert repaired == ["auto_output_average_account_benefits_ratio_bracket"]
+        test_payload = yaml.safe_load(test_file.read_text())
+        assert test_payload[0]["output"] == {
+            "us:statutes/26/3241/b#average_account_benefits_ratio_bracket": 1
+        }
 
     def test_encode_apply_removes_local_import_output_input_placeholders(
         self, capsys, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7951,6 +7951,13 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: 3.0
+  - name: average_account_benefits_ratio_band_3_min
+    kind: parameter
+    dtype: Decimal
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3.0
   - name: average_account_benefits_ratio_band
     kind: derived
     entity: TaxUnit
@@ -7973,6 +7980,7 @@ rules:
     assert "average_account_benefits_ratio_band_1_max" not in repaired
     assert "average_account_benefits_ratio_band_2_min" not in repaired
     assert "average_account_benefits_ratio_band_2_max" not in repaired
+    assert "average_account_benefits_ratio_band_3_min" not in repaired
     assert "average_account_benefits_ratio < 2.5" in repaired
     assert "< 3.0" in repaired
     assert ">= 2.5" in repaired

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.95"
+version = "0.2.96"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- use indexed table keys when auto-adding generated selector companion tests
- remove all structural source-table bound parameters after a bound repair triggers, including unreferenced leftover bounds
- bump axiom-encode to 0.2.96

## Validation
- `uv run --extra dev python -m pytest tests/test_cli.py::TestCmdEncode::test_derived_output_test_repair_uses_indexed_selector_key`
- `uv run --extra dev python -m pytest tests/test_rulespec_validation.py -k source_table_band`
- `uv run --extra dev python -m pytest tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_statutory_base_naming_guidance tests/test_rulespec_validation.py -k 'not test_rulespec_compile_ci_and_grounding' tests/test_evals.py`\n- `uv run --extra dev ruff check src/ tests/`\n- `uv run --extra dev ruff format --check src/ tests/`\n- replayed the failed 26 USC 3241(b) trace into `/tmp/rulespec-us`, applied the auto derived-output test repair, and ran `uv run axiom-encode validate /tmp/rulespec-us/statutes/26/3241/b.yaml --skip-reviewers`