### PR TITLE
Classify 3306(a) FUTA employer coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.264"
+version = "0.2.265"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.264"
+__version__ = "0.2.265"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9814,6 +9814,14 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(a)(8) agricultural-labor cash and noncash wage-exclusion thresholds, hand-harvest exception predicates, or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3306/a#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(a) defines FUTA employer-status thresholds and employer classification predicates; PolicyEngine exposes final FUTA taxable earnings, not these employer-definition thresholds and predicates separately.
+
   - legal_id_prefix: us:statutes/26/3306/c/1#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2135,6 +2135,64 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3306_a_employer_definition(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/a.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: general_calendar_quarter_wage_threshold
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 1500
+  - name: domestic_service_cash_wage_threshold
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 1000
+  - name: employer_under_general_rule
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: wages >= general_calendar_quarter_wage_threshold
+  - name: employer_for_domestic_service
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: domestic_wages >= domestic_service_cash_wage_threshold
+  - name: employer
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: employer_under_general_rule or employer_for_domestic_service
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 5}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {
+        "taxable_earnings_for_federal_unemployment_tax"
+    }
+
+
 def test_policyengine_coverage_classifies_3306_d_pay_period_deeming(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3306/d.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.264"
+version = "0.2.265"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary\n- classify section 3306(a) FUTA employer-definition outputs as known-not-comparable to PolicyEngine\n- add focused PolicyEngine coverage test for generated 3306(a) outputs\n- bump axiom-encode to 0.2.265\n\n## Tests\n- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3306_a_employer_definition tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3306_d_pay_period_deeming tests/test_cli.py::test_package_version_metadata_matches_pyproject\n- uv run --extra dev ruff check src/ tests/\n- uv run --extra dev ruff format --check src/ tests/\n- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-oracle-coverage-3306-a --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20