### PR TITLE
Classify 3306(c)(4) FUTA vessel and aircraft rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.242"
+version = "0.2.243"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.242"
+__version__ = "0.2.243"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9838,6 +9838,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(c)(3) defines nonbusiness-service cash-remuneration and regular-employment thresholds and exception predicates for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these nonbusiness-service eligibility parameters or predicates separately.
 
+  - legal_id_prefix: us:statutes/26/3306/c/4#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(c)(4) defines non-American vessel and aircraft service exception predicates for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these vessel-or-aircraft employment exception predicates separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1324,6 +1324,42 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3306_c_4_vessel_aircraft_employment(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/c/4.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: non_american_vessel_or_aircraft_service_excepted_from_employment
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_on_or_in_connection_with_vessel_or_aircraft
+          and not (american_vessel or american_aircraft)
+          and employee_employed_on_and_in_connection_with_vessel_or_aircraft_when_outside_united_states
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["status"] == "known_not_comparable"
+    assert (
+        item["policyengine_variable"] == "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3306(c)(4) FUTA non-American vessel/aircraft service output as known not comparable to direct PE outputs
- attach downstream PolicyEngine FUTA taxable earnings variable for oracle context
- bump axiom-encode to 0.2.243 for generated artifact provenance

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3306_c_4_vessel_aircraft_employment tests/test_cli.py::test_package_version_metadata_matches_pyproject
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-4-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev python -m towncrier build --draft --version 0.0.0