### PR TITLE
Classify 3306(c)(6) FUTA federal service rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.244"
+version = "0.2.245"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.244"
+__version__ = "0.2.245"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9854,6 +9854,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(c)(5) defines family-employment exception predicates and the child age threshold for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these family-relationship employment exception predicates separately.
 
+  - legal_id_prefix: us:statutes/26/3306/c/6#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(c)(6) defines United States Government and qualifying federal-instrumentality service exception predicates for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these federal-government employment exception predicates separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1415,6 +1415,53 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3306_c_6_federal_government_employment(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/c/6.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: service_in_employ_of_qualifying_united_states_instrumentality
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_instrumentality_of_united_states
+          and (
+            instrumentality_wholly_or_partially_owned_by_united_states
+            or instrumentality_exempt_from_federal_unemployment_excise_tax_by_specific_reference_to_section_3301_or_prior_law
+          )
+  - name: federal_government_or_qualifying_instrumentality_service_excepted_from_employment
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_united_states_government
+          or service_in_employ_of_qualifying_united_states_instrumentality
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {
+        "taxable_earnings_for_federal_unemployment_tax"
+    }
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3306(c)(6) federal-government and qualifying-instrumentality FUTA predicates as PolicyEngine known-not-comparable
- attach the mapping to PolicyEngine's downstream `taxable_earnings_for_federal_unemployment_tax` surface
- bump axiom-encode to 0.2.245 for generated RuleSpec provenance

## Tests
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3306_c_6_federal_government_employment tests/test_cli.py::test_package_version_metadata_matches_pyproject`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py`
- `uv run --extra dev python -m towncrier build --draft --version 0.0.0`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-6-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`