### PR TITLE
Classify legacy tax procedural oracle outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.207"
+version = "0.2.208"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.207"
+__version__ = "0.2.208"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1171,6 +1171,20 @@ mappings:
     candidate_priority: P4
     rationale: PolicyEngine exposes final FUTA taxable earnings, not the section 3306(b)(1) above-wage-base excluded-remuneration amount separately.
 
+  - legal_id: us:statutes/26/443/a/1#annual_accounting_period_change_with_secretary_approval
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 443(a)(1)'s annual-accounting-period change with Secretary approval is procedural filing-period logic, not a PolicyEngine tax calculation variable or parameter.
+
+  - legal_id: us:statutes/26/443/a/1#return_made_for_required_short_period_after_accounting_period_change
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 443(a)(1)'s required short-period return rule is procedural return-period logic; PolicyEngine does not expose the short-period filing requirement as a one-to-one oracle output.
+
   - legal_id: us:statutes/26/3121/a/1#successor_employer_base_continuity_applies
     country: us
     program: tax
@@ -2263,6 +2277,13 @@ mappings:
     unit: USD
     comparison: money
     rationale: Same federal taxable income after exemptions and taxable-income deductions.
+
+  - legal_id: us:statutes/26/68/b#section_68_applied_after_other_itemized_deduction_limitations
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 68(b) is a statutory ordering rule for applying the overall itemized-deduction limitation after other itemized-deduction limitations; PolicyEngine does not expose this ordering judgment as an oracle output.
 
   - legal_id: us:statutes/26/86#social_security_one_half_rate
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -287,6 +287,59 @@ rules:
     assert tax["policyengine_variable"] == "employer_federal_unemployment_tax"
 
 
+def test_policyengine_coverage_classifies_legacy_tax_procedural_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/68/b.yaml",
+        """format: rulespec/v1
+rules:
+  - name: section_68_applied_after_other_itemized_deduction_limitations
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: true
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/443/a/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: annual_accounting_period_change_with_secretary_approval
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: taxpayer_changes_annual_accounting_period
+  - name: return_made_for_required_short_period_after_accounting_period_change
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: return_is_made_for_short_period
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    statuses_by_id = {item["legal_id"]: item["status"] for item in report["items"]}
+    assert (
+        statuses_by_id[
+            "us:statutes/26/68/b#section_68_applied_after_other_itemized_deduction_limitations"
+        ]
+        == "known_not_comparable"
+    )
+    assert (
+        statuses_by_id[
+            "us:statutes/26/443/a/1#annual_accounting_period_change_with_secretary_approval"
+        ]
+        == "known_not_comparable"
+    )
+    assert (
+        statuses_by_id[
+            "us:statutes/26/443/a/1#return_made_for_required_short_period_after_accounting_period_change"
+        ]
+        == "known_not_comparable"
+    )
+
+
 def test_policyengine_coverage_maps_section_1401_rate_leaf_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/1401/a/rate.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.207"
+version = "0.2.208"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify the remaining section 68(b) and 443(a)(1) tax oracle outputs as not comparable to PolicyEngine
- add focused coverage tests for the legacy procedural outputs
- bump axiom-encode to 0.2.208

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k 'legacy_tax_procedural_outputs or 3301 or 3306_b_1'
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-tax-main-current --program tax --fail-on-unmapped --fail-on-untested-comparable