### PR TITLE
Classify 3306(b)(4) FUTA sickness exclusion outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.223"
+version = "0.2.224"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.223"
+__version__ = "0.2.224"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1475,6 +1475,21 @@ mappings:
     candidate_priority: P4
     rationale: Section 3306(b)(2) excludes qualifying employer-plan sickness, accident-disability, medical, hospitalization, and death payments from FUTA wages; PolicyEngine exposes final FUTA taxable earnings after wage exclusions, not this exclusion amount separately.
 
+  - legal_id: us:statutes/26/3306/b/4#sickness_accident_disability_payment_waiting_period_calendar_months
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 3306(b)(4)'s six-calendar-month waiting period is a statutory condition for a FUTA wage exclusion; PolicyEngine does not expose this waiting period as a separate payroll tax parameter.
+
+  - legal_id: us:statutes/26/3306/b/4#post_work_sickness_accident_or_medical_payment_excluded_from_wages
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(b)(4) excludes post-work sickness, accident-disability, medical, and hospitalization payments from FUTA wages after the six-calendar-month waiting period; PolicyEngine exposes final FUTA taxable earnings, not this exclusion predicate separately.
+
   - legal_id: us:statutes/26/443/a/1#annual_accounting_period_change_with_secretary_approval
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -302,6 +302,58 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_b_4_post_work_sickness_exclusion(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/b/4.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: sickness_accident_disability_payment_waiting_period_calendar_months
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 6
+  - name: post_work_sickness_accident_or_medical_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (payment_on_account_of_sickness_or_accident_disability
+          or payment_on_account_of_medical_or_hospitalization_expenses_in_connection_with_sickness_or_accident_disability)
+          and (payment_made_by_employer_to_employee
+          or payment_made_by_employer_on_behalf_of_employee)
+          and full_calendar_months_following_last_work_month_expired_before_payment >= sickness_accident_disability_payment_waiting_period_calendar_months
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    waiting_period = items_by_id[
+        "us:statutes/26/3306/b/4#sickness_accident_disability_payment_waiting_period_calendar_months"
+    ]
+    exclusion = items_by_id[
+        "us:statutes/26/3306/b/4#post_work_sickness_accident_or_medical_payment_excluded_from_wages"
+    ]
+    assert waiting_period["status"] == "known_not_comparable"
+    assert exclusion["status"] == "known_not_comparable"
+    assert (
+        exclusion["policyengine_variable"]
+        == "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- Classify the generated 26 USC 3306(b)(4) FUTA sickness/accident/medical exclusion outputs as known-not-comparable to PolicyEngine.
- Add a focused PolicyEngine coverage regression test for the waiting-period parameter and exclusion predicate.
- Bump `axiom-encode` to `0.2.224`.

## Rationale
PolicyEngine exposes final `taxable_earnings_for_federal_unemployment_tax`, not section 3306(b)(4)'s six-calendar-month waiting period or post-work sickness/accident/medical exclusion predicate separately.

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py`
- `git diff --check`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-4-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`

PE oracle coverage result after the mapping: tax outputs `comparable=226`, `known_not_comparable=779`, unmapped `0`, untested comparable outputs `0`.
