### PR TITLE
Reduce source quoting in encoder outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.200"
+version = "0.2.201"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.200"
+__version__ = "0.2.201"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -153,6 +153,41 @@ def _is_empty_nonassertable_artifact(content: str) -> bool:
     return status in {"deferred", "entity_not_supported"} and not payload.get("rules")
 
 
+def _extract_proof_source_excerpt_text(content: str) -> str:
+    """Return source excerpts from proof atoms for numeric grounding."""
+    with contextlib.suppress(ValueError, TypeError, yaml.YAMLError):
+        payload = yaml.safe_load(content)
+        if not isinstance(payload, dict):
+            return ""
+        rules = payload.get("rules")
+        if not isinstance(rules, list):
+            return ""
+        excerpts: list[str] = []
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            metadata = rule.get("metadata")
+            if not isinstance(metadata, dict):
+                continue
+            proof = metadata.get("proof")
+            if not isinstance(proof, dict):
+                continue
+            atoms = proof.get("atoms")
+            if not isinstance(atoms, list):
+                continue
+            for atom in atoms:
+                if not isinstance(atom, dict):
+                    continue
+                source = atom.get("source")
+                if not isinstance(source, dict):
+                    continue
+                excerpt = source.get("excerpt")
+                if isinstance(excerpt, str) and excerpt.strip():
+                    excerpts.append(excerpt.strip())
+        return "\n".join(excerpts)
+    return ""
+
+
 @dataclass(frozen=True)
 class EvalRunnerSpec:
     """How to invoke a model in an eval."""
@@ -2267,11 +2302,15 @@ def evaluate_artifact(
 
     content = rulespec_file.read_text()
     embedded_source = extract_embedded_source_text(content)
+    proof_excerpt_text = _extract_proof_source_excerpt_text(content)
     numeric_source_text = extract_numeric_grounding_source_text(content)
     if not numeric_source_text and source_text:
         numeric_source_text = source_text
     numeric_validation_source_text = embedded_source or numeric_source_text
-    source_numbers = extract_numbers_from_text(numeric_validation_source_text or "")
+    numeric_grounding_source_text = "\n".join(
+        part for part in (numeric_validation_source_text, proof_excerpt_text) if part
+    )
+    source_numbers = extract_numbers_from_text(numeric_grounding_source_text or "")
     source_numeric_occurrences = Counter(
         extract_numeric_occurrences_from_text(numeric_validation_source_text or "")
     )
@@ -2324,7 +2363,7 @@ def evaluate_artifact(
 
     ungrounded_numeric_issues = find_ungrounded_numeric_issues(
         content,
-        numeric_validation_source_text,
+        numeric_grounding_source_text,
     )
     ci_issues = []
     seen_ci_issues: set[str] = set()
@@ -3235,7 +3274,7 @@ Primary legal authority:
 {canonical_concept_section}
 RuleSpec requirements:
 - The RuleSpec file must begin with `format: rulespec/v1`.
-- Include `module.summary: |-` containing the exact operative source text or an exact compact excerpt sufficient to audit all encoded rules.
+- Include `module.summary: |-` with a concise exact audit excerpt, not the full source text when the source is more than a short paragraph. Corpus-backed validation reads the authoritative source from `corpus.provisions`; use the summary only to orient reviewers to the encoded provisions.
 - Do not emit `source_url`; RuleSpec source verification reads `corpus.provisions`, not raw PDFs or web pages.
 {corpus_rulespec_requirement.rstrip()}
 - Include `module.proof_validation.required: true` and add
@@ -3243,6 +3282,10 @@ RuleSpec requirements:
   `derived_relation` rule. Each atom
   must point to the corpus source, an accepted claim, or an explicit imported
   RuleSpec export supporting that rule's formula/value.
+- For source-backed proof atoms, `source.corpus_citation_path` is sufficient.
+  Add `source.excerpt` only for numeric amounts, rates, dates, or necessary
+  disambiguation; keep excerpts short and do not quote long definitions or
+  institutional descriptions.
 - For imported proof support, put `import:` at the proof atom top level
   (for example `kind: import` plus `import.target: us:statutes/...#symbol`);
   do not put imported RuleSpec targets under `source:`. Import proof atoms must
@@ -3653,7 +3696,7 @@ RuleSpec requirements:
 - Do not use Python inline ternaries like `x if cond else y`.
 - Use chained `if condition: value else: other_value` expressions; do not use YAML-style `if:` / `then:` / `else:` blocks, `else if`, or `elif`.
 - Do not append a multiline conditional directly onto another expression, and do not use inline assignment syntax like `:=` inside formula blocks.
-- For `dtype: Rate`, encode percentages as decimal ratios like `0.60` or `0.40`, never as `%` literals.
+- For `dtype: Rate`, encode percentages as decimal ratios like `0.60` or `0.40`, never as `%` literals and never as arithmetic like `25 / 100` unless the source itself states both numerator and denominator.
 - Do not simplify source-stated ratios or fractions into new decimal literals.
   If the source states `20/200`, encode grounded numerator and denominator
   parameters and compare with `20 / 200` or with those named parameters; do not
@@ -3769,7 +3812,7 @@ module:
   source_verification:
     corpus_citation_path: <corpus citation path from this prompt>
   summary: |-
-    <exact source text>
+    <concise exact audit excerpt from the source text>
 rules:
   - name: example_amount
     kind: parameter

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -78,7 +78,10 @@ Encode only the supplied legal source text into Axiom RuleSpec YAML.
 
 Hard requirements:
 - Emit `format: rulespec/v1`.
-- Include `module.summary: |-` with the operative source text or an exact audit excerpt.
+- Include `module.summary: |-` with a concise exact audit excerpt, not the full
+  source text when the source is more than a short paragraph. Corpus-backed
+  validation reads the authoritative source from `corpus.provisions`; use the
+  summary only to orient reviewers to the encoded provisions.
 - If the source has an ingested corpus provision, include
   `module.source_verification.corpus_citation_path` or
   `module.source_verification.corpus_citation_paths`.
@@ -91,6 +94,10 @@ Hard requirements:
   explicit imported RuleSpec export. If you cannot build that proof, stop and
   emit a typed request such as `missing_claim`, `bundle_expansion_request`,
   `corpus_defect`, `segmentation_fix`, `stale_claim`, or `conflicting_claims`.
+- For source-backed proof atoms, `source.corpus_citation_path` is sufficient.
+  Add `source.excerpt` only for numeric amounts, rates, dates, or necessary
+  disambiguation; keep excerpts short and do not quote long definitions or
+  institutional descriptions.
 - For imported proof support, put `import:` at the proof atom top level
   (for example `kind: import` plus `import.target: us:statutes/...#symbol`);
   do not put imported RuleSpec targets under `source:`. Import proof atoms must

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -2332,6 +2332,58 @@ rules:
         assert metrics.ungrounded_numeric_count == 1
         assert any("144" in issue for issue in metrics.ci_issues)
 
+    def test_generated_numeric_grounding_uses_proof_excerpts_with_compact_summary(
+        self, tmp_path
+    ):
+        rulespec_file = tmp_path / "statutes" / "26" / "3121" / "w.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  summary: |-
+    Church election timing rule.
+rules:
+  - name: election_timing_days_after_enactment_threshold
+    kind: parameter
+    dtype: Count
+    period: Day
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/26/3121
+              excerpt: more than 90 days after July 18, 1984
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 90
+"""
+        )
+
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline, "_run_compile_check", return_value=compile_result
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=tmp_path,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text="A different paragraph contains $144.",
+            )
+
+        assert metrics.ci_pass
+        assert metrics.grounded_numeric_count == 1
+        assert metrics.ungrounded_numeric_count == 0
+        assert metrics.source_numeric_occurrence_count == 0
+
     def test_numeric_occurrence_check_counts_imported_named_scalars(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"
         child = policy_repo / "statutes" / "7" / "2015" / "d" / "2" / "B.yaml"
@@ -4015,13 +4067,17 @@ class TestEvalPrompt:
         )
 
         assert (
-            "For `dtype: Rate`, encode percentages as decimal ratios like `0.60` or `0.40`, never as `%` literals."
+            "For `dtype: Rate`, encode percentages as decimal ratios like `0.60` or `0.40`, never as `%` literals"
             in prompt
         )
+        assert "never as arithmetic like `25 / 100`" in prompt
+        assert "source.corpus_citation_path` is sufficient" in prompt
         assert (
             "Do not respond with summaries, markdown prose, or file-write confirmations"
             in prompt
         )
+        assert "concise exact audit excerpt" in prompt
+        assert "not the full source text" in prompt
         assert (
             "do not use inline assignment syntax like `:=` inside formula blocks"
             in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.128"
+version = "0.2.201"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Guides generated RuleSpec files to use concise `module.summary` audit excerpts instead of copying full source text.
- Guides source proof atoms to keep excerpts short and omit them when `source.corpus_citation_path` is enough.
- Grounds generated numeric literals against proof excerpts as well as the module summary, so compact summaries can still pass numeric CI.
- Tightens rate guidance to avoid `25 / 100` when the source states a percentage.
- Bumps `axiom-encode` to `0.2.201`.

## Validation
- `uv run --extra dev python -m pytest tests/test_evals.py::TestEvalPrompt::test_build_eval_prompt_requires_decimal_ratios_for_rate_dtype tests/test_evals.py::TestEvaluateArtifact::test_generated_numeric_grounding_uses_embedded_operating_excerpt tests/test_evals.py::TestEvaluateArtifact::test_generated_numeric_grounding_uses_proof_excerpts_with_compact_summary tests/test_prompt_concept_injection.py -q`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check src/axiom_encode/harness/evals.py src/axiom_encode/prompts/encoder.py tests/test_evals.py`
- `git diff --check`

## Smoke
- No-apply `26 USC 3121(w)` with `gpt-5.5` no longer truncates on content filtering.
- The generated artifact compiles with zero ungrounded numeric literals; the remaining no-apply test resolution issue is expected until signed apply installs the file into a RuleSpec repo.
