### PR TITLE
Classify 3306(b)(10) FUTA death and disability exclusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.228"
+version = "0.2.229"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.228"
+__version__ = "0.2.229"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1530,6 +1530,14 @@ mappings:
     candidate_priority: P4
     rationale: Section 3306(b)(9) excludes remuneration to the extent a corresponding section 217 deduction is reasonably believed allowable; PolicyEngine exposes final FUTA taxable earnings, not this narrow exclusion amount separately.
 
+  - legal_id: us:statutes/26/3306/b/10#death_or_disability_retirement_termination_plan_payment_excluded_from_wages
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(b)(10) excludes employer-plan payments after employment termination due to death or disability retirement from FUTA wages; PolicyEngine exposes final FUTA taxable earnings, not this narrow exclusion amount separately.
+
   - legal_id: us:statutes/26/443/a/1#annual_accounting_period_change_with_secretary_approval
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -527,6 +527,54 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_b_10_death_disability_exclusion(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/b/10.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: death_or_disability_retirement_termination_plan_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if (
+            payment_or_series_paid_by_employer_to_employee_or_dependent
+            and payment_paid_upon_or_after_termination_of_employment_relationship
+            and (
+              employment_relationship_terminated_because_of_death
+              or employment_relationship_terminated_because_of_retirement_for_disability
+            )
+            and employer_established_plan_makes_provision_for_employees_generally_or_classes_and_dependents
+            and not payment_or_series_would_have_been_paid_if_employment_relationship_had_not_been_terminated
+          ): payment_or_series_amount else: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us:statutes/26/3306/b/10#death_or_disability_retirement_termination_plan_payment_excluded_from_wages"
+    )
+    assert item["status"] == "known_not_comparable"
+    assert (
+        item["policyengine_variable"] == "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify generated 3306(b)(10) FUTA death/disability retirement payment exclusion as PE not-comparable
- add a PE coverage regression for the generated legal ID
- bump axiom-encode to 0.2.229 for regenerated RuleSpec provenance

## Checks
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-10-with-encoder-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable