### PR TITLE
Guide excess-over-cap semantics

### DIFF
--- a/changelog.d/excess-cap-semantics.fixed.md
+++ b/changelog.d/excess-cap-semantics.fixed.md
@@ -1,0 +1,1 @@
+Guide encodings to treat "part in excess of" exclusions as caps on included amounts, not subtraction of the cap from the source amount.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.119"
+version = "0.2.120"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.119"
+__version__ = "0.2.120"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3463,6 +3463,11 @@ RuleSpec requirements:
   To count two boolean conditions over the same relation, write two
   `count_where(...)` calls and add them.
 - If a conditional is embedded inside arithmetic or another larger expression, wrap the whole conditional in parentheses, such as `amount + (if condition: extra else: 0)`. Do not write `amount + if condition: extra else: 0`.
+- When source text says an amount "shall not include" or excludes "the part in
+  excess of" a cap, the included amount is capped at that limit:
+  `min(source_amount, cap)`. The excluded excess is
+  `max(0, source_amount - cap)`, but do not return `source_amount - cap` or
+  `source_amount - remaining_cap` as the included amount.
 - Formula strings must use bare identifiers only. If an imported rule is listed
   as `us:statutes/...#example_rule`, add that exact target to `imports:` but
   reference `example_rule` inside formula text.

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -623,6 +623,11 @@ Hard requirements:
   wrap the whole conditional in parentheses, such as
   `amount + (if condition: extra else: 0)`. Do not write
   `amount + if condition: extra else: 0`.
+- When source text says an amount "shall not include" or excludes "the part in
+  excess of" a cap, the included amount is capped at that limit:
+  `min(source_amount, cap)`. The excluded excess is
+  `max(0, source_amount - cap)`, but do not return `source_amount - cap` or
+  `source_amount - remaining_cap` as the included amount.
 - Formula strings must use bare identifiers only. If an imported rule is listed
   as `us:statutes/...#example_rule`, add that exact target to `imports:` but
   reference `example_rule` inside formula text.

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -72,6 +72,8 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "increase before adding it to the base amount" in ENCODER_PROMPT
     assert "17300, not 17325" in ENCODER_PROMPT
     assert "Axiom formulas have no date literal type" in ENCODER_PROMPT
+    assert 'excess of" a cap' in ENCODER_PROMPT
+    assert "min(source_amount, cap)" in ENCODER_PROMPT
     assert (
         "Never use `post_YYYY`, `pre_YYYY`, `after_YYYY`, `before_YYYY`"
         in ENCODER_PROMPT
@@ -114,6 +116,8 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "increase before adding it to the base amount" in prompt
     assert "17300, not 17325" in prompt
     assert "Axiom formulas have no date literal type" in prompt
+    assert 'excess of" a cap' in prompt
+    assert "min(source_amount, cap)" in prompt
     assert "Never use `post_YYYY`, `pre_YYYY`, `after_YYYY`, `before_YYYY`" in prompt
     assert "overrides preservation of existing local input names" in prompt
     assert "module.summary` or the rule's proof excerpt" in prompt

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -6152,6 +6152,8 @@ class TestRepoAugmentedContext:
         assert "Never preserve, rename, or recreate a legacy local input" in prompt
         assert "source-stated formula executable" in prompt
         assert "defer only that branch" in prompt
+        assert 'excess of" a cap' in prompt
+        assert "min(source_amount, cap)" in prompt
 
     def test_prepare_eval_workspace_adds_same_section_subsection_context(
         self, tmp_path


### PR DESCRIPTION
## Summary
- guide the encoder that “part in excess of” exclusions cap the included amount with `min(source_amount, cap)`
- warn against returning `source_amount - cap` or `source_amount - remaining_cap` as the included amount
- bump axiom-encode to 0.2.120

## Tests
- uv run ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_encoder_backend.py tests/test_evals.py
- uv run ruff format --check src/ tests/
- uv run --extra dev python -m pytest -q tests/test_encoder_backend.py tests/test_evals.py -k "statutory_base_naming_guidance or existing_target_guidance"
- git diff --check