### PR TITLE
Classify 3121(a)(10) wage exclusions for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.160"
+version = "0.2.161"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.160"
+__version__ = "0.2.161"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9249,6 +9249,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(a)(8) agricultural-labor cash and noncash wage-exclusion thresholds, hand-harvest exception predicates, or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/a/10#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(10) home-worker cash-remuneration threshold predicates or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/a/13#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -482,6 +482,8 @@ rules:
             "nontrade_or_domestic_service_remuneration_excluded_from_wages",
         ),
         ("8", "agricultural_labor_remuneration_excluded_from_wages"),
+        ("10", "home_worker_low_cash_remuneration_exclusion_applies"),
+        ("10", "home_worker_low_cash_remuneration_excluded_from_wages"),
         ("13", "termination_plan_payment_excluded_from_wages"),
         ("14", "survivor_or_estate_post_death_year_payment_excluded_from_wages"),
         (
@@ -557,6 +559,30 @@ rules:
     assert (
         item["legal_id"]
         == "us:statutes/26/3121/a/8#agricultural_labor_cash_remuneration_employee_threshold"
+    )
+    assert item["status"] == "known_not_comparable"
+
+
+def test_policyengine_coverage_classifies_3121_a_10_threshold_parameter(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3121/a/10.yaml",
+        """format: rulespec/v1
+rules:
+  - name: home_worker_cash_remuneration_annual_threshold
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 100
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us:statutes/26/3121/a/10#home_worker_cash_remuneration_annual_threshold"
     )
     assert item["status"] == "known_not_comparable"
 


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3121(a)(10) home-worker wage-exclusion outputs as PolicyEngine known-not-comparable
- add coverage tests for the threshold parameter and generated exclusion outputs
- bump axiom-encode to 0.2.161

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- local PolicyEngine oracle coverage check: `3121(a)(10)` outputs are all `known_not_comparable`