### PR TITLE
Guide replacement-rate cross references

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.211"
+version = "0.2.212"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.211"
+__version__ = "0.2.212"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -360,6 +360,14 @@ Hard requirements:
   input such as `tier_1_applicable_percentage`. Import the upstream output when
   it exists; otherwise defer the affected output and name the cited legal
   dependency in `reason`.
+  If the current source instead states a purpose-limited replacement rate,
+  percentage, or amount for a cited section using phrases like `computed at`,
+  `in lieu of`, or `instead of the rate provided by`, encode that source-stated
+  replacement value as a purpose-scoped output named for the current source's
+  purpose, not as `section_<cited>_*` or `subsection_<cited>_*`. Do not
+  reconstruct the cited section's amount locally by dividing an imported amount
+  by its rate and multiplying by the replacement rate; downstream consumer
+  modules should import the purpose-scoped replacement value when they need it.
   When the omitted output covers a specific subsection or subparagraph, the
   `output` target path must include that source path segment, e.g.
   `us:statutes/26/3201/a#tier_1_employee_tax`, not

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -93,6 +93,11 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "do not import that consumer section" in ENCODER_PROMPT
     assert "rate or rate" in ENCODER_PROMPT
     assert "source-named numeric boundary input" in ENCODER_PROMPT
+    assert "purpose-limited replacement rate" in ENCODER_PROMPT
+    assert "computed at" in ENCODER_PROMPT
+    assert "instead of the rate provided by" in ENCODER_PROMPT
+    assert "not as `section_<cited>_*`" in ENCODER_PROMPT
+    assert "Do not\n  reconstruct the cited section's amount locally" in ENCODER_PROMPT
     assert "source-stated formula executable" in ENCODER_PROMPT
     assert "defer only that branch" in ENCODER_PROMPT
     assert "predicate for the excepted category" in ENCODER_PROMPT
@@ -156,6 +161,10 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "Importing an adjacent upstream output only as proof" in prompt
     assert "does not satisfy the dependency" in prompt
     assert "is not an executable dependency" in prompt
+    assert "purpose-limited replacement rate" in prompt
+    assert "computed at" in prompt
+    assert "instead of the rate provided by" in prompt
+    assert "not as `section_<cited>_*`" in prompt
     assert "source-stated formula executable" in prompt
     assert "defer only that branch" in prompt
     assert "predicate for the excepted category" in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.211"
+version = "0.2.212"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- tell the encoder to model purpose-limited replacement rates as current-source outputs
- prevent generated files from reconstructing cited section amounts with section-prefixed helpers
- bump axiom-encode to 0.2.212

## Validation
- uv run --extra dev python -m pytest tests/test_encoder_backend.py -q
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/prompts/encoder.py tests/test_encoder_backend.py
- git diff --check

## Motivation
While encoding 26 USC 3302(d)(1), the generated RuleSpec compiled but correctly failed apply validation because it created a local section_3301_* helper instead of emitting the source-stated replacement rate for subsection (c). This prompt change teaches the general pattern without policy-specific instructions.