### PR TITLE
Repair imported table test inputs

### DIFF
--- a/changelog.d/imported-table-test-inputs.fixed.md
+++ b/changelog.d/imported-table-test-inputs.fixed.md
@@ -1,0 +1,1 @@
+Repair missing imported test inputs on entity table rows when validation reports a specific entity id.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.181"
+version = "0.2.182"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.181"
+__version__ = "0.2.182"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -14275,7 +14275,9 @@ def _repair_dependent_proof_import_hashes(
 
 
 _MISSING_INPUT_RE = re.compile(
-    r"Test case `(?P<case>[^`]+)` execution failed: missing input `(?P<input>[^`]+)`"
+    r"Test case `(?P<case>[^`]+)` execution failed: "
+    r"missing input `(?P<input>[^`]+)`"
+    r"(?: for entity `(?P<entity>[^`]+)`)?"
 )
 _APPLY_OVERLAY_VALIDATION_REPAIR_LIMIT = 50
 
@@ -14517,7 +14519,8 @@ def _complete_missing_imported_test_inputs(
     """Fill missing input slots for imported modules in this file's tests."""
     if not test_file.exists():
         return False
-    missing_inputs = _missing_input_names_from_validation(validation)
+    missing_assignments = _missing_input_assignments_from_validation(validation)
+    missing_inputs = {assignment["input"] for assignment in missing_assignments}
     if not missing_inputs:
         return False
     imported_inputs = _imported_input_refs_by_name(rules_file, repo_path=repo_path)
@@ -14533,6 +14536,19 @@ def _complete_missing_imported_test_inputs(
                 input_ref,
                 _infer_missing_input_default(input_name),
             )
+    for assignment in missing_assignments:
+        entity_id = assignment.get("entity")
+        if not entity_id:
+            continue
+        input_name = assignment["input"]
+        for input_ref in imported_inputs.get(input_name, []):
+            updated = _insert_input_default_in_table_entity_rows(
+                updated,
+                input_ref=input_ref,
+                value=_infer_missing_input_default(input_name),
+                case_name=assignment["case"],
+                entity_id=entity_id,
+            )
     if updated == content:
         return False
     test_file.write_text(updated)
@@ -14540,15 +14556,35 @@ def _complete_missing_imported_test_inputs(
 
 
 def _missing_input_names_from_validation(validation: object) -> set[str]:
-    missing_inputs: set[str] = set()
+    return {
+        assignment["input"]
+        for assignment in _missing_input_assignments_from_validation(validation)
+    }
+
+
+def _missing_input_assignments_from_validation(
+    validation: object,
+) -> list[dict[str, str]]:
+    seen_assignments: set[tuple[str, str, str | None]] = set()
+    assignments: list[dict[str, str]] = []
     results = getattr(validation, "results", {})
     if not isinstance(results, dict):
-        return missing_inputs
+        return assignments
     for validator_result in results.values():
         error = getattr(validator_result, "error", "") or ""
         for match in _MISSING_INPUT_RE.finditer(str(error)):
-            missing_inputs.add(match.group("input"))
-    return missing_inputs
+            key = (match.group("case"), match.group("input"), match.group("entity"))
+            if key in seen_assignments:
+                continue
+            seen_assignments.add(key)
+            assignment = {
+                "case": match.group("case"),
+                "input": match.group("input"),
+            }
+            if match.group("entity"):
+                assignment["entity"] = match.group("entity")
+            assignments.append(assignment)
+    return assignments
 
 
 def _imported_input_refs_by_name(
@@ -14785,6 +14821,54 @@ def _insert_input_default_in_test_cases(
         lines.insert(start + 1, f"{indent}{input_ref}: {rendered}{newline}")
     lines = _insert_input_default_in_relation_rows(lines, input_ref, rendered)
     return "".join(lines)
+
+
+def _insert_input_default_in_table_entity_rows(
+    content: str,
+    *,
+    input_ref: str,
+    value: object,
+    case_name: str,
+    entity_id: str,
+) -> str:
+    """Insert an input default into table rows matching a validation entity id."""
+    try:
+        payload = yaml.safe_load(content) or []
+    except (ValueError, yaml.YAMLError):
+        return content
+    if not isinstance(payload, list):
+        return content
+
+    changed = False
+    for test_case in payload:
+        if not isinstance(test_case, dict) or test_case.get("name") != case_name:
+            continue
+        row_value = value
+        inputs = test_case.get("input")
+        if isinstance(inputs, dict) and input_ref in inputs:
+            row_value = inputs[input_ref]
+        tables = test_case.get("tables")
+        if not isinstance(tables, dict):
+            continue
+        for table_entity, rows in tables.items():
+            if not isinstance(rows, list):
+                continue
+            for row_index, row in enumerate(rows, 1):
+                if not isinstance(row, dict):
+                    continue
+                if (
+                    _rulespec_table_row_entity_id(str(table_entity), row, row_index)
+                    != entity_id
+                ):
+                    continue
+                if input_ref in row:
+                    continue
+                row[input_ref] = row_value
+                changed = True
+
+    if not changed:
+        return content
+    return yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
 
 
 def _insert_input_default_in_relation_rows(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6819,6 +6819,86 @@ rules: []
             in updated
         )
 
+    def test_complete_missing_imported_test_inputs_adds_table_entity_defaults(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        imported = policy_repo / "statutes/26/3121/y.yaml"
+        dependent = policy_repo / "statutes/26/3121/b/15.yaml"
+        dependent_test = policy_repo / "statutes/26/3121/b/15.test.yaml"
+        imported.parent.mkdir(parents=True)
+        dependent.parent.mkdir(parents=True, exist_ok=True)
+        imported.write_text(
+            """format: rulespec/v1
+rules:
+  - name: transferred_federal_employee_international_organization_service_constitutes_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+"""
+        )
+        dependent.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_constitutes_employment
+rules:
+  - name: international_organization_service_excluded_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          service_performed_in_employ_of_international_organization
+          and not transferred_federal_employee_international_organization_service_constitutes_employment
+"""
+        )
+        imported_ref = (
+            "us:statutes/26/3121/y#input."
+            "service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5"
+        )
+        dependent_test.write_text(
+            f"""- name: case_one
+  input:
+    {imported_ref}: true
+  tables:
+    Payment:
+    - us:statutes/26/3121/b/15#input.service_performed_in_employ_of_international_organization: true
+  output:
+    us:statutes/26/3121/b/15#international_organization_service_excluded_from_employment:
+    - holds
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    error=(
+                        "Test case `case_one` execution failed: missing input "
+                        "`service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5` "
+                        "for entity `payment-1` over 2026-01-01..2026-12-31"
+                    )
+                )
+            }
+        )
+
+        changed = _complete_missing_imported_test_inputs(
+            rules_file=dependent,
+            test_file=dependent_test,
+            repo_path=policy_repo,
+            validation=validation,
+        )
+
+        assert changed is True
+        payload = yaml.safe_load(dependent_test.read_text())
+        payment_row = payload[0]["tables"]["Payment"][0]
+        assert payment_row[imported_ref] is True
+
     def test_repair_imported_test_inputs_writes_signed_manifest(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"
         imported = policy_repo / "statutes/26/1/h.yaml"


### PR DESCRIPTION
## Summary
- repair signed-apply imported input completion when validation reports a missing input for a concrete table entity row
- preserve the generated case-level input value when copying it into the table row
- bump axiom-encode to 0.2.182 and add a changelog entry

## Verification
- `uv run --extra dev python -m pytest tests/test_cli.py::TestApplyDependencyValidation::test_complete_missing_imported_test_inputs_adds_import_defaults tests/test_cli.py::TestApplyDependencyValidation::test_complete_missing_imported_test_inputs_adds_transitive_import_defaults tests/test_cli.py::TestApplyDependencyValidation::test_complete_missing_imported_test_inputs_adds_table_entity_defaults tests/test_cli.py::test_package_version_metadata_matches_pyproject`
- `uv run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py`
- `uv run python - <<'PY'` / `from axiom_encode import __version__; print(__version__)` -> `0.2.182`
- `git diff --check`

This unblocks generated `26 USC 3121(b)(15)` apply where imported `3121(y)` inputs need to live on `Payment` rows rather than only in the case-level input block.