### PR TITLE
Encode section-described membership as boundaries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.177"
+version = "0.2.178"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.177"
+__version__ = "0.2.178"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3369,6 +3369,14 @@ RuleSpec requirements:
   mixed provision, add `module.deferred_outputs[]` with absolute RuleSpec
   targets for `output`, a plain-language `reason`, and `source_values` entries
   for any source-stated local parameters retained only for that deferred output.
+  Treat category membership phrases such as `person described in section X`,
+  `organization described in section X`, or `service described in section X` as
+  factual boundary predicates when the current source states the legal effect.
+  Use a source-named predicate like `organization_described_in_section_509_a_3`
+  plus any conditions stated in the current source. Do not defer merely because
+  the cited section is unavailable unless the current source requires computing
+  numeric amounts or legal mechanics from that section rather than testing
+  membership in the described category.
   If a source says a rate, percentage, amount, applicable percentage, or
   similar numeric term is determined under, in effect under, or equal to rates
   from another section or subsection, do not model that numeric term as a local

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -339,6 +339,14 @@ Hard requirements:
   mixed provision, add `module.deferred_outputs[]` with absolute RuleSpec
   targets for `output`, a plain-language `reason`, and `source_values` entries
   for any source-stated local parameters retained only for that deferred output.
+  Treat category membership phrases such as `person described in section X`,
+  `organization described in section X`, or `service described in section X` as
+  factual boundary predicates when the current source states the legal effect.
+  Use a source-named predicate like `organization_described_in_section_509_a_3`
+  plus any conditions stated in the current source. Do not defer merely because
+  the cited section is unavailable unless the current source requires computing
+  numeric amounts or legal mechanics from that section rather than testing
+  membership in the described category.
   If a source says a rate, percentage, amount, applicable percentage, or
   similar numeric term is determined under, in effect under, or equal to rates
   from another section or subsection, do not model that numeric term as a local

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -106,6 +106,10 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "section-described supporting organization" in ENCODER_PROMPT
     assert "treated-as-trade-or-business, unrelated-trade-or-business" in ENCODER_PROMPT
     assert "`within the\n  meaning of section ...` carve-outs" in ENCODER_PROMPT
+    assert "category membership phrases" in ENCODER_PROMPT
+    assert "`organization described in section X`" in ENCODER_PROMPT
+    assert "organization_described_in_section_509_a_3" in ENCODER_PROMPT
+    assert "testing\n  membership in the described category" in ENCODER_PROMPT
     assert "unrelated-trade-or-business" in ENCODER_PROMPT
     assert "within-meaning/described-in definitions" in ENCODER_PROMPT
     assert "positive/nonzero" in ENCODER_PROMPT

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -521,6 +521,10 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "section-described supporting organization" in prompt
     assert "covered-service, section-described supporting organization" in prompt
     assert "`within the\n  meaning of section ...` carve-outs" in prompt
+    assert "category membership phrases" in prompt
+    assert "`organization described in section X`" in prompt
+    assert "organization_described_in_section_509_a_3" in prompt
+    assert "testing\n  membership in the described category" in prompt
     assert (
         "unrelated-trade-or-business, or other\n  within-meaning/described-in definitions"
         in prompt


### PR DESCRIPTION
## Summary

- Add explicit prompt guidance that `person/organization/service described in section X` is category membership when the current source states the legal effect.
- Tell the encoder to use source-named boundary predicates such as `organization_described_in_section_509_a_3` plus current-source conditions instead of deferring solely because the cited section is unavailable.
- Bump the package version to 0.2.178.

## Why

The broader described-in-section guidance in #188 still let `26 USC 3121(b)(10)(B)` defer the supporting-organization branch. This makes the boundary-vs-mechanics distinction explicit: membership in a cited category can be a local factual boundary; mechanics or numeric computations from the cited section still require import or deferral.

## Checks

- `uv run --extra dev python -m pytest tests/test_encoder_backend.py tests/test_evals.py -q`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
