### PR TITLE
Map 3201 oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.101"
+version = "0.2.102"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.101"
+__version__ = "0.2.102"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -981,6 +981,12 @@ mappings:
     comparison: money
     rationale: Same statutory other-case additional Medicare wage threshold, stored in PE as parameter data.
 
+  - legal_id: us:statutes/26/3201#tier_2_employee_tax
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine models employee FICA payroll taxes and excess payroll tax withheld, but not Railroad Retirement Tax Act section 3201(b) tier 2 employee tax or the section 3241 applicable percentage as a comparable output.
+
   - legal_id: us:statutes/26/3111/a#employer_oasdi_excise_tax_rate
     country: us
     program: tax

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1670,6 +1670,11 @@ def test_policyengine_registry_is_legal_id_keyed():
         employee_medicare_rate_mapping.policyengine_parameter
         == "gov.irs.payroll.medicare.rate.employee"
     )
+    rrta_tier_2_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/3201#tier_2_employee_tax",
+        country="us",
+    )
+    assert rrta_tier_2_mapping.mapping_type == "not_comparable"
     employer_medicare_rate_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/3111/b#hospital_insurance_employer_tax_rate",
         country="us",


### PR DESCRIPTION
## Summary
- mark 26 USC 3201(b) tier 2 employee tax as known-not-comparable for PolicyEngine oracle coverage
- add a registry assertion for the new mapping
- bump axiom-encode to 0.2.102

## Validation
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run axiom-encode oracle-coverage --root /tmp/axiom-rulespec-ci-3201 --json