### PR TITLE
Classify 3302(c)(3) FUTA Trade Act outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.219"
+version = "0.2.220"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.219"
+__version__ = "0.2.220"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1350,6 +1350,37 @@ mappings:
     candidate_priority: P4
     rationale: This output computes an intermediate section 3302(c)(2)(C) reduction in credits based on state advance balances and wage-attribution inputs; PolicyEngine exposes final employer FUTA tax, not this intermediate reduction amount separately.
 
+  - legal_id: us:statutes/26/3302/c/3#trade_act_agreement_credit_reduction_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.payroll.federal_unemployment.effective_rate
+    candidate_priority: P4
+    rationale: Section 3302(c)(3)'s 7.5 percent Trade Act agreement failure reduction is an agreement-specific statutory credit-reduction rate; PolicyEngine exposes a final post-credit FUTA effective rate instead.
+
+  - legal_id: us:statutes/26/3302/c/3#trade_act_agreement_credit_reduction_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This output is a Secretary-of-Labor determination predicate for applying the section 3302(c)(3) Trade Act agreement credit reduction; PolicyEngine does not expose this predicate separately from final FUTA assumptions.
+
+  - legal_id: us:statutes/26/3302/c/3#trade_act_agreement_credit_reduction
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: This output computes an intermediate section 3302(c)(3) reduction in credits for Trade Act agreement noncompliance; PolicyEngine exposes final employer FUTA tax, not this statutory intermediate amount separately.
+
+  - legal_id: us:statutes/26/3302/c/3#total_credits_allowed_under_section_after_trade_act_agreement_reduction
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: This output applies the section 3302(c)(3) Trade Act agreement reduction to total allowed credits before final FUTA tax; PolicyEngine exposes final employer FUTA tax and does not expose the adjusted section 3302 credits separately.
+
   - legal_id: us:statutes/26/3302/d/1#subsection_c_tax_computation_rate
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -645,6 +645,64 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3302_c_3_trade_act_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3302/c/3.yaml",
+        """format: rulespec/v1
+rules:
+  - name: trade_act_agreement_credit_reduction_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.075
+  - name: trade_act_agreement_credit_reduction_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: taxpayer_subject and secretary_determination
+  - name: trade_act_agreement_credit_reduction
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: trade_act_agreement_credit_reduction_rate * tax
+  - name: total_credits_allowed_under_section_after_trade_act_agreement_reduction
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: max(0, credits_before_reduction - trade_act_agreement_credit_reduction)
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 4}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/3#trade_act_agreement_credit_reduction_rate"
+        ]["policyengine_parameter"]
+        == "gov.irs.payroll.federal_unemployment.effective_rate"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/3#trade_act_agreement_credit_reduction_applies"
+        ]["status"]
+        == "known_not_comparable"
+    )
+    assert (
+        items_by_id["us:statutes/26/3302/c/3#trade_act_agreement_credit_reduction"][
+            "policyengine_variable"
+        ]
+        == "employer_federal_unemployment_tax"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/c/3#total_credits_allowed_under_section_after_trade_act_agreement_reduction"
+        ]["policyengine_variable"]
+        == "employer_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3302_d_1_subsection_c_tax_outputs(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.219"
+version = "0.2.220"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map generated 26 USC 3302(c)(3) Trade Act agreement credit-reduction outputs in the PolicyEngine oracle registry as known not comparable
- add focused oracle coverage test for the four generated outputs
- bump axiom-encode to 0.2.220

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py`
- `git diff --check`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-c-3-v219-20260525b --program tax --fail-on-unmapped --fail-on-untested-comparable`
