### PR TITLE
Support employer-scoped generated rules

### DIFF
--- a/changelog.d/employer-entity.fixed.md
+++ b/changelog.d/employer-entity.fixed.md
@@ -1,0 +1,1 @@
+Added `Employer` as a supported RuleSpec entity for encoder prompts, repaired employer-imposed generated rules away from tax/business unit scope, and classified 26 USC 3221(b) RRTA tier 2 employer tax as not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.105"
+version = "0.2.106"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.105"
+__version__ = "0.2.106"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10445,6 +10445,34 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_employer_scoped_rules = (
+                    _try_repair_generated_employer_scope_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_employer_scoped_rules:
+                    outcome["auto_repaired_employer_scope"] = (
+                        repaired_employer_scoped_rules
+                    )
+                    print(
+                        "  apply=auto_repaired_employer_scope:"
+                        + ",".join(repaired_employer_scoped_rules)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_person_scoped_rules = (
                     _try_repair_generated_person_scoped_rate_base_for_apply(
                         result,
@@ -11117,6 +11145,9 @@ def _qualify_deferred_output_subsection_paths(
 _PERSON_SCOPE_RATE_BASE_ISSUE_PATTERN = re.compile(
     r"Person-scoped rate base at unit scope: `([^`]+)`"
 )
+_EMPLOYER_SCOPE_ISSUE_PATTERN = re.compile(
+    r"Employer-scoped rule at non-employer scope: `([^`]+)`"
+)
 _RULESPEC_IDENTIFIER_PATTERN = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")
 _RULESPEC_FORMULA_BUILTINS = {
     "abs",
@@ -11149,6 +11180,95 @@ _UNIT_ENTITY_NAMES = {
     "spmunit",
     "taxunit",
 }
+
+
+def _try_repair_generated_employer_scope_for_apply(
+    result,
+    *,
+    output_root: Path,
+    issues: list[str],
+) -> list[str]:
+    """Move generated employer-imposed rules to the Employer entity."""
+    target_names = _employer_scope_issue_names(issues)
+    if not target_names:
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    return _repair_employer_scoped_entities(
+        rules_file=rules_file,
+        target_names=target_names,
+    )
+
+
+def _employer_scope_issue_names(issues: list[str]) -> list[str]:
+    names: list[str] = []
+    for issue in issues:
+        match = _EMPLOYER_SCOPE_ISSUE_PATTERN.search(str(issue))
+        if match is not None:
+            names.append(match.group(1))
+    return names
+
+
+def _repair_employer_scoped_entities(
+    *,
+    rules_file: Path,
+    target_names: list[str],
+) -> list[str]:
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    by_name = {
+        str(rule.get("name")).strip(): rule
+        for rule in rules
+        if isinstance(rule, dict)
+        and isinstance(rule.get("name"), str)
+        and str(rule.get("name")).strip()
+    }
+    repaired: list[str] = []
+    for target_name in target_names:
+        target_rule = by_name.get(target_name)
+        if not isinstance(target_rule, dict):
+            continue
+        if _set_rule_entity_to_employer(target_rule):
+            repaired.append(target_name)
+        formula = _first_rule_formula(target_rule)
+        for identifier in sorted(_formula_identifiers(formula)):
+            helper = by_name.get(identifier)
+            if not isinstance(helper, dict):
+                continue
+            if str(helper.get("dtype") or "").strip().lower() != "rate":
+                continue
+            if _set_rule_entity_to_employer(helper):
+                repaired.append(identifier)
+
+    if not repaired:
+        return []
+
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repaired
+
+
+def _set_rule_entity_to_employer(rule: dict[str, object]) -> bool:
+    entity = str(rule.get("entity") or "").strip()
+    if entity == "Employer":
+        return False
+    if entity.replace("_", "").lower() not in {*_UNIT_ENTITY_NAMES, "corporation"}:
+        return False
+    rule["entity"] = "Employer"
+    return True
 
 
 def _try_repair_generated_person_scoped_rate_base_for_apply(

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -91,6 +91,7 @@ SUPPORTED_EVAL_ENTITIES = (
     "SPMUnit",
     "Corporation",
     "Business",
+    "Employer",
     "Asset",
 )
 SUPPORTED_EVAL_PERIODS = ("Year", "Month", "Week", "Day")
@@ -3132,9 +3133,12 @@ RuleSpec requirements:
 - Use `kind: derived_relation` only when the source text explicitly defines
   membership in a derived legal unit by filtering a source relation through a
   stated predicate. "This source is about SNAP" is not enough. If the source
-  uses an existing structural entity such as `Household`, `TaxUnit`, or
-  `Person`, and merely references a program-specific concept without defining
+  uses an existing structural entity such as `Household`, `TaxUnit`, `Employer`,
+  or `Person`, and merely references a program-specific concept without defining
   who belongs to it, stay on the source-stated structural entity.
+- For source text that imposes an amount, tax, credit, or limitation on each,
+  every, or any employer, use `entity: Employer`. Do not default to `TaxUnit`
+  merely because the output is tax-related.
 - Keep the membership predicate as an ordinary source-backed rule, then define
   the filtered entity under `derived_relation:` with `arity`, `source_relation`,
   `entity`, `member_relation`, `slot_entities`, and a `versions[].formula` that

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -4704,6 +4704,14 @@ _UNIT_SOURCE_ENTITY_PATTERNS = (
     ("family", re.compile(r"\bfamily\b(?!\s+member\b)", flags=re.IGNORECASE)),
     ("spmunit", re.compile(r"\bspm\s+unit\b", flags=re.IGNORECASE)),
 )
+_EMPLOYER_SCOPED_ENTITY_NAMES = {"business", "corporation", "taxunit"}
+_EMPLOYER_SCOPED_SOURCE_PATTERN = re.compile(
+    r"\b(?:each|every|any|an?|the)\s+employer\b"
+    r"|"
+    r"\bwith\s+respect\s+to\s+(?:having\s+individuals\s+in\s+his\s+employ|"
+    r"any\s+employer|an?\s+employer)\b",
+    flags=re.IGNORECASE,
+)
 _HOUSEHOLD_MEMBER_MIXED_SCOPE_PATTERN = re.compile(
     r"\bhousehold\b(?!\s+member\b)[\s\S]{0,180}"
     r"\b(?:each|every|all|no)\s+(?:household\s+)?member\b",
@@ -5014,6 +5022,41 @@ def find_person_scoped_rate_base_unit_issues(content: str) -> list[str]:
             "subject. Encode the rate-applied amount at that lower entity "
             "first, then aggregate through an explicit relation; do not "
             "multiply a unit-level placeholder or aggregate base by the rate."
+        )
+    return issues
+
+
+def find_employer_scoped_entity_issues(content: str) -> list[str]:
+    """Flag employer-imposed rules that are broadened to tax/business units."""
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+    source_text = extract_embedded_source_text(content)
+    if not source_text:
+        source_text = _extract_source_verification_text(content)
+    if not source_text:
+        return []
+
+    issues: list[str] = []
+    for name, kind, _formula, rule_source, rule in _rulespec_rule_formula_rule_records(
+        payload
+    ):
+        if kind != "derived":
+            continue
+        entity = str(rule.get("entity") or "").strip()
+        if entity.lower() not in _EMPLOYER_SCOPED_ENTITY_NAMES:
+            continue
+        scoped_source_text = " ".join(_rule_proof_source_excerpts(rule))
+        if not scoped_source_text:
+            scoped_source_text = _source_text_for_rule_source(source_text, rule_source)
+        if not _EMPLOYER_SCOPED_SOURCE_PATTERN.search(scoped_source_text):
+            continue
+        issues.append(
+            "Employer-scoped rule at non-employer scope: "
+            f"`{name}` is declared on `{entity}`, but the source text imposes "
+            "the amount, tax, credit, or limitation on an employer. Use "
+            "`entity: Employer` instead of broadening it to a tax, business, "
+            "or corporate unit."
         )
     return issues
 
@@ -13460,6 +13503,7 @@ class ValidatorPipeline:
         issues.extend(find_source_condition_coverage_issues(content))
         issues.extend(find_filtered_entity_dependency_issues(content))
         issues.extend(find_source_scope_consistency_issues(content))
+        issues.extend(find_employer_scoped_entity_issues(content))
         issues.extend(find_person_scoped_rate_base_unit_issues(content))
         issues.extend(find_helper_only_definition_issues(content))
         issues.extend(find_deferred_output_issues(content))

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -993,6 +993,12 @@ mappings:
     mapping_type: not_comparable
     rationale: PolicyEngine models employee FICA payroll taxes and excess payroll tax withheld, but not Railroad Retirement Tax Act section 3211(b) tier 2 employee-representative tax or the section 3241 applicable percentage as a comparable output.
 
+  - legal_id: us:statutes/26/3221#tier_2_employer_tax
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine models employer FICA payroll taxes, but not Railroad Retirement Tax Act section 3221(b) tier 2 employer tax or the section 3241 applicable percentage as a comparable output.
+
   - legal_id: us:statutes/26/3111/a#employer_oasdi_excise_tax_rate
     country: us
     program: tax

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -110,9 +110,12 @@ Hard requirements:
 - Use `kind: derived_relation` only when the source text explicitly defines
   membership in a derived legal unit by filtering a source relation through a
   stated predicate. "This source is about SNAP" is not enough. If the source
-  uses an existing structural entity such as `Household`, `TaxUnit`, or
-  `Person`, and merely references a program-specific concept without defining
+  uses an existing structural entity such as `Household`, `TaxUnit`, `Employer`,
+  or `Person`, and merely references a program-specific concept without defining
   who belongs to it, stay on the source-stated structural entity.
+- For source text that imposes an amount, tax, credit, or limitation on each,
+  every, or any employer, use `entity: Employer`. Do not default to `TaxUnit`
+  merely because the output is tax-related.
 - Keep the membership predicate as an ordinary source-backed rule, then define
   the filtered entity under `derived_relation:` with `arity`, `source_relation`,
   `entity`, `member_relation`, `slot_entities`, and a `versions[].formula` that

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,6 +31,7 @@ from axiom_encode.cli import (
     _has_zero_output_test,
     _insert_false_input_default,
     _local_factual_input_names_from_rules_content,
+    _repair_employer_scoped_entities,
     _repair_missing_source_proof_atoms,
     _repair_mixed_scalar_output_tests,
     _repair_section_151_imports,
@@ -3701,6 +3702,42 @@ rules:
         ]
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
+
+    def test_repair_employer_scoped_entities_sets_rate_helpers(self, tmp_path):
+        rules_file = tmp_path / "3221.yaml"
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: tier_2_employer_tax_rate
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: section_3211_and_3221_applicable_percentage_for_tax_unit
+  - name: tier_2_employer_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: compensation_paid * tier_2_employer_tax_rate
+"""
+        )
+
+        repaired = _repair_employer_scoped_entities(
+            rules_file=rules_file,
+            target_names=["tier_2_employer_tax"],
+        )
+
+        assert repaired == ["tier_2_employer_tax", "tier_2_employer_tax_rate"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert [rule["entity"] for rule in payload["rules"]] == [
+            "Employer",
+            "Employer",
+        ]
 
     def test_encode_apply_auto_repairs_generic_zero_branch_test(self, capsys, tmp_path):
         args = self._make_args(tmp_path, backend="codex", sync=False)

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3336,7 +3336,7 @@ class TestEvalPrompt:
         assert (
             "Allowed `entity:` values are `Payment`, `Person`, `TaxUnit`, `Household`, "
             "`Family`, `TanfUnit`, `SnapUnit`, `SPMUnit`, `Corporation`, `Business`, "
-            "`Asset`."
+            "`Employer`, `Asset`."
         ) in prompt
         assert "Allowed `period:` values are `Year`, `Month`, `Week`, `Day`." in prompt
         assert (

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -33,6 +33,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_current_year_final_amount_table_issues,
     find_deferred_output_issues,
     find_deprecated_source_url_issues,
+    find_employer_scoped_entity_issues,
     find_empty_rules_module_issues,
     find_entity_limited_aggregation_order_issues,
     find_exception_test_coverage_issues,
@@ -1680,6 +1681,11 @@ def test_policyengine_registry_is_legal_id_keyed():
         country="us",
     )
     assert rrta_employee_representative_tier_2_mapping.mapping_type == "not_comparable"
+    rrta_employer_tier_2_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/3221#tier_2_employer_tax",
+        country="us",
+    )
+    assert rrta_employer_tier_2_mapping.mapping_type == "not_comparable"
     employer_medicare_rate_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/3111/b#hospital_insurance_employer_tax_rate",
         country="us",
@@ -9014,6 +9020,56 @@ rules:
 """
 
     assert find_person_scoped_rate_base_unit_issues(content) == []
+
+
+def test_employer_scoped_entity_rejects_tax_unit():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    (b) Tier 2 tax In addition to other taxes, there is hereby imposed on every
+    employer an excise tax equal to the percentage determined under section 3241.
+rules:
+  - name: tier_2_employer_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3221(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: compensation_paid * applicable_percentage
+"""
+
+    issues = find_employer_scoped_entity_issues(content)
+
+    assert any(
+        "Employer-scoped rule at non-employer scope" in issue for issue in issues
+    )
+    assert "tier_2_employer_tax" in issues[0]
+    assert "TaxUnit" in issues[0]
+
+
+def test_employer_scoped_entity_accepts_employer():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    (b) Tier 2 tax In addition to other taxes, there is hereby imposed on every
+    employer an excise tax equal to the percentage determined under section 3241.
+rules:
+  - name: tier_2_employer_tax
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3221(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: compensation_paid * applicable_percentage
+"""
+
+    assert find_employer_scoped_entity_issues(content) == []
 
 
 def test_source_scope_consistency_checks_each_rule_independently():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.105"
+version = "0.2.106"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add `Employer` as a supported RuleSpec entity in encoder prompt/eval schema guidance
- reject and apply-repair employer-imposed generated rules that are incorrectly broadened to tax/business/corporate unit scope
- classify 26 USC 3221(b) RRTA tier 2 employer tax as not comparable to PolicyEngine and bump axiom-encode to 0.2.106

## Validation
- `uv run --extra dev ruff check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/cli.py tests/test_evals.py tests/test_rulespec_validation.py tests/test_cli.py`
- `uv run --extra dev ruff format --check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/cli.py tests/test_evals.py tests/test_rulespec_validation.py tests/test_cli.py`
- `uv run --extra dev python -m pytest tests/test_cli.py::TestCmdEncode::test_encode_apply_repairs_person_scoped_rate_base tests/test_cli.py::TestCmdEncode::test_repair_employer_scoped_entities_sets_rate_helpers tests/test_evals.py::TestEvalPrompt::test_build_eval_prompt_includes_supported_schema_enums tests/test_rulespec_validation.py::test_employer_scoped_entity_rejects_tax_unit tests/test_rulespec_validation.py::test_employer_scoped_entity_accepts_employer tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed`
- `uv run axiom-encode validate /tmp/rulespec-us-26-3221/statutes/26/3221.yaml --skip-reviewers` fails the existing generated 3221 output with the new employer-scope diagnostic, as intended
