### PR TITLE
Repair generated table band scalars on apply

### DIFF
--- a/changelog.d/apply-table-band-scalar-repair.fixed.md
+++ b/changelog.d/apply-table-band-scalar-repair.fixed.md
@@ -1,0 +1,1 @@
+Repaired generated source-table interval bound parameters during apply validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.109"
+version = "0.2.110"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.109"
+__version__ = "0.2.110"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -74,6 +74,7 @@ from .harness.validator_pipeline import (
     find_unused_import_issues,
     repair_current_year_final_amount_tables,
     repair_nonnegative_amount_reductions,
+    repair_source_table_band_scalar_parameters,
 )
 from .oracles.policyengine.coverage import (
     build_policyengine_candidate_report,
@@ -10473,6 +10474,34 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_table_band_scalars = (
+                    _try_repair_generated_source_table_band_scalars_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_table_band_scalars:
+                    outcome["auto_repaired_source_table_band_scalars"] = (
+                        repaired_table_band_scalars
+                    )
+                    print(
+                        "  apply=auto_repaired_source_table_band_scalars:"
+                        + ",".join(repaired_table_band_scalars)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_shared_rate_names = (
                     _try_repair_generated_shared_statutory_rate_names_for_apply(
                         result,
@@ -11211,6 +11240,41 @@ _UNIT_ENTITY_NAMES = {
     "spmunit",
     "taxunit",
 }
+
+
+def _try_repair_generated_source_table_band_scalars_for_apply(
+    result,
+    *,
+    output_root: Path,
+    issues: list[str],
+) -> list[str]:
+    """Inline generated structural table bounds and remove public scalars."""
+    if not any(
+        "Source table row/band scalar parameters" in str(issue) for issue in issues
+    ):
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    if not rules_file.exists():
+        return []
+
+    try:
+        original_content = rules_file.read_text()
+    except OSError:
+        return []
+
+    repaired_content, repaired_rules = repair_source_table_band_scalar_parameters(
+        original_content
+    )
+    if repaired_content == original_content:
+        return []
+
+    rules_file.write_text(repaired_content)
+    return repaired_rules
 
 
 def _try_repair_generated_shared_statutory_rate_names_for_apply(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2518,7 +2518,8 @@ def repair_source_table_band_scalar_parameters(
     if not isinstance(rules, list):
         return content, []
 
-    bound_values: dict[str, str] = {}
+    direct_bound_values: dict[str, str] = {}
+    bound_aliases: dict[str, str] = {}
     for rule in rules:
         if not isinstance(rule, dict):
             continue
@@ -2530,6 +2531,22 @@ def repair_source_table_band_scalar_parameters(
         if not _is_source_table_structural_bound_parameter_name(name):
             continue
         value = _single_version_numeric_formula(rule)
+        if value is not None:
+            direct_bound_values[name] = value
+            continue
+        alias = _single_version_identifier_formula(rule)
+        if alias is not None:
+            bound_aliases[name] = alias
+
+    bound_values: dict[str, str] = {}
+    bound_names = set(direct_bound_values) | set(bound_aliases)
+    for name in bound_names:
+        value = _resolve_bound_parameter_value(
+            name,
+            direct_values=direct_bound_values,
+            aliases=bound_aliases,
+            bound_names=bound_names,
+        )
         if value is not None:
             bound_values[name] = value
 
@@ -3397,8 +3414,20 @@ def _is_source_table_structural_bound_parameter_name(name: str) -> bool:
         r"(?:^|_)(?:min|max|minimum|maximum)_(?:row|band|bracket)_\d+(?:_|$)",
         normalized,
     )
+    has_adjacent_lower_upper = re.search(
+        r"(?:^|_)(?:row|band|bracket)_\d+_(?:lower|upper)(?:_|$)",
+        normalized,
+    ) or re.search(
+        r"(?:^|_)(?:lower|upper)_(?:row|band|bracket)_\d+(?:_|$)",
+        normalized,
+    )
     return bool(
-        has_index and ((has_bound_word and has_structural_noun) or has_adjacent_min_max)
+        has_index
+        and (
+            (has_bound_word and has_structural_noun)
+            or has_adjacent_min_max
+            or has_adjacent_lower_upper
+        )
     )
 
 
@@ -3418,6 +3447,42 @@ def _single_version_numeric_formula(rule: dict[str, Any]) -> str | None:
         return str(formula)
     if isinstance(formula, str) and re.fullmatch(r"-?\d+(?:\.\d+)?", formula.strip()):
         return formula.strip()
+    return None
+
+
+def _single_version_identifier_formula(rule: dict[str, Any]) -> str | None:
+    versions = rule.get("versions")
+    if not isinstance(versions, list) or len(versions) != 1:
+        return None
+    version = versions[0]
+    if not isinstance(version, dict):
+        return None
+    formula = version.get("formula")
+    if not isinstance(formula, str):
+        return None
+    stripped = formula.strip()
+    if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", stripped):
+        return stripped
+    return None
+
+
+def _resolve_bound_parameter_value(
+    name: str,
+    *,
+    direct_values: dict[str, str],
+    aliases: dict[str, str],
+    bound_names: set[str],
+) -> str | None:
+    seen: set[str] = set()
+    current = name
+    while current not in seen:
+        seen.add(current)
+        if current in direct_values:
+            return direct_values[current]
+        alias = aliases.get(current)
+        if alias is None or alias not in bound_names:
+            return None
+        current = alias
     return None
 
 
@@ -3460,13 +3525,32 @@ def _parse_multiline_else_if_formula(
     formula: str,
 ) -> list[tuple[str | None, str]] | None:
     lines = [line.rstrip() for line in formula.strip().splitlines() if line.strip()]
-    if len(lines) < 4:
+    if len(lines) < 2:
         return None
 
     branches: list[tuple[str | None, str]] = []
     index = 0
     while index < len(lines):
         header = lines[index].strip()
+        inline_if_match = re.fullmatch(
+            r"(?:if|elif|else\s+if)\s+(.+?):\s*(.+)",
+            header,
+        )
+        if inline_if_match is not None:
+            result = inline_if_match.group(2).strip()
+            if not result or re.match(r"(?:elif|else\b)", result):
+                return None
+            branches.append((inline_if_match.group(1).strip(), result))
+            index += 1
+            continue
+        inline_else_match = re.fullmatch(r"else:\s*(.+)", header)
+        if inline_else_match is not None:
+            result = inline_else_match.group(1).strip()
+            if not result or re.match(r"(?:if|elif|else\b)", result):
+                return None
+            branches.append((None, result))
+            index += 1
+            break
         if_match = re.fullmatch(r"(?:if|elif|else\s+if)\s+(.+):", header)
         if if_match is not None:
             if index + 1 >= len(lines):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,7 @@ from axiom_encode.cli import (
     _sign_applied_encoding_manifest,
     _source_relation_preservation_issues,
     _suppress_rulespec_ancestor_targets_for_subsection_overlay,
+    _try_repair_generated_source_table_band_scalars_for_apply,
     _validate_generated_encoding_in_policy_overlay,
     _write_applied_encoding_manifest,
     cmd_calibration,
@@ -3816,6 +3817,72 @@ rules:
         assert test_payload[0]["output"] == {
             "us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b": 0.181
         }
+
+    def test_apply_repair_source_table_band_scalars_inlines_bounds(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "statutes" / "26" / "3241" / "b.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: |-
+    Tax rate schedule | Average account benefits ratio | Applicable percentage
+    | At least | But less than | Section 3201(b) |
+    | .............. | 2.5 | 4.9 |
+    | 2.5 | 3.0 | 4.9 |
+rules:
+  - name: average_account_benefits_ratio_band_1_upper
+    kind: parameter
+    dtype: Decimal
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2.5
+  - name: average_account_benefits_ratio_band_2_lower
+    kind: parameter
+    dtype: Decimal
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: average_account_benefits_ratio_band_1_upper
+  - name: average_account_benefits_ratio_band_2_upper
+    kind: parameter
+    dtype: Decimal
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3.0
+  - name: average_account_benefits_ratio_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if average_account_benefits_ratio < average_account_benefits_ratio_band_1_upper: 1
+          elif average_account_benefits_ratio >= average_account_benefits_ratio_band_2_lower and average_account_benefits_ratio < average_account_benefits_ratio_band_2_upper: 2
+          else: 3
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_source_table_band_scalars_for_apply(
+            result,
+            output_root=output_root,
+            issues=[
+                "Source table row/band scalar parameters: "
+                "`average_account_benefits_ratio_band_1_upper`"
+            ],
+        )
+
+        content = rules_file.read_text()
+        assert "average_account_benefits_ratio_band_1_upper" not in content
+        assert "average_account_benefits_ratio_band_2_upper" not in content
+        assert "average_account_benefits_ratio < 2.5" in content
+        assert "average_account_benefits_ratio < 3.0" in content
+        assert "average_account_benefits_ratio_band" in repaired
 
     def test_encode_apply_auto_repairs_generic_zero_branch_test(self, capsys, tmp_path):
         args = self._make_args(tmp_path, backend="codex", sync=False)

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -8059,6 +8059,62 @@ rules:
     assert find_source_table_row_scalar_parameter_issues(repaired) == []
 
 
+def test_repair_source_table_band_bound_scalars_inlines_adjacent_upper_aliases():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Tax rate schedule | Average account benefits ratio | Applicable percentage
+    | At least | But less than | Section 3201(b) |
+    | .............. | 2.5 | 4.9 |
+    | 2.5 | 3.0 | 4.9 |
+rules:
+  - name: average_account_benefits_ratio_band_1_upper
+    kind: parameter
+    dtype: Decimal
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2.5
+  - name: average_account_benefits_ratio_band_2_lower
+    kind: parameter
+    dtype: Decimal
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: average_account_benefits_ratio_band_1_upper
+  - name: average_account_benefits_ratio_band_2_upper
+    kind: parameter
+    dtype: Decimal
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3.0
+  - name: average_account_benefits_ratio_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if average_account_benefits_ratio < average_account_benefits_ratio_band_1_upper: 1
+          elif average_account_benefits_ratio >= average_account_benefits_ratio_band_2_lower and average_account_benefits_ratio < average_account_benefits_ratio_band_2_upper: 2
+          else: 3
+"""
+
+    repaired, repaired_rules = repair_source_table_band_scalar_parameters(content)
+
+    assert "average_account_benefits_ratio_band_1_upper" not in repaired
+    assert "average_account_benefits_ratio_band_2_lower" not in repaired
+    assert "average_account_benefits_ratio_band_2_upper" not in repaired
+    assert "average_account_benefits_ratio < 2.5" in repaired
+    assert ">= 2.5" in repaired
+    assert "average_account_benefits_ratio < 3.0" in repaired
+    assert "average_account_benefits_ratio_band" in repaired_rules
+    assert find_source_table_row_scalar_parameter_issues(repaired) == []
+
+
 def test_repair_source_table_band_bound_scalars_uses_external_table_text():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.109"
+version = "0.2.110"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- inline generated source-table interval bound parameters during apply validation
- recognize generated names like `band_1_upper` / `band_2_lower` and alias lower bounds to prior numeric bounds
- support one-line `if`/`elif`/`else` generated selector formulas when rewriting conditional chains
- bump axiom-encode to 0.2.110

## Validation
- uv run --extra dev ruff check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_rulespec_validation.py
- uv run --extra dev ruff format --check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_rulespec_validation.py
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py -k "source_table_band or source_table_row_scalar or table_band_bound"
- uv run --extra dev python -m pytest tests/test_cli.py::TestCmdEncode::test_apply_repair_source_table_band_scalars_inlines_bounds tests/test_cli.py::TestCmdEncode::test_repair_shared_statutory_rate_names_updates_tests
- git diff --check