### PR TITLE
Classify 3306(c)(20) FUTA organized camp rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.259"
+version = "0.2.260"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.259"
+__version__ = "0.2.260"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9966,6 +9966,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(c)(19) defines a nonresident-alien F, J, M, or Q nonimmigrant purpose-service exception predicate for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not this immigration-status employment exception predicate separately.
 
+  - legal_id_prefix: us:statutes/26/3306/c/20#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(c)(20) defines full-time-student organized-camp service exception predicates and statutory thresholds for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these organized-camp employment exception predicates or thresholds separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2053,6 +2053,88 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_c_20_organized_camp_employment(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/c/20.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: organized_camp_operation_month_limit
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 7
+  - name: organized_camp_gross_receipts_percentage_limit
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.3333333333333333
+  - name: full_time_student_camp_service_week_limit
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 13
+  - name: camp_employing_student_short_season_test_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: months <= organized_camp_operation_month_limit
+  - name: camp_employing_student_gross_receipts_seasonality_test_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: selected_receipts <= organized_camp_gross_receipts_percentage_limit * other_receipts
+  - name: camp_employing_student_paragraph_a_test_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: camp_employing_student_short_season_test_satisfied or camp_employing_student_gross_receipts_seasonality_test_satisfied
+  - name: full_time_student_camp_service_week_test_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: weeks < full_time_student_camp_service_week_limit
+  - name: full_time_student_organized_camp_service_excepted_from_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: student and camp_employing_student_paragraph_a_test_satisfied and full_time_student_camp_service_week_test_satisfied
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 8}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {
+        "taxable_earnings_for_federal_unemployment_tax"
+    }
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3306(c)(20) organized-camp FUTA predicates and thresholds as PolicyEngine known-not-comparable
- add coverage fixture for the c20 outputs
- bump encoder version to 0.2.260 for signed RuleSpec apply provenance

## Tests
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-coverage-3306-c-20-patched-20260526 --program tax --fail-on-unmapped --fail-on-untested-comparable
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- git diff --check