### PR TITLE
Classify 3302(c)(1) FUTA credit cap outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.210"
+version = "0.2.211"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.210"
+__version__ = "0.2.211"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1201,6 +1201,30 @@ mappings:
     candidate_priority: P4
     rationale: Section 3302(b)'s additional-credit rate differential is an intermediate credit amount before final FUTA tax; PolicyEngine exposes final employer FUTA tax after effective-rate and credit-reduction assumptions, not this credit differential separately.
 
+  - legal_id: us:statutes/26/3302/c/1#total_credits_allowed_percentage_limit
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: Section 3302(c)(1)'s 90 percent total-credit limit is part of the statutory credit-cap calculation; PolicyEngine exposes a post-credit effective FUTA rate rather than this credit-limit percentage.
+
+  - legal_id: us:statutes/26/3302/c/1#total_credits_allowed_under_section_limit
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3302(c)(1)'s total-credit dollar limit is an intermediate cap before final FUTA tax; PolicyEngine exposes final employer FUTA tax after effective-rate and credit-reduction assumptions, not this cap separately.
+
+  - legal_id: us:statutes/26/3302/c/1#total_credits_allowed_under_section_after_limit
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: This section 3302(c)(1) output applies the total-credit cap before final FUTA tax; PolicyEngine exposes final employer FUTA tax and does not expose the capped total section 3302 credits separately.
+
   - legal_id: us:statutes/26/3306/b/1#annual_remuneration_wage_base_limit
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -392,6 +392,53 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3302_c_1_credit_limit_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3302/c/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: total_credits_allowed_percentage_limit
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.9
+  - name: total_credits_allowed_under_section_limit
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: total_credits_allowed_percentage_limit * tax
+  - name: total_credits_allowed_under_section_after_limit
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: min(credits_before_limit, total_credits_allowed_under_section_limit)
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id["us:statutes/26/3302/c/1#total_credits_allowed_percentage_limit"][
+            "policyengine_parameter"
+        ]
+        == "gov.irs.payroll.federal_unemployment.effective_rate"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/1#total_credits_allowed_under_section_limit"
+        ]["policyengine_variable"]
+        == "employer_federal_unemployment_tax"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/1#total_credits_allowed_under_section_after_limit"
+        ]["status"]
+        == "known_not_comparable"
+    )
+
+
 def test_policyengine_coverage_classifies_legacy_tax_procedural_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/68/b.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.210"
+version = "0.2.211"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3302(c)(1) total-credit cap outputs as PE-adjacent but not directly comparable
- document the distinction from PolicyEngine's final employer FUTA tax/effective-rate surface
- bump axiom-encode to 0.2.211

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k '3302_c_1 or 3302_b or 3302_a'
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-c-1-current --program tax --fail-on-unmapped --fail-on-untested-comparable