### PR TITLE
Fix RuleSpec test aliases

### DIFF
--- a/changelog.d/rulespec-test-cli-alias.fixed.md
+++ b/changelog.d/rulespec-test-cli-alias.fixed.md
@@ -1,0 +1,1 @@
+Fixed `axiom-encode test` for temporary RuleSpec checkouts whose directory name differs from the canonical repository name, and classified 26 USC 3211(b) RRTA tier 2 employee-representative tax as not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.104"
+version = "0.2.105"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.104"
+__version__ = "0.2.105"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -66,6 +66,8 @@ from .harness.evals import (
 from .harness.proof_validator import validate_rulespec_proofs
 from .harness.validator_pipeline import (
     ValidatorPipeline,
+    _canonical_rulespec_compile_path,
+    _rulespec_public_item_keys,
     find_proof_import_reference_issues,
     find_tax_filing_status_local_input_issues,
     find_tax_status_component_local_input_issues,
@@ -1795,6 +1797,7 @@ def cmd_test(args):
                 env=rulespec_env,
                 tmp_path=tmp_path,
                 compiled_cache=compiled_cache,
+                policy_repo_path=root,
             )
             case_count += result["cases"]
             compiled_count += result["compiled"]
@@ -1897,6 +1900,7 @@ def _execute_rulespec_test_file(
     env: dict[str, str],
     tmp_path: Path,
     compiled_cache: dict[Path, tuple[Path, dict]],
+    policy_repo_path: Path | None = None,
 ) -> dict:
     failures: list[dict[str, str | None]] = []
     program_file = _rulespec_program_for_test_file(test_file)
@@ -1916,13 +1920,18 @@ def _execute_rulespec_test_file(
     compiled = compiled_cache.get(program_file)
     compiled_count = 0
     if compiled is None:
+        compile_file = (
+            _canonical_rulespec_compile_path(program_file, policy_repo_path)
+            if policy_repo_path is not None
+            else program_file
+        )
         compiled_path = tmp_path / (_safe_artifact_stem(program_file) + ".json")
         result = subprocess.run(
             [
                 str(binary),
                 "compile",
                 "--program",
-                str(program_file),
+                str(compile_file),
                 "--output",
                 str(compiled_path),
             ],
@@ -1951,21 +1960,28 @@ def _execute_rulespec_test_file(
 
     compiled_path, artifact = compiled
     cases = _load_rulespec_test_cases(test_file)
-    parameter_by_id = {
-        parameter.get("id"): parameter
-        for parameter in artifact.get("program", {}).get("parameters", [])
-        if isinstance(parameter, dict) and parameter.get("id")
-    }
-    derived_ids = {
-        derived.get("id")
-        for derived in artifact.get("program", {}).get("derived", [])
-        if isinstance(derived, dict) and derived.get("id")
-    }
-    derived_by_id = {
-        str(derived.get("id")): derived
-        for derived in artifact.get("program", {}).get("derived", [])
-        if isinstance(derived, dict) and derived.get("id")
-    }
+    item_policy_repo_path = (
+        policy_repo_path or find_policy_repo_root(program_file) or program_file.parent
+    )
+    parameter_by_id: dict[str, dict] = {}
+    for parameter in artifact.get("program", {}).get("parameters", []):
+        if not isinstance(parameter, dict) or not parameter.get("id"):
+            continue
+        for key in _rulespec_public_item_keys(
+            parameter,
+            policy_repo_path=item_policy_repo_path,
+        ):
+            parameter_by_id[key] = parameter
+    derived_by_id: dict[str, dict] = {}
+    for derived in artifact.get("program", {}).get("derived", []):
+        if not isinstance(derived, dict) or not derived.get("id"):
+            continue
+        for key in _rulespec_public_item_keys(
+            derived,
+            policy_repo_path=item_policy_repo_path,
+        ):
+            derived_by_id[key] = derived
+    derived_ids = set(derived_by_id)
 
     for index, case in enumerate(cases):
         case_name = str(case.get("name") or f"case_{index}")
@@ -2233,6 +2249,10 @@ def _execute_rulespec_test_case(
         )
         return failures
 
+    runtime_output_by_expected = {
+        output: str(derived_by_id.get(output, {}).get("id") or output)
+        for output in derived_expected
+    }
     request = {
         "mode": "explain",
         "dataset": {"inputs": inputs, "relations": relations},
@@ -2240,7 +2260,7 @@ def _execute_rulespec_test_case(
             {
                 "entity_id": entity_id,
                 "period": period,
-                "outputs": list(derived_expected.keys()),
+                "outputs": list(runtime_output_by_expected.values()),
             }
             for entity_id in query_entity_ids
         ],
@@ -2269,7 +2289,8 @@ def _execute_rulespec_test_case(
         if isinstance(expected_value, list):
             for row_index, row_expected_value in enumerate(expected_value):
                 outputs = results[row_index]["outputs"]
-                actual = outputs.get(output)
+                runtime_output = runtime_output_by_expected[output]
+                actual = outputs.get(output) or outputs.get(runtime_output)
                 if actual is None:
                     failures.append(
                         {
@@ -2293,7 +2314,8 @@ def _execute_rulespec_test_case(
                     )
             continue
         outputs = results[0]["outputs"]
-        actual = outputs.get(output)
+        runtime_output = runtime_output_by_expected[output]
+        actual = outputs.get(output) or outputs.get(runtime_output)
         if actual is None:
             failures.append(
                 {
@@ -8718,6 +8740,7 @@ def _rulespec_companion_test_failures(
             env=rulespec_env,
             tmp_path=Path(tmpdir),
             compiled_cache={},
+            policy_repo_path=root,
         )
     return list(result["failures"])
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -987,6 +987,12 @@ mappings:
     mapping_type: not_comparable
     rationale: PolicyEngine models employee FICA payroll taxes and excess payroll tax withheld, but not Railroad Retirement Tax Act section 3201(b) tier 2 employee tax or the section 3241 applicable percentage as a comparable output.
 
+  - legal_id: us:statutes/26/3211#tier_2_employee_representative_tax
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine models employee FICA payroll taxes and excess payroll tax withheld, but not Railroad Retirement Tax Act section 3211(b) tier 2 employee-representative tax or the section 3241 applicable percentage as a comparable output.
+
   - legal_id: us:statutes/26/3111/a#employer_oasdi_excise_tax_rate
     country: us
     program: tax

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2264,6 +2264,119 @@ rules:
             assert roots[:2] == [str(repo.resolve()), str(repo.resolve().parent)]
             assert str(stale_repo) in roots
 
+    def test_executes_companion_tests_from_canonical_alias_checkout(
+        self, capsys, monkeypatch, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us-clean.abcd"
+        rules_file = repo / "statutes/1/alias.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2024-01-01'
+        formula: income + 1
+"""
+        )
+        rules_file.with_name("alias.test.yaml").write_text(
+            """- name: canonical_temp_checkout_output
+  period: 2026-01
+  input:
+    us:statutes/1/alias#input.income: 5
+  output:
+    us:statutes/1/alias#benefit: 6
+"""
+        )
+
+        engine_root = tmp_path / "axiom-rules-engine"
+        binary = engine_root / "target/debug/axiom-rules-engine"
+        compiled_ids: list[str] = []
+        compile_programs: list[Path] = []
+
+        def fake_binary(self):
+            return binary
+
+        def fake_run(cmd, **kwargs):
+            if len(cmd) >= 6 and cmd[:3] == ["git", "-C", str(repo)]:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout="https://github.com/TheAxiomFoundation/rulespec-us.git\n",
+                    stderr="",
+                )
+            if "compile" in cmd:
+                program_path = Path(cmd[cmd.index("--program") + 1])
+                compile_programs.append(program_path)
+                item_id = "us-clean.abcd:statutes/1/alias#benefit"
+                compiled_ids.append(item_id)
+                output_path = Path(cmd[cmd.index("--output") + 1])
+                output_path.write_text(
+                    json.dumps(
+                        {
+                            "program": {
+                                "parameters": [],
+                                "derived": [
+                                    {
+                                        "id": item_id,
+                                        "name": "benefit",
+                                        "entity": "Household",
+                                    }
+                                ],
+                            }
+                        }
+                    )
+                )
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if "run-compiled" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout=json.dumps(
+                        {
+                            "results": [
+                                {
+                                    "outputs": {
+                                        "us:statutes/1/alias#benefit": {
+                                            "kind": "scalar",
+                                            "value": {"kind": "integer", "value": 6},
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ),
+                    stderr="",
+                )
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        args = MagicMock()
+        args.root = repo
+        args.paths = []
+        args.json = True
+        args.axiom_rules_path = engine_root
+
+        monkeypatch.setattr(
+            "axiom_encode.harness.validator_pipeline.ValidatorPipeline._axiom_rules_binary",
+            fake_binary,
+        )
+        monkeypatch.setattr("axiom_encode.cli.subprocess.run", fake_run)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_test(args)
+
+        assert exc_info.value.code == 0
+        assert json.loads(capsys.readouterr().out)["success"] is True
+        assert compiled_ids == ["us-clean.abcd:statutes/1/alias#benefit"]
+        assert len(compile_programs) == 1
+        assert "rulespec-us" in compile_programs[0].parts
+        assert "rulespec-us-clean.abcd" not in str(compile_programs[0])
+
     def test_discovery_skips_axiom_dependency_tree(self, tmp_path):
         root = tmp_path / "workspace"
         valid_test = root / "statutes/1/1.test.yaml"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1675,6 +1675,11 @@ def test_policyengine_registry_is_legal_id_keyed():
         country="us",
     )
     assert rrta_tier_2_mapping.mapping_type == "not_comparable"
+    rrta_employee_representative_tier_2_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/3211#tier_2_employee_representative_tax",
+        country="us",
+    )
+    assert rrta_employee_representative_tier_2_mapping.mapping_type == "not_comparable"
     employer_medicare_rate_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/3111/b#hospital_insurance_employer_tax_rate",
         country="us",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.96"
+version = "0.2.105"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- route standalone `axiom-encode test` compiles through canonical RuleSpec checkout aliases
- index compiled outputs by public canonical IDs while querying the engine with runtime IDs
- classify 26 USC 3211(b) RRTA tier 2 employee-representative tax as not comparable to PolicyEngine
- bump axiom-encode to 0.2.105 and add a changelog fragment

## Tests
- `uv run --extra dev python -m pytest tests/test_cli.py::TestCmdTest tests/test_repo_routing.py tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed`
- `uv run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py tests/test_rulespec_validation.py`
- `uv run axiom-encode test --root /tmp/rulespec-us-26-3211 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine statutes/26/3211.test.yaml`
- `uv run axiom-encode test --root /tmp/rulespec-us-26-3211 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine statutes/26/3201.test.yaml`