### PR TITLE
Repair generated import list validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.102"
+version = "0.2.103"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.102"
+__version__ = "0.2.103"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10475,6 +10475,31 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_hashes = _try_repair_generated_proof_import_hashes_for_apply(
+                    result,
+                    output_root=args.output,
+                    policy_repo_path=policy_repo_path,
+                    issues=apply_issues,
+                )
+                if repaired_hashes:
+                    outcome["auto_repaired_proof_import_hashes"] = repaired_hashes
+                    print(
+                        "  apply=auto_repaired_proof_import_hashes:"
+                        + ",".join(repaired_hashes)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_test_cases = _try_repair_generated_zero_branch_tests_for_apply(
                     result,
                     output_root=args.output,
@@ -10898,6 +10923,43 @@ def _rulespec_rule_labels(rules: list[object]) -> list[str]:
         label = str(name).strip() if isinstance(name, str) and name.strip() else ""
         labels.append(label or f"rules[{index}]")
     return labels
+
+
+def _try_repair_generated_proof_import_hashes_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+    issues: list[str],
+) -> list[str]:
+    """Refresh stale proof import hashes in the generated target itself."""
+    if not any("Proof import hash mismatch" in str(issue) for issue in issues):
+        return []
+    try:
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    if not rules_file.exists():
+        return []
+    target_base = (
+        f"{_repo_jurisdiction_prefix(policy_repo_path)}:"
+        f"{_relative_rulespec_import_target(relative_output)}"
+    )
+    original = rules_file.read_text()
+    repaired, repair_count = _repair_proof_import_hashes(
+        original,
+        target_base=target_base,
+        rules_file=rules_file,
+        repo_path=policy_repo_path,
+    )
+    if repair_count <= 0 or repaired == original:
+        return []
+    rules_file.write_text(repaired)
+    return [f"hash[{index}]" for index in range(repair_count)]
 
 
 def _try_repair_generated_empty_deferred_source_values_for_apply(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -9787,7 +9787,10 @@ def _extract_import_paths_from_content(content: str) -> list[str]:
             continue
 
         indent = len(line) - len(line.lstrip())
-        if indent <= imports_indent:
+        top_level_sequence_item = (
+            indent == imports_indent and IMPORT_ITEM_PATTERN.match(line)
+        )
+        if indent <= imports_indent and not top_level_sequence_item:
             in_imports = False
             continue
 
@@ -13744,7 +13747,10 @@ class ValidatorPipeline:
                 continue
 
             indent = len(line) - len(line.lstrip())
-            if indent <= imports_indent:
+            top_level_sequence_item = (
+                indent == imports_indent and IMPORT_ITEM_PATTERN.match(line)
+            )
+            if indent <= imports_indent and not top_level_sequence_item:
                 in_imports = False
                 continue
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3410,6 +3410,82 @@ module:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_repairs_generated_proof_import_hashes(self, capsys, tmp_path):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        imported_file = args.policy_repo_path / "statutes/26/3241/b.yaml"
+        imported_file.parent.mkdir(parents=True)
+        imported_file.write_text("format: rulespec/v1\nrules: []\n")
+        expected_hash = _sha256_file(imported_file)
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path / "out" / "codex-test-model" / "statutes" / "26" / "3211.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+imports:
+- us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit
+rules:
+- name: employee_representative_tier_2_tax
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit
+          output: section_3211_and_3221_applicable_percentage_for_tax_unit
+          hash: sha256:old
+  versions:
+  - effective_from: '2026-01-01'
+    formula: compensation * section_3211_and_3221_applicable_percentage_for_tax_unit
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/26/3211.yaml"
+        hash_issue = (
+            "statutes/26/3211.yaml: ci: Proof import hash mismatch: "
+            "`employee_representative_tier_2_tax` proof atom 0 imports "
+            "`us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit` "
+            "with `hash: sha256:old`."
+        )
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (False, [hash_issue], {}),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert "apply=auto_repaired_proof_import_hashes:hash[0]" in output
+        assert "hash: sha256:old" not in output_file.read_text()
+        assert f"hash: sha256:{expected_hash}" in output_file.read_text()
+        assert mock_overlay.call_count == 2
+        mock_apply.assert_called_once()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_proof_import_hashes"] == ["hash[0]"]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_repairs_person_scoped_rate_base(self, capsys, tmp_path):
         args = self._make_args(tmp_path, backend="codex", sync=False)
         args.apply = True

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6082,6 +6082,60 @@ rules:
     assert any("statutes/26/3241" in issue for issue in issues)
 
 
+def test_cross_reference_numeric_placeholder_accepts_top_level_import_sequence(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "3211.yaml"
+    imported_file = repo / "statutes" / "26" / "3241" / "b.yaml"
+    rules_file.parent.mkdir(parents=True)
+    imported_file.parent.mkdir(parents=True, exist_ok=True)
+    imported_file.write_text(
+        """format: rulespec/v1
+rules:
+- name: section_3211_and_3221_applicable_percentage_for_tax_unit
+  kind: derived
+  entity: TaxUnit
+  dtype: Rate
+  period: Year
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 0.181
+"""
+    )
+    rules_file.write_text(
+        """format: rulespec/v1
+imports:
+- us:statutes/26/3241/b#section_3211_and_3221_applicable_percentage_for_tax_unit
+module:
+  summary: |-
+    (b) Tier 2 tax In addition to other taxes, there is hereby imposed on the
+    income of each employee representative a tax equal to the percentage
+    determined under section 3241 for any calendar year of the compensation
+    received during such calendar year by such employee representative.
+rules:
+- name: employee_representative_tier_2_tax
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  source: 26 USC 3211(b)
+  versions:
+  - effective_from: '2026-01-01'
+    formula: compensation * section_3211_and_3221_applicable_percentage_for_tax_unit
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_cross_reference_numeric_placeholders(rules_file)
+
+    assert issues == []
+
+
 def test_encoded_cross_reference_placeholder_allows_under_section_when_unencoded(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- recognize valid top-level YAML import sequences in RuleSpec import extraction
- auto-repair generated target proof import hashes during encode --apply
- add regressions for the 26 USC 3211 apply failure
- bump axiom-encode to 0.2.103

## Validation
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py::test_cross_reference_numeric_placeholder_rejects_locally_supplied_rates tests/test_rulespec_validation.py::test_cross_reference_numeric_placeholder_accepts_top_level_import_sequence tests/test_cli.py::TestCmdEncode::test_encode_apply_repairs_generated_proof_import_hashes
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/