### PR TITLE
Use release binary and raise per-surface timeout for tax-ecps-compare

### DIFF
--- a/changelog.d/ecps-tax-release-binary-and-timeout.fixed.md
+++ b/changelog.d/ecps-tax-release-binary-and-timeout.fixed.md
@@ -1,0 +1,1 @@
+`tax-ecps-compare` now invokes the release axiom-rules-engine binary and allows up to 600 s per `run-compiled` call, so full Enhanced CPS runs (~7 k tax units) complete instead of timing out the per-surface engine call (was hardcoded to 120 s against the debug binary).

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -1811,7 +1811,7 @@ def run_axiom_program(
     rulespec_root: Path,
     axiom_rules_path: Path,
 ) -> list[dict[str, Any]]:
-    binary = axiom_rules_path / "target" / "debug" / "axiom-rules-engine"
+    binary = axiom_rules_path / "target" / "release" / "axiom-rules-engine"
     if not binary.exists():
         raise SystemExit(f"axiom-rules-engine binary not found: {binary}")
     env = os.environ.copy()
@@ -1844,7 +1844,7 @@ def run_axiom_program(
             text=True,
             cwd=str(axiom_rules_path),
             env=env,
-            timeout=120,
+            timeout=600,
         )
         if run_result.returncode != 0:
             raise SystemExit(run_result.stderr.strip() or run_result.stdout.strip())


### PR DESCRIPTION
## Summary

`tax-ecps-compare` shelled out to the debug `axiom-rules-engine` binary with a hardcoded 120 s ceiling per `run-compiled` call. On the full Enhanced CPS (~7 k tax units), the debug build's per-surface evaluation exceeded that ceiling — full-ECPS oracle runs failed early with a subprocess timeout, while 1 k / 3 k samples completed cleanly.

Today's 1 k sample landed at **99.91 % agreement** (massive improvement: OASDI residuals from prior runs are gone). We need the full ECPS number on the same codepath to confirm the agreement holds at scale.

## Changes

`src/axiom_encode/oracles/policyengine/ecps_tax.py` — two lines:

- L1814: `target/debug/axiom-rules-engine` → `target/release/axiom-rules-engine`
- L1847: `timeout=120` → `timeout=600`

Release binary is ~5–10× faster end-to-end. The 600 s safety margin is a soft ceiling that should not actually fire at scale on the release build.

`ecps_snap.py` already resolves its engine binary via `resolve_axiom_binary` and doesn't hardcode the path; no parallel change there.

## Matching orchestrator change (axiom-oracles)

`scripts/run_comparison.py:192` calls `_ensure_engine_binary(axiom_rules_repo, kind="debug")` — needs to swap `"debug"` → `"release"` so the binary actually exists at the new path that this PR points at. Two-character change. Will land in a follow-up PR against axiom-oracles.

## Test plan

- [ ] Local re-run of `python3 scripts/run_comparison.py fiit-ecps --sample-size 0` against this branch + matching orchestrator change. Confirm: no engine timeout, headline agreement %, per-surface breakdown.
- [ ] Spot-check that 1 k sample still produces the same 99.91 % we saw on `main` today (no regression on the smaller path).
- [ ] CI is green.

Will post results on this PR once the full ECPS run lands locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)