### PR TITLE
Repair import output symbol near-misses

### DIFF
--- a/changelog.d/import-output-symbol-near-misses.fixed.md
+++ b/changelog.d/import-output-symbol-near-misses.fixed.md
@@ -1,0 +1,1 @@
+Repair generated proof import outputs and folded formulas when applying clear imported-symbol near-match fixes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.144"
+version = "0.2.145"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.144"
+__version__ = "0.2.145"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -13643,7 +13643,6 @@ def _repair_generated_import_symbol_near_misses(
         repo_path=repo_path,
         replacements=replacements,
     )
-    content = yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
     local_rule_names = _rulespec_rule_names_from_payload(payload)
     old_to_new: dict[str, str] = {}
     ambiguous_formula_symbols: set[str] = set()
@@ -13659,11 +13658,12 @@ def _repair_generated_import_symbol_near_misses(
     for old_symbol, new_symbol in sorted(old_to_new.items()):
         if old_symbol in local_rule_names:
             continue
-        content = _replace_formula_identifier(
-            content,
+        _replace_formula_identifier_in_payload(
+            payload,
             old=old_symbol,
             new=new_symbol,
         )
+    content = yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
     rules_file.write_text(content)
     return repaired
 
@@ -13739,6 +13739,31 @@ def _rulespec_rule_names_from_payload(payload: dict[str, object]) -> set[str]:
     return names
 
 
+def _replace_formula_identifier_in_payload(
+    payload: dict[str, object],
+    *,
+    old: str,
+    new: str,
+) -> None:
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return
+    token = re.compile(rf"\b{re.escape(old)}\b")
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            version["formula"] = token.sub(new, formula)
+
+
 def _closest_rulespec_exported_symbol(
     symbol: str,
     exported_symbols: set[str],
@@ -13794,7 +13819,15 @@ def _repair_import_proof_atom_symbols(
             if not isinstance(target, str):
                 continue
             parsed = _parse_same_repo_rulespec_import_ref(target, repo_path=repo_path)
-            if parsed is None or parsed.symbol is None:
+            if parsed is None:
+                continue
+            if parsed.symbol is None:
+                output = str(import_payload.get("output") or "").strip()
+                replacement = replacements.get((parsed.relative_path, output))
+                if replacement is None:
+                    continue
+                import_payload["target"] = parsed.canonical_base
+                import_payload["output"] = replacement
                 continue
             replacement = replacements.get((parsed.relative_path, parsed.symbol))
             if replacement is None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6153,13 +6153,14 @@ rules:
     unit: USD
     versions:
       - effective_from: '2024-01-01'
-        formula: old_age_survivors_and_disability_tax * 0.5
+        formula: 'if taxpayer_is_individual: self_employment_tax_deduction_fraction *
+          (old_age_survivors_and_disability_tax + self_employment_income_tax) else: 0'
     metadata:
       proof:
         atoms:
           - kind: import
             import:
-              target: us:statutes/26/1401/a#old_age_survivors_and_disability_tax
+              target: us:statutes/26/1401/a
               output: old_age_survivors_and_disability_tax
               hash: sha256:abc123
 """
@@ -6180,8 +6181,9 @@ rules:
             "us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax"
             in content
         )
-        assert "formula: old_age_survivors_and_disability_insurance_tax * 0.5" in (
-            content
+        assert (
+            "old_age_survivors_and_disability_insurance_tax + "
+            "self_employment_income_tax" in content
         )
         assert "output: old_age_survivors_and_disability_insurance_tax" in content
 


### PR DESCRIPTION
## Summary
- apply imported-symbol near-match repairs directly to parsed formula values, so folded YAML formulas are updated before validation
- repair proof import atoms where the imported symbol is carried in the output field and the target is only the module path
- extend the near-match regression test to cover the 164(f)/1401(a)-style folded formula and proof-output shape

## Tests
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run pytest tests/test_cli.py -k import_symbol_near_miss
- uv run pytest tests/test_cli.py tests/test_evals.py tests/test_rulespec_validation.py