### PR TITLE
Map section 1401 rate coverage

### DIFF
--- a/changelog.d/section-1401-rate-coverage.changed.md
+++ b/changelog.d/section-1401-rate-coverage.changed.md
@@ -1,0 +1,1 @@
+Map generated section 1401 self-employment tax rate leaves to PolicyEngine parameter coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.125"
+version = "0.2.126"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.125"
+__version__ = "0.2.126"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -813,6 +813,15 @@ mappings:
     comparison: rate
     rationale: Same statutory self-employment Medicare tax rate, stored in PE as parameter data.
 
+  - legal_id: us:statutes/26/1401/b/1/rate#self_employment_income_tax_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.self_employment.rate.medicare
+    period: year
+    comparison: rate
+    rationale: Same statutory section 1401(b)(1) self-employment Medicare tax rate, stored in PE as parameter data.
+
   - legal_id: us:statutes/26/1401#self_employment_hospital_insurance_tax
     country: us
     program: tax
@@ -827,6 +836,15 @@ mappings:
     period: year
     comparison: rate
     rationale: Same statutory self-employment OASDI tax rate, stored in PE as parameter data.
+
+  - legal_id: us:statutes/26/1401/a/rate#old_age_survivors_and_disability_insurance_tax_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.self_employment.rate.social_security
+    period: year
+    comparison: rate
+    rationale: Same statutory section 1401(a) self-employment OASDI tax rate, stored in PE as parameter data.
 
   - legal_id: us:statutes/26/1401#self_employment_oasdi_tax
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -200,6 +200,70 @@ rules:
     )
 
 
+def test_policyengine_coverage_maps_section_1401_rate_leaf_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/1401/a/rate.yaml",
+        """format: rulespec/v1
+rules:
+  - name: old_age_survivors_and_disability_insurance_tax_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: '0.124'
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/1401/a/rate.test.yaml",
+        """- name: section_1401_a_rate
+  output:
+    us:statutes/26/1401/a/rate#old_age_survivors_and_disability_insurance_tax_rate: 0.124
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/1401/b/1/rate.yaml",
+        """format: rulespec/v1
+rules:
+  - name: self_employment_income_tax_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: '0.029'
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/1401/b/1/rate.test.yaml",
+        """- name: section_1401_b_1_rate
+  output:
+    us:statutes/26/1401/b/1/rate#self_employment_income_tax_rate: 0.029
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["total_outputs"] == 2
+    assert report["status_counts"] == {"comparable": 2}
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    oasdi_rate = items_by_id[
+        "us:statutes/26/1401/a/rate#old_age_survivors_and_disability_insurance_tax_rate"
+    ]
+    assert oasdi_rate["status"] == "comparable"
+    assert (
+        oasdi_rate["policyengine_parameter"]
+        == "gov.irs.self_employment.rate.social_security"
+    )
+    assert oasdi_rate["tested"] is True
+    medicare_rate = items_by_id[
+        "us:statutes/26/1401/b/1/rate#self_employment_income_tax_rate"
+    ]
+    assert medicare_rate["status"] == "comparable"
+    assert (
+        medicare_rate["policyengine_parameter"]
+        == "gov.irs.self_employment.rate.medicare"
+    )
+    assert medicare_rate["tested"] is True
+
+
 def test_policyengine_coverage_maps_section_32_earned_income_to_adjusted_earnings(
     tmp_path,
 ):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1663,6 +1663,15 @@ def test_policyengine_registry_is_legal_id_keyed():
         == "gov.irs.payroll.social_security.rate.employee"
     )
     assert oasdi_rate_mapping.comparable is True
+    self_employment_oasdi_rate_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/1401/a/rate#old_age_survivors_and_disability_insurance_tax_rate",
+        country="us",
+    )
+    assert self_employment_oasdi_rate_mapping.mapping_type == "parameter_value"
+    assert (
+        self_employment_oasdi_rate_mapping.policyengine_parameter
+        == "gov.irs.self_employment.rate.social_security"
+    )
     employee_medicare_rate_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/3101/b/1#hospital_insurance_wage_tax_rate",
         country="us",
@@ -1671,6 +1680,15 @@ def test_policyengine_registry_is_legal_id_keyed():
     assert (
         employee_medicare_rate_mapping.policyengine_parameter
         == "gov.irs.payroll.medicare.rate.employee"
+    )
+    self_employment_medicare_rate_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/1401/b/1/rate#self_employment_income_tax_rate",
+        country="us",
+    )
+    assert self_employment_medicare_rate_mapping.mapping_type == "parameter_value"
+    assert (
+        self_employment_medicare_rate_mapping.policyengine_parameter
+        == "gov.irs.self_employment.rate.medicare"
     )
     rrta_tier_2_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/3201#tier_2_employee_tax",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.125"
+version = "0.2.126"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map generated section 1401 self-employment OASDI and Medicare rate leaf IDs to PolicyEngine parameters
- add focused coverage tests for generated rate leaf outputs
- bump axiom-encode to 0.2.126 with a changelog fragment

## Tests
- uv run ruff check src/axiom_encode/oracles/policyengine tests/test_policyengine_coverage.py
- uv run ruff check tests/test_policyengine_coverage.py tests/test_rulespec_validation.py
- uv run pytest tests/test_policyengine_coverage.py tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed
- local coverage probe against the generated RuleSpec #56 files