### PR TITLE
Bump tax ECPS PolicyEngine-US baseline

### DIFF
--- a/changelog.d/tax-ecps-policyengine-us-bump.changed.md
+++ b/changelog.d/tax-ecps-policyengine-us-bump.changed.md
@@ -1,0 +1,1 @@
+Bump the federal tax ECPS oracle baseline to policyengine-us 1.705.16 so payroll comparisons include the retirement-deferral FICA wage fix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.130"
+version = "0.2.131"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.130"
+__version__ = "0.2.131"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -28,7 +28,8 @@ except ImportError:  # pragma: no cover - exercised only without optional oracle
 
 POLICYENGINE_VERSION = "4.11.0"
 POLICYENGINE_CORE_VERSION = "3.26.11"
-POLICYENGINE_US_VERSION = "1.700.0"
+POLICYENGINE_DATA_MANIFEST_US_VERSION = "1.700.0"
+POLICYENGINE_US_VERSION = "1.705.16"
 DATASET = "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5"
 
 CTC_PROGRAM_PATH = Path("statutes/26/24.yaml")
@@ -591,7 +592,10 @@ def load_policyengine_tax_data(
     tax_unit_variables: tuple[str, ...] = PE_TAX_UNIT_VARIABLES,
     person_variables: tuple[str, ...] = PE_PERSON_VARIABLES,
 ) -> dict[str, Any]:
-    if allow_uncertified_policyengine_data:
+    if (
+        allow_uncertified_policyengine_data
+        or policyengine_data_certification_override_required()
+    ):
         _install_policyengine_data_certification_override()
     try:
         from policyengine.core import Simulation
@@ -729,11 +733,12 @@ def select_tax_unit_indices(
 def _install_policyengine_data_certification_override() -> None:
     """Allow ECPS oracle runs against a local policyengine-us fix branch.
 
-    policyengine.py 4.11.0 certifies the bundled ECPS data against
-    policyengine-us 1.700.0. When validating a local policyengine-us PR, the
-    installed model version can intentionally differ while the ECPS data is
-    still the desired oracle input. This override is intentionally reachable
-    only through an explicit CLI flag paired with --allow-policyengine-us-version.
+    policyengine.py 4.11.0 currently certifies the bundled ECPS data against
+    its manifest-pinned policyengine-us release. When validating a local
+    policyengine-us PR, the installed model version can intentionally differ
+    while the ECPS data is still the desired oracle input. This override is
+    also used when Axiom deliberately pins the oracle to a newer policyengine-us
+    release than policyengine.py's bundled manifest.
     """
     os.environ.setdefault("POLICYENGINE_SKIP_COUNTRY_IMPORTS", "1")
     try:
@@ -759,6 +764,11 @@ def _install_policyengine_data_certification_override() -> None:
     except ImportError:  # pragma: no cover - optional runtime dependency
         return
     model_version.certify_data_release_compatibility = _allow_local_oracle_data
+
+
+def policyengine_data_certification_override_required() -> bool:
+    """Return whether the pinned PE-US oracle intentionally exceeds the manifest."""
+    return POLICYENGINE_US_VERSION != POLICYENGINE_DATA_MANIFEST_US_VERSION
 
 
 def build_axiom_request(

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -16,6 +16,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     OASDI_WAGE_BASE_EXCLUSION_OUTPUT,
     OASDI_WAGE_BASE_PROGRAM_PATH,
     POLICYENGINE_CORE_VERSION,
+    POLICYENGINE_US_VERSION,
     POLICYENGINE_VERSION,
     SECTION_32_C_2_BASE,
     SECTION_112_BASE,
@@ -40,6 +41,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     individual_is_unmarried_and_not_surviving_spouse,
     output_number,
     person_entity_id,
+    policyengine_data_certification_override_required,
     project_capital_gain_definition_inputs,
     project_ctc_h_person_inputs,
     project_ctc_person_inputs,
@@ -1571,7 +1573,7 @@ def test_policyengine_version_guard_rejects_unpinned_core_version(monkeypatch):
         if package == "policyengine-core":
             return "999.0.0"
         if package == "policyengine-us":
-            return "1.700.0"
+            return POLICYENGINE_US_VERSION
         raise AssertionError(package)
 
     monkeypatch.setattr(ecps_tax, "version", fake_version)
@@ -1593,6 +1595,38 @@ def test_policyengine_version_guard_allows_local_us_override(monkeypatch):
     monkeypatch.setattr(ecps_tax, "version", fake_version)
 
     require_policyengine_versions(allow_policyengine_us_version=True)
+
+
+def test_policyengine_data_certification_override_is_required_for_pinned_us_bump():
+    assert policyengine_data_certification_override_required() is True
+
+
+def test_policyengine_data_certification_override_runs_on_default_pinned_bump(
+    monkeypatch, tmp_path
+):
+    def fake_install_override():
+        raise RuntimeError("certification override installed")
+
+    monkeypatch.setattr(
+        ecps_tax,
+        "policyengine_data_certification_override_required",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        ecps_tax,
+        "_install_policyengine_data_certification_override",
+        fake_install_override,
+    )
+
+    with pytest.raises(RuntimeError, match="certification override installed"):
+        ecps_tax.load_policyengine_tax_data(
+            year=2026,
+            sample_size=1,
+            positive_ctc_only=False,
+            data_folder=tmp_path,
+            tax_unit_variables=(),
+            person_variables=(),
+        )
 
 
 def test_uncertified_policyengine_data_requires_local_us_override(tmp_path):


### PR DESCRIPTION
## Summary
- bump the federal tax ECPS oracle baseline from policyengine-us 1.700.0 to 1.705.16
- install the existing ECPS data-certification override when Axiom intentionally pins PE-US beyond policyengine.py's bundled manifest
- bump axiom-encode to 0.2.131 and add a changelog fragment

## Why
The current pinned baseline predates PolicyEngine/policyengine-us#8374. On a 100-tax-unit payroll ECPS sample, the old pin reports retirement-deferral FICA wage residuals; the same sample has zero mismatches with policyengine-us 1.705.16.

## Tests
- uv run ruff check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py src/axiom_encode/__init__.py pyproject.toml
- uv run pytest tests/test_policyengine_ecps_tax.py::test_policyengine_version_guard_rejects_unpinned_us_version tests/test_policyengine_ecps_tax.py::test_policyengine_version_guard_rejects_unpinned_core_version tests/test_policyengine_ecps_tax.py::test_policyengine_version_guard_allows_local_us_override tests/test_policyengine_ecps_tax.py::test_policyengine_data_certification_override_is_required_for_pinned_us_bump tests/test_policyengine_ecps_tax.py::test_fica_wage_projection_does_not_subtract_retirement_deferrals tests/test_policyengine_ecps_tax.py::test_compare_oasdi_stage_runs_encoded_ssa_base_before_3121
- uv run --extra dev python -m towncrier build --draft
- uv run --with policyengine==4.11.0 --with policyengine-core==3.26.11 --with policyengine-us==1.705.16 axiom-encode tax-ecps-compare --rulespec-root /tmp/axiom-coverage-current/rulespec-us --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine --surface employee-oasdi --sample-size 10 --data-folder /tmp/axiom-policyengine-cache --json