### PR TITLE
Classify 3302(d)(5) FUTA benefit-cost scalars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.220"
+version = "0.2.221"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.220"
+__version__ = "0.2.221"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1413,6 +1413,20 @@ mappings:
     candidate_priority: P4
     rationale: Section 3302(d)(4)'s 2.7 percent threshold is a state average-employer-contribution-rate condition for subsection (c)(2)(C); PolicyEngine exposes a federal post-credit effective FUTA rate instead of this state-law threshold.
 
+  - legal_id: us:statutes/26/3302/d/5#benefit_cost_rate_compensation_lookback_years
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 3302(d)(5)'s 5-year lookback is a State unemployment-compensation benefit-cost-rate formula constant; PolicyEngine does not expose this State-scoped benefit-cost-rate formula separately from federal FUTA assumptions.
+
+  - legal_id: us:statutes/26/3302/d/5#benefit_cost_rate_compensation_averaging_fraction
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 3302(d)(5)'s one-fifth averaging fraction is a State unemployment-compensation benefit-cost-rate formula constant; PolicyEngine does not expose this State-scoped benefit-cost-rate formula separately from federal FUTA assumptions.
+
   - legal_id: us:statutes/26/3306/b/1#annual_remuneration_wage_base_limit
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -798,6 +798,44 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3302_d_5_benefit_cost_rate_scalars(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3302/d/5.yaml",
+        """format: rulespec/v1
+rules:
+  - name: benefit_cost_rate_compensation_lookback_years
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 5
+  - name: benefit_cost_rate_compensation_averaging_fraction
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 1 / 5
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/d/5#benefit_cost_rate_compensation_lookback_years"
+        ]["status"]
+        == "known_not_comparable"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/d/5#benefit_cost_rate_compensation_averaging_fraction"
+        ]["status"]
+        == "known_not_comparable"
+    )
+
+
 def test_policyengine_coverage_classifies_legacy_tax_procedural_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/68/b.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.220"
+version = "0.2.221"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map generated 26 USC 3302(d)(5) benefit-cost-rate scalar outputs in the PolicyEngine oracle registry as known not comparable
- add focused oracle coverage test for the 5-year lookback and one-fifth averaging fraction
- bump axiom-encode to 0.2.221

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py`
- `git diff --check`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-d-5-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`
