### PR TITLE
Classify 3121(i) wage computations for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.202"
+version = "0.2.203"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.202"
+__version__ = "0.2.203"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9369,6 +9369,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(h) American-employer definition predicates or source-specific partnership thresholds as one-to-one variables. These legal definitions support FICA employment and wage classifications before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/i#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(i) special wage-computation rules, rounding parameters, uniformed-service and religious-order remuneration intermediates, or retired-judge payment exclusions as one-to-one variables. These legal intermediates feed FICA wage construction before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/j#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -584,6 +584,11 @@ rules:
             "american_employer",
         ),
         (
+            "statutes/26/3121/i.yaml",
+            "us:statutes/26/3121/i#uniformed_service_remuneration_included_before_subsection_a_1_limit",
+            "uniformed_service_remuneration_included_before_subsection_a_1_limit",
+        ),
+        (
             "statutes/26/3121/j.yaml",
             "us:statutes/26/3121/j#covered_transportation_service",
             "covered_transportation_service",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.202"
+version = "0.2.203"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 26 USC 3121(i) RuleSpec outputs as PolicyEngine not-comparable payroll wage-construction intermediates
- add a focused coverage regression for the 3121(i) prefix
- bump axiom-encode to 0.2.203

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k 3121_employment_exclusions
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3121-i-v2-copy --oracle policyengine --program tax --limit 30 --fail-on-untested-comparable