### PR TITLE
Ground mixed-fraction percentage literals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.218"
+version = "0.2.219"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.218"
+__version__ = "0.2.219"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1670,6 +1670,18 @@ def _iter_normalized_special_numeric_matches(
 ) -> list[tuple[tuple[int, int], float]]:
     """Return normalized special-case numeric matches like percentages, pence, and table values."""
     matches: list[tuple[tuple[int, int], float]] = []
+    fraction_chars = "".join(re.escape(glyph) for glyph in _UNICODE_FRACTION_VALUES)
+
+    for match in re.finditer(
+        rf"(-?[\d,]+)\s*([{fraction_chars}])(?:\s+|-)(?:percent|per\s*cent(?:um)?)",
+        text,
+        re.IGNORECASE,
+    ):
+        with contextlib.suppress(ValueError):
+            whole = float(match.group(1).replace(",", ""))
+            fraction = _UNICODE_FRACTION_VALUES[match.group(2)]
+            sign = -1 if whole < 0 else 1
+            matches.append((match.span(), (whole + sign * fraction) / 100))
 
     for pattern in (
         re.compile(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -15095,6 +15095,27 @@ rules:
     assert 0.5 in extract_numeric_occurrences_from_text("The amount is ½.")
 
 
+def test_ungrounded_numeric_accepts_source_mixed_unicode_fraction_percentage():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3302
+rules:
+  - name: trade_act_agreement_noncompliance_reduction_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          0.075
+"""
+
+    source_text = "The total credits shall be reduced by 7½ percent of the tax."
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 0.075 in extract_numeric_occurrences_from_text(source_text)
+
+
 def test_non_rulespec_yaml_artifact_is_rejected(tmp_path):
     rules_file = tmp_path / "not-rulespec.yaml"
     rules_file.write_text("rules:\n  - name: missing_format_header\n")

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.218"
+version = "0.2.219"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- treat mixed vulgar-fraction percentages such as `7½ percent` as grounded decimal rates like `0.075`
- add a regression for the 26 USC 3302(c)(3) failure mode
- bump axiom-encode to 0.2.219

## Validation
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py -q -k 'unicode_fraction or mixed_unicode_fraction_percentage or source_verification_accepts_fractional_decimal_rate_values_as_word_percentages'
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- git diff --check

Unblocks rerunning `axiom-encode encode "26 USC 3302(c)(3)" --apply`, which was blocked because the generated source-faithful `0.075` rate was not recognized from `7½ percent`.
