### PR TITLE
Include child context for unavailable cited parents

### DIFF
--- a/changelog.d/cited-parent-child-context.fixed.md
+++ b/changelog.d/cited-parent-child-context.fixed.md
@@ -1,0 +1,1 @@
+Include executable child RuleSpec files when a cited parent section exists but has no executable exports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.282"
+version = "0.2.283"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.282"
+__version__ = "0.2.283"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2095,20 +2095,25 @@ def _citation_parts_from_match(match: re.Match[str]) -> CitationParts:
 def _cited_context_candidates(policy_root: Path, candidate_rel: Path) -> list[Path]:
     """Return an exact cited RuleSpec file or child fragments when only a section exists."""
     candidate = policy_root / candidate_rel
-    if candidate.exists():
-        return [candidate]
     child_root = policy_root / candidate_rel.with_suffix("")
-    if not child_root.is_dir():
-        return []
-    candidates = [
-        path
-        for path in child_root.rglob("*.yaml")
-        if not path.name.endswith(".test.yaml")
-    ]
-    candidates.sort(
-        key=lambda path: (len(path.relative_to(child_root).parts), str(path))
-    )
-    return candidates[:8]
+    child_candidates: list[Path] = []
+    if child_root.is_dir():
+        child_candidates = [
+            path
+            for path in child_root.rglob("*.yaml")
+            if not path.name.endswith(".test.yaml")
+        ]
+        child_candidates.sort(
+            key=lambda path: (len(path.relative_to(child_root).parts), str(path))
+        )
+        child_candidates = child_candidates[:8]
+
+    if candidate.exists():
+        if _context_file_exports(str(candidate)) or not child_candidates:
+            return [candidate]
+        return [candidate, *child_candidates]
+
+    return child_candidates
 
 
 def _select_child_fragment_context_files(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -6885,6 +6885,77 @@ rules:
             copied_sources[str(context_test)]["kind"] == "implementation_test_context"
         )
 
+    def test_prepare_eval_workspace_adds_child_context_for_unavailable_cited_parent(
+        self, tmp_path
+    ):
+        repo_root = tmp_path / "repos"
+        policy_repo_root = repo_root / "axiom-rules-engine"
+        policy_repo_root.mkdir(parents=True)
+        section_root = repo_root / "rulespec-us" / "statutes" / "26" / "3101"
+        section_root.mkdir(parents=True)
+        parent = section_root.with_suffix(".yaml")
+        parent.write_text(
+            "format: rulespec/v1\nmodule:\n  status: entity_not_supported\nrules: []\n"
+        )
+        oasdi = section_root / "a.yaml"
+        oasdi.write_text(
+            "format: rulespec/v1\n"
+            "rules:\n"
+            "  - name: oasdi_wage_tax_rate\n"
+            "    kind: parameter\n"
+            "    versions:\n"
+            "      - effective_from: '1990-01-01'\n"
+            "        formula: '0.062'\n"
+        )
+        hi = section_root / "b" / "1.yaml"
+        hi.parent.mkdir()
+        hi.write_text(
+            "format: rulespec/v1\n"
+            "rules:\n"
+            "  - name: hospital_insurance_wage_tax_rate\n"
+            "    kind: parameter\n"
+            "    versions:\n"
+            "      - effective_from: '1986-01-01'\n"
+            "        formula: '0.0145'\n"
+        )
+        source_text = (
+            "For purposes of the preceding sentence, the term applicable "
+            "percentage means the percentage equal to the sum of the rates "
+            "of tax in effect under subsections (a) and (b) of section 3101 "
+            "for the calendar year."
+        )
+
+        selected = _select_cross_section_context_files(
+            "26 USC 3201",
+            source_text,
+            repo_root / "rulespec-us",
+        )
+
+        assert selected == [parent, oasdi, hi]
+
+        runner = parse_runner_spec("openai:gpt-5.5")
+        with patch(
+            "axiom_encode.harness.evals.select_context_files",
+            return_value=[],
+        ):
+            workspace = prepare_eval_workspace(
+                citation="26 USC 3201",
+                runner=runner,
+                output_root=tmp_path / "out",
+                source_text=source_text,
+                axiom_rules_path=policy_repo_root,
+                mode="repo-augmented",
+                extra_context_paths=[],
+            )
+
+        manifest = json.loads(workspace.manifest_file.read_text())
+        copied_sources = {
+            item["source_path"]: item for item in manifest["context_files"]
+        }
+        assert copied_sources[str(parent)]["import_path"] == "us:statutes/26/3101"
+        assert copied_sources[str(oasdi)]["import_path"] == "us:statutes/26/3101/a"
+        assert copied_sources[str(hi)]["import_path"] == "us:statutes/26/3101/b/1"
+
     def test_prepare_eval_workspace_adds_cross_section_list_and_parent_fallback_context(
         self, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.282"
+version = "0.2.283"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- include executable child RuleSpec files when a cited parent section exists but has no executable exports
- add coverage for 3201-style cross references to 3101 child payroll rates
- bump axiom-encode to 0.2.283

## Tests
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev python -m pytest