### PR TITLE
Classify 3302(b) FUTA additional credit outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.209"
+version = "0.2.210"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.209"
+__version__ = "0.2.210"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1177,6 +1177,30 @@ mappings:
     candidate_priority: P4
     rationale: Section 3302(a)'s late-paid contribution credit limit is an intermediate credit calculation before final FUTA tax; PolicyEngine exposes final employer FUTA tax after effective-rate and credit-reduction assumptions, not this credit limit separately.
 
+  - legal_id: us:statutes/26/3302/b#additional_credit_comparison_rate_cap
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: Section 3302(b)'s 5.4 percent comparison-rate cap is part of the statutory additional-credit calculation; PolicyEngine exposes a final post-credit effective FUTA rate rather than this comparison cap.
+
+  - legal_id: us:statutes/26/3302/b#applicable_additional_credit_comparison_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: This section 3302(b) output selects the lower of the state highest rate and 5.4 percent for an additional-credit computation; PolicyEngine does not expose that state-law comparison rate separately.
+
+  - legal_id: us:statutes/26/3302/b#additional_credit_rate_differential_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3302(b)'s additional-credit rate differential is an intermediate credit amount before final FUTA tax; PolicyEngine exposes final employer FUTA tax after effective-rate and credit-reduction assumptions, not this credit differential separately.
+
   - legal_id: us:statutes/26/3306/b/1#annual_remuneration_wage_base_limit
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -345,6 +345,53 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3302_b_additional_credit_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3302/b.yaml",
+        """format: rulespec/v1
+rules:
+  - name: additional_credit_comparison_rate_cap
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.054
+  - name: applicable_additional_credit_comparison_rate
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: min(state_rate, additional_credit_comparison_rate_cap)
+  - name: additional_credit_rate_differential_amount
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: max(0, comparison_contributions - required_contributions)
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id["us:statutes/26/3302/b#additional_credit_comparison_rate_cap"][
+            "policyengine_parameter"
+        ]
+        == "gov.irs.payroll.federal_unemployment.effective_rate"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/b#applicable_additional_credit_comparison_rate"
+        ]["status"]
+        == "known_not_comparable"
+    )
+    assert (
+        items_by_id["us:statutes/26/3302/b#additional_credit_rate_differential_amount"][
+            "policyengine_variable"
+        ]
+        == "employer_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_legacy_tax_procedural_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/68/b.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.209"
+version = "0.2.210"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3302(b) additional-credit comparison outputs as PE-adjacent but not directly comparable
- document the distinction from PolicyEngine's post-credit effective FUTA rate/final tax surface
- bump axiom-encode to 0.2.210

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k '3302_b or 3302_a or 3301'
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-b-current --program tax --fail-on-unmapped --fail-on-untested-comparable