### PR TITLE
Canonicalize shared statutory rate names

### DIFF
--- a/changelog.d/canonical-shared-rate-names.fixed.md
+++ b/changelog.d/canonical-shared-rate-names.fixed.md
@@ -1,0 +1,1 @@
+Canonicalized shared statutory applicable-percentage names that use section-prefixed local names, preserving helper suffixes such as `_by_ratio_band`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.107"
+version = "0.2.108"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.107"
+__version__ = "0.2.108"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -11177,7 +11177,7 @@ _EMPLOYER_SCOPE_ISSUE_PATTERN = re.compile(
     r"Employer-scoped rule at non-employer scope: `([^`]+)`"
 )
 _SHARED_STATUTORY_RATE_NAME_ISSUE_PATTERN = re.compile(
-    r"Shared statutory rate name uses consumer entity suffix: `([^`]+)`"
+    r"Shared statutory rate name [^:]+: `([^`]+)`"
 )
 _RULESPEC_IDENTIFIER_PATTERN = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")
 _RULESPEC_FORMULA_BUILTINS = {
@@ -11314,7 +11314,13 @@ def _neutral_shared_statutory_rate_name(
     section_refs = _section_refs_for_rate_name(name, source_text)
     if section_refs:
         prefix = "sections" if len(section_refs) > 1 else "section"
-        return "applicable_percentage_for_" + prefix + "_" + "_and_".join(section_refs)
+        return (
+            "applicable_percentage_for_"
+            + prefix
+            + "_"
+            + "_and_".join(section_refs)
+            + _shared_statutory_rate_helper_suffix(name)
+        )
     for suffix in (
         "_for_tax_unit",
         "_for_person",
@@ -11327,6 +11333,17 @@ def _neutral_shared_statutory_rate_name(
         if name.endswith(suffix):
             return name[: -len(suffix)]
     return None
+
+
+def _shared_statutory_rate_helper_suffix(name: str) -> str:
+    for suffix in (
+        "_by_average_account_benefits_ratio_band",
+        "_by_ratio_band",
+        "_by_band",
+    ):
+        if name.endswith(suffix):
+            return suffix
+    return ""
 
 
 def _shared_statutory_rate_source_text(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -4721,6 +4721,11 @@ _SHARED_STATUTORY_RATE_ENTITY_SUFFIX_PATTERN = re.compile(
     r"(?P<entity>tax_unit|person|employer|household|family|business|corporation)$",
     flags=re.IGNORECASE,
 )
+_SHARED_STATUTORY_RATE_SECTION_PREFIX_PATTERN = re.compile(
+    r"^section_\d{3,4}(?:_and_\d{3,4})*_applicable_percentage"
+    r"(?:_by_[A-Za-z0-9_]+)?$",
+    flags=re.IGNORECASE,
+)
 _HOUSEHOLD_MEMBER_MIXED_SCOPE_PATTERN = re.compile(
     r"\bhousehold\b(?!\s+member\b)[\s\S]{0,180}"
     r"\b(?:each|every|all|no)\s+(?:household\s+)?member\b",
@@ -5097,18 +5102,28 @@ def find_shared_statutory_rate_entity_suffix_name_issues(content: str) -> list[s
         if dtype not in {"rate", "decimal"}:
             continue
         name = str(rule.get("name") or "").strip()
-        match = _SHARED_STATUTORY_RATE_ENTITY_SUFFIX_PATTERN.match(name)
-        if match is None:
+        suffix_match = _SHARED_STATUTORY_RATE_ENTITY_SUFFIX_PATTERN.match(name)
+        section_prefix_match = _SHARED_STATUTORY_RATE_SECTION_PREFIX_PATTERN.match(name)
+        if suffix_match is None and section_prefix_match is None:
             continue
-        entity = match.group("entity").lower()
-        entity_label = entity.replace("_", " ")
-        if re.search(rf"\b{re.escape(entity_label)}s?\b", source_text, re.IGNORECASE):
-            continue
+        detail = (
+            "is framed as a section-prefixed local cross-reference name"
+            if section_prefix_match is not None
+            else ""
+        )
+        if suffix_match is not None:
+            entity = suffix_match.group("entity").lower()
+            entity_label = entity.replace("_", " ")
+            if re.search(
+                rf"\b{re.escape(entity_label)}s?\b", source_text, re.IGNORECASE
+            ):
+                continue
+            detail = f"ends with `_for_{entity}`"
         issues.append(
-            "Shared statutory rate name uses consumer entity suffix: "
-            f"`{name}` ends with `_for_{entity}`, but the source names a "
+            "Shared statutory rate name should use source-stated application: "
+            f"`{name}` {detail}, but the source names a "
             "statutory rate or percentage by section rather than by that "
-            "consumer entity. Name the output after the source-stated legal "
+            "local consumer or cross-reference. Name the output after the source-stated legal "
             "application, such as `applicable_percentage_for_section_...` or "
             "`applicable_percentage_for_sections_...`."
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3759,6 +3759,14 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: 2
+  - name: section_3211_3221_applicable_percentage_by_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_band
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          2: 0.181
   - name: section_3211_and_3221_applicable_percentage_for_tax_unit
     kind: derived
     entity: TaxUnit
@@ -3782,16 +3790,28 @@ rules:
             rules_file=rules_file,
             test_file=test_file,
             relative_output=Path("statutes/26/3241/b.yaml"),
-            target_names=["section_3211_and_3221_applicable_percentage_for_tax_unit"],
+            target_names=[
+                "section_3211_3221_applicable_percentage_by_ratio_band",
+                "section_3211_and_3221_applicable_percentage_for_tax_unit",
+            ],
         )
 
         assert repaired == [
+            "section_3211_3221_applicable_percentage_by_ratio_band"
+            "->applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band",
             "section_3211_and_3221_applicable_percentage_for_tax_unit"
-            "->applicable_percentage_for_sections_3211_b_and_3221_b"
+            "->applicable_percentage_for_sections_3211_b_and_3221_b",
         ]
         payload = yaml.safe_load(rules_file.read_text())
         assert payload["rules"][1]["name"] == (
+            "applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band"
+        )
+        assert payload["rules"][2]["name"] == (
             "applicable_percentage_for_sections_3211_b_and_3221_b"
+        )
+        assert (
+            "applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band"
+            in payload["rules"][2]["versions"][0]["formula"]
         )
         test_payload = yaml.safe_load(test_file.read_text())
         assert test_payload[0]["output"] == {

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -9094,10 +9094,36 @@ rules:
     issues = find_shared_statutory_rate_entity_suffix_name_issues(content)
 
     assert any(
-        "Shared statutory rate name uses consumer entity suffix" in issue
+        "Shared statutory rate name should use source-stated application" in issue
         for issue in issues
     )
     assert "section_3211_and_3221_applicable_percentage_for_tax_unit" in issues[0]
+
+
+def test_shared_statutory_rate_name_rejects_section_prefix_name():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    (b) Tax rate schedule | Average account benefits ratio | Applicable percentage
+    for sections 3211(b) and 3221(b) | Applicable percentage for section 3201(b)
+rules:
+  - name: section_3201_applicable_percentage
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: section_3201_applicable_percentage_by_ratio_band[average_account_benefits_ratio_band]
+"""
+
+    issues = find_shared_statutory_rate_entity_suffix_name_issues(content)
+
+    assert any(
+        "section-prefixed local cross-reference name" in issue for issue in issues
+    )
+    assert "section_3201_applicable_percentage" in issues[0]
 
 
 def test_shared_statutory_rate_name_accepts_source_stated_section_name():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.107"
+version = "0.2.108"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- extend shared statutory rate naming validation to section-prefixed local names like `section_3201_applicable_percentage`
- preserve helper suffixes such as `_by_ratio_band` when apply-time repair canonicalizes generated names
- bump axiom-encode to 0.2.108

## Validation
- `uv run --extra dev ruff check src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/cli.py tests/test_rulespec_validation.py tests/test_cli.py`
- `uv run --extra dev ruff format --check src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/cli.py tests/test_rulespec_validation.py tests/test_cli.py`
- `uv run --extra dev python -m pytest tests/test_rulespec_validation.py::test_shared_statutory_rate_name_rejects_tax_unit_suffix tests/test_rulespec_validation.py::test_shared_statutory_rate_name_rejects_section_prefix_name tests/test_rulespec_validation.py::test_shared_statutory_rate_name_accepts_source_stated_section_name tests/test_cli.py::TestCmdEncode::test_repair_shared_statutory_rate_names_updates_tests`
- `uv run axiom-encode validate /tmp/axiom-encode-3241b-neutral-apply-2/codex-gpt-5.3-codex-spark/statutes/26/3241/b.yaml --skip-reviewers` now fails the generated retry on the canonical shared-rate-name diagnostic, so apply repair can run before revalidation
