### PR TITLE
Classify section 3121(l) PE oracle outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.191"
+version = "0.2.192"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.191"
+__version__ = "0.2.192"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9375,6 +9375,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(j) covered-transportation-service definition predicates as one-to-one variables. These legal definitions support FICA employment classifications for state and political-subdivision transportation systems before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/l#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(l) foreign-affiliate agreement predicates, agreement effective-period rules, or source-specific thresholds as one-to-one variables. These legal definitions support FICA wage and employment classifications for foreign-affiliate service before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/y#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -589,6 +589,11 @@ rules:
             "covered_transportation_service",
         ),
         (
+            "statutes/26/3121/l.yaml",
+            "us:statutes/26/3121/l#foreign_affiliate",
+            "foreign_affiliate",
+        ),
+        (
             "statutes/26/3121/y.yaml",
             "us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_is_employment",
             "transferred_federal_employee_international_organization_service_is_employment",


### PR DESCRIPTION
## Summary
- Classify generated 26 USC 3121(l) foreign-affiliate agreement outputs as known-not-comparable for the PolicyEngine tax oracle.
- Add a regression case for the 3121(l) prefix mapping.
- Bump axiom-encode to 0.2.192.

## Context
- Generated 3121(l) outputs are legal predicates, agreement timing rules, and source-specific thresholds. PolicyEngine does not expose these as one-to-one outputs; they support downstream FICA wage/employment classifications.

## Verification
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv tool run ruff check src/ tests/`
- `uv tool run ruff format --check src/ tests/`
- `uv run python -c "import axiom_encode; print(axiom_encode.__version__)"`
- `git diff --check`
- 3121(l) RuleSpec oracle coverage with this mapping: 899 total outputs, 225 comparable, 671 known-not-comparable, 3 legacy unmapped, 0 untested comparable.
