### PR TITLE
Classify 3302(a) FUTA credit outputs for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.208"
+version = "0.2.209"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.208"
+__version__ = "0.2.209"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1145,6 +1145,38 @@ mappings:
     candidate_priority: P4
     rationale: Section 3301 is the gross FUTA tax before section 3302 credits, while PolicyEngine exposes final employer FUTA tax after the effective rate and credit-reduction adjustment.
 
+  - legal_id: us:statutes/26/3302/a#late_paid_contributions_credit_percentage
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: Section 3302(a)'s 90 percent limit is a late-paid state-contribution credit rule; PolicyEngine exposes a final post-credit effective FUTA rate rather than this timing-specific credit percentage.
+
+  - legal_id: us:statutes/26/3302/a#title11_trustee_no_fault_late_paid_contributions_credit_percentage
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: Section 3302(a)(5)'s title 11 trustee no-fault substitution is a special late-payment credit rule; PolicyEngine does not expose this bankruptcy-trustee credit percentage separately.
+
+  - legal_id: us:statutes/26/3302/a#applicable_late_paid_contributions_credit_percentage
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: This section 3302(a) output selects the applicable late-paid state-contribution credit percentage, while PolicyEngine uses a final effective FUTA rate and does not model late-payment timing as a one-to-one oracle output.
+
+  - legal_id: us:statutes/26/3302/a#credit_for_late_paid_contributions_limit
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3302(a)'s late-paid contribution credit limit is an intermediate credit calculation before final FUTA tax; PolicyEngine exposes final employer FUTA tax after effective-rate and credit-reduction assumptions, not this credit limit separately.
+
   - legal_id: us:statutes/26/3306/b/1#annual_remuneration_wage_base_limit
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -287,6 +287,64 @@ rules:
     assert tax["policyengine_variable"] == "employer_federal_unemployment_tax"
 
 
+def test_policyengine_coverage_classifies_3302_a_late_credit_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3302/a.yaml",
+        """format: rulespec/v1
+rules:
+  - name: late_paid_contributions_credit_percentage
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.9
+  - name: title11_trustee_no_fault_late_paid_contributions_credit_percentage
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 1
+  - name: applicable_late_paid_contributions_credit_percentage
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: late_paid_contributions_credit_percentage
+  - name: credit_for_late_paid_contributions_limit
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: applicable_late_paid_contributions_credit_percentage * late_credit
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 4}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id["us:statutes/26/3302/a#late_paid_contributions_credit_percentage"][
+            "policyengine_parameter"
+        ]
+        == "gov.irs.payroll.federal_unemployment.effective_rate"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/a#title11_trustee_no_fault_late_paid_contributions_credit_percentage"
+        ]["status"]
+        == "known_not_comparable"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/a#applicable_late_paid_contributions_credit_percentage"
+        ]["status"]
+        == "known_not_comparable"
+    )
+    assert (
+        items_by_id["us:statutes/26/3302/a#credit_for_late_paid_contributions_limit"][
+            "policyengine_variable"
+        ]
+        == "employer_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_legacy_tax_procedural_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/68/b.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.208"
+version = "0.2.209"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3302(a) late-paid FUTA state-contribution credit outputs as PE-adjacent but not directly comparable
- document the distinction from PolicyEngine's post-credit effective FUTA rate/final tax surface
- bump axiom-encode to 0.2.209

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k '3302_a or 3301 or legacy_tax_procedural_outputs'
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-a-current --program tax --fail-on-unmapped --fail-on-untested-comparable