### PR TITLE
Sync encoder version metadata

### DIFF
--- a/changelog.d/encoder-version-metadata.fixed.md
+++ b/changelog.d/encoder-version-metadata.fixed.md
@@ -1,0 +1,1 @@
+Keep pyproject and package version metadata in sync for signed RuleSpec apply provenance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.179"
+version = "0.2.180"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.178"
+__version__ = "0.2.180"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ import json
 import os
 import subprocess
 import tempfile
+import tomllib
 from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
@@ -111,6 +112,14 @@ from axiom_encode.harness.evals import EvalArtifactMetrics
 from axiom_encode.statute import citation_to_citation_path, parse_usc_citation
 
 TEST_APPLY_SIGNING_KEY = "test-apply-signing-key"
+
+
+def test_package_version_metadata_matches_pyproject():
+    pyproject = tomllib.loads(
+        (Path(__file__).parents[1] / "pyproject.toml").read_text()
+    )
+
+    assert pyproject["project"]["version"] == AXIOM_ENCODE_TEST_VERSION
 
 
 def _signed_manifest_payload(payload: dict) -> dict:


### PR DESCRIPTION
## Summary
- Bumps both pyproject and package `__version__` metadata to 0.2.180.
- Adds a regression test that pyproject and runtime package version metadata stay in sync.
- Adds a towncrier fragment for the signed apply provenance fix.

## Validation
- `uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::TestCmdEncode::test_apply_version_provenance_allows_changes_in_version_bump_commit tests/test_cli.py::TestCmdEncode::test_apply_version_provenance_rejects_code_after_version_bump`
- `uv run --extra dev ruff check tests/test_cli.py src/axiom_encode/__init__.py`
- `uv run python - <<PY ... print(__version__) ... PY` -> 0.2.180
- `git diff --check`