### PR TITLE
Repair stale dependent test inputs during apply

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.153"
+version = "0.2.154"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.153"
+__version__ = "0.2.154"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -14281,7 +14281,7 @@ def _remove_invalid_dependent_test_inputs(
     relative_output: Path,
     validations: list[tuple[Path, object]],
 ) -> list[Path]:
-    """Remove obsolete generated-target input refs from dependent tests."""
+    """Remove obsolete input refs from dependent tests."""
     target_ref = (
         f"{_repo_jurisdiction_prefix(overlay_repo)}:"
         f"{_relative_rulespec_import_target(relative_output)}"
@@ -14293,26 +14293,61 @@ def _remove_invalid_dependent_test_inputs(
         test_path = _rulespec_test_path(validated_file)
         if not test_path.exists():
             continue
+        try:
+            relative_validated = validated_file.relative_to(overlay_repo)
+        except ValueError:
+            continue
+        dependent_ref = (
+            f"{_repo_jurisdiction_prefix(overlay_repo)}:"
+            f"{_relative_rulespec_import_target(relative_validated)}"
+        )
         invalid_refs: set[str] = set()
         for validator_result in validation.results.values():
             error = validator_result.error or ""
             for input_ref in _invalid_input_refs_from_issues([error]):
-                if input_ref.startswith(
-                    f"{target_ref}#input."
-                ) or _input_ref_is_import_output_placeholder(
+                if _invalid_dependent_test_input_ref_is_removable(
                     input_ref,
+                    target_ref=target_ref,
+                    dependent_ref=dependent_ref,
                     repo_path=overlay_repo,
                 ):
                     invalid_refs.add(input_ref)
         if not invalid_refs:
             continue
         content = test_path.read_text()
-        updated = _remove_input_refs_from_test_cases(content, invalid_refs)
+        try:
+            test_payload = yaml.safe_load(content) or []
+        except (OSError, ValueError, yaml.YAMLError):
+            continue
+        removable_refs = _expand_refs_with_matching_test_input_keys(
+            test_payload,
+            invalid_refs,
+        )
+        updated = _remove_input_refs_from_test_cases(content, removable_refs)
         if updated == content:
             continue
         test_path.write_text(updated)
         changed.append(test_path)
     return changed
+
+
+def _invalid_dependent_test_input_ref_is_removable(
+    input_ref: str,
+    *,
+    target_ref: str,
+    dependent_ref: str,
+    repo_path: Path,
+) -> bool:
+    if "#input." not in input_ref:
+        return False
+    if _rulespec_ref_matches_base(input_ref, target_ref):
+        return True
+    if _input_ref_is_import_output_placeholder(input_ref, repo_path=repo_path):
+        return True
+    return bool(
+        _ABSOLUTE_RULESPEC_REF_RE.match(input_ref)
+        and not _rulespec_ref_matches_base(input_ref, dependent_ref)
+    )
 
 
 def _remove_cross_module_dependent_test_outputs(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -36,6 +36,7 @@ from axiom_encode.cli import (
     _local_factual_input_names_from_rules_content,
     _person_scoped_definition_issue_names,
     _remove_cross_module_dependent_test_outputs,
+    _remove_invalid_dependent_test_inputs,
     _repair_employer_scoped_entities,
     _repair_generated_import_symbol_near_misses,
     _repair_input_field_accesses_in_formulas,
@@ -3809,6 +3810,61 @@ rules:
         assert changed == [test_file]
         repaired = yaml.safe_load(test_file.read_text())
         assert repaired[0]["output"] == {"us:statutes/26/24/d#refundable_ctc": 2550}
+
+    def test_remove_invalid_dependent_test_inputs_drops_cross_module_stale_ref(
+        self, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us"
+        rules_file = repo / "statutes/26/24/d.yaml"
+        test_file = repo / "statutes/26/24/d.test.yaml"
+        target_file = repo / "statutes/26/32/c/2.yaml"
+        rules_file.parent.mkdir(parents=True)
+        target_file.parent.mkdir(parents=True)
+        rules_file.write_text("format: rulespec/v1\nrules: []\n")
+        target_file.write_text("format: rulespec/v1\nrules: []\n")
+        test_file.write_text(
+            """- name: stale_cross_module_input
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/24/d#input.qualifying_children_count: 2
+    us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income: 20000
+    us:statutes/26/1401#input.self_employment_income: 0
+  output:
+    us:statutes/26/24/d#refundable_ctc: 2550
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    error=(
+                        "Test case `stale_cross_module_input` execution failed: "
+                        "dataset input "
+                        "`tmp-rulespec:statutes/26/1401#input.self_employment_income` "
+                        "must use an absolute legal RuleSpec reference that resolves "
+                        "to an input slot, derived rule, or parameter in the compiled "
+                        "program"
+                    )
+                )
+            }
+        )
+
+        changed = _remove_invalid_dependent_test_inputs(
+            overlay_repo=repo,
+            relative_output=Path("statutes/26/32/c/2.yaml"),
+            validations=[(rules_file, validation)],
+        )
+
+        assert changed == [test_file]
+        repaired = test_file.read_text()
+        assert "us:statutes/26/1401#input.self_employment_income" not in repaired
+        assert "us:statutes/26/24/d#input.qualifying_children_count" in repaired
+        assert (
+            "us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income"
+            in repaired
+        )
 
     def test_encode_apply_auto_repairs_section_1401_policyengine_oracle_inputs(
         self, capsys, tmp_path


### PR DESCRIPTION
## Summary
- allow generated apply overlay repair to remove validator-proven stale absolute input refs from dependent tests
- match diagnostics that use temporary repository prefixes back to the concrete RuleSpec YAML keys
- bump axiom-encode to 0.2.154

## Tests
- uv run pytest tests/test_cli.py -q -k 'invalid_dependent_test_inputs or cross_module_dependent_test_outputs or person_scoped_definition_issue_names'
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py pyproject.toml src/axiom_encode/__init__.py
- uv run ruff format --check src/ tests/