### PR TITLE
Classify 3121(x) threshold rules for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.203"
+version = "0.2.204"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.203"
+__version__ = "0.2.204"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9423,6 +9423,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(w) church and qualified church-controlled organization election predicates, revocation rules, support tests, or service-exclusion intermediates as one-to-one payroll tax variables. These definitions determine FICA employment coverage before downstream wage and tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/x#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(x) domestic-service applicable dollar threshold parameters or Social Security Act indexing and rounding intermediates as one-to-one payroll tax variables. These thresholds feed FICA wage construction before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/y#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -629,6 +629,11 @@ rules:
             "services_excluded_from_employment_by_church_election",
         ),
         (
+            "statutes/26/3121/x.yaml",
+            "us:statutes/26/3121/x#applicable_dollar_threshold",
+            "applicable_dollar_threshold",
+        ),
+        (
             "statutes/26/3121/y.yaml",
             "us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_is_employment",
             "transferred_federal_employee_international_organization_service_is_employment",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.203"
+version = "0.2.204"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 26 USC 3121(x) RuleSpec outputs as PolicyEngine not-comparable payroll wage-construction thresholds
- add a focused coverage regression for the 3121(x) prefix
- bump axiom-encode to 0.2.204

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k 3121_employment_exclusions
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3121-x-copy --oracle policyengine --program tax --limit 30 --fail-on-untested-comparable