### PR TITLE
Repair misindented generated test periods

### DIFF
--- a/changelog.d/misindented-test-periods.fixed.md
+++ b/changelog.d/misindented-test-periods.fixed.md
@@ -1,0 +1,1 @@
+Repair generated test cases with misindented period fields before apply validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.139"
+version = "0.2.140"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.139"
+__version__ = "0.2.140"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -17,7 +17,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import date, datetime, timezone
 from pathlib import Path
 from statistics import mean
-from typing import Iterator, Literal, Sequence
+from typing import Any, Iterator, Literal, Sequence
 
 import requests
 import yaml
@@ -6719,7 +6719,7 @@ def _normalize_test_periods_to_effective_dates(
     def normalize_case(case: object) -> object:
         if not isinstance(case, dict):
             return case
-        normalized_case = dict(case)
+        normalized_case = _repair_misindented_period_mapping_fields(case)
         if granularity == "Year" and effective_date is not None:
             normalized_case["period"] = _normalize_annual_test_period_value(
                 normalized_case.get("period"),
@@ -6773,6 +6773,26 @@ def _normalize_test_periods_to_effective_dates(
         )
 
     return normalized
+
+
+def _repair_misindented_period_mapping_fields(case: dict[str, Any]) -> dict[str, Any]:
+    """Move generated top-level period fields back under `period` when unambiguous."""
+    normalized_case = dict(case)
+    period = normalized_case.get("period")
+    if not isinstance(period, dict):
+        return normalized_case
+
+    repaired_period = dict(period)
+    for key in ("period_kind", "start", "end"):
+        if key not in normalized_case:
+            continue
+        if key not in repaired_period:
+            repaired_period[key] = normalized_case.pop(key)
+            continue
+        if normalized_case[key] == repaired_period[key]:
+            normalized_case.pop(key)
+    normalized_case["period"] = repaired_period
+    return normalized_case
 
 
 def _parse_simple_rulespec_literal(value: str) -> object | None:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3376,6 +3376,41 @@ rules:
         assert "pre_effective_zero" not in test_text
         assert "period: 2026-01" in test_text
 
+    def test_normalize_test_periods_repairs_misindented_period_end(self):
+        rulespec_text = """format: rulespec/v1
+module:
+  summary: Section defines an annual table.
+rules:
+  - name: annual_rate
+    kind: parameter
+    dtype: Rate
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.05
+"""
+        test_text = _normalize_test_periods_to_effective_dates(
+            """- name: ratio_at_9_0
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+  end: '2026-12-31'
+  input: {}
+  output:
+    annual_rate: 0.05
+""",
+            rulespec_content=rulespec_text,
+        )
+
+        cases = yaml.safe_load(test_text)
+
+        assert cases[0]["period"] == {
+            "period_kind": "tax_year",
+            "start": "2026-01-01",
+            "end": "2026-12-31",
+        }
+        assert "end" not in cases[0]
+
     def test_materialize_eval_artifact_normalizes_mapping_style_tests_to_list(
         self, tmp_path
     ):


### PR DESCRIPTION
## Summary
- normalize generated test cases that accidentally put period fields at case scope
- move unambiguous period_kind/start/end fields back under the period mapping before apply validation
- bump axiom-encode to 0.2.140

## Tests
- uv run pytest tests/test_evals.py -k 'misindented_period_end or source_table or named_band_threshold or inline_source_table_bounds'
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run pytest tests/test_evals.py tests/test_rulespec_validation.py