### PR TITLE
Classify 3306(b)(6) FUTA state unemployment exclusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.224"
+version = "0.2.225"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.224"
+__version__ = "0.2.225"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1490,6 +1490,14 @@ mappings:
     candidate_priority: P4
     rationale: Section 3306(b)(4) excludes post-work sickness, accident-disability, medical, and hospitalization payments from FUTA wages after the six-calendar-month waiting period; PolicyEngine exposes final FUTA taxable earnings, not this exclusion predicate separately.
 
+  - legal_id: us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(b)(6) excludes employer-paid State unemployment compensation amounts required from employees for domestic service or agricultural labor; PolicyEngine exposes final FUTA taxable earnings, not this narrow exclusion amount separately.
+
   - legal_id: us:statutes/26/443/a/1#annual_accounting_period_change_with_secretary_approval
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -354,6 +354,52 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_b_6_state_unemployment_exclusion(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/b/6.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: employer_state_unemployment_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if (
+            payment_made_by_employer_without_deduction_from_employee_remuneration
+            and payment_required_from_employee_under_state_unemployment_compensation_law
+            and (
+              remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer
+              or remuneration_paid_to_employee_for_agricultural_labor
+            )
+          ): payment_amount else: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages"
+    )
+    assert item["status"] == "known_not_comparable"
+    assert (
+        item["policyengine_variable"] == "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- Classify the generated 26 USC 3306(b)(6) State unemployment compensation payment exclusion output as known-not-comparable to PolicyEngine.
- Add a focused PolicyEngine coverage regression test for the exclusion output.
- Bump `axiom-encode` to `0.2.225`.

## Rationale
PolicyEngine exposes final `taxable_earnings_for_federal_unemployment_tax`, not section 3306(b)(6)'s narrow exclusion amount for employer-paid State unemployment amounts required from employees for domestic service or agricultural labor.

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py`
- `git diff --check`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-6-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`

PE oracle coverage result after the mapping: tax outputs `comparable=226`, `known_not_comparable=780`, unmapped `0`, untested comparable outputs `0`.
