### PR TITLE
Classify 3121(r) religious order election as PE not comparable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.199"
+version = "0.2.200"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.199"
+__version__ = "0.2.200"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9405,6 +9405,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine has a generic annual tip_income input for deduction and reform surfaces, and payroll taxes flow through employment-income wage aggregates. It does not expose section 3121(q) tip-remuneration, employer-deemed-payment, or statement and notice-and-demand timing intermediates as one-to-one variables.
 
+  - legal_id_prefix: us:statutes/26/3121/r#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(r) religious-order coverage-election certificates, vow-of-poverty member predicates, retroactive effective-period limits, or assessment timing intermediates as one-to-one payroll tax variables. These definitions determine FICA coverage before downstream wage and tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/y#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -614,6 +614,11 @@ rules:
             "tips_considered_remuneration_for_employment",
         ),
         (
+            "statutes/26/3121/r.yaml",
+            "us:statutes/26/3121/r#member",
+            "member",
+        ),
+        (
             "statutes/26/3121/y.yaml",
             "us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_is_employment",
             "transferred_federal_employee_international_organization_service_is_employment",


### PR DESCRIPTION
## Summary
- Classify section 3121(r) religious-order coverage-election outputs as PE known-not-comparable.
- Add a regression fixture for the generated 3121(r) `member` output.
- Bump axiom-encode to `0.2.200`.

## Rationale
PolicyEngine does not expose section 3121(r) religious-order coverage-election certificates, vow-of-poverty member predicates, retroactive effective-period limits, or assessment timing intermediates as one-to-one payroll tax variables. These definitions determine FICA coverage before downstream wage and tax comparisons.

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k 3121_employment_exclusions` (16 passed)
- `uv tool run ruff check src/ tests/`
- `uv tool run ruff format --check src/ tests/`
- `git diff --check`
- Coverage smoke on generated 3121(r): 917 outputs, 225 comparable, 689 known-not-comparable, 3 legacy unmapped, 0 untested comparables