### PR TITLE
Repair generated Python ternary formulas

### DIFF
--- a/changelog.d/amount-attribution-prompt.fixed.md
+++ b/changelog.d/amount-attribution-prompt.fixed.md
@@ -1,0 +1,1 @@
+Tell the encoder to preserve amount-level treated-as-attributable rules as numeric outputs instead of boolean predicates.

--- a/changelog.d/python-ternary-formulas.fixed.md
+++ b/changelog.d/python-ternary-formulas.fixed.md
@@ -1,0 +1,1 @@
+Repair generated Python-style ternary formulas before apply validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.141"
+version = "0.2.142"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.141"
+__version__ = "0.2.142"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2635,6 +2635,7 @@ def repair_unsupported_chained_conditionals(content: str) -> tuple[str, list[str
             if not isinstance(formula, str):
                 continue
             repaired = _repair_then_conditional_formula(formula)
+            repaired = _repair_python_ternary_formula(repaired)
             repaired = _repair_else_if_formula(repaired)
             if repaired == formula:
                 continue
@@ -3638,6 +3639,30 @@ def _repair_then_conditional_formula(formula: str) -> str:
     ):
         return formula
     return f"if {match['condition'].strip()}: {true_result} else: {false_result}"
+
+
+def _repair_python_ternary_formula(formula: str) -> str:
+    compact = " ".join(line.strip() for line in formula.strip().splitlines())
+    if compact.startswith("if "):
+        return formula
+    match = re.fullmatch(
+        r"(?P<true_result>.+?)\s+if\s+(?P<condition>.+?)\s+else\s+"
+        r"(?P<false_result>.+)",
+        compact,
+    )
+    if match is None:
+        return formula
+
+    true_result = match["true_result"].strip()
+    condition = match["condition"].strip()
+    false_result = match["false_result"].strip()
+    if not true_result or not condition or not false_result:
+        return formula
+    if re.search(r"\b(?:if|else)\b", true_result) or re.search(
+        r"\b(?:if|else)\b", false_result
+    ):
+        return formula
+    return f"if {condition}: {true_result} else: {false_result}"
 
 
 def _parse_multiline_else_if_formula(

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -43,6 +43,12 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   the entity of the current amount, tax, credit, deduction, contribution, or
   limit. Encode the current result on the individual/person/employee first,
   even if the imported base definition or its tests are unit-scoped.
+- When a source says an amount, tax, credit, deduction, contribution, payment,
+  or other numeric result is "treated as attributable to" a trade, business,
+  category, period, purpose, or person, preserve that treated-as-attributable
+  result as the same numeric amount and dtype unless the source separately
+  defines an eligibility or applicability test. Do not turn an amount-level
+  attribution rule into a boolean or `dtype: Judgment` predicate.
 - Do not create a roll-up, top-level program output, or connection merely
   because downstream consumers want it, sibling/state files patched it, or the
   program conventionally has such a concept. The output must be directly

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1277,6 +1277,46 @@ rules:
     ) == formula
 
 
+def test_materialize_eval_artifact_repairs_python_ternary_formulas(
+    tmp_path,
+):
+    output_file = tmp_path / "runner" / "statutes" / "26" / "164" / "f.yaml"
+    llm_response = """=== FILE: f.yaml ===
+format: rulespec/v1
+module:
+  summary: Section allows a self-employment tax deduction.
+rules:
+  - name: self_employment_tax_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          self_employment_tax_deduction_fraction * (
+            old_age_survivors_and_disability_insurance_tax
+            + self_employment_income_tax
+          ) if taxpayer_is_individual else 0
+"""
+
+    wrote = _materialize_eval_artifact(
+        llm_response,
+        output_file,
+        source_text="An individual may deduct one-half of self-employment taxes.",
+    )
+
+    assert wrote is True
+    payload = yaml.safe_load(output_file.read_text())
+    formula = payload["rules"][0]["versions"][0]["formula"]
+    assert (
+        "if taxpayer_is_individual: self_employment_tax_deduction_fraction * "
+        "( old_age_survivors_and_disability_insurance_tax + "
+        "self_employment_income_tax ) else: 0"
+    ) == formula
+
+
 def test_materialize_eval_artifact_preserves_open_interval_source_table_rows(
     tmp_path,
 ):
@@ -3686,6 +3726,9 @@ class TestEvalPrompt:
         assert "Never drop the jurisdiction prefix" in prompt
         assert "listed under invalid copied local inputs" in prompt
         assert "do not preserve, rename, or recreate" in prompt
+        assert "treated as attributable to" in prompt
+        assert "amount-level" in prompt
+        assert "boolean or `dtype: Judgment` predicate" in prompt
 
     def test_build_eval_prompt_for_broad_application_clause_discourages_passthrough_outputs(
         self, tmp_path


### PR DESCRIPTION
## Summary
- repair generated Python-style ternary formulas into Axiom conditional expression syntax before apply validation
- add source-scope prompt guidance to keep amount-level treated-as-attributable rules numeric instead of boolean/Judgment outputs
- bump package version to 0.2.142 with Towncrier fragments

## Validation
- uv run pytest tests/test_evals.py -k 'python_ternary or then_conditionals or rulespec_schema_guardrails'
- uv run pytest tests/test_rulespec_validation.py -k 'chained_conditionals or judgment_conditional'
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run pytest tests/test_evals.py tests/test_rulespec_validation.py
