### PR TITLE
Fill transitive imported test inputs

### DIFF
--- a/changelog.d/transitive-imported-test-inputs.fixed.md
+++ b/changelog.d/transitive-imported-test-inputs.fixed.md
@@ -1,0 +1,1 @@
+Fill generated companion-test defaults for missing inputs of transitive imported RuleSpec dependencies during apply validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.145"
+version = "0.2.146"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.145"
+__version__ = "0.2.146"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -14178,6 +14178,31 @@ def _imported_input_refs_by_name(
     *,
     repo_path: Path,
 ) -> dict[str, list[str]]:
+    return _collect_imported_input_refs_by_name(
+        rules_file,
+        repo_path=repo_path,
+        seen=set(),
+        depth_remaining=4,
+    )
+
+
+def _collect_imported_input_refs_by_name(
+    rules_file: Path,
+    *,
+    repo_path: Path,
+    seen: set[Path],
+    depth_remaining: int,
+) -> dict[str, list[str]]:
+    if depth_remaining < 0:
+        return {}
+    try:
+        resolved_rules_file = rules_file.resolve()
+    except OSError:
+        resolved_rules_file = rules_file
+    if resolved_rules_file in seen:
+        return {}
+    seen.add(resolved_rules_file)
+
     try:
         payload = yaml.safe_load(rules_file.read_text()) or {}
     except (OSError, ValueError, yaml.YAMLError):
@@ -14187,27 +14212,77 @@ def _imported_input_refs_by_name(
         return {}
 
     refs_by_name: dict[str, list[str]] = {}
-    jurisdiction = _repo_jurisdiction_prefix(repo_path)
     for raw_import in imports:
         if not isinstance(raw_import, str):
             continue
-        import_base = raw_import.split("#", 1)[0].strip().strip("/")
-        if not import_base:
+        resolved_import = _same_repo_import_base_and_file(
+            raw_import,
+            repo_path=repo_path,
+        )
+        if resolved_import is None:
             continue
-        import_file = _import_base_to_repo_file(import_base, repo_path=repo_path)
+        canonical_base, import_file = resolved_import
         if import_file is None or not import_file.exists():
             continue
         input_names = _local_factual_input_names_from_rules_content(
             import_file.read_text()
         )
-        canonical_base = (
-            import_base if ":" in import_base else f"{jurisdiction}:{import_base}"
-        )
         for input_name in sorted(input_names):
-            refs_by_name.setdefault(input_name, []).append(
-                f"{canonical_base}#input.{input_name}"
+            _append_unique_input_ref(
+                refs_by_name,
+                input_name,
+                f"{canonical_base}#input.{input_name}",
             )
+        transitive_refs = _collect_imported_input_refs_by_name(
+            import_file,
+            repo_path=repo_path,
+            seen=seen,
+            depth_remaining=depth_remaining - 1,
+        )
+        for input_name, refs in transitive_refs.items():
+            for input_ref in refs:
+                _append_unique_input_ref(
+                    refs_by_name,
+                    input_name,
+                    input_ref,
+                )
     return refs_by_name
+
+
+def _same_repo_import_base_and_file(
+    raw_import: str,
+    *,
+    repo_path: Path,
+) -> tuple[str, Path] | None:
+    import_base = raw_import.split("#", 1)[0].strip().strip('"').strip("'").strip("/")
+    if not import_base:
+        return None
+    jurisdiction = _repo_jurisdiction_prefix(repo_path)
+    if ":" in import_base:
+        prefix, target = import_base.split(":", 1)
+        if prefix != jurisdiction:
+            return None
+        target = target.strip().strip("/")
+        canonical_base = f"{prefix}:{target}"
+    else:
+        target = import_base
+        canonical_base = f"{jurisdiction}:{target}"
+    if not target:
+        return None
+    import_file = _import_base_to_repo_file(canonical_base, repo_path=repo_path)
+    if import_file is None:
+        return None
+    return canonical_base, import_file
+
+
+def _append_unique_input_ref(
+    refs_by_name: dict[str, list[str]],
+    input_name: str,
+    input_ref: str,
+) -> None:
+    refs = refs_by_name.setdefault(input_name, [])
+    if input_ref not in refs:
+        refs.append(input_ref)
 
 
 def _import_base_to_repo_file(import_base: str, *, repo_path: Path) -> Path | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6412,6 +6412,87 @@ rules: []
             updated.count("us:statutes/26/1/h#input.investment_income_amount: 0") == 2
         )
 
+    def test_complete_missing_imported_test_inputs_adds_transitive_import_defaults(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        leaf = policy_repo / "statutes/26/1402/b.yaml"
+        middle = policy_repo / "statutes/26/1401/a.yaml"
+        dependent = policy_repo / "statutes/26/164/f.yaml"
+        dependent_test = policy_repo / "statutes/26/164/f.test.yaml"
+        leaf.parent.mkdir(parents=True)
+        middle.parent.mkdir(parents=True, exist_ok=True)
+        dependent.parent.mkdir(parents=True, exist_ok=True)
+        leaf.write_text(
+            """format: rulespec/v1
+rules:
+  - name: self_employment_income_for_section_1401_a
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if individual_is_nonresident_alien: 0
+          else: net_earnings_from_self_employment
+"""
+        )
+        middle.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/1402/b#self_employment_income_for_section_1401_a
+rules:
+  - name: old_age_survivors_and_disability_insurance_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: self_employment_income_for_section_1401_a * 0.124
+"""
+        )
+        dependent.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax
+rules: []
+"""
+        )
+        dependent_test.write_text(
+            """- name: case_one
+  input:
+    us:statutes/26/164/f#input.taxpayer_is_individual: true
+  output:
+    us:statutes/26/164/f#self_employment_tax_deduction: 0
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    error=(
+                        "Test case `case_one` execution failed: "
+                        "missing input `individual_is_nonresident_alien`"
+                    )
+                )
+            }
+        )
+
+        changed = _complete_missing_imported_test_inputs(
+            rules_file=dependent,
+            test_file=dependent_test,
+            repo_path=policy_repo,
+            validation=validation,
+        )
+
+        assert changed is True
+        updated = dependent_test.read_text()
+        assert (
+            "us:statutes/26/1402/b#input.individual_is_nonresident_alien: false"
+            in updated
+        )
+
     def test_repair_imported_test_inputs_writes_signed_manifest(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"
         imported = policy_repo / "statutes/26/1/h.yaml"


### PR DESCRIPTION
## Summary
- collect factual input defaults through same-repo transitive RuleSpec imports during apply validation
- add coverage for a 164(f)-style dependency chain through 1401(a) into 1402(b)
- bump axiom-encode to 0.2.146 and add a Towncrier fragment

## Tests
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run pytest tests/test_cli.py -k "imported_test_inputs"
- uv run pytest tests/test_cli.py tests/test_evals.py tests/test_rulespec_validation.py
- git diff --check