### PR TITLE
Repair invalid rate proof atom kinds during apply

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.270"
+version = "0.2.271"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.270"
+__version__ = "0.2.271"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10843,6 +10843,32 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_kinds = (
+                    _try_repair_generated_invalid_proof_atom_kinds_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_kinds:
+                    outcome["auto_repaired_invalid_proof_atom_kinds"] = repaired_kinds
+                    print(
+                        "  apply=auto_repaired_invalid_proof_atom_kinds:"
+                        + ",".join(repaired_kinds)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_hashes = _try_repair_generated_proof_import_hashes_for_apply(
                     result,
                     output_root=args.output,
@@ -11544,6 +11570,57 @@ def _try_repair_generated_proof_import_hashes_for_apply(
         return []
     rules_file.write_text(repaired)
     return [f"hash[{index}]" for index in range(repair_count)]
+
+
+def _try_repair_generated_invalid_proof_atom_kinds_for_apply(
+    result,
+    *,
+    output_root: Path,
+    issues: list[str],
+) -> list[str]:
+    """Normalize schema-invalid proof kind synonyms in generated output."""
+    if not any("Proof atom kind invalid" in str(issue) for issue in issues):
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+
+    repairs: list[str] = []
+    for rule in payload.get("rules") or []:
+        if not isinstance(rule, dict):
+            continue
+        rule_name = str(rule.get("name") or "<unnamed>")
+        atoms = (
+            ((rule.get("metadata") or {}).get("proof") or {}).get("atoms")
+            if isinstance(rule.get("metadata"), dict)
+            else None
+        )
+        if not isinstance(atoms, list):
+            continue
+        for index, atom in enumerate(atoms):
+            if not isinstance(atom, dict):
+                continue
+            kind = str(atom.get("kind") or "").strip()
+            if kind != "rate":
+                continue
+            atom["kind"] = "parameter"
+            repairs.append(f"{rule_name}[{index}]:rate->parameter")
+
+    if not repairs:
+        return []
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repairs
 
 
 def _try_repair_generated_empty_deferred_source_values_for_apply(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3628,6 +3628,85 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_repairs_invalid_rate_proof_atom_kind(self, capsys, tmp_path):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path
+            / "out"
+            / "codex-test-model"
+            / "statutes"
+            / "26"
+            / "3302"
+            / "f.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: credit_reduction_limitation_wage_rate
+  kind: parameter
+  dtype: Rate
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: rate
+        source:
+          corpus_citation_path: us/statute/26/3302
+          excerpt: 0.6 percent
+  versions:
+  - effective_from: '2026-01-01'
+    formula: 0.006
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/26/3302/f.yaml"
+        kind_issue = (
+            "statutes/26/3302/f.yaml: ci: Proof atom kind invalid: "
+            "rule `credit_reduction_limitation_wage_rate` proof atom 0 "
+            "has kind `rate`."
+        )
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (False, [kind_issue], {}),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert (
+            "apply=auto_repaired_invalid_proof_atom_kinds:"
+            "credit_reduction_limitation_wage_rate[0]:rate->parameter" in output
+        )
+        repaired = yaml.safe_load(output_file.read_text())
+        assert (
+            repaired["rules"][0]["metadata"]["proof"]["atoms"][0]["kind"] == "parameter"
+        )
+        assert mock_overlay.call_count == 2
+        mock_apply.assert_called_once()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_invalid_proof_atom_kinds"] == [
+            "credit_reduction_limitation_wage_rate[0]:rate->parameter"
+        ]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_repairs_person_scoped_rate_base(self, capsys, tmp_path):
         args = self._make_args(tmp_path, backend="codex", sync=False)
         args.apply = True

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.270"
+version = "0.2.271"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a deterministic apply-time repair for generated proof atoms with invalid kind rate
- normalize rate to the valid parameter proof kind for source-stated rates
- add a regression test covering apply recovery and recorded outcome metadata
- bump axiom-encode to 0.2.271

## Checks
- uv run --extra dev ruff format src/ tests/
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::TestCmdEncode::test_encode_apply_repairs_invalid_rate_proof_atom_kind
- uv run --extra dev python -m pytest