### PR TITLE
Validate absolute row-ordered test outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.156"
+version = "0.2.157"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.156"
+__version__ = "0.2.157"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -14323,6 +14323,7 @@ class ValidatorPipeline:
         case_index: int,
         period: dict[str, Any],
         output_names: list[str],
+        output_runtime_keys: dict[str, str] | None = None,
         derived_by_key: dict[str, Any],
         require_legal_input_keys: bool,
         legal_ids_by_friendly_name: dict[str, list[str]],
@@ -14348,10 +14349,22 @@ class ValidatorPipeline:
             return None, [f"Test case `{case_name}` input invalid: {exc}"]
 
         output_map = case.get("output") if isinstance(case.get("output"), dict) else {}
+        output_values_by_runtime_key: dict[str, Any] = {}
+        if output_runtime_keys is None:
+            output_runtime_keys = {}
+        for output_key, runtime_key in output_runtime_keys.items():
+            if output_key in output_map:
+                output_values_by_runtime_key[runtime_key] = output_map[output_key]
+        for output_name in output_names:
+            if (
+                output_name in output_map
+                and output_name not in output_values_by_runtime_key
+            ):
+                output_values_by_runtime_key[output_name] = output_map[output_name]
         row_ordered_outputs = {
             output_name
             for output_name in output_names
-            if isinstance(output_map.get(output_name), list)
+            if isinstance(output_values_by_runtime_key.get(output_name), list)
         }
         query_entity_ids = [query_entity_id]
         if row_ordered_outputs:
@@ -14367,7 +14380,7 @@ class ValidatorPipeline:
                 ]
             expected_row_count = len(table_rows)
             for output_name in row_ordered_outputs:
-                expected_value = output_map.get(output_name)
+                expected_value = output_values_by_runtime_key.get(output_name)
                 if (
                     isinstance(expected_value, list)
                     and len(expected_value) != expected_row_count
@@ -14631,6 +14644,7 @@ class ValidatorPipeline:
                         case_index=index,
                         period=period,
                         output_names=derived_outputs,
+                        output_runtime_keys=output_runtime_keys,
                         derived_by_key=derived_by_key,
                         require_legal_input_keys=require_legal_input_keys,
                         legal_ids_by_friendly_name=legal_ids_by_friendly_name,

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -184,6 +184,86 @@ def test_rulespec_validation_run_compiled_uses_current_repo_env(monkeypatch, tmp
     assert str(stale_root) in roots
 
 
+def test_rulespec_companion_runner_uses_rows_for_absolute_list_outputs(
+    monkeypatch, tmp_path
+):
+    repo_parent = tmp_path / "repos"
+    policy_repo = repo_parent / "rulespec-us"
+    policy_repo.mkdir(parents=True)
+    pipeline = ValidatorPipeline(
+        policy_repo_path=policy_repo,
+        axiom_rules_path=repo_parent / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+    captured_request: dict[str, object] | None = None
+
+    def fake_run(cmd, **kwargs):
+        nonlocal captured_request
+        if "input" not in kwargs:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        captured_request = json.loads(kwargs["input"])
+        return subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=json.dumps(
+                {
+                    "results": [
+                        {
+                            "outputs": {
+                                "excluded_from_wages": {
+                                    "kind": "scalar",
+                                    "id": "us:statutes/26/3121/a/6#excluded_from_wages",
+                                    "value": {"kind": "money", "value": 300},
+                                }
+                            }
+                        }
+                    ]
+                }
+            ),
+            stderr="",
+        )
+
+    monkeypatch.setattr(validator_pipeline.subprocess, "run", fake_run)
+
+    outputs, issues = pipeline._run_rulespec_derived_test_case(
+        binary=tmp_path / "engine",
+        compiled_path=tmp_path / "compiled.json",
+        case={
+            "input": {},
+            "tables": {
+                "Payment": [
+                    {
+                        "payment_amount": 300,
+                    }
+                ]
+            },
+            "output": {
+                "us:statutes/26/3121/a/6#excluded_from_wages": [300],
+            },
+        },
+        case_name="excluded_payment",
+        case_index=1,
+        period={
+            "period_kind": "tax_year",
+            "start": "2026-01-01",
+            "end": "2026-12-31",
+        },
+        output_names=["excluded_from_wages"],
+        output_runtime_keys={
+            "us:statutes/26/3121/a/6#excluded_from_wages": "excluded_from_wages",
+        },
+        derived_by_key={"excluded_from_wages": {"entity": "Payment"}},
+        require_legal_input_keys=False,
+        legal_ids_by_friendly_name={},
+        module_target=None,
+    )
+
+    assert issues == []
+    assert outputs is not None
+    assert captured_request is not None
+    assert captured_request["queries"][0]["entity_id"] == "payment-1"
+
+
 def test_cross_statute_definition_import_check_uses_cited_title_and_existing_targets(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- make inline RuleSpec validation treat absolute legal output IDs as row-ordered when their runtime output maps to a list expectation
- add regression coverage for table-row execution using absolute output references
- bump axiom-encode to 0.2.157

## Verification
- uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py pyproject.toml src/axiom_encode/__init__.py
- uv run ruff format --check src/ tests/
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py -q -k 'companion_runner_uses_rows or source_subparagraph_coverage'
- uv run axiom-encode validate /private/tmp/rulespec-us-3121-a-6-20260524/statutes/26/3121/a/6.yaml --skip-reviewers --json