### PR TITLE
Classify 3302(e) successor credit coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.269"
+version = "0.2.270"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.269"
+__version__ = "0.2.270"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9814,6 +9814,14 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(a)(8) agricultural-labor cash and noncash wage-exclusion thresholds, hand-harvest exception predicates, or excluded amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3302/e#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3302(e) defines successor-employer credit eligibility and a pre-subsection-(c) credit amount; PolicyEngine exposes final employer FUTA tax, not this successor-credit intermediate separately.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2488,6 +2488,37 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3302_e_successor_credit_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3302/e.yaml",
+        """format: rulespec/v1
+rules:
+  - name: successor_employer_credit_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: acquisition_conditions_hold
+  - name: successor_employer_credit_before_subsection_c_limit
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if successor_employer_credit_applies: other_person_credit else: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert {item["status"] for item in items_by_id.values()} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in items_by_id.values()} == {
+        "employer_federal_unemployment_tax"
+    }
+
+
 def test_policyengine_coverage_classifies_3302_c_2_a_advance_reduction_outputs(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.269"
+version = "0.2.270"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3302(e) successor-credit outputs as known not comparable to PolicyEngine final FUTA tax
- add focused PE oracle coverage regression for the 3302(e) prefix classifier
- bump axiom-encode to 0.2.270

## Checks
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3302_e_successor_credit_outputs
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-oracle-3302-e-classifier-20260526 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20