### PR TITLE
Repair missing deferred outputs for unsupported modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.265"
+version = "0.2.266"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.265"
+__version__ = "0.2.266"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10593,6 +10593,35 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_missing_deferred_outputs = (
+                    _try_repair_generated_missing_deferred_outputs_for_apply(
+                        result,
+                        output_root=args.output,
+                        policy_repo_path=policy_repo_path,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_missing_deferred_outputs:
+                    outcome["auto_repaired_missing_deferred_outputs"] = (
+                        repaired_missing_deferred_outputs
+                    )
+                    print(
+                        "  apply=auto_repaired_missing_deferred_outputs:"
+                        + ",".join(repaired_missing_deferred_outputs)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_employer_scoped_rules = (
                     _try_repair_generated_employer_scope_for_apply(
                         result,
@@ -11495,6 +11524,110 @@ def _qualify_deferred_output_subsection_paths(
 
     rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
     return repaired
+
+
+def _try_repair_generated_missing_deferred_outputs_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+    issues: list[str],
+) -> list[str]:
+    """Add a concrete deferred output when an empty deferred module omits one."""
+    if not any(
+        "Source sub-paragraph coverage missing" in str(issue)
+        and "module.deferred_outputs" in str(issue)
+        for issue in issues
+    ):
+        return []
+    try:
+        relative_output = _relative_generated_output_path(
+            result,
+            output_root=output_root,
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+
+    rules = payload.get("rules")
+    if rules not in (None, []) and rules != []:
+        return []
+    module = payload.get("module")
+    if not isinstance(module, dict):
+        return []
+    status = str(module.get("status") or "").strip().lower()
+    if status not in {"deferred", "entity_not_supported"}:
+        return []
+
+    deferred_outputs = module.get("deferred_outputs")
+    if deferred_outputs is None:
+        deferred_outputs = []
+        module["deferred_outputs"] = deferred_outputs
+    if not isinstance(deferred_outputs, list):
+        return []
+
+    summary = str(module.get("summary") or "")
+    symbol, label = _infer_deferred_output_symbol_from_summary(summary)
+    if not symbol:
+        symbol = "deferred_output"
+        label = "deferred output"
+    base_anchor = _relative_output_to_anchor(
+        relative_output,
+        policy_repo_path=policy_repo_path,
+    )
+    output = f"{base_anchor}#{symbol}"
+    existing_outputs = {
+        str(record.get("output") or "").strip()
+        for record in deferred_outputs
+        if isinstance(record, dict)
+    }
+    if output in existing_outputs:
+        return []
+
+    reason = (
+        f"Generated module is marked `{status}`; the source definition for "
+        f"{label} cannot be encoded as an executable RuleSpec output until the "
+        "target entity or surface is supported."
+    )
+    deferred_outputs.append(
+        {
+            "output": output,
+            "reason": reason,
+        }
+    )
+    payload["rules"] = []
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return [output]
+
+
+def _infer_deferred_output_symbol_from_summary(summary: str) -> tuple[str, str]:
+    """Infer a stable deferred-output symbol from a simple definition summary."""
+    normalized = " ".join(str(summary or "").strip().split())
+    if not normalized:
+        return "", ""
+    match = re.search(r"[“\"]([^”\"]+)[”\"]\s+means\b", normalized)
+    if match is None:
+        match = re.search(
+            r"\b(?:the\s+term\s+)?([A-Za-z][A-Za-z0-9 /,&'-]{1,80}?)\s+means\b",
+            normalized,
+            flags=re.IGNORECASE,
+        )
+    if match is None:
+        return "", ""
+    label = match.group(1).strip(" .,:;\"'“”")
+    symbol = re.sub(r"[^0-9A-Za-z]+", "_", label.lower()).strip("_")
+    if symbol and symbol[0].isdigit():
+        symbol = f"deferred_{symbol}"
+    return symbol, label
 
 
 _PERSON_SCOPE_RATE_BASE_ISSUE_PATTERN = re.compile(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,7 @@ from axiom_encode.cli import (
     _sign_applied_encoding_manifest,
     _source_relation_preservation_issues,
     _suppress_rulespec_ancestor_targets_for_subsection_overlay,
+    _try_repair_generated_missing_deferred_outputs_for_apply,
     _try_repair_generated_policyengine_oracle_inputs_for_apply,
     _try_repair_generated_section_1401_b_1_self_employment_income_for_apply,
     _try_repair_generated_source_table_band_scalars_for_apply,
@@ -6456,6 +6457,55 @@ rules:
         )
         assert proof_import["hash"] == f"sha256:{_sha256_file(upstream_file)}"
         assert test_cases[0]["output"] == {"us:statutes/26/3306/d#pay_period": "holds"}
+
+    def test_missing_deferred_output_repair_adds_definition_target(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "codex-gpt-5.5" / "statutes/26/3306/e.yaml"
+        rules_file.parent.mkdir(parents=True)
+        policy_repo = tmp_path / "rulespec-us"
+        policy_repo.mkdir()
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  status: entity_not_supported
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+  summary: |-
+    “State agency” means any State officer, board, or other authority.
+rules: []
+"""
+        )
+        result = SimpleNamespace(
+            runner="codex-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = _try_repair_generated_missing_deferred_outputs_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "statutes/26/3306/e.yaml: ci: Source sub-paragraph coverage missing: "
+                "26 USC 3306(e) has no rule citing it and no entry in "
+                "`module.deferred_outputs`."
+            ],
+        )
+
+        payload = yaml.safe_load(rules_file.read_text())
+        assert repaired == ["us:statutes/26/3306/e#state_agency"]
+        assert payload["module"]["deferred_outputs"] == [
+            {
+                "output": "us:statutes/26/3306/e#state_agency",
+                "reason": (
+                    "Generated module is marked `entity_not_supported`; the source "
+                    "definition for State agency cannot be encoded as an executable "
+                    "RuleSpec output until the target entity or surface is supported."
+                ),
+            }
+        ]
+        assert payload["rules"] == []
 
     def test_mixed_derived_entity_output_test_repair_splits_entity_outputs(
         self, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.265"
+version = "0.2.266"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- auto-repair empty deferred/entity-not-supported modules that fail apply coverage because `module.deferred_outputs` is missing
- infer a stable deferred output anchor from simple definition summaries, e.g. quoted terms like State agency
- bump axiom-encode to 0.2.266

## Validation
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::TestCmdEncode::test_missing_deferred_output_repair_adds_definition_target`
- smoke: repaired generated 26 USC 3306(e) artifact and overlay validation passed