### PR TITLE
Guide source-stated cap boundaries

### DIFF
--- a/changelog.d/source-stated-cap-boundaries.fixed.md
+++ b/changelog.d/source-stated-cap-boundaries.fixed.md
@@ -1,0 +1,1 @@
+Guide encodings to keep source-stated cap and base formulas executable with legal boundary inputs when external bases or branch facts are unavailable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.116"
+version = "0.2.117"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.116"
+__version__ = "0.2.117"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3328,6 +3328,16 @@ RuleSpec requirements:
   amount but depends on externally determined classifications, official
   designations, statuses, event facts, or source-document categories, encode
   the amount with boundary inputs for those facts instead of deferring.
+- If the requested source itself states a cap, threshold, exclusion, or base
+  formula that uses an externally determined official base, wage amount,
+  compensation amount, rate, status, or special-case fact that is not available
+  as copied RuleSpec context, keep the source-stated formula executable with
+  semantic local boundary inputs named for those legal values or facts instead
+  of deferring the whole output.
+- If a missing special rule or unavailable cited definition affects only one
+  subtype, carve-out, or branch, defer only that branch or expose a
+  source-named boundary input for that branch. Do not defer an unrelated
+  source-stated cap/base computation that can be executed from the source text.
 - Importing a child rate or threshold is not enough when the child file already
   exports the executable tax, benefit, deduction, or eligibility result. For
   aggregate parent sections, import the child result output itself and sum,

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -388,6 +388,16 @@ Hard requirements:
   amount but depends on externally determined classifications, official
   designations, statuses, event facts, or source-document categories, encode
   the amount with boundary inputs for those facts instead of deferring.
+- If the requested source itself states a cap, threshold, exclusion, or base
+  formula that uses an externally determined official base, wage amount,
+  compensation amount, rate, status, or special-case fact that is not available
+  as copied RuleSpec context, keep the source-stated formula executable with
+  semantic local boundary inputs named for those legal values or facts instead
+  of deferring the whole output.
+- If a missing special rule or unavailable cited definition affects only one
+  subtype, carve-out, or branch, defer only that branch or expose a
+  source-named boundary input for that branch. Do not defer an unrelated
+  source-stated cap/base computation that can be executed from the source text.
 - Do not create parallel statutory-dollar executable parameters when a copied
   current-year authority already provides the applicable inflation-adjusted
   parameter. Import the current-year authority unless the task is to encode the

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -82,6 +82,8 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "Importing an adjacent upstream output only as proof" in ENCODER_PROMPT
     assert "does not satisfy the dependency" in ENCODER_PROMPT
     assert "is not an executable dependency" in ENCODER_PROMPT
+    assert "source-stated formula executable" in ENCODER_PROMPT
+    assert "defer only that branch" in ENCODER_PROMPT
     assert "rate-applied result at the source-stated lower entity" in ENCODER_PROMPT
     assert "unit-level placeholder or aggregate base by the rate" in ENCODER_PROMPT
     assert "Never drop the jurisdiction prefix" in ENCODER_PROMPT
@@ -117,6 +119,8 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "Importing an adjacent upstream output only as proof" in prompt
     assert "does not satisfy the dependency" in prompt
     assert "is not an executable dependency" in prompt
+    assert "source-stated formula executable" in prompt
+    assert "defer only that branch" in prompt
     assert "rate-applied result at the source-stated lower entity" in prompt
     assert "unit-level placeholder or aggregate base by the rate" in prompt
     assert "Never drop the jurisdiction prefix" in prompt

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -6058,6 +6058,8 @@ class TestRepoAugmentedContext:
         assert "not as backward compatibility contracts" in prompt
         assert "Source-faithful RuleSpec with canonical legal pointers" in prompt
         assert "Never preserve, rename, or recreate a legacy local input" in prompt
+        assert "source-stated formula executable" in prompt
+        assert "defer only that branch" in prompt
 
     def test_prepare_eval_workspace_adds_same_section_subsection_context(
         self, tmp_path


### PR DESCRIPTION
## Summary
- tell the encoder to keep source-stated cap/base formulas executable with legal boundary inputs when external official bases or facts are unavailable
- tell it to defer only affected branches when a missing special rule applies to one subtype
- bump axiom-encode to 0.2.117

## Tests
- uv run ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_encoder_backend.py tests/test_evals.py
- uv run ruff format --check src/ tests/
- uv run --extra dev python -m pytest -q tests/test_encoder_backend.py tests/test_evals.py -k "statutory_base_naming_guidance or existing_target_guidance"
- git diff --check