### PR TITLE
Repair apply validation edge cases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.99"
+version = "0.2.100"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.99"
+__version__ = "0.2.100"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10330,6 +10330,34 @@ def cmd_encode(args):
             )
             outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_deferred_source_values = (
+                    _try_repair_generated_empty_deferred_source_values_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_deferred_source_values:
+                    outcome["auto_repaired_empty_deferred_source_values"] = (
+                        repaired_deferred_source_values
+                    )
+                    print(
+                        "  apply=auto_repaired_empty_deferred_source_values:"
+                        + ",".join(repaired_deferred_source_values)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_rules = _try_repair_generated_nonnegative_floors_for_apply(
                     result,
                     output_root=args.output,
@@ -10678,6 +10706,57 @@ def _can_attempt_apply(result) -> bool:
         "Generated RuleSpec failed compile validation",
         "Generated RuleSpec failed CI validation",
     }
+
+
+def _try_repair_generated_empty_deferred_source_values_for_apply(
+    result,
+    *,
+    output_root: Path,
+    issues: list[str],
+) -> list[str]:
+    """Remove empty optional deferred-output source_values emitted by the model."""
+    if not _only_pending_empty_deferred_source_values_issues(issues):
+        return []
+
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    return _remove_empty_deferred_source_values(rules_file=rules_file)
+
+
+def _only_pending_empty_deferred_source_values_issues(issues: list[str]) -> bool:
+    return bool(issues) and all(
+        "module.deferred_outputs[" in str(issue)
+        and ".source_values must list absolute RuleSpec targets" in str(issue)
+        for issue in issues
+    )
+
+
+def _remove_empty_deferred_source_values(*, rules_file: Path) -> list[str]:
+    if not rules_file.exists():
+        return []
+
+    try:
+        lines = rules_file.read_text().splitlines(keepends=True)
+    except OSError:
+        return []
+
+    repaired: list[str] = []
+    removed = 0
+    for line in lines:
+        if re.match(r"^\s*source_values:\s*\[\s*\]\s*(?:#.*)?$", line):
+            removed += 1
+            continue
+        repaired.append(line)
+
+    if removed == 0:
+        return []
+
+    rules_file.write_text("".join(repaired))
+    return [f"source_values[{index}]" for index in range(removed)]
 
 
 def _try_repair_generated_nonnegative_floors_for_apply(
@@ -11521,8 +11600,13 @@ def _validate_generated_encoding_in_policy_overlay(
 
     with tempfile.TemporaryDirectory() as tmpdir:
         overlay_parent = Path(tmpdir)
+        overlay_repo_name = (
+            canonical_rulespec_repo_name(policy_repo_path) or policy_repo_path.name
+        )
         for sibling in policy_repo_path.parent.glob("rulespec-*"):
             if sibling.resolve() == policy_repo_path.resolve() or not sibling.is_dir():
+                continue
+            if sibling.name == overlay_repo_name:
                 continue
             sibling_target = overlay_parent / sibling.name
             try:
@@ -11530,9 +11614,6 @@ def _validate_generated_encoding_in_policy_overlay(
             except OSError:
                 shutil.copytree(sibling, sibling_target, dirs_exist_ok=True)
 
-        overlay_repo_name = (
-            canonical_rulespec_repo_name(policy_repo_path) or policy_repo_path.name
-        )
         overlay_repo = overlay_parent / overlay_repo_name
         shutil.copytree(policy_repo_path, overlay_repo)
         overlay_target = overlay_repo / relative_output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3266,6 +3266,70 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_removes_empty_deferred_source_values(self, capsys, tmp_path):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path / "out" / "codex-test-model" / "statutes" / "26" / "3201.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3201
+  deferred_outputs:
+    - output: us:statutes/26/3201#tier_1_applicable_percentage
+      reason: Requires upstream section 3101 rates.
+      source_values: []
+rules: []
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/26/3201.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "statutes/26/3201.yaml: ci: "
+                            "module.deferred_outputs[0].source_values must list "
+                            "absolute RuleSpec targets for source-stated values "
+                            "retained for the deferred output."
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert "apply=auto_repaired_empty_deferred_source_values:" in output
+        assert "source_values:" not in output_file.read_text()
+        assert mock_overlay.call_count == 2
+        mock_apply.assert_called_once()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_empty_deferred_source_values"] == [
+            "source_values[0]"
+        ]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_auto_repairs_generic_zero_branch_test(self, capsys, tmp_path):
         args = self._make_args(tmp_path, backend="codex", sync=False)
         args.apply = True
@@ -5478,6 +5542,45 @@ rules: []
                 return SimpleNamespace(all_passed=True, results={})
 
         with patch("axiom_encode.cli.ValidatorPipeline", FakePipeline):
+            ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+            )
+
+        assert ok is True
+        assert issues == []
+        assert supplemental == {}
+
+    def test_apply_overlay_validation_skips_sibling_with_active_canonical_name(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us-worktree"
+        sibling_repo = tmp_path / "rulespec-us"
+        generated = output_root / "codex-test-model" / "statutes/26/3201.yaml"
+        policy_repo.mkdir()
+        sibling_repo.mkdir()
+        generated.parent.mkdir(parents=True)
+        generated.write_text("format: rulespec/v1\nrules: []\n")
+        result = SimpleNamespace(output_file=str(generated), runner="codex-test-model")
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert Path(kwargs["policy_repo_path"]).name == "rulespec-us"
+
+            def validate(self, _path, *, skip_reviewers):
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch(
+                "axiom_encode.cli.canonical_rulespec_repo_name",
+                return_value="rulespec-us",
+            ),
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+        ):
             ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
                 result,
                 output_root=output_root,


### PR DESCRIPTION
## Summary
- remove empty generated module.deferred_outputs[].source_values entries during apply-time repair when validation reports them
- avoid overlay copy collisions when an active rulespec worktree has a canonical repo name that matches a sibling checkout
- bump axiom-encode to 0.2.100

## Validation
- uv run --extra dev python -m pytest tests/test_cli.py::TestCmdEncode::test_encode_apply_removes_empty_deferred_source_values tests/test_cli.py::TestApplyDependencyValidation::test_apply_overlay_validation_skips_sibling_with_active_canonical_name
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/

## Replay
- Reran axiom-encode encode "26 USC 3201" --apply against /tmp/rulespec-us-26-3201 from this branch. The run no longer failed on empty deferred source_values or the overlay copy collision; it advanced to a separate generated-test issue around imported 3241(b) rate inputs.