### PR TITLE
Classify remaining 3121 payroll definitions for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.204"
+version = "0.2.205"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.204"
+__version__ = "0.2.205"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9417,6 +9417,24 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(r) religious-order coverage-election certificates, vow-of-poverty member predicates, retroactive effective-period limits, or assessment timing intermediates as one-to-one payroll tax variables. These definitions determine FICA coverage before downstream wage and tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/s#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(s) concurrent-employment common-paymaster disbursement allocation rules for related corporations as one-to-one payroll tax variables. These employer-level allocation rules affect wage-base administration before downstream payroll-tax comparisons.
+
+  - legal_id_prefix: us:statutes/26/3121/u#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(u) Medicare qualified government employment rules, section 218 agreement exceptions, election-worker thresholds, pre-1986 continuity exceptions, or state and local agency aggregation rules as one-to-one payroll tax variables.
+
+  - legal_id_prefix: us:statutes/26/3121/v#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(v) deferred-compensation and salary-reduction wage-timing, once-taxed, or exempt-governmental-plan definition rules as one-to-one payroll tax variables. PolicyEngine uses aggregate payroll wage inputs and downstream tax calculations instead of plan-level FICA wage-construction intermediates.
+
   - legal_id_prefix: us:statutes/26/3121/w#
     country: us
     program: tax
@@ -9434,6 +9452,12 @@ prefixes:
     program: tax
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(y) transferred-federal-employee international-organization employment predicates as one-to-one variables. These legal intermediates determine whether international-organization service is employment for FICA before downstream payroll-tax comparisons.
+
+  - legal_id_prefix: us:statutes/26/3121/z#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(z) foreign-person American-employer treatment rules, domestically controlled group definitions, common-parent liability rules, or double-taxation exceptions as one-to-one payroll tax variables.
 
   - legal_id_prefix: us:statutes/26/225#
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -624,6 +624,21 @@ rules:
             "member",
         ),
         (
+            "statutes/26/3121/s.yaml",
+            "us:statutes/26/3121/s#common_paymaster_remuneration_allocated_to_disbursing_corporation",
+            "common_paymaster_remuneration_allocated_to_disbursing_corporation",
+        ),
+        (
+            "statutes/26/3121/u.yaml",
+            "us:statutes/26/3121/u#medicare_qualified_government_employment",
+            "medicare_qualified_government_employment",
+        ),
+        (
+            "statutes/26/3121/v.yaml",
+            "us:statutes/26/3121/v#nonqualified_deferred_compensation_taken_into_account_as_wages",
+            "nonqualified_deferred_compensation_taken_into_account_as_wages",
+        ),
+        (
             "statutes/26/3121/w.yaml",
             "us:statutes/26/3121/w#services_excluded_from_employment_by_church_election",
             "services_excluded_from_employment_by_church_election",
@@ -637,6 +652,11 @@ rules:
             "statutes/26/3121/y.yaml",
             "us:statutes/26/3121/y#transferred_federal_employee_international_organization_service_is_employment",
             "transferred_federal_employee_international_organization_service_is_employment",
+        ),
+        (
+            "statutes/26/3121/z.yaml",
+            "us:statutes/26/3121/z#foreign_person_treated_as_american_employer_for_government_contract_service",
+            "foreign_person_treated_as_american_employer_for_government_contract_service",
         ),
     ],
 )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.204"
+version = "0.2.205"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify remaining missing 26 USC 3121 payroll-definition prefixes as PolicyEngine not-comparable: 3121(s), 3121(u), 3121(v), and 3121(z)
- add focused coverage regressions for each prefix
- bump axiom-encode to 0.2.205

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k 3121_employment_exclusions
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check