### PR TITLE
Classify 3306(c)(11) FUTA foreign government rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.249"
+version = "0.2.250"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.249"
+__version__ = "0.2.250"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9894,6 +9894,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(c)(10) defines exempt-organization, school-student, work-experience, and hospital-patient service exception predicates and a low-remuneration threshold for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these educational, health, and exempt-organization employment exception predicates separately.
 
+  - legal_id_prefix: us:statutes/26/3306/c/11#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(c)(11) defines foreign-government service as an exception predicate for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not this foreign-government employment exception predicate separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1699,6 +1699,42 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3306_c_11_foreign_government_employment(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/c/11.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: foreign_government_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_foreign_government
+          or service_performed_as_consular_or_other_officer_or_employee_of_foreign_government
+          or service_performed_as_nondiplomatic_representative_of_foreign_government
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["status"] == "known_not_comparable"
+    assert (
+        item["policyengine_variable"] == "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3306(c)(11) foreign-government FUTA exception output as PolicyEngine known-not-comparable
- add a coverage regression for the generated foreign-government service predicate
- bump axiom-encode to 0.2.250

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3306_c_11_foreign_government_employment tests/test_cli.py::test_package_version_metadata_matches_pyproject
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-11-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py
- uv run --extra dev python -m towncrier build --draft --version 0.0.0