### PR TITLE
Classify 3121(a)(19) wage exclusions for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.165"
+version = "0.2.166"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.165"
+__version__ = "0.2.166"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9297,6 +9297,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(a)(18) employee benefit reasonable-belief income-exclusion predicates or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/a/19#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(19) employer-furnished meals or lodging reasonable-belief section 119 exclusion predicates or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/225#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -502,6 +502,8 @@ rules:
         ("16", "exempt_organization_low_remuneration_excluded_from_wages"),
         ("18", "employee_benefit_income_exclusion_reasonable_belief_applies"),
         ("18", "employee_benefit_income_exclusion_excluded_from_wages"),
+        ("19", "meals_or_lodging_section_119_reasonable_belief_exclusion_applies"),
+        ("19", "meals_or_lodging_section_119_reasonable_belief_excluded_from_wages"),
     ],
 )
 def test_policyengine_coverage_classifies_3121_wage_exclusions(


### PR DESCRIPTION
## Summary
- classify generated 3121(a)(19) meals/lodging section 119 reasonable-belief outputs as PE-known-not-comparable
- add coverage test cases for the two generated 3121(a)(19) rules
- bump axiom-encode to 0.2.166

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3121a19.vX3SdQ --oracle policyengine --program tax --json