### PR TITLE
Classify 3306(c)(12) FUTA foreign instrumentality rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.250"
+version = "0.2.251"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.250"
+__version__ = "0.2.251"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9902,6 +9902,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(c)(11) defines foreign-government service as an exception predicate for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not this foreign-government employment exception predicate separately.
 
+  - legal_id_prefix: us:statutes/26/3306/c/12#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(c)(12) defines foreign-government wholly owned instrumentality service as an exception predicate for FUTA coverage, including service-character and State Department reciprocity certification conditions; PolicyEngine exposes final FUTA taxable earnings, not this foreign-government-instrumentality employment exception predicate separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1735,6 +1735,42 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_c_12_foreign_government_instrumentality_employment(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/c/12.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: foreign_government_wholly_owned_instrumentality_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_in_employ_of_instrumentality_wholly_owned_by_foreign_government
+          and service_character_similar_to_service_performed_in_foreign_countries_by_united_states_government_or_instrumentality_employees
+          and secretary_of_state_certifies_foreign_government_grants_equivalent_exemption_for_similar_service_by_united_states_government_or_instrumentality_employees
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["status"] == "known_not_comparable"
+    assert (
+        item["policyengine_variable"] == "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3306(c)(12) foreign-government-instrumentality FUTA exception output as PolicyEngine known-not-comparable
- add a coverage regression for the generated wholly owned foreign-government instrumentality service predicate
- bump axiom-encode to 0.2.251

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3306_c_12_foreign_government_instrumentality_employment tests/test_cli.py::test_package_version_metadata_matches_pyproject
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-12-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py
- uv run --extra dev python -m towncrier build --draft --version 0.0.0