### PR TITLE
Allow pure notwithstanding subsection overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.192"
+version = "0.2.193"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.192"
+__version__ = "0.2.193"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3709,12 +3709,14 @@ RuleSpec requirements:
 - Preserve existing or copied `kind: source_relation` records unless `./source.txt` proves the legal/provenance edge is wrong.
 - For state-set standards, allowances, thresholds, or options implementing federal delegation, include `source_relation.value` pointing to the local executable RuleSpec output and `source_relation.basis.delegation` when context identifies the upstream delegated slot.
 - When the source says a value is determined `in accordance with section X`, emit the upstream import instead of restating the concept locally when that import target is available.
-- When the source uses `except`, `unless`, or `notwithstanding` with cited
-  sections or same-section subsections, do not create local `section_...` or
-  `subsection_...` inputs for those cited sources. Import the cited RuleSpec
-  source when it exists; if the target source is needed but unavailable, stop
-  with an explicit missing-upstream/dependency request instead of encoding an
-  opaque placeholder.
+- When the source uses `except` or `unless` with cited sections or same-section
+  subsections, do not create local `section_...` or `subsection_...` inputs for
+  those cited sources. Import the cited RuleSpec source when it exists; if the
+  target source is needed but unavailable, stop with an explicit
+  missing-upstream/dependency request instead of encoding an opaque placeholder.
+- A pure `notwithstanding subsection ...` override does not require importing
+  the overridden subsection unless the formula actually needs that cited
+  subsection's computed output.
 - If the cited same-section subsection is supplied in context as a RuleSpec file, add an `imports:` entry for that file and reference its exported rule; do not summarize the cited subsection into a local fact like `person_meets_...requirements`.
 - Do not copy the body of a cited cross-reference provision into this module's `summary` or re-encode that cited provision locally. Keep this module scoped to the requested citation and import the cited provision instead.
 - Do not fabricate sibling-file imports, do not guess unavailable import targets, and do not invent `import` statements or `imports:` blocks for uncopied same-instrument provisions.

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -10190,7 +10190,7 @@ def find_missing_same_section_subsection_import_issues(
     """Require imports for cited same-section subsections used as carve-outs."""
     source_text = extract_embedded_source_text(content)
     if not source_text or not re.search(
-        r"\b(?:except|unless|notwithstanding)\b",
+        r"\b(?:except|unless)\b",
         source_text,
         flags=re.IGNORECASE,
     ):

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -609,12 +609,15 @@ Hard requirements:
   one aggregate fact such as `sections_..._do_not_preclude...`. Encode or
   import each cited exception separately, then combine them in a helper if
   useful.
-- When an exception, exclusion, `unless`, or `notwithstanding` clause cites
-  another legal section or same-section subsection, do not create a local
+- When an exception, exclusion, or `unless` clause cites another legal section
+  or same-section subsection, do not create a local
   `section_...` or `subsection_...` placeholder input for that cited source.
   Import the cited RuleSpec source when it exists; if that upstream source is
   required but unavailable, stop with a missing-upstream/dependency request
   rather than encoding an opaque local fact.
+- A pure `notwithstanding subsection ...` override does not require importing
+  the overridden subsection unless the formula actually needs that cited
+  subsection's computed output.
 - If the cited same-section subsection is supplied in context as a RuleSpec
   file, add an `imports:` entry for that file and reference its exported rule;
   do not summarize the cited subsection into a local fact like

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5527,6 +5527,42 @@ rules:
     assert "statutes/26/3121/y" in issues[0]
 
 
+def test_same_section_notwithstanding_override_does_not_require_import(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    cited_dir = repo / "statutes" / "26" / "3121" / "b"
+    cited_dir.mkdir(parents=True)
+    (cited_dir / "1.yaml").write_text("format: rulespec/v1\nrules: []\n")
+    rules_file = repo / "statutes" / "26" / "3121" / "m.yaml"
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    The term employment shall, notwithstanding the provisions of subsection (b)
+    of this section, include service performed by an individual as a member of a
+    uniformed service on active duty.
+rules:
+  - name: uniformed_service_included_in_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: service_performed_by_individual_as_member_of_uniformed_service_on_active_duty
+"""
+    )
+
+    assert (
+        find_missing_same_section_subsection_import_issues(
+            rules_file.read_text(),
+            rules_file=rules_file,
+            policy_repo_path=repo,
+        )
+        == []
+    )
+
+
 def test_same_section_subsection_reference_allows_missing_source(tmp_path):
     repo = tmp_path / "rulespec-us"
     rules_file = repo / "statutes" / "26" / "3121" / "i.yaml"


### PR DESCRIPTION
## Summary
- Allow pure `notwithstanding subsection ...` override citations without requiring same-section imports.
- Keep import requirements for same-section `except` and `unless` carve-outs.
- Update encoder prompt guidance and bump axiom-encode to 0.2.193.

## Context
- `26 USC 3121(m)` says employment includes uniformed-service work notwithstanding section 3121(b). That override does not depend on computing 3121(b), and there is no aggregate `3121/b.yaml` to import.
- The previous validator treated the override as a missing import and blocked generated apply.

## Verification
- `uv run --extra dev python -m pytest tests/test_rulespec_validation.py -q -k "same_section_subsection_reference_requires_import or same_section_under_subsection_reference_requires_import or same_section_notwithstanding_override_does_not_require_import"`
- `uv tool run ruff check src/ tests/`
- `uv tool run ruff format --check src/ tests/`
- `uv run python -c "import axiom_encode; print(axiom_encode.__version__)"`
- `git diff --check`
