### PR TITLE
Repair all shared statutory rate names

### DIFF
--- a/changelog.d/repair-all-shared-rate-names.fixed.md
+++ b/changelog.d/repair-all-shared-rate-names.fixed.md
@@ -1,0 +1,1 @@
+Repaired all canonicalizable shared statutory rate names in a generated file once a shared-rate naming issue is detected.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.108"
+version = "0.2.109"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.108"
+__version__ = "0.2.109"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -11273,9 +11273,14 @@ def _repair_shared_statutory_rate_names(
         if not isinstance(rule, dict):
             continue
         name = str(rule.get("name") or "").strip()
-        if name not in targets:
-            continue
         new_name = _neutral_shared_statutory_rate_name(name, rule=rule, payload=payload)
+        if name not in targets and not _is_canonicalizable_shared_rate_name(
+            name,
+            new_name,
+            rule=rule,
+            payload=payload,
+        ):
+            continue
         if not new_name or new_name == name or new_name in replacements:
             continue
         rule["name"] = new_name
@@ -11302,6 +11307,26 @@ def _repair_shared_statutory_rate_names(
         )
 
     return [f"{old}->{new}" for old, new in replacements.items()]
+
+
+def _is_canonicalizable_shared_rate_name(
+    name: str,
+    new_name: str | None,
+    *,
+    rule: dict[str, object],
+    payload: dict[str, object],
+) -> bool:
+    if not new_name or new_name == name:
+        return False
+    dtype = str(rule.get("dtype") or "").strip().lower()
+    if dtype not in {"rate", "decimal"}:
+        return False
+    return bool(
+        _section_refs_for_rate_name(
+            name,
+            _shared_statutory_rate_source_text(rule=rule, payload=payload),
+        )
+    )
 
 
 def _neutral_shared_statutory_rate_name(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3791,7 +3791,6 @@ rules:
             test_file=test_file,
             relative_output=Path("statutes/26/3241/b.yaml"),
             target_names=[
-                "section_3211_3221_applicable_percentage_by_ratio_band",
                 "section_3211_and_3221_applicable_percentage_for_tax_unit",
             ],
         )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.108"
+version = "0.2.109"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair every canonicalizable shared statutory rate name in a generated file once shared-rate validation fires
- keep the repair scoped to Rate/Decimal rules whose section references are supported by source text
- bump axiom-encode to 0.2.109 and add a changelog fragment

## Validation
- uv run --extra dev python -m pytest tests/test_cli.py::TestCmdEncode::test_repair_shared_statutory_rate_names_updates_tests
- git diff --check