### PR TITLE
Map 3241(b) oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.98"
+version = "0.2.99"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.98"
+__version__ = "0.2.99"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9237,6 +9237,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 933 Puerto Rico income exclusion outputs and related deduction or credit disallowance rules are territory-specific legal intermediates outside PolicyEngine's current one-to-one oracle surface.
 
+  - legal_id_prefix: us:statutes/26/3241/b#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3241(b) Railroad Retirement Tax Act applicable-percentage schedule outputs are not exposed as one-to-one PolicyEngine variables or parameters.
+
   - legal_id_prefix: us:statutes/26/63#
     country: us
     program: tax


### PR DESCRIPTION
## Summary
- mark generated 26 USC 3241(b) Railroad Retirement Tax Act schedule outputs as known not comparable for PolicyEngine oracle coverage
- bump axiom-encode to 0.2.99

## Validation
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed
- uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --json > /tmp/coverage-3241b.json

The local coverage check classifies the five generated rulespec-us 3241(b) legal IDs as known_not_comparable.