### PR TITLE
Repair deferred output citation paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.103"
+version = "0.2.104"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.103"
+__version__ = "0.2.104"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -11068,6 +11068,13 @@ def _qualify_deferred_output_subsection_paths(
         reason = str(record.get("reason") or "")
         match = re.search(r"\b[Ss]ubsection\s*\(([A-Za-z0-9]+)\)", reason)
         if match is None:
+            match = re.search(
+                r"\b(?:[0-9A-Za-z]+\s+USC\s+|section\s+)"
+                r"[0-9A-Za-z.-]+\s*\(([A-Za-z0-9]+)\)",
+                reason,
+                flags=re.IGNORECASE,
+            )
+        if match is None:
             continue
         subsection = match.group(1).strip()
         symbol = output.rsplit("#", 1)[1].strip()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3504,7 +3504,7 @@ module:
     corpus_citation_path: us/statute/26/3201
   deferred_outputs:
     - output: us:statutes/26/3201#a#tier_1_income_tax
-      reason: Subsection (a) depends on section 3101 rates.
+      reason: 26 USC 3201(a) depends on section 3101 rates.
       source_values: []
 rules:
   - name: tier_2_income_tax_rate


### PR DESCRIPTION
## Summary
- qualify deferred outputs when their reason cites a legal subsection like 26 USC 3211(a)
- keep the existing subsection-word repair path
- bump axiom-encode to 0.2.104

## Validation
- uv run --extra dev python -m pytest tests/test_cli.py::TestCmdEncode::test_encode_apply_repairs_person_scoped_rate_base
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/