### PR TITLE
Avoid current-title inference for named-act crossrefs

### DIFF
--- a/changelog.d/named-act-crossrefs.fixed.md
+++ b/changelog.d/named-act-crossrefs.fixed.md
@@ -1,0 +1,1 @@
+Avoid mapping named-act section references without an explicit USC title to the current title during placeholder validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.113"
+version = "0.2.114"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.113"
+__version__ = "0.2.114"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -10730,6 +10730,23 @@ def _title_qualified_reference_for_section(
     return None
 
 
+def _section_reference_to_named_act_without_title(
+    section: str,
+    source_text: str,
+) -> bool:
+    """Return whether source cites `section X of the Some Act` without USC title."""
+    return (
+        re.search(
+            rf"\bsection\s+{re.escape(section)}(?:\([^)]+\))*\s+of\s+"
+            r"(?:the\s+)?(?!title\s+\d+\b)"
+            r"[A-Z][A-Za-z0-9'&.-]*(?:\s+[A-Z][A-Za-z0-9'&.-]*){0,8}\s+Act\b",
+            source_text,
+            flags=re.IGNORECASE,
+        )
+        is not None
+    )
+
+
 def _is_exception_identifier(identifier: str) -> bool:
     normalized = identifier.lower()
     return any(
@@ -14553,6 +14570,8 @@ class ValidatorPipeline:
                 continue
             break
         section = match.group("section")
+        if _section_reference_to_named_act_without_title(section, source_text):
+            return None
         target_title = (
             _title_qualified_reference_for_section(section, source_text) or title
         )
@@ -14614,6 +14633,8 @@ class ValidatorPipeline:
             )
             and citation.lower() not in source_text.lower()
         ):
+            return None
+        if _section_reference_to_named_act_without_title(section, source_text):
             return None
         target_title = (
             _title_qualified_reference_for_section(section, source_text) or title

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -4972,6 +4972,45 @@ rules:
     assert "statutes/26/556" not in issues[0]
 
 
+def test_cross_reference_placeholder_does_not_infer_current_title_for_named_act(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "1402" / "b.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    The term self-employment income means net earnings derived by an individual
+    other than a nonresident alien individual, except as provided by an
+    agreement under section 233 of the Social Security Act.
+rules:
+  - name: self_employment_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if (
+            nonresident_alien_individual
+            and not agreement_under_section_233_of_social_security_act_applies
+          ): 0 else: net_earnings_from_self_employment
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_cross_reference_exception_placeholders(rules_file)
+
+    assert issues == []
+
+
 def test_cross_reference_placeholder_allows_current_section_helpers(tmp_path):
     repo = tmp_path / "rulespec-us"
     rules_file = repo / "statutes" / "26" / "22.yaml"


### PR DESCRIPTION
## Summary
- avoid mapping references like `section 233 of the Social Security Act` to the current USC title during placeholder validation
- preserve explicit `section X of title Y` handling
- add a regression case from the generated 26 USC 1402(b) surface
- bump axiom-encode to 0.2.114 and add changelog entry

## Validation
- `uv run ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `uv run ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest -q tests/test_rulespec_validation.py -k "cross_reference_placeholder_uses_explicit_usc_title or named_act"`

## Context
This was exposed by 26 USC 1402(b): the validator told the encoder to import `statutes/26/233` for a Social Security Act reference, which is the wrong title inference.