### PR TITLE
Prefer child imports for excluded cited branches

### DIFF
--- a/changelog.d/excluded-child-imports.fixed.md
+++ b/changelog.d/excluded-child-imports.fixed.md
@@ -1,0 +1,1 @@
+Guide generated encodings to compose included child RuleSpec outputs when a source cites an ancestor section but excludes a child branch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.142"
+version = "0.2.143"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.142"
+__version__ = "0.2.143"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2962,6 +2962,10 @@ import or re-export that exact canonical concept instead of duplicating it local
             source_text,
             context_files,
         )
+        excluded_child_context_section = _format_excluded_child_context_guidance(
+            source_text,
+            context_files,
+        )
         unavailable_cited_context_section = _format_unavailable_cited_context_guidance(
             source_text, context_files
         )
@@ -3007,6 +3011,7 @@ Context files are precedent and dependency context, not independent legal author
 {existing_target_valid_input_section}
 {branch_child_naming_section}
 {cited_context_imports_section}
+{excluded_child_context_section}
 {unavailable_cited_context_section}
 {partial_extent_child_schema_section}
 {child_exception_import_section}
@@ -4413,6 +4418,127 @@ input, or a local `_provided_in_section_...`, `_allowed_under_section_...`,
 `_deduction_under_section_...`, or `_credit_allowed_under_section_...` input,
 for an already copied RuleSpec context target.
 """
+
+
+def _format_excluded_child_context_guidance(
+    source_text: str,
+    context_files: list[EvalContextFile],
+) -> str:
+    """Guide ancestor/child import choice when the source excludes a child branch."""
+    if not re.search(
+        r"\b(?:other\s+than|except(?:ing)?|excluding)\b",
+        source_text,
+        flags=re.IGNORECASE,
+    ):
+        return ""
+
+    contexts: list[tuple[EvalContextFile, _StatuteCitation, list[str]]] = []
+    for item in context_files:
+        if item.kind.endswith("_test_context"):
+            continue
+        citation = _import_target_to_statute_citation(item.import_path)
+        if citation is None or not _source_text_cites_statute(source_text, citation):
+            continue
+        exports = _context_file_exports(item.source_path)
+        if not exports:
+            continue
+        contexts.append((item, citation, exports))
+
+    parent_by_section = {
+        citation.section: (item, exports)
+        for item, citation, exports in contexts
+        if not citation.fragments
+    }
+    child_by_section: dict[
+        str, list[tuple[EvalContextFile, _StatuteCitation, list[str]]]
+    ] = defaultdict(list)
+    for item, citation, exports in contexts:
+        if citation.fragments:
+            child_by_section[citation.section].append((item, citation, exports))
+
+    lines: list[str] = []
+    for excluded in _excluded_child_citations(source_text):
+        parent = parent_by_section.get(excluded.section)
+        children = child_by_section.get(excluded.section, [])
+        if parent is None or not children:
+            continue
+        included_children = [
+            (item, citation, exports)
+            for item, citation, exports in children
+            if not _citation_is_same_or_descendant(citation, excluded)
+        ]
+        if not included_children:
+            continue
+
+        parent_item, _parent_exports = parent
+        child_summary = "; ".join(
+            f"`{item.import_path}` exports "
+            + ", ".join(f"`{item.import_path}#{name}`" for name in exports[:4])
+            for item, _citation, exports in included_children[:4]
+        )
+        lines.append(
+            f"- Source cites ancestor section `{excluded.section}` but excludes "
+            f"`{excluded.label}`. Copied context includes ancestor "
+            f"`{parent_item.import_path}` and more specific included child "
+            f"targets: {child_summary}."
+        )
+
+    if not lines:
+        return ""
+
+    return f"""
+Excluded cited child branch guidance:
+{chr(10).join(lines)}
+For an amount that excludes a child branch, do not import an ancestor aggregate
+output from the cited section when more specific copied child outputs are
+available for the included branches. Import the exact included child outputs and
+compose them directly; omit the excluded child branch unless the current source
+adds it back.
+"""
+
+
+def _excluded_child_citations(source_text: str) -> list[_StatuteCitation]:
+    """Return child citations that appear in an exclusion phrase."""
+    excluded: list[_StatuteCitation] = []
+    seen: set[tuple[str, tuple[str, ...]]] = set()
+    for cited_parts, start, end in _iter_cited_usc_sections(source_text):
+        if not cited_parts.fragments:
+            continue
+        window_start = max(0, start - 120)
+        window_end = min(len(source_text), end + 40)
+        window = source_text[window_start:window_end]
+        if not re.search(
+            r"\b(?:other\s+than|except(?:ing)?|excluding)\b",
+            window,
+            flags=re.IGNORECASE,
+        ):
+            continue
+        key = (cited_parts.section, cited_parts.fragments)
+        if key in seen:
+            continue
+        seen.add(key)
+        label = cited_parts.section + "".join(
+            f"({fragment})" for fragment in cited_parts.fragments
+        )
+        excluded.append(
+            _StatuteCitation(
+                label=label,
+                section=cited_parts.section,
+                fragments=cited_parts.fragments,
+            )
+        )
+    return excluded
+
+
+def _citation_is_same_or_descendant(
+    citation: _StatuteCitation,
+    ancestor: _StatuteCitation,
+) -> bool:
+    """Return whether citation is the excluded citation or nested under it."""
+    return (
+        citation.section == ancestor.section
+        and citation.fragments[: len(ancestor.fragments)] == ancestor.fragments
+    )
 
 
 def _format_unavailable_cited_context_guidance(

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -408,6 +408,12 @@ Hard requirements:
   `<jurisdiction>:<repo-path>#input.<fact>`.
 - If an upstream output is already executable, do not replace it with a local
   placeholder fact or compatibility alias.
+- If the current source computes an amount by reference to an ancestor section
+  but expressly excludes one child paragraph, subparagraph, or clause, and
+  copied RuleSpec context includes child files for the included branches, import
+  the included child outputs and compose them. Do not import the ancestor
+  aggregate output when that aggregate may include the excluded branch or stale
+  mechanics from sibling branches.
 - If the requested source text includes a limitation, cap, exception, or
   cross-referenced subparagraph that changes the final exported amount, the
   final exported amount must apply that limitation. If a copied sibling/context

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -5183,6 +5183,86 @@ rules:
         assert "`us:statutes/26/1211#other_taxpayer_capital_losses_allowed`" in prompt
         assert "Do not keep a local `_under_section_...`" in prompt
 
+    def test_build_eval_prompt_guides_excluded_child_branch_imports(self, tmp_path):
+        policy_repo_root = tmp_path / "rulespec-us"
+        parent_file = policy_repo_root / "statutes" / "26" / "1401.yaml"
+        child_a_file = policy_repo_root / "statutes" / "26" / "1401" / "a.yaml"
+        child_b1_file = policy_repo_root / "statutes" / "26" / "1401" / "b" / "1.yaml"
+        parent_file.parent.mkdir(parents=True, exist_ok=True)
+        child_a_file.parent.mkdir(parents=True, exist_ok=True)
+        child_b1_file.parent.mkdir(parents=True, exist_ok=True)
+        parent_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: self_employment_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: old_age_survivors_and_disability_insurance_tax + self_employment_income_tax + additional_tax
+"""
+        )
+        child_a_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: old_age_survivors_and_disability_insurance_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: limited_income * rate
+"""
+        )
+        child_b1_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: self_employment_income_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: income * rate
+"""
+        )
+        workspace = prepare_eval_workspace(
+            citation="26 USC 164(f)",
+            runner=parse_runner_spec("codex:gpt-5.4"),
+            output_root=tmp_path / "out",
+            source_text=(
+                "There shall be allowed a deduction equal to one-half of the "
+                "taxes imposed by section 1401 (other than the taxes imposed by "
+                "section 1401(b)(2))."
+            ),
+            axiom_rules_path=policy_repo_root,
+            mode="repo-augmented",
+            extra_context_paths=[parent_file, child_a_file, child_b1_file],
+        )
+
+        prompt = _build_eval_prompt(
+            "26 USC 164(f)",
+            "repo-augmented",
+            workspace,
+            workspace.context_files,
+            target_file_name="f.yaml",
+            target_ref_prefix="us:statutes/26/164/f",
+            include_tests=True,
+        )
+
+        assert "Excluded cited child branch guidance" in prompt
+        assert "excludes `1401(b)(2)`" in prompt
+        assert (
+            "`us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax`"
+            in prompt
+        )
+        assert "`us:statutes/26/1401/b/1#self_employment_income_tax`" in prompt
+        assert "do not import an ancestor aggregate" in prompt
+
     def test_build_eval_prompt_highlights_terminal_child_exports(self, tmp_path):
         policy_repo_root = tmp_path / "rulespec-us"
         child_file = policy_repo_root / "statutes" / "26" / "3101" / "b" / "2.yaml"


### PR DESCRIPTION
## Summary
- add prompt guidance for sources that cite an ancestor section while excluding a child branch
- list available included child RuleSpec exports so generation composes the precise child outputs instead of preserving ancestor aggregates
- bump package version to 0.2.143 with a Towncrier fragment

## Validation
- uv run pytest tests/test_evals.py -k 'excluded_child_branch_imports or rulespec_schema_guardrails or cited_context_import_exports'
- uv run ruff format src/ tests/
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run pytest tests/test_evals.py tests/test_rulespec_validation.py
