### PR TITLE
Classify 3121(a)(12) tip exclusions for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.162"
+version = "0.2.163"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.162"
+__version__ = "0.2.163"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9261,6 +9261,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(a)(11) moving-expense reasonable-belief wage-exclusion predicates or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/a/12#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(12) noncash-tip or low-monthly-cash-tip wage-exclusion predicates, thresholds, or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/a/13#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -486,6 +486,11 @@ rules:
         ("10", "home_worker_low_cash_remuneration_excluded_from_wages"),
         ("11", "moving_expense_deduction_reasonable_belief_exclusion_applies"),
         ("11", "moving_expense_deduction_reasonable_belief_excluded_from_wages"),
+        ("12", "noncash_tip_exclusion_applies"),
+        ("12", "noncash_tips_excluded_from_wages"),
+        ("12", "low_monthly_cash_tip_exclusion_applies"),
+        ("12", "low_monthly_cash_tips_excluded_from_wages"),
+        ("12", "tips_excluded_from_wages"),
         ("13", "termination_plan_payment_excluded_from_wages"),
         ("14", "survivor_or_estate_post_death_year_payment_excluded_from_wages"),
         (
@@ -586,6 +591,27 @@ rules:
         item["legal_id"]
         == "us:statutes/26/3121/a/10#home_worker_cash_remuneration_annual_threshold"
     )
+    assert item["status"] == "known_not_comparable"
+
+
+def test_policyengine_coverage_classifies_3121_a_12_tip_threshold_parameter(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3121/a/12.yaml",
+        """format: rulespec/v1
+rules:
+  - name: monthly_cash_tip_threshold
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 20
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == "us:statutes/26/3121/a/12#monthly_cash_tip_threshold"
     assert item["status"] == "known_not_comparable"
 
 


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3121(a)(12) tip wage-exclusion outputs as PolicyEngine known-not-comparable
- add coverage tests for noncash-tip, low-monthly-cash-tip, aggregate tip-exclusion, and threshold outputs
- bump axiom-encode to 0.2.163

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- local PolicyEngine oracle coverage check: `3121(a)(12)` outputs are all `known_not_comparable`