### PR TITLE
Classify 3302(c)(2)(A) FUTA advance reductions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.215"
+version = "0.2.216"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.215"
+__version__ = "0.2.216"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1225,6 +1225,38 @@ mappings:
     candidate_priority: P4
     rationale: This section 3302(c)(1) output applies the total-credit cap before final FUTA tax; PolicyEngine exposes final employer FUTA tax and does not expose the capped total section 3302 credits separately.
 
+  - legal_id: us:statutes/26/3302/c/2/A#second_consecutive_january1_advances_balance_reduction_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: Section 3302(c)(2)(A)(i)'s 5 percent advance-balance credit-reduction rate is a statutory intermediate rate, while PolicyEngine exposes a final post-credit effective FUTA rate.
+
+  - legal_id: us:statutes/26/3302/c/2/A#succeeding_consecutive_january1_advances_balance_additional_reduction_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: Section 3302(c)(2)(A)(ii)'s additional 5 percent succeeding-year advance-balance rate is a statutory intermediate credit-reduction rate; PolicyEngine exposes a final post-credit effective FUTA rate instead.
+
+  - legal_id: us:statutes/26/3302/c/2/A#advances_credit_reduction_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: This output computes the statutory section 3302(c)(2)(A) advance-balance credit-reduction rate, while PolicyEngine exposes final FUTA effective-rate assumptions rather than this intermediate statutory rate.
+
+  - legal_id: us:statutes/26/3302/c/2/A#advances_credit_reduction_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: This output computes an intermediate section 3302(c)(2)(A) reduction in credits based on advance balances; PolicyEngine exposes final employer FUTA tax after effective-rate and credit-reduction assumptions, not this statutory intermediate amount separately.
+
   - legal_id: us:statutes/26/3302/d/1#subsection_c_tax_computation_rate
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -439,6 +439,66 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3302_c_2_a_advance_reduction_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3302/c/2/A.yaml",
+        """format: rulespec/v1
+rules:
+  - name: second_consecutive_january1_advances_balance_reduction_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.05
+  - name: succeeding_consecutive_january1_advances_balance_additional_reduction_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.05
+  - name: advances_credit_reduction_rate
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: second_consecutive_january1_advances_balance_reduction_rate
+  - name: advances_credit_reduction_amount
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: advances_credit_reduction_rate * tax
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 4}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/2/A#second_consecutive_january1_advances_balance_reduction_rate"
+        ]["policyengine_parameter"]
+        == "gov.irs.payroll.federal_unemployment.effective_rate"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/2/A#succeeding_consecutive_january1_advances_balance_additional_reduction_rate"
+        ]["status"]
+        == "known_not_comparable"
+    )
+    assert (
+        items_by_id["us:statutes/26/3302/c/2/A#advances_credit_reduction_rate"][
+            "policyengine_parameter"
+        ]
+        == "gov.irs.payroll.federal_unemployment.effective_rate"
+    )
+    assert (
+        items_by_id["us:statutes/26/3302/c/2/A#advances_credit_reduction_amount"][
+            "policyengine_variable"
+        ]
+        == "employer_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3302_d_1_subsection_c_tax_outputs(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.215"
+version = "0.2.216"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 26 USC 3302(c)(2)(A) advance-balance FUTA credit-reduction rate outputs as known not comparable to PolicyEngine final FUTA effective-rate assumptions
- classify the generated advance credit-reduction amount as known not comparable to PolicyEngine final employer FUTA tax
- add a focused coverage regression and bump axiom-encode to 0.2.216

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k '3302_c_2_a or 3302_d_4 or 3302_c_1'
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-c-2-a-current --program tax --fail-on-unmapped --fail-on-untested-comparable