### PR TITLE
Classify 3302(d)(2) FUTA state attribution output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.213"
+version = "0.2.214"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.213"
+__version__ = "0.2.214"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1241,6 +1241,14 @@ mappings:
     candidate_priority: P4
     rationale: Section 3302(d)(1)'s purpose-specific section 3301 tax amount is an intermediate gross-tax amount for applying subsection (c), while PolicyEngine exposes final employer FUTA tax after credits and credit-reduction assumptions.
 
+  - legal_id: us:statutes/26/3302/d/2#wages_attributable_to_particular_state_for_subsection_c
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3302(d)(2) defines a state-attribution predicate for wages used in subsection (c) credit computations; PolicyEngine does not expose this state-law attribution predicate separately from final employer FUTA tax.
+
   - legal_id: us:statutes/26/3306/b/1#annual_remuneration_wage_base_limit
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -477,6 +477,33 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3302_d_2_state_attribution_output(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3302/d/2.yaml",
+        """format: rulespec/v1
+rules:
+  - name: wages_attributable_to_particular_state_for_subsection_c
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: state_law_applies or secretary_rules_attribute_state
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us:statutes/26/3302/d/2#wages_attributable_to_particular_state_for_subsection_c"
+    )
+    assert item["status"] == "known_not_comparable"
+    assert item["policyengine_variable"] == "employer_federal_unemployment_tax"
+
+
 def test_policyengine_coverage_classifies_legacy_tax_procedural_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/68/b.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.213"
+version = "0.2.214"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3302(d)(2) state-attribution output as not comparable to PolicyEngine
- add focused coverage test for the generated output
- bump axiom-encode to 0.2.214

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k '3302_d_2 or 3302_d_1 or 3302_c_1'
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-d-2-current --program tax --fail-on-unmapped --fail-on-untested-comparable