### PR TITLE
Classify section 3121(j) PE oracle outputs

### DIFF
--- a/changelog.d/section-3121-j-oracle.fixed.md
+++ b/changelog.d/section-3121-j-oracle.fixed.md
@@ -1,0 +1,1 @@
+Classified section 3121(j) FICA covered-transportation-service definition outputs as PolicyEngine known-not-comparable oracle outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.189"
+version = "0.2.190"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.189"
+__version__ = "0.2.190"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9369,6 +9369,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(h) American-employer definition predicates or source-specific partnership thresholds as one-to-one variables. These legal definitions support FICA employment and wage classifications before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/j#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(j) covered-transportation-service definition predicates as one-to-one variables. These legal definitions support FICA employment classifications for state and political-subdivision transportation systems before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/y#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -584,6 +584,11 @@ rules:
             "american_employer",
         ),
         (
+            "statutes/26/3121/j.yaml",
+            "us:statutes/26/3121/j#covered_transportation_service",
+            "covered_transportation_service",
+        ),
+        (
             "statutes/26/3121/y.yaml",
             "us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_is_employment",
             "transferred_federal_employee_international_organization_service_is_employment",


### PR DESCRIPTION
## Summary
- Classify `us:statutes/26/3121/j#...` covered-transportation-service definition outputs as PolicyEngine known-not-comparable.
- Add a regression case for a generated 3121(j) covered-transportation-service output.
- Bump `axiom-encode` to `0.2.190` with a changelog fragment.

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv tool run ruff check src/ tests/`
- `uv tool run ruff format --check src/ tests/`
- `uv run python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('src/axiom_encode/oracles/policyengine/mappings/us.yaml').read_text()); import axiom_encode; print(axiom_encode.__version__)"`
- `git diff --check`

## Context
This unblocks the generated RuleSpec PR for 26 USC 3121(j), whose transportation-service outputs are FICA employment-classification definitions rather than one-to-one PolicyEngine tax variables.
