### PR TITLE
Classify section 1402(b) PolicyEngine coverage

### DIFF
--- a/changelog.d/1402b-policyengine-coverage.changed.md
+++ b/changelog.d/1402b-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classified section 1402(b) self-employment income outputs in the PolicyEngine oracle coverage registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.122"
+version = "0.2.123"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.122"
+__version__ = "0.2.123"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -857,6 +857,38 @@ mappings:
     comparison: rate
     rationale: Same section 1402(a)(12)(B) one-half factor used in PE to compute the employer-share deduction from net earnings.
 
+  - legal_id: us:statutes/26/1402/b#self_employment_income_inclusion_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.self_employment.net_earnings_exemption
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same section 1402(b)(2) minimum net-earnings threshold, stored in PE as the self-employment net earnings exemption.
+
+  - legal_id: us:statutes/26/1402/b#self_employment_income
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_self_employment_income
+    candidate_priority: P2
+    rationale: Section 1402(b) self-employment income is adjacent to PE taxable_self_employment_income, but this RuleSpec output is a tax-unit statutory boundary with nonresident-alien exclusions and imported section 1402(a) source components. Use a section-specific adapter before treating it as an exact PE oracle target.
+
+  - legal_id: us:statutes/26/1402/b#self_employment_income_for_section_1401_a
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: social_security_taxable_self_employment_income
+    candidate_priority: P2
+    rationale: Section 1402(b)(1) wage-base-limited self-employment income is adjacent to PE social_security_taxable_self_employment_income, but the generated RuleSpec tests can supply source-specific wage-base inputs and nonresident-alien exclusions that PE does not expose as direct scenario inputs. Compare through an explicit SECA adapter.
+
+  - legal_id: us:statutes/26/1402/b#self_employment_income_excluded_for_taxpayer
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the section 1402(b) nonresident-alien, agreement, and territory-resident exclusion predicate as a one-to-one variable.
+
   - legal_id: us:statutes/26/164/f#self_employment_tax_deduction_fraction
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -224,6 +224,80 @@ rules:
     assert item["policyengine_variable"] == "filer_adjusted_earnings"
 
 
+def test_policyengine_coverage_classifies_section_1402_b_self_employment_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/1402/b.yaml",
+        """format: rulespec/v1
+rules:
+  - name: self_employment_income_inclusion_threshold
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: '400'
+  - name: self_employment_income
+    kind: derived
+    entity: TaxUnit
+    versions:
+      - effective_from: '1990-01-01'
+        formula: net_earnings_from_self_employment
+  - name: self_employment_income_for_section_1401_a
+    kind: derived
+    entity: TaxUnit
+    versions:
+      - effective_from: '1990-01-01'
+        formula: min(net_earnings_from_self_employment, contribution_base - wages)
+  - name: self_employment_income_excluded_for_taxpayer
+    kind: derived
+    entity: TaxUnit
+    versions:
+      - effective_from: '1990-01-01'
+        formula: individual_is_nonresident_alien
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/1402/b.test.yaml",
+        """- name: section_1402_b
+  output:
+    us:statutes/26/1402/b#self_employment_income_inclusion_threshold: 400
+    us:statutes/26/1402/b#self_employment_income: 923.5
+    us:statutes/26/1402/b#self_employment_income_for_section_1401_a: 923.5
+    us:statutes/26/1402/b#self_employment_income_excluded_for_taxpayer: false
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 3,
+    }
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    threshold = items_by_id[
+        "us:statutes/26/1402/b#self_employment_income_inclusion_threshold"
+    ]
+    assert threshold["status"] == "comparable"
+    assert (
+        threshold["policyengine_parameter"]
+        == "gov.irs.self_employment.net_earnings_exemption"
+    )
+    assert threshold["tested"] is True
+    assert (
+        items_by_id["us:statutes/26/1402/b#self_employment_income"][
+            "policyengine_variable"
+        ]
+        == "taxable_self_employment_income"
+    )
+    assert (
+        items_by_id["us:statutes/26/1402/b#self_employment_income_for_section_1401_a"][
+            "policyengine_variable"
+        ]
+        == "social_security_taxable_self_employment_income"
+    )
+
+
 def test_policyengine_coverage_treats_ssa_policy_parameters_as_tax(tmp_path):
     _write_rulespec_file(
         tmp_path


### PR DESCRIPTION
## Summary
- classify generated section 1402(b) outputs in the PolicyEngine oracle coverage registry
- map the 1402(b)(2) threshold to `gov.irs.self_employment.net_earnings_exemption`
- mark adjacent SECA income outputs as known-not-comparable until an explicit adapter exists

## Validation
- `uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode python -m pytest tests/test_policyengine_coverage.py tests/test_cli.py -q`
- `uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- local replay of rulespec-us #54 oracle coverage: 4/4 section 1402(b) outputs classified, 0 unmapped

Unblocks TheAxiomFoundation/rulespec-us#54 without hand-editing generated RuleSpec artifacts.
