### PR TITLE
Repair source-scope person mismatches during apply

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.151"
+version = "0.2.152"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.151"
+__version__ = "0.2.152"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -11495,6 +11495,9 @@ _PERSON_SCOPE_RATE_BASE_ISSUE_PATTERN = re.compile(
 _PERSON_SCOPE_DEFINITION_ISSUE_PATTERN = re.compile(
     r"Person-scoped definition at unit scope: `([^`]+)`"
 )
+_SOURCE_SCOPE_PERSON_MISMATCH_ISSUE_PATTERN = re.compile(
+    r"Source scope mismatch: `([^`]+)` is declared on `(?:Household|SnapUnit|TaxUnit|Family|SPMUnit)`"
+)
 _EMPLOYER_SCOPE_ISSUE_PATTERN = re.compile(
     r"Employer-scoped rule at non-employer scope: `([^`]+)`"
 )
@@ -12083,9 +12086,15 @@ def _try_repair_generated_person_scoped_definition_for_apply(
 def _person_scoped_definition_issue_names(issues: list[str]) -> list[str]:
     names: list[str] = []
     for issue in issues:
-        match = _PERSON_SCOPE_DEFINITION_ISSUE_PATTERN.search(str(issue))
-        if match is not None:
-            names.append(match.group(1))
+        text = str(issue)
+        for pattern in (
+            _PERSON_SCOPE_DEFINITION_ISSUE_PATTERN,
+            _SOURCE_SCOPE_PERSON_MISMATCH_ISSUE_PATTERN,
+        ):
+            match = pattern.search(text)
+            if match is not None:
+                names.append(match.group(1))
+                break
     return names
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,7 @@ from axiom_encode.cli import (
     _infer_missing_input_default,
     _insert_false_input_default,
     _local_factual_input_names_from_rules_content,
+    _person_scoped_definition_issue_names,
     _repair_employer_scoped_entities,
     _repair_generated_import_symbol_near_misses,
     _repair_input_field_accesses_in_formulas,
@@ -3753,6 +3754,17 @@ rules:
         ]
         payload = yaml.safe_load(rules_file.read_text())
         assert [rule["entity"] for rule in payload["rules"]] == ["Person", "Person"]
+
+    def test_person_scoped_definition_issue_names_includes_source_scope_mismatch(self):
+        issues = [
+            "Source scope mismatch: `earned_income` is declared on `TaxUnit`, "
+            "but the embedded source states an individual/person/member-scoped "
+            "eligibility or disqualification. Encode the rule at the "
+            "person/member scope or cite source text that states the unit-level "
+            "test."
+        ]
+
+        assert _person_scoped_definition_issue_names(issues) == ["earned_income"]
 
     def test_encode_apply_auto_repairs_section_1401_policyengine_oracle_inputs(
         self, capsys, tmp_path


### PR DESCRIPTION
## Summary
- extend person-scope apply repair to source-scope mismatch validation errors
- add a regression test that extracts the mismatched rule name from the source-scope guard
- bump axiom-encode to 0.2.152

## Tests
- uv run pytest tests/test_cli.py -q -k "person_scoped_definition or source_scope_mismatch"
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py pyproject.toml src/axiom_encode/__init__.py
- uv run ruff format --check src/ tests/