### PR TITLE
Guide mixed taxpayer individual source scope

### DIFF
--- a/changelog.d/mixed-taxpayer-individual-source-scope.fixed.md
+++ b/changelog.d/mixed-taxpayer-individual-source-scope.fixed.md
@@ -1,0 +1,1 @@
+Guide mixed taxpayer/individual source definitions to keep individual-scoped components on Person before any source-stated aggregate roll-up.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.146"
+version = "0.2.147"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.146"
+__version__ = "0.2.147"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -39,6 +39,12 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   `entity: TaxUnit`, `Household`, `Family`, or another aggregate entity merely
   because an imported base amount or companion test is currently declared at
   that aggregate entity.
+- When a definition uses "taxpayer" but also says the amount is "of an
+  individual" or applies exclusions for services, income, payments, or statuses
+  of an individual/person/employee/member, encode those components on `Person`.
+  Add an aggregate rule only when the same source defines how those person
+  amounts roll up to a tax unit, household, family, or other unit. Do not let
+  the word "taxpayer" erase a source-stated individual/person subject.
 - Phrases like "on the [base] of every individual/person/employee" identify
   the entity of the current amount, tax, credit, deduction, contribution, or
   limit. Encode the current result on the individual/person/employee first,

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -453,6 +453,8 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "rate-applied result at that lower entity" in prompt
     assert "Treat legal subject nouns as stronger evidence" in prompt
     assert "usually require\n  `entity: Person`" in prompt
+    assert 'definition uses "taxpayer" but also says the amount is "of an' in prompt
+    assert 'Do not let\n  the word "taxpayer"' in prompt
     assert "on the [base] of every individual/person/employee" in prompt
     assert "even if the imported base definition or its tests are unit-scoped" in prompt
     assert "Do not narrate your plan" in prompt


### PR DESCRIPTION
## Summary
- add generic prompt guidance for definitions that use taxpayer language while also stating individual/person-scoped amounts or exclusions
- keep those components on Person before any source-stated aggregate roll-up
- bump axiom-encode to 0.2.147 and add a Towncrier fragment

## Tests
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run pytest tests/test_evals.py::test_build_eval_prompt_targets_rulespec_yaml
- git diff --check

## Context
A generated 26 USC 32(c)(2) refresh was correctly blocked by source-scope validation because it encoded individual-service exclusions as TaxUnit components. This keeps the fix in the general encoder prompt rather than adding policy-specific rules.
