### PR TITLE
Classify 3306(b)(18) FUTA section 106(d) payments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.235"
+version = "0.2.236"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.235"
+__version__ = "0.2.236"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1618,6 +1618,22 @@ mappings:
     candidate_priority: P4
     rationale: Section 3306(b)(17) excludes payments reasonably believed excludable from income under section 106(b) from FUTA wages; PolicyEngine exposes final FUTA taxable earnings, not this narrow payment exclusion amount separately.
 
+  - legal_id: us:statutes/26/3306/b/18#section_106_d_income_exclusion_reasonably_expected_at_payment
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(b)(18)'s reasonable-belief predicate is a statutory gate for excluding payments reasonably believed excludable from income under section 106(d) from FUTA wages; PolicyEngine exposes final FUTA taxable earnings, not this predicate separately.
+
+  - legal_id: us:statutes/26/3306/b/18#payment_excluded_from_wages_due_to_expected_section_106_d_income_exclusion
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(b)(18) excludes payments reasonably believed excludable from income under section 106(d) from FUTA wages; PolicyEngine exposes final FUTA taxable earnings, not this narrow payment exclusion amount separately.
+
   - legal_id: us:statutes/26/443/a/1#annual_accounting_period_change_with_secretary_approval
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -894,6 +894,63 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_b_18_section_106_d_payments(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/b/18.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: section_106_d_income_exclusion_reasonably_expected_at_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          payment_made_to_or_for_benefit_of_employee
+          and reasonable_at_time_of_payment_to_believe_employee_can_exclude_payment_from_income_under_section_106_d
+  - name: payment_excluded_from_wages_due_to_expected_section_106_d_income_exclusion
+    kind: derived
+    entity: Payment
+    dtype: Money
+    unit: USD
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if section_106_d_income_exclusion_reasonably_expected_at_payment: payment_amount else: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    predicate = items_by_id[
+        "us:statutes/26/3306/b/18#section_106_d_income_exclusion_reasonably_expected_at_payment"
+    ]
+    exclusion = items_by_id[
+        "us:statutes/26/3306/b/18#payment_excluded_from_wages_due_to_expected_section_106_d_income_exclusion"
+    ]
+    assert predicate["status"] == "known_not_comparable"
+    assert (
+        predicate["policyengine_variable"]
+        == "taxable_earnings_for_federal_unemployment_tax"
+    )
+    assert exclusion["status"] == "known_not_comparable"
+    assert (
+        exclusion["policyengine_variable"]
+        == "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- mark generated 26 USC 3306(b)(18) section 106(d) FUTA payment predicate/output as known-not-comparable to PolicyEngine's final FUTA taxable earnings variable
- add a focused PolicyEngine oracle coverage regression test
- bump axiom-encode to 0.2.236

## Local checks
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-18-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable