### PR TITLE
Teach encoder not to use Judgment imports as scalars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.271"
+version = "0.2.272"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.271"
+__version__ = "0.2.272"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3106,6 +3106,16 @@ Import and context rules:
   the canonical home for the scalar. Import the exact child export and use it
   in the current formula; do not emit a duplicate local `parameter` with the
   same value or name in the parent/composition file.
+- Before using any imported output in arithmetic, check the copied context
+  export's `dtype:`. An imported `dtype: Judgment` is a predicate, not a scalar
+  amount, rate, or base. Never multiply, add, subtract, divide, `min`, or `max`
+  a Judgment import as if it were Money, Rate, Count, or another numeric value.
+  If the current source states a numeric base such as wages, remuneration,
+  payments, or amounts attributable to a category and the copied import only
+  identifies whether an item is attributable to that category, encode the source-stated numeric base as a local amount fact, or as a relation-filtered
+  aggregate only when a compatible relation and numeric amount field are
+  present. If neither is available, defer the numeric output instead of using
+  the Judgment import as a placeholder scalar.
 - If a copied context file for this target or a same-program sibling contains a `kind: source_relation` record, preserve the legal/provenance edge unless `./source.txt` proves it wrong; executable formula changes are not a reason to drop source graph context.
 - Do not fabricate same-instrument imports or `statutes/...#symbol` paths unless that exact `path#symbol` import target is listed.
 - do not fabricate sibling-file imports for uncopied same-instrument provisions.
@@ -3764,6 +3774,16 @@ RuleSpec requirements:
 - If the cited same-section subsection is supplied in context as a RuleSpec file, add an `imports:` entry for that file and reference its exported rule; do not summarize the cited subsection into a local fact like `person_meets_...requirements`.
 - Do not copy the body of a cited cross-reference provision into this module's `summary` or re-encode that cited provision locally. Keep this module scoped to the requested citation and import the cited provision instead.
 - Do not fabricate sibling-file imports, do not guess unavailable import targets, and do not invent `import` statements or `imports:` blocks for uncopied same-instrument provisions.
+- Before using any imported output in arithmetic, check the copied context
+  export's `dtype:`. An imported `dtype: Judgment` is a predicate, not a scalar
+  amount, rate, or base. Never multiply, add, subtract, divide, `min`, or `max`
+  a Judgment import as if it were Money, Rate, Count, or another numeric value.
+  If the current source states a numeric base such as wages, remuneration,
+  payments, or amounts attributable to a category and the copied import only
+  identifies whether an item is attributable to that category, encode the source-stated numeric base as a local amount fact, or as a relation-filtered
+  aggregate only when a compatible relation and numeric amount field are
+  present. If neither is available, defer the numeric output instead of using
+  the Judgment import as a placeholder scalar.
 - Before finalizing, do this self-check:
   1. Numeric inventory: every source-stated legal amount, rate, threshold, cap,
      or limit has a named local `parameter` or an exact imported parameter from

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -198,6 +198,16 @@ Hard requirements:
   the canonical home for the scalar. Import the exact child export and use it
   in the current formula; do not emit a duplicate local `parameter` with the
   same value or name in the parent/composition file.
+- Before using any imported output in arithmetic, check the copied context
+  export's `dtype:`. An imported `dtype: Judgment` is a predicate, not a scalar
+  amount, rate, or base. Never multiply, add, subtract, divide, `min`, or `max`
+  a Judgment import as if it were Money, Rate, Count, or another numeric value.
+  If the current source states a numeric base such as wages, remuneration,
+  payments, or amounts attributable to a category and the copied import only
+  identifies whether an item is attributable to that category, encode the source-stated numeric base as a local amount fact, or as a relation-filtered
+  aggregate only when a compatible relation and numeric amount field are present.
+  If neither is available, defer the numeric output instead of using the
+  Judgment import as a placeholder scalar.
 - Treat any existing copied target file as context, not as a backward
   compatibility contract. You may drop, rename, rebuild, or defer existing
   executable rules, tests, imports, and local factual inputs when the source

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -494,6 +494,9 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "Numeric inventory: every source-stated legal amount" in prompt
     assert "exact imported parameter from\n     context" in prompt
     assert "import it instead of duplicating it locally" in prompt
+    assert "An imported `dtype: Judgment` is a predicate, not a scalar" in prompt
+    assert "Never multiply, add, subtract, divide, `min`, or `max`" in prompt
+    assert "encode the source-stated numeric base as a local amount fact" in prompt
     assert "Test input inventory: for every local factual identifier" in prompt
     assert "For proration, average, ratio, or percentage tests" in prompt
     assert "use totals like 600" in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.271"
+version = "0.2.272"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add prompt guidance that imported `dtype: Judgment` outputs are predicates, not numeric scalars
- mirror the guidance in eval prompt construction and assert it in prompt tests
- bump axiom-encode to 0.2.272

## Verification
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_evals.py::test_build_eval_prompt_targets_rulespec_yaml`
- `uv run --extra dev python -m pytest`