### PR TITLE
Classify 3306(b)(5) FUTA qualified-plan exclusions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.238"
+version = "0.2.239"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.238"
+__version__ = "0.2.239"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1490,6 +1490,22 @@ mappings:
     candidate_priority: P4
     rationale: Section 3306(b)(4) excludes post-work sickness, accident-disability, medical, and hospitalization payments from FUTA wages after the six-calendar-month waiting period; PolicyEngine exposes final FUTA taxable earnings, not this exclusion predicate separately.
 
+  - legal_id: us:statutes/26/3306/b/5#qualified_plan_cafeteria_or_deferred_compensation_exclusion_category_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(b)(5)'s qualified-plan, cafeteria-plan, and deferred-compensation category predicate feeds a narrow FUTA wage exclusion; PolicyEngine exposes final FUTA taxable earnings, not this eligibility predicate separately.
+
+  - legal_id: us:statutes/26/3306/b/5#qualified_plan_cafeteria_or_deferred_compensation_payment_excluded_from_wages
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(b)(5) excludes qualifying retirement-plan, cafeteria-plan, and deferred-compensation payments from FUTA wages; PolicyEngine exposes final FUTA taxable earnings, not this narrow exclusion amount separately.
+
   - legal_id: us:statutes/26/3306/b/6#employer_state_unemployment_payment_excluded_from_wages
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -354,6 +354,66 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_b_5_qualified_plan_exclusion(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/b/5.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: qualified_plan_cafeteria_or_deferred_compensation_exclusion_category_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          (
+            payment_from_or_to_trust_described_in_section_401_a_exempt_under_section_501_a_at_time_of_payment
+            and not payment_made_to_employee_of_trust_as_remuneration_for_services_rendered_as_employee_and_not_as_beneficiary
+          )
+          or payment_under_or_to_annuity_plan_described_in_section_403_a_at_time_of_payment
+  - name: qualified_plan_cafeteria_or_deferred_compensation_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if payment_made_to_or_on_behalf_of_employee_or_beneficiary
+          and qualified_plan_cafeteria_or_deferred_compensation_exclusion_category_applies: payment_amount else: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    predicate = items_by_id[
+        "us:statutes/26/3306/b/5#qualified_plan_cafeteria_or_deferred_compensation_exclusion_category_applies"
+    ]
+    exclusion = items_by_id[
+        "us:statutes/26/3306/b/5#qualified_plan_cafeteria_or_deferred_compensation_payment_excluded_from_wages"
+    ]
+    assert predicate["status"] == "known_not_comparable"
+    assert (
+        predicate["policyengine_variable"]
+        == "taxable_earnings_for_federal_unemployment_tax"
+    )
+    assert exclusion["status"] == "known_not_comparable"
+    assert exclusion["policyengine_variable"] == (
+        "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3306_b_6_state_unemployment_exclusion(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- mark generated 26 USC 3306(b)(5) FUTA qualified-plan/cafeteria/deferred-compensation outputs as known-not-comparable for PolicyEngine
- add a focused coverage regression for the generated b5 legal ids
- bump axiom-encode to 0.2.239

## Rationale
PolicyEngine exposes final FUTA taxable earnings, but does not expose narrow section 3306(b)(5) exclusion predicates or exclusion amounts separately.

## Local checks
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-b-5-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable