### PR TITLE
Classify 3306(b)(15) FUTA survivor payment exclusion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.232"
+version = "0.2.233"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.232"
+__version__ = "0.2.233"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1578,6 +1578,14 @@ mappings:
     candidate_priority: P4
     rationale: Section 3306(b)(14) excludes employer-furnished meals or lodging reasonably believed excludable under section 119 from FUTA wages; PolicyEngine exposes final FUTA taxable earnings, not this narrow exclusion amount separately.
 
+  - legal_id: us:statutes/26/3306/b/15#survivor_or_estate_payment_after_employee_death_year_excluded_from_wages
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(b)(15) excludes payments made by an employer to a survivor or estate of a former employee after the employee's year of death from FUTA wages; PolicyEngine exposes final FUTA taxable earnings, not this narrow survivor-or-estate exclusion amount separately.
+
   - legal_id: us:statutes/26/443/a/1#annual_accounting_period_change_with_secretary_approval
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -733,6 +733,51 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_b_15_survivor_estate_payment(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/b/15.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: survivor_or_estate_payment_after_employee_death_year_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if (
+            (
+              payment_made_by_employer_to_survivor_of_former_employee
+              or payment_made_by_employer_to_estate_of_former_employee
+            )
+            and payment_made_after_calendar_year_in_which_former_employee_died
+          ): payment_amount else: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us:statutes/26/3306/b/15#survivor_or_estate_payment_after_employee_death_year_excluded_from_wages"
+    )
+    assert item["status"] == "known_not_comparable"
+    assert (
+        item["policyengine_variable"] == "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
Adds PolicyEngine coverage classification for generated 26 USC 3306(b)(15) survivor-or-estate payment FUTA wage exclusion output.

Changes:
- bump axiom-encode to 0.2.233
- classify the b15 survivor-or-estate exclusion output as known not comparable to PE's final FUTA taxable earnings variable
- add focused PE coverage regression test

Local checks:
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-15-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable