### PR TITLE
Require positive scoped exception controls

### DIFF
--- a/changelog.d/positive-scoped-exception-controls.fixed.md
+++ b/changelog.d/positive-scoped-exception-controls.fixed.md
@@ -1,0 +1,1 @@
+Require scoped-exception companion control cases to set the exception input positive or nonzero.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.133"
+version = "0.2.134"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.133"
+__version__ = "0.2.134"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3074,8 +3074,9 @@ Test file rules:
   companion tests for the positive path and the carve-out path so exclusions
   cannot be silently dropped.
 - For scoped exceptions, include a control case proving a non-excepted
-  qualifying item is not reduced or blocked by the exception amount, plus a case
-  where the same exception applies to the source-stated excepted category.
+  qualifying item is not reduced or blocked even when the exception amount or
+  exception fact is positive/nonzero, plus a case where the same exception
+  applies to the source-stated excepted category.
 - When a local formula has five or fewer independent source-stated boolean
   gates joined by `and`, include one all-gates-positive case and enough negative
   cases to toggle each gate at least once. Do not leave a source-stated gate
@@ -3564,8 +3565,9 @@ RuleSpec requirements:
 - If the same numeric value appears twice in materially different legal roles, including separate numbered exceptions or subparagraphs, give those roles distinct named scalars; otherwise reuse that named scalar everywhere the rule compares against or computes with that number.
 - Adjacent bracket thresholds repeated as both an upper bound and the next bracket's lower bound are separate source-stated legal roles; define distinct semantic scalars for those occurrences and use them in the branch conditions.
 - For scoped exceptions, include a control case proving a non-excepted
-  qualifying item is not reduced or blocked by the exception amount, plus a case
-  where the same exception applies to the source-stated excepted category.
+  qualifying item is not reduced or blocked even when the exception amount or
+  exception fact is positive/nonzero, plus a case where the same exception
+  applies to the source-stated excepted category.
 - When a local formula has five or fewer independent source-stated boolean
   gates joined by `and`, include one all-gates-positive case and enough negative
   cases to toggle each gate at least once. Do not leave a source-stated gate

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -541,8 +541,9 @@ Hard requirements:
   companion tests for the positive path and the carve-out path so exclusions
   cannot be silently dropped.
 - For scoped exceptions, include a control case proving a non-excepted
-  qualifying item is not reduced or blocked by the exception amount, plus a case
-  where the same exception applies to the source-stated excepted category.
+  qualifying item is not reduced or blocked even when the exception amount or
+  exception fact is positive/nonzero, plus a case where the same exception
+  applies to the source-stated excepted category.
 - When a local formula has five or fewer independent source-stated boolean
   gates joined by `and`, include one all-gates-positive case and enough negative
   cases to toggle each gate at least once. Do not leave a source-stated gate

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -96,7 +96,7 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "source-stated formula executable" in ENCODER_PROMPT
     assert "defer only that branch" in ENCODER_PROMPT
     assert "predicate for the excepted category" in ENCODER_PROMPT
-    assert "non-excepted" in ENCODER_PROMPT
+    assert "positive/nonzero" in ENCODER_PROMPT
     assert "toggle each gate at least once" in ENCODER_PROMPT
     assert "rate-applied result at the source-stated lower entity" in ENCODER_PROMPT
     assert "unit-level placeholder or aggregate base by the rate" in ENCODER_PROMPT
@@ -139,7 +139,7 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "source-stated formula executable" in prompt
     assert "defer only that branch" in prompt
     assert "predicate for the excepted category" in prompt
-    assert "non-excepted" in prompt
+    assert "positive/nonzero" in prompt
     assert "toggle each gate at least once" in prompt
     assert "rate-applied result at the source-stated lower entity" in prompt
     assert "unit-level placeholder or aggregate base by the rate" in prompt

--- a/tests/test_prompt_concept_injection.py
+++ b/tests/test_prompt_concept_injection.py
@@ -207,5 +207,5 @@ def test_build_rulespec_eval_prompt_includes_scoped_exception_test_guidance(
         "Do not respond with summaries",
         maxsplit=1,
     )[0]
-    assert "non-excepted" in test_file_rules
+    assert "positive/nonzero" in test_file_rules
     assert "toggle each gate at least once" in test_file_rules


### PR DESCRIPTION
## Summary
- clarify scoped-exception companion-test guidance so control cases use positive/nonzero exception facts or amounts
- bump axiom-encode to 0.2.134 and add a changelog fragment

## Tests
- uv run ruff format src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_encoder_backend.py tests/test_prompt_concept_injection.py
- uv run ruff check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_encoder_backend.py tests/test_prompt_concept_injection.py src/axiom_encode/__init__.py pyproject.toml
- uv run pytest tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_statutory_base_naming_guidance tests/test_prompt_concept_injection.py::test_build_rulespec_eval_prompt_includes_scoped_exception_test_guidance
- uv run --extra dev python -m towncrier build --draft --version 0.0.0