### PR TITLE
Classify 3212 compensation coverage

### DIFF
--- a/changelog.d/section-3212-policyengine-coverage.changed.md
+++ b/changelog.d/section-3212-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated 26 USC 3212 RRTA employee-representative compensation output in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.274"
+version = "0.2.275"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.274"
+__version__ = "0.2.275"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9570,6 +9570,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3202 defines Railroad Retirement Tax Act employer collection, payment liability, indemnification, tip-collection deadlines, and post-employment group-term life insurance withholding rules; PolicyEngine does not expose RRTA withholding-collection or employer-liability surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3212#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3212 determines employee-representative compensation for Railroad Retirement Tax Act tax ascertainment as if the employee organization were a section 3231(a) employer; PolicyEngine does not expose RRTA employee-representative compensation-determination surfaces as one-to-one outputs.
+
   - legal_id_prefix: us-co:regulations/10-ccr-2506-1/
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2585,6 +2585,30 @@ rules:
     assert {item["policyengine_variable"] for item in items_by_id.values()} == {None}
 
 
+def test_policyengine_coverage_classifies_3212_compensation_output(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3212.yaml",
+        """format: rulespec/v1
+rules:
+  - name: employee_representative_compensation_for_tax_ascertainment
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: compensation_paid_by_employee_organization
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == (
+        "us:statutes/26/3212#employee_representative_compensation_for_tax_ascertainment"
+    )
+    assert item["status"] == "known_not_comparable"
+    assert item["policyengine_variable"] is None
+
+
 def test_policyengine_coverage_classifies_3302_c_2_a_advance_reduction_outputs(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.274"
+version = "0.2.275"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3212 RRTA employee-representative compensation output as known not comparable to PolicyEngine
- add a PolicyEngine coverage regression for the 3212 legal-id prefix
- bump package metadata to 0.2.275 and add a changelog fragment

## Local checks
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3212_compensation_output`
- `uv run --extra dev python -m pytest` (`1280 passed, 15 skipped`)

## Oracle coverage
Using the generated 26 USC 3212 RuleSpec worktree locally with this mapping change:
- total outputs: 1128
- comparable: 226
- known not comparable: 902
- unmapped: 0
- untested comparable: 0
