### PR TITLE
Reject generic outputs for deferred purpose-specific bases

### DIFF
--- a/changelog.d/purpose-specific-base-guards.fixed.md
+++ b/changelog.d/purpose-specific-base-guards.fixed.md
@@ -1,0 +1,1 @@
+Reject generated RuleSpec artifacts that hide purpose-specific base or carve-out mechanics behind broad current-purpose placeholders or generic outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.285"
+version = "0.2.286"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.285"
+__version__ = "0.2.286"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3382,6 +3382,18 @@ RuleSpec requirements:
   broader meaning. Downstream provisions must import the output that matches
   their cited purpose rather than using a stale local input or an over-broad
   generic output.
+- If one purpose-specific exception, rate portion, or base branch is not
+  executable yet, do not export a generic `x_after_cap`, `x_included`,
+  `x_excluded`, `taxable_x`, or similar output that silently applies the
+  non-excepted branch to every downstream purpose. Either split the executable
+  surface into concrete purpose-scoped outputs and defer only the unresolved
+  purpose, or defer the generic surface entirely.
+- Do not use boundary inputs named like `applicable_base_for_current_purpose`,
+  `amount_for_current_context`, or `rate_under_current_use`. Those hide
+  purpose-specific legal mechanics from downstream importers. Use the concrete
+  source-stated purpose in the rule name and formula input, such as
+  `applicable_base_for_section_3201_a_non_hospital_insurance_rate_portion`, or
+  defer that purpose-specific surface.
 - When a child provision substitutes, increases, caps, or otherwise modifies a
   sibling or parent output, give the replacement a branch-specific name such as
   `_under_subsection_h`, `_after_temporary_amendment`, or another source-stated

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -9402,6 +9402,183 @@ def find_scoped_exception_category_gate_issues(content: str) -> list[str]:
     return issues
 
 
+_CURRENT_PURPOSE_PLACEHOLDER_PATTERN = re.compile(
+    r"(?:^|_)current_(?:purpose|use|context)(?:_|$)|"
+    r"(?:^|_)(?:for|under)_current_(?:purpose|use|context)(?:_|$)",
+    flags=re.IGNORECASE,
+)
+_PURPOSE_SPECIFIC_NAME_MARKER_PATTERN = re.compile(
+    r"(?:^|_)(?:for|under|with_respect_to|in_case_of)_"
+    r"(?:section|subsection|paragraph|clause|tax|rate|purpose|portion|category|use|case)"
+    r"(?:_|$)|(?:^|_)hospital_insurance(?:_|$)|(?:^|_)rate_portion(?:_|$)|"
+    r"(?:^|_)tier_[0-9]+(?:_|$)",
+    flags=re.IGNORECASE,
+)
+_DEFERRED_PURPOSE_LIMITATION_REASON_PATTERN = re.compile(
+    r"\b(?:shall\s+not\s+apply|does\s+not\s+apply|except(?:ion)?|carve-?out|"
+    r"purpose-specific|rate\s+portion|for\s+purposes\s+of|for\s+the\s+tax\s+imposed\s+by)\b",
+    flags=re.IGNORECASE,
+)
+_PURPOSE_SPLIT_PATTERN = re.compile(
+    r"_(?:for|under|with_respect_to|in_case_of)_(?:section|subsection|paragraph|"
+    r"clause|tax|rate|purpose|portion|category|use|case)",
+    flags=re.IGNORECASE,
+)
+_PURPOSE_TOKEN_STOPWORDS = {
+    "a",
+    "after",
+    "and",
+    "any",
+    "applicable",
+    "before",
+    "by",
+    "current",
+    "for",
+    "from",
+    "in",
+    "of",
+    "or",
+    "purpose",
+    "the",
+    "to",
+    "under",
+    "with",
+}
+_PURPOSE_AMOUNT_TOKENS = {
+    "amount",
+    "base",
+    "benefit",
+    "compensation",
+    "credit",
+    "deduction",
+    "earnings",
+    "excess",
+    "exclusion",
+    "inclusion",
+    "income",
+    "rate",
+    "tax",
+    "wage",
+    "wages",
+}
+
+
+def find_current_purpose_placeholder_issues(content: str) -> list[str]:
+    """Reject broad current-purpose placeholders in executable formulas."""
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+
+    issues: list[str] = []
+    for name, kind, formula in _rulespec_rule_formulas(payload):
+        if kind != "derived":
+            continue
+        for identifier in sorted(_formula_local_identifiers(formula)):
+            if not _CURRENT_PURPOSE_PLACEHOLDER_PATTERN.search(identifier):
+                continue
+            issues.append(
+                "Current-purpose placeholder input: "
+                f"`{name}` references `{identifier}`. Do not make callers supply "
+                "a broad current-purpose/current-context base; encode concrete "
+                "purpose-specific outputs or defer the affected executable surface."
+            )
+    return issues
+
+
+def find_deferred_purpose_specific_limitation_issues(content: str) -> list[str]:
+    """Reject generic executable outputs when purpose-specific limitations defer."""
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+
+    deferred_prefix_tokens: list[tuple[str, set[str]]] = []
+    module = payload.get("module")
+    deferred_outputs = (
+        module.get("deferred_outputs") if isinstance(module, dict) else None
+    )
+    if not isinstance(deferred_outputs, list):
+        return []
+    for record in deferred_outputs:
+        if not isinstance(record, dict):
+            continue
+        output = str(record.get("output") or "").strip()
+        reason = str(record.get("reason") or "").strip()
+        if not output or "#" not in output:
+            continue
+        symbol = output.rsplit("#", 1)[1]
+        if not (
+            _PURPOSE_SPECIFIC_NAME_MARKER_PATTERN.search(symbol)
+            or _DEFERRED_PURPOSE_LIMITATION_REASON_PATTERN.search(reason)
+        ):
+            continue
+        if not _DEFERRED_PURPOSE_LIMITATION_REASON_PATTERN.search(reason):
+            continue
+        prefix = _purpose_specific_prefix(symbol)
+        tokens = _purpose_surface_tokens(prefix)
+        if len(tokens) < 2:
+            continue
+        deferred_prefix_tokens.append((symbol, tokens))
+    if not deferred_prefix_tokens:
+        return []
+
+    issues: list[str] = []
+    for name, kind, _formula, _source, rule in _rulespec_rule_formula_rule_records(
+        payload
+    ):
+        if kind != "derived":
+            continue
+        dtype = str(rule.get("dtype") or "").strip().lower()
+        if dtype in {"judgment", "boolean", "bool"}:
+            continue
+        if _PURPOSE_SPECIFIC_NAME_MARKER_PATTERN.search(name):
+            continue
+        rule_tokens = _purpose_surface_tokens(name)
+        if not rule_tokens or not rule_tokens.intersection(_PURPOSE_AMOUNT_TOKENS):
+            continue
+        for deferred_symbol, deferred_tokens in deferred_prefix_tokens:
+            overlap = rule_tokens & deferred_tokens
+            if len(overlap) < 3:
+                continue
+            overlap_hint = ", ".join(f"`{token}`" for token in sorted(overlap)[:4])
+            issues.append(
+                "Generic output with deferred purpose-specific limitation: "
+                f"`{name}` overlaps deferred purpose-specific output "
+                f"`{deferred_symbol}` on {overlap_hint}. Do not export a broad "
+                "amount/base/inclusion/exclusion that applies the non-excepted "
+                "rule to every purpose while a source-stated purpose-specific "
+                "carve-out is deferred; rename/split into concrete "
+                "purpose-specific outputs or defer the generic surface."
+            )
+            break
+    return issues
+
+
+def _purpose_specific_prefix(symbol: str) -> str:
+    match = _PURPOSE_SPLIT_PATTERN.search(symbol)
+    if match:
+        return symbol[: match.start()]
+    return symbol
+
+
+def _purpose_surface_tokens(name: str) -> set[str]:
+    tokens = {
+        _normalize_purpose_token(token)
+        for token in _normalize_identifier(name).split("_")
+        if token and token not in _PURPOSE_TOKEN_STOPWORDS
+    }
+    return {token for token in tokens if token}
+
+
+def _normalize_purpose_token(token: str) -> str:
+    if token in {"exclude", "excluded", "excludes", "excluding"}:
+        return "exclusion"
+    if token in {"include", "included", "includes", "including", "includable"}:
+        return "inclusion"
+    if token in {"earning"}:
+        return "earnings"
+    return token
+
+
 def _rule_scoped_exception_categories(rule: dict[str, Any]) -> list[str]:
     proof = _rule_proof_payload(rule)
     atoms = proof.get("atoms") if isinstance(proof, dict) else None
@@ -14901,6 +15078,8 @@ class ValidatorPipeline:
         issues.extend(find_source_limitation_application_issues(content))
         issues.extend(find_partial_extent_zeroing_issues(content))
         issues.extend(find_scoped_exception_category_gate_issues(content))
+        issues.extend(find_current_purpose_placeholder_issues(content))
+        issues.extend(find_deferred_purpose_specific_limitation_issues(content))
         issues.extend(find_broad_application_passthrough_issues(content))
         issues.extend(find_formula_absolute_reference_issues(content))
         issues.extend(find_import_shape_issues(content))

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -293,6 +293,18 @@ Hard requirements:
   broader meaning. Downstream provisions must import the output that matches
   their cited purpose rather than using a stale local input or an over-broad
   generic output.
+- If one purpose-specific exception, rate portion, or base branch is not
+  executable yet, do not export a generic `x_after_cap`, `x_included`,
+  `x_excluded`, `taxable_x`, or similar output that silently applies the
+  non-excepted branch to every downstream purpose. Either split the executable
+  surface into concrete purpose-scoped outputs and defer only the unresolved
+  purpose, or defer the generic surface entirely.
+- Do not use boundary inputs named like `applicable_base_for_current_purpose`,
+  `amount_for_current_context`, or `rate_under_current_use`. Those hide
+  purpose-specific legal mechanics from downstream importers. Use the concrete
+  source-stated purpose in the rule name and formula input, such as
+  `applicable_base_for_section_3201_a_non_hospital_insurance_rate_portion`, or
+  defer that purpose-specific surface.
 - When a child provision substitutes, increases, caps, or otherwise modifies a
   sibling or parent output, give the replacement a branch-specific name such as
   `_under_subsection_h`, `_after_temporary_amendment`, or another source-stated

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -31,8 +31,10 @@ from axiom_encode.harness.validator_pipeline import (
     find_broad_application_passthrough_issues,
     find_child_fragment_reencoding_issues,
     find_copied_cross_reference_source_issues,
+    find_current_purpose_placeholder_issues,
     find_current_year_final_amount_table_issues,
     find_deferred_output_issues,
+    find_deferred_purpose_specific_limitation_issues,
     find_deprecated_source_url_issues,
     find_employer_scoped_entity_issues,
     find_empty_rules_module_issues,
@@ -15237,3 +15239,74 @@ def test_non_rulespec_yaml_artifact_is_rejected(tmp_path):
 
     assert result.passed is False
     assert "RuleSpec YAML artifacts are required" in result.issues[0]
+
+
+def test_current_purpose_placeholder_input_is_rejected():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3231
+rules:
+  - name: remaining_applicable_base_before_payment
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(0, applicable_base_for_current_purpose - compensation_paid_before_payment)
+"""
+
+    issues = find_current_purpose_placeholder_issues(content)
+
+    assert len(issues) == 1
+    assert "applicable_base_for_current_purpose" in issues[0]
+    assert "Current-purpose placeholder input" in issues[0]
+
+
+def test_deferred_purpose_specific_limitation_rejects_generic_output():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3231
+  deferred_outputs:
+    - output: us:statutes/26/3231/e/2#compensation_excess_base_exclusion_for_section_3201_a_hospital_insurance_rate_portion
+      reason: Clause (iii) provides that the clause (i) base exclusion shall not apply to the hospital-insurance rate portion.
+rules:
+  - name: compensation_excess_applicable_base_excluded
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(0, remuneration_paid - remaining_applicable_base_before_payment)
+  - name: compensation_excess_base_exclusion_for_section_3201_a_non_hospital_insurance_rate_portion
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(0, remuneration_paid - remaining_applicable_base_before_payment)
+"""
+
+    issues = find_deferred_purpose_specific_limitation_issues(content)
+
+    assert len(issues) == 1
+    assert "Generic output with deferred purpose-specific limitation" in issues[0]
+    assert "compensation_excess_applicable_base_excluded" in issues[0]
+
+
+def test_deferred_purpose_specific_limitation_allows_named_tier_output():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3231
+  deferred_outputs:
+    - output: us:statutes/26/3231/e/2#applicable_base_for_tier_2_taxes_and_average_monthly_compensation
+      reason: Clause (ii) defines a purpose-specific base for tier 2 taxes, but section 230(c) mechanics are not yet executable.
+rules:
+  - name: applicable_base_for_tier_1_taxes
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: contribution_and_benefit_base_for_calendar_year
+"""
+
+    assert find_deferred_purpose_specific_limitation_issues(content) == []

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.285"
+version = "0.2.286"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add validator guards against broad `current_purpose`/`current_context` placeholders in generated formulas
- reject generic executable amount/base/inclusion/exclusion outputs that overlap deferred purpose-specific carveouts
- strengthen encoder/eval prompt guidance for purpose-specific base and rate-portion branches
- bump axiom-encode to 0.2.286

## Payroll tax context
This blocks the bad generated `26 USC 3231(e)(2)` candidate that exposed capped compensation while deferring the hospital-insurance rate-portion exception. The candidate now fails with:
- `applicable_base_for_current_purpose` placeholder
- generic `compensation_excess_applicable_base_excluded`
- generic `compensation_included_after_applicable_base_exclusion`

## Validation
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `git diff --check`
- `uv run --extra dev python -m pytest tests/test_rulespec_validation.py::test_current_purpose_placeholder_input_is_rejected tests/test_rulespec_validation.py::test_deferred_purpose_specific_limitation_rejects_generic_output tests/test_rulespec_validation.py::test_deferred_purpose_specific_limitation_allows_named_tier_output`
- `uv run --extra dev python -m pytest` -> 1296 passed, 15 skipped