### PR TITLE
Classify 3231(e) compensation coverage

### DIFF
--- a/changelog.d/section-3231e-policyengine-coverage.changed.md
+++ b/changelog.d/section-3231e-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated 26 USC 3231(e) RRTA compensation-definition outputs as known not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.276"
+version = "0.2.277"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.276"
+__version__ = "0.2.277"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9582,6 +9582,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3231(a) defines Railroad Retirement Tax Act employer status and related inclusion or exception predicates; PolicyEngine does not expose railroad-employer definition surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3231/e#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3231(e) defines Railroad Retirement Tax Act compensation and its purpose-specific inclusions, exclusions, tip thresholds, and local-lodge disregards; PolicyEngine does not expose RRTA compensation-definition surfaces as one-to-one outputs.
+
   - legal_id_prefix: us-co:regulations/10-ccr-2506-1/
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2659,6 +2659,66 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3231_e_compensation_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3231/e.yaml",
+        """format: rulespec/v1
+rules:
+  - name: monthly_cash_tip_inclusion_threshold
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 20
+  - name: local_lodge_monthly_disregard_threshold
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 25
+  - name: money_remuneration_for_employee_services
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: payment_is_money_remuneration
+  - name: cash_tips_included_as_compensation_for_section_3201_taxes
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: cash_tip_amount
+  - name: employer_sickness_accident_medical_death_plan_exclusion_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: sickness_plan_payment
+  - name: identified_business_expense_reimbursement_exclusion_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: business_expense_reimbursement
+  - name: qualifying_nonresident_alien_service_exclusion_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: nonresident_alien_service
+  - name: convention_delegate_compensation_disregard_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: convention_delegate_service
+  - name: local_lodge_low_monthly_compensation_disregard_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: local_lodge_low_monthly_compensation
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 9}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3302_c_2_a_advance_reduction_outputs(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.276"
+version = "0.2.277"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3231(e) RRTA compensation-definition outputs as known not comparable to PolicyEngine
- add a PolicyEngine coverage regression for the 3231(e) legal-id prefix
- bump package metadata to 0.2.277 and add a changelog fragment

## Local checks
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3231_e_compensation_outputs`
- `uv run --extra dev python -m pytest` (`1282 passed, 15 skipped`)

## Oracle coverage
Using the generated 26 USC 3231(e) RuleSpec worktree locally with this mapping change:
- total outputs: 1150
- comparable: 226
- known not comparable: 924
- unmapped: 0
- untested comparable: 0
