### PR TITLE
Classify 3231(f) company coverage

### DIFF
--- a/changelog.d/section-3231f-policyengine-coverage.changed.md
+++ b/changelog.d/section-3231f-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify 26 USC 3231(f) company-definition outputs as outside PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.281"
+version = "0.2.282"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.281"
+__version__ = "0.2.282"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9606,6 +9606,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3231(e) defines Railroad Retirement Tax Act compensation and its purpose-specific inclusions, exclusions, tip thresholds, and local-lodge disregards; PolicyEngine does not expose RRTA compensation-definition surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3231/f#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3231(f) defines company status for Railroad Retirement Tax Act purposes; PolicyEngine does not expose RRTA company-definition surfaces as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3231/g#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2831,6 +2831,28 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3231_f_company_output(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3231/f.yaml",
+        """format: rulespec/v1
+rules:
+  - name: company
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: corporation or association or joint_stock_company
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == "us:statutes/26/3231/f#company"
+    assert item["status"] == "known_not_comparable"
+    assert item["policyengine_variable"] is None
+
+
 def test_policyengine_coverage_classifies_3231_g_carrier_output(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3231/g.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.281"
+version = "0.2.282"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Classifies generated 26 USC 3231(f) company-definition outputs as outside PolicyEngine's one-to-one tax oracle surface.
- Adds a focused regression test for `us:statutes/26/3231/f#company`.
- Bumps `axiom-encode` to `0.2.282` and adds a changelog fragment.

## Validation
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3231_f_company_output`
- `uv run --extra dev python -m pytest` (`1287 passed, 15 skipped`)
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-rulespec-3231f-20260526 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20`
  - total outputs: 1165
  - comparable: 226
  - known not comparable: 939
  - unmapped: 0
  - untested comparable: 0
