### PR TITLE
Classify 3302(f) credit limitation coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.272"
+version = "0.2.273"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.272"
+__version__ = "0.2.273"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9822,6 +9822,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3302(e) defines successor-employer credit eligibility and a pre-subsection-(c) credit amount; PolicyEngine exposes final employer FUTA tax, not this successor-credit intermediate separately.
 
+  - legal_id_prefix: us:statutes/26/3302/f#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3302(f) defines State-specific limitation and partial-limitation rules for subsection (c)(2) credit reductions, including benefit-cost ratios, State unemployment tax rates, and intermediate capped reduction amounts; PolicyEngine exposes final employer FUTA tax, not these statutory credit-reduction limitation components separately.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2519,6 +2519,41 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3302_f_credit_reduction_limitation_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3302/f.yaml",
+        """format: rulespec/v1
+rules:
+  - name: credit_reduction_limitation_wage_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.006
+  - name: state_meets_credit_reduction_limitation_requirements
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: secretary_determination
+  - name: credit_reduction_after_partial_limitation
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: max(0, credit_reduction - partial_limitation)
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert {item["status"] for item in items_by_id.values()} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in items_by_id.values()} == {
+        "employer_federal_unemployment_tax"
+    }
+
+
 def test_policyengine_coverage_classifies_3302_c_2_a_advance_reduction_outputs(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.272"
+version = "0.2.273"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify `us:statutes/26/3302/f#` outputs as known not comparable to PE final employer FUTA tax
- add a coverage regression for section 3302(f) credit-reduction limitation outputs
- bump axiom-encode to 0.2.273

## Verification
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3302_f_credit_reduction_limitation_outputs`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-rulespec-3302-f-20260526 --oracle policyengine --program tax --json`
- `uv run --extra dev python -m pytest`