### PR TITLE
Classify 3306(d) FUTA pay-period coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.263"
+version = "0.2.264"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.263"
+__version__ = "0.2.264"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9974,6 +9974,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(c)(20) defines full-time-student organized-camp service exception predicates and statutory thresholds for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these organized-camp employment exception predicates or thresholds separately.
 
+  - legal_id_prefix: us:statutes/26/3306/d#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(d) defines pay-period included-and-excluded-service deeming predicates for FUTA coverage; PolicyEngine exposes final FUTA taxable earnings, not these pay-period employment deeming intermediates separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2135,6 +2135,52 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3306_d_pay_period_deeming(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/d.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: pay_period_for_included_and_excluded_service
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '1990-01-01'
+        formula: pay_period_consecutive_days <= pay_period_max_consecutive_days
+  - name: local_all_services_for_pay_period_deemed_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '1990-01-01'
+        formula: pay_period_for_included_and_excluded_service and employment_fraction >= one_half_services_threshold
+  - name: local_no_services_for_pay_period_deemed_employment
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '1990-01-01'
+        formula: pay_period_for_included_and_excluded_service and nonemployment_fraction > one_half_services_threshold
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {
+        "taxable_earnings_for_federal_unemployment_tax"
+    }
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.263"
+version = "0.2.264"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary\n- classify section 3306(d) FUTA pay-period deeming outputs as known-not-comparable to PolicyEngine\n- add focused PolicyEngine coverage test for generated 3306(d) outputs\n- bump axiom-encode to 0.2.264\n\n## Tests\n- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3306_d_pay_period_deeming tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3306_c_20_organized_camp_employment tests/test_cli.py::test_package_version_metadata_matches_pyproject\n- uv run --extra dev ruff check src/ tests/\n- uv run --extra dev ruff format --check src/ tests/\n- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-oracle-coverage-3306-d --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20