### PR TITLE
Classify section 3121(e) PE oracle outputs

### DIFF
--- a/changelog.d/section-3121-e-oracle.fixed.md
+++ b/changelog.d/section-3121-e-oracle.fixed.md
@@ -1,0 +1,1 @@
+Classified section 3121(e) FICA definition outputs as PolicyEngine known-not-comparable oracle outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.184"
+version = "0.2.185"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.184"
+__version__ = "0.2.185"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9345,6 +9345,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(d) employee-definition predicates as one-to-one variables. These legal classifications determine who is treated as an employee for FICA before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/e#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(e) State, United States, or citizenship definition predicates as one-to-one variables. These legal definitions support FICA employment and wage classifications before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/y#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -564,6 +564,11 @@ rules:
             "employee",
         ),
         (
+            "statutes/26/3121/e.yaml",
+            "us:statutes/26/3121/e#citizen_of_united_states_for_section",
+            "citizen_of_united_states_for_section",
+        ),
+        (
             "statutes/26/3121/y.yaml",
             "us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_is_employment",
             "transferred_federal_employee_international_organization_service_is_employment",


### PR DESCRIPTION
## Summary
- Classify `us:statutes/26/3121/e#...` FICA definition outputs as PolicyEngine known-not-comparable.
- Add a regression case for the generated 3121(e) citizenship definition output.
- Bump `axiom-encode` to `0.2.185` with a changelog fragment.

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv tool run ruff check src/ tests/`
- `uv tool run ruff format --check src/ tests/`
- `uv run python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('src/axiom_encode/oracles/policyengine/mappings/us.yaml').read_text()); import axiom_encode; print(axiom_encode.__version__)"`
- `git diff --check`

## Context
This unblocks the generated RuleSpec PR for 26 USC 3121(e), whose new `citizen_of_united_states_for_section` output is a legal definition predicate, not a one-to-one PolicyEngine tax variable.
