### PR TITLE
Localize same-section import trigger detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.193"
+version = "0.2.194"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.193"
+__version__ = "0.2.194"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -10213,6 +10213,8 @@ def find_missing_same_section_subsection_import_issues(
         source_text,
         flags=re.IGNORECASE,
     ):
+        if not _same_section_subsection_citation_requires_import(source_text, match):
+            continue
         subsection = match.group("subsection")
         if subsection in current_fragments or subsection in seen:
             continue
@@ -10237,6 +10239,28 @@ def find_missing_same_section_subsection_import_issues(
             "subsection instead of modeling its requirements as a local fact."
         )
     return issues
+
+
+def _same_section_subsection_citation_requires_import(
+    source_text: str,
+    match: re.Match[str],
+) -> bool:
+    """Return whether a same-section citation is locally an exception dependency."""
+    sentence_start = max(
+        source_text.rfind(".", 0, match.start()),
+        source_text.rfind(";", 0, match.start()),
+    )
+    prefix = source_text[sentence_start + 1 : match.start()]
+    triggers = list(
+        re.finditer(
+            r"\b(?:except|unless|notwithstanding)\b",
+            prefix,
+            flags=re.IGNORECASE,
+        )
+    )
+    if not triggers:
+        return False
+    return triggers[-1].group(0).lower() in {"except", "unless"}
 
 
 def _rulespec_path_or_child_exists_static(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5540,7 +5540,10 @@ module:
   summary: |-
     The term employment shall, notwithstanding the provisions of subsection (b)
     of this section, include service performed by an individual as a member of a
-    uniformed service on active duty.
+    uniformed service on active duty. Active duty means active duty as described
+    in paragraph (21) of section 101 of title 38, except that it shall also
+    include active duty for training as described in paragraph (22) of that
+    section.
 rules:
   - name: uniformed_service_included_in_employment
     kind: derived


### PR DESCRIPTION
## Summary
- Localize same-section import detection to the trigger nearest each cited subsection.
- Keep `except`/`unless` same-section citations import-required, while allowing citations locally governed by `notwithstanding` even when another exception phrase appears elsewhere in the source.
- Bump axiom-encode to 0.2.194.

## Context
- `26 USC 3121(m)` includes employment notwithstanding subsection 3121(b), then separately says active duty includes active duty for training “except that ...”. The source-level exception phrase caused the earlier validator to still flag the 3121(b) override.

## Verification
- `uv run --extra dev python -m pytest tests/test_rulespec_validation.py -q -k "same_section_subsection_reference_requires_import or same_section_under_subsection_reference_requires_import or same_section_notwithstanding_override_does_not_require_import"`
- `uv tool run ruff check src/ tests/`
- `uv tool run ruff format --check src/ tests/`
- `uv run python -c "import axiom_encode; print(axiom_encode.__version__)"`
- `git diff --check`
- Smoke validation of generated 3121(m) YAML/test copy passed under this branch.
