### PR TITLE
Classify 3121(a)(6) wage exclusions for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.157"
+version = "0.2.158"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.157"
+__version__ = "0.2.158"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9231,6 +9231,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(a)(4) post-work sickness, disability, or medical payment wage-exclusion predicates and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/a/6#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(6) employer-paid employee FICA or state unemployment contribution wage-exclusion predicates and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/a/13#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -469,6 +469,14 @@ rules:
     [
         ("2", "employer_plan_sickness_medical_death_payment_excluded_from_wages"),
         ("4", "post_work_sickness_disability_medical_payment_excluded_from_wages"),
+        (
+            "6",
+            "state_unemployment_domestic_or_agricultural_payment_exclusion_applies",
+        ),
+        (
+            "6",
+            "state_unemployment_domestic_or_agricultural_payment_excluded_from_wages",
+        ),
         ("13", "termination_plan_payment_excluded_from_wages"),
         ("14", "survivor_or_estate_post_death_year_payment_excluded_from_wages"),
         (


### PR DESCRIPTION
## Summary
- classify generated section 3121(a)(6) wage-exclusion outputs as known not comparable to PolicyEngine
- extend the oracle coverage regression test for both 3121(a)(6) outputs
- bump axiom-encode to 0.2.158

## Tests
- `uv run ruff check tests/test_policyengine_coverage.py pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/oracles/policyengine/registry.py src/axiom_encode/oracles/policyengine/coverage.py`
- `uv run ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- local oracle coverage check against rulespec-us PR #63 generated output

This unblocks TheAxiomFoundation/rulespec-us#63, whose generated outputs were otherwise reported as unmapped by the shared RuleSpec CI.