### PR TITLE
Classify 3231(c) employee representative coverage

### DIFF
--- a/changelog.d/section-3231c-policyengine-coverage.changed.md
+++ b/changelog.d/section-3231c-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated 26 USC 3231(c) employee-representative definition outputs as known not comparable to the PolicyEngine oracle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.278"
+version = "0.2.279"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.278"
+__version__ = "0.2.279"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9588,6 +9588,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3231(b) defines Railroad Retirement Tax Act employee status and coal-operations exclusion predicates; PolicyEngine does not expose RRTA employee-definition surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3231/c#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3231(c) defines Railroad Retirement Tax Act employee-representative status and related qualifying predicates; PolicyEngine does not expose RRTA employee-representative definition surfaces as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3231/e#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2684,6 +2684,38 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3231_c_employee_representative_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3231/c.yaml",
+        """format: rulespec/v1
+rules:
+  - name: regularly_assigned_or_employed_individual_qualifies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: regular_assignment_or_employment_for_employee_representation
+  - name: railway_labor_officer_representative_qualifies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: officer_or_official_representing_employees
+  - name: employee_representative
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: regularly_assigned_or_employed_individual_qualifies
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3231_e_compensation_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3231/e.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.278"
+version = "0.2.279"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3231(c) RRTA employee-representative definition outputs as known not comparable to PolicyEngine
- add a PolicyEngine coverage regression for the 3231(c) legal-id prefix
- bump package metadata to 0.2.279 and add a changelog fragment

## Local checks
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3231_c_employee_representative_outputs`
- `uv run --extra dev python -m pytest` (`1284 passed, 15 skipped`)

## Oracle coverage
Using the generated 26 USC 3231(c) RuleSpec worktree locally with this mapping change:
- total outputs: 1155
- comparable: 226
- known not comparable: 929
- unmapped: 0
- untested comparable: 0
