### PR TITLE
Encode source-stated exception categories as boundaries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.172"
+version = "0.2.173"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.172"
+__version__ = "0.2.173"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3442,6 +3442,12 @@ RuleSpec requirements:
   whose name is explicitly scoped to that category. Do not subtract, disallow,
   or reduce all qualifying branches merely because an exception amount input is
   nonzero.
+- If the requested source itself enumerates exception categories and cites other
+  laws only to define those category labels, encode each source-stated category
+  as its own boundary predicate and combine them into the final rule. Do not
+  defer the final exported output solely because cited title, chapter, schedule,
+  appointment, office, retirement-system, or election definitions are not
+  encoded when the requested source states the exception's operative effect.
 - If the copied target file is already executable, do not let its old surface
   force local placeholders or compatibility names. Rebuild, drop, or defer
   individual outputs as needed. Prefer retaining or replacing source-backed

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -431,6 +431,12 @@ Hard requirements:
   whose name is explicitly scoped to that category. Do not subtract, disallow,
   or reduce all qualifying branches merely because an exception amount input is
   nonzero.
+- If the requested source itself enumerates exception categories and cites other
+  laws only to define those category labels, encode each source-stated category
+  as its own boundary predicate and combine them into the final rule. Do not
+  defer the final exported output solely because cited title, chapter, schedule,
+  appointment, office, retirement-system, or election definitions are not
+  encoded when the requested source states the exception's operative effect.
 - If the copied target file is already executable, do not let its old surface
   force local placeholders or compatibility names. Rebuild, drop, or defer
   individual outputs as needed. Prefer retaining or replacing source-backed

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -96,6 +96,8 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "source-stated formula executable" in ENCODER_PROMPT
     assert "defer only that branch" in ENCODER_PROMPT
     assert "predicate for the excepted category" in ENCODER_PROMPT
+    assert "enumerates exception categories" in ENCODER_PROMPT
+    assert "retirement-system, or election definitions" in ENCODER_PROMPT
     assert "positive/nonzero" in ENCODER_PROMPT
     assert "toggle each gate at least once" in ENCODER_PROMPT
     assert "rate-applied result at the source-stated lower entity" in ENCODER_PROMPT

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -513,6 +513,9 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "exclusions conditioned on a reasonable belief" in prompt
     assert "Do not defer solely because" in prompt
     assert "model the source-stated\n  reasonable-belief condition" in prompt
+    assert "enumerates exception categories" in prompt
+    assert "cites other\n  laws only to define those category labels" in prompt
+    assert "appointment, office, retirement-system, or election definitions" in prompt
     assert "imported test inputs from copied files" in prompt
     assert "Do not stub imported derived" in prompt
     assert "never assign prohibited derived" in prompt


### PR DESCRIPTION
## Summary
- tell the encoder to model source-enumerated exception categories as boundary predicates when cited laws only define category labels
- keep final exported outputs executable instead of deferring solely due title/chapter/schedule/appointment/office/retirement/election definitions
- bump axiom-encode to 0.2.173

## Tests
- uv run --extra dev python -m pytest tests/test_encoder_backend.py tests/test_evals.py -q
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/

Motivated by 26 USC 3121(b)(5), where the source itself lists federal-service exception categories.