### PR TITLE
Allow cited category boundaries in exception rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.173"
+version = "0.2.174"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.173"
+__version__ = "0.2.174"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3142,6 +3142,9 @@ Test file rules:
   untested just because another negative case toggles a different gate.
 - If a formula negates multiple exception predicates, include a separate companion test for each predicate that sets that exception input true and expects the directly affected Judgment rule to be `not_holds`.
 - For any negated exception predicate, include a paired positive case with the same output rule where only the exception input changes from `false` to `true`; do not combine the exception test with another branch change.
+- Validation fails if a direct local `#input.*_exception_applies` or
+  `#input.*_exception_*` predicate is negated by an exported Judgment rule
+  without this paired positive/negative companion.
 - Do not collapse a list of cited exceptions or cross-reference carve-outs into one aggregate fact such as `sections_..._do_not_preclude...`. Encode or import each cited exception separately, then combine them in a helper if useful.
 - If context files import this target file or reference this target file's outputs, use that as a signal to repair the dependency graph, not as a requirement to preserve old names. Keep an old output only when it remains the cleanest source-faithful RuleSpec surface.
 - Do not preserve existing factual input slots referenced by copied formulas or companion tests when a cleaner source-faithful encoding removes them. This is especially important for names listed under invalid copied local inputs.
@@ -3351,8 +3354,11 @@ RuleSpec requirements:
   not available as RuleSpec. If the citation appears in definition,
   same-meaning, treated-as, rules-similar, exception, exclusion, `unless`,
   `notwithstanding`, shall-not-apply, or not-treated-as logic and the cited
-  source is unavailable, do not invent a local cross-reference fact. If the
-  dependency is essential to the only requested executable concept, emit
+  source is unavailable, do not invent a local cross-reference fact for the
+  cited mechanics. If the requested source itself states the operative effect
+  and only uses the citation to label a category, encode a source-named boundary
+  predicate for that category instead of deferring. Otherwise, if the dependency
+  is essential to the only requested executable concept, emit
   `module.status: deferred` or `module.status: entity_not_supported` with
   `rules: []`. In a mixed provision, omit or defer only the affected executable
   surface and still encode independent source-backed outputs that do not require
@@ -3446,8 +3452,9 @@ RuleSpec requirements:
   laws only to define those category labels, encode each source-stated category
   as its own boundary predicate and combine them into the final rule. Do not
   defer the final exported output solely because cited title, chapter, schedule,
-  appointment, office, retirement-system, or election definitions are not
-  encoded when the requested source states the exception's operative effect.
+  appointment, office, retirement-system, election, covered-service, or
+  treated-as-trade-or-business definitions are not encoded when the requested
+  source states the exception's operative effect.
 - If the copied target file is already executable, do not let its old surface
   force local placeholders or compatibility names. Rebuild, drop, or defer
   individual outputs as needed. Prefer retaining or replacing source-backed

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -15210,6 +15210,13 @@ class ValidatorPipeline:
                     rulespec_file=rulespec_file,
                 ):
                     continue
+                if self._is_source_stated_category_boundary(
+                    block=block,
+                    identifier=identifier,
+                    import_base=import_base,
+                    source_text=source_text,
+                ):
+                    continue
                 key = (str(block["name"]), identifier)
                 if key in seen:
                     continue
@@ -15234,6 +15241,83 @@ class ValidatorPipeline:
                     f"for a cited legal section. {resolution}"
                 )
         return issues
+
+    def _is_source_stated_category_boundary(
+        self,
+        *,
+        block: dict[str, object],
+        identifier: str,
+        import_base: str,
+        source_text: str,
+    ) -> bool:
+        """Allow cited-law category labels without allowing cited mechanics."""
+        if identifier.startswith(("section_", "subsection_")):
+            return False
+        if not re.search(
+            r"(?:^|_)(?:included|constitutes|covered|entered|established|treated|meaning)(?:_|$)",
+            identifier,
+            flags=re.IGNORECASE,
+        ):
+            return False
+
+        proof_excerpts = block.get("proof_excerpts")
+        scoped_text = (
+            " ".join(str(item) for item in proof_excerpts)
+            if isinstance(proof_excerpts, list)
+            else ""
+        ).strip()
+        if not scoped_text:
+            scoped_text = source_text
+        if not self._source_text_mentions_import_base(scoped_text, import_base):
+            return False
+        if not re.search(
+            r"\b(?:"
+            r"included\s+under|"
+            r"constitutes\b|"
+            r"covered\s+by|"
+            r"entered\s+into\s+pursuant\s+to|"
+            r"established\s+by|"
+            r"treated\s+(?:pursuant\s+to|under|as)|"
+            r"meaning\s+given"
+            r")\b",
+            scoped_text,
+            flags=re.IGNORECASE,
+        ):
+            return False
+        return bool(
+            re.search(
+                r"\b(?:"
+                r"agreement|category|class|employee|employment|instrumentality|"
+                r"member|officer|official|position|retirement\s+system|service|"
+                r"status|worker"
+                r")\b",
+                scoped_text,
+                flags=re.IGNORECASE,
+            )
+        )
+
+    def _source_text_mentions_import_base(
+        self, source_text: str, import_base: str
+    ) -> bool:
+        parts = import_base.split("/")
+        try:
+            statutes_index = parts.index("statutes")
+        except ValueError:
+            return False
+        citation_parts = parts[statutes_index + 1 :]
+        if len(citation_parts) < 2:
+            return False
+        section = re.escape(citation_parts[1])
+        fragments = "".join(
+            rf"\s*\(\s*{re.escape(fragment)}\s*\)" for fragment in citation_parts[2:]
+        )
+        return bool(
+            re.search(
+                rf"\bsection\s+{section}{fragments}(?:\b|\s|,|\))",
+                source_text,
+                flags=re.IGNORECASE,
+            )
+        )
 
     def _check_encoded_cross_reference_placeholders(
         self, rulespec_file: Path
@@ -16151,6 +16235,7 @@ class ValidatorPipeline:
                     "dtype": rule.get("dtype"),
                     "source": rule.get("source"),
                     "status": rule.get("status"),
+                    "proof_excerpts": _rule_proof_source_excerpts(rule),
                     "constant_boolean": constant_boolean,
                 }
             )

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -324,8 +324,11 @@ Hard requirements:
   not available as RuleSpec. If the citation appears in definition,
   same-meaning, treated-as, rules-similar, exception, exclusion, `unless`,
   `notwithstanding`, shall-not-apply, or not-treated-as logic and the cited
-  source is unavailable, do not invent a local cross-reference fact. If the
-  dependency is essential to the only requested executable concept, emit
+  source is unavailable, do not invent a local cross-reference fact for the
+  cited mechanics. If the requested source itself states the operative effect
+  and only uses the citation to label a category, encode a source-named boundary
+  predicate for that category instead of deferring. Otherwise, if the dependency
+  is essential to the only requested executable concept, emit
   `module.status: deferred` or `module.status: entity_not_supported` with
   `rules: []`. In a mixed provision, omit or defer only the affected executable
   surface and still encode independent source-backed outputs that do not require
@@ -435,8 +438,9 @@ Hard requirements:
   laws only to define those category labels, encode each source-stated category
   as its own boundary predicate and combine them into the final rule. Do not
   defer the final exported output solely because cited title, chapter, schedule,
-  appointment, office, retirement-system, or election definitions are not
-  encoded when the requested source states the exception's operative effect.
+  appointment, office, retirement-system, election, covered-service, or
+  treated-as-trade-or-business definitions are not encoded when the requested
+  source states the exception's operative effect.
 - If the copied target file is already executable, do not let its old surface
   force local placeholders or compatibility names. Rebuild, drop, or defer
   individual outputs as needed. Prefer retaining or replacing source-backed
@@ -583,6 +587,9 @@ Hard requirements:
 - For any negated exception predicate, include a paired positive case with the
   same output rule where only the exception input changes from `false` to
   `true`; do not combine the exception test with another branch change.
+- Validation fails if a direct local `#input.*_exception_applies` or
+  `#input.*_exception_*` predicate is negated by an exported Judgment rule
+  without this paired positive/negative companion.
 - Do not collapse a list of cited exceptions or cross-reference carve-outs into
   one aggregate fact such as `sections_..._do_not_preclude...`. Encode or
   import each cited exception separately, then combine them in a helper if

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -97,9 +97,15 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "defer only that branch" in ENCODER_PROMPT
     assert "predicate for the excepted category" in ENCODER_PROMPT
     assert "enumerates exception categories" in ENCODER_PROMPT
-    assert "retirement-system, or election definitions" in ENCODER_PROMPT
+    assert "only uses the citation to label a category" in ENCODER_PROMPT
+    assert "retirement-system, election, covered-service" in ENCODER_PROMPT
+    assert "treated-as-trade-or-business definitions" in ENCODER_PROMPT
     assert "positive/nonzero" in ENCODER_PROMPT
     assert "toggle each gate at least once" in ENCODER_PROMPT
+    assert (
+        "Validation fails if a direct local `#input.*_exception_applies`"
+        in ENCODER_PROMPT
+    )
     assert "rate-applied result at the source-stated lower entity" in ENCODER_PROMPT
     assert "unit-level placeholder or aggregate base by the rate" in ENCODER_PROMPT
     assert "Never drop the jurisdiction prefix" in ENCODER_PROMPT

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -515,7 +515,10 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "model the source-stated\n  reasonable-belief condition" in prompt
     assert "enumerates exception categories" in prompt
     assert "cites other\n  laws only to define those category labels" in prompt
-    assert "appointment, office, retirement-system, or election definitions" in prompt
+    assert "only uses the citation to label a category" in prompt
+    assert "appointment, office, retirement-system, election" in prompt
+    assert "covered-service, or\n  treated-as-trade-or-business definitions" in prompt
+    assert "Validation fails if a direct local `#input.*_exception_applies`" in prompt
     assert "imported test inputs from copied files" in prompt
     assert "Do not stub imported derived" in prompt
     assert "never assign prohibited derived" in prompt

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5157,6 +5157,58 @@ rules:
     assert "statutes/7/2015/b" in issues[0]
 
 
+def test_cross_reference_exception_placeholder_allows_category_label_boundary(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "3121" / "b" / "7.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    Paragraph (7) shall not apply in the case of service performed by any
+    individual as an employee included under section 5351(2) of title 5,
+    other than as a medical or dental intern or resident.
+rules:
+  - name: student_hospital_employee_exception_branch
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(7)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "by any individual as an employee included under section 5351(2) of title 5, United States Code (relating to certain interns, student nurses, and other student employees of hospitals)"
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: "other than as a medical or dental intern or as a medical or dental resident in training"
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          individual_is_employee_included_under_section_5351_2_of_title_5_for_hospitals
+          and not service_performed_as_medical_or_dental_intern
+          and not service_performed_as_medical_or_dental_resident_in_training
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_cross_reference_exception_placeholders(rules_file)
+
+    assert issues == []
+
+
 def test_cross_reference_placeholder_uses_explicit_usc_title(tmp_path):
     repo = tmp_path / "rulespec-us"
     rules_file = repo / "statutes" / "26" / "2" / "a.yaml"


### PR DESCRIPTION
## Summary\n- allow source-stated exception category labels backed by cited law to remain local boundary predicates without opening the door to cited mechanics placeholders\n- make the encoder prompt explicit that treated-as/covered-service/category labels should not force deferral when the requested source states the operative effect\n- strengthen test-generation guidance for direct negated exception inputs\n- bump axiom-encode to 0.2.174\n\n## Validation\n- uv run --extra dev python -m pytest tests/test_encoder_backend.py tests/test_evals.py -q\n- uv run --extra dev python -m pytest tests/test_rulespec_validation.py::test_cross_reference_exception_placeholder_requires_import tests/test_rulespec_validation.py::test_cross_reference_exception_placeholder_allows_category_label_boundary tests/test_encoder_backend.py tests/test_evals.py -q\n- uv run --extra dev python -m pytest tests/test_rulespec_validation.py -q\n- uv run --extra dev ruff check src/ tests/\n- uv run --extra dev ruff format --check src/ tests/\n\nEnd-to-end proof: signed apply for 26 USC 3121(b)(7) using this clean encoder commit succeeded in /private/tmp/rulespec-us-3121-b-7-v5-20260524.