### PR TITLE
Classify 3302(d)(6) FUTA rounding outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.221"
+version = "0.2.222"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.221"
+__version__ = "0.2.222"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1427,6 +1427,20 @@ mappings:
     candidate_priority: P4
     rationale: Section 3302(d)(5)'s one-fifth averaging fraction is a State unemployment-compensation benefit-cost-rate formula constant; PolicyEngine does not expose this State-scoped benefit-cost-rate formula separately from federal FUTA assumptions.
 
+  - legal_id: us:statutes/26/3302/d/6#subparagraph_b_or_c_percentage_rounding_multiple
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 3302(d)(6)'s 0.1 percent rounding increment applies to State advance-balance percentages under section 3302(c)(2)(B) and (C); PolicyEngine does not expose this statutory rounding increment separately from final FUTA assumptions.
+
+  - legal_id: us:statutes/26/3302/d/6#subparagraph_b_or_c_percentage_after_rounding
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This output applies section 3302(d)(6)'s rounding rule to State advance-balance percentages; PolicyEngine does not expose the rounded statutory percentage separately from final FUTA assumptions.
+
   - legal_id: us:statutes/26/3306/b/1#annual_remuneration_wage_base_limit
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -836,6 +836,42 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3302_d_6_rounding_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3302/d/6.yaml",
+        """format: rulespec/v1
+rules:
+  - name: subparagraph_b_or_c_percentage_rounding_multiple
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.001
+  - name: subparagraph_b_or_c_percentage_after_rounding
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: floor((rate / subparagraph_b_or_c_percentage_rounding_multiple) + 0.5) * subparagraph_b_or_c_percentage_rounding_multiple
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/d/6#subparagraph_b_or_c_percentage_rounding_multiple"
+        ]["status"]
+        == "known_not_comparable"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/3302/d/6#subparagraph_b_or_c_percentage_after_rounding"
+        ]["status"]
+        == "known_not_comparable"
+    )
+
+
 def test_policyengine_coverage_classifies_legacy_tax_procedural_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/68/b.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.221"
+version = "0.2.222"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map generated 26 USC 3302(d)(6) rounding outputs in the PolicyEngine oracle registry as known not comparable
- add focused oracle coverage test for the 0.1 percent rounding increment and rounded percentage output
- bump axiom-encode to 0.2.222

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py`
- `git diff --check`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3302-d-6-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`
