### PR TITLE
Classify section 3121(c) PE oracle outputs

### DIFF
--- a/changelog.d/section-3121-c-oracle.fixed.md
+++ b/changelog.d/section-3121-c-oracle.fixed.md
@@ -1,0 +1,1 @@
+Classify section 3121(c) pay-period employment deeming outputs as PolicyEngine known-not-comparable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.182"
+version = "0.2.183"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.182"
+__version__ = "0.2.183"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9333,6 +9333,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(b) employment-definition child-fragment service-classification predicates as one-to-one variables. These legal intermediates determine whether service is employment for FICA before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/c#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(c) pay-period employment deeming predicates or thresholds as one-to-one variables. These legal intermediates determine whether service is employment for FICA before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/y#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -554,6 +554,11 @@ rules:
             "foreign_agricultural_worker_service_excluded_from_employment",
         ),
         (
+            "statutes/26/3121/c.yaml",
+            "us:statutes/26/3121/c#all_services_for_pay_period_deemed_employment",
+            "all_services_for_pay_period_deemed_employment",
+        ),
+        (
             "statutes/26/3121/y.yaml",
             "us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_is_employment",
             "transferred_federal_employee_international_organization_service_is_employment",
@@ -580,6 +585,27 @@ rules:
     assert report["status_counts"] == {"known_not_comparable": 1}
     item = report["items"][0]
     assert item["legal_id"] == legal_id
+    assert item["status"] == "known_not_comparable"
+
+
+def test_policyengine_coverage_classifies_3121_c_pay_period_parameter(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3121/c.yaml",
+        """format: rulespec/v1
+rules:
+  - name: pay_period_max_consecutive_days
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 31
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == "us:statutes/26/3121/c#pay_period_max_consecutive_days"
     assert item["status"] == "known_not_comparable"
 
 


### PR DESCRIPTION
## Summary
- classify section 3121(c) pay-period employment deeming outputs as PolicyEngine known-not-comparable
- add coverage for a generated 3121(c) derived predicate and pay-period parameter
- bump axiom-encode to 0.2.183 with a changelog fragment

## Verification
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev ruff check .
- uv run python -c "import yaml; yaml.safe_load(open('src/axiom_encode/oracles/policyengine/mappings/us.yaml'))"
- uv run python -c "import axiom_encode; print(axiom_encode.__version__)"
- git diff --check
- PE oracle coverage on generated 3121(c): 865 total, 225 comparable, 637 known-not-comparable, 3 legacy unmapped, 0 untested comparable