### PR TITLE
Model reasonable-belief exclusions with boundary inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.166"
+version = "0.2.167"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.166"
+__version__ = "0.2.167"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3459,6 +3459,11 @@ RuleSpec requirements:
   amount but depends on externally determined classifications, official
   designations, statuses, event facts, or source-document categories, encode
   the amount with boundary inputs for those facts instead of deferring.
+- This includes exclusions conditioned on a reasonable belief that an item can
+  be excluded from income under another section. Do not defer solely because
+  the cited exclusion section is not encoded; model the source-stated
+  reasonable-belief condition as a local factual predicate and gate the
+  source-stated excluded amount with it.
 - If the requested source itself states a cap, threshold, exclusion, or base
   formula that uses an externally determined official base, wage amount,
   compensation amount, rate, status, or special-case fact that is not available

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -448,6 +448,11 @@ Hard requirements:
   amount but depends on externally determined classifications, official
   designations, statuses, event facts, or source-document categories, encode
   the amount with boundary inputs for those facts instead of deferring.
+- This includes exclusions conditioned on a reasonable belief that an item can
+  be excluded from income under another section. Do not defer solely because
+  the cited exclusion section is not encoded; model the source-stated
+  reasonable-belief condition as a local factual predicate and gate the
+  source-stated excluded amount with it.
 - If the requested source itself states a cap, threshold, exclusion, or base
   formula that uses an externally determined official base, wage amount,
   compensation amount, rate, status, or special-case fact that is not available

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -510,6 +510,9 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     )
     assert "Do not list bare legal provisions" in prompt
     assert "us:statutes/us-ca/17000" in prompt
+    assert "exclusions conditioned on a reasonable belief" in prompt
+    assert "Do not defer solely because" in prompt
+    assert "model the source-stated\n  reasonable-belief condition" in prompt
     assert "imported test inputs from copied files" in prompt
     assert "Do not stub imported derived" in prompt
     assert "never assign prohibited derived" in prompt


### PR DESCRIPTION
## Summary
- teach encoder prompts that reasonable-belief income-exclusion wage rules should use local boundary predicates instead of deferring solely because cited exclusion sections are unencoded
- update eval prompt coverage for the new guidance
- bump axiom-encode to 0.2.167

## Motivation
- A generated 3121(a)(20) run deferred the whole section even though adjacent 3121(a)(18) and 3121(a)(19) can be modeled as reasonable-belief predicates plus excluded amounts.

## Tests
- uv run --extra dev python -m pytest tests/test_evals.py::test_build_eval_prompt_targets_rulespec_yaml -q
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/

## Scratch verification
- Reran 26 USC 3121(a)(20) with gpt-5.5 from this branch; generated executable rules for the reasonable-belief benefit exclusion instead of a deferred module. The scratch apply was blocked only because the temporary copied policy repo lacked the expected rulespec-us alias.