### PR TITLE
Map 3306(b)(1) FUTA wage base to PE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.205"
+version = "0.2.206"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.205"
+__version__ = "0.2.206"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1129,6 +1129,32 @@ mappings:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose the section 3111(c) foreign-social-security agreement wage exemption as a separate variable.
 
+  - legal_id: us:statutes/26/3306/b/1#annual_remuneration_wage_base_limit
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.taxable_wage_base
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same FUTA annual taxable wage base, stored in PE as the federal unemployment taxable wage base parameter.
+
+  - legal_id: us:statutes/26/3306/b/1#successor_predecessor_remuneration_considered_paid
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: PolicyEngine exposes final FUTA taxable earnings from aggregate payroll wages and the wage-base parameter, not predecessor remuneration counted under section 3306(b)(1)'s successor-employer continuity rule.
+
+  - legal_id: us:statutes/26/3306/b/1#remuneration_excluded_from_wages_after_annual_limit
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: PolicyEngine exposes final FUTA taxable earnings, not the section 3306(b)(1) above-wage-base excluded-remuneration amount separately.
+
   - legal_id: us:statutes/26/3121/a/1#successor_employer_base_continuity_applies
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -202,6 +202,58 @@ rules:
     )
 
 
+def test_policyengine_coverage_maps_3306_b_1_futa_wage_base(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/b/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: annual_remuneration_wage_base_limit
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 7000
+  - name: successor_predecessor_remuneration_considered_paid
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: predecessor_remuneration
+  - name: remuneration_excluded_from_wages_after_annual_limit
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: max(0, wages - annual_remuneration_wage_base_limit)
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 2,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    wage_base = items_by_id[
+        "us:statutes/26/3306/b/1#annual_remuneration_wage_base_limit"
+    ]
+    assert wage_base["status"] == "comparable"
+    assert (
+        wage_base["policyengine_parameter"]
+        == "gov.irs.payroll.federal_unemployment.taxable_wage_base"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3306/b/1#successor_predecessor_remuneration_considered_paid"
+        ]["status"]
+        == "known_not_comparable"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3306/b/1#remuneration_excluded_from_wages_after_annual_limit"
+        ]["status"]
+        == "known_not_comparable"
+    )
+
+
 def test_policyengine_coverage_maps_section_1401_rate_leaf_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/1401/a/rate.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.205"
+version = "0.2.206"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map the 26 USC 3306(b)(1) annual FUTA wage-base output to PolicyEngine's federal unemployment taxable wage-base parameter
- classify the 3306(b)(1) successor and excluded-remuneration intermediates as not comparable to PE's final taxable FUTA earnings variable
- add focused coverage regression and bump axiom-encode to 0.2.206

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k "3306_b_1 or tax_parameter_outputs"
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-1-copy --oracle policyengine --program tax --limit 30 --fail-on-untested-comparable