### PR TITLE
Classify section 3121 wage exclusions for oracle coverage

### DIFF
--- a/changelog.d/3121-wage-exclusion-coverage.fixed.md
+++ b/changelog.d/3121-wage-exclusion-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify section 3121 wage-exclusion intermediates in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.136"
+version = "0.2.137"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.136"
+__version__ = "0.2.137"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9219,6 +9219,36 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 224 qualified-tips deduction outputs are new statutory caps, phaseouts, eligibility predicates, and formula intermediates that PolicyEngine does not yet expose as one-to-one variables.
 
+  - legal_id_prefix: us:statutes/26/3121/a/2#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(2) employer-plan sickness, disability, medical, death, or group-term-life wage-exclusion predicates and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
+  - legal_id_prefix: us:statutes/26/3121/a/4#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(4) post-work sickness, disability, or medical payment wage-exclusion predicates and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
+  - legal_id_prefix: us:statutes/26/3121/a/13#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(13) death or disability-retirement termination-plan wage-exclusion predicates and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
+  - legal_id_prefix: us:statutes/26/3121/a/14#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(14) survivor or estate post-death-year payment wage-exclusion predicates and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
+  - legal_id_prefix: us:statutes/26/3121/a/15#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(15) Social Security disability-insurance no-services wage-exclusion predicates and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/225#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from axiom_encode.oracles.policyengine.coverage import (
     build_policyengine_candidate_report,
     build_policyengine_coverage_report,
@@ -460,6 +462,42 @@ rules:
         ]
         == "comparable"
     )
+
+
+@pytest.mark.parametrize(
+    ("subsection", "rule_name"),
+    [
+        ("2", "employer_plan_sickness_medical_death_payment_excluded_from_wages"),
+        ("4", "post_work_sickness_disability_medical_payment_excluded_from_wages"),
+        ("13", "termination_plan_payment_excluded_from_wages"),
+        ("14", "survivor_or_estate_post_death_year_payment_excluded_from_wages"),
+        (
+            "15",
+            "social_security_disability_insurance_prior_year_no_services_payment_excluded_from_wages",
+        ),
+    ],
+)
+def test_policyengine_coverage_classifies_3121_wage_exclusions(
+    tmp_path, subsection, rule_name
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / f"statutes/26/3121/a/{subsection}.yaml",
+        f"""format: rulespec/v1
+rules:
+  - name: {rule_name}
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: payment_amount
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == f"us:statutes/26/3121/a/{subsection}#{rule_name}"
+    assert item["status"] == "known_not_comparable"
 
 
 def test_policyengine_coverage_tracks_comparable_test_outputs(tmp_path):


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3121(a)(2), (4), (13), (14), and (15) wage-exclusion outputs as known not comparable in the PolicyEngine oracle registry
- add coverage tests proving those generated legal IDs resolve to known_not_comparable
- bump axiom-encode to 0.2.137 with a changelog fragment

## Why
This unblocks TheAxiomFoundation/rulespec-us#58. The generated RuleSpec artifacts are valid, but their section-specific wage-exclusion intermediates do not have one-to-one PolicyEngine variables.

## Checks
- uv run pytest tests/test_policyengine_coverage.py
- uv run ruff check tests/test_policyengine_coverage.py pyproject.toml src/axiom_encode/__init__.py
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run python - <<'PY'
from axiom_encode.oracles.policyengine.registry import load_policyengine_registry
load_policyengine_registry()
print('registry-ok')
PY
- git diff --check