### PR TITLE
Repair multiline conditional formulas

### DIFF
--- a/changelog.d/multiline-conditional-repair.fixed.md
+++ b/changelog.d/multiline-conditional-repair.fixed.md
@@ -1,0 +1,1 @@
+Repair generated multiline `else if` conditional formulas whose branch result spans multiple lines.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.112"
+version = "0.2.113"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.112"
+__version__ = "0.2.113"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3528,6 +3528,26 @@ def _parse_multiline_else_if_formula(
     if len(lines) < 2:
         return None
 
+    def collect_block_result(start: int) -> tuple[str, int] | None:
+        result_lines: list[str] = []
+        index = start
+        while index < len(lines):
+            stripped = lines[index].strip()
+            if result_lines and re.fullmatch(
+                r"(?:if|elif|else\s+if)\s+.+?:|else:",
+                stripped,
+            ):
+                break
+            if not result_lines and re.match(r"(?:if|elif|else\b)", stripped):
+                return None
+            result_lines.append(stripped)
+            index += 1
+
+        result = " ".join(result_lines).strip()
+        if not result or re.match(r"(?:if|elif|else\b)", result):
+            return None
+        return result, index
+
     branches: list[tuple[str | None, str]] = []
     index = 0
     while index < len(lines):
@@ -3553,22 +3573,18 @@ def _parse_multiline_else_if_formula(
             break
         if_match = re.fullmatch(r"(?:if|elif|else\s+if)\s+(.+):", header)
         if if_match is not None:
-            if index + 1 >= len(lines):
+            collected = collect_block_result(index + 1)
+            if collected is None:
                 return None
-            result = lines[index + 1].strip()
-            if not result or re.match(r"(?:if|elif|else\b)", result):
-                return None
+            result, index = collected
             branches.append((if_match.group(1).strip(), result))
-            index += 2
             continue
         if header == "else:":
-            if index + 1 >= len(lines):
+            collected = collect_block_result(index + 1)
+            if collected is None:
                 return None
-            result = lines[index + 1].strip()
-            if not result or re.match(r"(?:if|elif|else\b)", result):
-                return None
+            result, index = collected
             branches.append((None, result))
-            index += 2
             break
         return None
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -950,6 +950,60 @@ rules:
     assert " else: if average_account_benefits_ratio >= " in formula
 
 
+def test_materialize_eval_artifact_repairs_multiline_conditional_branch(
+    tmp_path,
+):
+    output_file = tmp_path / "runner" / "statutes" / "26" / "1402" / "b.yaml"
+    llm_response = """=== FILE: b.yaml ===
+format: rulespec/v1
+module:
+  summary: Section defines self-employment income.
+rules:
+  - name: self_employment_income_for_section_1401_a
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if self_employment_income_excluded_as_nonresident_alien:
+            0
+          else if net_earnings_from_self_employment < minimum_self_employment_income_threshold:
+            0
+          else:
+            min(
+              max(0, net_earnings_from_self_employment),
+              max(
+                0,
+                contribution_and_benefit_base_under_section_230_of_social_security_act
+                  - wages_paid_to_individual_during_taxable_year
+              )
+            )
+"""
+
+    wrote = _materialize_eval_artifact(
+        llm_response,
+        output_file,
+        source_text="The OASDI base is reduced by wages paid during the year.",
+    )
+
+    assert wrote is True
+    payload = yaml.safe_load(output_file.read_text())
+    formula = payload["rules"][0]["versions"][0]["formula"]
+    assert "else if" not in formula
+    assert "elif" not in formula
+    assert (
+        "else: if net_earnings_from_self_employment "
+        "< minimum_self_employment_income_threshold: 0 else: min("
+    ) in formula
+    assert (
+        "contribution_and_benefit_base_under_section_230_of_social_security_act"
+        in formula
+    )
+
+
 def test_materialize_eval_artifact_preserves_open_interval_source_table_rows(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- extend generated `else if` repair to handle branch results that span multiple formula lines
- add a regression case matching the 26 USC 1402(b) generated OASDI cap formula shape
- bump axiom-encode to 0.2.113 and add changelog entry

## Validation
- `uv run ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py`
- `uv run --extra dev python -m pytest -q tests/test_evals.py -k "chained_conditionals or multiline_conditional_branch"`

## Context
This is a general encoder repair. It was exposed by 26 USC 1402(b), where the generated final conditional branch was a multiline `min(max(...), max(...))` expression.