### PR TITLE
Map section 1401 child tax coverage

### DIFF
--- a/changelog.d/section-1401-child-tax-coverage.changed.md
+++ b/changelog.d/section-1401-child-tax-coverage.changed.md
@@ -1,0 +1,1 @@
+Map generated section 1401 self-employment child tax outputs to PolicyEngine component variables and allow PolicyEngine-only oracle inputs for legal RuleSpec facts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.127"
+version = "0.2.128"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.127"
+__version__ = "0.2.128"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3049,6 +3049,10 @@ Test file rules:
 - For annual tax tests, use an explicit tax-year mapping such as `period: {{period_kind: tax_year, start: '2024-01-01', end: '2024-12-31'}}`.
 - For non-tax annual periods, use `period: {{period_kind: custom, name: calendar_year, start: '2024-01-01', end: '2024-12-31'}}`.
 - For `period: Day` outputs, use a custom day mapping such as `period: {{period_kind: custom, name: day, start: '2024-01-15', end: '2024-01-15'}}`; never use bare `YYYY-MM-DD` shorthand.
+- If an external oracle uses different public scenario inputs from the legal
+  RuleSpec facts needed under `input:`, keep the legal facts in `input:` and add
+  `oracle_inputs.<oracle>` with equivalent oracle-native inputs. Do not put
+  oracle-only scenario keys directly in `input:`.
 - Emit 1-4 cases unless a source-driven coverage rule below requires more. If
   `module.status` is `deferred` or `entity_not_supported`, the test file may be
   empty.
@@ -3095,6 +3099,10 @@ Preferred principal output:
 - Name the main derived rule `{policyengine_rule_hint}` unless the source clearly defines a different canonical concept.
 - Keep oracle-comparable tests at that named semantic level; do not assert only helper parameters or documentary scalars.
 - Keep `.test.yaml` inputs oracle-comparable: prefer the oracle's direct component facts over inverted household proxy inputs, preserve direct component surfaces when available, and assert the canonical RuleSpec output whose local name is `{policyengine_rule_hint}` in every non-empty `output:` mapping.
+- When PolicyEngine can compare the output but cannot consume the source-level
+  legal facts directly, add `oracle_inputs.policyengine` with equivalent
+  PolicyEngine-native scenario inputs instead of weakening the RuleSpec `input:`
+  coverage.
 - Prefer a contemporary monthly `.test.yaml` period like `2022-01` or `2024-01` when the source is current-effective and lacks a better effective date; avoid pre-2015 historical periods that PolicyEngine US cannot evaluate.
 - If that output has a durable `jurisdiction:path#rule` id, key the test by that id rather than the friendly local name.
 - Key inputs by their resolving legal RuleSpec target too, e.g. `jurisdiction:path#input.fact`, `jurisdiction:path#relation.name`, or `jurisdiction:path#upstream_rule`.

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -15763,10 +15763,12 @@ Output ONLY valid JSON:
             expected = test.get("expect")
             raw_inputs = test.get("inputs", {})
             inputs = dict(raw_inputs) if isinstance(raw_inputs, dict) else raw_inputs
+            policyengine_inputs = {}
             oracle_inputs = test.get("oracle_inputs", {})
             if isinstance(inputs, dict) and isinstance(oracle_inputs, dict):
-                policyengine_inputs = oracle_inputs.get("policyengine", {})
-                if isinstance(policyengine_inputs, dict):
+                raw_policyengine_inputs = oracle_inputs.get("policyengine", {})
+                if isinstance(raw_policyengine_inputs, dict):
+                    policyengine_inputs = dict(raw_policyengine_inputs)
                     inputs.update(policyengine_inputs)
             period = (
                 test.get("period")
@@ -15793,10 +15795,11 @@ Output ONLY valid JSON:
                 coverage.unsupported += 1
                 continue
 
+            mappability_inputs = policyengine_inputs or inputs
             mappable, reason = self._is_pe_test_mappable(
                 country,
                 raw_test_rule_name,
-                inputs,
+                mappability_inputs,
                 expected,
                 pe_var=pe_var,
                 mapping=mapping,
@@ -17120,6 +17123,10 @@ print("BENCHMARK:" + json.dumps(result))
         "rental_income": "rental_income",
         "employee_social_security_tax": "employee_social_security_tax",
         "employee_medicare_tax": "employee_medicare_tax",
+        "self_employment_income": "self_employment_income",
+        "sstb_self_employment_income": "sstb_self_employment_income",
+        "farm_operations_income": "farm_operations_income",
+        "partnership_se_income": "partnership_se_income",
         "pension_annuity_disability_benefits_received": "pension_income",
         "taxable_pension_annuity_disability_benefits_included": (
             "taxable_pension_income"

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -822,6 +822,17 @@ mappings:
     comparison: rate
     rationale: Same statutory section 1401(b)(1) self-employment Medicare tax rate, stored in PE as parameter data.
 
+  - legal_id: us:statutes/26/1401/b/1#self_employment_income_tax
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: self_employment_medicare_tax
+    entity: person
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same section 1401(b)(1) person-level Medicare self-employment tax component.
+
   - legal_id: us:statutes/26/1401#self_employment_hospital_insurance_tax
     country: us
     program: tax
@@ -845,6 +856,17 @@ mappings:
     period: year
     comparison: rate
     rationale: Same statutory section 1401(a) self-employment OASDI tax rate, stored in PE as parameter data.
+
+  - legal_id: us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: self_employment_social_security_tax
+    entity: person
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same section 1401(a) person-level Social Security self-employment tax component.
 
   - legal_id: us:statutes/26/1401#self_employment_oasdi_tax
     country: us

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -7303,6 +7303,9 @@ class TestSourceEval:
             "prefer the oracle's direct component facts over inverted household proxy inputs"
             in prompt
         )
+        assert "oracle_inputs.policyengine" in prompt
+        assert "equivalent" in prompt
+        assert "PolicyEngine-native scenario inputs" in prompt
         assert "assert that canonical copied output" in prompt
         assert "key the test by that id rather than the friendly local name" in prompt
         assert "Key inputs by their resolving legal RuleSpec target too" in prompt

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -264,6 +264,68 @@ rules:
     assert medicare_rate["tested"] is True
 
 
+def test_policyengine_coverage_maps_section_1401_child_tax_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/1401/a.yaml",
+        """format: rulespec/v1
+rules:
+  - name: old_age_survivors_and_disability_insurance_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: '0'
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/1401/a.test.yaml",
+        """- name: section_1401_a_tax
+  output:
+    us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax: 0
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/1401/b/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: self_employment_income_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: '0'
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/1401/b/1.test.yaml",
+        """- name: section_1401_b_1_tax
+  output:
+    us:statutes/26/1401/b/1#self_employment_income_tax: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["total_outputs"] == 2
+    assert report["status_counts"] == {"comparable": 2}
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    oasdi_tax = items_by_id[
+        "us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax"
+    ]
+    assert oasdi_tax["status"] == "comparable"
+    assert oasdi_tax["policyengine_variable"] == "self_employment_social_security_tax"
+    assert oasdi_tax["tested"] is True
+    medicare_tax = items_by_id["us:statutes/26/1401/b/1#self_employment_income_tax"]
+    assert medicare_tax["status"] == "comparable"
+    assert medicare_tax["policyengine_variable"] == "self_employment_medicare_tax"
+    assert medicare_tax["tested"] is True
+
+
 def test_policyengine_coverage_maps_section_32_earned_income_to_adjusted_earnings(
     tmp_path,
 ):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1672,6 +1672,15 @@ def test_policyengine_registry_is_legal_id_keyed():
         self_employment_oasdi_rate_mapping.policyengine_parameter
         == "gov.irs.self_employment.rate.social_security"
     )
+    self_employment_oasdi_tax_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax",
+        country="us",
+    )
+    assert self_employment_oasdi_tax_mapping.mapping_type == "direct_variable"
+    assert (
+        self_employment_oasdi_tax_mapping.policyengine_variable
+        == "self_employment_social_security_tax"
+    )
     employee_medicare_rate_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/3101/b/1#hospital_insurance_wage_tax_rate",
         country="us",
@@ -1689,6 +1698,15 @@ def test_policyengine_registry_is_legal_id_keyed():
     assert (
         self_employment_medicare_rate_mapping.policyengine_parameter
         == "gov.irs.self_employment.rate.medicare"
+    )
+    self_employment_medicare_tax_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/1401/b/1#self_employment_income_tax",
+        country="us",
+    )
+    assert self_employment_medicare_tax_mapping.mapping_type == "direct_variable"
+    assert (
+        self_employment_medicare_tax_mapping.policyengine_variable
+        == "self_employment_medicare_tax"
     )
     rrta_tier_2_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/3201#tier_2_employee_tax",
@@ -2056,6 +2074,105 @@ def test_policyengine_oracle_has_no_issue_noise_for_unsupported_only(tmp_path):
     assert result.issues == []
     assert result.details["coverage"]["unsupported"] == 1
     assert result.details["coverage"]["unmapped"] == 0
+
+
+def test_policyengine_oracle_uses_policyengine_only_inputs_for_legal_facts(tmp_path):
+    rules_file = tmp_path / "rules.yaml"
+    rules_file.write_text("format: rulespec/v1\n")
+    rules_file.with_name("rules.test.yaml").write_text(
+        """- name: section_1401_a_oracle_case
+  period: 2024
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 1200
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 200
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+    us:statutes/26/1402/b#input.contribution_and_benefit_base_under_section_230_of_social_security_act: 5000
+    us:statutes/26/1402/b#input.wages_paid_to_individual_for_section_1401_a: 100
+  oracle_inputs:
+    policyengine:
+      self_employment_income: 1000
+      employment_income: 100
+  output:
+    us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax: 114.514
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=True,
+        oracle_validators=("policyengine",),
+    )
+    pipeline.policyengine_registry = PolicyEngineOracleRegistry(
+        {
+            "us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax": PolicyEngineMapping(
+                legal_id="us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax",
+                country="us",
+                mapping_type="direct_variable",
+                policyengine_variable="self_employment_social_security_tax",
+            )
+        }
+    )
+    pipeline._detect_policyengine_country = lambda *_args, **_kwargs: "us"
+    pipeline._find_pe_python = lambda _country: Path("python")
+
+    scripts = []
+
+    def fake_run(script, *_args, **_kwargs):
+        scripts.append(script)
+        return OracleSubprocessResult(returncode=0, stdout="RESULT:114.514\n")
+
+    pipeline._run_pe_subprocess_detailed = fake_run
+
+    result = pipeline._run_policyengine(rules_file)
+
+    assert result.score == 1.0
+    assert result.passed is True
+    assert result.issues == []
+    assert result.details["coverage"]["comparable"] == 1
+    assert result.details["coverage"]["passed"] == 1
+    assert "'self_employment_income': {'2024': 1000}" in scripts[0]
+    assert "'employment_income': {'2024': 100}" in scripts[0]
+
+
+def test_policyengine_oracle_rejects_untranslated_legal_facts(tmp_path):
+    rules_file = tmp_path / "rules.yaml"
+    rules_file.write_text("format: rulespec/v1\n")
+    rules_file.with_name("rules.test.yaml").write_text(
+        """- name: section_1401_a_untranslated_case
+  period: 2024
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 1200
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 200
+  output:
+    us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax: 114.514
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=True,
+        oracle_validators=("policyengine",),
+    )
+    pipeline.policyengine_registry = PolicyEngineOracleRegistry(
+        {
+            "us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax": PolicyEngineMapping(
+                legal_id="us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax",
+                country="us",
+                mapping_type="direct_variable",
+                policyengine_variable="self_employment_social_security_tax",
+            )
+        }
+    )
+    pipeline._detect_policyengine_country = lambda *_args, **_kwargs: "us"
+    pipeline._find_pe_python = lambda _country: Path("python")
+
+    result = pipeline._run_policyengine(rules_file)
+
+    assert result.score is None
+    assert result.passed is True
+    assert result.details["coverage"]["unsupported"] == 1
+    assert result.details["coverage"]["comparable"] == 0
+    assert "unprojectable RuleSpec legal input" in result.issues[0]
 
 
 def test_policyengine_oracle_compares_parameter_value_mapping(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.127"
+version = "0.2.128"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map generated section 1401(a) OASDI self-employment tax output to PolicyEngine `self_employment_social_security_tax`
- map generated section 1401(b)(1) Medicare self-employment tax output to PolicyEngine `self_employment_medicare_tax`
- allow `oracle_inputs.policyengine` to provide PE-native scenario inputs while legal RuleSpec facts remain in `input:`
- add direct PE person scenario support for self-employment income inputs
- add coverage, registry, prompt, and oracle regressions so generated section 1401 child tax artifacts can be classified and compared without pretending PE consumes legal facts directly

## Validation
- `uv run ruff check src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/harness/evals.py tests/test_rulespec_validation.py tests/test_policyengine_coverage.py tests/test_evals.py src/axiom_encode/__init__.py`
- `uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/harness/evals.py tests/test_rulespec_validation.py tests/test_policyengine_coverage.py tests/test_evals.py src/axiom_encode/__init__.py`
- `uv run pytest tests/test_policyengine_coverage.py tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_rulespec_validation.py::test_policyengine_oracle_uses_policyengine_only_inputs_for_legal_facts tests/test_rulespec_validation.py::test_policyengine_oracle_rejects_untranslated_legal_facts tests/test_evals.py::TestSourceEval::test_build_eval_prompt_includes_policyengine_rule_hint`
- `uv run python -m towncrier build --draft --version 0.0.0`
- local `axiom-encode oracle-coverage` over the generated section 1401 RuleSpec worktree: both child tax outputs comparable/tested