### PR TITLE
Classify 3121(a)(8) wage exclusions for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.159"
+version = "0.2.160"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.159"
+__version__ = "0.2.160"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9243,6 +9243,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(a)(7) noncash, domestic-service, and nontrade-service wage-exclusion predicates, thresholds, and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/a/8#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(8) agricultural-labor cash and noncash wage-exclusion thresholds, hand-harvest exception predicates, or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/a/13#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -481,6 +481,7 @@ rules:
             "7",
             "nontrade_or_domestic_service_remuneration_excluded_from_wages",
         ),
+        ("8", "agricultural_labor_remuneration_excluded_from_wages"),
         ("13", "termination_plan_payment_excluded_from_wages"),
         ("14", "survivor_or_estate_post_death_year_payment_excluded_from_wages"),
         (
@@ -532,6 +533,30 @@ rules:
     assert (
         item["legal_id"]
         == "us:statutes/26/3121/a/7#cash_nontrade_service_annual_remuneration_threshold"
+    )
+    assert item["status"] == "known_not_comparable"
+
+
+def test_policyengine_coverage_classifies_3121_a_8_threshold_parameter(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3121/a/8.yaml",
+        """format: rulespec/v1
+rules:
+  - name: agricultural_labor_cash_remuneration_employee_threshold
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 150
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us:statutes/26/3121/a/8#agricultural_labor_cash_remuneration_employee_threshold"
     )
     assert item["status"] == "known_not_comparable"
 


### PR DESCRIPTION
## Summary
- classify generated section 3121(a)(8) agricultural-labor wage-exclusion outputs as known not comparable to PolicyEngine
- add coverage regressions for the derived exclusion and threshold parameter shapes
- bump axiom-encode to 0.2.160

## Tests
- `uv run ruff check tests/test_policyengine_coverage.py pyproject.toml src/axiom_encode/__init__.py`
- `uv run ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k '3121'`\n- `uv run python -c 'from axiom_encode.oracles.policyengine.registry import load_policyengine_registry; r=load_policyengine_registry(); print(len(r.mappings_by_legal_id), len(r.prefix_mappings))'`\n- local oracle coverage check against generated rulespec-us 3121(a)(8) output\n\nThis unblocks the generated-only rulespec-us PR for 26 USC 3121(a)(8).