### PR TITLE
Repair guarded interval test outputs

### DIFF
--- a/changelog.d/guarded-interval-test-outputs.fixed.md
+++ b/changelog.d/guarded-interval-test-outputs.fixed.md
@@ -1,0 +1,1 @@
+Repair generated interval-table tests for derived outputs guarded by zero-band fallbacks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.140"
+version = "0.2.141"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.140"
+__version__ = "0.2.141"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3409,13 +3409,22 @@ def _interval_derived_output_parameter_map(
         if str(rule.get("kind") or "").strip().lower() != "derived":
             continue
         name = str(rule.get("name") or "").strip()
-        formula = (_first_version_formula(rule) or "").strip()
-        lookup_match = re.fullmatch(
-            rf"([A-Za-z_][A-Za-z0-9_]*)\s*\[\s*{re.escape(spec.selector_name)}\s*\]",
-            formula,
+        formula = re.sub(r"\s+", " ", (_first_version_formula(rule) or "").strip())
+        lookup_pattern = (
+            rf"([A-Za-z_][A-Za-z0-9_]*)\s*"
+            rf"\[\s*{re.escape(spec.selector_name)}\s*\]"
         )
+        lookup_match = re.fullmatch(lookup_pattern, formula)
         if lookup_match and lookup_match.group(1) in output_names:
             direct[name] = lookup_match.group(1)
+            continue
+        guarded_lookup_match = re.fullmatch(
+            rf"if\s+{re.escape(spec.selector_name)}\s*(?:==|=)\s*0\s*:\s*"
+            rf"0(?:\.0)?\s+else:\s*{lookup_pattern}",
+            formula,
+        )
+        if guarded_lookup_match and guarded_lookup_match.group(1) in output_names:
+            direct[name] = guarded_lookup_match.group(1)
             continue
         if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", formula):
             aliases[name] = formula

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -83,6 +83,7 @@ from axiom_encode.harness.validator_pipeline import (
     repair_nonnegative_amount_reductions,
     repair_source_table_band_scalar_parameters,
     repair_source_table_interval_row_alignment,
+    repair_source_table_interval_tests,
 )
 from axiom_encode.oracles.policyengine.registry import (
     PolicyEngineMapping,
@@ -9047,6 +9048,91 @@ rules:
     assert section_3201["versions"][0]["values"][5] == 0.049
     assert section_3201["versions"][0]["values"][11] == 0.009
     assert section_3201["versions"][0]["values"][12] == 0.0
+
+
+def test_repair_source_table_interval_tests_updates_guarded_lookup_outputs():
+    rulespec_content = """format: rulespec/v1
+module:
+  summary: |-
+    (b) Tax rate schedule | Average account benefits ratio | Applicable percentage for sections 3211(b) and 3221(b) | Applicable percentage for section 3201(b) | | | ------------------------------ | ------------------------------------------------------ | ----------------------------------------- | --- | | At least | But less than | | | | .............. | 2.5 | 22.1 | 4.9 | | 2.5 | .............. | 18.1 | 4.9 |
+rules:
+  - name: average_account_benefits_ratio_band
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if average_account_benefits_ratio < 2.5: 1 else: 2
+  - name: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_band
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          1: 0.221
+          2: 0.181
+  - name: applicable_percentage_for_section_3201_b_by_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_band
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          1: 0.049
+          2: 0.049
+  - name: applicable_percentage_for_sections_3211_b_and_3221_b
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if average_account_benefits_ratio_band == 0: 0 else: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band[average_account_benefits_ratio_band]
+  - name: applicable_percentage_for_section_3201_b
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if average_account_benefits_ratio_band == 0: 0 else: applicable_percentage_for_section_3201_b_by_ratio_band[average_account_benefits_ratio_band]
+"""
+    test_content = """- name: ratio_under_first_band
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3241/b#input.average_account_benefits_ratio: 2.4
+  output:
+    us:statutes/26/3241/b#average_account_benefits_ratio_band: 1
+    us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b: 0
+    us:statutes/26/3241/b#applicable_percentage_for_section_3201_b: 0
+"""
+
+    repaired, repaired_cases = repair_source_table_interval_tests(
+        test_content,
+        rulespec_content=rulespec_content,
+    )
+
+    assert repaired_cases == ["ratio_under_first_band"]
+    cases = yaml.safe_load(repaired)
+    outputs = cases[0]["output"]
+    assert (
+        outputs[
+            "us:statutes/26/3241/b#applicable_percentage_for_sections_3211_b_and_3221_b"
+        ]
+        == 0.221
+    )
+    assert (
+        outputs["us:statutes/26/3241/b#applicable_percentage_for_section_3201_b"]
+        == 0.049
+    )
 
 
 def test_repair_source_table_band_bound_scalars_inlines_adjacent_min_max():


### PR DESCRIPTION
## Summary
- recognize derived interval-table outputs guarded by impossible zero-band fallbacks
- repair generated companion-test expectations for those derived outputs from the indexed source table
- bump axiom-encode to 0.2.141

## Tests
- uv run pytest tests/test_rulespec_validation.py -k 'guarded_lookup_outputs or compact_rows or source_table_interval or source_table_named_band_threshold or repair_source_table_named_band_thresholds'
- actual failed 3241(b) generated test repair check against /private/tmp/axiom-encode-3241b-final-v3
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run pytest tests/test_evals.py tests/test_rulespec_validation.py