### PR TITLE
Classify 3302(d)(4) FUTA contribution-rate threshold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.214"
+version = "0.2.215"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.214"
+__version__ = "0.2.215"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1249,6 +1249,14 @@ mappings:
     candidate_priority: P4
     rationale: Section 3302(d)(2) defines a state-attribution predicate for wages used in subsection (c) credit computations; PolicyEngine does not expose this state-law attribution predicate separately from final employer FUTA tax.
 
+  - legal_id: us:statutes/26/3302/d/4#average_employer_contribution_rate_employee_payment_adjustment_threshold
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: Section 3302(d)(4)'s 2.7 percent threshold is a state average-employer-contribution-rate condition for subsection (c)(2)(C); PolicyEngine exposes a federal post-credit effective FUTA rate instead of this state-law threshold.
+
   - legal_id: us:statutes/26/3306/b/1#annual_remuneration_wage_base_limit
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -504,6 +504,36 @@ rules:
     assert item["policyengine_variable"] == "employer_federal_unemployment_tax"
 
 
+def test_policyengine_coverage_classifies_3302_d_4_state_rate_threshold_output(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3302/d/4.yaml",
+        """format: rulespec/v1
+rules:
+  - name: average_employer_contribution_rate_employee_payment_adjustment_threshold
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.027
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us:statutes/26/3302/d/4#average_employer_contribution_rate_employee_payment_adjustment_threshold"
+    )
+    assert item["status"] == "known_not_comparable"
+    assert (
+        item["policyengine_parameter"]
+        == "gov.irs.payroll.federal_unemployment.effective_rate"
+    )
+
+
 def test_policyengine_coverage_classifies_legacy_tax_procedural_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/68/b.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.214"
+version = "0.2.215"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3302(d)(4) state contribution-rate threshold as not comparable to PolicyEngine
- add focused coverage test for the generated threshold output
- bump axiom-encode to 0.2.215

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k '3302_d_4 or 3302_d_2 or 3302_d_1'
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-d-4-current --program tax --fail-on-unmapped --fail-on-untested-comparable