### PR TITLE
Skip named-act numeric cross-reference placeholders

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.174"
+version = "0.2.175"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.174"
+__version__ = "0.2.175"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -15574,6 +15574,10 @@ class ValidatorPipeline:
                 for match in pattern.finditer(segment_text):
                     label = _normalize_identifier(match.group("label"))
                     section = match.group("section")
+                    if _section_reference_to_named_act_without_title(
+                        section, source_text
+                    ):
+                        continue
                     target_title = (
                         _title_qualified_reference_for_section(section, source_text)
                         or title

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6405,6 +6405,44 @@ rules:
     assert any("statutes/26/3241" in issue for issue in issues)
 
 
+def test_cross_reference_numeric_placeholder_does_not_infer_named_act_title(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "3121" / "b" / "7.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    The exception applies for an election worker if remuneration is less than
+    the adjusted amount determined under section 218(c)(8)(B) of the Social
+    Security Act for any calendar year commencing on or after January 1, 2000.
+rules:
+  - name: election_worker_low_remuneration_exception
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3121(b)(7)(F)(iv)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          service_performed_by_election_worker
+          and remuneration < adjusted_amount_determined_under_social_security_act_section_218_c_8_B
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_cross_reference_numeric_placeholders(rules_file)
+
+    assert issues == []
+
+
 def test_cross_reference_numeric_placeholder_accepts_top_level_import_sequence(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary\n- prevent the numeric cross-reference placeholder validator from inferring the current USC title for references to named acts, e.g. section 218 of the Social Security Act\n- add a regression test covering an externally adjusted amount under a named act\n- bump axiom-encode to 0.2.175\n\n## Validation\n- uv run --extra dev python -m pytest tests/test_rulespec_validation.py::test_cross_reference_numeric_placeholder_rejects_locally_supplied_rates tests/test_rulespec_validation.py::test_cross_reference_numeric_placeholder_does_not_infer_named_act_title tests/test_rulespec_validation.py::test_cross_reference_numeric_placeholder_accepts_top_level_import_sequence -q\n- uv run --extra dev ruff check src/ tests/\n- uv run --extra dev ruff format --check src/ tests/\n\nEnd-to-end proof: signed apply for 26 USC 3121(b)(7) using this clean encoder commit succeeded in /private/tmp/rulespec-us-3121-b-7-v7-20260524.