### PR TITLE
Encode described-in-section categories as boundaries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.176"
+version = "0.2.177"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.176"
+__version__ = "0.2.177"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3358,9 +3358,10 @@ RuleSpec requirements:
   cited mechanics. If the requested source itself states the operative effect
   and only uses the citation to label a category, encode a source-named boundary
   predicate for that category instead of deferring. This includes `within the
-  meaning of section ...` carve-outs where the current source states that the
-  category is included, excluded, or not treated in a specified way. Otherwise,
-  if the dependency is essential to the only requested executable concept, emit
+  meaning of section ...` carve-outs and `described in section ...` category
+  labels where the current source states that the category is included,
+  excluded, or not treated in a specified way. Otherwise, if the dependency is
+  essential to the only requested executable concept, emit
   `module.status: deferred` or `module.status: entity_not_supported` with
   `rules: []`. In a mixed provision, omit or defer only the affected executable
   surface and still encode independent source-backed outputs that do not require
@@ -3450,14 +3451,15 @@ RuleSpec requirements:
   whose name is explicitly scoped to that category. Do not subtract, disallow,
   or reduce all qualifying branches merely because an exception amount input is
   nonzero.
-- If the requested source itself enumerates exception categories and cites other
-  laws only to define those category labels, encode each source-stated category
-  as its own boundary predicate and combine them into the final rule. Do not
-  defer the final exported output solely because cited title, chapter, schedule,
-  appointment, office, retirement-system, election, covered-service, or
+- If the requested source itself enumerates qualifying or exception categories
+  and cites other laws only to define those category labels, encode each
+  source-stated category as its own boundary predicate and combine them into the
+  final rule. Do not defer the final exported output solely because cited title,
+  chapter, schedule, appointment, office, retirement-system, election,
+  covered-service, section-described supporting organization,
   treated-as-trade-or-business, unrelated-trade-or-business, or other
-  within-meaning definitions are not encoded when the requested source states
-  the exception's operative effect.
+  within-meaning/described-in definitions are not encoded when the requested
+  source states the operative effect.
 - If the copied target file is already executable, do not let its old surface
   force local placeholders or compatibility names. Rebuild, drop, or defer
   individual outputs as needed. Prefer retaining or replacing source-backed

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -328,9 +328,10 @@ Hard requirements:
   cited mechanics. If the requested source itself states the operative effect
   and only uses the citation to label a category, encode a source-named boundary
   predicate for that category instead of deferring. This includes `within the
-  meaning of section ...` carve-outs where the current source states that the
-  category is included, excluded, or not treated in a specified way. Otherwise,
-  if the dependency is essential to the only requested executable concept, emit
+  meaning of section ...` carve-outs and `described in section ...` category
+  labels where the current source states that the category is included,
+  excluded, or not treated in a specified way. Otherwise, if the dependency is
+  essential to the only requested executable concept, emit
   `module.status: deferred` or `module.status: entity_not_supported` with
   `rules: []`. In a mixed provision, omit or defer only the affected executable
   surface and still encode independent source-backed outputs that do not require
@@ -436,14 +437,15 @@ Hard requirements:
   whose name is explicitly scoped to that category. Do not subtract, disallow,
   or reduce all qualifying branches merely because an exception amount input is
   nonzero.
-- If the requested source itself enumerates exception categories and cites other
-  laws only to define those category labels, encode each source-stated category
-  as its own boundary predicate and combine them into the final rule. Do not
-  defer the final exported output solely because cited title, chapter, schedule,
-  appointment, office, retirement-system, election, covered-service, or
+- If the requested source itself enumerates qualifying or exception categories
+  and cites other laws only to define those category labels, encode each
+  source-stated category as its own boundary predicate and combine them into the
+  final rule. Do not defer the final exported output solely because cited title,
+  chapter, schedule, appointment, office, retirement-system, election,
+  covered-service, section-described supporting organization,
   treated-as-trade-or-business, unrelated-trade-or-business, or other
-  within-meaning definitions are not encoded when the requested source states
-  the exception's operative effect.
+  within-meaning/described-in definitions are not encoded when the requested
+  source states the operative effect.
 - If the copied target file is already executable, do not let its old surface
   force local placeholders or compatibility names. Rebuild, drop, or defer
   individual outputs as needed. Prefer retaining or replacing source-backed

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -96,13 +96,18 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "source-stated formula executable" in ENCODER_PROMPT
     assert "defer only that branch" in ENCODER_PROMPT
     assert "predicate for the excepted category" in ENCODER_PROMPT
-    assert "enumerates exception categories" in ENCODER_PROMPT
+    assert "enumerates qualifying or exception categories" in ENCODER_PROMPT
     assert "only uses the citation to label a category" in ENCODER_PROMPT
-    assert "retirement-system, election, covered-service" in ENCODER_PROMPT
+    assert "retirement-system, election" in ENCODER_PROMPT
+    assert (
+        "covered-service, section-described supporting organization" in ENCODER_PROMPT
+    )
+    assert "`described in section ...` category\n  labels" in ENCODER_PROMPT
+    assert "section-described supporting organization" in ENCODER_PROMPT
     assert "treated-as-trade-or-business, unrelated-trade-or-business" in ENCODER_PROMPT
     assert "`within the\n  meaning of section ...` carve-outs" in ENCODER_PROMPT
     assert "unrelated-trade-or-business" in ENCODER_PROMPT
-    assert "within-meaning definitions" in ENCODER_PROMPT
+    assert "within-meaning/described-in definitions" in ENCODER_PROMPT
     assert "positive/nonzero" in ENCODER_PROMPT
     assert "toggle each gate at least once" in ENCODER_PROMPT
     assert (

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -513,14 +513,17 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "exclusions conditioned on a reasonable belief" in prompt
     assert "Do not defer solely because" in prompt
     assert "model the source-stated\n  reasonable-belief condition" in prompt
-    assert "enumerates exception categories" in prompt
-    assert "cites other\n  laws only to define those category labels" in prompt
+    assert "enumerates qualifying or exception categories" in prompt
+    assert "cites other laws only to define those category labels" in prompt
     assert "only uses the citation to label a category" in prompt
     assert "appointment, office, retirement-system, election" in prompt
-    assert "covered-service, or\n  treated-as-trade-or-business" in prompt
+    assert "`described in section ...` category\n  labels" in prompt
+    assert "section-described supporting organization" in prompt
+    assert "covered-service, section-described supporting organization" in prompt
     assert "`within the\n  meaning of section ...` carve-outs" in prompt
     assert (
-        "unrelated-trade-or-business, or other\n  within-meaning definitions" in prompt
+        "unrelated-trade-or-business, or other\n  within-meaning/described-in definitions"
+        in prompt
     )
     assert "Validation fails if a direct local `#input.*_exception_applies`" in prompt
     assert "imported test inputs from copied files" in prompt


### PR DESCRIPTION
## Summary

- Treat `described in section ...` category labels like source-stated boundary predicates when the current source states the operative rule.
- Generalize the existing category-label guidance from exception-only categories to qualifying or exception categories.
- Bump the package version to 0.2.177.

## Why

`26 USC 3121(b)(10)(B)` states the supporting-organization student-service exclusion and uses section 509(a)(3) to label the organization category. The encoder should emit a boundary predicate for that category instead of deferring the branch solely because 509(a)(3) is not encoded.

## Checks

- `uv run --extra dev python -m pytest tests/test_encoder_backend.py tests/test_evals.py -q`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
