### PR TITLE
Classify 3121(p) as PE not comparable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.196"
+version = "0.2.197"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.196"
+__version__ = "0.2.197"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9393,6 +9393,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(o) crew-leader definition predicates or deemed-employee relationship surfaces as one-to-one variables. These legal definitions support FICA employment classifications for agricultural crew leaders and furnished workers before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/p#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(p) Peace Corps volunteer-service employment-inclusion predicates as one-to-one variables. These legal definitions support FICA employment classifications before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/y#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -604,6 +604,11 @@ rules:
             "crew_leader",
         ),
         (
+            "statutes/26/3121/p.yaml",
+            "us:statutes/26/3121/p#peace_corps_volunteer_service_constitutes_employment",
+            "peace_corps_volunteer_service_constitutes_employment",
+        ),
+        (
             "statutes/26/3121/y.yaml",
             "us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_is_employment",
             "transferred_federal_employee_international_organization_service_is_employment",


### PR DESCRIPTION
## Summary
- Adds a PolicyEngine oracle `not_comparable` prefix for `us:statutes/26/3121/p#`.
- Covers Peace Corps volunteer-service employment-inclusion predicates, which PolicyEngine does not expose as one-to-one tax variables.
- Bumps `axiom-encode` to `0.2.197`.

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k '3121_employment_exclusions'`
- `uv tool run ruff check src/ tests/`
- `uv tool run ruff format --check src/ tests/`
- `uv run python -c "import axiom_encode; print(axiom_encode.__version__)"`
- `git diff --check`
- Real coverage smoke on generated `3121(p)`: 905 total outputs, 225 comparable, 677 known-not-comparable, 3 legacy unmapped, 0 untested comparable
