### PR TITLE
Classify 3306(b)(20) FUTA third-party employer treatment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.237"
+version = "0.2.238"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.237"
+__version__ = "0.2.238"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1650,6 +1650,13 @@ mappings:
     candidate_priority: P4
     rationale: Section 3306(b)(19) excludes remuneration on account of qualifying incentive stock option or employee stock purchase plan stock transfers and dispositions from FUTA wages; PolicyEngine exposes final FUTA taxable earnings, not this narrow exclusion amount separately.
 
+  - legal_id: us:statutes/26/3306/b/20#third_party_treated_as_employer_for_this_chapter_and_chapter_22_wages
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 3306(b)(20)'s third-party-employer treatment rule identifies when a third-party payer is treated as the employer for FUTA and chapter 22 purposes; PolicyEngine does not expose employer-identity treatment predicates separately.
+
   - legal_id: us:statutes/26/443/a/1#annual_accounting_period_change_with_secretary_approval
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1014,6 +1014,43 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_b_20_third_party_employer_treatment(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/b/20.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: third_party_treated_as_employer_for_this_chapter_and_chapter_22_wages
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          third_party_makes_payment
+          and payment_included_in_wages_solely_by_reason_of_parenthetical_matter_contained_in_paragraph_2_subparagraph_A
+          and not regulations_prescribed_by_secretary_provide_otherwise_for_third_party_payment
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us:statutes/26/3306/b/20#third_party_treated_as_employer_for_this_chapter_and_chapter_22_wages"
+    )
+    assert item["status"] == "known_not_comparable"
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- mark the generated 26 USC 3306(b)(20) third-party-employer treatment predicate as known-not-comparable for PolicyEngine
- add a focused coverage regression for the generated legal id
- bump axiom-encode to 0.2.238

## Rationale
PolicyEngine exposes FUTA tax outputs, but does not expose employer identity/treatment predicates separately. Section 3306(b)(20) determines when a third-party payer is treated as the employer for FUTA and chapter 22 purposes, so this generated predicate should not block oracle coverage as unmapped.

## Local checks
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-20-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable