### PR TITLE
Classify 3302(c)(2)(C) FUTA advance reductions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.217"
+version = "0.2.218"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.217"
+__version__ = "0.2.218"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1296,6 +1296,60 @@ mappings:
     candidate_priority: P4
     rationale: This output computes an intermediate section 3302(c)(2)(B) reduction in credits based on state advance balances and wage-attribution inputs; PolicyEngine exposes final employer FUTA tax, not this intermediate reduction amount separately.
 
+  - legal_id: us:statutes/26/3302/c/2/C#fifth_or_succeeding_benefit_cost_floor_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: Section 3302(c)(2)(C)(i)'s 2.7 percent floor is a statutory intermediate for the fifth-or-succeeding-year credit-reduction computation; PolicyEngine exposes final FUTA effective-rate assumptions instead.
+
+  - legal_id: us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_reduction_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This output is a state advance-balance timing and Secretary-of-Labor exception predicate for applying section 3302(c)(2)(C); PolicyEngine does not expose this predicate separately from final FUTA assumptions.
+
+  - legal_id: us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_subparagraph_b_applies_instead
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This output models the section 3302(c)(2)(C) exception under which subparagraph (B) applies instead; PolicyEngine does not expose this source-specific routing predicate separately.
+
+  - legal_id: us:statutes/26/3302/c/2/C#fifth_or_succeeding_benefit_cost_rate_after_floor
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: This output computes the statutory greater-of 5-year benefit-cost rate and 2.7 percent floor; PolicyEngine exposes a final post-credit FUTA effective rate rather than this component separately.
+
+  - legal_id: us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_excess_percentage
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: This output computes the statutory fifth-or-succeeding-year excess percentage over the state's average employer contribution rate; PolicyEngine exposes final FUTA effective-rate assumptions rather than this intermediate separately.
+
+  - legal_id: us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_reduction_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: This output computes a statutory fifth-or-succeeding-year advance-balance credit-reduction rate subject to the subparagraph (B) substitution exception; PolicyEngine exposes final FUTA effective-rate assumptions instead.
+
+  - legal_id: us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_credit_reduction_amount
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: This output computes an intermediate section 3302(c)(2)(C) reduction in credits based on state advance balances and wage-attribution inputs; PolicyEngine exposes final employer FUTA tax, not this intermediate reduction amount separately.
+
   - legal_id: us:statutes/26/3302/d/1#subsection_c_tax_computation_rate
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -564,6 +564,87 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3302_c_2_c_fifth_succeeding_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3302/c/2/C.yaml",
+        """format: rulespec/v1
+rules:
+  - name: fifth_or_succeeding_benefit_cost_floor_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.027
+  - name: fifth_or_succeeding_advances_balance_reduction_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: fifth_or_succeeding_balance and not secretary_exception
+  - name: fifth_or_succeeding_advances_balance_subparagraph_b_applies_instead
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: fifth_or_succeeding_balance and secretary_exception
+  - name: fifth_or_succeeding_benefit_cost_rate_after_floor
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: max(five_year_rate, fifth_or_succeeding_benefit_cost_floor_rate)
+  - name: fifth_or_succeeding_advances_balance_excess_percentage
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: fifth_or_succeeding_benefit_cost_rate_after_floor - average_rate
+  - name: fifth_or_succeeding_advances_balance_reduction_rate
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: fifth_or_succeeding_advances_balance_excess_percentage
+  - name: fifth_or_succeeding_advances_balance_credit_reduction_amount
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: fifth_or_succeeding_advances_balance_reduction_rate * wages
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 7}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/2/C#fifth_or_succeeding_benefit_cost_floor_rate"
+        ]["policyengine_parameter"]
+        == "gov.irs.payroll.federal_unemployment.effective_rate"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_reduction_applies"
+        ]["status"]
+        == "known_not_comparable"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_subparagraph_b_applies_instead"
+        ]["status"]
+        == "known_not_comparable"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/2/C#fifth_or_succeeding_benefit_cost_rate_after_floor"
+        ]["policyengine_parameter"]
+        == "gov.irs.payroll.federal_unemployment.effective_rate"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/2/C#fifth_or_succeeding_advances_balance_credit_reduction_amount"
+        ]["policyengine_variable"]
+        == "employer_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3302_d_1_subsection_c_tax_outputs(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.217"
+version = "0.2.218"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 26 USC 3302(c)(2)(C) fifth-or-succeeding-year FUTA credit-reduction outputs as known not comparable to PolicyEngine final FUTA assumptions
- cover benefit-cost floor/rate intermediates, application/routing predicates, excess percentage, reduction rate, and credit-reduction amount
- add a focused coverage regression and bump axiom-encode to 0.2.218

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k '3302_c_2_c or 3302_c_2_b or 3302_c_2_a'
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-c-2-c-current --program tax --fail-on-unmapped --fail-on-untested-comparable