### PR TITLE
Classify 3231(g) carrier coverage

### DIFF
--- a/changelog.d/section-3231g-policyengine-coverage.changed.md
+++ b/changelog.d/section-3231g-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated 26 USC 3231(g) RRTA carrier-definition outputs as known not comparable to the PolicyEngine oracle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.280"
+version = "0.2.281"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.280"
+__version__ = "0.2.281"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9606,6 +9606,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3231(e) defines Railroad Retirement Tax Act compensation and its purpose-specific inclusions, exclusions, tip thresholds, and local-lodge disregards; PolicyEngine does not expose RRTA compensation-definition surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3231/g#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3231(g) defines Railroad Retirement Tax Act carrier status; PolicyEngine does not expose RRTA carrier-definition surfaces as one-to-one outputs.
+
   - legal_id_prefix: us-co:regulations/10-ccr-2506-1/
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2831,6 +2831,28 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3231_g_carrier_output(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3231/g.yaml",
+        """format: rulespec/v1
+rules:
+  - name: carrier
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: subject_to_part_i_of_interstate_commerce_act
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == "us:statutes/26/3231/g#carrier"
+    assert item["status"] == "known_not_comparable"
+    assert item["policyengine_variable"] is None
+
+
 def test_policyengine_coverage_classifies_3302_c_2_a_advance_reduction_outputs(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.280"
+version = "0.2.281"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3231(g) RRTA carrier-definition outputs as known not comparable to PolicyEngine
- add a PolicyEngine coverage regression for the 3231(g) legal-id prefix
- bump package metadata to 0.2.281 and add a changelog fragment

## Local checks
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3231_g_carrier_output`
- `uv run --extra dev python -m pytest` (`1286 passed, 15 skipped`)

## Oracle coverage
Using the generated 26 USC 3231(g) RuleSpec worktree locally with this mapping change:
- total outputs: 1164
- comparable: 226
- known not comparable: 938
- unmapped: 0
- untested comparable: 0
