### PR TITLE
Classify 3306(c)(3) FUTA nonbusiness service rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.241"
+version = "0.2.242"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.241"
+__version__ = "0.2.242"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9830,6 +9830,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(c)(2) defines domestic-service employment thresholds and exception predicates for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these domestic-service eligibility parameters or predicates separately.
 
+  - legal_id_prefix: us:statutes/26/3306/c/3#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(c)(3) defines nonbusiness-service cash-remuneration and regular-employment thresholds and exception predicates for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these nonbusiness-service eligibility parameters or predicates separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1246,6 +1246,84 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3306_c_3_nonbusiness_service_employment(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/c/3.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: nonbusiness_service_cash_remuneration_quarter_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 50
+  - name: nonbusiness_service_regular_employment_days_threshold
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 24
+  - name: nonbusiness_service_cash_remuneration_test_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          cash_remuneration_paid_for_nonbusiness_service_in_calendar_quarter >= nonbusiness_service_cash_remuneration_quarter_threshold
+  - name: nonbusiness_service_current_quarter_regular_employment_test_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          counted_days_in_calendar_quarter_person_performed_nonbusiness_service_for_employer >= nonbusiness_service_regular_employment_days_threshold
+  - name: nonbusiness_service_regular_employment_test_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          nonbusiness_service_current_quarter_regular_employment_test_satisfied
+          or person_was_regularly_employed_by_employer_for_nonbusiness_service_during_preceding_calendar_quarter
+  - name: nonbusiness_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          person_performed_service_not_in_course_of_employer_trade_or_business_as_employee_in_calendar_quarter
+          and not (
+            nonbusiness_service_cash_remuneration_test_satisfied
+            and nonbusiness_service_regular_employment_test_satisfied
+          )
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 6}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {
+        "taxable_earnings_for_federal_unemployment_tax"
+    }
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3306(c)(3) FUTA nonbusiness-service outputs as known not comparable to direct PE outputs
- attach the downstream PolicyEngine FUTA taxable earnings variable for oracle context
- bump axiom-encode to 0.2.242 for generated artifact provenance

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3306_c_3_nonbusiness_service_employment tests/test_cli.py::test_package_version_metadata_matches_pyproject
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-3-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py