### PR TITLE
Classify 3306(b)(6) FUTA state unemployment predicate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.225"
+version = "0.2.226"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.225"
+__version__ = "0.2.226"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1498,6 +1498,14 @@ mappings:
     candidate_priority: P4
     rationale: Section 3306(b)(6) excludes employer-paid State unemployment compensation amounts required from employees for domestic service or agricultural labor; PolicyEngine exposes final FUTA taxable earnings, not this narrow exclusion amount separately.
 
+  - legal_id: us:statutes/26/3306/b/6#state_unemployment_payment_exclusion_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(b)(6)'s State unemployment payment exclusion predicate feeds a narrow FUTA wage exclusion; PolicyEngine exposes final FUTA taxable earnings, not this eligibility predicate separately.
+
   - legal_id: us:statutes/26/443/a/1#annual_accounting_period_change_with_secretary_approval
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -366,6 +366,20 @@ module:
   source_verification:
     corpus_citation_path: us/statute/26/3306
 rules:
+  - name: state_unemployment_payment_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_by_employer_without_deduction_from_employee_remuneration
+          and payment_required_from_employee_under_state_unemployment_compensation_law
+          and (
+            remuneration_paid_to_employee_for_domestic_service_in_private_home_of_employer
+            or remuneration_paid_to_employee_for_agricultural_labor
+          )
   - name: employer_state_unemployment_payment_excluded_from_wages
     kind: derived
     entity: Payment
@@ -388,15 +402,22 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path, program="tax")
 
-    assert report["status_counts"] == {"known_not_comparable": 1}
-    item = report["items"][0]
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    predicate = items_by_id[
+        "us:statutes/26/3306/b/6#state_unemployment_payment_exclusion_applies"
+    ]
+    exclusion = items_by_id[
+        "us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages"
+    ]
+    assert predicate["status"] == "known_not_comparable"
     assert (
-        item["legal_id"]
-        == "us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages"
+        predicate["policyengine_variable"]
+        == "taxable_earnings_for_federal_unemployment_tax"
     )
-    assert item["status"] == "known_not_comparable"
-    assert (
-        item["policyengine_variable"] == "taxable_earnings_for_federal_unemployment_tax"
+    assert exclusion["status"] == "known_not_comparable"
+    assert exclusion["policyengine_variable"] == (
+        "taxable_earnings_for_federal_unemployment_tax"
     )
 
 


### PR DESCRIPTION
## Summary
- Classify the generated 26 USC 3306(b)(6) State unemployment exclusion predicate as known-not-comparable to PolicyEngine.
- Update the existing 3306(b)(6) coverage regression to include both the predicate and exclusion amount outputs.
- Bump `axiom-encode` to `0.2.226`.

## Rationale
The regenerated RuleSpec splits the section 3306(b)(6) State unemployment exclusion into an eligibility predicate and a money output. PolicyEngine exposes final `taxable_earnings_for_federal_unemployment_tax`, not either intermediate output separately.

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py`
- `git diff --check`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-6-v225-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`

PE oracle coverage result after the mapping: tax outputs `comparable=226`, `known_not_comparable=781`, unmapped `0`, untested comparable outputs `0`.
