### PR TITLE
Classify 3121(y) PE coverage as not comparable

### DIFF
--- a/changelog.d/3121-y-policyengine-coverage.fixed.md
+++ b/changelog.d/3121-y-policyengine-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify 3121(y) transferred-federal-employee international-organization employment intermediates as not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.178"
+version = "0.2.179"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9333,6 +9333,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(b) employment-definition child-fragment service-classification predicates as one-to-one variables. These legal intermediates determine whether service is employment for FICA before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/y#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(y) transferred-federal-employee international-organization employment predicates as one-to-one variables. These legal intermediates determine whether international-organization service is employment for FICA before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/225#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -553,6 +553,11 @@ rules:
             "us:statutes/26/3121/b/1#foreign_agricultural_worker_service_excluded_from_employment",
             "foreign_agricultural_worker_service_excluded_from_employment",
         ),
+        (
+            "statutes/26/3121/y.yaml",
+            "us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_is_employment",
+            "transferred_federal_employee_international_organization_service_is_employment",
+        ),
     ],
 )
 def test_policyengine_coverage_classifies_3121_employment_exclusions(


### PR DESCRIPTION
## Summary
- Classifies 26 USC 3121(y) transferred-federal-employee international-organization employment intermediates as not comparable to PolicyEngine.
- Extends the existing 3121 employment-definition coverage regression test.
- Bumps axiom-encode to 0.2.179 and adds a towncrier fragment.

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3121_employment_exclusions tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3121_wage_exclusions`
- `uv run --extra dev python -m pytest tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed`
- `uv run --extra dev ruff check tests/test_policyengine_coverage.py`
- `git diff --check`
- Reran PE oracle coverage on generated 3121(y): 225 comparable / 625 known_not_comparable / 3 unmapped; 0 untested comparable.