### PR TITLE
Handle nested same-section context references

### DIFF
--- a/changelog.d/same-section-nested-context.fixed.md
+++ b/changelog.d/same-section-nested-context.fixed.md
@@ -1,0 +1,1 @@
+Copied precise nested same-section RuleSpec context for references such as `subsection (a)(7)(B)` before falling back to broader subsection context, and only require same-section imports when the cited RuleSpec source exists locally.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.188"
+version = "0.2.189"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.188"
+__version__ = "0.2.189"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1953,23 +1953,36 @@ def _select_same_section_subsection_context_files(
     seen: set[Path] = set()
     for match in re.finditer(
         r"\bsubsection\s+\((?P<subsection>[A-Za-z0-9]+)\)"
+        r"(?P<tail>(?:\([A-Za-z0-9]+\))*)"
         r"(?:\s+of\s+this\s+section)?(?=\W|$)",
         source_text,
         flags=re.IGNORECASE,
     ):
-        subsection = match.group("subsection")
-        if subsection in parts.fragments:
-            continue
-        candidate_rel = citation_to_relative_rulespec_path(
-            CitationParts(parts.title, parts.section, (subsection,))
+        referenced_fragments = (
+            match.group("subsection"),
+            *re.findall(r"\(([A-Za-z0-9]+)\)", match.group("tail") or ""),
         )
-        if candidate_rel == target_rel:
+        if referenced_fragments[0] in parts.fragments:
             continue
-        candidate = policy_root / candidate_rel
-        resolved = candidate.resolve()
-        if candidate.exists() and resolved not in seen:
-            selected.append(candidate)
-            seen.add(resolved)
+        for length in range(len(referenced_fragments), 0, -1):
+            candidate_rel = citation_to_relative_rulespec_path(
+                CitationParts(
+                    parts.title,
+                    parts.section,
+                    referenced_fragments[:length],
+                )
+            )
+            if candidate_rel == target_rel:
+                continue
+            candidates = _cited_context_candidates(policy_root, candidate_rel)
+            if not candidates:
+                continue
+            for candidate in candidates:
+                resolved = candidate.resolve()
+                if resolved not in seen:
+                    selected.append(candidate)
+                    seen.add(resolved)
+            break
     return selected
 
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -10217,6 +10217,8 @@ def find_missing_same_section_subsection_import_issues(
         if subsection in current_fragments or subsection in seen:
             continue
         import_base = "/".join(["statutes", title, section, subsection])
+        if not _rulespec_path_or_child_exists_static(policy_repo_path, import_base):
+            continue
         if _imports_cover_path_static(
             imports,
             import_base,
@@ -10235,6 +10237,17 @@ def find_missing_same_section_subsection_import_issues(
             "subsection instead of modeling its requirements as a local fact."
         )
     return issues
+
+
+def _rulespec_path_or_child_exists_static(
+    policy_repo_path: Path,
+    import_base: str,
+) -> bool:
+    """Return whether a cited same-section RuleSpec source exists locally."""
+    relative = Path(import_base)
+    return (policy_repo_path / relative.with_suffix(".yaml")).exists() or (
+        policy_repo_path / relative
+    ).is_dir()
 
 
 def find_rule_name_path_suffix_issues(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -6735,6 +6735,52 @@ rules:
             copied_sources[str(context_test)]["kind"] == "implementation_test_context"
         )
 
+    def test_prepare_eval_workspace_adds_nested_same_section_context(self, tmp_path):
+        repo_root = tmp_path / "repos"
+        policy_repo_root = repo_root / "axiom-rules-engine"
+        policy_repo_root.mkdir(parents=True)
+        subsection_root = repo_root / "rulespec-us" / "statutes" / "26" / "3121" / "a"
+        subsection_root.mkdir(parents=True)
+        cap_file = subsection_root / "1.yaml"
+        domestic_file = subsection_root / "7.yaml"
+        domestic_test = subsection_root / "7.test.yaml"
+        cap_file.write_text("format: rulespec/v1\nrules: []\n")
+        domestic_file.write_text("format: rulespec/v1\nrules: []\n")
+        domestic_test.write_text("- name: domestic_service_case\n  period: 2026\n")
+
+        runner = parse_runner_spec("codex:gpt-5.4")
+        with patch(
+            "axiom_encode.harness.evals.select_context_files",
+            return_value=[],
+        ):
+            workspace = prepare_eval_workspace(
+                citation="26 USC 3121(i)",
+                runner=runner,
+                output_root=tmp_path / "out",
+                source_text=(
+                    "Wages shall be subject to the provisions of subsection "
+                    "(a)(1) of this section. Domestic service described in "
+                    "subsection (a)(7)(B) shall be computed to the nearest dollar."
+                ),
+                axiom_rules_path=policy_repo_root,
+                mode="repo-augmented",
+                extra_context_paths=[],
+            )
+
+        manifest = json.loads(workspace.manifest_file.read_text())
+        copied_sources = {
+            item["source_path"]: item for item in manifest["context_files"]
+        }
+        assert copied_sources[str(cap_file)]["kind"] == "implementation_precedent"
+        assert copied_sources[str(cap_file)]["import_path"] == "us:statutes/26/3121/a/1"
+        assert (
+            copied_sources[str(domestic_file)]["import_path"]
+            == "us:statutes/26/3121/a/7"
+        )
+        assert (
+            copied_sources[str(domestic_test)]["kind"] == "implementation_test_context"
+        )
+
     def test_prepare_eval_workspace_adds_cross_section_context(self, tmp_path):
         repo_root = tmp_path / "repos"
         policy_repo_root = repo_root / "axiom-rules-engine"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5454,6 +5454,9 @@ rules:
 
 def test_same_section_subsection_reference_requires_import(tmp_path):
     repo = tmp_path / "rulespec-us"
+    cited_file = repo / "statutes" / "7" / "2015" / "e.yaml"
+    cited_file.parent.mkdir(parents=True)
+    cited_file.write_text("format: rulespec/v1\nrules: []\n")
     rules_file = repo / "statutes" / "7" / "2015" / "d" / "2" / "C.yaml"
     rules_file.parent.mkdir(parents=True)
     rules_file.write_text(
@@ -5488,6 +5491,9 @@ rules:
 
 def test_same_section_under_subsection_reference_requires_import(tmp_path):
     repo = tmp_path / "rulespec-us"
+    cited_file = repo / "statutes" / "26" / "3121" / "y.yaml"
+    cited_file.parent.mkdir(parents=True)
+    cited_file.write_text("format: rulespec/v1\nrules: []\n")
     rules_file = repo / "statutes" / "26" / "3121" / "b" / "15.yaml"
     rules_file.parent.mkdir(parents=True)
     rules_file.write_text(
@@ -5519,6 +5525,37 @@ rules:
     assert len(issues) == 1
     assert "Same-section subsection import missing" in issues[0]
     assert "statutes/26/3121/y" in issues[0]
+
+
+def test_same_section_subsection_reference_allows_missing_source(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "3121" / "i.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    Service applies unless the provisions of subsection (m)(1) are unavailable.
+rules:
+  - name: service_applies_until_missing_subsection_boundary
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: service_applies_and_subsection_m_boundary_not_met
+"""
+    )
+
+    assert (
+        find_missing_same_section_subsection_import_issues(
+            rules_file.read_text(),
+            rules_file=rules_file,
+            policy_repo_path=repo,
+        )
+        == []
+    )
 
 
 def test_same_section_subsection_reference_allows_import(tmp_path):


### PR DESCRIPTION
## Summary
- Select precise nested same-section RuleSpec context for references such as `subsection (a)(7)(B)`, falling back to the nearest encoded ancestor when the exact child is not encoded.
- Keep the same-section missing-import guard strict for cited RuleSpec sources that exist locally, but do not require imports for same-section sources that have not been encoded yet.
- Bump `axiom-encode` to `0.2.189` with a changelog fragment.

## Validation
- `uv run --extra dev python -m pytest tests/test_evals.py -q -k "nested_same_section_context or same_section_subsection_context or same_section_under_subsection_context"`
- `uv run --extra dev python -m pytest tests/test_rulespec_validation.py -q -k "same_section_subsection_reference"`
- `uv tool run ruff check src/ tests/`
- `uv tool run ruff format --check src/ tests/`
- `uv run python -c "import axiom_encode; print(axiom_encode.__version__)"`
- `git diff --check`

## Context
This came up while trying to encode 26 USC 3121(i). The selector now provides the existing 3121(a)(1) and 3121(a)(7) context, and the validator no longer blocks references to unencoded 3121(m)/3121(p)/3121(r) sources. 3121(i) still needs a follow-up repair because the model currently keeps local `before_subsection_a_1` outputs instead of composing the available 3121(a)(1) cap.
