### PR TITLE
Classify 3231(b) employee coverage

### DIFF
--- a/changelog.d/section-3231b-policyengine-coverage.changed.md
+++ b/changelog.d/section-3231b-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated 26 USC 3231(b) RRTA employee-definition outputs as known not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.277"
+version = "0.2.278"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.277"
+__version__ = "0.2.278"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9582,6 +9582,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3231(a) defines Railroad Retirement Tax Act employer status and related inclusion or exception predicates; PolicyEngine does not expose railroad-employer definition surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3231/b#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3231(b) defines Railroad Retirement Tax Act employee status and coal-operations exclusion predicates; PolicyEngine does not expose RRTA employee-definition surfaces as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3231/e#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2659,6 +2659,31 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3231_b_employee_definition_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3231/b.yaml",
+        """format: rulespec/v1
+rules:
+  - name: coal_physical_operations_exclusion_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: engaged_in_physical_operations_consisting_of_mining_of_coal
+  - name: employee
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: individual_in_service_of_one_or_more_employers_for_compensation
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3231_e_compensation_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3231/e.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.277"
+version = "0.2.278"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3231(b) RRTA employee-definition outputs as known not comparable to PolicyEngine
- add a PolicyEngine coverage regression for the 3231(b) legal-id prefix
- bump package metadata to 0.2.278 and add a changelog fragment

## Local checks
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3231_b_employee_definition_outputs`
- `uv run --extra dev python -m pytest` (`1283 passed, 15 skipped`)

## Oracle coverage
Using the generated 26 USC 3231(b) RuleSpec worktree locally with this mapping change:
- total outputs: 1152
- comparable: 226
- known not comparable: 926
- unmapped: 0
- untested comparable: 0
