### PR TITLE
Repair source table band threshold scalars

### DIFF
--- a/changelog.d/source-table-band-threshold-scalars.fixed.md
+++ b/changelog.d/source-table-band-threshold-scalars.fixed.md
@@ -1,0 +1,1 @@
+Repair generated source-table band threshold scalars before RuleSpec apply validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.137"
+version = "0.2.138"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.137"
+__version__ = "0.2.138"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -60,6 +60,7 @@ from .validator_pipeline import (
     _candidate_local_corpus_provision_files,
     _fetch_supabase_corpus_source_text,
     _read_local_corpus_provision_file,
+    _source_text_looks_like_table,
     extract_embedded_source_text,
     extract_grounding_values,
     extract_named_scalar_occurrences,
@@ -80,6 +81,10 @@ from .validator_pipeline import (
 EvalMode = Literal["cold", "repo-augmented"]
 EvalOracleMode = Literal["none", "policyengine", "all"]
 IMPORT_ITEM_PATTERN = re.compile(r"^\s*-\s*(['\"]?)([^'\"]+?)\1\s*$")
+TABLE_BOUND_COMPARATOR_NUMBER_PATTERN = re.compile(
+    r"(?:(?:<=|>=|<|>|==)\s*(-?[\d,]+(?:\.\d+)?)"
+    r"|(-?[\d,]+(?:\.\d+)?)\s*(?:<=|>=|<|>|==))"
+)
 SUPPORTED_EVAL_ENTITIES = (
     "Payment",
     "Person",
@@ -2264,6 +2269,14 @@ def evaluate_artifact(
     named_scalar_occurrences.update(
         _imported_named_scalar_occurrences(content, policy_repo_root)
     )
+    source_is_table = _source_text_looks_like_table(
+        numeric_validation_source_text or ""
+    )
+    inline_table_formula_occurrences = (
+        _inline_table_formula_numeric_occurrences(content)
+        if source_is_table
+        else Counter()
+    )
 
     grounding_metrics: list[GroundingMetric] = []
     for line, raw, value in extract_grounding_values(content):
@@ -2284,6 +2297,8 @@ def evaluate_artifact(
             expected_count,
             _matching_numeric_occurrence_count(named_scalar_occurrences, value),
         )
+        if inline_table_formula_occurrences.get(value):
+            covered_count = max(covered_count, expected_count)
         covered_source_numeric_occurrence_count += covered_count
         if covered_count < expected_count:
             missing_count = expected_count - covered_count
@@ -2375,6 +2390,45 @@ def _imported_named_scalar_occurrences(
                 )
             break
     return occurrences
+
+
+def _inline_table_formula_numeric_occurrences(content: str) -> Counter[float]:
+    """Count inline formula literals that are allowed as structural table bounds."""
+    occurrences: Counter[float] = Counter()
+    with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
+        payload = yaml.safe_load(content)
+        if not (
+            isinstance(payload, dict)
+            and payload.get("format") == "rulespec/v1"
+            and isinstance(payload.get("rules"), list)
+        ):
+            return occurrences
+        for rule in payload["rules"]:
+            if not isinstance(rule, dict):
+                continue
+            versions = rule.get("versions")
+            if not isinstance(versions, list):
+                continue
+            for version in versions:
+                if not isinstance(version, dict):
+                    continue
+                formula = version.get("formula")
+                if not isinstance(formula, str):
+                    continue
+                occurrences.update(_formula_comparator_numeric_values(formula))
+    return occurrences
+
+
+def _formula_comparator_numeric_values(formula_text: str) -> list[float]:
+    """Return numeric literals used as comparison bounds in a formula."""
+    values: list[float] = []
+    for line in formula_text.splitlines():
+        cleaned = line.split("#", 1)[0]
+        for match in TABLE_BOUND_COMPARATOR_NUMBER_PATTERN.finditer(cleaned):
+            raw = (match.group(1) or match.group(2) or "").replace(",", "")
+            with contextlib.suppress(ValueError):
+                values.append(float(raw))
+    return values
 
 
 def _candidate_import_rule_files(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2497,6 +2497,7 @@ def _is_source_table_structural_scalar_name(name: str) -> bool:
     return bool(
         re.search(r"(?:^|_)row_\d+(?:_|$)", name)
         or re.search(r"(?:^|_)(?:band|bracket)_\d+(?:_|$)", name)
+        or _is_source_table_structural_bound_parameter_name(name)
     )
 
 
@@ -3423,13 +3424,23 @@ def _is_source_table_structural_bound_parameter_name(name: str) -> bool:
         r"(?:^|_)(?:lower|upper)_(?:row|band|bracket)_\d+(?:_|$)",
         normalized,
     )
+    has_named_band_bound = re.search(
+        r"(?:^|_)(?:band|bracket)_(?:bound|threshold|limit)_\d",
+        normalized,
+    ) or re.search(
+        r"(?:^|_)(?:bound|threshold|limit)_(?:band|bracket)_\d",
+        normalized,
+    )
     return bool(
-        has_index
-        and (
-            (has_bound_word and has_structural_noun)
-            or has_adjacent_min_max
-            or has_adjacent_lower_upper
+        (
+            has_index
+            and (
+                (has_bound_word and has_structural_noun)
+                or has_adjacent_min_max
+                or has_adjacent_lower_upper
+            )
         )
+        or has_named_band_bound
     )
 
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -975,6 +975,84 @@ rules:
     assert "average_account_benefits_ratio_band" in test_content
 
 
+def test_materialize_eval_artifact_repairs_named_band_threshold_scalars(tmp_path):
+    output_file = tmp_path / "runner" / "statutes" / "26" / "3241" / "b.yaml"
+    llm_response = """=== FILE: b.yaml ===
+format: rulespec/v1
+module:
+  summary: Section defines applicable percentages by benefits ratio.
+rules:
+  - name: average_account_benefits_ratio_band_threshold_2_5
+    kind: parameter
+    dtype: Float
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2.5
+  - name: average_account_benefits_ratio_band_threshold_3_0
+    kind: parameter
+    dtype: Float
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3.0
+  - name: average_account_benefits_ratio_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_2_5: 1
+          else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_3_0: 2
+          else: 3
+  - name: applicable_percentage_3201_by_average_account_benefits_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_band
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          1: 0.049
+          2: 0.049
+          3: 0
+=== FILE: b.test.yaml ===
+- name: selector_band
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.75
+  output:
+    us:statutes/26/3241/b#average_account_benefits_ratio_band_threshold_2_5: 2.5
+    us:statutes/26/3241/b#applicable_percentage_3201_by_average_account_benefits_ratio_band:
+      1: 0.049
+      2: 0.049
+      3: 0
+    us:statutes/26/3241/b#average_account_benefits_ratio_band: 2
+"""
+
+    wrote = _materialize_eval_artifact(
+        llm_response,
+        output_file,
+        source_text="Tax rate schedule | Average account benefits ratio | 2.5 | 3.0",
+    )
+
+    assert wrote is True
+    content = output_file.read_text()
+    assert "average_account_benefits_ratio_band_threshold_2_5" not in content
+    assert "average_account_benefits_ratio_band_threshold_3_0" not in content
+    assert "average_account_benefits_ratio < 2.5" in content
+    assert "average_account_benefits_ratio < 3.0" in content
+    test_content = output_file.with_name("b.test.yaml").read_text()
+    assert "average_account_benefits_ratio_band_threshold_2_5" not in test_content
+    assert (
+        "applicable_percentage_3201_by_average_account_benefits_ratio_band"
+        not in test_content
+    )
+    assert "average_account_benefits_ratio_band" in test_content
+
+
 def test_materialize_eval_artifact_repairs_chained_conditionals_without_table_scalars(
     tmp_path,
 ):
@@ -2038,6 +2116,67 @@ rules:
 
         assert metrics.ci_pass
         assert metrics.source_numeric_occurrence_count == 0
+        assert metrics.numeric_occurrence_issues == []
+
+    def test_numeric_occurrence_check_counts_inline_source_table_bounds(self, tmp_path):
+        rulespec_file = tmp_path / "statutes" / "26" / "3241" / "b.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: |-
+    Tax rate schedule | Average account benefits ratio | Applicable percentage
+    | At least | But less than | Section 3201(b) |
+    | .............. | 2.5 | 4.9 |
+    | 2.5 | 3.0 | 4.9 |
+rules:
+  - name: average_account_benefits_ratio_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if average_account_benefits_ratio < 2.5: 1
+          else: if average_account_benefits_ratio < 3.0: 2
+          else: 3
+  - name: section_3201_applicable_percentage_by_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_band
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          1: 0.049
+          2: 0.049
+          3: 0
+"""
+        )
+
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline, "_run_compile_check", return_value=compile_result
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=tmp_path,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text=(
+                    "Tax rate schedule | Average account benefits ratio | Applicable percentage\n"
+                    "| At least | But less than | Section 3201(b) |\n"
+                    "| .............. | 2.5 | 4.9 |\n"
+                    "| 2.5 | 3.0 | 4.9 |"
+                ),
+            )
+
+        assert metrics.ci_pass
+        assert metrics.missing_source_numeric_occurrence_count == 0
         assert metrics.numeric_occurrence_issues == []
 
     def test_numeric_occurrence_check_skips_empty_deferred_artifact(self, tmp_path):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -750,7 +750,7 @@ module:
   source_verification:
     corpus_citation_path: us/guidance/example/sua
 rules:
-  - name: snap_standard_utility_allowance_value
+  - name: standard_utility_allowance_value
     kind: parameter
     dtype: Money
     unit: USD
@@ -758,16 +758,16 @@ rules:
       - effective_from: '2024-01-01'
         formula: |-
           451
-  - name: snap_standard_utility_allowance
+  - name: standard_utility_allowance
     kind: derived
-    entity: SnapUnit
+    entity: Household
     dtype: Money
     period: Month
     unit: USD
     versions:
       - effective_from: '2024-01-01'
         formula: |-
-          snap_standard_utility_allowance_value
+          standard_utility_allowance_value
 """
     )
     rules_file.with_name("rules.test.yaml").write_text(
@@ -775,7 +775,7 @@ rules:
   period: 2024-01
   input: {}
   output:
-    snap_standard_utility_allowance: 451
+    standard_utility_allowance: 451
 """
     )
 
@@ -794,7 +794,7 @@ rules:
     assert [
         (item.name, item.value)
         for item in extract_named_scalar_occurrences(rules_file.read_text())
-    ] == [("snap_standard_utility_allowance_value", 451.0)]
+    ] == [("standard_utility_allowance_value", 451.0)]
 
 
 def test_rulespec_ci_rejects_repo_backed_friendly_output_keys(tmp_path):
@@ -8064,6 +8064,46 @@ rules:
     assert "`indexed_by`" in issues[0]
 
 
+def test_source_table_named_band_threshold_parameters_are_rejected():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Tax rate schedule | Average account benefits ratio | Applicable percentage
+    | At least | But less than | Section 3201(b) |
+    | .............. | 2.5 | 4.9 |
+    | 2.5 | 3.0 | 4.9 |
+    | 3.0 | 3.5 | 4.9 |
+rules:
+  - name: average_account_benefits_ratio_band_threshold_2_5
+    kind: parameter
+    dtype: Float
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2.5
+  - name: average_account_benefits_ratio_band_threshold_3_0
+    kind: parameter
+    dtype: Float
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3.0
+  - name: average_account_benefits_ratio_band_threshold_3_5
+    kind: parameter
+    dtype: Float
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3.5
+"""
+
+    issues = find_source_table_row_scalar_parameter_issues(content)
+
+    assert len(issues) == 1
+    assert "Source table row/band scalar parameters" in issues[0]
+    assert "average_account_benefits_ratio_band_threshold_2_5" in issues[0]
+
+
 def test_scoped_exception_category_amount_requires_category_gate():
     content = """format: rulespec/v1
 module:
@@ -8847,6 +8887,64 @@ rules:
     assert "average_account_benefits_ratio < 2.5" in repaired
     assert "< 3.0" in repaired
     assert "else if" not in repaired
+    assert "average_account_benefits_ratio_band" in repaired_rules
+    assert find_source_table_row_scalar_parameter_issues(repaired) == []
+
+
+def test_repair_source_table_named_band_thresholds_inlines_selector_bounds():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Tax rate schedule | Average account benefits ratio | Applicable percentage
+    | At least | But less than | Section 3201(b) |
+    | .............. | 2.5 | 4.9 |
+    | 2.5 | 3.0 | 4.9 |
+rules:
+  - name: average_account_benefits_ratio_band_threshold_2_5
+    kind: parameter
+    dtype: Float
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2.5
+  - name: average_account_benefits_ratio_band_threshold_3_0
+    kind: parameter
+    dtype: Float
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3.0
+  - name: average_account_benefits_ratio_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_2_5: 1
+          else: if average_account_benefits_ratio < average_account_benefits_ratio_band_threshold_3_0: 2
+          else: 3
+  - name: applicable_percentage_3201_by_average_account_benefits_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_band
+    source: 26 USC 3241(b)
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          1: 0.049
+          2: 0.049
+          3: 0
+"""
+
+    repaired, repaired_rules = repair_source_table_band_scalar_parameters(content)
+
+    assert "average_account_benefits_ratio_band_threshold_2_5" not in repaired
+    assert "average_account_benefits_ratio_band_threshold_3_0" not in repaired
+    assert "average_account_benefits_ratio < 2.5" in repaired
+    assert "average_account_benefits_ratio < 3.0" in repaired
     assert "average_account_benefits_ratio_band" in repaired_rules
     assert find_source_table_row_scalar_parameter_issues(repaired) == []
 


### PR DESCRIPTION
## Summary
- detect generated source-table band threshold parameters like `*_band_threshold_2_5` as structural table bounds
- repair those threshold scalars into inline selector comparisons before apply validation
- count inline source-table comparison bounds during eval numeric occurrence checks
- update the grounding smoke test to avoid filtered-entity dependency validation

## Tests
- `uv run pytest tests/test_evals.py tests/test_rulespec_validation.py`
- `uv run pytest tests/test_evals.py tests/test_rulespec_validation.py -k 'source_table or numeric_occurrence or 3241 or compile_ci_and_grounding'`
- `uv run pytest tests/test_rulespec_validation.py::test_rulespec_compile_ci_and_grounding`
- `uv run ruff check src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py tests/test_rulespec_validation.py pyproject.toml src/axiom_encode/__init__.py`
- `git diff --check`
- `uv run --extra dev python -m towncrier build --draft --version 0.0.0`