### PR TITLE
Classify 3301 gross FUTA tax for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.206"
+version = "0.2.207"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.206"
+__version__ = "0.2.207"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1129,6 +1129,22 @@ mappings:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose the section 3111(c) foreign-social-security agreement wage exemption as a separate variable.
 
+  - legal_id: us:statutes/26/3301#federal_unemployment_excise_tax_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: Section 3301 imposes the gross 6 percent FUTA excise tax rate before section 3302 credits; PolicyEngine exposes the post-credit effective base rate used on Form 940.
+
+  - legal_id: us:statutes/26/3301#federal_unemployment_excise_tax
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3301 is the gross FUTA tax before section 3302 credits, while PolicyEngine exposes final employer FUTA tax after the effective rate and credit-reduction adjustment.
+
   - legal_id: us:statutes/26/3306/b/1#annual_remuneration_wage_base_limit
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -254,6 +254,39 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3301.yaml",
+        """format: rulespec/v1
+rules:
+  - name: federal_unemployment_excise_tax_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.06
+  - name: federal_unemployment_excise_tax
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: federal_unemployment_excise_tax_rate * wages
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    rate = items_by_id["us:statutes/26/3301#federal_unemployment_excise_tax_rate"]
+    tax = items_by_id["us:statutes/26/3301#federal_unemployment_excise_tax"]
+    assert rate["status"] == "known_not_comparable"
+    assert (
+        rate["policyengine_parameter"]
+        == "gov.irs.payroll.federal_unemployment.effective_rate"
+    )
+    assert tax["status"] == "known_not_comparable"
+    assert tax["policyengine_variable"] == "employer_federal_unemployment_tax"
+
+
 def test_policyengine_coverage_maps_section_1401_rate_leaf_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/1401/a/rate.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.206"
+version = "0.2.207"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3301 gross FUTA rate and tax outputs as PE-adjacent but not directly comparable
- document the distinction between section 3301 gross FUTA tax and PE's post-credit effective FUTA tax surface
- bump axiom-encode to 0.2.207

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k '3301 or 3306_b_1'
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3301-current --program tax --fail-on-untested-comparable