### PR TITLE
Classify 3202 withholding coverage

### DIFF
--- a/changelog.d/section-3202-policyengine-coverage.changed.md
+++ b/changelog.d/section-3202-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated 26 USC 3202 RRTA withholding-collection outputs in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.273"
+version = "0.2.274"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.273"
+__version__ = "0.2.274"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9564,6 +9564,12 @@ mappings:
     rationale: Same statutory percentage of adjusted gross income that floors deductible medical-care expenses.
 
 prefixes:
+  - legal_id_prefix: us:statutes/26/3202#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3202 defines Railroad Retirement Tax Act employer collection, payment liability, indemnification, tip-collection deadlines, and post-employment group-term life insurance withholding rules; PolicyEngine does not expose RRTA withholding-collection or employer-liability surfaces as one-to-one outputs.
+
   - legal_id_prefix: us-co:regulations/10-ccr-2506-1/
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2554,6 +2554,37 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3202_collection_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3202.yaml",
+        """format: rulespec/v1
+rules:
+  - name: monthly_tip_collection_deadline_day
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 10
+  - name: tier_2_employee_tax_collectible_by_employer_deduction
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: min(compensation, tier_2_employee_tax)
+  - name: employer_section_3201_tax_payment_liability
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: tax_required_to_deduct
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert {item["status"] for item in items_by_id.values()} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in items_by_id.values()} == {None}
+
+
 def test_policyengine_coverage_classifies_3302_c_2_a_advance_reduction_outputs(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.273"
+version = "0.2.274"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3202 RRTA withholding-collection outputs as known not comparable to PolicyEngine
- add a PolicyEngine coverage regression for the 3202 legal-id prefix
- bump package metadata to 0.2.274 and add a changelog fragment

## Local checks
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3202_collection_outputs`
- `uv run --extra dev python -m pytest` (`1279 passed, 15 skipped`)

## Oracle coverage
Using the generated 26 USC 3202 RuleSpec worktree locally with this mapping change:
- total outputs: 1127
- comparable: 226
- known not comparable: 901
- unmapped: 0
- untested comparable: 0
