### PR TITLE
Classify 3121(a)(22) wage exclusions for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.169"
+version = "0.2.170"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.169"
+__version__ = "0.2.170"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9315,6 +9315,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(a)(21) Indian fishing-rights remuneration exclusion predicates or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/a/22#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(22) incentive-stock-option, employee-stock-purchase-plan, or related stock-disposition remuneration exclusion predicates and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/225#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -508,6 +508,13 @@ rules:
         ("20", "benefit_income_exclusion_reasonable_belief_excluded_from_wages"),
         ("21", "indian_fishing_rights_remuneration_exclusion_applies"),
         ("21", "indian_fishing_rights_remuneration_excluded_from_wages"),
+        (
+            "22",
+            "stock_option_or_purchase_plan_share_transfer_remuneration_exclusion_applies",
+        ),
+        ("22", "stock_disposition_remuneration_exclusion_applies"),
+        ("22", "stock_option_transfer_or_disposition_remuneration_exclusion_applies"),
+        ("22", "stock_option_transfer_or_disposition_remuneration_excluded_from_wages"),
     ],
 )
 def test_policyengine_coverage_classifies_3121_wage_exclusions(


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3121(a)(22) wage-exclusion outputs as known-not-comparable to PolicyEngine
- add the generated rule names to the 3121 wage-exclusion coverage regression test
- bump axiom-encode to 0.2.170

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/