### PR TITLE
Split generated tests with mixed output entities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.190"
+version = "0.2.191"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.190"
+__version__ = "0.2.191"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -13698,6 +13698,24 @@ def _validate_generated_encoding_in_policy_overlay(
                     dependents=dependents,
                 )
                 continue
+            mixed_derived_entity_repairs = _repair_mixed_derived_entity_output_tests(
+                rules_file=overlay_target,
+                test_file=_rulespec_test_path(overlay_target),
+                repo_path=overlay_repo,
+                relative_output=relative_output,
+            )
+            if mixed_derived_entity_repairs:
+                test_path = _rulespec_test_path(overlay_target)
+                supplemental_files[test_path.relative_to(overlay_repo)] = (
+                    test_path.read_text()
+                )
+                validations = _validate_overlay_files(
+                    pipeline,
+                    dependent_pipeline=dependent_pipeline,
+                    overlay_target=overlay_target,
+                    dependents=dependents,
+                )
+                continue
             target_validation = next(
                 (
                     validation
@@ -14202,6 +14220,125 @@ def _repair_mixed_scalar_output_tests(
         return []
     test_file.write_text(yaml.safe_dump(repaired_cases, sort_keys=False))
     return repaired_names
+
+
+def _repair_mixed_derived_entity_output_tests(
+    *,
+    rules_file: Path,
+    test_file: Path,
+    repo_path: Path,
+    relative_output: Path,
+) -> list[str]:
+    """Split companion tests whose derived outputs span multiple entities."""
+    if not test_file.exists():
+        return []
+    try:
+        rules_document = yaml.safe_load(rules_file.read_text()) or {}
+        test_cases = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(rules_document, dict) or not isinstance(test_cases, list):
+        return []
+
+    target_base = (
+        f"{_repo_jurisdiction_prefix(repo_path)}:"
+        f"{_relative_rulespec_import_target(relative_output)}"
+    )
+    derived_entity_by_output: dict[str, str] = {}
+    for rule in rules_document.get("rules") or []:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "derived":
+            continue
+        entity = str(rule.get("entity") or "Case").strip() or "Case"
+        for key in _local_rulespec_output_keys(
+            rule,
+            target_base=target_base,
+            repo_path=repo_path,
+        ):
+            derived_entity_by_output[key] = entity
+    if not derived_entity_by_output:
+        return []
+
+    repaired_cases: list[object] = []
+    repaired_names: list[str] = []
+    existing_names = {
+        str(case.get("name") or "") for case in test_cases if isinstance(case, dict)
+    }
+    for case in test_cases:
+        if not isinstance(case, dict):
+            repaired_cases.append(case)
+            continue
+        output = case.get("output")
+        if not isinstance(output, dict):
+            repaired_cases.append(case)
+            continue
+
+        entity_order: list[str] = []
+        for key in output:
+            entity = derived_entity_by_output.get(str(key))
+            if entity is not None and entity not in entity_order:
+                entity_order.append(entity)
+        if len(entity_order) <= 1:
+            repaired_cases.append(case)
+            continue
+
+        case_name = str(case.get("name") or "case").strip() or "case"
+        for index, entity in enumerate(entity_order):
+            entity_output = {
+                key: value
+                for key, value in output.items()
+                if derived_entity_by_output.get(str(key)) == entity
+            }
+            if index == 0:
+                for key, value in output.items():
+                    if str(key) not in derived_entity_by_output:
+                        entity_output[key] = value
+                repaired_case = dict(case)
+                repaired_case["output"] = entity_output
+                repaired_cases.append(repaired_case)
+                continue
+
+            derived_case_name = _unique_test_case_name(
+                f"{case_name}_{_test_case_entity_suffix(entity)}_outputs",
+                existing_names,
+            )
+            existing_names.add(derived_case_name)
+            derived_case = dict(case)
+            derived_case["name"] = derived_case_name
+            derived_case["period"] = copy.deepcopy(case.get("period"))
+            derived_case["input"] = copy.deepcopy(case.get("input", {}))
+            derived_case["output"] = entity_output
+            repaired_cases.append(derived_case)
+        repaired_names.append(case_name)
+
+    if not repaired_names:
+        return []
+    test_file.write_text(yaml.safe_dump(repaired_cases, sort_keys=False))
+    return repaired_names
+
+
+def _local_rulespec_output_keys(
+    rule: dict[str, Any],
+    *,
+    target_base: str,
+    repo_path: Path,
+) -> set[str]:
+    name = str(rule.get("name") or "").strip()
+    keys = set(_rulespec_public_item_keys(rule, policy_repo_path=repo_path))
+    if name:
+        keys.add(name)
+        keys.add(f"{target_base}#{name}")
+    item_id = str(rule.get("id") or "").strip()
+    if item_id:
+        keys.add(item_id)
+    return {key for key in keys if key}
+
+
+def _test_case_entity_suffix(entity: str) -> str:
+    suffix = re.sub(r"[^a-z0-9]+", "_", entity.strip().lower())
+    suffix = suffix.strip("_")
+    return suffix or "entity"
 
 
 def _scalar_parameter_test_expected_value(value: Any) -> Any:

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3136,7 +3136,7 @@ Test file rules:
 - Never turn an imported derived rule into a fabricated `#input.<same_rule_name>` key. For example, use `<jurisdiction>:<repo-path>#imported_judgment: holds` or `not_holds`, not `<jurisdiction>:<repo-path>#input.imported_judgment`.
 - Do not invent `#input` keys for imported files. Use only the bare fact names that the imported file's formulas actually reference, or mirror the imported file's companion `.test.yaml` input pattern when it is supplied in context. If that imported output is driven by an upstream structural relation, set the upstream `#relation.<name>` rows used by the companion test instead of creating a local input under the imported file.
 - A `#relation.<name>` input value must be a YAML list of row mappings. Never use a scalar row such as `- true`. Bad: `<jurisdiction>:<repo-path>#relation.member_of_household: [- true]`. Good: `<jurisdiction>:<repo-path>#relation.member_of_household:` followed by `- <jurisdiction>:<repo-path>#input.member_has_required_status: true`.
-- Each `.test.yaml` case may assert derived outputs for only one entity type. If a module defines both `Person` and `TaxUnit` outputs, create separate cases: `Person` cases set person facts at the top level and assert person outputs; `TaxUnit` cases use relation rows to supply person facts and assert only tax-unit outputs. Do not assert relation-child outputs in the parent entity's case.
+- Each `.test.yaml` case may assert derived outputs for only one entity type. If a module defines outputs on multiple entities, create separate cases for each entity pair, such as `Person`/`TaxUnit`, `Person`/`Employer`, or `Employer`/`Payment`. For example: `Person` cases set person facts at the top level and assert person outputs; `TaxUnit` cases use relation rows to supply person facts and assert only tax-unit outputs. Do not assert relation-child outputs in the parent entity's case.
 - Use `holds` and `not_holds` for actual `dtype: Judgment` rule keys in test inputs and outputs; do not use YAML booleans for Judgment rule values.
 - Use YAML booleans `true` and `false` for local factual `#input.<fact>` keys referenced directly by formulas.
 - For proration tests with a source-stated denominator, choose input amounts divisible by that denominator so expected outputs are exact decimals, not rounded approximations. For example, if the denominator is 365, use a base amount like 36500 so `36500 * 182 / 365 = 18200`.
@@ -3683,7 +3683,9 @@ RuleSpec requirements:
   leave scalar parameters, helper parameters, or helper derived rules
   unasserted.
 - Each `.test.yaml` case may assert derived outputs for only one entity type. If
-  a module defines both `Person` and `TaxUnit` outputs, create separate cases:
+  a module defines outputs on multiple entities, create separate cases for each
+  entity pair, such as `Person`/`TaxUnit`, `Person`/`Employer`, or
+  `Employer`/`Payment`. For example:
   `Person` cases set person facts at the top level and assert person outputs;
   `TaxUnit` cases use relation rows to supply person facts and assert only
   tax-unit outputs. Do not assert relation-child outputs in the parent entity's

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -537,7 +537,9 @@ Hard requirements:
   leave scalar parameters, helper parameters, or helper derived rules
   unasserted.
 - Each `.test.yaml` case may assert derived outputs for only one entity type. If
-  a module defines both `Person` and `TaxUnit` outputs, create separate cases:
+  a module defines outputs on multiple entities, create separate cases for each
+  entity pair, such as `Person`/`TaxUnit`, `Person`/`Employer`, or
+  `Employer`/`Payment`. For example:
   `Person` cases set person facts at the top level and assert person outputs;
   `TaxUnit` cases use relation rows to supply person facts and assert only
   tax-unit outputs. Do not assert relation-child outputs in the parent entity's

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,6 +43,7 @@ from axiom_encode.cli import (
     _repair_generated_import_symbol_near_misses,
     _repair_input_field_accesses_in_formulas,
     _repair_missing_source_proof_atoms,
+    _repair_mixed_derived_entity_output_tests,
     _repair_mixed_scalar_output_tests,
     _repair_person_scoped_definition_entities,
     _repair_section_151_imports,
@@ -6187,6 +6188,99 @@ rules:
         assert cases[1]["output"] == {
             "us:statutes/26/3121/a/7#cash_nontrade_service_annual_threshold": 100
         }
+
+    def test_mixed_derived_entity_output_test_repair_splits_entity_outputs(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        rules_file = policy_repo / "statutes/26/3121/l.yaml"
+        test_file = policy_repo / "statutes/26/3121/l.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: agreement_covers_foreign_affiliate_service
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: employee_is_citizen_or_resident_of_united_states
+  - name: termination_of_subsection_l_agreement_prohibited
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: agreement_under_subsection_l
+  - name: overpayment_claim_filing_limit_years
+    kind: parameter
+    dtype: Number
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 2
+"""
+        )
+        test_file.write_text(
+            """- name: excluded_service_and_unadjustable_overpayment
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/l#input.employee_is_citizen_or_resident_of_united_states: false
+    us:statutes/26/3121/l#input.agreement_under_subsection_l: true
+  output:
+    us:statutes/26/3121/l#agreement_covers_foreign_affiliate_service: not_holds
+    us:statutes/26/3121/l#termination_of_subsection_l_agreement_prohibited: holds
+    us:statutes/26/3121/l#overpayment_claim_filing_limit_years: 2
+"""
+        )
+
+        repaired = _repair_mixed_derived_entity_output_tests(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=policy_repo,
+            relative_output=Path("statutes/26/3121/l.yaml"),
+        )
+
+        cases = yaml.safe_load(test_file.read_text())
+        assert repaired == ["excluded_service_and_unadjustable_overpayment"]
+        assert cases == [
+            {
+                "name": "excluded_service_and_unadjustable_overpayment",
+                "period": {
+                    "period_kind": "tax_year",
+                    "start": "2026-01-01",
+                    "end": "2026-12-31",
+                },
+                "input": {
+                    "us:statutes/26/3121/l#input.employee_is_citizen_or_resident_of_united_states": False,
+                    "us:statutes/26/3121/l#input.agreement_under_subsection_l": True,
+                },
+                "output": {
+                    "us:statutes/26/3121/l#agreement_covers_foreign_affiliate_service": "not_holds",
+                    "us:statutes/26/3121/l#overpayment_claim_filing_limit_years": 2,
+                },
+            },
+            {
+                "name": "excluded_service_and_unadjustable_overpayment_employer_outputs",
+                "period": {
+                    "period_kind": "tax_year",
+                    "start": "2026-01-01",
+                    "end": "2026-12-31",
+                },
+                "input": {
+                    "us:statutes/26/3121/l#input.employee_is_citizen_or_resident_of_united_states": False,
+                    "us:statutes/26/3121/l#input.agreement_under_subsection_l": True,
+                },
+                "output": {
+                    "us:statutes/26/3121/l#termination_of_subsection_l_agreement_prohibited": "holds"
+                },
+            },
+        ]
 
 
 class TestGuardGenerated:


### PR DESCRIPTION
## Summary
- Add an apply-time repair that splits generated companion test cases when their derived outputs span multiple RuleSpec entities.
- Strengthen encoder prompt/test guidance so mixed entity examples are not limited to Person/TaxUnit.
- Bump axiom-encode to 0.2.191.

## Context
- `26 USC 3121(l)` generation exposed this: one generated case asserted both Person and Employer outputs, which the validator correctly rejected.
- This keeps the fix in the encoder path instead of manually editing generated RuleSpec artifacts.

## Verification
- `uv run --extra dev python -m pytest tests/test_cli.py -q -k "package_version_metadata_matches_pyproject or mixed_derived_entity_output_test_repair or mixed_scalar_output_test_repair or remove_cross_module_dependent_test_outputs"`
- `uv tool run ruff check src/ tests/`
- `uv tool run ruff format --check src/ tests/`
- `uv run python -c "import axiom_encode; print(axiom_encode.__version__)"`
- `git diff --check`
