### PR TITLE
Classify 3306(c)(13) FUTA health training rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.251"
+version = "0.2.252"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.251"
+__version__ = "0.2.252"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9910,6 +9910,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(c)(12) defines foreign-government wholly owned instrumentality service as an exception predicate for FUTA coverage, including service-character and State Department reciprocity certification conditions; PolicyEngine exposes final FUTA taxable earnings, not this foreign-government-instrumentality employment exception predicate separately.
 
+  - legal_id_prefix: us:statutes/26/3306/c/13#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(c)(13) defines student-nurse and hospital-intern service exception predicates for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these health-training employment exception predicates separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1771,6 +1771,54 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_c_13_health_training_employment(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/c/13.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: student_nurse_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: service_performed_as_student_nurse
+  - name: hospital_intern_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: service_performed_as_intern and service_performed_in_employ_of_hospital
+  - name: student_nurse_or_hospital_intern_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: student_nurse_service_excepted_from_employment or hospital_intern_service_excepted_from_employment
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {
+        "taxable_earnings_for_federal_unemployment_tax"
+    }
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3306(c)(13) FUTA health-training exception outputs as PolicyEngine known-not-comparable
- add focused PE oracle coverage regression for the student nurse and hospital intern predicates
- bump encoder package/provenance version to 0.2.252

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-13-20260525 --program tax --fail-on-unmapped --fail-on-untested-comparable