### PR TITLE
Copy context for same-section subsection references

### DIFF
--- a/changelog.d/same-section-under-subsection-context.fixed.md
+++ b/changelog.d/same-section-under-subsection-context.fixed.md
@@ -1,0 +1,1 @@
+Copy same-section subsection context for references such as "under subsection (y)", not only "subsection (y) of this section".

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.180"
+version = "0.2.181"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.180"
+__version__ = "0.2.181"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1952,7 +1952,8 @@ def _select_same_section_subsection_context_files(
     selected: list[Path] = []
     seen: set[Path] = set()
     for match in re.finditer(
-        r"\bsubsection\s+\((?P<subsection>[A-Za-z0-9]+)\)\s+of\s+this\s+section\b",
+        r"\bsubsection\s+\((?P<subsection>[A-Za-z0-9]+)\)"
+        r"(?:\s+of\s+this\s+section)?(?=\W|$)",
         source_text,
         flags=re.IGNORECASE,
     ):

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -10155,7 +10155,8 @@ def find_copied_cross_reference_source_issues(
     issues: list[str] = []
     seen: set[str] = set()
     for match in re.finditer(
-        r"\bsubsection\s+\((?P<subsection>[A-Za-z0-9]+)\)\s+of\s+this\s+section\b",
+        r"\bsubsection\s+\((?P<subsection>[A-Za-z0-9]+)\)"
+        r"(?:\s+of\s+this\s+section)?(?=\W|$)",
         source_text,
         flags=re.IGNORECASE,
     ):
@@ -10207,7 +10208,8 @@ def find_missing_same_section_subsection_import_issues(
     issues: list[str] = []
     seen: set[str] = set()
     for match in re.finditer(
-        r"\bsubsection\s+\((?P<subsection>[A-Za-z0-9]+)\)\s+of\s+this\s+section\b",
+        r"\bsubsection\s+\((?P<subsection>[A-Za-z0-9]+)\)"
+        r"(?:\s+of\s+this\s+section)?(?=\W|$)",
         source_text,
         flags=re.IGNORECASE,
     ):

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -6691,6 +6691,50 @@ rules:
             copied_sources[str(context_test)]["kind"] == "implementation_test_context"
         )
 
+    def test_prepare_eval_workspace_adds_same_section_under_subsection_context(
+        self, tmp_path
+    ):
+        repo_root = tmp_path / "repos"
+        policy_repo_root = repo_root / "axiom-rules-engine"
+        policy_repo_root.mkdir(parents=True)
+        statute_root = repo_root / "rulespec-us" / "statutes" / "26" / "3121"
+        statute_root.mkdir(parents=True)
+        context_file = statute_root / "y.yaml"
+        context_test = statute_root / "y.test.yaml"
+        context_file.write_text("format: rulespec/v1\nrules: []\n")
+        context_test.write_text("- name: transferred_employee_case\n  period: 2026\n")
+
+        runner = parse_runner_spec("codex:gpt-5.4")
+        with patch(
+            "axiom_encode.harness.evals.select_context_files",
+            return_value=[],
+        ):
+            workspace = prepare_eval_workspace(
+                citation="26 USC 3121(b)(15)",
+                runner=runner,
+                output_root=tmp_path / "out",
+                source_text=(
+                    "Service performed in the employ of an international "
+                    "organization, except service which constitutes employment "
+                    "under subsection (y)."
+                ),
+                axiom_rules_path=policy_repo_root,
+                mode="repo-augmented",
+                extra_context_paths=[],
+            )
+
+        manifest = json.loads(workspace.manifest_file.read_text())
+        copied_sources = {
+            item["source_path"]: item for item in manifest["context_files"]
+        }
+        assert copied_sources[str(context_file)]["kind"] == "implementation_precedent"
+        assert (
+            copied_sources[str(context_file)]["import_path"] == "us:statutes/26/3121/y"
+        )
+        assert (
+            copied_sources[str(context_test)]["kind"] == "implementation_test_context"
+        )
+
     def test_prepare_eval_workspace_adds_cross_section_context(self, tmp_path):
         repo_root = tmp_path / "repos"
         policy_repo_root = repo_root / "axiom-rules-engine"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5486,6 +5486,41 @@ rules:
     assert "statutes/7/2015/e" in issues[0]
 
 
+def test_same_section_under_subsection_reference_requires_import(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "3121" / "b" / "15.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    Service performed in the employ of an international organization, except
+    service which constitutes employment under subsection (y).
+rules:
+  - name: international_organization_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          service_performed_in_employ_of_international_organization
+          and not service_constitutes_employment_under_subsection_y
+"""
+    )
+
+    issues = find_missing_same_section_subsection_import_issues(
+        rules_file.read_text(),
+        rules_file=rules_file,
+        policy_repo_path=repo,
+    )
+
+    assert len(issues) == 1
+    assert "Same-section subsection import missing" in issues[0]
+    assert "statutes/26/3121/y" in issues[0]
+
+
 def test_same_section_subsection_reference_allows_import(tmp_path):
     repo = tmp_path / "rulespec-us"
     rules_file = repo / "statutes" / "7" / "2015" / "d" / "2" / "C.yaml"


### PR DESCRIPTION
## Summary
- Copies same-section subsection RuleSpec context for references like `under subsection (y)`, not only `subsection (y) of this section`.
- Applies the same broader reference detection to the validator import guard.
- Bumps axiom-encode to 0.2.181 and adds a towncrier fragment.

## Validation
- `uv run --extra dev python -m pytest tests/test_evals.py::TestRepoAugmentedContext::test_prepare_eval_workspace_adds_same_section_subsection_context tests/test_evals.py::TestRepoAugmentedContext::test_prepare_eval_workspace_adds_same_section_under_subsection_context tests/test_rulespec_validation.py::test_same_section_subsection_reference_requires_import tests/test_rulespec_validation.py::test_same_section_under_subsection_reference_requires_import tests/test_cli.py::test_package_version_metadata_matches_pyproject`
- `uv run --extra dev ruff check src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py tests/test_rulespec_validation.py tests/test_cli.py`
- `uv run python - <<PY ... print(__version__) ... PY` -> 0.2.181
- `git diff --check`

## Context
This is needed for 26 USC 3121(b)(15), whose source says the exception applies to service that constitutes employment `under subsection (y)`.