### PR TITLE
Repair fractional parameter companion tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.260"
+version = "0.2.261"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.260"
+__version__ = "0.2.261"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -19,6 +19,7 @@ import difflib
 import hashlib
 import hmac
 import json
+import math
 import os
 import re
 import shutil
@@ -14158,7 +14159,7 @@ def _repair_mixed_scalar_output_tests(
         f"{_repo_jurisdiction_prefix(repo_path)}:"
         f"{_relative_rulespec_import_target(relative_output)}"
     )
-    scalar_outputs: set[str] = set()
+    scalar_parameter_rules: dict[str, dict[str, Any]] = {}
     for rule in rules_document.get("rules") or []:
         if not isinstance(rule, dict):
             continue
@@ -14166,9 +14167,10 @@ def _repair_mixed_scalar_output_tests(
             continue
         name = str(rule.get("name") or "").strip()
         if name:
-            scalar_outputs.add(f"{target_base}#{name}")
-    if not scalar_outputs:
+            scalar_parameter_rules[f"{target_base}#{name}"] = rule
+    if not scalar_parameter_rules:
         return []
+    scalar_outputs = set(scalar_parameter_rules)
 
     repaired_cases: list[object] = []
     repaired_names: list[str] = []
@@ -14183,13 +14185,36 @@ def _repair_mixed_scalar_output_tests(
         if not isinstance(output, dict):
             repaired_cases.append(case)
             continue
+
+        output = dict(output)
+        dropped_fractional_parameter_outputs = [
+            key
+            for key in output
+            if _parameter_output_assertion_uses_nonterminating_fraction(
+                scalar_parameter_rules.get(str(key))
+            )
+        ]
+        for key in dropped_fractional_parameter_outputs:
+            output.pop(key, None)
+        if dropped_fractional_parameter_outputs:
+            case_name = str(case.get("name") or "case").strip() or "case"
+            if case_name not in repaired_names:
+                repaired_names.append(case_name)
+        if not output:
+            continue
+
         scalar_items = {
             key: _scalar_parameter_test_expected_value(value)
             for key, value in output.items()
             if str(key) in scalar_outputs
         }
         if not scalar_items or len(scalar_items) == len(output):
-            repaired_cases.append(case)
+            if dropped_fractional_parameter_outputs:
+                repaired_case = dict(case)
+                repaired_case["output"] = output
+                repaired_cases.append(repaired_case)
+            else:
+                repaired_cases.append(case)
             continue
 
         entity_items = {
@@ -14214,7 +14239,8 @@ def _repair_mixed_scalar_output_tests(
             "output": scalar_items,
         }
         repaired_cases.append(scalar_case)
-        repaired_names.append(case_name)
+        if case_name not in repaired_names:
+            repaired_names.append(case_name)
 
     if not repaired_names:
         return []
@@ -14349,6 +14375,43 @@ def _scalar_parameter_test_expected_value(value: Any) -> Any:
     if all(item == first for item in value):
         return first
     return value
+
+
+def _parameter_output_assertion_uses_nonterminating_fraction(
+    rule: dict[str, Any] | None,
+) -> bool:
+    """Return true when a raw parameter output cannot be stably represented in YAML."""
+    if not isinstance(rule, dict):
+        return False
+    formula = _first_parameter_formula_text(rule)
+    if formula is None:
+        return False
+    match = re.fullmatch(r"\(?\s*(-?\d+)\s*/\s*(-?\d+)\s*\)?", formula)
+    if not match:
+        return False
+    numerator = int(match.group(1))
+    denominator = int(match.group(2))
+    if denominator == 0:
+        return False
+    denominator = abs(denominator) // math.gcd(abs(numerator), abs(denominator))
+    for factor in (2, 5):
+        while denominator % factor == 0 and denominator > 1:
+            denominator //= factor
+    return denominator != 1
+
+
+def _first_parameter_formula_text(rule: dict[str, Any]) -> str | None:
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return None
+    for version in versions:
+        if not isinstance(version, dict):
+            continue
+        formula = version.get("formula")
+        if formula is None:
+            continue
+        return str(formula).strip()
+    return None
 
 
 def _unique_test_case_name(base: str, existing_names: set[str]) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6189,6 +6189,74 @@ rules:
             "us:statutes/26/3121/a/7#cash_nontrade_service_annual_threshold": 100
         }
 
+    def test_mixed_scalar_output_test_repair_drops_nonterminating_fraction_parameter(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        rules_file = policy_repo / "statutes/26/3306/c/20.yaml"
+        test_file = policy_repo / "statutes/26/3306/c/20.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: organized_camp_operation_month_limit
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 7
+  - name: organized_camp_gross_receipts_percentage_limit
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 1 / 3
+  - name: organized_camp_gross_receipts_test_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: selected_receipts <= organized_camp_gross_receipts_percentage_limit * other_receipts
+"""
+        )
+        test_file.write_text(
+            """- name: gross_receipts_path_qualifies
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3306/c/20#input.selected_receipts: 90
+    us:statutes/26/3306/c/20#input.other_receipts: 300
+  output:
+    us:statutes/26/3306/c/20#organized_camp_operation_month_limit: 7
+    us:statutes/26/3306/c/20#organized_camp_gross_receipts_percentage_limit: 0.3333333333333333
+    us:statutes/26/3306/c/20#organized_camp_gross_receipts_test_satisfied: holds
+"""
+        )
+
+        repaired = _repair_mixed_scalar_output_tests(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=policy_repo,
+            relative_output=Path("statutes/26/3306/c/20.yaml"),
+        )
+
+        cases = yaml.safe_load(test_file.read_text())
+        assert repaired == ["gross_receipts_path_qualifies"]
+        assert cases[0]["output"] == {
+            "us:statutes/26/3306/c/20#organized_camp_gross_receipts_test_satisfied": "holds"
+        }
+        assert cases[1]["output"] == {
+            "us:statutes/26/3306/c/20#organized_camp_operation_month_limit": 7
+        }
+        assert (
+            "organized_camp_gross_receipts_percentage_limit"
+            not in test_file.read_text()
+        )
+
     def test_mixed_derived_entity_output_test_repair_splits_entity_outputs(
         self, tmp_path
     ):


### PR DESCRIPTION
## Summary
- drop raw companion assertions for generated parameter formulas that are exact non-terminating fractions such as 1 / 3
- keep derived output tests that exercise those fractional parameters
- bump encoder version to 0.2.261 for signed RuleSpec apply provenance

## Context
- 26 USC 3306(c)(20) encodes the statutory 33 1/3 percent threshold as 1 / 3; the generated test asserted a truncated decimal and failed exact RuleSpec validation.

## Tests
- uv run --extra dev python -m pytest tests/test_cli.py::TestCmdEncode::test_mixed_scalar_output_test_repair_splits_parameter_outputs tests/test_cli.py::TestCmdEncode::test_mixed_scalar_output_test_repair_unwraps_row_shaped_parameter_output tests/test_cli.py::TestCmdEncode::test_mixed_scalar_output_test_repair_drops_nonterminating_fraction_parameter
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- smoke: repaired the generated c20 artifact and ran axiom-encode validate --skip-reviewers
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- git diff --check