### PR TITLE
Classify 3121(a)(11) wage exclusions for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.161"
+version = "0.2.162"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.161"
+__version__ = "0.2.162"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9255,6 +9255,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(a)(10) home-worker cash-remuneration threshold predicates or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/a/11#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(11) moving-expense reasonable-belief wage-exclusion predicates or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/a/13#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -484,6 +484,8 @@ rules:
         ("8", "agricultural_labor_remuneration_excluded_from_wages"),
         ("10", "home_worker_low_cash_remuneration_exclusion_applies"),
         ("10", "home_worker_low_cash_remuneration_excluded_from_wages"),
+        ("11", "moving_expense_deduction_reasonable_belief_exclusion_applies"),
+        ("11", "moving_expense_deduction_reasonable_belief_excluded_from_wages"),
         ("13", "termination_plan_payment_excluded_from_wages"),
         ("14", "survivor_or_estate_post_death_year_payment_excluded_from_wages"),
         (


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3121(a)(11) moving-expense wage-exclusion outputs as PolicyEngine known-not-comparable
- add coverage tests for the generated exclusion predicate and amount outputs
- bump axiom-encode to 0.2.162

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- local PolicyEngine oracle coverage check: `3121(a)(11)` outputs are all `known_not_comparable`