### PR TITLE
Repair generated input field formulas

### DIFF
--- a/changelog.d/apply-input-field-formula-repair.fixed.md
+++ b/changelog.d/apply-input-field-formula-repair.fixed.md
@@ -1,0 +1,1 @@
+Repaired generated formula references like `input.foo` during apply validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.110"
+version = "0.2.111"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.110"
+__version__ = "0.2.111"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10474,6 +10474,34 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_input_field_accesses = (
+                    _try_repair_generated_input_field_access_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_input_field_accesses:
+                    outcome["auto_repaired_input_field_access"] = (
+                        repaired_input_field_accesses
+                    )
+                    print(
+                        "  apply=auto_repaired_input_field_access:"
+                        + ",".join(repaired_input_field_accesses)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_table_band_scalars = (
                     _try_repair_generated_source_table_band_scalars_for_apply(
                         result,
@@ -11208,6 +11236,9 @@ _EMPLOYER_SCOPE_ISSUE_PATTERN = re.compile(
 _SHARED_STATUTORY_RATE_NAME_ISSUE_PATTERN = re.compile(
     r"Shared statutory rate name [^:]+: `([^`]+)`"
 )
+_INPUT_FIELD_ACCESS_PATTERN = re.compile(
+    r"(?<![A-Za-z0-9_])input\.([A-Za-z_][A-Za-z0-9_]*)"
+)
 _RULESPEC_IDENTIFIER_PATTERN = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")
 _RULESPEC_FORMULA_BUILTINS = {
     "abs",
@@ -11240,6 +11271,66 @@ _UNIT_ENTITY_NAMES = {
     "spmunit",
     "taxunit",
 }
+
+
+def _try_repair_generated_input_field_access_for_apply(
+    result,
+    *,
+    output_root: Path,
+    issues: list[str],
+) -> list[str]:
+    """Rewrite generated `input.foo` formula accesses to local fact names."""
+    if not any(
+        "bare field access in scalar position" in str(issue) for issue in issues
+    ):
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    return _repair_input_field_accesses_in_formulas(rules_file=rules_file)
+
+
+def _repair_input_field_accesses_in_formulas(*, rules_file: Path) -> list[str]:
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    repaired: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        rule_name = str(rule.get("name") or "<unknown>").strip() or "<unknown>"
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        for version_index, version in enumerate(versions):
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            new_formula = _INPUT_FIELD_ACCESS_PATTERN.sub(r"\1", formula)
+            if new_formula == formula:
+                continue
+            version["formula"] = new_formula
+            repaired.append(f"{rule_name}:versions[{version_index}].formula")
+
+    if not repaired:
+        return []
+
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repaired
 
 
 def _try_repair_generated_source_table_band_scalars_for_apply(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,6 +32,7 @@ from axiom_encode.cli import (
     _insert_false_input_default,
     _local_factual_input_names_from_rules_content,
     _repair_employer_scoped_entities,
+    _repair_input_field_accesses_in_formulas,
     _repair_missing_source_proof_atoms,
     _repair_mixed_scalar_output_tests,
     _repair_section_151_imports,
@@ -3883,6 +3884,30 @@ rules:
         assert "average_account_benefits_ratio < 2.5" in content
         assert "average_account_benefits_ratio < 3.0" in content
         assert "average_account_benefits_ratio_band" in repaired
+
+    def test_repair_input_field_accesses_in_formulas(self, tmp_path):
+        rules_file = tmp_path / "statutes" / "26" / "3221.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: tier_2_employer_tax
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: applicable_percentage * max(0, input.compensation_paid)
+"""
+        )
+
+        repaired = _repair_input_field_accesses_in_formulas(rules_file=rules_file)
+
+        content = rules_file.read_text()
+        assert repaired == ["tier_2_employer_tax:versions[0].formula"]
+        assert "input.compensation_paid" not in content
+        assert "max(0, compensation_paid)" in content
 
     def test_encode_apply_auto_repairs_generic_zero_branch_test(self, capsys, tmp_path):
         args = self._make_args(tmp_path, backend="codex", sync=False)

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.110"
+version = "0.2.111"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair generated formula references like `input.foo` into local fact identifiers during apply validation
- trigger the repair on the rules-engine bare field access compile error
- bump axiom-encode to 0.2.111

## Validation
- uv run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run --extra dev ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- uv run --extra dev python -m pytest tests/test_cli.py::TestCmdEncode::test_repair_input_field_accesses_in_formulas tests/test_cli.py::TestCmdEncode::test_apply_repair_source_table_band_scalars_inlines_bounds tests/test_cli.py::TestCmdEncode::test_repair_shared_statutory_rate_names_updates_tests
- git diff --check