### PR TITLE
Allow derived helpers over imported cross-references

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.150"
+version = "0.2.151"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.150"
+__version__ = "0.2.151"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -15173,10 +15173,14 @@ class ValidatorPipeline:
             return []
         current_section = self._infer_section_from_rulespec_path(rulespec_file)
         import_items = self._extract_import_items(content)
+        local_blocks = {
+            str(block["name"]): block
+            for block in self._extract_definition_blocks(content)
+        }
 
         issues: list[str] = []
         seen: set[tuple[str, str]] = set()
-        for block in self._extract_definition_blocks(content):
+        for block in local_blocks.values():
             formula = "\n".join(str(line) for line in block["body_lines"])
             for identifier in sorted(_formula_local_identifiers(formula)):
                 import_base = self._cross_reference_placeholder_import_base(
@@ -15200,17 +15204,27 @@ class ValidatorPipeline:
                     source_text
                 ):
                     continue
-                if self._imports_cover_placeholder_identifier(
-                    import_items,
-                    import_base,
-                    identifier,
-                    rulespec_file=rulespec_file,
-                ) or self._imports_cover_relation_field_placeholder(
-                    import_items,
-                    import_base,
-                    identifier,
-                    formula=formula,
-                    rulespec_file=rulespec_file,
+                if (
+                    self._imports_cover_placeholder_identifier(
+                        import_items,
+                        import_base,
+                        identifier,
+                        rulespec_file=rulespec_file,
+                    )
+                    or self._imports_cover_relation_field_placeholder(
+                        import_items,
+                        import_base,
+                        identifier,
+                        formula=formula,
+                        rulespec_file=rulespec_file,
+                    )
+                    or self._local_definition_resolves_cross_reference_placeholder(
+                        local_blocks,
+                        import_items,
+                        import_base,
+                        identifier,
+                        rulespec_file=rulespec_file,
+                    )
                 ):
                     continue
                 key = (str(block["name"]), identifier)
@@ -15236,6 +15250,56 @@ class ValidatorPipeline:
                     f"encoded or required cited source. {resolution}"
                 )
         return issues
+
+    def _local_definition_resolves_cross_reference_placeholder(
+        self,
+        local_blocks: dict[str, dict[str, object]],
+        import_items: list[str],
+        expected_path: str,
+        identifier: str,
+        *,
+        rulespec_file: Path,
+    ) -> bool:
+        """Return whether a local helper composes an imported cited source.
+
+        Section-looking local inputs are placeholders. A same-file derived helper
+        with a section-looking name can still be legitimate when it directly
+        references an imported output from that cited section and applies the
+        current source's own condition around it.
+        """
+        block = local_blocks.get(identifier)
+        if block is None:
+            return False
+
+        formula = "\n".join(str(line) for line in block["body_lines"])
+        formula_identifiers = _formula_local_identifiers(formula)
+        if not formula_identifiers:
+            return False
+
+        expected = expected_path.strip("/")
+        for import_item in import_items:
+            normalized = self._normalize_rulespec_import_path(import_item)
+            if not self._imports_cover_path({normalized}, expected):
+                continue
+
+            fragment = self._import_item_fragment(import_item)
+            if fragment and fragment in formula_identifiers:
+                return True
+
+            import_file = _resolve_rulespec_import_file_static(
+                import_item,
+                rules_file=rulespec_file,
+                policy_repo_path=self.policy_repo_path,
+            )
+            if import_file is None:
+                continue
+            with contextlib.suppress(OSError):
+                imported_symbols = set(
+                    self._extract_defined_symbols(import_file.read_text())
+                )
+                if formula_identifiers & imported_symbols:
+                    return True
+        return False
 
     def _check_cross_reference_numeric_placeholders(
         self, rulespec_file: Path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6445,6 +6445,66 @@ rules:
     assert pipeline._check_encoded_cross_reference_placeholders(rules_file) == []
 
 
+def test_encoded_cross_reference_placeholder_allows_local_helper_using_import(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "32" / "c" / "2.yaml"
+    imported_file = repo / "statutes" / "26" / "112.yaml"
+    rules_file.parent.mkdir(parents=True)
+    imported_file.parent.mkdir(parents=True, exist_ok=True)
+    imported_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: amount_excluded_from_gross_income_by_reason_of_section_112
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: combat_zone_compensation
+"""
+    )
+    rules_file.write_text(
+        """format: rulespec/v1
+imports:
+  - us:statutes/26/112#amount_excluded_from_gross_income_by_reason_of_section_112
+module:
+  summary: |-
+    A taxpayer may elect to treat amounts excluded from gross income by reason
+    of section 112 as earned income.
+rules:
+  - name: section_112_excluded_amounts_treated_as_earned_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if taxpayer_elects_to_treat_section_112_excluded_amounts_as_earned_income:
+            amount_excluded_from_gross_income_by_reason_of_section_112
+          else: 0
+  - name: earned_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: wages + section_112_excluded_amounts_treated_as_earned_income
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    assert pipeline._check_encoded_cross_reference_placeholders(rules_file) == []
+
+
 def test_validate_rulespec_proofs_can_require_policy_proofs_without_module_flag():
     content = """format: rulespec/v1
 module:


### PR DESCRIPTION
## Summary
- allow same-file derived helpers to compose imported cross-reference outputs without being flagged as placeholder inputs
- add a regression test for the 26 USC 32(c)(2) / 112 helper pattern
- bump axiom-encode to 0.2.151

## Tests
- uv run pytest tests/test_rulespec_validation.py -q -k cross_reference_placeholder
- uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py pyproject.toml src/axiom_encode/__init__.py