### PR TITLE
Classify 3302(d)(1) FUTA subsection c outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.212"
+version = "0.2.213"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.212"
+__version__ = "0.2.213"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1225,6 +1225,22 @@ mappings:
     candidate_priority: P4
     rationale: This section 3302(c)(1) output applies the total-credit cap before final FUTA tax; PolicyEngine exposes final employer FUTA tax and does not expose the capped total section 3302 credits separately.
 
+  - legal_id: us:statutes/26/3302/d/1#subsection_c_tax_computation_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: Section 3302(d)(1)'s 6 percent rate is a purpose-specific gross section 3301 tax computation rate used when applying subsection (c); PolicyEngine exposes a post-credit effective FUTA rate instead.
+
+  - legal_id: us:statutes/26/3302/d/1#tax_imposed_by_section_3301_for_applying_subsection_c
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3302(d)(1)'s purpose-specific section 3301 tax amount is an intermediate gross-tax amount for applying subsection (c), while PolicyEngine exposes final employer FUTA tax after credits and credit-reduction assumptions.
+
   - legal_id: us:statutes/26/3306/b/1#annual_remuneration_wage_base_limit
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -439,6 +439,44 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3302_d_1_subsection_c_tax_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3302/d/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: subsection_c_tax_computation_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.06
+  - name: tax_imposed_by_section_3301_for_applying_subsection_c
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: federal_unemployment_excise_tax
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id["us:statutes/26/3302/d/1#subsection_c_tax_computation_rate"][
+            "policyengine_parameter"
+        ]
+        == "gov.irs.payroll.federal_unemployment.effective_rate"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/d/1#tax_imposed_by_section_3301_for_applying_subsection_c"
+        ]["policyengine_variable"]
+        == "employer_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_legacy_tax_procedural_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/68/b.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.212"
+version = "0.2.213"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3302(d)(1) subsection (c) FUTA computation outputs as not comparable to PolicyEngine
- add focused coverage test for the two generated outputs
- bump axiom-encode to 0.2.213

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k '3302_d_1 or 3302_c_1 or 3302_b or 3302_a'
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-d-1-current --program tax --fail-on-unmapped --fail-on-untested-comparable