### PR TITLE
Classify 3302(c)(2)(B) FUTA advance reductions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.216"
+version = "0.2.217"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.216"
+__version__ = "0.2.217"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1257,6 +1257,45 @@ mappings:
     candidate_priority: P4
     rationale: This output computes an intermediate section 3302(c)(2)(A) reduction in credits based on advance balances; PolicyEngine exposes final employer FUTA tax after effective-rate and credit-reduction assumptions, not this statutory intermediate amount separately.
 
+  - legal_id: us:statutes/26/3302/c/2/B#federal_unemployment_credit_reduction_benchmark_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: Section 3302(c)(2)(B)(i)'s 2.7 percent benchmark is a statutory intermediate for the third/fourth-year credit-reduction computation; PolicyEngine exposes a final post-credit FUTA effective rate instead.
+
+  - legal_id: us:statutes/26/3302/c/2/B#taxable_year_begins_with_third_or_fourth_consecutive_january1_with_balance_of_advances
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This output is a state advance-balance timing predicate for applying section 3302(c)(2)(B); PolicyEngine does not expose the predicate separately from final FUTA assumptions.
+
+  - legal_id: us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_excess_percentage
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: This output computes the statutory excess-percentage intermediate for the third/fourth-year advance-balance reduction; PolicyEngine exposes final FUTA effective-rate assumptions rather than this component separately.
+
+  - legal_id: us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_reduction_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: This output computes a statutory third/fourth-year advance-balance credit-reduction rate after state and national wage adjustments; PolicyEngine exposes a final post-credit FUTA effective rate instead.
+
+  - legal_id: us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_credit_reduction_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: This output computes an intermediate section 3302(c)(2)(B) reduction in credits based on state advance balances and wage-attribution inputs; PolicyEngine exposes final employer FUTA tax, not this intermediate reduction amount separately.
+
   - legal_id: us:statutes/26/3302/d/1#subsection_c_tax_computation_rate
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -499,6 +499,71 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3302_c_2_b_third_fourth_year_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3302/c/2/B.yaml",
+        """format: rulespec/v1
+rules:
+  - name: federal_unemployment_credit_reduction_benchmark_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.027
+  - name: taxable_year_begins_with_third_or_fourth_consecutive_january1_with_balance_of_advances
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: third_year or fourth_year
+  - name: third_or_fourth_consecutive_january1_advances_balance_excess_percentage
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: federal_unemployment_credit_reduction_benchmark_rate - average_rate
+  - name: third_or_fourth_consecutive_january1_advances_balance_reduction_rate
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: third_or_fourth_consecutive_january1_advances_balance_excess_percentage
+  - name: third_or_fourth_consecutive_january1_advances_balance_credit_reduction_amount
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: third_or_fourth_consecutive_january1_advances_balance_reduction_rate * wages
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 5}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/2/B#federal_unemployment_credit_reduction_benchmark_rate"
+        ]["policyengine_parameter"]
+        == "gov.irs.payroll.federal_unemployment.effective_rate"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/2/B#taxable_year_begins_with_third_or_fourth_consecutive_january1_with_balance_of_advances"
+        ]["status"]
+        == "known_not_comparable"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_excess_percentage"
+        ]["policyengine_parameter"]
+        == "gov.irs.payroll.federal_unemployment.effective_rate"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/2/B#third_or_fourth_consecutive_january1_advances_balance_credit_reduction_amount"
+        ]["policyengine_variable"]
+        == "employer_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3302_d_1_subsection_c_tax_outputs(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.216"
+version = "0.2.217"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 26 USC 3302(c)(2)(B) third/fourth-year FUTA credit-reduction outputs as known not comparable to PolicyEngine final FUTA assumptions
- cover the benchmark rate, timing predicate, excess percentage, reduction rate, and credit-reduction amount
- add a focused coverage regression and bump axiom-encode to 0.2.217

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k '3302_c_2_b or 3302_c_2_a or 3302_d_4'
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-c-2-b-current --program tax --fail-on-unmapped --fail-on-untested-comparable