### PR TITLE
Classify section 3121(d) PE oracle outputs

### DIFF
--- a/changelog.d/section-3121-d-oracle.fixed.md
+++ b/changelog.d/section-3121-d-oracle.fixed.md
@@ -1,0 +1,1 @@
+Classify section 3121(d) employee-definition outputs as PolicyEngine known-not-comparable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.183"
+version = "0.2.184"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.183"
+__version__ = "0.2.184"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9339,6 +9339,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(c) pay-period employment deeming predicates or thresholds as one-to-one variables. These legal intermediates determine whether service is employment for FICA before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/d#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(d) employee-definition predicates as one-to-one variables. These legal classifications determine who is treated as an employee for FICA before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/y#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -559,6 +559,11 @@ rules:
             "all_services_for_pay_period_deemed_employment",
         ),
         (
+            "statutes/26/3121/d.yaml",
+            "us:statutes/26/3121/d#employee",
+            "employee",
+        ),
+        (
             "statutes/26/3121/y.yaml",
             "us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_is_employment",
             "transferred_federal_employee_international_organization_service_is_employment",


### PR DESCRIPTION
## Summary
- classify section 3121(d) employee-definition outputs as PolicyEngine known-not-comparable
- add focused coverage for the generated employee predicate
- bump axiom-encode to 0.2.184 with a changelog fragment

## Verification
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv tool run ruff check src/ tests/
- uv tool run ruff format --check src/ tests/
- uv run python -c "import yaml; yaml.safe_load(open('src/axiom_encode/oracles/policyengine/mappings/us.yaml'))"
- uv run python -c "import axiom_encode; print(axiom_encode.__version__)"
- git diff --check
- PE oracle coverage on generated 3121(d): 867 total, 225 comparable, 639 known-not-comparable, 3 legacy unmapped, 0 untested comparable