### PR TITLE
Classify 3306(b)(16) FUTA benefit exclusions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.233"
+version = "0.2.234"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.233"
+__version__ = "0.2.234"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1586,6 +1586,22 @@ mappings:
     candidate_priority: P4
     rationale: Section 3306(b)(15) excludes payments made by an employer to a survivor or estate of a former employee after the employee's year of death from FUTA wages; PolicyEngine exposes final FUTA taxable earnings, not this narrow survivor-or-estate exclusion amount separately.
 
+  - legal_id: us:statutes/26/3306/b/16#benefit_income_exclusion_reasonably_expected_under_cited_sections
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(b)(16)'s reasonable-belief predicate is a statutory gate for excluding benefits reasonably believed excludable from income under section 74(c), 108(f)(4), 117, or 132 from FUTA wages; PolicyEngine exposes final FUTA taxable earnings, not this predicate separately.
+
+  - legal_id: us:statutes/26/3306/b/16#benefit_excluded_from_wages_due_to_expected_income_exclusion
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(b)(16) excludes benefits reasonably believed excludable from income under section 74(c), 108(f)(4), 117, or 132 from FUTA wages; PolicyEngine exposes final FUTA taxable earnings, not this narrow benefit exclusion amount separately.
+
   - legal_id: us:statutes/26/443/a/1#annual_accounting_period_change_with_secretary_approval
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -778,6 +778,65 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_b_16_income_exclusion_benefits(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/b/16.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: benefit_income_exclusion_reasonably_expected_under_cited_sections
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_74_c
+          or reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_108_f_4
+          or reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_117
+          or reasonable_at_time_benefit_provided_to_believe_employee_can_exclude_benefit_from_income_under_section_132
+  - name: benefit_excluded_from_wages_due_to_expected_income_exclusion
+    kind: derived
+    entity: Payment
+    dtype: Money
+    unit: USD
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if benefit_provided_to_or_on_behalf_of_employee and benefit_income_exclusion_reasonably_expected_under_cited_sections: benefit_amount else: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    predicate = items_by_id[
+        "us:statutes/26/3306/b/16#benefit_income_exclusion_reasonably_expected_under_cited_sections"
+    ]
+    exclusion = items_by_id[
+        "us:statutes/26/3306/b/16#benefit_excluded_from_wages_due_to_expected_income_exclusion"
+    ]
+    assert predicate["status"] == "known_not_comparable"
+    assert (
+        predicate["policyengine_variable"]
+        == "taxable_earnings_for_federal_unemployment_tax"
+    )
+    assert exclusion["status"] == "known_not_comparable"
+    assert (
+        exclusion["policyengine_variable"]
+        == "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
Adds PolicyEngine coverage classification for generated 26 USC 3306(b)(16) benefit exclusion outputs.

Changes:
- bump axiom-encode to 0.2.234
- classify the b16 reasonable-belief predicate and benefit exclusion amount as known not comparable to PE's final FUTA taxable earnings variable
- add focused PE coverage regression test

Local checks:
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-16-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable