### PR TITLE
Classify all 3121(q) outputs as PE not comparable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.198"
+version = "0.2.199"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.198"
+__version__ = "0.2.199"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9399,13 +9399,11 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(p) Peace Corps volunteer-service employment-inclusion predicates as one-to-one variables. These legal definitions support FICA employment classifications before downstream payroll-tax comparisons.
 
-  - legal_id: us:statutes/26/3121/q#tip_remuneration_for_employment
+  - legal_id_prefix: us:statutes/26/3121/q#
     country: us
     program: tax
     mapping_type: not_comparable
-    policyengine_variable: tip_income
-    candidate_priority: P4
-    rationale: PolicyEngine has a generic annual tip_income input for deduction and reform surfaces, and payroll taxes flow through employment-income wage aggregates. It does not expose the section 3121(q) month-level intermediate that treats tips received in employment as remuneration for FICA employment.
+    rationale: PolicyEngine has a generic annual tip_income input for deduction and reform surfaces, and payroll taxes flow through employment-income wage aggregates. It does not expose section 3121(q) tip-remuneration, employer-deemed-payment, or statement and notice-and-demand timing intermediates as one-to-one variables.
 
   - legal_id_prefix: us:statutes/26/3121/y#
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -610,8 +610,8 @@ rules:
         ),
         (
             "statutes/26/3121/q.yaml",
-            "us:statutes/26/3121/q#tip_remuneration_for_employment",
-            "tip_remuneration_for_employment",
+            "us:statutes/26/3121/q#tips_considered_remuneration_for_employment",
+            "tips_considered_remuneration_for_employment",
         ),
         (
             "statutes/26/3121/y.yaml",


### PR DESCRIPTION
## Summary
- Broaden the 3121(q) PE oracle classification from one exact output to a section prefix.
- Update the regression fixture to use the richer generated 3121(q) output name.
- Bump axiom-encode to `0.2.199`.

## Rationale
The fresh `gpt-5.5` generation for 3121(q) emits multiple legal intermediates for tip remuneration, employer deemed payment, statement timing, and notice-and-demand timing. PolicyEngine does not expose those as one-to-one payroll tax oracle variables; payroll taxes flow through wage aggregates instead.

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k 3121_employment_exclusions` (15 passed)
- `uv tool run ruff check src/ tests/`
- `uv tool run ruff format --check src/ tests/`
- `git diff --check`
- Coverage smoke on generated 3121(q): 910 outputs, 225 comparable, 682 known-not-comparable, 3 legacy unmapped, 0 untested comparables