### PR TITLE
Repair generated table conditionals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.96"
+version = "0.2.97"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.96"
+__version__ = "0.2.97"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -71,6 +71,8 @@ from .validator_pipeline import (
     find_unused_modifier_parameter_issues,
     numeric_value_is_grounded,
     repair_source_table_band_scalar_parameters,
+    repair_source_table_open_ended_bound_sentinels,
+    repair_unsupported_chained_conditionals,
 )
 
 EvalMode = Literal["cold", "repo-augmented"]
@@ -5871,6 +5873,13 @@ def _normalize_main_eval_content(
     normalized, _repaired_rules = repair_source_table_band_scalar_parameters(
         normalized,
         source_text=source_text,
+    )
+    normalized, _bound_repairs = repair_source_table_open_ended_bound_sentinels(
+        normalized,
+        source_text=source_text,
+    )
+    normalized, _conditional_repairs = repair_unsupported_chained_conditionals(
+        normalized
     )
     return normalized
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2591,6 +2591,159 @@ def repair_source_table_band_scalar_parameters(
     return repaired_content, sorted(changed_rules | removed_bounds)
 
 
+def repair_unsupported_chained_conditionals(content: str) -> tuple[str, list[str]]:
+    """Rewrite generated multiline `elif`/`else if` formulas into expressions."""
+    payload = _rulespec_payload(content)
+    if payload is None or payload.get("format") != "rulespec/v1":
+        return content, []
+
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return content, []
+
+    changed_rules: set[str] = set()
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        rule_name = str(rule.get("name") or "<unknown>").strip() or "<unknown>"
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            repaired = _repair_else_if_formula(formula)
+            if repaired == formula:
+                continue
+            if _formula_has_unsupported_chained_conditional(repaired):
+                continue
+            version["formula"] = repaired
+            changed_rules.add(rule_name)
+
+    if not changed_rules:
+        return content, []
+
+    repaired_content = yaml.safe_dump(payload, sort_keys=False).strip() + "\n"
+    return repaired_content, sorted(changed_rules)
+
+
+def repair_source_table_open_ended_bound_sentinels(
+    content: str,
+    *,
+    source_text: str | None = None,
+) -> tuple[str, list[str]]:
+    """Remove invented sentinel values for open-ended source table bounds."""
+    payload = _rulespec_payload(content)
+    if payload is None or payload.get("format") != "rulespec/v1":
+        return content, []
+
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return content, []
+
+    source = (
+        source_text.strip()
+        if source_text is not None
+        else (extract_numeric_grounding_source_text(content) or "").strip()
+    )
+    source_numbers = extract_numbers_from_text(source) if source else set()
+    changed_rules: set[str] = set()
+
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "parameter":
+            continue
+        if rule.get("indexed_by") is None:
+            continue
+        rule_name = str(rule.get("name") or "").strip()
+        if not _looks_like_open_ended_upper_bound_parameter(rule):
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            values = version.get("values")
+            if not isinstance(values, dict) or len(values) < 2:
+                continue
+            max_key = _max_structural_integer_table_key(values)
+            if max_key is None:
+                continue
+            numeric = _numeric_rule_value(values.get(max_key))
+            if numeric is None:
+                continue
+            _raw, value = numeric
+            if not _is_generated_open_ended_bound_sentinel(value, source_numbers):
+                continue
+            del values[max_key]
+            changed_rules.add(rule_name or "<unknown>")
+
+    if not changed_rules:
+        return content, []
+
+    repaired_content = yaml.safe_dump(payload, sort_keys=False).strip() + "\n"
+    return repaired_content, sorted(changed_rules)
+
+
+def _looks_like_open_ended_upper_bound_parameter(rule: dict[str, Any]) -> bool:
+    name = str(rule.get("name") or "").strip().lower()
+    text_parts = [name]
+    metadata = rule.get("metadata")
+    if isinstance(metadata, dict):
+        proof = metadata.get("proof")
+        if isinstance(proof, dict):
+            atoms = proof.get("atoms")
+            if isinstance(atoms, list):
+                for atom in atoms:
+                    if not isinstance(atom, dict):
+                        continue
+                    source = atom.get("source")
+                    if not isinstance(source, dict):
+                        continue
+                    table = source.get("table")
+                    if not isinstance(table, dict):
+                        continue
+                    for key in ("header", "row_key", "column_key"):
+                        value = table.get(key)
+                        if isinstance(value, str):
+                            text_parts.append(value.lower())
+    text = " ".join(text_parts)
+    return bool(
+        re.search(r"\bbut\s+less\s+than\b", text)
+        or re.search(r"\bless\s+than\b", text)
+        or re.search(r"(?:^|_)(?:upper|maximum|max)(?:_|$)", name)
+    )
+
+
+def _max_structural_integer_table_key(values: dict[Any, Any]) -> Any | None:
+    keyed: list[tuple[int, Any]] = []
+    for key in values:
+        normalized = _structural_integer_key(key)
+        if normalized is None:
+            continue
+        with contextlib.suppress(ValueError):
+            keyed.append((int(normalized), key))
+    if not keyed:
+        return None
+    return max(keyed, key=lambda item: item[0])[1]
+
+
+def _is_generated_open_ended_bound_sentinel(
+    value: float,
+    source_numbers: set[float],
+) -> bool:
+    if abs(value) < 1_000_000:
+        return False
+    if source_numbers and numeric_value_is_grounded(value, source_numbers):
+        return False
+    return True
+
+
 def _is_source_table_structural_bound_parameter_name(name: str) -> bool:
     normalized = name.strip().lower()
     if not normalized:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -867,6 +867,84 @@ rules:
     assert "average_account_benefits_ratio_band" in test_content
 
 
+def test_materialize_eval_artifact_repairs_chained_conditionals_without_table_scalars(
+    tmp_path,
+):
+    output_file = tmp_path / "runner" / "statutes" / "26" / "3241" / "b.yaml"
+    llm_response = """=== FILE: b.yaml ===
+format: rulespec/v1
+module:
+  summary: Section defines applicable percentages by benefits ratio.
+rules:
+  - name: average_account_benefits_ratio_at_least_threshold_by_band
+    kind: parameter
+    dtype: Decimal
+    indexed_by: average_account_benefits_ratio_band
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          1: 2.5
+          2: 3.0
+  - name: average_account_benefits_ratio_but_less_than_threshold_by_band
+    kind: parameter
+    dtype: Decimal
+    indexed_by: average_account_benefits_ratio_band
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us/statute/26/3241
+              table:
+                header: Tax rate schedule
+                row_key: Average account benefits ratio band
+                column_key: But less than
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          1: 3.0
+          2: 1000000.0
+  - name: average_account_benefits_ratio_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if average_account_benefits_ratio < average_account_benefits_ratio_at_least_threshold_by_band[1]:
+            0
+          else if average_account_benefits_ratio >= average_account_benefits_ratio_at_least_threshold_by_band[2]:
+            2
+          else:
+            1
+=== FILE: b.test.yaml ===
+- name: selector_band
+  period: 2026
+  input:
+    average_account_benefits_ratio: 2.75
+  output:
+    average_account_benefits_ratio_band: 1
+"""
+
+    wrote = _materialize_eval_artifact(
+        llm_response,
+        output_file,
+        source_text="Tax rate schedule | Average account benefits ratio | 2.5 | 3.0",
+    )
+
+    assert wrote is True
+    content = output_file.read_text()
+    assert "elif" not in content
+    assert "else if" not in content
+    assert "1000000.0" not in content
+    payload = yaml.safe_load(content)
+    assert 2 not in payload["rules"][1]["versions"][0]["values"]
+    formula = payload["rules"][2]["versions"][0]["formula"]
+    assert formula.startswith("if average_account_benefits_ratio < ")
+    assert " else: if average_account_benefits_ratio >= " in formula
+
+
 def test_run_source_eval_retries_once_when_first_response_has_no_rulespec(tmp_path):
     policy_repo_root = tmp_path / "axiom-rules-engine"
     policy_repo_root.mkdir()


### PR DESCRIPTION
## Summary
- rewrite generated multiline `else if`/`elif` formulas into RuleSpec conditional expressions during materialization
- remove invented open-ended source-table upper-bound sentinel values when they are not grounded in the source
- bump axiom-encode to 0.2.97

## Validation
- `uv run --extra dev python -m pytest tests/test_evals.py::test_materialize_eval_artifact_repairs_chained_conditionals_without_table_scalars tests/test_evals.py::test_materialize_eval_artifact_repairs_source_table_band_scalars`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- replayed failed 26 USC 3241(b) trace: no `else if`/`elif`, no `1000000.0` sentinel; remaining direct-validate failure is the expected zero-branch coverage repair handled by apply