### PR TITLE
Allow 3121(b)(3) family service status facts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.171"
+version = "0.2.172"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.171"
+__version__ = "0.2.172"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -5738,19 +5738,32 @@ def find_tax_status_component_local_input_issues(content: str) -> list[str]:
     if payload is None:
         return []
 
+    module_source_text = extract_embedded_source_text(content) or content
     available_symbols = _rulespec_executable_names_from_payload(payload)
     available_symbols.update(_rulespec_import_symbol_names(payload))
 
     issues: list[str] = []
-    for name, _kind, formula in _rulespec_rule_formulas(payload):
+    for name, _kind, formula, source, rule in _rulespec_rule_formula_rule_records(
+        payload
+    ):
         protected_identifiers = {
             identifier
             for identifier in _formula_local_identifiers(formula)
             if identifier in _US_TAX_STATUS_COMPONENT_NAMES
             or _US_TAX_STATUS_COMPONENT_FRAGMENT_PATTERN.search(identifier)
         }
+        source_context = _filing_status_rule_source_context(
+            content=content,
+            module_source_text=module_source_text,
+            rule=rule,
+            source=source,
+        )
         for identifier in sorted(protected_identifiers):
             if identifier in available_symbols:
+                continue
+            if _source_context_allows_local_tax_status_component(
+                identifier, source_context
+            ):
                 continue
             issues.append(
                 "Tax filing-status component is a derived legal classification, "
@@ -5761,6 +5774,24 @@ def find_tax_status_component_local_input_issues(content: str) -> list[str]:
             )
 
     return issues
+
+
+def _source_context_allows_local_tax_status_component(
+    identifier: str, source_context: str
+) -> bool:
+    """Allow non-tax-status uses of words that overlap filing-status vocabulary."""
+    if "surviving_spouse" not in identifier.lower():
+        return False
+
+    return bool(
+        re.search(
+            r"\bemployer\s+is\s+a\s+surviving\s+spouse\s+or\s+a\s+divorced\s+individual\b",
+            source_context,
+            flags=re.IGNORECASE,
+        )
+        and re.search(r"\bdomestic\s+service\b", source_context, flags=re.IGNORECASE)
+        and re.search(r"\bhas\s+not\s+remarried\b", source_context, flags=re.IGNORECASE)
+    )
 
 
 _MODIFIER_PARAMETER_SOURCE_PATTERN = re.compile(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -10690,6 +10690,39 @@ rules:
     assert find_tax_status_component_local_input_issues(content) == []
 
 
+def test_tax_status_component_local_input_allows_3121_b_3_family_service_context():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    (3) domestic service in a private home of the employer, except that the
+    provisions of this subparagraph shall not be applicable to such domestic
+    service performed by an individual in the employ of his son or daughter if
+    the employer is a surviving spouse or a divorced individual and has not
+    remarried.
+rules:
+  - name: family_employment_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(3)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              excerpt: "the employer is a surviving spouse or a divorced individual and has not remarried"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          domestic_service_in_private_home_of_employer
+          and employer_is_surviving_spouse_or_divorced_individual_and_has_not_remarried
+"""
+
+    assert find_tax_status_component_local_input_issues(content) == []
+
+
 def test_unused_modifier_parameter_rejects_ignored_substitution_amount():
     content = """format: rulespec/v1
 rules:


### PR DESCRIPTION
## Summary
- allow the 3121(b)(3) domestic-service exception to use a local employer surviving-spouse/divorced-not-remarried condition
- keep generic tax filing-status component local inputs rejected
- bump axiom-encode to 0.2.172

## Tests
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py -q
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/