### PR TITLE
Repair section 1401(b)(1) income import

### DIFF
--- a/changelog.d/section-1401-b1-uncapped-income.fixed.md
+++ b/changelog.d/section-1401-b1-uncapped-income.fixed.md
@@ -1,0 +1,1 @@
+Repair generated section 1401(b)(1) encodings to use uncapped 1402(b) self-employment income.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.129"
+version = "0.2.130"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.129"
+__version__ = "0.2.130"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10342,6 +10342,21 @@ def cmd_encode(args):
             outcome["final_success"] = False
             print(f"  apply=blocked_generation:{detail}")
         else:
+            repaired_section_1401_b_1_income = (
+                _try_repair_generated_section_1401_b_1_self_employment_income_for_apply(
+                    result,
+                    output_root=args.output,
+                    policy_repo_path=policy_repo_path,
+                )
+            )
+            if repaired_section_1401_b_1_income:
+                outcome["auto_repaired_section_1401_b_1_self_employment_income"] = (
+                    repaired_section_1401_b_1_income
+                )
+                print(
+                    "  apply=auto_repaired_section_1401_b_1_self_employment_income:"
+                    + ",".join(repaired_section_1401_b_1_income)
+                )
             repaired_policyengine_oracle_inputs = (
                 _try_repair_generated_policyengine_oracle_inputs_for_apply(
                     result,
@@ -12086,6 +12101,12 @@ _SECTION_1401_A_OUTPUT = (
     "us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax"
 )
 _SECTION_1401_B_1_OUTPUT = "us:statutes/26/1401/b/1#self_employment_income_tax"
+_SECTION_1402_B_SELF_EMPLOYMENT_INCOME_OUTPUT = (
+    "us:statutes/26/1402/b#self_employment_income"
+)
+_SECTION_1402_B_SELF_EMPLOYMENT_INCOME_FOR_1401_A_OUTPUT = (
+    "us:statutes/26/1402/b#self_employment_income_for_section_1401_a"
+)
 _SECTION_1401_TAXABLE_SELF_EMPLOYMENT_RATE = Decimal("0.9235")
 _SECTION_1401_SELF_EMPLOYMENT_THRESHOLD = Decimal("400")
 _SECTION_1401_OASDI_BASE_BY_YEAR = {
@@ -12094,6 +12115,190 @@ _SECTION_1401_OASDI_BASE_BY_YEAR = {
     2025: Decimal("176100"),
     2026: Decimal("184500"),
 }
+
+
+def _try_repair_generated_section_1401_b_1_self_employment_income_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+) -> list[str]:
+    """Use uncapped 1402(b) self-employment income for 1401(b)(1) Medicare tax."""
+    try:
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
+    except RuntimeError:
+        return []
+    if relative_output.as_posix() != "statutes/26/1401/b/1.yaml":
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    test_file = _rulespec_test_path(rules_file)
+    repaired = _repair_section_1401_b_1_self_employment_income_import(
+        rules_file=rules_file,
+        policy_repo_path=policy_repo_path,
+    )
+    repaired.extend(
+        _append_section_1401_b_1_uncapped_self_employment_income_test(
+            test_file=test_file,
+        )
+    )
+    return repaired
+
+
+def _repair_section_1401_b_1_self_employment_income_import(
+    *,
+    rules_file: Path,
+    policy_repo_path: Path,
+) -> list[str]:
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+
+    repaired: list[str] = []
+    imports = payload.get("imports")
+    if isinstance(imports, list):
+        changed_imports = False
+        for index, item in enumerate(imports):
+            if item == _SECTION_1402_B_SELF_EMPLOYMENT_INCOME_FOR_1401_A_OUTPUT:
+                imports[index] = _SECTION_1402_B_SELF_EMPLOYMENT_INCOME_OUTPUT
+                changed_imports = True
+        if changed_imports:
+            repaired.append("import:self_employment_income")
+
+    imported_file = policy_repo_path / "statutes/26/1402/b.yaml"
+    imported_hash = _sha256_file(imported_file) if imported_file.exists() else None
+    rules = payload.get("rules")
+    if isinstance(rules, list):
+        for rule in rules:
+            if (
+                not isinstance(rule, dict)
+                or rule.get("name") != "self_employment_income_tax"
+            ):
+                continue
+            if _repair_section_1401_b_1_rule_formula(rule):
+                repaired.append("formula:self_employment_income_tax")
+            if _repair_section_1401_b_1_rule_proof_import(
+                rule,
+                imported_hash=imported_hash,
+            ):
+                repaired.append("proof:self_employment_income")
+
+    if not repaired:
+        return []
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repaired
+
+
+def _repair_section_1401_b_1_rule_formula(rule: dict[str, object]) -> bool:
+    changed = False
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return False
+    for version in versions:
+        if not isinstance(version, dict):
+            continue
+        formula = version.get("formula")
+        if not isinstance(formula, str):
+            continue
+        repaired_formula = re.sub(
+            r"\bself_employment_income_for_section_1401_a\b",
+            "self_employment_income",
+            formula,
+        )
+        if repaired_formula != formula:
+            version["formula"] = repaired_formula
+            changed = True
+    return changed
+
+
+def _repair_section_1401_b_1_rule_proof_import(
+    rule: dict[str, object],
+    *,
+    imported_hash: str | None,
+) -> bool:
+    metadata = rule.get("metadata")
+    if not isinstance(metadata, dict):
+        return False
+    proof = metadata.get("proof")
+    if not isinstance(proof, dict):
+        return False
+    atoms = proof.get("atoms")
+    if not isinstance(atoms, list):
+        return False
+
+    changed = False
+    for atom in atoms:
+        if not isinstance(atom, dict) or atom.get("kind") != "import":
+            continue
+        import_payload = atom.get("import")
+        if not isinstance(import_payload, dict):
+            continue
+        if (
+            import_payload.get("target")
+            != _SECTION_1402_B_SELF_EMPLOYMENT_INCOME_FOR_1401_A_OUTPUT
+        ):
+            continue
+        import_payload["target"] = _SECTION_1402_B_SELF_EMPLOYMENT_INCOME_OUTPUT
+        import_payload["output"] = "self_employment_income"
+        if imported_hash is not None:
+            import_payload["hash"] = f"sha256:{imported_hash}"
+        changed = True
+    return changed
+
+
+def _append_section_1401_b_1_uncapped_self_employment_income_test(
+    *,
+    test_file: Path,
+) -> list[str]:
+    if not test_file.exists():
+        return []
+    try:
+        test_payload = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, yaml.YAMLError):
+        return []
+    if not isinstance(test_payload, list):
+        return []
+
+    case_name = "self_employment_income_tax_ignores_section_1401_a_cap"
+    if any(
+        isinstance(test_case, dict) and test_case.get("name") == case_name
+        for test_case in test_payload
+    ):
+        return []
+    test_payload.append(
+        {
+            "name": case_name,
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2024-01-01",
+                "end": "2024-12-31",
+            },
+            "input": {
+                "us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income": 2500,
+                "us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions": 200,
+                "us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss": 0,
+                "us:statutes/26/1402/b#input.contribution_and_benefit_base_under_section_230_of_social_security_act": 1200,
+                "us:statutes/26/1402/b#input.wages_paid_to_individual_for_section_1401_a": 500,
+                "us:statutes/26/1402/b#input.individual_is_nonresident_alien": False,
+                "us:statutes/26/1402/b#input.social_security_agreement_under_section_233_applies_to_nonresident_alien": False,
+                "us:statutes/26/1402/b#input.individual_is_noncitizen_territory_resident": False,
+            },
+            "output": {
+                _SECTION_1401_B_1_OUTPUT: 61.59745,
+            },
+        }
+    )
+    test_file.write_text(
+        yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
+    )
+    return [f"test:{case_name}"]
 
 
 def _try_repair_generated_policyengine_oracle_inputs_for_apply(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,6 +47,7 @@ from axiom_encode.cli import (
     _source_relation_preservation_issues,
     _suppress_rulespec_ancestor_targets_for_subsection_overlay,
     _try_repair_generated_policyengine_oracle_inputs_for_apply,
+    _try_repair_generated_section_1401_b_1_self_employment_income_for_apply,
     _try_repair_generated_source_table_band_scalars_for_apply,
     _validate_generated_encoding_in_policy_overlay,
     _write_applied_encoding_manifest,
@@ -3880,6 +3881,108 @@ rules:
         test_payload = yaml.safe_load(test_file.read_text())
         assert test_payload[0]["oracle_inputs"]["policyengine"] == {
             "self_employment_income": 1000,
+        }
+
+    def test_apply_repair_uses_uncapped_1402b_income_for_section_1401_b_1(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us"
+        imported_file = policy_repo / "statutes" / "26" / "1402" / "b.yaml"
+        imported_file.parent.mkdir(parents=True)
+        imported_file.write_text("format: rulespec/v1\nrules: []\n")
+        imported_hash = _sha256_file(imported_file)
+        output_file = (
+            output_root
+            / "codex-test-model"
+            / "statutes"
+            / "26"
+            / "1401"
+            / "b"
+            / "1.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/1401/b/1/rate#self_employment_income_tax_rate
+  - us:statutes/26/1402/b#self_employment_income_for_section_1401_a
+rules:
+  - name: self_employment_income_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/1402/b#self_employment_income_for_section_1401_a
+              output: self_employment_income_for_section_1401_a
+              hash: sha256:old
+    versions:
+      - effective_from: '1990-01-01'
+        formula: self_employment_income_tax_rate * self_employment_income_for_section_1401_a
+"""
+        )
+        test_file = output_file.with_name("1.test.yaml")
+        test_file.write_text(
+            """- name: self_employment_income_tax_applies_2_9_percent_to_self_employment_income
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 1200
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_deductions: 200
+    us:statutes/26/1402/a#input.partnership_section_702_a_8_income_or_loss: 0
+  output:
+    us:statutes/26/1401/b/1#self_employment_income_tax: 26.7815
+"""
+        )
+        result = SimpleNamespace(
+            output_file=str(output_file),
+            runner="codex-test-model",
+        )
+
+        repaired = (
+            _try_repair_generated_section_1401_b_1_self_employment_income_for_apply(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+            )
+        )
+
+        assert repaired == [
+            "import:self_employment_income",
+            "formula:self_employment_income_tax",
+            "proof:self_employment_income",
+            "test:self_employment_income_tax_ignores_section_1401_a_cap",
+        ]
+        rules_payload = yaml.safe_load(output_file.read_text())
+        assert rules_payload["imports"] == [
+            "us:statutes/26/1401/b/1/rate#self_employment_income_tax_rate",
+            "us:statutes/26/1402/b#self_employment_income",
+        ]
+        rule = rules_payload["rules"][0]
+        assert (
+            rule["versions"][0]["formula"]
+            == "self_employment_income_tax_rate * self_employment_income"
+        )
+        import_atom = rule["metadata"]["proof"]["atoms"][0]["import"]
+        assert import_atom == {
+            "target": "us:statutes/26/1402/b#self_employment_income",
+            "output": "self_employment_income",
+            "hash": f"sha256:{imported_hash}",
+        }
+        test_payload = yaml.safe_load(test_file.read_text())
+        assert test_payload[-1]["name"] == (
+            "self_employment_income_tax_ignores_section_1401_a_cap"
+        )
+        assert test_payload[-1]["output"] == {
+            "us:statutes/26/1401/b/1#self_employment_income_tax": 61.59745
         }
 
     def test_repair_employer_scoped_entities_sets_rate_helpers(self, tmp_path):


### PR DESCRIPTION
## Summary
- repair generated section 1401(b)(1) outputs to import uncapped 1402(b) self-employment income instead of the OASDI-capped helper
- add a cap-binding generated test so Medicare SE tax keeps using the full 1402(b) base
- bump axiom-encode to 0.2.130 and add a changelog fragment

## Tests
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py src/axiom_encode/__init__.py pyproject.toml
- uv run pytest tests/test_cli.py::TestCmdEncode::test_apply_repair_uses_uncapped_1402b_income_for_section_1401_b_1 tests/test_cli.py::TestCmdEncode::test_encode_apply_auto_repairs_section_1401_policyengine_oracle_inputs tests/test_cli.py::TestCmdEncode::test_apply_repair_adds_section_1401_b_policyengine_oracle_inputs tests/test_rulespec_validation.py::test_policyengine_oracle_uses_policyengine_only_inputs_for_legal_facts tests/test_rulespec_validation.py::test_policyengine_oracle_rejects_untranslated_legal_facts tests/test_policyengine_coverage.py::test_policyengine_coverage_maps_section_1401_child_tax_outputs
- uv run --extra dev python -m towncrier build --draft