### PR TITLE
Repair compact source table interval rows

### DIFF
--- a/changelog.d/compact-source-table-rows.fixed.md
+++ b/changelog.d/compact-source-table-rows.fixed.md
@@ -1,0 +1,1 @@
+Repair compact source-table interval rows before RuleSpec apply validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.138"
+version = "0.2.139"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.138"
+__version__ = "0.2.139"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2985,6 +2985,20 @@ def _parse_interval_source_table(text: str | None) -> _IntervalSourceTable | Non
                 candidate_headers
             ):
                 output_headers = candidate_headers
+            elif candidate_headers:
+                compact_headers = _compact_interval_output_headers(
+                    cells,
+                    row_key_index,
+                )
+                compact_rows = _compact_interval_rows_from_cells(
+                    candidate_headers,
+                    output_count=len(compact_headers) or None,
+                )
+                if compact_rows:
+                    if compact_headers:
+                        output_headers = compact_headers
+                    rows.extend(compact_rows)
+                    continue
         row_cells = _interval_row_cells_from_cells(cells)
         if row_cells is None:
             continue
@@ -3004,6 +3018,64 @@ def _source_table_cells(line: str) -> list[str]:
     if "|" not in line:
         return []
     return [cell.strip() for cell in line.split("|") if cell.strip()]
+
+
+def _compact_interval_output_headers(
+    cells: list[str],
+    row_key_index: int,
+) -> tuple[str, ...]:
+    prefix = cells[:row_key_index]
+    separator_index = next(
+        (
+            index
+            for index, cell in enumerate(prefix)
+            if _is_markdown_separator_cell(cell)
+        ),
+        None,
+    )
+    if separator_index is not None:
+        prefix = prefix[:separator_index]
+    prefix = [cell for cell in prefix if not _is_markdown_separator_cell(cell)]
+    return tuple(prefix[2:]) if len(prefix) > 2 else ()
+
+
+def _compact_interval_rows_from_cells(
+    cells: tuple[str, ...],
+    *,
+    output_count: int | None,
+) -> list[_IntervalSourceRow]:
+    output_counts = [output_count] if output_count else list(range(1, 8))
+    for candidate_output_count in output_counts:
+        group_size = candidate_output_count + 2
+        if group_size <= 2 or len(cells) % group_size != 0:
+            continue
+        rows: list[_IntervalSourceRow] = []
+        valid = True
+        for start in range(0, len(cells), group_size):
+            group = cells[start : start + group_size]
+            lower = _parse_interval_bound_cell(group[0])
+            upper = _parse_interval_bound_cell(group[1])
+            if lower is _UNPARSED_BOUND or upper is _UNPARSED_BOUND:
+                valid = False
+                break
+            outputs = tuple(group[2:])
+            if any(_parse_source_numeric_cell(output) is None for output in outputs):
+                valid = False
+                break
+            rows.append(
+                _IntervalSourceRow(
+                    lower=lower,
+                    upper=upper,
+                    outputs=outputs,
+                )
+            )
+        if valid and len(rows) > 1:
+            return rows
+    return []
+
+
+def _is_markdown_separator_cell(cell: str) -> bool:
+    return bool(re.fullmatch(r":?-{2,}:?", cell.strip()))
 
 
 def _find_interval_row_key_header_index(cells: list[str]) -> int | None:
@@ -3234,9 +3306,15 @@ def _coerce_interval_source_output_value(
         return 0.0
     dtype = str(rule.get("dtype") or "").strip().lower()
     name = str(rule.get("name") or "").strip().lower()
-    if (dtype == "rate" or "percentage" in name or "percent" in name) and abs(
-        value
-    ) > 1:
+    parameter_text = _interval_parameter_text(rule)
+    percentage_labeled = (
+        "percentage" in name
+        or "percent" in name
+        or re.search(r"\bpercent(?:age)?\b", parameter_text) is not None
+    )
+    if percentage_labeled and value != 0:
+        value = value / 100
+    elif dtype == "rate" and abs(value) > 1:
         value = value / 100
     return round(value, 12)
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import yaml
 
 from axiom_encode.harness import validator_pipeline
 from axiom_encode.harness.proof_validator import (
@@ -81,6 +82,7 @@ from axiom_encode.harness.validator_pipeline import (
     repair_current_year_final_amount_tables,
     repair_nonnegative_amount_reductions,
     repair_source_table_band_scalar_parameters,
+    repair_source_table_interval_row_alignment,
 )
 from axiom_encode.oracles.policyengine.registry import (
     PolicyEngineMapping,
@@ -8947,6 +8949,104 @@ rules:
     assert "average_account_benefits_ratio < 3.0" in repaired
     assert "average_account_benefits_ratio_band" in repaired_rules
     assert find_source_table_row_scalar_parameter_issues(repaired) == []
+
+
+def test_repair_source_table_interval_alignment_parses_compact_rows():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    (b) Tax rate schedule | Average account benefits ratio | Applicable percentage for sections 3211(b) and 3221(b) | Applicable percentage for section 3201(b) | | | ------------------------------ | ------------------------------------------------------ | ----------------------------------------- | --- | | At least | But less than | | | | .............. | 2.5 | 22.1 | 4.9 | | 2.5 | 3.0 | 18.1 | 4.9 | | 3.0 | 3.5 | 15.1 | 4.9 | | 3.5 | 4.0 | 14.1 | 4.9 | | 4.0 | 6.1 | 13.1 | 4.9 | | 6.1 | 6.5 | 12.6 | 4.4 | | 6.5 | 7.0 | 12.1 | 3.9 | | 7.0 | 7.5 | 11.6 | 3.4 | | 7.5 | 8.0 | 11.1 | 2.9 | | 8.0 | 8.5 | 10.1 | 1.9 | | 8.5 | 9.0 | 9.1 | 0.9 | | 9.0 | .............. | 8.2 | 0 |
+rules:
+  - name: average_account_benefits_ratio_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if average_account_benefits_ratio >= 2.5 and average_account_benefits_ratio < 3.0: 1
+          else: if average_account_benefits_ratio >= 3.0 and average_account_benefits_ratio < 3.5: 2
+          else: if average_account_benefits_ratio >= 3.5 and average_account_benefits_ratio < 4.0: 3
+          else: if average_account_benefits_ratio >= 4.0 and average_account_benefits_ratio < 6.1: 4
+          else: if average_account_benefits_ratio >= 6.1 and average_account_benefits_ratio < 6.5: 5
+          else: if average_account_benefits_ratio >= 6.5 and average_account_benefits_ratio < 7.0: 6
+          else: if average_account_benefits_ratio >= 7.0 and average_account_benefits_ratio < 7.5: 7
+          else: if average_account_benefits_ratio >= 7.5 and average_account_benefits_ratio < 8.0: 8
+          else: if average_account_benefits_ratio >= 8.0 and average_account_benefits_ratio < 8.5: 9
+          else: if average_account_benefits_ratio >= 8.5 and average_account_benefits_ratio < 9.0: 10
+          else: if average_account_benefits_ratio >= 9.0: 11 else: 0
+  - name: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_band
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          1: 0.221
+          2: 0.181
+          3: 0.151
+          4: 0.141
+          5: 0.131
+          6: 0.126
+          7: 0.121
+          8: 0.116
+          9: 0.111
+          10: 0.101
+          11: 0.082
+  - name: applicable_percentage_for_section_3201_b_by_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_band
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          1: 0.049
+          2: 0.049
+          3: 0.049
+          4: 0.049
+          5: 0.044
+          6: 0.039
+          7: 0.034
+          8: 0.029
+          9: 0.019
+          10: 0.009
+          11: 0.0
+"""
+
+    repaired, repaired_rules = repair_source_table_interval_row_alignment(content)
+
+    assert "average_account_benefits_ratio_band" in repaired_rules
+    payload = yaml.safe_load(repaired)
+    selector = next(
+        rule
+        for rule in payload["rules"]
+        if rule["name"] == "average_account_benefits_ratio_band"
+    )
+    assert selector["versions"][0]["formula"].startswith(
+        "if average_account_benefits_ratio < 2.5: 1 else: "
+        "if average_account_benefits_ratio >= 2.5"
+    )
+    assert selector["versions"][0]["formula"].endswith(
+        "if average_account_benefits_ratio >= 8.5 and "
+        "average_account_benefits_ratio < 9.0: 11 else: 12"
+    )
+    sections_3211_3221 = next(
+        rule
+        for rule in payload["rules"]
+        if rule["name"]
+        == "applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band"
+    )
+    section_3201 = next(
+        rule
+        for rule in payload["rules"]
+        if rule["name"] == "applicable_percentage_for_section_3201_b_by_ratio_band"
+    )
+    assert sections_3211_3221["versions"][0]["values"][11] == 0.091
+    assert sections_3211_3221["versions"][0]["values"][12] == 0.082
+    assert section_3201["versions"][0]["values"][5] == 0.049
+    assert section_3201["versions"][0]["values"][11] == 0.009
+    assert section_3201["versions"][0]["values"][12] == 0.0
 
 
 def test_repair_source_table_band_bound_scalars_inlines_adjacent_min_max():


### PR DESCRIPTION
## Summary
- parse compact one-line interval source tables before RuleSpec apply validation
- preserve open-ended lower rows such as 3241(b)'s ratio below 2.5 band
- coerce percentage-labeled source cells like 0.9 to 0.009 rates

## Tests
- uv run pytest tests/test_evals.py tests/test_rulespec_validation.py
- uv run pytest tests/test_rulespec_validation.py -k 'compact_rows or source_table_interval or source_table_named_band_threshold or repair_source_table_named_band_thresholds'
- uv run pytest tests/test_evals.py -k 'preserves_open_interval_source_table_rows or repairs_named_band_threshold_scalars or inline_source_table_bounds'
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check
- uv run --extra dev python -m towncrier build --draft --version 0.0.0