### PR TITLE
Classify 3121(q) tip remuneration as PE not comparable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.197"
+version = "0.2.198"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.197"
+__version__ = "0.2.198"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9399,6 +9399,14 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(p) Peace Corps volunteer-service employment-inclusion predicates as one-to-one variables. These legal definitions support FICA employment classifications before downstream payroll-tax comparisons.
 
+  - legal_id: us:statutes/26/3121/q#tip_remuneration_for_employment
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: tip_income
+    candidate_priority: P4
+    rationale: PolicyEngine has a generic annual tip_income input for deduction and reform surfaces, and payroll taxes flow through employment-income wage aggregates. It does not expose the section 3121(q) month-level intermediate that treats tips received in employment as remuneration for FICA employment.
+
   - legal_id_prefix: us:statutes/26/3121/y#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -609,6 +609,11 @@ rules:
             "peace_corps_volunteer_service_constitutes_employment",
         ),
         (
+            "statutes/26/3121/q.yaml",
+            "us:statutes/26/3121/q#tip_remuneration_for_employment",
+            "tip_remuneration_for_employment",
+        ),
+        (
             "statutes/26/3121/y.yaml",
             "us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_is_employment",
             "transferred_federal_employee_international_organization_service_is_employment",


### PR DESCRIPTION
## Summary
- Classify `us:statutes/26/3121/q#tip_remuneration_for_employment` as PE known-not-comparable.
- Add a PE coverage regression for the generated 3121(q) output.
- Bump axiom-encode to `0.2.198`.

## Rationale
PolicyEngine has a generic annual `tip_income` input for deduction and reform surfaces, while payroll taxes flow through `irs_employment_income` / `payroll_tax_gross_wages`. It does not expose the section 3121(q) month-level intermediate treating tips received in employment as FICA remuneration.

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k 3121_employment_exclusions` (15 passed)
- `uv tool run ruff check src/ tests/`
- `uv tool run ruff format --check src/ tests/`
- `git diff --check`
- Coverage smoke on generated 3121(q): 906 outputs, 225 comparable, 678 known-not-comparable, 3 legacy unmapped, 0 untested comparables