### PR TITLE
Repair mixed dependent test outputs during apply

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.152"
+version = "0.2.153"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.152"
+__version__ = "0.2.153"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -13740,6 +13740,23 @@ def _validate_generated_encoding_in_policy_overlay(
                     dependents=dependents,
                 )
                 continue
+            removed_cross_module_outputs = _remove_cross_module_dependent_test_outputs(
+                overlay_repo=overlay_repo,
+                relative_output=relative_output,
+                validations=validations,
+            )
+            if removed_cross_module_outputs:
+                for path in removed_cross_module_outputs:
+                    supplemental_files[path.relative_to(overlay_repo)] = (
+                        path.read_text()
+                    )
+                validations = _validate_overlay_files(
+                    pipeline,
+                    dependent_pipeline=dependent_pipeline,
+                    overlay_target=overlay_target,
+                    dependents=dependents,
+                )
+                continue
             changed_tests = _complete_missing_dependent_test_inputs(
                 overlay_repo=overlay_repo,
                 relative_output=relative_output,
@@ -14252,6 +14269,10 @@ _MISSING_INPUT_RE = re.compile(
 _INVALID_INPUT_REF_RE = re.compile(
     r"input `(?P<input>[^`]+)` does not resolve to an input slot"
 )
+_ABSOLUTE_RULESPEC_REF_RE = re.compile(r"^[a-z][a-z0-9_-]*:[^\s]+$")
+_MIXED_DERIVED_OUTPUT_ENTITIES_RE = re.compile(
+    r"Test case `(?P<case>[^`]+)` mixes derived output entities \([^)]+\)"
+)
 
 
 def _remove_invalid_dependent_test_inputs(
@@ -14290,6 +14311,72 @@ def _remove_invalid_dependent_test_inputs(
         if updated == content:
             continue
         test_path.write_text(updated)
+        changed.append(test_path)
+    return changed
+
+
+def _remove_cross_module_dependent_test_outputs(
+    *,
+    overlay_repo: Path,
+    relative_output: Path,
+    validations: list[tuple[Path, object]],
+) -> list[Path]:
+    """Remove imported output assertions that make dependent tests entity-mixed."""
+    changed: list[Path] = []
+    jurisdiction = _repo_jurisdiction_prefix(overlay_repo)
+    target_path = overlay_repo / relative_output
+    for validated_file, validation in validations:
+        if validated_file == target_path:
+            continue
+        test_path = _rulespec_test_path(validated_file)
+        if not test_path.exists():
+            continue
+        mixed_cases: set[str] = set()
+        for validator_result in validation.results.values():
+            error = validator_result.error or ""
+            mixed_cases.update(
+                match.group("case")
+                for match in _MIXED_DERIVED_OUTPUT_ENTITIES_RE.finditer(error)
+            )
+        if not mixed_cases:
+            continue
+
+        try:
+            test_cases = yaml.safe_load(test_path.read_text()) or []
+            relative_validated = validated_file.relative_to(overlay_repo)
+        except (OSError, ValueError, yaml.YAMLError):
+            continue
+        if not isinstance(test_cases, list):
+            continue
+
+        local_ref = (
+            f"{jurisdiction}:{_relative_rulespec_import_target(relative_validated)}#"
+        )
+        file_changed = False
+        for test_case in test_cases:
+            if not isinstance(test_case, dict):
+                continue
+            if str(test_case.get("name") or "") not in mixed_cases:
+                continue
+            output = test_case.get("output")
+            if not isinstance(output, dict) or len(output) <= 1:
+                continue
+            removable = [
+                key
+                for key in output
+                if _ABSOLUTE_RULESPEC_REF_RE.match(str(key))
+                and not str(key).startswith(local_ref)
+            ]
+            if not removable or len(removable) == len(output):
+                continue
+            for key in removable:
+                output.pop(key, None)
+            file_changed = True
+        if not file_changed:
+            continue
+        test_path.write_text(
+            yaml.safe_dump(test_cases, sort_keys=False, allow_unicode=False)
+        )
         changed.append(test_path)
     return changed
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,7 @@ from axiom_encode.cli import (
     _insert_false_input_default,
     _local_factual_input_names_from_rules_content,
     _person_scoped_definition_issue_names,
+    _remove_cross_module_dependent_test_outputs,
     _repair_employer_scoped_entities,
     _repair_generated_import_symbol_near_misses,
     _repair_input_field_accesses_in_formulas,
@@ -3765,6 +3766,49 @@ rules:
         ]
 
         assert _person_scoped_definition_issue_names(issues) == ["earned_income"]
+
+    def test_remove_cross_module_dependent_test_outputs_drops_imported_output(
+        self, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us"
+        rules_file = repo / "statutes/26/24/d.yaml"
+        test_file = repo / "statutes/26/24/d.test.yaml"
+        target_file = repo / "statutes/26/32/c/2.yaml"
+        rules_file.parent.mkdir(parents=True)
+        target_file.parent.mkdir(parents=True)
+        rules_file.write_text("format: rulespec/v1\nrules: []\n")
+        target_file.write_text("format: rulespec/v1\nrules: []\n")
+        test_file.write_text(
+            """- name: mixed_case
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us:statutes/26/24/d#refundable_ctc: 2550
+    us:statutes/26/32/c/2#self_employment_earned_income_component: 0
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    error="Test case `mixed_case` mixes derived output entities "
+                    "(Person, TaxUnit); put outputs for each entity in separate "
+                    "test cases."
+                )
+            }
+        )
+
+        changed = _remove_cross_module_dependent_test_outputs(
+            overlay_repo=repo,
+            relative_output=Path("statutes/26/32/c/2.yaml"),
+            validations=[(rules_file, validation)],
+        )
+
+        assert changed == [test_file]
+        repaired = yaml.safe_load(test_file.read_text())
+        assert repaired[0]["output"] == {"us:statutes/26/24/d#refundable_ctc": 2550}
 
     def test_encode_apply_auto_repairs_section_1401_policyengine_oracle_inputs(
         self, capsys, tmp_path


### PR DESCRIPTION
## Summary
- remove cross-module output assertions from dependent generated tests when they trigger mixed-entity validation failures during apply
- keep dependent tests focused on their local output assertions while preserving target/generated files in the signed apply manifest
- bump axiom-encode to 0.2.153

## Tests
- uv run pytest tests/test_cli.py -q -k 'cross_module_dependent_test_outputs or person_scoped_definition_issue_names'
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py pyproject.toml src/axiom_encode/__init__.py
- uv run ruff format --check src/ tests/