### PR TITLE
Encode within-meaning carve-outs as boundaries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.175"
+version = "0.2.176"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.175"
+__version__ = "0.2.176"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3357,8 +3357,10 @@ RuleSpec requirements:
   source is unavailable, do not invent a local cross-reference fact for the
   cited mechanics. If the requested source itself states the operative effect
   and only uses the citation to label a category, encode a source-named boundary
-  predicate for that category instead of deferring. Otherwise, if the dependency
-  is essential to the only requested executable concept, emit
+  predicate for that category instead of deferring. This includes `within the
+  meaning of section ...` carve-outs where the current source states that the
+  category is included, excluded, or not treated in a specified way. Otherwise,
+  if the dependency is essential to the only requested executable concept, emit
   `module.status: deferred` or `module.status: entity_not_supported` with
   `rules: []`. In a mixed provision, omit or defer only the affected executable
   surface and still encode independent source-backed outputs that do not require
@@ -3453,8 +3455,9 @@ RuleSpec requirements:
   as its own boundary predicate and combine them into the final rule. Do not
   defer the final exported output solely because cited title, chapter, schedule,
   appointment, office, retirement-system, election, covered-service, or
-  treated-as-trade-or-business definitions are not encoded when the requested
-  source states the exception's operative effect.
+  treated-as-trade-or-business, unrelated-trade-or-business, or other
+  within-meaning definitions are not encoded when the requested source states
+  the exception's operative effect.
 - If the copied target file is already executable, do not let its old surface
   force local placeholders or compatibility names. Rebuild, drop, or defer
   individual outputs as needed. Prefer retaining or replacing source-backed

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -327,8 +327,10 @@ Hard requirements:
   source is unavailable, do not invent a local cross-reference fact for the
   cited mechanics. If the requested source itself states the operative effect
   and only uses the citation to label a category, encode a source-named boundary
-  predicate for that category instead of deferring. Otherwise, if the dependency
-  is essential to the only requested executable concept, emit
+  predicate for that category instead of deferring. This includes `within the
+  meaning of section ...` carve-outs where the current source states that the
+  category is included, excluded, or not treated in a specified way. Otherwise,
+  if the dependency is essential to the only requested executable concept, emit
   `module.status: deferred` or `module.status: entity_not_supported` with
   `rules: []`. In a mixed provision, omit or defer only the affected executable
   surface and still encode independent source-backed outputs that do not require
@@ -439,8 +441,9 @@ Hard requirements:
   as its own boundary predicate and combine them into the final rule. Do not
   defer the final exported output solely because cited title, chapter, schedule,
   appointment, office, retirement-system, election, covered-service, or
-  treated-as-trade-or-business definitions are not encoded when the requested
-  source states the exception's operative effect.
+  treated-as-trade-or-business, unrelated-trade-or-business, or other
+  within-meaning definitions are not encoded when the requested source states
+  the exception's operative effect.
 - If the copied target file is already executable, do not let its old surface
   force local placeholders or compatibility names. Rebuild, drop, or defer
   individual outputs as needed. Prefer retaining or replacing source-backed

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -99,7 +99,10 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "enumerates exception categories" in ENCODER_PROMPT
     assert "only uses the citation to label a category" in ENCODER_PROMPT
     assert "retirement-system, election, covered-service" in ENCODER_PROMPT
-    assert "treated-as-trade-or-business definitions" in ENCODER_PROMPT
+    assert "treated-as-trade-or-business, unrelated-trade-or-business" in ENCODER_PROMPT
+    assert "`within the\n  meaning of section ...` carve-outs" in ENCODER_PROMPT
+    assert "unrelated-trade-or-business" in ENCODER_PROMPT
+    assert "within-meaning definitions" in ENCODER_PROMPT
     assert "positive/nonzero" in ENCODER_PROMPT
     assert "toggle each gate at least once" in ENCODER_PROMPT
     assert (

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -517,7 +517,11 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "cites other\n  laws only to define those category labels" in prompt
     assert "only uses the citation to label a category" in prompt
     assert "appointment, office, retirement-system, election" in prompt
-    assert "covered-service, or\n  treated-as-trade-or-business definitions" in prompt
+    assert "covered-service, or\n  treated-as-trade-or-business" in prompt
+    assert "`within the\n  meaning of section ...` carve-outs" in prompt
+    assert (
+        "unrelated-trade-or-business, or other\n  within-meaning definitions" in prompt
+    )
     assert "Validation fails if a direct local `#input.*_exception_applies`" in prompt
     assert "imported test inputs from copied files" in prompt
     assert "Do not stub imported derived" in prompt


### PR DESCRIPTION
## Summary

- Treat `within the meaning of section ...` carve-outs as source-stated category boundaries when the current source states the operative effect.
- Expand prompt examples to cover unrelated-trade-or-business and other within-meaning definitions.
- Bump the package version to 0.2.176.

## Why

`26 USC 3121(b)(8)(B)` states the exclusion rule and uses section 513(a) only to label the unrelated-trade-or-business carve-out. The encoder should emit a boundary predicate for that category instead of deferring the branch just because section 513(a) is not encoded.

## Checks

- `uv run --extra dev python -m pytest tests/test_encoder_backend.py tests/test_evals.py -q`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
