### PR TITLE
Repair imported RuleSpec name collisions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.261"
+version = "0.2.262"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.261"
+__version__ = "0.2.262"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -13681,6 +13681,26 @@ def _validate_generated_encoding_in_policy_overlay(
         for _ in range(_APPLY_OVERLAY_VALIDATION_REPAIR_LIMIT):
             if all(validation.all_passed for _, validation in validations):
                 return True, [], supplemental_files
+            imported_collision_repairs = _repair_imported_rule_name_collisions(
+                rules_file=overlay_target,
+                test_file=_rulespec_test_path(overlay_target),
+                repo_path=overlay_repo,
+                relative_output=relative_output,
+            )
+            if imported_collision_repairs:
+                supplemental_files[relative_output] = overlay_target.read_text()
+                test_path = _rulespec_test_path(overlay_target)
+                if test_path.exists():
+                    supplemental_files[test_path.relative_to(overlay_repo)] = (
+                        test_path.read_text()
+                    )
+                validations = _validate_overlay_files(
+                    pipeline,
+                    dependent_pipeline=dependent_pipeline,
+                    overlay_target=overlay_target,
+                    dependents=dependents,
+                )
+                continue
             mixed_scalar_repairs = _repair_mixed_scalar_output_tests(
                 rules_file=overlay_target,
                 test_file=_rulespec_test_path(overlay_target),
@@ -14135,6 +14155,193 @@ def _rulespec_ancestor_target_paths(relative_output: Path) -> list[Path]:
         ancestors.append(Path(f"{current.as_posix()}.yaml"))
         current = current.parent
     return ancestors
+
+
+def _repair_imported_rule_name_collisions(
+    *,
+    rules_file: Path,
+    test_file: Path,
+    repo_path: Path,
+    relative_output: Path,
+) -> list[str]:
+    """Rename generated local outputs that collide with imported module exports."""
+    try:
+        rules_document = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(rules_document, dict):
+        return []
+
+    rules = rules_document.get("rules")
+    if not isinstance(rules, list):
+        return []
+    imports = rules_document.get("imports")
+    if not isinstance(imports, list):
+        return []
+
+    imported_names = _imported_module_exported_rule_names(
+        imports,
+        repo_path=repo_path,
+    )
+    if not imported_names:
+        return []
+
+    local_names = _rulespec_rule_names_from_payload(rules_document)
+    collisions = sorted(local_names & imported_names)
+    if not collisions:
+        return []
+
+    existing_names = set(local_names) | imported_names
+    replacements: dict[str, str] = {}
+    for name in collisions:
+        candidate = f"local_{name}"
+        index = 2
+        while candidate in existing_names:
+            candidate = f"local_{name}_{index}"
+            index += 1
+        replacements[name] = candidate
+        existing_names.add(candidate)
+
+    target_base = (
+        f"{_repo_jurisdiction_prefix(repo_path)}:"
+        f"{_relative_rulespec_import_target(relative_output)}"
+    )
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        name = str(rule.get("name") or "").strip()
+        if name in replacements:
+            rule["name"] = replacements[name]
+        for old, new in replacements.items():
+            _replace_formula_identifier_in_rule(rule, old=old, new=new)
+        _replace_local_proof_import_targets_in_rule(
+            rule,
+            target_base=target_base,
+            replacements=replacements,
+        )
+
+    rules_file.write_text(
+        yaml.safe_dump(rules_document, sort_keys=False, allow_unicode=False)
+    )
+
+    if test_file.exists():
+        _replace_local_test_output_refs(
+            test_file,
+            target_base=target_base,
+            replacements=replacements,
+        )
+
+    return collisions
+
+
+def _imported_module_exported_rule_names(
+    imports: list[object],
+    *,
+    repo_path: Path,
+) -> set[str]:
+    names: set[str] = set()
+    seen_files: set[Path] = set()
+    for raw_import in imports:
+        if not isinstance(raw_import, str):
+            continue
+        resolved = _same_repo_import_base_and_file(raw_import, repo_path=repo_path)
+        if resolved is None:
+            continue
+        _, import_file = resolved
+        try:
+            resolved_file = import_file.resolve()
+        except OSError:
+            resolved_file = import_file
+        if resolved_file in seen_files or not import_file.exists():
+            continue
+        seen_files.add(resolved_file)
+        names.update(_rulespec_exported_rule_names(import_file))
+    return names
+
+
+def _replace_formula_identifier_in_rule(
+    rule: dict[str, Any],
+    *,
+    old: str,
+    new: str,
+) -> None:
+    token = re.compile(rf"\b{re.escape(old)}\b")
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return
+    for version in versions:
+        if not isinstance(version, dict):
+            continue
+        formula = version.get("formula")
+        if isinstance(formula, str):
+            version["formula"] = token.sub(new, formula)
+
+
+def _replace_local_proof_import_targets_in_rule(
+    rule: dict[str, Any],
+    *,
+    target_base: str,
+    replacements: dict[str, str],
+) -> None:
+    metadata = rule.get("metadata")
+    proof = metadata.get("proof") if isinstance(metadata, dict) else None
+    atoms = proof.get("atoms") if isinstance(proof, dict) else None
+    if not isinstance(atoms, list):
+        return
+    for atom in atoms:
+        if not isinstance(atom, dict) or atom.get("kind") != "import":
+            continue
+        import_payload = atom.get("import")
+        if not isinstance(import_payload, dict):
+            continue
+        target = str(import_payload.get("target") or "").strip()
+        if "#" not in target or not _rulespec_ref_matches_base(target, target_base):
+            continue
+        output = str(import_payload.get("output") or "").strip()
+        if output in replacements:
+            import_payload["output"] = replacements[output]
+        base, _, fragment = target.partition("#")
+        if fragment in replacements:
+            import_payload["target"] = f"{base}#{replacements[fragment]}"
+
+
+def _replace_local_test_output_refs(
+    test_file: Path,
+    *,
+    target_base: str,
+    replacements: dict[str, str],
+) -> None:
+    try:
+        test_cases = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, yaml.YAMLError, ValueError):
+        return
+    if not isinstance(test_cases, list):
+        return
+
+    changed = False
+    for case in test_cases:
+        if not isinstance(case, dict):
+            continue
+        output = case.get("output")
+        if not isinstance(output, dict):
+            continue
+        case_changed = False
+        updated: dict[object, object] = {}
+        for key, value in output.items():
+            key_text = str(key)
+            if "#" in key_text and _rulespec_ref_matches_base(key_text, target_base):
+                base, _, fragment = key_text.partition("#")
+                replacement = replacements.get(fragment)
+                if replacement is not None:
+                    key = f"{base}#{replacement}"
+                    case_changed = True
+            updated[key] = value
+        if case_changed:
+            case["output"] = updated
+            changed = True
+
+    if changed:
+        test_file.write_text(yaml.safe_dump(test_cases, sort_keys=False))
 
 
 def _repair_mixed_scalar_output_tests(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ from axiom_encode.cli import (
     _remove_invalid_dependent_test_inputs,
     _repair_employer_scoped_entities,
     _repair_generated_import_symbol_near_misses,
+    _repair_imported_rule_name_collisions,
     _repair_input_field_accesses_in_formulas,
     _repair_missing_source_proof_atoms,
     _repair_mixed_derived_entity_output_tests,
@@ -6256,6 +6257,97 @@ rules:
             "organized_camp_gross_receipts_percentage_limit"
             not in test_file.read_text()
         )
+
+    def test_imported_rule_name_collision_repair_prefixes_local_outputs(self, tmp_path):
+        policy_repo = tmp_path / "rulespec-us"
+        imported_file = policy_repo / "statutes/26/3121/c.yaml"
+        rules_file = policy_repo / "statutes/26/3306/d.yaml"
+        test_file = policy_repo / "statutes/26/3306/d.test.yaml"
+        imported_file.parent.mkdir(parents=True)
+        rules_file.parent.mkdir(parents=True)
+        imported_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: one_half_services_threshold
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 1 / 2
+  - name: all_services_for_pay_period_deemed_employment
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: true
+"""
+        )
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/3121/c#one_half_services_threshold
+rules:
+  - name: all_services_for_pay_period_deemed_employment
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: services_fraction >= one_half_services_threshold
+  - name: pay_period_result
+    kind: derived
+    metadata:
+      proof:
+        atoms:
+          - kind: import
+            import:
+              target: us:statutes/26/3306/d#all_services_for_pay_period_deemed_employment
+              output: all_services_for_pay_period_deemed_employment
+              hash: sha256:local
+    versions:
+      - effective_from: '1990-01-01'
+        formula: all_services_for_pay_period_deemed_employment
+"""
+        )
+        test_file.write_text(
+            """- name: collision_case
+  period: 2026-01
+  input:
+    us:statutes/26/3306/d#input.services_fraction: 0.5
+  output:
+    us:statutes/26/3306/d#all_services_for_pay_period_deemed_employment: holds
+    us:statutes/26/3306/d#pay_period_result: holds
+"""
+        )
+
+        repaired = _repair_imported_rule_name_collisions(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=policy_repo,
+            relative_output=Path("statutes/26/3306/d.yaml"),
+        )
+
+        rules_payload = yaml.safe_load(rules_file.read_text())
+        test_cases = yaml.safe_load(test_file.read_text())
+        assert repaired == ["all_services_for_pay_period_deemed_employment"]
+        assert [rule["name"] for rule in rules_payload["rules"]] == [
+            "local_all_services_for_pay_period_deemed_employment",
+            "pay_period_result",
+        ]
+        assert (
+            rules_payload["rules"][1]["versions"][0]["formula"]
+            == "local_all_services_for_pay_period_deemed_employment"
+        )
+        proof_import = rules_payload["rules"][1]["metadata"]["proof"]["atoms"][0][
+            "import"
+        ]
+        assert proof_import["target"] == (
+            "us:statutes/26/3306/d#local_all_services_for_pay_period_deemed_employment"
+        )
+        assert (
+            proof_import["output"]
+            == "local_all_services_for_pay_period_deemed_employment"
+        )
+        assert test_cases[0]["output"] == {
+            "us:statutes/26/3306/d#local_all_services_for_pay_period_deemed_employment": "holds",
+            "us:statutes/26/3306/d#pay_period_result": "holds",
+        }
 
     def test_mixed_derived_entity_output_test_repair_splits_entity_outputs(
         self, tmp_path


### PR DESCRIPTION
## Summary
- add an apply-time repair for generated local RuleSpec output names that collide with exported names from imported modules
- update renamed local outputs in formulas, local proof imports, and companion test output references
- bump encoder version to 0.2.262 for signed RuleSpec apply provenance

## Context
- 26 USC 3306(d) imports parameters from 26 USC 3121(c), but the generated file reused 3121(c)'s generic pay-period derived names locally, causing duplicate exported rule names at compile time.

## Tests
- uv run --extra dev python -m pytest tests/test_cli.py::TestCmdEncode::test_imported_rule_name_collision_repair_prefixes_local_outputs tests/test_cli.py::TestCmdEncode::test_mixed_scalar_output_test_repair_drops_nonterminating_fraction_parameter
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- smoke: repaired the generated 3306(d) artifact, then ran axiom-encode validate --skip-reviewers and axiom-encode test
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- git diff --check