### PR TITLE
Classify 3306(c)(7) FUTA state and tribal service rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.245"
+version = "0.2.246"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.245"
+__version__ = "0.2.246"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9862,6 +9862,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(c)(6) defines United States Government and qualifying federal-instrumentality service exception predicates for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these federal-government employment exception predicates separately.
 
+  - legal_id_prefix: us:statutes/26/3306/c/7#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(c)(7) defines State, political-subdivision, Indian-tribe, and constitutionally immune instrumentality service exception predicates for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these governmental or tribal employment exception predicates separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1462,6 +1462,72 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3306_c_7_state_tribal_employment(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/c/7.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: service_in_employ_of_state_political_subdivision_or_indian_tribe
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_state
+          or service_performed_in_employ_of_political_subdivision_of_state
+          or service_performed_in_employ_of_indian_tribe
+  - name: service_in_employ_of_wholly_owned_state_political_subdivision_or_indian_tribe_instrumentality
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_instrumentality_of_state_political_subdivision_or_indian_tribe
+          and instrumentality_wholly_owned_by_one_or_more_states_political_subdivisions_or_indian_tribes
+  - name: service_in_employ_of_constitutionally_immune_state_or_political_subdivision_instrumentality
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_instrumentality_of_one_or_more_states_or_political_subdivisions
+          and instrumentality_is_with_respect_to_service_immune_under_constitution_from_federal_unemployment_excise_tax
+  - name: state_political_subdivision_indian_tribe_or_immune_instrumentality_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_in_employ_of_state_political_subdivision_or_indian_tribe
+          or service_in_employ_of_wholly_owned_state_political_subdivision_or_indian_tribe_instrumentality
+          or service_in_employ_of_constitutionally_immune_state_or_political_subdivision_instrumentality
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 4}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {
+        "taxable_earnings_for_federal_unemployment_tax"
+    }
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3306(c)(7) state, political-subdivision, Indian-tribe, and immune-instrumentality FUTA predicates as PolicyEngine known-not-comparable
- attach the mapping to PolicyEngine's downstream `taxable_earnings_for_federal_unemployment_tax` surface
- bump axiom-encode to 0.2.246 for generated RuleSpec provenance

## Tests
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3306_c_7_state_tribal_employment tests/test_cli.py::test_package_version_metadata_matches_pyproject`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py`
- `uv run --extra dev python -m towncrier build --draft --version 0.0.0`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-7-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable`