### PR TITLE
Allow empty repealed source slices

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.155"
+version = "0.2.156"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.155"
+__version__ = "0.2.156"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -5893,6 +5893,8 @@ def find_source_subparagraph_coverage_issues(
     ) or extract_embedded_source_text(content)
     if not source_text:
         return []
+    if _empty_deferred_editorial_source_slice(payload, content):
+        return []
 
     source_children = _high_signal_top_level_subparagraphs(source_text)
     coverage_scope_prefix = _source_subparagraph_coverage_scope_prefix(
@@ -5927,6 +5929,35 @@ def find_source_subparagraph_coverage_issues(
             f"`source: {citation}` or add a deferred_outputs entry naming the blocker."
         )
     return issues
+
+
+def _empty_deferred_editorial_source_slice(
+    payload: dict[str, Any],
+    content: str,
+) -> bool:
+    """Allow explicitly deferred empty modules for repealed/editorial slices."""
+    rules = payload.get("rules")
+    if not isinstance(rules, list) or rules:
+        return False
+    module = payload.get("module")
+    if not isinstance(module, dict):
+        return False
+    status = str(module.get("status") or "").strip().lower()
+    if status not in {"deferred", "entity_not_supported"}:
+        return False
+    summary = extract_embedded_source_text(content)
+    return _source_slice_is_editorial_omission(summary)
+
+
+def _source_slice_is_editorial_omission(source_text: str) -> bool:
+    normalized = re.sub(r"\s+", " ", source_text).strip()
+    if not normalized:
+        return False
+    if re.match(r"^\([A-Za-z0-9]+\)\s+Repealed\b", normalized):
+        return True
+    if re.fullmatch(r"\(?[A-Za-z0-9]+\)?\s*(?:\[?\s*)?\.{3,}(?:\s*\]?)?", normalized):
+        return True
+    return False
 
 
 def _high_signal_top_level_subparagraphs(source_text: str) -> list[tuple[str, str]]:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -10908,6 +10908,31 @@ rules: []
     ]
 
 
+def test_source_subparagraph_coverage_allows_repealed_empty_slice(tmp_path):
+    source_text = """Wages
+(a) Wages means all remuneration for employment.
+"""
+    content = """format: rulespec/v1
+module:
+  status: deferred
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    (3) Repealed. Pub. L. 98-21, title III, section 324(a)(3)(B).
+rules: []
+"""
+    rules_file = tmp_path / "rulespec-us" / "statutes" / "26" / "3121" / "a" / "3.yaml"
+
+    assert (
+        find_source_subparagraph_coverage_issues(
+            content,
+            rules_file=rules_file,
+            source_texts={"us/statute/26/3121": source_text},
+        )
+        == []
+    )
+
+
 def test_source_subparagraph_coverage_allows_rule_citing_child():
     source_text = """Definitions
 (a) Benefit means the amount payable under this program.


### PR DESCRIPTION
## Summary
- allow explicitly deferred empty RuleSpec modules when the embedded source slice is editorial or repealed
- preserve source-subparagraph coverage checks for operative omissions
- bump axiom-encode to 0.2.156

## Verification
- uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py pyproject.toml src/axiom_encode/__init__.py
- uv run ruff format --check src/ tests/
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py -q -k 'source_subparagraph_coverage'
- uv run axiom-encode validate /private/tmp/axiom-encode-3121-a-3-20260524/openai-gpt-5.5/statutes/26/3121/a/3.yaml --skip-reviewers --json
- axiom-encode encode "26 USC 3121(a)(3)" --backend openai --model gpt-5.5 --mode repo-augmented --apply