### PR TITLE
Classify 3231(d) service coverage

### DIFF
--- a/changelog.d/section-3231d-policyengine-coverage.changed.md
+++ b/changelog.d/section-3231d-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated 26 USC 3231(d) RRTA service-definition outputs as known not comparable to the PolicyEngine oracle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.279"
+version = "0.2.280"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.279"
+__version__ = "0.2.280"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9594,6 +9594,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3231(c) defines Railroad Retirement Tax Act employee-representative status and related qualifying predicates; PolicyEngine does not expose RRTA employee-representative definition surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3231/d#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3231(d) defines Railroad Retirement Tax Act service status, service exceptions, and special general-chairman compensation treatment; PolicyEngine does not expose RRTA service-definition surfaces as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3231/e#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2716,6 +2716,61 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3231_d_service_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3231/d.yaml",
+        """format: rulespec/v1
+rules:
+  - name: basic_service_conditions_satisfied
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: subject_to_continuing_authority
+  - name: general_chairman_minimum_compensation_percentage
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.75
+  - name: general_chairman_service_remuneration_regarded_as_compensation
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: remuneration_for_service
+  - name: general_committee_service_qualifies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: general_committee_service
+  - name: local_lodge_or_division_service_qualifies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: local_lodge_service
+  - name: non_us_principal_non_labor_organization_employer_service_qualifies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: non_us_principal_service
+  - name: noncitizen_nonresident_foreign_required_hire_exception_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: foreign_required_hire
+  - name: service
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: basic_service_conditions_satisfied
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 8}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3231_e_compensation_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3231/e.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.279"
+version = "0.2.280"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3231(d) RRTA service-definition outputs as known not comparable to PolicyEngine
- add a PolicyEngine coverage regression for the 3231(d) legal-id prefix
- bump package metadata to 0.2.280 and add a changelog fragment

## Local checks
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3231_d_service_outputs`
- `uv run --extra dev python -m pytest` (`1285 passed, 15 skipped`)

## Oracle coverage
Using the generated 26 USC 3231(d) RuleSpec worktree locally with this mapping change:
- total outputs: 1163
- comparable: 226
- known not comparable: 937
- unmapped: 0
- untested comparable: 0
