### PR TITLE
Classify 3121(b) employment exclusions for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.170"
+version = "0.2.171"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.170"
+__version__ = "0.2.171"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9321,6 +9321,18 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(a)(22) incentive-stock-option, employee-stock-purchase-plan, or related stock-disposition remuneration exclusion predicates and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/b#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(b) employment-definition service-classification predicates as one-to-one variables. These legal intermediates determine whether service is employment for FICA before downstream payroll-tax comparisons.
+
+  - legal_id_prefix: us:statutes/26/3121/b/
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(b) employment-definition child-fragment service-classification predicates as one-to-one variables. These legal intermediates determine whether service is employment for FICA before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/225#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -540,6 +540,44 @@ rules:
     assert item["status"] == "known_not_comparable"
 
 
+@pytest.mark.parametrize(
+    ("path", "legal_id", "rule_name"),
+    [
+        (
+            "statutes/26/3121/b.yaml",
+            "us:statutes/26/3121/b#service_excluded_from_employment",
+            "service_excluded_from_employment",
+        ),
+        (
+            "statutes/26/3121/b/1.yaml",
+            "us:statutes/26/3121/b/1#foreign_agricultural_worker_service_excluded_from_employment",
+            "foreign_agricultural_worker_service_excluded_from_employment",
+        ),
+    ],
+)
+def test_policyengine_coverage_classifies_3121_employment_exclusions(
+    tmp_path, path, legal_id, rule_name
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / path,
+        f"""format: rulespec/v1
+rules:
+  - name: {rule_name}
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: service_condition
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == legal_id
+    assert item["status"] == "known_not_comparable"
+
+
 def test_policyengine_coverage_classifies_3121_a_7_threshold_parameter(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3121/a/7.yaml",


### PR DESCRIPTION
## Summary
- classify 26 USC 3121(b) employment-definition outputs as known-not-comparable to PolicyEngine
- add top-level and child-fragment coverage regression tests for 3121(b)
- bump axiom-encode to 0.2.171

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/