### PR TITLE
Repair invalid test inputs during proof hash repair

### DIFF
--- a/changelog.d/eitc-ecps-1402b-inputs.fixed.md
+++ b/changelog.d/eitc-ecps-1402b-inputs.fixed.md
@@ -1,0 +1,1 @@
+Project EITC ECPS oracle inputs into Section 1402(b) after generated SECA rules stopped accepting stale Section 1401 self-employment income inputs.

--- a/changelog.d/proof-hash-invalid-test-inputs.fixed.md
+++ b/changelog.d/proof-hash-invalid-test-inputs.fixed.md
@@ -1,0 +1,1 @@
+Let proof import hash repairs remove stale invalid companion-test inputs before filling imported dependency defaults.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.148"
+version = "0.2.149"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.148"
+__version__ = "0.2.149"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3798,16 +3798,28 @@ def cmd_repair_proof_import_hashes(args):
                     issues=issues,
                 )
             )
+            removed_invalid_refs = _remove_invalid_test_input_refs(
+                test_file=test_file,
+                issues=issues,
+            )
             completed_missing_inputs = _complete_missing_imported_test_inputs(
                 rules_file=rules_file,
                 test_file=test_file,
                 repo_path=repo_path,
                 validation=validation,
             )
+            repaired_output_cases = _repair_imported_output_test_mismatches(
+                test_file=test_file,
+                policy_repo_path=repo_path,
+                relative_output=relative_output,
+                issues=issues,
+            )
             if (
                 not removed_refs
                 and not repaired_exclusion_refs
+                and not removed_invalid_refs
                 and not completed_missing_inputs
+                and not repaired_output_cases
             ):
                 break
             validation = ValidatorPipeline(
@@ -4023,11 +4035,18 @@ def cmd_repair_imported_test_inputs(args):
             repo_path=repo_path,
             validation=validation,
         )
+        repaired_output_cases = _repair_imported_output_test_mismatches(
+            test_file=test_file,
+            policy_repo_path=repo_path,
+            relative_output=relative_output,
+            issues=issues,
+        )
         if (
             not removed_invalid_refs
             and not removed_refs
             and not repaired_exclusion_refs
             and not completed_missing_inputs
+            and not repaired_output_cases
         ):
             break
         repaired = True
@@ -9347,19 +9366,24 @@ def _remove_invalid_test_input_refs(
     if not isinstance(test_payload, list):
         return []
 
+    removable_refs = _expand_refs_with_matching_test_input_keys(
+        test_payload,
+        invalid_refs,
+    )
+
     changed = False
     for test_case in test_payload:
         if not isinstance(test_case, dict):
             continue
         inputs = test_case.get("input")
-        if _remove_mapping_keys_recursive(inputs, invalid_refs):
+        if _remove_mapping_keys_recursive(inputs, removable_refs):
             changed = True
     if not changed:
         return []
     test_file.write_text(
         yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
     )
-    return sorted(invalid_refs)
+    return sorted(removable_refs)
 
 
 def _remove_invalid_import_output_test_input_refs(
@@ -9612,6 +9636,71 @@ def _invalid_input_refs_from_issues(issues: list[str]) -> set[str]:
             for match in re.finditer(pattern, text):
                 refs.add(match.group("input").strip())
     return refs
+
+
+def _expand_refs_with_matching_test_input_keys(
+    value: object,
+    refs: set[str],
+) -> set[str]:
+    if not refs:
+        return set()
+    tails = {_rulespec_ref_without_jurisdiction(ref) for ref in refs}
+    expanded = set(refs)
+    for key in _mapping_keys_recursive(value):
+        key_text = str(key)
+        if "#input." not in key_text:
+            continue
+        if _rulespec_ref_without_jurisdiction(key_text) in tails:
+            expanded.add(key_text)
+    return expanded
+
+
+def _mapping_keys_recursive(value: object) -> list[object]:
+    keys: list[object] = []
+    if isinstance(value, dict):
+        for key, child in value.items():
+            keys.append(key)
+            keys.extend(_mapping_keys_recursive(child))
+    elif isinstance(value, list):
+        for item in value:
+            keys.extend(_mapping_keys_recursive(item))
+    return keys
+
+
+def _rulespec_ref_without_jurisdiction(ref: str) -> str:
+    if ":" not in ref:
+        return ref
+    prefix, tail = ref.split(":", 1)
+    if "/" in prefix or "#" in prefix or not tail:
+        return ref
+    return tail
+
+
+def _rulespec_ref_base_without_jurisdiction(ref: str) -> str:
+    return _rulespec_ref_without_jurisdiction(ref.split("#", 1)[0].strip())
+
+
+def _rulespec_ref_matches_base(ref: str, base: str) -> bool:
+    ref_base = ref.split("#", 1)[0].strip()
+    base = base.strip()
+    return ref_base == base or (
+        _rulespec_ref_base_without_jurisdiction(ref)
+        == _rulespec_ref_base_without_jurisdiction(base)
+    )
+
+
+def _matching_mapping_key_by_rulespec_ref(
+    mapping: dict[object, object],
+    ref: str,
+) -> object | None:
+    if ref in mapping:
+        return ref
+    ref_tail = _rulespec_ref_without_jurisdiction(ref)
+    for key in mapping:
+        key_text = str(key)
+        if _rulespec_ref_without_jurisdiction(key_text) == ref_tail:
+            return key
+    return None
 
 
 def _remove_mapping_keys_recursive(value: object, keys: set[str]) -> bool:
@@ -12757,7 +12846,7 @@ def _repair_imported_output_test_mismatches(
         if parsed is None:
             return []
         case_name, output_ref, actual_value = parsed
-        if not output_ref.startswith(f"{anchor}#"):
+        if not _rulespec_ref_matches_base(output_ref, anchor):
             return []
         if re.search(r"\b(?:threshold|boundary)\b", case_name, flags=re.IGNORECASE):
             return []
@@ -12781,10 +12870,11 @@ def _repair_imported_output_test_mismatches(
             return []
         changed = False
         for output_ref, actual_value in replacements.items():
-            if output_ref not in outputs:
+            output_key = _matching_mapping_key_by_rulespec_ref(outputs, output_ref)
+            if output_key is None:
                 return []
-            if outputs[output_ref] != actual_value:
-                outputs[output_ref] = actual_value
+            if outputs[output_key] != actual_value:
+                outputs[output_key] = actual_value
                 changed = True
         if changed:
             repaired_cases.append(case_name)
@@ -12837,12 +12927,11 @@ def _rulespec_mismatch_actual_value(kind: str, raw_value: str) -> object:
 def _test_case_has_imported_inputs(inputs: object, *, target_anchor: str) -> bool:
     if not isinstance(inputs, dict):
         return False
-    target_input_prefix = f"{target_anchor}#input."
     for key in inputs:
         key_text = str(key)
         if "#input." not in key_text:
             continue
-        if not key_text.startswith(target_input_prefix):
+        if not _rulespec_ref_matches_base(key_text, target_anchor):
             return True
     return False
 
@@ -14340,17 +14429,32 @@ def _default_refs_for_missing_input(
 
 def _infer_missing_input_default(input_name: str) -> object:
     normalized = input_name.lower()
+    if "contribution_and_benefit_base" in normalized:
+        return 999999999
+    tokens = set(re.split(r"[^a-z0-9]+", normalized))
     numeric_markers = (
         "amount",
+        "base",
         "count",
+        "credit",
         "deduction",
+        "expense",
+        "gross",
         "income",
+        "limit",
+        "net",
         "number",
-        "num_",
+        "num",
+        "rate",
+        "tax",
+        "threshold",
+        "value",
         "wage",
+        "wages",
         "earning",
+        "earnings",
     )
-    if any(marker in normalized for marker in numeric_markers):
+    if tokens.intersection(numeric_markers):
         return 0
     return False
 

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -73,6 +73,7 @@ SECTION_152_C_BASE = "us:statutes/26/152/c"
 SECTION_164_F_BASE = "us:statutes/26/164/f"
 SECTION_1401_BASE = "us:statutes/26/1401"
 SECTION_1402_A_BASE = "us:statutes/26/1402/a"
+SECTION_1402_B_BASE = "us:statutes/26/1402/b"
 SECTION_7703_BASE = "us:statutes/26/7703"
 
 
@@ -523,7 +524,9 @@ def compare_tax_ecps(
         program = resolved_rulespec_root / SURFACE_PROGRAM_PATHS[selected_surface]
         if not program.exists():
             raise SystemExit(f"{selected_surface} RuleSpec not found: {program}")
-        if payroll_surface_uses_axiom_3121(selected_surface):
+        if selected_surface == "eitc" or payroll_surface_uses_axiom_3121(
+            selected_surface
+        ):
             if contribution_base is None:
                 contribution_base_program = (
                     resolved_rulespec_root
@@ -566,6 +569,7 @@ def compare_tax_ecps(
             year=year,
             surface=selected_surface,
             oasdi_wage_base_results=oasdi_wage_base_results,
+            contribution_base=contribution_base,
         )
         surface_results[selected_surface] = run_axiom_program(
             program=program,
@@ -777,6 +781,7 @@ def build_axiom_request(
     year: int,
     surface: str = "ctc",
     oasdi_wage_base_results: list[dict[str, Any]] | None = None,
+    contribution_base: float | None = None,
 ) -> dict[str, Any]:
     if surface == "ctc":
         return build_ctc_request(pe_data=pe_data, year=year)
@@ -785,7 +790,13 @@ def build_axiom_request(
     if surface == "capital-gain-definitions":
         return build_capital_gain_definitions_request(pe_data=pe_data, year=year)
     if surface == "eitc":
-        return build_eitc_request(pe_data=pe_data, year=year)
+        if contribution_base is None:
+            raise ValueError("EITC comparison requires a contribution-and-benefit base")
+        return build_eitc_request(
+            pe_data=pe_data,
+            year=year,
+            contribution_base=contribution_base,
+        )
     if surface in PAYROLL_SURFACES:
         return build_payroll_request(
             pe_data=pe_data,
@@ -952,7 +963,9 @@ def build_capital_gain_definitions_request(
     }
 
 
-def build_eitc_request(*, pe_data: dict[str, Any], year: int) -> dict[str, Any]:
+def build_eitc_request(
+    *, pe_data: dict[str, Any], year: int, contribution_base: float
+) -> dict[str, Any]:
     interval = {
         "period_kind": "tax_year",
         "start": f"{year:04d}-01-01",
@@ -1011,6 +1024,19 @@ def build_eitc_request(*, pe_data: dict[str, Any], year: int) -> dict[str, Any]:
             inputs.append(
                 input_record(
                     f"{SECTION_1402_A_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        for name, value in project_section_1402_b_tax_unit_inputs(
+            persons=tax_unit_persons,
+            contexts=contexts,
+            contribution_base=contribution_base,
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{SECTION_1402_B_BASE}#input.{name}",
                     entity_id,
                     interval,
                     value,
@@ -1505,31 +1531,37 @@ def project_section_164_f_tax_unit_inputs() -> dict[str, Any]:
     return {"taxpayer_is_individual": True}
 
 
+def project_section_1402_b_tax_unit_inputs(
+    *,
+    persons: list[Any],
+    contexts: list[PersonProjectionContext],
+    contribution_base: float,
+) -> dict[str, Any]:
+    wages_paid = sum(
+        project_fica_wages(person)
+        for person, context in zip(persons, contexts, strict=True)
+        if context.is_head or context.is_spouse
+    )
+    return {
+        "individual_is_nonresident_alien": False,
+        "social_security_agreement_under_section_233_applies_to_nonresident_alien": False,
+        "individual_is_noncitizen_territory_resident": False,
+        "contribution_and_benefit_base_under_section_230_of_social_security_act": (
+            contribution_base
+        ),
+        "wages_paid_to_individual_for_section_1401_a": money(wages_paid),
+    }
+
+
 def project_section_1401_tax_unit_inputs(
     *,
     row: Any,
     persons: list[Any],
     contexts: list[PersonProjectionContext],
 ) -> dict[str, Any]:
-    section_1402_inputs = project_section_1402_a_tax_unit_inputs(
-        persons=persons,
-        contexts=contexts,
-    )
-    net_earnings_before_paragraph_12 = (
-        section_1402_inputs["self_employment_trade_or_business_gross_income"]
-        - section_1402_inputs["self_employment_trade_or_business_deductions"]
-        + section_1402_inputs["partnership_section_702_a_8_income_or_loss"]
-    )
-    net_earnings_after_paragraph_12 = net_earnings_before_paragraph_12 * (1 - 0.0765)
-    self_employment_income = (
-        0
-        if net_earnings_after_paragraph_12 < 400
-        else max(0, net_earnings_after_paragraph_12)
-    )
     return {
         "international_social_security_agreement_under_section_233_in_effect": False,
         "filing_status": filing_status_code(str(row["filing_status"])),
-        "self_employment_income": money(self_employment_income),
         "wages_taken_into_account_for_additional_medicare_tax": 0,
     }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,6 +31,7 @@ from axiom_encode.cli import (
     _find_rulespec_dependents,
     _has_zero_output_test,
     _hoist_nested_test_tables,
+    _infer_missing_input_default,
     _insert_false_input_default,
     _local_factual_input_names_from_rules_content,
     _repair_employer_scoped_entities,
@@ -6703,7 +6704,8 @@ rules: []
   input:
     us:statutes/26/1401#input.self_employment_income: 1000
     us:statutes/26/32/c/2#input.taxpayer_is_individual: true
-  output: {}
+  output:
+    us:statutes/26/32/c/2#self_employment_earned_income_component: 900
 """
         )
         args = SimpleNamespace(
@@ -6730,7 +6732,7 @@ rules: []
                                 error=(
                                     "Test case `transitive_case` execution failed: "
                                     "dataset input "
-                                    "`us:statutes/26/1401#input.self_employment_income` "
+                                    "`tmp-rulespec:statutes/26/1401#input.self_employment_income` "
                                     "must use an absolute legal RuleSpec reference "
                                     "that resolves to an input slot, derived rule, "
                                     "or parameter in the compiled program"
@@ -6746,6 +6748,19 @@ rules: []
                                 error=(
                                     "Test case `transitive_case` execution failed: "
                                     "missing input `self_employment_income`"
+                                )
+                            )
+                        },
+                    )
+                if FakePipeline.calls == 3:
+                    return SimpleNamespace(
+                        all_passed=False,
+                        results={
+                            "ci": SimpleNamespace(
+                                error=(
+                                    "Test case `transitive_case` output "
+                                    "`tmp-rulespec:statutes/26/32/c/2#self_employment_earned_income_component` "
+                                    "expected decimal 900, got decimal 1000."
                                 )
                             )
                         },
@@ -6769,6 +6784,10 @@ rules: []
         assert "us:statutes/26/1401#input.self_employment_income" not in updated
         assert "us:statutes/26/32/c/2#input.taxpayer_is_individual: true" in updated
         assert "us:statutes/26/1401/b/1#input.self_employment_income: 0" in updated
+        assert (
+            "us:statutes/26/32/c/2#self_employment_earned_income_component: 1000"
+            in updated
+        )
         manifest = policy_repo / ".axiom/encoding-manifests/statutes/26/32/c/2.json"
         payload = json.loads(manifest.read_text())
         assert payload["model"] == "imported-test-inputs-v1"
@@ -9651,6 +9670,164 @@ rules:
             "statutes/26/22.yaml",
             "statutes/26/22.test.yaml",
         ]
+
+    def test_repair_proof_import_hashes_removes_stale_invalid_test_inputs(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        imported = policy_repo / "statutes/26/1401/b/1.yaml"
+        target = policy_repo / "statutes/26/32/c/2.yaml"
+        test_file = policy_repo / "statutes/26/32/c/2.test.yaml"
+        imported.parent.mkdir(parents=True)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        imported.write_text(
+            """format: rulespec/v1
+rules:
+  - name: self_employment_income_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: self_employment_income * 0.029
+"""
+        )
+        target.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/1401/b/1#self_employment_income_tax
+rules:
+  - name: self_employment_earned_income_component
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/1401/b/1#self_employment_income_tax
+              output: self_employment_income_tax
+              hash: sha256:old
+    versions:
+      - effective_from: '2026-01-01'
+        formula: self_employment_income_tax
+"""
+        )
+        test_file.write_text(
+            """- name: transitive_case
+  input:
+    us:statutes/26/1401#input.self_employment_income: 1000
+    us:statutes/26/32/c/2#input.taxpayer_is_individual: true
+  output:
+    us:statutes/26/32/c/2#self_employment_earned_income_component: 900
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("statutes/26/32/c/2.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            calls = 0
+
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is False
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                FakePipeline.calls += 1
+                if FakePipeline.calls == 1:
+                    return SimpleNamespace(
+                        all_passed=False,
+                        results={
+                            "ci": SimpleNamespace(
+                                error=(
+                                    "Test case `transitive_case` execution failed: "
+                                    "dataset input "
+                                    "`tmp-rulespec:statutes/26/1401#input.self_employment_income` "
+                                    "must use an absolute legal RuleSpec reference "
+                                    "that resolves to an input slot, derived rule, "
+                                    "or parameter in the compiled program"
+                                )
+                            )
+                        },
+                    )
+                if FakePipeline.calls == 2:
+                    return SimpleNamespace(
+                        all_passed=False,
+                        results={
+                            "ci": SimpleNamespace(
+                                error=(
+                                    "Test case `transitive_case` execution failed: "
+                                    "missing input `self_employment_income`"
+                                )
+                            )
+                        },
+                    )
+                if FakePipeline.calls == 3:
+                    return SimpleNamespace(
+                        all_passed=False,
+                        results={
+                            "ci": SimpleNamespace(
+                                error=(
+                                    "Test case `transitive_case` output "
+                                    "`tmp-rulespec:statutes/26/32/c/2#self_employment_earned_income_component` "
+                                    "expected decimal 900, got decimal 1000."
+                                )
+                            )
+                        },
+                    )
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_proof_import_hashes(args)
+
+        target_content = target.read_text()
+        assert "sha256:old" not in target_content
+        updated_test = test_file.read_text()
+        assert "us:statutes/26/1401#input.self_employment_income" not in updated_test
+        assert "us:statutes/26/1401/b/1#input.self_employment_income: 0" in updated_test
+        assert (
+            "us:statutes/26/32/c/2#self_employment_earned_income_component: 1000"
+            in updated_test
+        )
+        manifest = policy_repo / ".axiom/encoding-manifests/statutes/26/32/c/2.json"
+        payload = json.loads(manifest.read_text())
+        assert payload["model"] == "proof-import-hash-v1"
+        assert [item["path"] for item in payload["applied_files"]] == [
+            "statutes/26/32/c/2.yaml",
+            "statutes/26/32/c/2.test.yaml",
+        ]
+
+    def test_missing_input_default_treats_base_as_numeric(self):
+        assert (
+            _infer_missing_input_default(
+                "contribution_and_benefit_base_under_section_230_of_social_security_act"
+            )
+            == 999999999
+        )
+
+    def test_missing_input_default_does_not_treat_taxpayer_as_tax_numeric(self):
+        assert (
+            _infer_missing_input_default("is_dependent_under_section_152_of_taxpayer")
+            is False
+        )
 
     def test_repair_imported_proof_hashes_writes_target_file_hash(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -24,6 +24,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     SECTION_164_F_BASE,
     SECTION_1401_BASE,
     SECTION_1402_A_BASE,
+    SECTION_1402_B_BASE,
     SECTION_7703_BASE,
     additional_standard_deduction_entitlement_count,
     build_capital_gain_definitions_request,
@@ -56,6 +57,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     project_section_164_f_tax_unit_inputs,
     project_section_1401_tax_unit_inputs,
     project_section_1402_a_tax_unit_inputs,
+    project_section_1402_b_tax_unit_inputs,
     project_section_7703_tax_unit_inputs,
     project_standard_deduction_inputs,
     project_tax_unit_inputs,
@@ -664,6 +666,17 @@ def test_eitc_projection_sends_self_employment_to_section_1402_not_earned_income
     assert project_section_164_f_tax_unit_inputs() == {
         "taxpayer_is_individual": True,
     }
+    assert project_section_1402_b_tax_unit_inputs(
+        persons=persons,
+        contexts=contexts,
+        contribution_base=184_500,
+    ) == {
+        "individual_is_nonresident_alien": False,
+        "social_security_agreement_under_section_233_applies_to_nonresident_alien": False,
+        "individual_is_noncitizen_territory_resident": False,
+        "contribution_and_benefit_base_under_section_230_of_social_security_act": 184_500.0,
+        "wages_paid_to_individual_for_section_1401_a": 23_000,
+    }
     assert project_section_1401_tax_unit_inputs(
         row=row,
         persons=persons,
@@ -671,7 +684,6 @@ def test_eitc_projection_sends_self_employment_to_section_1402_not_earned_income
     ) == {
         "international_social_security_agreement_under_section_233_in_effect": False,
         "filing_status": 0,
-        "self_employment_income": 3647.825,
         "wages_taken_into_account_for_additional_medicare_tax": 0,
     }
 
@@ -816,7 +828,11 @@ def test_build_eitc_request_uses_structural_child_relation_and_component_outputs
         "person_ids": [7, 8],
     }
 
-    request = build_eitc_request(pe_data=pe_data, year=2026)
+    request = build_eitc_request(
+        pe_data=pe_data,
+        year=2026,
+        contribution_base=184_500.0,
+    )
 
     assert request["queries"] == [
         {
@@ -888,7 +904,19 @@ def test_build_eitc_request_uses_structural_child_relation_and_component_outputs
         ]
         is False
     )
-    assert input_values[f"{SECTION_1401_BASE}#input.self_employment_income"] == "0.0"
+    assert f"{SECTION_1401_BASE}#input.self_employment_income" not in input_values
+    assert (
+        input_values[
+            f"{SECTION_1402_B_BASE}#input.contribution_and_benefit_base_under_section_230_of_social_security_act"
+        ]
+        == "184500.0"
+    )
+    assert (
+        input_values[
+            f"{SECTION_1402_B_BASE}#input.wages_paid_to_individual_for_section_1401_a"
+        ]
+        == "18000.0"
+    )
     assert (
         input_values[
             f"{SECTION_152_C_BASE}#input.individual_is_child_of_taxpayer_or_descendant_of_such_child"


### PR DESCRIPTION
## Summary
- remove stale invalid companion-test input refs during proof import hash repair
- fill current imported dependency defaults after invalid refs are removed
- add a regression test for stale parent imports during proof hash repair

## Tests
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run pytest tests/test_cli.py -k "proof_import_hashes"
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- git diff --check