### PR TITLE
Fix canonical context imports for composed encodings

### DIFF
--- a/changelog.d/canonical-context-composition.fixed.md
+++ b/changelog.d/canonical-context-composition.fixed.md
@@ -1,0 +1,1 @@
+Use absolute canonical-concept imports, include companion tests, and prefer imported child scalars when composing generated RuleSpec artifacts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.126"
+version = "0.2.127"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.126"
+__version__ = "0.2.127"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/dependency_stubs.py
+++ b/src/axiom_encode/harness/dependency_stubs.py
@@ -12,6 +12,8 @@ from typing import Sequence
 
 import yaml
 
+from axiom_encode.repo_routing import canonical_rulespec_repo_name
+
 
 @dataclass(frozen=True)
 class ResolvedDefinedTerm:
@@ -160,6 +162,10 @@ def find_registered_stub_specs(
 def import_target_to_relative_rulespec_path(import_target: str) -> Path:
     """Convert an import target like legislation/...#name into a .yaml path."""
     normalized = import_target.strip().strip('"').strip("'").split("#", 1)[0]
+    if ":" in normalized:
+        prefix, rest = normalized.split(":", 1)
+        if re.fullmatch(r"[a-z][a-z0-9-]*", prefix) and rest:
+            normalized = rest
     if normalized.endswith((".yaml", ".yml")):
         return Path(normalized)
     return Path(f"{normalized}.yaml")
@@ -500,6 +506,9 @@ def _build_canonical_concept_candidate(
 
     citation = _first_nonempty_line(source_text) or relative.as_posix()
     import_base = relative.with_suffix("").as_posix()
+    repo_name = canonical_rulespec_repo_name(candidate_file)
+    if repo_name and len(repo_name) > len("rulespec-"):
+        import_base = f"{repo_name.removeprefix('rulespec-')}:{import_base}"
     return ResolvedCanonicalConcept(
         term="",
         import_target=f"{import_base}#{symbol}",

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1481,13 +1481,19 @@ def prepare_eval_workspace(
         axiom_rules_path,
         current_file=current_file,
     ):
-        context_files.append(
-            _materialize_resolved_canonical_concept(
-                context_root=context_root,
-                resolved_concept=resolved_concept,
-                workspace_root=workspace_root,
-            )
+        context_item = _materialize_resolved_canonical_concept(
+            context_root=context_root,
+            resolved_concept=resolved_concept,
+            workspace_root=workspace_root,
         )
+        context_files.append(context_item)
+        companion_item = _materialize_resolved_canonical_concept_companion_test(
+            context_item=context_item,
+            resolved_concept=resolved_concept,
+            workspace_root=workspace_root,
+        )
+        if companion_item is not None:
+            context_files.append(companion_item)
 
     context_corpus_root = _repo_augmented_context_root(axiom_rules_path)
 
@@ -1866,14 +1872,39 @@ def _materialize_resolved_canonical_concept(
     target = workspace_root / relative_target
     target.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(resolved_concept.rulespec_file, target)
+    import_path = resolved_concept.import_target.split("#", 1)[0]
     return EvalContextFile(
         source_path=str(resolved_concept.rulespec_file),
         workspace_path=str(relative_target),
-        import_path=_relative_rulespec_path_to_import_target(
-            relative_target.relative_to("context")
-        ),
+        import_path=import_path,
         kind="canonical_concept",
         label=resolved_concept.label,
+    )
+
+
+def _materialize_resolved_canonical_concept_companion_test(
+    *,
+    context_item: EvalContextFile,
+    resolved_concept: ResolvedCanonicalConcept,
+    workspace_root: Path,
+) -> EvalContextFile | None:
+    """Copy the companion test for a resolved canonical concept when available."""
+    test_source = _rulespec_test_path(resolved_concept.rulespec_file)
+    if not test_source.exists():
+        return None
+
+    test_import_path = f"{context_item.import_path}.test"
+    relative_target = Path("context") / import_target_to_relative_rulespec_path(
+        test_import_path
+    )
+    target = workspace_root / relative_target
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(test_source, target)
+    return EvalContextFile(
+        source_path=str(test_source),
+        workspace_path=str(relative_target),
+        import_path=test_import_path,
+        kind="implementation_test_context",
     )
 
 
@@ -2957,6 +2988,12 @@ Import and context rules:
   already encode subparagraphs, import those child outputs and compose them.
   Do not redefine the child parameters, helper rules, or copied executable
   outputs in the parent file.
+- If context contains a more specific child file under the current target path
+  that exports the exact scalar needed by this source, such as a `/rate`,
+  `/threshold`, `/amount`, `/cap`, or `/limit` file, treat that child file as
+  the canonical home for the scalar. Import the exact child export and use it
+  in the current formula; do not emit a duplicate local `parameter` with the
+  same value or name in the parent/composition file.
 - If a copied context file for this target or a same-program sibling contains a `kind: source_relation` record, preserve the legal/provenance edge unless `./source.txt` proves it wrong; executable formula changes are not a reason to drop source graph context.
 - Do not fabricate same-instrument imports or `statutes/...#symbol` paths unless that exact `path#symbol` import target is listed.
 - do not fabricate sibling-file imports for uncopied same-instrument provisions.
@@ -3547,8 +3584,10 @@ RuleSpec requirements:
 - Do not fabricate sibling-file imports, do not guess unavailable import targets, and do not invent `import` statements or `imports:` blocks for uncopied same-instrument provisions.
 - Before finalizing, do this self-check:
   1. Numeric inventory: every source-stated legal amount, rate, threshold, cap,
-     or limit has a named `parameter`, and derived formulas reference the name
-     rather than an inline literal.
+     or limit has a named local `parameter` or an exact imported parameter from
+     context, and derived formulas reference that local or imported name rather
+     than an inline literal. If an exact same-path child scalar is available in
+     context, import it instead of duplicating it locally.
   2. Test input inventory: for every local factual identifier referenced by a
      local derived formula, every companion test case assigns the corresponding
      `#input.<fact>` explicitly, including false facts. Do not rely on implicit

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -24,6 +24,25 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   those lower-entity results through an explicit relation; it must not multiply
   a unit-level placeholder or aggregate base by the rate unless the source
   defines the base on that unit.
+- Imported definitions do not override the current source's legal subject. If
+  the current source imposes a rate-applied amount on each/every individual,
+  person, employee, member, claimant, child, dependent, or spouse, declare this
+  file's rate-applied result at that lower entity even when the imported base
+  definition is currently encoded at a filing-unit, tax-unit, household, or
+  other unit boundary. Only add a unit-level roll-up when this source text
+  itself states that aggregate.
+- Treat legal subject nouns as stronger evidence than nearby repository
+  context. In particular, "individual", "person", "employee", "member",
+  "claimant", "child", "dependent", and "spouse" usually require
+  `entity: Person` for the current source's own amount, tax, credit,
+  deduction, contribution, limit, or eligibility result. Do not choose
+  `entity: TaxUnit`, `Household`, `Family`, or another aggregate entity merely
+  because an imported base amount or companion test is currently declared at
+  that aggregate entity.
+- Phrases like "on the [base] of every individual/person/employee" identify
+  the entity of the current amount, tax, credit, deduction, contribution, or
+  limit. Encode the current result on the individual/person/employee first,
+  even if the imported base definition or its tests are unit-scoped.
 - Do not create a roll-up, top-level program output, or connection merely
   because downstream consumers want it, sibling/state files patched it, or the
   program conventionally has such a concept. The output must be directly
@@ -154,6 +173,12 @@ Hard requirements:
   formula must reference the imported child output by name rather than copying
   the child literal, even when the parent source excerpt includes the child
   subsection text.
+- If context contains a more specific child file under the current target path
+  that exports the exact scalar needed by this source, such as a `/rate`,
+  `/threshold`, `/amount`, `/cap`, or `/limit` file, treat that child file as
+  the canonical home for the scalar. Import the exact child export and use it
+  in the current formula; do not emit a duplicate local `parameter` with the
+  same value or name in the parent/composition file.
 - Treat any existing copied target file as context, not as a backward
   compatibility contract. You may drop, rename, rebuild, or defer existing
   executable rules, tests, imports, and local factual inputs when the source
@@ -713,9 +738,11 @@ Hard requirements:
   semantic scalars for those occurrences and use them in the branch conditions.
 - Before finalizing, do this self-check:
   1. Numeric inventory: every source-stated legal amount, rate, threshold, cap,
-     or limit has a named `parameter`, and derived formulas reference the name
-     rather than an inline literal, except structural interval-table row labels
-     used only by the band selector.
+     or limit has a named local `parameter` or an exact imported parameter from
+     context, and derived formulas reference that local or imported name rather
+     than an inline literal, except structural interval-table row labels used
+     only by the band selector. If an exact same-path child scalar is available
+     in context, import it instead of duplicating it locally.
   2. Test input inventory: for every local factual identifier referenced by a
      local derived formula, every companion test case assigns the corresponding
      `#input.<fact>` explicitly, including false facts. Do not rely on implicit

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -446,7 +446,10 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "then cap the aggregate" in prompt
     assert "rate-applied result at the source-stated lower entity" in prompt
     assert "unit-level placeholder or aggregate base by the rate" in prompt
-    assert "Imported definitions do not override the current source's legal subject" in prompt
+    assert (
+        "Imported definitions do not override the current source's legal subject"
+        in prompt
+    )
     assert "rate-applied result at that lower entity" in prompt
     assert "Treat legal subject nouns as stronger evidence" in prompt
     assert "usually require\n  `entity: Person`" in prompt

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -446,6 +446,12 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "then cap the aggregate" in prompt
     assert "rate-applied result at the source-stated lower entity" in prompt
     assert "unit-level placeholder or aggregate base by the rate" in prompt
+    assert "Imported definitions do not override the current source's legal subject" in prompt
+    assert "rate-applied result at that lower entity" in prompt
+    assert "Treat legal subject nouns as stronger evidence" in prompt
+    assert "usually require\n  `entity: Person`" in prompt
+    assert "on the [base] of every individual/person/employee" in prompt
+    assert "even if the imported base definition or its tests are unit-scoped" in prompt
     assert "Do not narrate your plan" in prompt
     assert "snap_standard_utility_allowance" in prompt
     assert "Do not use bare year periods like `2024`" in prompt
@@ -481,6 +487,8 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "not strings such as `2_5_to_less_than_3_0`" in prompt
     assert "Before finalizing, do this self-check:" in prompt
     assert "Numeric inventory: every source-stated legal amount" in prompt
+    assert "exact imported parameter from\n     context" in prompt
+    assert "import it instead of duplicating it locally" in prompt
     assert "Test input inventory: for every local factual identifier" in prompt
     assert "Do not assert raw `kind: parameter` rules directly" in prompt
     assert "assert derived outputs that consume the parameters" in prompt
@@ -790,6 +798,9 @@ rules:
     assert "`us:statutes/26/999#input.existing_fact`" in prompt
     assert "Cycle-prone context imports:" in prompt
     assert "`us:statutes/26/7703` already imports `us:statutes/26/999`" in prompt
+    assert "more specific child file under the current target path" in prompt
+    assert "such as a `/rate`" in prompt
+    assert "do not emit a duplicate local `parameter`" in prompt
 
 
 def test_build_eval_prompt_lists_existing_target_validation_failures(tmp_path):
@@ -4728,7 +4739,7 @@ rules:
         assert (
             concept_files[0].workspace_path == "context/statutes/crs/26-2-703/12.yaml"
         )
-        assert concept_files[0].import_path == "statutes/crs/26-2-703/12"
+        assert concept_files[0].import_path == "us-co:statutes/crs/26-2-703/12"
         copied_path = workspace.root / concept_files[0].workspace_path
         assert copied_path.exists()
         assert "is_individual_responsibility_contract" in copied_path.read_text()
@@ -6162,6 +6173,74 @@ class TestRepoAugmentedContext:
             workspace.root / copied_sources[str(context_test)]["workspace_path"]
         )
         assert copied_test.read_text() == "- name: context_case\n  period: 2026-01\n"
+
+    def test_prepare_eval_workspace_canonical_concepts_use_absolute_imports_and_tests(
+        self, tmp_path
+    ):
+        policy_repo_root = tmp_path / "rulespec-us"
+        statute_root = policy_repo_root / "statutes" / "26" / "1402"
+        statute_root.mkdir(parents=True)
+        context_file = statute_root / "b.yaml"
+        context_test = statute_root / "b.test.yaml"
+        context_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: |-
+    (b) Self-employment income The term "self-employment income" means the net earnings from self-employment; except that the section 1401(a) cap applies.
+rules:
+  - name: self_employment_income_for_section_1401_a
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: net_earnings_from_self_employment
+"""
+        )
+        context_test.write_text(
+            "- name: context_case\n"
+            "  input:\n"
+            "    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 1000\n"
+            "  output:\n"
+            "    us:statutes/26/1402/b#self_employment_income_for_section_1401_a: 923.5\n"
+        )
+
+        workspace = prepare_eval_workspace(
+            citation="26 USC 1401(a)",
+            runner=parse_runner_spec("openai:gpt-5.4"),
+            output_root=tmp_path / "out",
+            source_text=(
+                "There shall be imposed on the self-employment income of every "
+                "individual a tax equal to 12.4 percent."
+            ),
+            axiom_rules_path=policy_repo_root,
+            mode="repo-augmented",
+            extra_context_paths=[],
+        )
+
+        manifest = json.loads(workspace.manifest_file.read_text())
+        copied_sources = {
+            (item["source_path"], item["kind"]): item
+            for item in manifest["context_files"]
+        }
+        canonical_item = copied_sources[(str(context_file), "canonical_concept")]
+        assert canonical_item["import_path"] == "us:statutes/26/1402/b"
+        assert (
+            "`self-employment income` -> import "
+            "`us:statutes/26/1402/b#self_employment_income_for_section_1401_a`"
+            in canonical_item["label"]
+        )
+        companion_item = copied_sources[
+            (str(context_test), "implementation_test_context")
+        ]
+        assert companion_item["import_path"] == "us:statutes/26/1402/b.test"
+        copied_test = workspace.root / companion_item["workspace_path"]
+        assert copied_test.read_text() == context_test.read_text()
+        assert not any(
+            item["import_path"] == "statutes/26/1402/b"
+            for item in manifest["context_files"]
+        )
 
     def test_prepare_eval_workspace_copies_existing_target_file_as_context(
         self, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.126"
+version = "0.2.127"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- preserve jurisdiction-prefixed canonical concept imports when materializing repo-augmented context
- copy canonical concept companion tests into eval workspaces so downstream compositions can mirror upstream inputs
- strengthen prompt guidance for person-scoped rate bases and imported child scalar reuse
- bump axiom-encode to 0.2.127 with a changelog fragment

## Validation
- `uv run ruff check src/axiom_encode/harness/dependency_stubs.py src/axiom_encode/harness/evals.py src/axiom_encode/prompts/encoder.py tests/test_evals.py pyproject.toml src/axiom_encode/__init__.py`
- `uv run pytest tests/test_evals.py`
- `uv run python -m towncrier build --draft --version 0.0.0`
- live encode: `26 USC 1401(a)` against rulespec-us main after #56: compile=yes ci=yes
- live encode: `26 USC 1401(b)(1)` against rulespec-us main after #56: compile=yes ci=yes

## Review
- `/cycle` read-only subagent review: no actionable findings
