### PR TITLE
Classify 3306(c)(16) FUTA international organization rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.254"
+version = "0.2.255"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.254"
+__version__ = "0.2.255"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9934,6 +9934,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(c)(15) defines newspaper delivery, distribution, and ultimate-consumer sales service exception predicates for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these newspaper-service employment exception predicates separately.
 
+  - legal_id_prefix: us:statutes/26/3306/c/16#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(c)(16) defines international-organization service as an exception predicate for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not this international-organization employment exception predicate separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1900,6 +1900,39 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3306_c_16_international_organization_employment(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/c/16.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: international_organization_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: service_performed_in_employ_of_international_organization
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["status"] == "known_not_comparable"
+    assert (
+        item["policyengine_variable"] == "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3306(c)(16) FUTA international-organization service output as PolicyEngine known-not-comparable
- add focused PE oracle coverage regression for the generated predicate
- bump encoder package/provenance version to 0.2.255

## Tests
- uv run --extra dev ruff format tests/test_policyengine_coverage.py
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3306_c_16_international_organization_employment tests/test_cli.py::test_package_version_metadata_matches_pyproject
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-16-20260526 --program tax --fail-on-unmapped --fail-on-untested-comparable