### PR TITLE
Complete transitive dependent test inputs during apply

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.154"
+version = "0.2.155"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.154"
+__version__ = "0.2.155"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -13677,7 +13677,7 @@ def _validate_generated_encoding_in_policy_overlay(
             overlay_target=overlay_target,
             dependents=dependents,
         )
-        for _ in range(10):
+        for _ in range(_APPLY_OVERLAY_VALIDATION_REPAIR_LIMIT):
             if all(validation.all_passed for _, validation in validations):
                 return True, [], supplemental_files
             mixed_scalar_repairs = _repair_mixed_scalar_output_tests(
@@ -14265,6 +14265,7 @@ def _repair_dependent_proof_import_hashes(
 _MISSING_INPUT_RE = re.compile(
     r"Test case `(?P<case>[^`]+)` execution failed: missing input `(?P<input>[^`]+)`"
 )
+_APPLY_OVERLAY_VALIDATION_REPAIR_LIMIT = 50
 
 _INVALID_INPUT_REF_RE = re.compile(
     r"input `(?P<input>[^`]+)` does not resolve to an input slot"
@@ -14456,6 +14457,10 @@ def _complete_missing_dependent_test_inputs(
     baseline_inputs = _load_test_input_baseline(
         _rulespec_test_path(overlay_repo / relative_output)
     )
+    imported_inputs = _imported_input_refs_by_name(
+        overlay_repo / relative_output,
+        repo_path=overlay_repo,
+    )
     changed: list[Path] = []
     for validated_file, validation in validations:
         if validated_file == overlay_repo / relative_output:
@@ -14477,6 +14482,7 @@ def _complete_missing_dependent_test_inputs(
                 input_name,
                 target_ref=target_ref,
                 baseline_inputs=baseline_inputs,
+                imported_inputs=imported_inputs,
             ):
                 updated = _insert_input_default_in_test_cases(
                     updated,
@@ -14679,6 +14685,7 @@ def _default_refs_for_missing_input(
     *,
     target_ref: str,
     baseline_inputs: dict[str, object],
+    imported_inputs: dict[str, list[str]] | None = None,
 ) -> list[tuple[str, object]]:
     suffix = f"#input.{input_name}"
     matches = [
@@ -14688,6 +14695,12 @@ def _default_refs_for_missing_input(
     ]
     if matches:
         return matches
+    imported_matches = [
+        (reference, _infer_missing_input_default(input_name))
+        for reference in (imported_inputs or {}).get(input_name, [])
+    ]
+    if imported_matches:
+        return imported_matches
     return [
         (f"{target_ref}#input.{input_name}", _infer_missing_input_default(input_name))
     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ from axiom_encode.cli import (
     APPLIED_ENCODING_SIGNING_KEY_ENV,
     _append_generated_derived_output_tests_if_missing,
     _apply_generated_encoding_result,
+    _complete_missing_dependent_test_inputs,
     _complete_missing_imported_test_inputs,
     _default_generated_test_input_value,
     _discover_rulespec_test_files,
@@ -3864,6 +3865,101 @@ rules:
         assert (
             "us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income"
             in repaired
+        )
+
+    def test_complete_missing_dependent_test_inputs_uses_transitive_import_ref(
+        self, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us"
+        target_file = repo / "statutes/26/32/c/2.yaml"
+        dependent_file = repo / "statutes/26/24/d.yaml"
+        imported_file = repo / "statutes/26/164/f.yaml"
+        transitive_file = repo / "statutes/26/1402/b.yaml"
+        test_file = repo / "statutes/26/24/d.test.yaml"
+        target_file.parent.mkdir(parents=True)
+        dependent_file.parent.mkdir(parents=True, exist_ok=True)
+        imported_file.parent.mkdir(parents=True, exist_ok=True)
+        transitive_file.parent.mkdir(parents=True, exist_ok=True)
+        target_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/164/f#self_employment_tax_deduction
+rules:
+  - name: self_employment_component
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: self_employment_tax_deduction
+"""
+        )
+        imported_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/1402/b#self_employment_income
+rules:
+  - name: self_employment_tax_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: self_employment_income / 2
+"""
+        )
+        transitive_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: self_employment_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if individual_is_nonresident_alien: 0 else: net_earnings
+"""
+        )
+        dependent_file.write_text("format: rulespec/v1\nrules: []\n")
+        test_file.write_text(
+            """- name: dependent_case
+  input:
+    us:statutes/26/24/d#input.qualifying_children_count: 2
+  output:
+    us:statutes/26/24/d#refundable_ctc: 2550
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    error=(
+                        "Test case `dependent_case` execution failed: missing input "
+                        "`individual_is_nonresident_alien` for entity `case-1` over "
+                        "2026-01-01..2026-12-31"
+                    )
+                )
+            }
+        )
+
+        changed = _complete_missing_dependent_test_inputs(
+            overlay_repo=repo,
+            relative_output=Path("statutes/26/32/c/2.yaml"),
+            validations=[(dependent_file, validation)],
+        )
+
+        assert changed == [test_file]
+        repaired = test_file.read_text()
+        assert (
+            "us:statutes/26/1402/b#input.individual_is_nonresident_alien: false"
+            in repaired
+        )
+        assert (
+            "us:statutes/26/32/c/2#input.individual_is_nonresident_alien"
+            not in repaired
         )
 
     def test_encode_apply_auto_repairs_section_1401_policyengine_oracle_inputs(


### PR DESCRIPTION
## Summary
- let dependent apply repair fill missing inputs from the generated target's transitive imports
- raise the overlay validation repair cap so dependent tests can converge across stale inputs, mixed outputs, and imported inputs
- bump axiom-encode to 0.2.155

## Verification
- uv run pytest tests/test_cli.py -q -k 'dependent_test_inputs or cross_module_dependent_test_outputs or person_scoped_definition_issue_names'
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py pyproject.toml src/axiom_encode/__init__.py
- uv run ruff format --check src/ tests/
- local generated apply succeeded: axiom-encode encode '26 USC 32(c)(2)' --backend openai --model gpt-5.5 --mode repo-augmented --apply