### PR TITLE
Classify section 3231(e)(2) PolicyEngine coverage

### DIFF
--- a/changelog.d/section-3231-e-2-policyengine-coverage.changed.md
+++ b/changelog.d/section-3231-e-2-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify 26 USC 3231(e)(2) Railroad Retirement Tax Act contribution-base helper outputs as not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.286"
+version = "0.2.287"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.286"
+__version__ = "0.2.287"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9606,6 +9606,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3231(e) defines Railroad Retirement Tax Act compensation and its purpose-specific inclusions, exclusions, tip thresholds, and local-lodge disregards; PolicyEngine does not expose RRTA compensation-definition surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3231/e/2#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3231(e)(2) defines Railroad Retirement Tax Act contribution-base application, successor-employer continuity, and hospital-insurance carveout helper surfaces; PolicyEngine does not expose these RRTA contribution-base mechanics as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3231/f#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2831,6 +2831,48 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3231_e_2_contribution_base_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3231/e/2.yaml",
+        """format: rulespec/v1
+rules:
+  - name: successor_employer_compensation_base_continuity_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: successor_acquisition and immediate_service
+  - name: predecessor_compensation_counted_for_successor_applicable_base
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: predecessor_compensation
+  - name: compensation_counted_toward_applicable_base_before_payment
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: compensation_before_payment
+  - name: remaining_applicable_base_before_payment
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: applicable_base - compensation_before_payment
+  - name: compensation_excess_excluded_before_hospital_insurance_carveout
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: max(0, remuneration - remaining_applicable_base_before_payment)
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 5}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3231_f_company_output(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3231/f.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.286"
+version = "0.2.287"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 26 USC 3231(e)(2) RRTA contribution-base helper outputs as not comparable to PolicyEngine
- add a regression test covering the five generated helper outputs from rulespec-us #190
- bump axiom-encode to 0.2.287

## Context
rulespec-us #190 failed the changed PolicyEngine oracle coverage gate because the new 3231(e)(2) helper outputs were unmapped. PolicyEngine does not expose these RRTA contribution-base and successor-employer helper surfaces one-to-one.

## Validation
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `git diff --check`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3231_e_2_contribution_base_outputs`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-rulespec-3231-e-2-20260526 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20` -> comparable=226, known_not_comparable=944, untested comparable=0