### PR TITLE
Repair multiline else-if conditions

### DIFF
--- a/changelog.d/multiline-else-if-conditions.fixed.md
+++ b/changelog.d/multiline-else-if-conditions.fixed.md
@@ -1,0 +1,1 @@
+Repair generated chained conditionals whose `else if` condition spans multiple lines.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.117"
+version = "0.2.118"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.117"
+__version__ = "0.2.118"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3534,7 +3534,7 @@ def _parse_multiline_else_if_formula(
         while index < len(lines):
             stripped = lines[index].strip()
             if result_lines and re.fullmatch(
-                r"(?:if|elif|else\s+if)\s+.+?:|else:",
+                r"(?:if|elif|else\s+if)\b.*|else:",
                 stripped,
             ):
                 break
@@ -3551,7 +3551,10 @@ def _parse_multiline_else_if_formula(
     branches: list[tuple[str | None, str]] = []
     index = 0
     while index < len(lines):
-        header = lines[index].strip()
+        collected_header = _collect_multiline_conditional_header(lines, index)
+        if collected_header is None:
+            return None
+        header, next_index = collected_header
         inline_if_match = re.fullmatch(
             r"(?:if|elif|else\s+if)\s+(.+?):\s*(.+)",
             header,
@@ -3561,7 +3564,7 @@ def _parse_multiline_else_if_formula(
             if not result or re.match(r"(?:elif|else\b)", result):
                 return None
             branches.append((inline_if_match.group(1).strip(), result))
-            index += 1
+            index = next_index
             continue
         inline_else_match = re.fullmatch(r"else:\s*(.+)", header)
         if inline_else_match is not None:
@@ -3569,18 +3572,18 @@ def _parse_multiline_else_if_formula(
             if not result or re.match(r"(?:if|elif|else\b)", result):
                 return None
             branches.append((None, result))
-            index += 1
+            index = next_index
             break
         if_match = re.fullmatch(r"(?:if|elif|else\s+if)\s+(.+):", header)
         if if_match is not None:
-            collected = collect_block_result(index + 1)
+            collected = collect_block_result(next_index)
             if collected is None:
                 return None
             result, index = collected
             branches.append((if_match.group(1).strip(), result))
             continue
         if header == "else:":
-            collected = collect_block_result(index + 1)
+            collected = collect_block_result(next_index)
             if collected is None:
                 return None
             result, index = collected
@@ -3595,6 +3598,27 @@ def _parse_multiline_else_if_formula(
     if not any(condition is not None for condition, _result in branches):
         return None
     return branches
+
+
+def _collect_multiline_conditional_header(
+    lines: list[str],
+    index: int,
+) -> tuple[str, int] | None:
+    header = lines[index].strip()
+    if not re.match(r"(?:if|elif|else\s+if)\b", header) or ":" in header:
+        return header, index + 1
+
+    parts = [header]
+    cursor = index + 1
+    while cursor < len(lines):
+        part = lines[cursor].strip()
+        if re.match(r"(?:if|elif|else\s+if)\b|else:", part):
+            return None
+        parts.append(part)
+        cursor += 1
+        if ":" in part:
+            return " ".join(parts), cursor
+    return None
 
 
 def _formula_has_unsupported_chained_conditional(formula: str) -> bool:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1005,6 +1005,58 @@ rules:
     )
 
 
+def test_materialize_eval_artifact_repairs_multiline_else_if_conditions(
+    tmp_path,
+):
+    output_file = tmp_path / "runner" / "statutes" / "26" / "1402" / "b.yaml"
+    llm_response = """=== FILE: b.yaml ===
+format: rulespec/v1
+module:
+  summary: Section defines self-employment income.
+rules:
+  - name: self_employment_income_for_section_1401_a
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if is_nonresident_alien_individual_for_chapter_1402:
+            0
+          else if church_employee_income
+              and apply_section_1402_j_2_special_rules_for_church_income:
+            self_employment_income_for_church_employee_under_section_1402_j_2
+          else if net_earnings_from_self_employment
+              < self_employment_income_small_amount_exclusion_threshold:
+            0
+          else:
+            net_earnings_from_self_employment
+"""
+
+    wrote = _materialize_eval_artifact(
+        llm_response,
+        output_file,
+        source_text="The special rules apply in the case of church employee income.",
+    )
+
+    assert wrote is True
+    payload = yaml.safe_load(output_file.read_text())
+    formula = payload["rules"][0]["versions"][0]["formula"]
+    assert "else if" not in formula
+    assert "elif" not in formula
+    assert (
+        "if church_employee_income and "
+        "apply_section_1402_j_2_special_rules_for_church_income: "
+        "self_employment_income_for_church_employee_under_section_1402_j_2"
+    ) in formula
+    assert (
+        "if net_earnings_from_self_employment "
+        "< self_employment_income_small_amount_exclusion_threshold: 0"
+    ) in formula
+
+
 def test_materialize_eval_artifact_preserves_open_interval_source_table_rows(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- repair generated chained conditionals where the `else if` condition spans multiple lines
- preserve existing multiline branch-result repair coverage
- bump axiom-encode to 0.2.118

## Tests
- uv run ruff format --check src/ tests/
- uv run ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py
- uv run --extra dev python -m pytest -q tests/test_evals.py -k "multiline_conditional_branch or multiline_else_if_conditions"
- uv run --extra dev python -m pytest -q tests/test_evals.py -k "chained_conditionals or multiline_conditional_branch or multiline_else_if_conditions"
- git diff --check