### PR TITLE
Classify 3231(a) employer coverage

### DIFF
--- a/changelog.d/section-3231a-policyengine-coverage.changed.md
+++ b/changelog.d/section-3231a-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated 26 USC 3231(a) RRTA employer-definition outputs as known not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.275"
+version = "0.2.276"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.275"
+__version__ = "0.2.276"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9576,6 +9576,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3212 determines employee-representative compensation for Railroad Retirement Tax Act tax ascertainment as if the employee organization were a section 3231(a) employer; PolicyEngine does not expose RRTA employee-representative compensation-determination surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3231/a#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3231(a) defines Railroad Retirement Tax Act employer status and related inclusion or exception predicates; PolicyEngine does not expose railroad-employer definition surfaces as one-to-one outputs.
+
   - legal_id_prefix: us-co:regulations/10-ccr-2506-1/
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2609,6 +2609,56 @@ rules:
     assert item["policyengine_variable"] is None
 
 
+def test_policyengine_coverage_classifies_3231_a_employer_definition_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3231/a.yaml",
+        """format: rulespec/v1
+rules:
+  - name: carrier_or_controlled_service_company_included
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: carrier_as_defined_in_subsection_g
+  - name: receiver_or_trustee_of_employer_included
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: receiver_or_trustee
+  - name: railroad_association_or_organization_included
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: railroad_association
+  - name: railway_labor_organization_included
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: railway_labor_organization
+  - name: electric_railway_exception_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: electric_railway_exception
+  - name: coal_company_exception_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: coal_company_exception
+  - name: employer
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: carrier_or_controlled_service_company_included
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 7}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3302_c_2_a_advance_reduction_outputs(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.275"
+version = "0.2.276"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3231(a) RRTA employer-definition outputs as known not comparable to PolicyEngine
- add a PolicyEngine coverage regression for the seven 3231(a) legal-id outputs
- bump package metadata to 0.2.276 and add a changelog fragment

## Local checks
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3231_a_employer_definition_outputs`
- `uv run --extra dev python -m pytest` (`1281 passed, 15 skipped`)

## Oracle coverage
Using the generated 26 USC 3231(a) RuleSpec worktree locally with this mapping change:
- total outputs: 1135
- comparable: 226
- known not comparable: 909
- unmapped: 0
- untested comparable: 0
