### PR TITLE
Classify 3121(w) church elections as not PE comparable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.201"
+version = "0.2.202"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.201"
+__version__ = "0.2.202"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9411,6 +9411,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(r) religious-order coverage-election certificates, vow-of-poverty member predicates, retroactive effective-period limits, or assessment timing intermediates as one-to-one payroll tax variables. These definitions determine FICA coverage before downstream wage and tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/w#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(w) church and qualified church-controlled organization election predicates, revocation rules, support tests, or service-exclusion intermediates as one-to-one payroll tax variables. These definitions determine FICA employment coverage before downstream wage and tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/y#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -619,6 +619,11 @@ rules:
             "member",
         ),
         (
+            "statutes/26/3121/w.yaml",
+            "us:statutes/26/3121/w#services_excluded_from_employment_by_church_election",
+            "services_excluded_from_employment_by_church_election",
+        ),
+        (
             "statutes/26/3121/y.yaml",
             "us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_is_employment",
             "transferred_federal_employee_international_organization_service_is_employment",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.201"
+version = "0.2.202"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Adds a PolicyEngine oracle prefix classification for `26 USC 3121(w)` church and qualified church-controlled organization election outputs.
- Covers the new generated `3121(w)` employment/service-exclusion intermediates as known not comparable.
- Bumps `axiom-encode` to `0.2.202`.

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k 3121_employment_exclusions`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- `git diff --check`

## Coverage smoke
Against the generated `3121(w)` RuleSpec tree:
- Total outputs: `928`
- Comparable: `225`
- Known not comparable: `700`
- Legacy unmapped: `3`
- Untested comparable: `0`
