### PR TITLE
Classify 3306(c)(1) FUTA agricultural employment rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.239"
+version = "0.2.240"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.239"
+__version__ = "0.2.240"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9814,6 +9814,14 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(a)(8) agricultural-labor cash and noncash wage-exclusion thresholds, hand-harvest exception predicates, or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3306/c/1#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(c)(1) defines agricultural-labor employment thresholds and exception predicates for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these agricultural-employment eligibility parameters or predicates separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1111,6 +1111,91 @@ rules:
     assert item["status"] == "known_not_comparable"
 
 
+def test_policyengine_coverage_classifies_3306_c_1_agricultural_labor_employment(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/c/1.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: agricultural_labor_cash_remuneration_quarter_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 20000
+  - name: agricultural_labor_days_different_weeks_threshold
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 20
+  - name: agricultural_labor_individuals_per_day_threshold
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 10
+  - name: agricultural_labor_cash_remuneration_test_satisfied
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          maximum_cash_remuneration_paid_to_agricultural_labor_individuals_in_any_calendar_quarter >= agricultural_labor_cash_remuneration_quarter_threshold
+  - name: agricultural_labor_day_count_test_satisfied
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          counted_days_during_calendar_year_or_preceding_calendar_year_each_in_different_calendar_week >= agricultural_labor_days_different_weeks_threshold
+          and minimum_agricultural_labor_individuals_employed_for_some_portion_of_each_counted_day >= agricultural_labor_individuals_per_day_threshold
+  - name: agricultural_labor_employer_test_satisfied
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          agricultural_labor_cash_remuneration_test_satisfied
+          or agricultural_labor_day_count_test_satisfied
+  - name: agricultural_labor_excepted_from_employment
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          labor_is_agricultural_labor
+          and (
+            not agricultural_labor_employer_test_satisfied
+            or labor_performed_by_immigration_and_nationality_act_agricultural_worker_alien
+          )
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 7}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {
+        "taxable_earnings_for_federal_unemployment_tax"
+    }
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3306(c)(1) agricultural-labor FUTA employment outputs as known-not-comparable to PolicyEngine
- add a focused coverage regression for the generated c(1) legal-id prefix
- bump axiom-encode to 0.2.240

## Rationale
PolicyEngine exposes final FUTA taxable earnings and rates, but does not expose the section 3306(c)(1) agricultural-labor employment thresholds, employer tests, or alien-worker exception predicates separately.

## Local checks
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-1-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable