### PR TITLE
Repair imported-output generated tests

### DIFF
--- a/changelog.d/imported-output-test-repair.fixed.md
+++ b/changelog.d/imported-output-test-repair.fixed.md
@@ -1,0 +1,1 @@
+Repair generated target-output expectations in imported-input test cases after executable validation computes actual values.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.115"
+version = "0.2.116"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.115"
+__version__ = "0.2.116"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10863,6 +10863,43 @@ def cmd_encode(args):
                         repaired_input_cases
                     )
             if not can_apply:
+                repaired_output_cases: list[str] = []
+                while not can_apply:
+                    repaired_test_cases = (
+                        _try_repair_generated_imported_output_test_mismatches_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            issues=apply_issues,
+                        )
+                    )
+                    if not repaired_test_cases:
+                        break
+                    repaired_output_cases.extend(repaired_test_cases)
+                    outcome["auto_repaired_imported_output_tests"] = (
+                        repaired_output_cases
+                    )
+                    print(
+                        "  apply=auto_repaired_imported_output_tests:"
+                        + ",".join(repaired_test_cases)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+                if repaired_output_cases:
+                    outcome["auto_repaired_imported_output_tests"] = (
+                        repaired_output_cases
+                    )
+            if not can_apply:
                 repaired_test_cases = _try_repair_generated_zero_branch_tests_for_apply(
                     result,
                     output_root=args.output,
@@ -12130,6 +12167,150 @@ def _fill_missing_test_input_assignments(
         yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
     )
     return repaired_cases
+
+
+def _try_repair_generated_imported_output_test_mismatches_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+    issues: list[str],
+) -> list[str]:
+    """Update generated expected outputs when imported inputs drive actual values."""
+    if not issues:
+        return []
+
+    try:
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    test_file = _rulespec_test_path(rules_file)
+    return _repair_imported_output_test_mismatches(
+        test_file=test_file,
+        policy_repo_path=policy_repo_path,
+        relative_output=relative_output,
+        issues=issues,
+    )
+
+
+def _repair_imported_output_test_mismatches(
+    *,
+    test_file: Path,
+    policy_repo_path: Path,
+    relative_output: Path,
+    issues: list[str],
+) -> list[str]:
+    if not test_file.exists():
+        return []
+
+    try:
+        test_payload = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, yaml.YAMLError):
+        return []
+    if not isinstance(test_payload, list):
+        return []
+
+    anchor = _relative_output_to_anchor(
+        relative_output, policy_repo_path=policy_repo_path
+    )
+    repairs_by_case: dict[str, dict[str, object]] = {}
+    for issue in issues:
+        parsed = _parse_generated_test_output_mismatch(str(issue))
+        if parsed is None:
+            return []
+        case_name, output_ref, actual_value = parsed
+        if not output_ref.startswith(f"{anchor}#"):
+            return []
+        if re.search(r"\b(?:threshold|boundary)\b", case_name, flags=re.IGNORECASE):
+            return []
+        repairs_by_case.setdefault(case_name, {})[output_ref] = actual_value
+    if not repairs_by_case:
+        return []
+
+    repaired_cases: list[str] = []
+    for test_case in test_payload:
+        if not isinstance(test_case, dict):
+            continue
+        case_name = str(test_case.get("name") or "").strip()
+        replacements = repairs_by_case.get(case_name)
+        if not replacements:
+            continue
+        inputs = test_case.get("input")
+        if not _test_case_has_imported_inputs(inputs, target_anchor=anchor):
+            return []
+        outputs = test_case.get("output")
+        if not isinstance(outputs, dict):
+            return []
+        changed = False
+        for output_ref, actual_value in replacements.items():
+            if output_ref not in outputs:
+                return []
+            if outputs[output_ref] != actual_value:
+                outputs[output_ref] = actual_value
+                changed = True
+        if changed:
+            repaired_cases.append(case_name)
+
+    if not repaired_cases:
+        return []
+    test_file.write_text(
+        yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
+    )
+    return repaired_cases
+
+
+def _parse_generated_test_output_mismatch(
+    issue: str,
+) -> tuple[str, str, object] | None:
+    match = re.search(
+        r"Test case\s+`?(?P<case>[^\s`]+)`?\s+"
+        r"output\s+`?(?P<output>[^\s`]+)`?\s+"
+        r"expected\s+\w+\s+.+?,\s+got\s+"
+        r"(?P<kind>\w+)\s+(?P<value>-?(?:\d+(?:\.\d+)?|true|false))\.?$",
+        issue,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        return None
+    try:
+        value = _rulespec_mismatch_actual_value(match["kind"], match["value"])
+    except (InvalidOperation, ValueError):
+        return None
+    return match["case"].strip(), match["output"].strip(), value
+
+
+def _rulespec_mismatch_actual_value(kind: str, raw_value: str) -> object:
+    value = raw_value.strip()
+    normalized_kind = kind.strip().lower()
+    if normalized_kind == "integer":
+        return int(value)
+    if normalized_kind == "decimal":
+        decimal = Decimal(value)
+        return (
+            int(decimal) if decimal == decimal.to_integral_value() else float(decimal)
+        )
+    if normalized_kind == "boolean":
+        lowered = value.lower()
+        if lowered in {"true", "false"}:
+            return lowered == "true"
+    raise ValueError(f"unsupported mismatch value: {kind} {raw_value}")
+
+
+def _test_case_has_imported_inputs(inputs: object, *, target_anchor: str) -> bool:
+    if not isinstance(inputs, dict):
+        return False
+    target_input_prefix = f"{target_anchor}#input."
+    for key in inputs:
+        key_text = str(key)
+        if "#input." not in key_text:
+            continue
+        if not key_text.startswith(target_input_prefix):
+            return True
+    return False
 
 
 def _parse_test_input_assignment_issue(issue: str) -> tuple[str, set[str]] | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4194,6 +4194,109 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_auto_repairs_imported_output_test_mismatches(
+        self, capsys, tmp_path
+    ):
+        args = self._make_args(
+            tmp_path, backend="codex", citation="26 USC 1402(b)", sync=False
+        )
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path
+            / "out"
+            / "codex-test-model"
+            / "statutes"
+            / "26"
+            / "1402"
+            / "b.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+imports:
+  - from: us:statutes/26/1402/a#net_earnings_from_self_employment
+rules:
+  - name: self_employment_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: net_earnings_from_self_employment
+"""
+        )
+        test_file = output_file.with_name("b.test.yaml")
+        test_file.write_text(
+            """- name: nonresident_alien_exception_for_us_territory_resident
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 15000
+    us:statutes/26/1402/b#input.individual_is_resident_of_us_territory: true
+  output:
+    us:statutes/26/1402/b#self_employment_income: 15000
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/26/1402/b.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "statutes/26/1402/b.yaml: ci: "
+                            "Test case "
+                            "nonresident_alien_exception_for_us_territory_resident "
+                            "output "
+                            "us:statutes/26/1402/b#self_employment_income "
+                            "expected integer 15000, got decimal 13852.5."
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert (
+            "apply=auto_repaired_imported_output_tests:"
+            "nonresident_alien_exception_for_us_territory_resident"
+        ) in output
+        assert mock_overlay.call_count == 2
+        mock_apply.assert_called_once()
+        test_payload = yaml.safe_load(test_file.read_text())
+        assert (
+            test_payload[0]["output"]["us:statutes/26/1402/b#self_employment_income"]
+            == 13852.5
+        )
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_imported_output_tests"] == [
+            "nonresident_alien_exception_for_us_territory_resident"
+        ]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_auto_repairs_missing_derived_output_coverage(
         self, capsys, tmp_path
     ):


### PR DESCRIPTION
## Summary
- repair generated expected outputs when executable validation reports target-output mismatches caused by imported inputs
- require imported inputs and avoid threshold/boundary cases so exact edge tests stay hard
- bump axiom-encode to 0.2.116

## Tests
- uv run ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/ tests/
- uv run --extra dev python -m pytest -q tests/test_cli.py -k "imported_output_test"
- uv run --extra dev python -m pytest -q tests/test_cli.py -k "auto_repairs"
- git diff --check