### PR TITLE
Repair then conditional formulas

### DIFF
--- a/changelog.d/then-conditional-repair.fixed.md
+++ b/changelog.d/then-conditional-repair.fixed.md
@@ -1,0 +1,1 @@
+Repair generated conditional formulas that use `then:` syntax instead of RuleSpec expression syntax.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.118"
+version = "0.2.119"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.118"
+__version__ = "0.2.119"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2632,7 +2632,8 @@ def repair_unsupported_chained_conditionals(content: str) -> tuple[str, list[str
             formula = version.get("formula")
             if not isinstance(formula, str):
                 continue
-            repaired = _repair_else_if_formula(formula)
+            repaired = _repair_then_conditional_formula(formula)
+            repaired = _repair_else_if_formula(repaired)
             if repaired == formula:
                 continue
             if _formula_has_unsupported_chained_conditional(repaired):
@@ -3519,6 +3520,25 @@ def _repair_else_if_formula(formula: str) -> str:
     for condition, result in reversed(branches[:-1]):
         tail = f"if {condition}: {result} else: {tail}"
     return tail
+
+
+def _repair_then_conditional_formula(formula: str) -> str:
+    compact = " ".join(line.strip() for line in formula.strip().splitlines())
+    match = re.fullmatch(
+        r"if\s+(?P<condition>.+?)\s+then:\s+"
+        r"(?P<true_result>.+?)\s+else:\s+(?P<false_result>.+)",
+        compact,
+    )
+    if match is None:
+        return formula
+
+    true_result = match["true_result"].strip()
+    false_result = match["false_result"].strip()
+    if re.match(r"(?:if|elif|else\b)", true_result) or re.match(
+        r"(?:elif|else\b)", false_result
+    ):
+        return formula
+    return f"if {match['condition'].strip()}: {true_result} else: {false_result}"
 
 
 def _parse_multiline_else_if_formula(

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -628,7 +628,7 @@ Hard requirements:
   reference `example_rule` inside formula text.
 - Axiom conditionals are expression syntax, not YAML syntax. Money/scalar
   formulas may use `if condition: value else: other`; do not use Python ternary
-  syntax, `else if`, or `elif`.
+  syntax, `then:`, `else if`, or `elif`.
 - Function calls in formulas are expression syntax, not Python syntax. Do not
   include trailing commas in calls such as `min(a, b)` or `max(0, x)`, and do
   not write tuple-style expressions.

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -78,6 +78,7 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     )
     assert "overrides preservation of existing local input names" in ENCODER_PROMPT
     assert "Do not write `else if` or `elif`" in ENCODER_PROMPT
+    assert "then:" in ENCODER_PROMPT
     assert "module.summary` or the rule's proof excerpt" in ENCODER_PROMPT
     assert "Importing an adjacent upstream output only as proof" in ENCODER_PROMPT
     assert "does not satisfy the dependency" in ENCODER_PROMPT
@@ -116,6 +117,7 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "Never use `post_YYYY`, `pre_YYYY`, `after_YYYY`, `before_YYYY`" in prompt
     assert "overrides preservation of existing local input names" in prompt
     assert "module.summary` or the rule's proof excerpt" in prompt
+    assert "then:" in prompt
     assert "Importing an adjacent upstream output only as proof" in prompt
     assert "does not satisfy the dependency" in prompt
     assert "is not an executable dependency" in prompt

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1057,6 +1057,46 @@ rules:
     ) in formula
 
 
+def test_materialize_eval_artifact_repairs_then_conditionals(
+    tmp_path,
+):
+    output_file = tmp_path / "runner" / "statutes" / "26" / "1402" / "b.yaml"
+    llm_response = """=== FILE: b.yaml ===
+format: rulespec/v1
+module:
+  summary: Section defines self-employment income.
+rules:
+  - name: self_employment_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if net_earnings_from_self_employment >= self_employment_income_minimum_amount
+              and not individual_is_nonresident_alien_individual
+              then: net_earnings_from_self_employment else: 0
+"""
+
+    wrote = _materialize_eval_artifact(
+        llm_response,
+        output_file,
+        source_text="Self-employment income excludes net earnings below $400.",
+    )
+
+    assert wrote is True
+    payload = yaml.safe_load(output_file.read_text())
+    formula = payload["rules"][0]["versions"][0]["formula"]
+    assert "then:" not in formula
+    assert (
+        "if net_earnings_from_self_employment >= self_employment_income_minimum_amount "
+        "and not individual_is_nonresident_alien_individual: "
+        "net_earnings_from_self_employment else: 0"
+    ) == formula
+
+
 def test_materialize_eval_artifact_preserves_open_interval_source_table_rows(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- repair generated `if ... then: ... else: ...` formulas into RuleSpec conditional expression syntax
- add static prompt guidance against `then:` conditionals
- bump axiom-encode to 0.2.119

## Tests
- uv run ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/prompts/encoder.py tests/test_encoder_backend.py tests/test_evals.py
- uv run ruff format --check src/ tests/
- uv run --extra dev python -m pytest -q tests/test_encoder_backend.py tests/test_evals.py -k "then_conditionals or statutory_base_naming_guidance"
- uv run --extra dev python -m pytest -q tests/test_evals.py -k "chained_conditionals or multiline_conditional_branch or multiline_else_if_conditions or then_conditionals"
- git diff --check