### PR TITLE
Guide transitive import cycle boundaries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.120"
+version = "0.2.121"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.120"
+__version__ = "0.2.121"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3293,10 +3293,14 @@ RuleSpec requirements:
   overriding rule makes the cited branch unreachable for the encoded effective
   period, encode only that overriding branch and leave the unresolved branch out
   of executable formulas.
-- Never introduce an import cycle. If a cited source already imports the current
-  target module, do not import that source back into the same module; keep a
-  source-named boundary predicate for that cyclic condition until the sources
-  are split into acyclic subsection modules.
+- Never introduce an import cycle. If a cited source directly or transitively
+  imports the current target module, do not import that source back into the
+  same module; keep a source-named boundary predicate or numeric boundary input
+  for that cyclic condition until the sources are split into acyclic subsection
+  modules. This applies to cross-referenced rates or parameters as well as
+  eligibility predicates: if importing a rate-bearing source would complete a
+  cycle with a foundational base definition, keep the rate as a source-named
+  boundary input and continue encoding the non-cyclic base formula.
 - When a copied context file encodes a cited upstream source on a different
   entity, import that upstream output and bridge entities with a structural
   relation instead of replacing the import with a local cross-reference amount.

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -343,10 +343,14 @@ Hard requirements:
   overriding rule makes the cited branch unreachable for the encoded effective
   period, encode only that overriding branch and leave the unresolved branch out
   of executable formulas.
-- Never introduce an import cycle. If a cited source already imports the current
-  target module, do not import that source back into the same module; keep a
-  source-named boundary predicate for that cyclic condition until the sources
-  are split into acyclic subsection modules.
+- Never introduce an import cycle. If a cited source directly or transitively
+  imports the current target module, do not import that source back into the
+  same module; keep a source-named boundary predicate or numeric boundary input
+  for that cyclic condition until the sources are split into acyclic subsection
+  modules. This applies to cross-referenced rates or parameters as well as
+  eligibility predicates: if importing a rate-bearing source would complete a
+  cycle with a foundational base definition, keep the rate as a source-named
+  boundary input and continue encoding the non-cyclic base formula.
 - When a copied context file encodes a cited upstream source on a different
   entity, import that upstream output and bridge entities with a structural
   relation instead of replacing the import with a local cross-reference amount.

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -85,6 +85,10 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "Importing an adjacent upstream output only as proof" in ENCODER_PROMPT
     assert "does not satisfy the dependency" in ENCODER_PROMPT
     assert "is not an executable dependency" in ENCODER_PROMPT
+    assert "directly or transitively" in ENCODER_PROMPT
+    assert "numeric boundary input" in ENCODER_PROMPT
+    assert "rate-bearing source" in ENCODER_PROMPT
+    assert "cycle with a foundational base definition" in ENCODER_PROMPT
     assert "source-stated formula executable" in ENCODER_PROMPT
     assert "defer only that branch" in ENCODER_PROMPT
     assert "rate-applied result at the source-stated lower entity" in ENCODER_PROMPT

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -461,6 +461,8 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "Never use `post_YYYY`, `pre_YYYY`, `after_YYYY`, `before_YYYY`" in prompt
     assert "overrides preservation of existing local input names" in prompt
     assert "Never introduce an import cycle" in prompt
+    assert "directly or transitively" in prompt
+    assert "numeric boundary input" in prompt
     assert "purpose-specific outputs such as `x_for_section_1234_a`" in prompt
     assert "purpose-specific branch into one generic output" in prompt
     assert "same-named local input such as `x`" in prompt
@@ -3564,6 +3566,8 @@ class TestEvalPrompt:
         assert "Hard requirement for IRC sections 2, 6013, and 7703" not in prompt
         assert "section 151 deduction is `allowed` or `allowable`" not in prompt
         assert "Never introduce an import cycle" in prompt
+        assert "rate-bearing source" in prompt
+        assert "cycle with a foundational base definition" in prompt
 
     def test_build_eval_prompt_for_editorially_omitted_slice_allows_deferred_docstring(
         self, tmp_path


### PR DESCRIPTION
## Summary
- expand encoder import-cycle guidance to cover transitive dependencies
- tell the encoder to use source-named numeric boundary inputs for cyclic cross-referenced rates
- bump axiom-encode to 0.2.121

## Tests
- uv run --with pytest --with pytest-cov --with pytest-asyncio python -m pytest tests/test_encoder_backend.py tests/test_evals.py -q