### PR TITLE
Classify 3121(a)(16) wage exclusions for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.163"
+version = "0.2.164"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.163"
+__version__ = "0.2.164"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9285,6 +9285,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(a)(15) Social Security disability-insurance no-services wage-exclusion predicates and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/a/16#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(16) exempt-organization low-remuneration wage-exclusion predicates, thresholds, or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/225#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -497,6 +497,9 @@ rules:
             "15",
             "social_security_disability_insurance_prior_year_no_services_payment_excluded_from_wages",
         ),
+        ("16", "qualifying_exempt_organization_for_low_remuneration_exclusion"),
+        ("16", "exempt_organization_low_remuneration_exclusion_applies"),
+        ("16", "exempt_organization_low_remuneration_excluded_from_wages"),
     ],
 )
 def test_policyengine_coverage_classifies_3121_wage_exclusions(
@@ -612,6 +615,30 @@ rules:
     assert report["status_counts"] == {"known_not_comparable": 1}
     item = report["items"][0]
     assert item["legal_id"] == "us:statutes/26/3121/a/12#monthly_cash_tip_threshold"
+    assert item["status"] == "known_not_comparable"
+
+
+def test_policyengine_coverage_classifies_3121_a_16_threshold_parameter(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3121/a/16.yaml",
+        """format: rulespec/v1
+rules:
+  - name: exempt_organization_remuneration_annual_threshold
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 100
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us:statutes/26/3121/a/16#exempt_organization_remuneration_annual_threshold"
+    )
     assert item["status"] == "known_not_comparable"
 
 


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3121(a)(16) exempt-organization low-remuneration wage-exclusion outputs as PolicyEngine known-not-comparable
- add coverage tests for the threshold, qualifying-organization predicate, exclusion predicate, and excluded amount
- bump axiom-encode to 0.2.164

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- local PolicyEngine oracle coverage check: `3121(a)(16)` outputs are all `known_not_comparable`