### PR TITLE
Classify 3306(b)(7) FUTA noncash exclusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.226"
+version = "0.2.227"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.226"
+__version__ = "0.2.227"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1506,6 +1506,14 @@ mappings:
     candidate_priority: P4
     rationale: Section 3306(b)(6)'s State unemployment payment exclusion predicate feeds a narrow FUTA wage exclusion; PolicyEngine exposes final FUTA taxable earnings, not this eligibility predicate separately.
 
+  - legal_id: us:statutes/26/3306/b/7#noncash_nonbusiness_service_remuneration_excluded_from_wages
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(b)(7) excludes noncash remuneration for service outside the employer's trade or business from FUTA wages; PolicyEngine exposes final FUTA taxable earnings, not this narrow exclusion amount separately.
+
   - legal_id: us:statutes/26/443/a/1#annual_accounting_period_change_with_secretary_approval
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -421,6 +421,49 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_b_7_noncash_nonbusiness_exclusion(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/b/7.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: noncash_nonbusiness_service_remuneration_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if (
+            remuneration_paid_to_employee
+            and remuneration_paid_in_medium_other_than_cash
+            and remuneration_for_service_not_in_course_of_employers_trade_or_business
+          ): payment_amount else: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us:statutes/26/3306/b/7#noncash_nonbusiness_service_remuneration_excluded_from_wages"
+    )
+    assert item["status"] == "known_not_comparable"
+    assert (
+        item["policyengine_variable"] == "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify `us:statutes/26/3306/b/7#noncash_nonbusiness_service_remuneration_excluded_from_wages` as PE-known-not-comparable
- point the classification at `taxable_earnings_for_federal_unemployment_tax`, since PE exposes final FUTA taxable earnings rather than this narrow exclusion amount
- add a focused PolicyEngine coverage regression test
- bump axiom-encode to 0.2.227

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py`
- `git diff --check`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-7-encoder-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable` -> comparable=226, known_not_comparable=782, untested comparable=0