### PR TITLE
Normalize 3121(a)(7) scalar tests and PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.158"
+version = "0.2.159"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.158"
+__version__ = "0.2.159"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -14166,7 +14166,9 @@ def _repair_mixed_scalar_output_tests(
             repaired_cases.append(case)
             continue
         scalar_items = {
-            key: value for key, value in output.items() if str(key) in scalar_outputs
+            key: _scalar_parameter_test_expected_value(value)
+            for key, value in output.items()
+            if str(key) in scalar_outputs
         }
         if not scalar_items or len(scalar_items) == len(output):
             repaired_cases.append(case)
@@ -14200,6 +14202,16 @@ def _repair_mixed_scalar_output_tests(
         return []
     test_file.write_text(yaml.safe_dump(repaired_cases, sort_keys=False))
     return repaired_names
+
+
+def _scalar_parameter_test_expected_value(value: Any) -> Any:
+    """Normalize accidental row-shaped expectations for scalar parameters."""
+    if not isinstance(value, list) or not value:
+        return value
+    first = value[0]
+    if all(item == first for item in value):
+        return first
+    return value
 
 
 def _unique_test_case_name(base: str, existing_names: set[str]) -> str:

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9237,6 +9237,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(a)(6) employer-paid employee FICA or state unemployment contribution wage-exclusion predicates and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/a/7#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(7) noncash, domestic-service, and nontrade-service wage-exclusion predicates, thresholds, and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/a/13#
     country: us
     program: tax

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6113,6 +6113,72 @@ rules:
             },
         ]
 
+    def test_mixed_scalar_output_test_repair_unwraps_row_shaped_parameter_output(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        rules_file = policy_repo / "statutes/26/3121/a/7.yaml"
+        test_file = policy_repo / "statutes/26/3121/a/7.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: cash_nontrade_service_annual_threshold
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 100
+  - name: private_or_nontrade_service_remuneration_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: payment_amount
+"""
+        )
+        test_file.write_text(
+            """- name: cash_nontrade_service_below_one_hundred_dollars_is_excluded
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  tables:
+    Payment:
+      - us:statutes/26/3121/a/7#input.payment_amount: 75
+  output:
+    us:statutes/26/3121/a/7#cash_nontrade_service_annual_threshold:
+      - 100
+    us:statutes/26/3121/a/7#private_or_nontrade_service_remuneration_excluded_from_wages:
+      - 75
+"""
+        )
+
+        repaired = _repair_mixed_scalar_output_tests(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=policy_repo,
+            relative_output=Path("statutes/26/3121/a/7.yaml"),
+        )
+
+        cases = yaml.safe_load(test_file.read_text())
+        assert repaired == [
+            "cash_nontrade_service_below_one_hundred_dollars_is_excluded"
+        ]
+        assert cases[0]["output"] == {
+            "us:statutes/26/3121/a/7#private_or_nontrade_service_remuneration_excluded_from_wages": [
+                75
+            ]
+        }
+        assert cases[1]["name"] == (
+            "cash_nontrade_service_below_one_hundred_dollars_is_excluded_scalar_outputs"
+        )
+        assert cases[1]["output"] == {
+            "us:statutes/26/3121/a/7#cash_nontrade_service_annual_threshold": 100
+        }
+
 
 class TestGuardGenerated:
     def test_rejects_rulespec_change_without_encoder_manifest(self, tmp_path):

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -477,6 +477,10 @@ rules:
             "6",
             "state_unemployment_domestic_or_agricultural_payment_excluded_from_wages",
         ),
+        (
+            "7",
+            "nontrade_or_domestic_service_remuneration_excluded_from_wages",
+        ),
         ("13", "termination_plan_payment_excluded_from_wages"),
         ("14", "survivor_or_estate_post_death_year_payment_excluded_from_wages"),
         (
@@ -505,6 +509,30 @@ rules:
     assert report["status_counts"] == {"known_not_comparable": 1}
     item = report["items"][0]
     assert item["legal_id"] == f"us:statutes/26/3121/a/{subsection}#{rule_name}"
+    assert item["status"] == "known_not_comparable"
+
+
+def test_policyengine_coverage_classifies_3121_a_7_threshold_parameter(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3121/a/7.yaml",
+        """format: rulespec/v1
+rules:
+  - name: cash_nontrade_service_annual_remuneration_threshold
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 100
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us:statutes/26/3121/a/7#cash_nontrade_service_annual_remuneration_threshold"
+    )
     assert item["status"] == "known_not_comparable"
 
 


### PR DESCRIPTION
## Summary
- unwrap accidental row-shaped scalar parameter expectations when splitting mixed scalar/entity companion tests
- classify generated section 3121(a)(7) wage-exclusion outputs as known not comparable to PolicyEngine
- add regressions for the 3121(a)(7) generated failure shape and oracle coverage
- bump axiom-encode to 0.2.159

## Tests
- `uv run ruff check src/axiom_encode/cli.py tests/test_cli.py tests/test_policyengine_coverage.py pyproject.toml src/axiom_encode/__init__.py`
- `uv run ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_cli.py tests/test_policyengine_coverage.py -q -k 'mixed_scalar_output_test_repair or 3121'`\n- `uv run python -c 'from axiom_encode.oracles.policyengine.registry import load_policyengine_registry; r=load_policyengine_registry(); print(len(r.mappings_by_legal_id), len(r.prefix_mappings))'`\n- local oracle coverage check against provisional rulespec-us 3121(a)(7) generated output\n\nThis prepares TheAxiomFoundation/rulespec-us 3121(a)(7) for a generated-only PR without scalar/list validation or PE coverage failures.