### PR TITLE
Classify 3306(g) contributions coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.268"
+version = "0.2.269"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.268"
+__version__ = "0.2.269"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9998,6 +9998,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(f) defines State unemployment-fund status and maintained-fund predicates for FUTA administration; PolicyEngine exposes final FUTA taxable earnings, not State fund entity predicates separately.
 
+  - legal_id_prefix: us:statutes/26/3306/g#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(g) defines payment-level State-law unemployment fund contributions for chapter 23 credit calculations; PolicyEngine exposes final employer FUTA tax, not these State contribution amounts separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2271,6 +2271,38 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_g_contributions(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/g.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: contributions
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if payment_required_by_state_law: payment_amount else: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == "us:statutes/26/3306/g#contributions"
+    assert item["status"] == "known_not_comparable"
+    assert item["policyengine_variable"] == "employer_federal_unemployment_tax"
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.268"
+version = "0.2.269"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 26 USC 3306(g) contributions as not comparable to PolicyEngine's final FUTA tax surface
- add a coverage regression for the mapping
- bump axiom-encode to 0.2.269

## Tests
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3306_g_contributions
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-oracle-3306-g-classifier-20260526 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20