### PR TITLE
Strengthen scoped exception prompt guidance

### DIFF
--- a/changelog.d/scoped-exception-test-guidance.fixed.md
+++ b/changelog.d/scoped-exception-test-guidance.fixed.md
@@ -1,0 +1,1 @@
+Strengthen encoder guidance for scoped exception predicates and source-gate companion test coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.132"
+version = "0.2.133"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.132"
+__version__ = "0.2.133"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3073,6 +3073,13 @@ Test file rules:
 - For every encoded `except`, `unless`, or `notwithstanding` carve-out, include
   companion tests for the positive path and the carve-out path so exclusions
   cannot be silently dropped.
+- For scoped exceptions, include a control case proving a non-excepted
+  qualifying item is not reduced or blocked by the exception amount, plus a case
+  where the same exception applies to the source-stated excepted category.
+- When a local formula has five or fewer independent source-stated boolean
+  gates joined by `and`, include one all-gates-positive case and enough negative
+  cases to toggle each gate at least once. Do not leave a source-stated gate
+  untested just because another negative case toggles a different gate.
 - If a formula negates multiple exception predicates, include a separate companion test for each predicate that sets that exception input true and expects the directly affected Judgment rule to be `not_holds`.
 - For any negated exception predicate, include a paired positive case with the same output rule where only the exception input changes from `false` to `true`; do not combine the exception test with another branch change.
 - Do not collapse a list of cited exceptions or cross-reference carve-outs into one aggregate fact such as `sections_..._do_not_preclude...`. Encode or import each cited exception separately, then combine them in a helper if useful.
@@ -3369,6 +3376,12 @@ RuleSpec requirements:
   final exported amount must apply that limitation. If a copied sibling/context
   file already encodes the limitation, import it and compose with it instead of
   duplicating or ignoring it.
+- When an exception or carve-out applies only to a source-stated category of an
+  otherwise qualifying payment, person, household, expense, or amount, gate that
+  exception with a predicate for the excepted category or use an input amount
+  whose name is explicitly scoped to that category. Do not subtract, disallow,
+  or reduce all qualifying branches merely because an exception amount input is
+  nonzero.
 - If the copied target file is already executable, do not let its old surface
   force local placeholders or compatibility names. Rebuild, drop, or defer
   individual outputs as needed. Prefer retaining or replacing source-backed
@@ -3550,6 +3563,13 @@ RuleSpec requirements:
 - Represent every substantive source amount, rate, threshold, cap, or limit as a named `parameter` rule, then reference that parameter from derived formulas.
 - If the same numeric value appears twice in materially different legal roles, including separate numbered exceptions or subparagraphs, give those roles distinct named scalars; otherwise reuse that named scalar everywhere the rule compares against or computes with that number.
 - Adjacent bracket thresholds repeated as both an upper bound and the next bracket's lower bound are separate source-stated legal roles; define distinct semantic scalars for those occurrences and use them in the branch conditions.
+- For scoped exceptions, include a control case proving a non-excepted
+  qualifying item is not reduced or blocked by the exception amount, plus a case
+  where the same exception applies to the source-stated excepted category.
+- When a local formula has five or fewer independent source-stated boolean
+  gates joined by `and`, include one all-gates-positive case and enough negative
+  cases to toggle each gate at least once. Do not leave a source-stated gate
+  untested just because another negative case toggles a different gate.
 - If a formula negates multiple exception predicates, include a separate companion test for each predicate that sets that exception input true and expects the directly affected Judgment rule to be `not_holds`.
 - For any negated exception predicate, include a paired positive case with the same output rule where only the exception input changes from `false` to `true`; do not combine the exception test with another branch change.
 - Every local executable `kind: parameter` and `kind: derived` rule must appear

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -407,6 +407,12 @@ Hard requirements:
   final exported amount must apply that limitation. If a copied sibling/context
   file already encodes the limitation, import it and compose with it instead of
   duplicating or ignoring it.
+- When an exception or carve-out applies only to a source-stated category of an
+  otherwise qualifying payment, person, household, expense, or amount, gate that
+  exception with a predicate for the excepted category or use an input amount
+  whose name is explicitly scoped to that category. Do not subtract, disallow,
+  or reduce all qualifying branches merely because an exception amount input is
+  nonzero.
 - If the copied target file is already executable, do not let its old surface
   force local placeholders or compatibility names. Rebuild, drop, or defer
   individual outputs as needed. Prefer retaining or replacing source-backed
@@ -534,6 +540,13 @@ Hard requirements:
 - For every encoded `except`, `unless`, or `notwithstanding` carve-out, include
   companion tests for the positive path and the carve-out path so exclusions
   cannot be silently dropped.
+- For scoped exceptions, include a control case proving a non-excepted
+  qualifying item is not reduced or blocked by the exception amount, plus a case
+  where the same exception applies to the source-stated excepted category.
+- When a local formula has five or fewer independent source-stated boolean
+  gates joined by `and`, include one all-gates-positive case and enough negative
+  cases to toggle each gate at least once. Do not leave a source-stated gate
+  untested just because another negative case toggles a different gate.
 - If a formula negates multiple exception predicates, include a separate
   companion test for each predicate that sets that exception input true and
   expects the directly affected Judgment rule to be `not_holds`.

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -95,6 +95,9 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "source-named numeric boundary input" in ENCODER_PROMPT
     assert "source-stated formula executable" in ENCODER_PROMPT
     assert "defer only that branch" in ENCODER_PROMPT
+    assert "predicate for the excepted category" in ENCODER_PROMPT
+    assert "non-excepted" in ENCODER_PROMPT
+    assert "toggle each gate at least once" in ENCODER_PROMPT
     assert "rate-applied result at the source-stated lower entity" in ENCODER_PROMPT
     assert "unit-level placeholder or aggregate base by the rate" in ENCODER_PROMPT
     assert "Never drop the jurisdiction prefix" in ENCODER_PROMPT
@@ -135,6 +138,9 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "is not an executable dependency" in prompt
     assert "source-stated formula executable" in prompt
     assert "defer only that branch" in prompt
+    assert "predicate for the excepted category" in prompt
+    assert "non-excepted" in prompt
+    assert "toggle each gate at least once" in prompt
     assert "rate-applied result at the source-stated lower entity" in prompt
     assert "unit-level placeholder or aggregate base by the rate" in prompt
     assert "Never drop the jurisdiction prefix" in prompt

--- a/tests/test_prompt_concept_injection.py
+++ b/tests/test_prompt_concept_injection.py
@@ -179,3 +179,33 @@ def test_build_rulespec_eval_prompt_omits_section_when_no_match(tmp_path: Path):
     )
 
     assert "Canonical concept names:" not in prompt
+
+
+def test_build_rulespec_eval_prompt_includes_scoped_exception_test_guidance(
+    tmp_path: Path,
+):
+    source_text = (
+        "Any qualifying expense is excluded except that this paragraph does "
+        "not apply to expenses for a nonqualified service to the extent paid."
+    )
+    workspace = _minimal_workspace(tmp_path, source_text)
+
+    prompt = _build_rulespec_eval_prompt(
+        citation="7 CFR 273.9(d)(1)",
+        mode="cold",
+        workspace=workspace,
+        context_files=[],
+        target_file_name="regulations/7-cfr/273/9/d/1.yaml",
+        target_ref_prefix="us:regulations/7-cfr/273/9/d/1",
+        include_tests=True,
+        runner_backend="codex",
+        policyengine_rule_hint=None,
+    )
+
+    assert "predicate for the excepted category" in prompt
+    test_file_rules = prompt.split("Test file rules:", maxsplit=1)[1].split(
+        "Do not respond with summaries",
+        maxsplit=1,
+    )[0]
+    assert "non-excepted" in test_file_rules
+    assert "toggle each gate at least once" in test_file_rules


### PR DESCRIPTION
## Summary
- require scoped exception/carve-out branches to be gated by source-stated category predicates or scoped amounts
- require companion tests for scoped-exception controls and small boolean gate coverage
- bump axiom-encode to 0.2.133 with a changelog fragment

## Tests
- uv run ruff format src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_encoder_backend.py tests/test_prompt_concept_injection.py
- uv run ruff check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_encoder_backend.py tests/test_prompt_concept_injection.py src/axiom_encode/__init__.py pyproject.toml
- uv run pytest tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_statutory_base_naming_guidance tests/test_prompt_concept_injection.py::test_build_rulespec_eval_prompt_includes_scoped_exception_test_guidance
- uv run --extra dev python -m towncrier build --draft --version 0.0.0