### PR TITLE
Repair person-scoped generated definitions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.149"
+version = "0.2.150"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.149"
+__version__ = "0.2.150"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10725,6 +10725,34 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_person_scoped_definitions = (
+                    _try_repair_generated_person_scoped_definition_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_person_scoped_definitions:
+                    outcome["auto_repaired_person_scoped_definition"] = (
+                        repaired_person_scoped_definitions
+                    )
+                    print(
+                        "  apply=auto_repaired_person_scoped_definition:"
+                        + ",".join(repaired_person_scoped_definitions)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_rules = _try_repair_generated_nonnegative_floors_for_apply(
                     result,
                     output_root=args.output,
@@ -11464,6 +11492,9 @@ def _qualify_deferred_output_subsection_paths(
 _PERSON_SCOPE_RATE_BASE_ISSUE_PATTERN = re.compile(
     r"Person-scoped rate base at unit scope: `([^`]+)`"
 )
+_PERSON_SCOPE_DEFINITION_ISSUE_PATTERN = re.compile(
+    r"Person-scoped definition at unit scope: `([^`]+)`"
+)
 _EMPLOYER_SCOPE_ISSUE_PATTERN = re.compile(
     r"Employer-scoped rule at non-employer scope: `([^`]+)`"
 )
@@ -12019,6 +12050,110 @@ def _repair_person_scoped_rate_base_entities(
                 continue
             if _set_rule_entity_to_person(helper):
                 repaired.append(identifier)
+
+    if not repaired:
+        return []
+
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repaired
+
+
+def _try_repair_generated_person_scoped_definition_for_apply(
+    result,
+    *,
+    output_root: Path,
+    issues: list[str],
+) -> list[str]:
+    """Move generated person-scoped definitions back to the Person entity."""
+    target_names = _person_scoped_definition_issue_names(issues)
+    if not target_names:
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    return _repair_person_scoped_definition_entities(
+        rules_file=rules_file,
+        target_names=target_names,
+    )
+
+
+def _person_scoped_definition_issue_names(issues: list[str]) -> list[str]:
+    names: list[str] = []
+    for issue in issues:
+        match = _PERSON_SCOPE_DEFINITION_ISSUE_PATTERN.search(str(issue))
+        if match is not None:
+            names.append(match.group(1))
+    return names
+
+
+def _repair_person_scoped_definition_entities(
+    *,
+    rules_file: Path,
+    target_names: list[str],
+) -> list[str]:
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    by_name = {
+        str(rule.get("name")).strip(): rule
+        for rule in rules
+        if isinstance(rule, dict)
+        and isinstance(rule.get("name"), str)
+        and str(rule.get("name")).strip()
+    }
+    reverse_dependencies: dict[str, list[str]] = {}
+    for rule_name, rule in by_name.items():
+        if str(rule.get("kind") or "").strip().lower() != "derived":
+            continue
+        for identifier in _formula_identifiers(_first_rule_formula(rule)):
+            reverse_dependencies.setdefault(identifier, []).append(rule_name)
+
+    repaired: list[str] = []
+    pending = list(dict.fromkeys(target_names))
+    seen: set[str] = set()
+    while pending:
+        target_name = pending.pop(0)
+        if target_name in seen:
+            continue
+        seen.add(target_name)
+        target_rule = by_name.get(target_name)
+        if not isinstance(target_rule, dict):
+            continue
+        if _set_rule_entity_to_person(target_rule):
+            repaired.append(target_name)
+        formula = _first_rule_formula(target_rule)
+        for identifier in sorted(_formula_identifiers(formula)):
+            helper = by_name.get(identifier)
+            if not isinstance(helper, dict):
+                continue
+            if str(helper.get("kind") or "").strip().lower() != "derived":
+                continue
+            helper_entity = str(helper.get("entity") or "").replace("_", "").lower()
+            if helper_entity not in _UNIT_ENTITY_NAMES:
+                continue
+            pending.append(identifier)
+        for dependent_name in sorted(reverse_dependencies.get(target_name, [])):
+            dependent = by_name.get(dependent_name)
+            if not isinstance(dependent, dict):
+                continue
+            dependent_entity = (
+                str(dependent.get("entity") or "").replace("_", "").lower()
+            )
+            if dependent_entity not in _UNIT_ENTITY_NAMES:
+                continue
+            pending.append(dependent_name)
 
     if not repaired:
         return []

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -5308,6 +5308,67 @@ def find_person_scoped_rate_base_unit_issues(content: str) -> list[str]:
     return issues
 
 
+_PERSON_SCOPED_DEFINITION_SOURCE_PATTERN = re.compile(
+    r"\bterm\b[\s\S]{0,120}\bmeans\b[\s\S]{0,260}\bnet\s+earnings?\b"
+    r"[\s\S]{0,180}\bderived\s+by\s+(?:an?|the|such)\s+"
+    r"(?:individual|person|employee|member)\b"
+    r"|"
+    r"\bnet\s+earnings?\b[\s\S]{0,220}\bwages\s+paid\s+to\s+"
+    r"(?:an?|the|such)\s+(?:individual|person|employee|member)\b"
+    r"|"
+    r"\bremuneration\b[\s\S]{0,220}\bpaid\s+to\s+"
+    r"(?:an?|the|such)\s+"
+    r"(?:individual|person|employee|member)\b",
+    flags=re.IGNORECASE,
+)
+
+
+def find_person_scoped_definition_unit_issues(content: str) -> list[str]:
+    """Flag unit-level derived definitions for person-scoped legal amounts."""
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+    source_text = extract_embedded_source_text(content)
+    if not source_text:
+        source_text = _extract_source_verification_text(content)
+    if not source_text:
+        return []
+
+    formula_records = _rulespec_rule_formula_rule_records(payload)
+    formula_by_name = {
+        name: formula
+        for name, kind, formula, _source, _rule in formula_records
+        if kind == "derived"
+    }
+    issues: list[str] = []
+    for name, kind, formula, rule_source, rule in formula_records:
+        if kind != "derived":
+            continue
+        entity = str(rule.get("entity") or "").strip()
+        if entity.lower() not in _UNIT_SCOPED_ENTITY_NAMES:
+            continue
+        scoped_source_text = " ".join(_rule_proof_source_excerpts(rule))
+        if not scoped_source_text:
+            scoped_source_text = _source_text_for_rule_source(source_text, rule_source)
+        if not _PERSON_SCOPED_DEFINITION_SOURCE_PATTERN.search(scoped_source_text):
+            continue
+        if _formula_or_referenced_helpers_use_relation_aggregate(
+            formula,
+            formula_by_name=formula_by_name,
+        ):
+            continue
+        issues.append(
+            "Person-scoped definition at unit scope: "
+            f"`{name}` is declared on `{entity}`, but the source text defines "
+            "an amount, income, earnings, wage, tax, deduction, credit, or "
+            "benefit for an individual, person, employee, or member. Encode "
+            "that definition at the lower entity first, then aggregate only "
+            "through an explicit relation when the source states a unit-level "
+            "roll-up."
+        )
+    return issues
+
+
 def find_employer_scoped_entity_issues(content: str) -> list[str]:
     """Flag employer-imposed rules that are broadened to tax/business units."""
     payload = _rulespec_payload(content)
@@ -14646,6 +14707,7 @@ class ValidatorPipeline:
         issues.extend(find_employer_scoped_entity_issues(content))
         issues.extend(find_shared_statutory_rate_entity_suffix_name_issues(content))
         issues.extend(find_person_scoped_rate_base_unit_issues(content))
+        issues.extend(find_person_scoped_definition_unit_issues(content))
         issues.extend(find_helper_only_definition_issues(content))
         issues.extend(find_deferred_output_issues(content))
         issues.extend(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,7 @@ from axiom_encode.cli import (
     _repair_input_field_accesses_in_formulas,
     _repair_missing_source_proof_atoms,
     _repair_mixed_scalar_output_tests,
+    _repair_person_scoped_definition_entities,
     _repair_section_151_imports,
     _repair_section_151_temporal_fact_names,
     _repair_shared_statutory_rate_names,
@@ -3711,6 +3712,47 @@ rules:
         ]
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
+
+    def test_repair_person_scoped_definition_entities_moves_helpers(self, tmp_path):
+        rules_file = tmp_path / "statutes/26/1402/b.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: self_employment_income_excluded_for_taxpayer
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: individual_is_nonresident_alien
+  - name: self_employment_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if self_employment_income_excluded_for_taxpayer:
+            0
+          else:
+            net_earnings_from_self_employment
+"""
+        )
+
+        repaired = _repair_person_scoped_definition_entities(
+            rules_file=rules_file,
+            target_names=["self_employment_income_excluded_for_taxpayer"],
+        )
+
+        assert repaired == [
+            "self_employment_income_excluded_for_taxpayer",
+            "self_employment_income",
+        ]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert [rule["entity"] for rule in payload["rules"]] == ["Person", "Person"]
 
     def test_encode_apply_auto_repairs_section_1401_policyengine_oracle_inputs(
         self, capsys, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -49,6 +49,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_missing_same_section_subsection_import_issues,
     find_nonnegative_amount_reduction_issues,
     find_partial_extent_zeroing_issues,
+    find_person_scoped_definition_unit_issues,
     find_person_scoped_rate_base_unit_issues,
     find_proof_import_hash_consistency_issues,
     find_proof_import_reference_issues,
@@ -10220,6 +10221,74 @@ rules:
 """
 
     assert find_person_scoped_rate_base_unit_issues(content) == []
+
+
+def test_person_scoped_definition_unit_rejects_individual_income_definition():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    The term self-employment income means the net earnings from self-employment
+    derived by an individual during any taxable year; except that such term
+    shall not include net earnings below $400.
+rules:
+  - name: self_employment_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 1402(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if net_earnings_from_self_employment < 400:
+            0
+          else:
+            net_earnings_from_self_employment
+"""
+
+    issues = find_person_scoped_definition_unit_issues(content)
+
+    assert any("Person-scoped definition at unit scope" in issue for issue in issues)
+    assert "self_employment_income" in issues[0]
+    assert "TaxUnit" in issues[0]
+
+
+def test_person_scoped_definition_unit_accepts_relation_rollup():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Each employee's covered wages are wages paid to such employee. The tax unit
+    amount is the sum of covered wages for members of the tax unit.
+rules:
+  - name: member_of_tax_unit
+    kind: data_relation
+    data_relation:
+      predicate: member_of_tax_unit
+      arity: 2
+  - name: covered_wages
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: source
+    versions:
+      - effective_from: '2026-01-01'
+        formula: wages_paid_to_employee
+  - name: tax_unit_covered_wages
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: source
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum_where(member_of_tax_unit, covered_wages, member_has_wages)
+"""
+
+    assert find_person_scoped_definition_unit_issues(content) == []
 
 
 def test_employer_scoped_entity_rejects_tax_unit():


### PR DESCRIPTION
## Summary\n- add a validation guard for generated unit-scoped definitions of person-level self-employment-style income\n- add deterministic apply repair that moves the flagged generated rule, local helpers, and local dependents to Person\n- cover the guard and repair with focused tests\n\n## Tests\n- uv run pytest tests/test_rulespec_validation.py -q -k 'person_scoped_definition or person_scoped_rate_base or source_scope_consistency'\n- uv run pytest tests/test_cli.py::TestCmdEncode::test_repair_person_scoped_definition_entities_moves_helpers tests/test_cli.py::TestCmdEncode::test_encode_apply_repairs_person_scoped_rate_base -q\n- uv run ruff check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_rulespec_validation.py