### PR TITLE
Classify 3306(c)(14) FUTA insurance rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.252"
+version = "0.2.253"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.252"
+__version__ = "0.2.253"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9918,6 +9918,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(c)(13) defines student-nurse and hospital-intern service exception predicates for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these health-training employment exception predicates separately.
 
+  - legal_id_prefix: us:statutes/26/3306/c/14#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(c)(14) defines an insurance-agent or insurance-solicitor commission service exception predicate for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not this insurance-service employment exception predicate separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1819,6 +1819,39 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3306_c_14_insurance_commission_employment(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/c/14.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: insurance_agent_or_solicitor_commission_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: service_performed_for_person_as_insurance_agent_or_insurance_solicitor
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["status"] == "known_not_comparable"
+    assert (
+        item["policyengine_variable"] == "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3306(c)(14) FUTA insurance agent/solicitor commission exception output as PolicyEngine known-not-comparable
- add focused PE oracle coverage regression for the generated predicate
- bump encoder package/provenance version to 0.2.253

## Tests
- uv run --extra dev ruff format tests/test_policyengine_coverage.py
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3306_c_14_insurance_commission_employment tests/test_cli.py::test_package_version_metadata_matches_pyproject
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-14-20260526 --program tax --fail-on-unmapped --fail-on-untested-comparable