### PR TITLE
Classify 3306(c)(18) FUTA fishing boat rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.256"
+version = "0.2.257"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.256"
+__version__ = "0.2.257"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9950,6 +9950,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(c)(17) defines aquatic-life service exception predicates and statutory carveouts for FUTA coverage, including the vessel net-ton threshold; PolicyEngine exposes final FUTA taxable earnings, not these fishing and aquatic-life employment exception predicates or the vessel-tonnage threshold separately.
 
+  - legal_id_prefix: us:statutes/26/3306/c/18#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(c)(18) incorporates the section 3121(b)(20) fishing-boat service exception as a FUTA employment exception predicate; PolicyEngine exposes final FUTA taxable earnings, not this fishing-boat employment exception predicate separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1987,6 +1987,39 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3306_c_18_fishing_boat_employment(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/c/18.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: fishing_boat_service_excepted_from_employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: fishing_boat_service_excluded_from_employment
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["status"] == "known_not_comparable"
+    assert (
+        item["policyengine_variable"] == "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
Adds PolicyEngine oracle coverage classification for generated 26 USC 3306(c)(18) FUTA fishing-boat employment exception outputs. PolicyEngine exposes final FUTA taxable earnings, not the incorporated section 3121(b)(20) fishing-boat exception predicate separately.\n\nAlso bumps axiom-encode to 0.2.257 for signed apply provenance.\n\nValidation:\n- uv run --extra dev ruff format tests/test_policyengine_coverage.py\n- uv run --extra dev ruff check src/ tests/\n- uv run --extra dev ruff format --check src/ tests/\n- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3306_c_18_fishing_boat_employment tests/test_cli.py::TestCmdEncode::test_apply_version_provenance_allows_changes_in_version_bump_commit\n- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-18-patched-20260526 --program tax --fail-on-unmapped --fail-on-untested-comparable\n- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py\n- uv run --extra dev python -m towncrier build --draft --version 0.0.0\n- git diff --check