### PR TITLE
Reject flattened thresholded rates and repair row tests

### DIFF
--- a/changelog.d/cross-ref-thresholded-rates.fixed.md
+++ b/changelog.d/cross-ref-thresholded-rates.fixed.md
@@ -1,0 +1,1 @@
+Tell the encoder not to flatten thresholded or base-limited cited rates into flat current-source percentages.

--- a/changelog.d/row-ordered-test-rows.fixed.md
+++ b/changelog.d/row-ordered-test-rows.fixed.md
@@ -1,0 +1,1 @@
+Repair generated one-row entity tests that assert row-ordered outputs without creating the corresponding table row.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.283"
+version = "0.2.284"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.283"
+__version__ = "0.2.284"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -14132,6 +14132,23 @@ def _validate_generated_encoding_in_policy_overlay(
                 None,
             )
             target_test_path = _rulespec_test_path(overlay_target)
+            if (
+                target_validation is not None
+                and _repair_missing_entity_table_rows_for_row_ordered_outputs(
+                    test_file=target_test_path,
+                    validation=target_validation,
+                )
+            ):
+                supplemental_files[target_test_path.relative_to(overlay_repo)] = (
+                    target_test_path.read_text()
+                )
+                validations = _validate_overlay_files(
+                    pipeline,
+                    dependent_pipeline=dependent_pipeline,
+                    overlay_target=overlay_target,
+                    dependents=dependents,
+                )
+                continue
             if target_validation is not None and _complete_missing_imported_test_inputs(
                 rules_file=overlay_target,
                 test_file=target_test_path,
@@ -15041,6 +15058,98 @@ def _repair_mixed_scalar_output_tests(
     return repaired_names
 
 
+def _repair_missing_entity_table_rows_for_row_ordered_outputs(
+    *,
+    test_file: Path,
+    validation: object,
+) -> list[str]:
+    """Move one-row entity test inputs from scalar input into tables.<Entity>."""
+    if not test_file.exists():
+        return []
+    repairs_by_case: dict[str, str] = {}
+    for issue in _validation_issue_strings(validation):
+        match = _ROW_ORDERED_WITHOUT_TABLE_RE.search(str(issue))
+        if match is None:
+            continue
+        repairs_by_case[match.group("case")] = match.group("entity")
+    if not repairs_by_case:
+        return []
+
+    try:
+        loaded = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    cases: list[object]
+    if isinstance(loaded, dict) and isinstance(loaded.get("cases"), list):
+        cases = loaded["cases"]
+        output_payload: object = loaded
+    elif isinstance(loaded, list):
+        cases = loaded
+        output_payload = cases
+    else:
+        return []
+
+    repaired_names: list[str] = []
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        case_name = str(case.get("name") or "").strip()
+        entity = repairs_by_case.get(case_name)
+        if not entity:
+            continue
+        output = case.get("output")
+        if not isinstance(output, dict):
+            continue
+        row_lengths = {
+            len(value) for value in output.values() if isinstance(value, list)
+        }
+        if row_lengths != {1}:
+            continue
+        case_input = case.get("input")
+        if not isinstance(case_input, dict):
+            continue
+        row_inputs = {
+            key: value
+            for key, value in case_input.items()
+            if isinstance(key, str) and "#input." in key
+        }
+        if not row_inputs:
+            continue
+        remaining_input = {
+            key: value for key, value in case_input.items() if key not in row_inputs
+        }
+        tables = copy.deepcopy(case.get("tables") or {})
+        if not isinstance(tables, dict):
+            continue
+        existing_rows = tables.get(entity)
+        if isinstance(existing_rows, list) and existing_rows:
+            continue
+        tables[entity] = [row_inputs]
+        case["input"] = remaining_input
+        case["tables"] = tables
+        repaired_names.append(case_name)
+
+    if not repaired_names:
+        return []
+    test_file.write_text(yaml.safe_dump(output_payload, sort_keys=False))
+    return repaired_names
+
+
+def _validation_issue_strings(validation: object) -> list[str]:
+    """Collect issue strings from a PipelineResult-like object."""
+    issues: list[str] = []
+    results = getattr(validation, "results", {})
+    if not isinstance(results, dict):
+        return issues
+    for validator_result in results.values():
+        for issue in getattr(validator_result, "issues", []) or []:
+            issues.append(str(issue))
+        error = getattr(validator_result, "error", None)
+        if error:
+            issues.append(str(error))
+    return issues
+
+
 def _repair_mixed_derived_entity_output_tests(
     *,
     rules_file: Path,
@@ -15280,6 +15389,10 @@ _INVALID_INPUT_REF_RE = re.compile(
 _ABSOLUTE_RULESPEC_REF_RE = re.compile(r"^[a-z][a-z0-9_-]*:[^\s]+$")
 _MIXED_DERIVED_OUTPUT_ENTITIES_RE = re.compile(
     r"Test case `(?P<case>[^`]+)` mixes derived output entities \([^)]+\)"
+)
+_ROW_ORDERED_WITHOUT_TABLE_RE = re.compile(
+    r"Test case `(?P<case>[^`]+)` output .+ uses a row-ordered "
+    r"list but has no `tables\.(?P<entity>[^`]+)` rows\."
 )
 
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3456,6 +3456,16 @@ RuleSpec requirements:
   input such as `tier_1_applicable_percentage`. Import the upstream output when
   it exists; otherwise defer the affected output and name the cited legal
   dependency in `reason`.
+  Before applying any imported rate to the current source's whole base, check
+  whether the cited source makes that rate thresholded, capped, base-limited, or
+  part of an amount formula that applies only above or below a specified amount.
+  If so, do not flatten the cited mechanics into `current_base * imported_rate`
+  or into a combined percentage that is later multiplied by the whole current
+  base. Import and compose the cited executable amount or the cited base,
+  threshold, cap, and excess-amount outputs faithfully. If the current schema
+  cannot pass the correct adjusted base into those cited mechanics, defer the
+  affected executable output and name the missing cited computation rather than
+  approximating it with a flat rate.
   When the omitted output covers a specific subsection or subparagraph, the
   `output` target path must include that source path segment, e.g.
   `us:statutes/26/3201/a#tier_1_employee_tax`, not

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -11262,6 +11262,46 @@ def _normalize_identifier(value: str) -> str:
     return re.sub(r"_+", "_", normalized).strip("_")
 
 
+def _imported_rate_source_is_thresholded(content: str, rate_name: str) -> bool:
+    """Return whether an imported rate file also encodes limited rate mechanics."""
+    if rate_name not in _formula_local_identifiers(content):
+        return False
+    normalized = _normalize_identifier(content)
+    return any(
+        token in normalized
+        for token in (
+            "threshold",
+            "excess",
+            "cap",
+            "capped",
+            "ceiling",
+            "limit",
+            "limited",
+            "above",
+            "below",
+        )
+    )
+
+
+def _formula_preserves_thresholded_rate_mechanics(formula: str) -> bool:
+    """Return whether a local formula appears to preserve limited-rate mechanics."""
+    normalized = _normalize_identifier(formula)
+    if any(
+        token in normalized
+        for token in (
+            "threshold",
+            "excess",
+            "cap",
+            "capped",
+            "ceiling",
+            "limit",
+            "limited",
+        )
+    ):
+        return True
+    return bool(re.search(r"\bmin\s*\(", formula))
+
+
 def find_test_input_assignment_issues(
     content: str,
     test_cases: Any,
@@ -14898,6 +14938,7 @@ class ValidatorPipeline:
         issues.extend(self._check_cross_reference_exception_placeholders(rules_file))
         issues.extend(self._check_encoded_cross_reference_placeholders(rules_file))
         issues.extend(self._check_cross_reference_numeric_placeholders(rules_file))
+        issues.extend(self._check_flattened_thresholded_imported_rates(rules_file))
         issues.extend(
             find_source_relation_issues(content, policy_repo_path=self.policy_repo_path)
         )
@@ -15583,6 +15624,54 @@ class ValidatorPipeline:
                         f"`{block['name']}` uses local `{identifier}` for "
                         f"`{label}` set by a cited legal section. {resolution}"
                     )
+        return issues
+
+    def _check_flattened_thresholded_imported_rates(
+        self, rulespec_file: Path
+    ) -> list[str]:
+        """Reject formulas that flatten thresholded imported rates into flat rates."""
+        content = rulespec_file.read_text()
+        imported_rate_sources: dict[str, str] = {}
+        for import_item in self._extract_import_items(content):
+            fragment = self._import_item_fragment(import_item)
+            if not fragment or "rate" not in fragment.lower():
+                continue
+            import_file = _resolve_rulespec_import_file_static(
+                import_item,
+                rules_file=rulespec_file,
+                policy_repo_path=self.policy_repo_path,
+            )
+            if import_file is None:
+                continue
+            with contextlib.suppress(OSError):
+                imported_content = import_file.read_text()
+                if _imported_rate_source_is_thresholded(
+                    imported_content,
+                    fragment,
+                ):
+                    imported_rate_sources[fragment] = import_item
+
+        if not imported_rate_sources:
+            return []
+
+        issues: list[str] = []
+        for block in self._extract_definition_blocks(content):
+            formula = "\n".join(str(line) for line in block["body_lines"])
+            identifiers = _formula_local_identifiers(formula)
+            for rate_name, import_item in sorted(imported_rate_sources.items()):
+                if rate_name not in identifiers:
+                    continue
+                if _formula_preserves_thresholded_rate_mechanics(formula):
+                    continue
+                issues.append(
+                    "Flattened thresholded imported rate: "
+                    f"`{block['name']}` uses imported `{rate_name}` from "
+                    f"`{import_item}` without the cited source's threshold, "
+                    "cap, base, or excess-amount mechanics. Import and compose "
+                    "the cited executable amount or the cited base/threshold "
+                    "outputs, or defer the affected output instead of applying "
+                    "the rate as a flat percentage."
+                )
         return issues
 
     def _extract_cross_reference_numeric_obligations(

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -370,6 +370,16 @@ Hard requirements:
   input such as `tier_1_applicable_percentage`. Import the upstream output when
   it exists; otherwise defer the affected output and name the cited legal
   dependency in `reason`.
+  Before applying any imported rate to the current source's whole base, check
+  whether the cited source makes that rate thresholded, capped, base-limited, or
+  part of an amount formula that applies only above or below a specified amount.
+  If so, do not flatten the cited mechanics into `current_base * imported_rate`
+  or into a combined percentage that is later multiplied by the whole current
+  base. Import and compose the cited executable amount or the cited base,
+  threshold, cap, and excess-amount outputs faithfully. If the current schema
+  cannot pass the correct adjusted base into those cited mechanics, defer the
+  affected executable output and name the missing cited computation rather than
+  approximating it with a flat rate.
   If the current source instead states a purpose-limited replacement rate,
   percentage, or amount for a cited section using phrases like `computed at`,
   `in lieu of`, or `instead of the rate provided by`, encode that source-stated

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,6 +43,7 @@ from axiom_encode.cli import (
     _repair_generated_import_symbol_near_misses,
     _repair_imported_rule_name_collisions,
     _repair_input_field_accesses_in_formulas,
+    _repair_missing_entity_table_rows_for_row_ordered_outputs,
     _repair_missing_source_proof_atoms,
     _repair_mixed_derived_entity_output_tests,
     _repair_mixed_scalar_output_tests,
@@ -6730,6 +6731,84 @@ rules:
                 },
             },
         ]
+
+    def test_missing_entity_table_rows_repair_moves_inputs_to_row(self, tmp_path):
+        test_file = tmp_path / "3231-e-2.test.yaml"
+        test_file.write_text(
+            """- name: payment_partly_exceeds_applicable_base_without_successor
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/3121/a/1#input.successor_employer_acquired_substantially_all_trade_or_business_property_from_predecessor_during_calendar_year: false
+    us:statutes/26/3231/e/2#input.compensation_paid_to_individual_by_employer_during_calendar_year_before_payment: 90000
+    scenario_id: base
+  output:
+    us:statutes/26/3231/e/2#compensation_counted_toward_applicable_base_before_payment:
+    - 90000
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    issues=[
+                        "Test case `payment_partly_exceeds_applicable_base_without_successor` "
+                        "output `compensation_counted_toward_applicable_base_before_payment` "
+                        "uses a row-ordered list but has no `tables.Payment` rows."
+                    ]
+                )
+            }
+        )
+
+        repaired = _repair_missing_entity_table_rows_for_row_ordered_outputs(
+            test_file=test_file,
+            validation=validation,
+        )
+
+        cases = yaml.safe_load(test_file.read_text())
+        assert repaired == ["payment_partly_exceeds_applicable_base_without_successor"]
+        assert cases[0]["input"] == {"scenario_id": "base"}
+        assert cases[0]["tables"] == {
+            "Payment": [
+                {
+                    "us:statutes/26/3121/a/1#input.successor_employer_acquired_substantially_all_trade_or_business_property_from_predecessor_during_calendar_year": False,
+                    "us:statutes/26/3231/e/2#input.compensation_paid_to_individual_by_employer_during_calendar_year_before_payment": 90000,
+                }
+            ]
+        }
+
+    def test_missing_entity_table_rows_repair_skips_multirow_outputs(self, tmp_path):
+        test_file = tmp_path / "3231-e-2.test.yaml"
+        test_file.write_text(
+            """- name: two_payments
+  input:
+    us:statutes/26/3231/e/2#input.compensation_paid_to_individual_by_employer_during_calendar_year_before_payment: 90000
+  output:
+    us:statutes/26/3231/e/2#compensation_counted_toward_applicable_base_before_payment:
+    - 90000
+    - 95000
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    issues=[
+                        "Test case `two_payments` output "
+                        "`compensation_counted_toward_applicable_base_before_payment` "
+                        "uses a row-ordered list but has no `tables.Payment` rows."
+                    ]
+                )
+            }
+        )
+
+        repaired = _repair_missing_entity_table_rows_for_row_ordered_outputs(
+            test_file=test_file,
+            validation=validation,
+        )
+
+        assert repaired == []
+        assert "tables" not in yaml.safe_load(test_file.read_text())[0]
 
 
 class TestGuardGenerated:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -453,6 +453,12 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "rate-applied result at that lower entity" in prompt
     assert "Treat legal subject nouns as stronger evidence" in prompt
     assert "usually require\n  `entity: Person`" in prompt
+    assert "thresholded, capped, base-limited" in prompt
+    assert (
+        "do not flatten the cited mechanics into `current_base * imported_rate`"
+        in prompt
+    )
+    assert "defer the\n  affected executable output" in prompt
     assert 'definition uses "taxpayer" but also says the amount is "of an' in prompt
     assert 'Do not let\n  the word "taxpayer"' in prompt
     assert "on the [base] of every individual/person/employee" in prompt

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6516,6 +6516,114 @@ rules:
     assert any("statutes/26/3241" in issue for issue in issues)
 
 
+def test_flattened_thresholded_imported_rate_is_rejected(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    imported_file = repo / "statutes" / "26" / "3101" / "b" / "2.yaml"
+    rules_file = repo / "statutes" / "26" / "3201.yaml"
+    imported_file.parent.mkdir(parents=True)
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    imported_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: additional_medicare_tax_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2013-01-01'
+        formula: 0.009
+  - name: additional_medicare_wage_tax_threshold
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2013-01-01'
+        formula: 200000
+  - name: additional_medicare_excess_wages
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2013-01-01'
+        formula: max(0, wages - additional_medicare_wage_tax_threshold)
+"""
+    )
+    rules_file.write_text(
+        """format: rulespec/v1
+imports:
+  - us:statutes/26/3101/b/2#additional_medicare_tax_rate
+rules:
+  - name: tier_1_applicable_percentage
+    kind: derived
+    dtype: Rate
+    versions:
+      - effective_from: '2013-01-01'
+        formula: base_rate + additional_medicare_tax_rate
+  - name: tier_1_employee_tax
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2013-01-01'
+        formula: compensation * tier_1_applicable_percentage
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_flattened_thresholded_imported_rates(rules_file)
+
+    assert len(issues) == 1
+    assert "Flattened thresholded imported rate" in issues[0]
+    assert "additional_medicare_tax_rate" in issues[0]
+
+
+def test_thresholded_imported_rate_allows_excess_amount_formula(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    imported_file = repo / "statutes" / "26" / "3101" / "b" / "2.yaml"
+    rules_file = repo / "statutes" / "26" / "3201.yaml"
+    imported_file.parent.mkdir(parents=True)
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    imported_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: additional_medicare_tax_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2013-01-01'
+        formula: 0.009
+  - name: additional_medicare_wage_tax_threshold
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2013-01-01'
+        formula: 200000
+"""
+    )
+    rules_file.write_text(
+        """format: rulespec/v1
+imports:
+  - us:statutes/26/3101/b/2#additional_medicare_tax_rate
+rules:
+  - name: additional_medicare_component_tax
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2013-01-01'
+        formula: additional_medicare_excess_wages * additional_medicare_tax_rate
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_flattened_thresholded_imported_rates(rules_file)
+
+    assert issues == []
+
+
 def test_cross_reference_numeric_placeholder_does_not_infer_named_act_title(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.283"
+version = "0.2.284"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add encoder prompt guidance against flattening thresholded, capped, or base-limited cited rates into flat current-source percentages
- add a RuleSpec CI guard that rejects imported `*rate` outputs when the cited file contains threshold/cap/excess mechanics and the local formula does not preserve them
- add an apply-overlay repair for generated one-row entity tests that assert row-ordered outputs without creating the matching `tables.<Entity>` row
- add regression tests for the payroll-tax Additional Medicare failure mode, prompt surface, and generated row-test repair

## Validation
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `git diff --check`
- `uv run --extra dev python -m pytest`
- confirmed the guard flags the generated bad `26 USC 3201` and `26 USC 3211` diagnostics that flattened `additional_medicare_tax_rate`
- confirmed the apply-overlay repair validates the blocked generated `26 USC 3231(e)(2)` candidate with supplemental `statutes/26/3231/e/2.test.yaml`
