### PR TITLE
Guide rate boundaries for base sources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.121"
+version = "0.2.122"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.121"
+__version__ = "0.2.122"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3301,6 +3301,13 @@ RuleSpec requirements:
   eligibility predicates: if importing a rate-bearing source would complete a
   cycle with a foundational base definition, keep the rate as a source-named
   boundary input and continue encoding the non-cyclic base formula.
+- When the requested source defines a base, net amount, includable amount, wage
+  base, income base, deduction base, or similar amount that a tax, contribution,
+  credit, or deduction section will consume, do not import that consumer section
+  only to use its rate parameters. If the requested source merely cites the
+  consumer section's rates for an adjustment to the base, keep that rate or rate
+  sum as a source-named numeric boundary input unless a non-cyclic standalone
+  rate table/source is available.
 - When a copied context file encodes a cited upstream source on a different
   entity, import that upstream output and bridge entities with a structural
   relation instead of replacing the import with a local cross-reference amount.

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -351,6 +351,13 @@ Hard requirements:
   eligibility predicates: if importing a rate-bearing source would complete a
   cycle with a foundational base definition, keep the rate as a source-named
   boundary input and continue encoding the non-cyclic base formula.
+- When the requested source defines a base, net amount, includable amount, wage
+  base, income base, deduction base, or similar amount that a tax, contribution,
+  credit, or deduction section will consume, do not import that consumer section
+  only to use its rate parameters. If the requested source merely cites the
+  consumer section's rates for an adjustment to the base, keep that rate or rate
+  sum as a source-named numeric boundary input unless a non-cyclic standalone
+  rate table/source is available.
 - When a copied context file encodes a cited upstream source on a different
   entity, import that upstream output and bridge entities with a structural
   relation instead of replacing the import with a local cross-reference amount.

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -89,6 +89,10 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "numeric boundary input" in ENCODER_PROMPT
     assert "rate-bearing source" in ENCODER_PROMPT
     assert "cycle with a foundational base definition" in ENCODER_PROMPT
+    assert "defines a base, net amount" in ENCODER_PROMPT
+    assert "do not import that consumer section" in ENCODER_PROMPT
+    assert "rate or rate" in ENCODER_PROMPT
+    assert "source-named numeric boundary input" in ENCODER_PROMPT
     assert "source-stated formula executable" in ENCODER_PROMPT
     assert "defer only that branch" in ENCODER_PROMPT
     assert "rate-applied result at the source-stated lower entity" in ENCODER_PROMPT

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -463,6 +463,7 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "Never introduce an import cycle" in prompt
     assert "directly or transitively" in prompt
     assert "numeric boundary input" in prompt
+    assert "do not import that consumer section" in prompt
     assert "purpose-specific outputs such as `x_for_section_1234_a`" in prompt
     assert "purpose-specific branch into one generic output" in prompt
     assert "same-named local input such as `x`" in prompt
@@ -3568,6 +3569,8 @@ class TestEvalPrompt:
         assert "Never introduce an import cycle" in prompt
         assert "rate-bearing source" in prompt
         assert "cycle with a foundational base definition" in prompt
+        assert "rate or rate" in prompt
+        assert "source-named numeric boundary input" in prompt
 
     def test_build_eval_prompt_for_editorially_omitted_slice_allows_deferred_docstring(
         self, tmp_path


### PR DESCRIPTION
## Summary
- guide the encoder to keep consumer-section rates as source-named numeric boundary inputs when encoding base/net amount sources
- keep the rule generic for tax, contribution, credit, and deduction consumers
- bump axiom-encode to 0.2.122

## Tests
- uv run --with pytest --with pytest-cov --with pytest-asyncio python -m pytest tests/test_encoder_backend.py tests/test_evals.py -q