### PR TITLE
Prune unused imports during generated apply

### DIFF
--- a/changelog.d/apply-unused-import-prune.fixed.md
+++ b/changelog.d/apply-unused-import-prune.fixed.md
@@ -1,0 +1,1 @@
+Prune generated unused imports during apply-overlay validation before revalidating generated RuleSpec artifacts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.284"
+version = "0.2.285"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.284"
+__version__ = "0.2.285"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3709,15 +3709,14 @@ def _prune_unused_imports(content: str) -> tuple[str, list[str]]:
             stripped = line.strip()
             if stripped:
                 indent = len(line) - len(line.lstrip())
-                if indent <= imports_indent:
+                item_match = re.match(r"^\s*-\s+(.+?)\s*$", line)
+                if item_match and indent >= imports_indent:
+                    item = _strip_yaml_scalar_quotes(item_match.group(1).strip())
+                    if item in unused:
+                        removed.append(item)
+                        continue
+                elif indent <= imports_indent:
                     in_imports = False
-                else:
-                    item_match = re.match(r"^\s*-\s+(.+?)\s*$", line)
-                    if item_match:
-                        item = _strip_yaml_scalar_quotes(item_match.group(1).strip())
-                        if item in unused:
-                            removed.append(item)
-                            continue
 
         repaired_lines.append(line)
 
@@ -14134,6 +14133,21 @@ def _validate_generated_encoding_in_policy_overlay(
             target_test_path = _rulespec_test_path(overlay_target)
             if (
                 target_validation is not None
+                and _repair_generated_unused_imports_for_apply(
+                    rules_file=overlay_target,
+                    validation=target_validation,
+                )
+            ):
+                supplemental_files[relative_output] = overlay_target.read_text()
+                validations = _validate_overlay_files(
+                    pipeline,
+                    dependent_pipeline=dependent_pipeline,
+                    overlay_target=overlay_target,
+                    dependents=dependents,
+                )
+                continue
+            if (
+                target_validation is not None
                 and _repair_missing_entity_table_rows_for_row_ordered_outputs(
                     test_file=target_test_path,
                     validation=target_validation,
@@ -15133,6 +15147,27 @@ def _repair_missing_entity_table_rows_for_row_ordered_outputs(
         return []
     test_file.write_text(yaml.safe_dump(output_payload, sort_keys=False))
     return repaired_names
+
+
+def _repair_generated_unused_imports_for_apply(
+    *,
+    rules_file: Path,
+    validation: object,
+) -> list[str]:
+    """Prune generated imports that validation proves are unused."""
+    if not any(
+        "Unused import `" in issue for issue in _validation_issue_strings(validation)
+    ):
+        return []
+    try:
+        content = rules_file.read_text()
+    except OSError:
+        return []
+    repaired_content, removed_imports = _prune_unused_imports(content)
+    if not removed_imports:
+        return []
+    rules_file.write_text(repaired_content)
+    return removed_imports
 
 
 def _validation_issue_strings(validation: object) -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ from axiom_encode.cli import (
     _remove_invalid_dependent_test_inputs,
     _repair_employer_scoped_entities,
     _repair_generated_import_symbol_near_misses,
+    _repair_generated_unused_imports_for_apply,
     _repair_imported_rule_name_collisions,
     _repair_input_field_accesses_in_formulas,
     _repair_missing_entity_table_rows_for_row_ordered_outputs,
@@ -6809,6 +6810,47 @@ rules:
 
         assert repaired == []
         assert "tables" not in yaml.safe_load(test_file.read_text())[0]
+
+    def test_apply_unused_import_repair_prunes_validated_unused_import(self, tmp_path):
+        rules_file = tmp_path / "3231-e-2.yaml"
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+- us:statutes/26/3101/b/1#hospital_insurance_wage_tax_rate
+- us:statutes/26/1401/b/1/rate#self_employment_income_tax_rate
+module:
+  deferred_outputs:
+    - output: us:statutes/26/3231/e/2#hospital_insurance_rate_portion
+      reason: downstream rate unavailable
+rules:
+  - name: section_1401_rate_copy
+    kind: derived
+    dtype: Rate
+    versions:
+      - effective_from: '1990-01-01'
+        formula: self_employment_income_tax_rate
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    issues=[
+                        "Unused import `us:statutes/26/3101/b/1#hospital_insurance_wage_tax_rate`: "
+                        "imported symbol `hospital_insurance_wage_tax_rate` is not referenced by any formula or proof import."
+                    ]
+                )
+            }
+        )
+
+        removed = _repair_generated_unused_imports_for_apply(
+            rules_file=rules_file,
+            validation=validation,
+        )
+
+        content = rules_file.read_text()
+        assert removed == ["us:statutes/26/3101/b/1#hospital_insurance_wage_tax_rate"]
+        assert "hospital_insurance_wage_tax_rate" not in content
+        assert "self_employment_income_tax_rate" in content
 
 
 class TestGuardGenerated:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.284"
+version = "0.2.285"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- run the existing unused-import pruner during apply-overlay validation when generated RuleSpec validation reports unused imports
- handle top-level, indentless YAML import lists under `imports:` so generated files can be repaired before revalidation
- add a focused regression test and bump axiom-encode to 0.2.285

## Validation
- `git diff --check`
- `uv run --extra dev python -m pytest tests/test_cli.py::TestCmdEncode::test_apply_unused_import_repair_prunes_validated_unused_import`
- prior full local suite on this diff: `uv run --extra dev python -m pytest` -> 1293 passed, 15 skipped