### PR TITLE
Classify 3306(b)(9) FUTA section 217 exclusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.227"
+version = "0.2.228"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.227"
+__version__ = "0.2.228"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1514,6 +1514,22 @@ mappings:
     candidate_priority: P4
     rationale: Section 3306(b)(7) excludes noncash remuneration for service outside the employer's trade or business from FUTA wages; PolicyEngine exposes final FUTA taxable earnings, not this narrow exclusion amount separately.
 
+  - legal_id: us:statutes/26/3306/b/9#corresponding_section_217_deduction_reasonably_believed_allowable_without_section_274_n
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(b)(9)'s reasonable-belief predicate is a statutory gate for excluding section 217 moving-expense remuneration from FUTA wages; PolicyEngine exposes final FUTA taxable earnings, not this predicate separately.
+
+  - legal_id: us:statutes/26/3306/b/9#section_217_deduction_remuneration_excluded_from_wages
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(b)(9) excludes remuneration to the extent a corresponding section 217 deduction is reasonably believed allowable; PolicyEngine exposes final FUTA taxable earnings, not this narrow exclusion amount separately.
+
   - legal_id: us:statutes/26/443/a/1#annual_accounting_period_change_with_secretary_approval
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -464,6 +464,69 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_b_9_section_217_exclusion(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/b/9.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: corresponding_section_217_deduction_reasonably_believed_allowable_without_section_274_n
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (remuneration_paid_to_employee
+          or remuneration_paid_on_behalf_of_employee)
+          and reasonable_to_believe_at_time_of_payment_corresponding_deduction_allowable_under_section_217_determined_without_regard_to_section_274_n
+  - name: section_217_deduction_remuneration_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if corresponding_section_217_deduction_reasonably_believed_allowable_without_section_274_n:
+            min(
+              max(0, payment_amount),
+              max(0, corresponding_deduction_amount_reasonably_believed_allowable_under_section_217_determined_without_regard_to_section_274_n)
+            )
+          else: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    predicate = items_by_id[
+        "us:statutes/26/3306/b/9#corresponding_section_217_deduction_reasonably_believed_allowable_without_section_274_n"
+    ]
+    exclusion = items_by_id[
+        "us:statutes/26/3306/b/9#section_217_deduction_remuneration_excluded_from_wages"
+    ]
+    assert predicate["status"] == "known_not_comparable"
+    assert (
+        predicate["policyengine_variable"]
+        == "taxable_earnings_for_federal_unemployment_tax"
+    )
+    assert exclusion["status"] == "known_not_comparable"
+    assert (
+        exclusion["policyengine_variable"]
+        == "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify the 26 USC 3306(b)(9) reasonable-belief predicate and section 217 exclusion amount as PE-known-not-comparable
- point both classifications at `taxable_earnings_for_federal_unemployment_tax`, since PE exposes final FUTA taxable earnings rather than these narrow exclusion outputs
- add a focused PolicyEngine coverage regression test
- bump axiom-encode to 0.2.228

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py`
- `git diff --check`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-9-encoder-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable` -> comparable=226, known_not_comparable=784, untested comparable=0