### PR TITLE
Classify 3121(a)(18) wage exclusions for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.164"
+version = "0.2.165"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.164"
+__version__ = "0.2.165"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9291,6 +9291,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(a)(16) exempt-organization low-remuneration wage-exclusion predicates, thresholds, or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/a/18#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(18) employee benefit reasonable-belief income-exclusion predicates or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/225#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -500,6 +500,8 @@ rules:
         ("16", "qualifying_exempt_organization_for_low_remuneration_exclusion"),
         ("16", "exempt_organization_low_remuneration_exclusion_applies"),
         ("16", "exempt_organization_low_remuneration_excluded_from_wages"),
+        ("18", "employee_benefit_income_exclusion_reasonable_belief_applies"),
+        ("18", "employee_benefit_income_exclusion_excluded_from_wages"),
     ],
 )
 def test_policyengine_coverage_classifies_3121_wage_exclusions(


### PR DESCRIPTION
## Summary
- classify generated 3121(a)(18) benefit income exclusion outputs as PE-known-not-comparable
- add coverage test cases for the two generated 3121(a)(18) rules
- bump axiom-encode to 0.2.165

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3121a18.6wZwqq --oracle policyengine --program tax --json