### PR TITLE
Honor rate-only source boundaries

### DIFF
--- a/changelog.d/rate-only-source-boundaries.changed.md
+++ b/changelog.d/rate-only-source-boundaries.changed.md
@@ -1,0 +1,1 @@
+Teach source-id-driven encoding prompts to honor explicit `/rate` percentage artifacts as acyclic rate-only boundaries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.124"
+version = "0.2.125"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.124"
+__version__ = "0.2.125"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3065,6 +3065,8 @@ Preferred principal output:
 """
 
     guidance_parts = [render_uk_legislation_guidance()]
+    if _source_identifier_requests_percentage_rate_boundary(citation, source_text):
+        guidance_parts.append(render_rate_only_source_boundary_guidance())
     if _is_single_amount_table_slice(source_text):
         guidance_parts.append(render_single_amount_row_guidance())
     if not re.search(r"\b\d{4}-\d{2}-\d{2}\b", source_text) and not scaffold_dates:
@@ -3550,9 +3552,9 @@ RuleSpec requirements:
   2. Test input inventory: for every local factual identifier referenced by a
      local derived formula, every companion test case assigns the corresponding
      `#input.<fact>` explicitly, including false facts. Do not rely on implicit
-     defaults. Do not assert raw `kind: parameter` rules directly in companion
-     test `output:` blocks; assert derived outputs that consume the parameters
-     instead.
+     defaults. Explicit rate-only source-boundary artifacts that contain only
+     scalar parameters may assert those canonical parameter outputs directly.
+     Do not assert raw `kind: parameter` rules directly in companion test `output:` blocks for other artifacts; assert derived outputs that consume the parameters instead.
      For imported modules, only assign imported `#input` or `#relation` keys
      that exist in the current imported RuleSpec context. Do not preserve stale
      imported test inputs from copied files. Do not stub imported derived
@@ -3712,6 +3714,38 @@ def _is_single_amount_table_slice(source_text: str) -> bool:
         if re.search(r"[£$€]\s*\d[\d,]*(?:\.\d+)?", line)
     ]
     return len(money_lines) == 1
+
+
+def _source_identifier_requests_percentage_rate_boundary(
+    citation: str, source_text: str
+) -> bool:
+    parts = [part for part in citation.strip().strip("/").split("/") if part]
+    if not parts or parts[-1].lower() != "rate":
+        return False
+    return bool(re.search(r"(?i)(?:\bper\s+cent\b|\bpercent(?:age)?\b|%)", source_text))
+
+
+def render_rate_only_source_boundary_guidance() -> str:
+    return """
+Rate-only source boundary:
+- The requested source id ends in `/rate`, and this source states a percentage
+  rate, so this artifact must expose only source-stated rate or percentage
+  parameters anchored in `./source.txt` for that branch.
+- Do not encode the downstream tax, contribution, credit, deduction, wage
+  base, income base, exemption, exception, or other non-rate output merely
+  because the broader source text mentions it.
+- Prefer `kind: parameter`, `dtype: Rate`, and one scalar output per
+  source-stated rate. Use a `derived` rate only when the source itself states
+  the rate as an expression of other rates.
+- Name each output after the legal application stated in the source text, such
+  as `<tax_or_application>_rate`, not after the path fragment alone.
+- Do not import a consumer or base source solely to compute a rate. A rate-only
+  boundary must stay acyclic and reusable by base definitions that cite the
+  rate.
+- Because this is a pure rate boundary, companion tests may assert the
+  canonical parameter output directly when there is no derived output to
+  exercise.
+"""
 
 
 def _format_inline_context_snippets(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -554,6 +554,91 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     )
 
 
+def test_build_eval_prompt_for_rate_only_source_id_limits_scope(tmp_path):
+    runner = parse_runner_spec("codex:gpt-5.4")
+    workspace = prepare_eval_workspace(
+        citation="us/statute/26/1401/a/rate",
+        runner=runner,
+        output_root=tmp_path / "out",
+        source_text=(
+            "(a) Old-age, survivors, and disability insurance There shall be "
+            "imposed for each taxable year, on the self-employment income of "
+            "every individual, a tax equal to 12.4 percent of the amount of "
+            "the self-employment income for such taxable year."
+        ),
+        axiom_rules_path=tmp_path / "rulespec-us",
+        mode="cold",
+    )
+
+    prompt = _build_eval_prompt(
+        "us/statute/26/1401/a/rate",
+        "cold",
+        workspace,
+        [],
+        target_file_name="rate.yaml",
+        target_ref_prefix="us:statutes/26/1401/a/rate",
+        include_tests=True,
+    )
+
+    assert "Rate-only source boundary:" in prompt
+    assert "source-stated rate or percentage" in prompt
+    assert "parameters anchored in `./source.txt`" in prompt
+    assert "Do not encode the downstream tax" in prompt
+    assert "Prefer `kind: parameter`, `dtype: Rate`" in prompt
+    assert "boundary must stay acyclic" in prompt
+    assert "companion tests may assert" in prompt
+    assert "canonical parameter output directly" in prompt
+    assert "Explicit rate-only source-boundary artifacts" in prompt
+
+
+def test_build_eval_prompt_does_not_treat_rates_path_as_rate_only(tmp_path):
+    runner = parse_runner_spec("codex:gpt-5.4")
+    workspace = prepare_eval_workspace(
+        citation="us/statute/26/1401/rates",
+        runner=runner,
+        output_root=tmp_path / "out",
+        source_text="The table states several percentage rates.",
+        axiom_rules_path=tmp_path / "rulespec-us",
+        mode="cold",
+    )
+
+    prompt = _build_eval_prompt(
+        "us/statute/26/1401/rates",
+        "cold",
+        workspace,
+        [],
+        target_file_name="rates.yaml",
+        target_ref_prefix="us:statutes/26/1401/rates",
+        include_tests=True,
+    )
+
+    assert "Rate-only source boundary:" not in prompt
+
+
+def test_build_eval_prompt_does_not_treat_monetary_rate_as_rate_only(tmp_path):
+    runner = parse_runner_spec("codex:gpt-5.4")
+    workspace = prepare_eval_workspace(
+        citation="us/statute/26/9999/rate",
+        runner=runner,
+        output_root=tmp_path / "out",
+        source_text="The reimbursement rate is 67 cents per mile.",
+        axiom_rules_path=tmp_path / "rulespec-us",
+        mode="cold",
+    )
+
+    prompt = _build_eval_prompt(
+        "us/statute/26/9999/rate",
+        "cold",
+        workspace,
+        [],
+        target_file_name="rate.yaml",
+        target_ref_prefix="us:statutes/26/9999/rate",
+        include_tests=True,
+    )
+
+    assert "Rate-only source boundary:" not in prompt
+
+
 def test_context_file_surfaces_include_derived_relation(tmp_path):
     context_file = tmp_path / "snap_unit.yaml"
     context_file.write_text(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.111"
+version = "0.2.125"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Fixes #133 by adding source-id-driven guidance for explicit `/rate` percentage artifacts.
- Keeps the trigger narrow: `/rates` paths and non-percentage monetary rates do not receive rate-only guidance.
- Allows pure rate-boundary companion tests to assert the canonical parameter output directly.
- Bumps axiom-encode to 0.2.125 and updates the lockfile metadata.

## Validation
- `uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode ruff check src/axiom_encode/harness/evals.py tests/test_evals.py`
- `uv run --project /Users/maxghenis/TheAxiomFoundation/axiom-encode python -m pytest tests/test_evals.py::test_build_eval_prompt_for_rate_only_source_id_limits_scope tests/test_evals.py::test_build_eval_prompt_does_not_treat_rates_path_as_rate_only tests/test_evals.py::test_build_eval_prompt_does_not_treat_monetary_rate_as_rate_only tests/test_cli.py -q`
- Live non-apply encode: `26 USC 1401(a)` with `--source-id us/statute/26/1401/a/rate` compiled and passed CI, score 8.5/10.
- Live non-apply encode: `26 USC 1401(b)(1)` with `--source-id us/statute/26/1401/b/1/rate` compiled and passed CI, score 9.0/10.