### PR TITLE
Classify 3306(b)(2) FUTA wage exclusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.222"
+version = "0.2.223"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.222"
+__version__ = "0.2.223"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1467,6 +1467,14 @@ mappings:
     candidate_priority: P4
     rationale: PolicyEngine exposes final FUTA taxable earnings, not the section 3306(b)(1) above-wage-base excluded-remuneration amount separately.
 
+  - legal_id: us:statutes/26/3306/b/2#employer_plan_payment_excluded_from_wages
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(b)(2) excludes qualifying employer-plan sickness, accident-disability, medical, hospitalization, and death payments from FUTA wages; PolicyEngine exposes final FUTA taxable earnings after wage exclusions, not this exclusion amount separately.
+
   - legal_id: us:statutes/26/443/a/1#annual_accounting_period_change_with_secretary_approval
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -254,6 +254,54 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_b_2_employer_plan_payment_exclusion(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/b/2.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: employer_plan_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if payment_made_to_or_on_behalf_of_employee_or_dependent
+          and employer_plan_or_system_makes_provision_for_employees_or_classes_and_dependents
+          and (
+            payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability
+            or payment_on_account_of_death
+            or (
+              payment_on_account_of_sickness_or_accident_disability
+              and payment_received_under_workmens_compensation_law
+            )
+          ): payment_amount else: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us:statutes/26/3306/b/2#employer_plan_payment_excluded_from_wages"
+    )
+    assert item["status"] == "known_not_comparable"
+    assert (
+        item["policyengine_variable"] == "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.222"
+version = "0.2.223"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map generated 26 USC 3306(b)(2) employer-plan payment wage exclusion in the PolicyEngine oracle registry as known not comparable
- add focused oracle coverage test mirroring the generated Payment-entity output
- bump axiom-encode to 0.2.223

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py`
- `git diff --check`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-2-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`
