### PR TITLE
Guard payroll tax base mechanics during apply

### DIFF
--- a/changelog.d/payroll-base-mechanics-guard.changed.md
+++ b/changelog.d/payroll-base-mechanics-guard.changed.md
@@ -1,0 +1,1 @@
+Guard generated payroll tax outputs against raw-base formulas when the source requires cited contribution-base mechanics.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.287"
+version = "0.2.288"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.287"
+__version__ = "0.2.288"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10649,6 +10649,35 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_deferred_rules = (
+                    _try_repair_generated_unsafe_formula_outputs_for_apply(
+                        result,
+                        output_root=args.output,
+                        policy_repo_path=policy_repo_path,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_deferred_rules:
+                    outcome["auto_deferred_unsafe_formula_outputs"] = (
+                        repaired_deferred_rules
+                    )
+                    print(
+                        "  apply=auto_deferred_unsafe_formula_outputs:"
+                        + ",".join(repaired_deferred_rules)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_employer_scoped_rules = (
                     _try_repair_generated_employer_scope_for_apply(
                         result,
@@ -11855,6 +11884,279 @@ def _infer_deferred_output_symbol_from_summary(summary: str) -> tuple[str, str]:
     return symbol, label
 
 
+def _try_repair_generated_unsafe_formula_outputs_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+    issues: list[str],
+) -> list[str]:
+    """Defer generated outputs that validation proved use unsafe formulas."""
+    seed_rules: set[str] = set()
+    issue_reasons: dict[str, list[str]] = defaultdict(list)
+    for issue in issues:
+        issue_text = str(issue)
+        flattened_match = _FLATTENED_THRESHOLDED_RATE_ISSUE_PATTERN.search(issue_text)
+        if flattened_match:
+            rule_name = flattened_match.group(1)
+            seed_rules.add(rule_name)
+            issue_reasons[rule_name].append("flattened_thresholded_rate")
+        base_match = _CROSS_REFERENCE_BASE_MECHANICS_ISSUE_PATTERN.search(issue_text)
+        if base_match:
+            rule_name = base_match.group(1)
+            seed_rules.add(rule_name)
+            issue_reasons[rule_name].append("cross_reference_base_mechanics")
+        numeric_match = _CROSS_REFERENCE_NUMERIC_PLACEHOLDER_ISSUE_PATTERN.search(
+            issue_text
+        )
+        if numeric_match:
+            rule_name = numeric_match.group(1)
+            seed_rules.add(rule_name)
+            issue_reasons[rule_name].append("cross_reference_numeric_placeholder")
+    if not seed_rules:
+        return []
+
+    try:
+        relative_output = _relative_generated_output_path(
+            result,
+            output_root=output_root,
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    rules_by_name = {
+        str(rule.get("name") or ""): rule
+        for rule in rules
+        if isinstance(rule, dict) and str(rule.get("name") or "")
+    }
+    affected_rules = _expand_affected_generated_rule_dependencies(
+        rules_by_name=rules_by_name,
+        seed_rules=seed_rules,
+    )
+    if not affected_rules:
+        return []
+
+    base_anchor = _relative_output_to_anchor(
+        relative_output,
+        policy_repo_path=policy_repo_path,
+    )
+    module = payload.setdefault("module", {})
+    if not isinstance(module, dict):
+        return []
+    deferred_outputs = module.setdefault("deferred_outputs", [])
+    if not isinstance(deferred_outputs, list):
+        return []
+    existing_outputs = {
+        str(record.get("output") or "").strip()
+        for record in deferred_outputs
+        if isinstance(record, dict)
+    }
+
+    deferred_targets: list[str] = []
+    for rule_name in sorted(affected_rules):
+        rule = rules_by_name.get(rule_name)
+        if not isinstance(rule, dict):
+            continue
+        output = _deferred_output_target_for_generated_rule(
+            rule_name=rule_name,
+            rule=rule,
+            base_anchor=base_anchor,
+        )
+        if not output:
+            continue
+        reasons = issue_reasons.get(rule_name) or []
+        dependency_reasons = sorted(seed_rules.intersection(affected_rules))
+        if not reasons and dependency_reasons:
+            reason = (
+                "Generated rule depends on an output that validation deferred "
+                "because it flattened thresholded, capped, base-limited, or "
+                "cross-referenced base mechanics."
+            )
+        elif "cross_reference_base_mechanics" in reasons:
+            reason = (
+                "Generated rule computed the tax on a raw compensation, wage, "
+                "remuneration, or payment base even though the source applies "
+                "cited base mechanics. This output is deferred until the cited "
+                "base, cap, exclusion, or excess outputs can be composed without "
+                "multiplying an unadjusted base."
+            )
+        elif "cross_reference_numeric_placeholder" in reasons:
+            reason = (
+                "Generated rule kept a local numeric rate, percentage, amount, or "
+                "base that the source sets by cross-reference to another legal "
+                "section. This output is deferred until the cited numeric "
+                "mechanics can be imported or composed without a local placeholder."
+            )
+        else:
+            reason = (
+                "Generated rule used a thresholded, capped, base-limited, or "
+                "excess-amount imported rate as a flat percentage. This output "
+                "is deferred until the cited mechanics can be composed without "
+                "flattening the imported rate."
+            )
+        if output not in existing_outputs:
+            deferred_outputs.append({"output": output, "reason": reason})
+            existing_outputs.add(output)
+        deferred_targets.append(output)
+
+    if not deferred_targets:
+        return []
+
+    payload["rules"] = [
+        rule
+        for rule in rules
+        if not (
+            isinstance(rule, dict) and str(rule.get("name") or "") in affected_rules
+        )
+    ]
+    if not payload["rules"]:
+        module.setdefault("status", "deferred")
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+
+    _remove_generated_test_outputs_for_deferred_rules(
+        test_file=_rulespec_test_path(rules_file),
+        base_anchor=base_anchor,
+        rule_names=affected_rules,
+    )
+    return deferred_targets
+
+
+def _expand_affected_generated_rule_dependencies(
+    *,
+    rules_by_name: dict[str, dict[str, Any]],
+    seed_rules: set[str],
+) -> set[str]:
+    affected = {rule for rule in seed_rules if rule in rules_by_name}
+    changed = True
+    while changed:
+        changed = False
+        for rule_name, rule in rules_by_name.items():
+            if rule_name in affected:
+                continue
+            identifiers = _generated_rule_formula_identifiers(rule)
+            if identifiers.intersection(affected):
+                affected.add(rule_name)
+                changed = True
+    return affected
+
+
+def _generated_rule_formula_identifiers(rule: dict[str, Any]) -> set[str]:
+    identifiers: set[str] = set()
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return identifiers
+    for version in versions:
+        if not isinstance(version, dict):
+            continue
+        formula = version.get("formula")
+        if isinstance(formula, str):
+            identifiers.update(_RULESPEC_IDENTIFIER_PATTERN.findall(formula))
+    return identifiers - _RULESPEC_FORMULA_BUILTINS
+
+
+def _deferred_output_target_for_generated_rule(
+    *,
+    rule_name: str,
+    rule: dict[str, Any],
+    base_anchor: str,
+) -> str:
+    source = str(rule.get("source") or "")
+    path_suffix = _top_level_source_suffix_from_rule_source(source)
+    return f"{base_anchor}{path_suffix}#{rule_name}"
+
+
+def _top_level_source_suffix_from_rule_source(source: str) -> str:
+    match = re.search(
+        r"\b[0-9A-Za-z]+\s+USC\s+[0-9A-Za-z.-]+"
+        r"(?P<suffix>(?:\([A-Za-z0-9]+\))+)",
+        source,
+    )
+    if match is None:
+        return ""
+    parts = re.findall(r"\(([A-Za-z0-9]+)\)", match.group("suffix"))
+    if not parts:
+        return ""
+    return "/" + str(parts[0]).lower()
+
+
+def _remove_generated_test_outputs_for_deferred_rules(
+    *,
+    test_file: Path,
+    base_anchor: str,
+    rule_names: set[str],
+) -> list[str]:
+    if not test_file.exists():
+        return []
+    try:
+        test_cases = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(test_cases, list):
+        return []
+
+    removed_cases: list[str] = []
+    repaired_cases: list[Any] = []
+    for index, case in enumerate(test_cases):
+        if not isinstance(case, dict):
+            repaired_cases.append(case)
+            continue
+        outputs = case.get("output")
+        if not isinstance(outputs, dict):
+            repaired_cases.append(case)
+            continue
+        repaired_outputs = {
+            key: value
+            for key, value in outputs.items()
+            if not _test_output_targets_deferred_rule(
+                str(key),
+                base_anchor=base_anchor,
+                rule_names=rule_names,
+            )
+        }
+        if repaired_outputs == outputs:
+            repaired_cases.append(case)
+            continue
+        case_name = str(case.get("name") or f"case[{index}]")
+        if repaired_outputs:
+            repaired_case = dict(case)
+            repaired_case["output"] = repaired_outputs
+            repaired_cases.append(repaired_case)
+        else:
+            removed_cases.append(case_name)
+
+    if len(repaired_cases) == len(test_cases) and not removed_cases:
+        return []
+    test_file.write_text(yaml.safe_dump(repaired_cases, sort_keys=False))
+    return removed_cases
+
+
+def _test_output_targets_deferred_rule(
+    output_key: str,
+    *,
+    base_anchor: str,
+    rule_names: set[str],
+) -> bool:
+    if "#" not in output_key:
+        return False
+    path, fragment = output_key.split("#", 1)
+    if not path.startswith(base_anchor):
+        return False
+    return fragment in rule_names
+
+
 _PERSON_SCOPE_RATE_BASE_ISSUE_PATTERN = re.compile(
     r"Person-scoped rate base at unit scope: `([^`]+)`"
 )
@@ -11866,6 +12168,15 @@ _SOURCE_SCOPE_PERSON_MISMATCH_ISSUE_PATTERN = re.compile(
 )
 _EMPLOYER_SCOPE_ISSUE_PATTERN = re.compile(
     r"Employer-scoped rule at non-employer scope: `([^`]+)`"
+)
+_FLATTENED_THRESHOLDED_RATE_ISSUE_PATTERN = re.compile(
+    r"Flattened thresholded imported rate: `([^`]+)`"
+)
+_CROSS_REFERENCE_BASE_MECHANICS_ISSUE_PATTERN = re.compile(
+    r"Cross-reference base mechanics omitted: `([^`]+)`"
+)
+_CROSS_REFERENCE_NUMERIC_PLACEHOLDER_ISSUE_PATTERN = re.compile(
+    r"Cross-reference numeric placeholder: `([^`]+)`"
 )
 _SHARED_STATUTORY_RATE_NAME_ISSUE_PATTERN = re.compile(
     r"Shared statutory rate name [^:]+: `([^`]+)`"
@@ -14046,6 +14357,22 @@ def _validate_generated_encoding_in_policy_overlay(
         for _ in range(_APPLY_OVERLAY_VALIDATION_REPAIR_LIMIT):
             if all(validation.all_passed for _, validation in validations):
                 return True, [], supplemental_files
+            changed_proof_hash_files = _repair_dependent_proof_import_hashes(
+                overlay_repo=overlay_repo,
+                dependents=dependents,
+            )
+            if changed_proof_hash_files:
+                for path in changed_proof_hash_files:
+                    supplemental_files[path.relative_to(overlay_repo)] = (
+                        path.read_text()
+                    )
+                validations = _validate_overlay_files(
+                    pipeline,
+                    dependent_pipeline=dependent_pipeline,
+                    overlay_target=overlay_target,
+                    dependents=dependents,
+                )
+                continue
             upstream_placement_repairs = _repair_upstream_placement_duplicate_imports(
                 rules_file=overlay_target,
                 test_file=_rulespec_test_path(overlay_target),

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3618,6 +3618,13 @@ RuleSpec requirements:
   If imported child calculations cannot receive the adjusted basis faithfully
   under the current executable schema, emit `module.status: entity_not_supported`
   or `deferred` instead of an approximate executable formula.
+- If the source has a cross-reference such as `For application of different
+  contribution bases ... see section X`, do not repair it by keeping tax,
+  amount, or rate-times-compensation formulas on the raw wage, compensation,
+  remuneration, or payment base. Import and compose the cited
+  base/cap/exclusion/excess outputs; if those cited base mechanics are missing,
+  purpose-specific, or deferred, add `module.deferred_outputs[]` for each
+  affected source subsection output.
 - Do not repair that case by importing child rates or thresholds and rebuilding
   the child branch locally with an adjusted basis. That still re-encodes the
   child branch and is invalid unless the schema can explicitly wire the

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -11479,6 +11479,128 @@ def _formula_preserves_thresholded_rate_mechanics(formula: str) -> bool:
     return bool(re.search(r"\bmin\s*\(", formula))
 
 
+@dataclass(frozen=True)
+class _CrossReferenceBaseObligation:
+    section: str
+    subsections: str
+    affected_children: tuple[str, ...]
+
+
+def _extract_cross_reference_base_obligations(
+    source_text: str,
+) -> list[_CrossReferenceBaseObligation]:
+    """Return cited base-mechanics sections that must affect local amount rules."""
+    obligations: list[_CrossReferenceBaseObligation] = []
+    seen: set[tuple[str, str, tuple[str, ...]]] = set()
+    pattern = re.compile(
+        r"\bFor\s+application\s+of\s+"
+        r"(?P<description>.{0,220}?\b(?:base|bases|cap|caps|limit|limits)"
+        r".{0,220}?)"
+        r"\s+(?:with\s+respect\s+to|to|for)\s+"
+        r"(?P<target>.{0,220}?)"
+        r"\bsee\s+section\s+(?P<section>[0-9][A-Za-z0-9.-]*)"
+        r"(?P<subsections>(?:\([A-Za-z0-9]+\))+)?",
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    for match in pattern.finditer(source_text):
+        description = match.group("description") or ""
+        target = match.group("target") or ""
+        if not re.search(
+            r"\b(?:compensation|contribution|wage|remuneration|payment|taxable)\b",
+            description,
+            flags=re.IGNORECASE,
+        ):
+            continue
+        if not re.search(r"\b(?:tax|taxes|amount|rate|rates)\b", target, re.I):
+            continue
+        affected_children = _extract_referenced_source_children(target)
+        section = str(match.group("section") or "").strip()
+        subsections = str(match.group("subsections") or "").strip()
+        key = (section, subsections, affected_children)
+        if not section or key in seen:
+            continue
+        seen.add(key)
+        obligations.append(
+            _CrossReferenceBaseObligation(
+                section=section,
+                subsections=subsections,
+                affected_children=affected_children,
+            )
+        )
+    return obligations
+
+
+def _extract_referenced_source_children(text: str) -> tuple[str, ...]:
+    """Extract top-level source children from phrases like ``subsections (a) and (b)``."""
+    children: list[str] = []
+    for match in re.finditer(
+        r"\bsubsections?\s+((?:\([A-Za-z0-9]+\)"
+        r"(?:\s*(?:,|and|or)\s*)?)+)",
+        text,
+        flags=re.IGNORECASE,
+    ):
+        children.extend(re.findall(r"\(([A-Za-z0-9]+)\)", match.group(1)))
+    return tuple(dict.fromkeys(child.lower() for child in children if child))
+
+
+def _formula_uses_raw_compensation_base(identifiers: set[str]) -> bool:
+    """Return whether a formula appears to use a raw payroll-style amount base."""
+    raw_base_tokens = {
+        "compensation",
+        "wage",
+        "wages",
+        "remuneration",
+        "payment",
+        "payments",
+        "paid",
+        "pay",
+        "salary",
+    }
+    for identifier in identifiers:
+        tokens = set(_normalize_identifier(identifier).split("_"))
+        if tokens.intersection(raw_base_tokens):
+            return True
+    return False
+
+
+def _formula_uses_cross_reference_base_mechanics(
+    identifiers: set[str],
+    *,
+    imports_by_fragment: dict[str, str],
+    section: str,
+) -> bool:
+    """Return whether a formula imports or references cited base mechanics."""
+    normalized_section = _normalize_identifier(section)
+    mechanics_tokens = {
+        "base",
+        "bases",
+        "cap",
+        "capped",
+        "ceiling",
+        "contribution",
+        "excess",
+        "exclude",
+        "excluded",
+        "exclusion",
+        "limit",
+        "limited",
+        "remaining",
+    }
+    for identifier in identifiers:
+        import_item = imports_by_fragment.get(identifier)
+        if import_item and f"/{section}" in import_item:
+            return True
+        normalized = _normalize_identifier(identifier)
+        tokens = set(normalized.split("_"))
+        if normalized_section and normalized_section in tokens:
+            return True
+        if tokens.intersection(mechanics_tokens) and "base" in tokens:
+            return True
+        if tokens.intersection({"excess", "excluded", "remaining", "limit"}):
+            return True
+    return False
+
+
 def find_test_input_assignment_issues(
     content: str,
     test_cases: Any,
@@ -15118,6 +15240,7 @@ class ValidatorPipeline:
         issues.extend(self._check_encoded_cross_reference_placeholders(rules_file))
         issues.extend(self._check_cross_reference_numeric_placeholders(rules_file))
         issues.extend(self._check_flattened_thresholded_imported_rates(rules_file))
+        issues.extend(self._check_unapplied_cross_reference_base_mechanics(rules_file))
         issues.extend(
             find_source_relation_issues(content, policy_repo_path=self.policy_repo_path)
         )
@@ -15851,6 +15974,68 @@ class ValidatorPipeline:
                     "outputs, or defer the affected output instead of applying "
                     "the rate as a flat percentage."
                 )
+        return issues
+
+    def _check_unapplied_cross_reference_base_mechanics(
+        self,
+        rulespec_file: Path,
+    ) -> list[str]:
+        """Reject raw-base tax formulas when source requires cited base mechanics."""
+        content = rulespec_file.read_text()
+        source_text = _extract_source_verification_text(content)
+        if not source_text:
+            source_text = extract_embedded_source_text(content)
+        if not source_text:
+            return []
+
+        obligations = _extract_cross_reference_base_obligations(source_text)
+        if not obligations:
+            return []
+
+        import_items = self._extract_import_items(content)
+        imports_by_fragment = {
+            self._import_item_fragment(import_item): import_item
+            for import_item in import_items
+            if self._import_item_fragment(import_item)
+        }
+
+        issues: list[str] = []
+        for block in self._extract_definition_blocks(content):
+            source_child = self._rule_source_top_level_child(block)
+            if not source_child:
+                continue
+            dtype = str(block.get("dtype") or "").strip().lower()
+            if dtype != "money":
+                continue
+            formula = "\n".join(str(line) for line in block["body_lines"])
+            identifiers = _formula_local_identifiers(formula)
+            if not _formula_uses_raw_compensation_base(identifiers):
+                continue
+            for obligation in obligations:
+                if obligation.affected_children and source_child not in (
+                    (child,) for child in obligation.affected_children
+                ):
+                    continue
+                if _formula_uses_cross_reference_base_mechanics(
+                    identifiers,
+                    imports_by_fragment=imports_by_fragment,
+                    section=obligation.section,
+                ):
+                    continue
+                citation = f"section {obligation.section}" + (
+                    obligation.subsections if obligation.subsections else ""
+                )
+                issues.append(
+                    "Cross-reference base mechanics omitted: "
+                    f"`{block['name']}` cites source child "
+                    f"`{''.join(f'({part})' for part in source_child)}` and "
+                    "computes on a raw compensation, wage, remuneration, or "
+                    f"payment base without applying {citation}'s base mechanics. "
+                    "Import and compose the cited base, cap, exclusion, or "
+                    "excess outputs, or defer this output under "
+                    "`module.deferred_outputs` instead of multiplying the raw base."
+                )
+                break
         return issues
 
     def _extract_cross_reference_numeric_obligations(

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -392,6 +392,14 @@ Hard requirements:
   cannot pass the correct adjusted base into those cited mechanics, defer the
   affected executable output and name the missing cited computation rather than
   approximating it with a flat rate.
+  If the source has a cross-reference such as `For application of different
+  contribution bases ... see section X`, do not emit executable tax, amount, or
+  rate-times-compensation formulas for the referenced subsections on the raw
+  wage, compensation, remuneration, or payment base. Import and compose the
+  cited base/cap/exclusion/excess outputs; if the cited base mechanics are
+  missing, purpose-specific, or deferred, add `module.deferred_outputs[]` for
+  each affected source subsection output instead of preserving a raw-base
+  formula.
   If the current source instead states a purpose-limited replacement rate,
   percentage, or amount for a cited section using phrases like `computed at`,
   `in lieu of`, or `instead of the rate provided by`, encode that source-stated

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,6 +65,7 @@ from axiom_encode.cli import (
     _try_repair_generated_policyengine_oracle_inputs_for_apply,
     _try_repair_generated_section_1401_b_1_self_employment_income_for_apply,
     _try_repair_generated_source_table_band_scalars_for_apply,
+    _try_repair_generated_unsafe_formula_outputs_for_apply,
     _validate_generated_encoding_in_policy_overlay,
     _write_applied_encoding_manifest,
     cmd_calibration,
@@ -6640,6 +6641,89 @@ rules: []
         ]
         assert payload["rules"] == []
 
+    def test_unsafe_formula_output_repair_defers_rules_and_tests(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "openai-gpt-5.5" / "statutes/26/3201.yaml"
+        test_file = output_root / "openai-gpt-5.5" / "statutes/26/3201.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        policy_repo = tmp_path / "rulespec-us"
+        policy_repo.mkdir()
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  summary: Section 3201 payroll taxes.
+rules:
+  - name: tier_1_applicable_percentage
+    kind: derived
+    entity: Person
+    dtype: Rate
+    source: 26 USC 3201(a)
+    versions:
+      - effective_from: '2013-01-01'
+        formula: base_rate + additional_medicare_tax_rate
+  - name: tier_1_employee_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    source: 26 USC 3201(a)
+    versions:
+      - effective_from: '2013-01-01'
+        formula: compensation * tier_1_applicable_percentage
+  - name: tier_2_employee_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    source: 26 USC 3201(b)
+    versions:
+      - effective_from: '2013-01-01'
+        formula: compensation * tier_2_rate
+"""
+        )
+        test_file.write_text(
+            """- name: unsafe_outputs
+  output:
+    us:statutes/26/3201#tier_1_applicable_percentage: 0.0855
+    us:statutes/26/3201#tier_1_employee_tax: 8550
+    us:statutes/26/3201#tier_2_employee_tax: 4900
+"""
+        )
+        result = SimpleNamespace(
+            runner="openai-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = _try_repair_generated_unsafe_formula_outputs_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "statutes/26/3201.yaml: ci: Flattened thresholded imported rate: "
+                "`tier_1_applicable_percentage` uses imported "
+                "`additional_medicare_tax_rate`.",
+                "statutes/26/3201.yaml: ci: Cross-reference numeric placeholder: "
+                "`tier_1_applicable_percentage` uses local "
+                "`additional_medicare_tax_rate` for `percentage`.",
+                "statutes/26/3201.yaml: ci: Cross-reference base mechanics omitted: "
+                "`tier_2_employee_tax` cites source child `(b)`.",
+            ],
+        )
+
+        payload = yaml.safe_load(rules_file.read_text())
+        test_cases = yaml.safe_load(test_file.read_text())
+        assert repaired == [
+            "us:statutes/26/3201/a#tier_1_applicable_percentage",
+            "us:statutes/26/3201/a#tier_1_employee_tax",
+            "us:statutes/26/3201/b#tier_2_employee_tax",
+        ]
+        assert payload["module"]["status"] == "deferred"
+        assert payload["rules"] == []
+        assert [
+            record["output"] for record in payload["module"]["deferred_outputs"]
+        ] == repaired
+        assert test_cases == []
+
     def test_mixed_derived_entity_output_test_repair_splits_entity_outputs(
         self, tmp_path
     ):
@@ -11723,6 +11807,116 @@ rules:
         updated = supplemental[Path("statutes/26/63.yaml")]
         assert "hash: sha256:old" not in updated
         assert f"hash: sha256:{_sha256_file(generated)}" in updated
+
+    def test_apply_overlay_validation_refreshes_dependent_hashes_after_target_repair(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us"
+        generated = output_root / "codex-test-model" / "statutes/26/151.yaml"
+        unused_import = policy_repo / "statutes/26/999.yaml"
+        dependent = policy_repo / "statutes/26/63.yaml"
+        generated.parent.mkdir(parents=True)
+        dependent.parent.mkdir(parents=True)
+        unused_import.write_text(
+            """format: rulespec/v1
+rules:
+  - name: unused_parameter
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '1'
+"""
+        )
+        generated.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/999#unused_parameter
+rules:
+  - name: section_151_exemption_deduction
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          0
+"""
+        )
+        dependent.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/151
+rules:
+  - name: deductions_referred_to_in_subsection_b
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/151#section_151_exemption_deduction
+              output: section_151_exemption_deduction
+              hash: sha256:old
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          section_151_exemption_deduction
+"""
+        )
+        result = SimpleNamespace(output_file=str(generated), runner="codex-test-model")
+
+        class FakePipeline:
+            def __init__(self, **_kwargs):
+                pass
+
+            def validate(self, path, *, skip_reviewers):
+                assert skip_reviewers is True
+                path = Path(path)
+                content = path.read_text()
+                if path.name == "151.yaml" and "unused_parameter" in content:
+                    return SimpleNamespace(
+                        all_passed=False,
+                        results={
+                            "ci": SimpleNamespace(
+                                issues=[
+                                    "Unused import "
+                                    "`us:statutes/26/999#unused_parameter`."
+                                ]
+                            )
+                        },
+                    )
+                if path.name == "63.yaml":
+                    current_hash = _sha256_file(path.parent / "151.yaml")
+                    if f"hash: sha256:{current_hash}" not in content:
+                        return SimpleNamespace(
+                            all_passed=False,
+                            results={
+                                "ci": SimpleNamespace(
+                                    error="Proof import hash mismatch"
+                                )
+                            },
+                        )
+                return SimpleNamespace(all_passed=True, results={})
+
+        with patch("axiom_encode.cli.ValidatorPipeline", FakePipeline):
+            ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+            )
+
+        assert ok is True
+        assert issues == []
+        assert "unused_parameter" not in supplemental[Path("statutes/26/151.yaml")]
+        refreshed_dependent = supplemental[Path("statutes/26/63.yaml")]
+        final_target_hash = _sha256_text(supplemental[Path("statutes/26/151.yaml")])
+        assert f"hash: sha256:{final_target_hash}" in refreshed_dependent
 
     def test_apply_overlay_validation_removes_obsolete_dependent_test_inputs(
         self, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6626,6 +6626,87 @@ rules:
     assert issues == []
 
 
+def test_cross_reference_base_mechanics_raw_compensation_tax_is_rejected(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "3201.yaml"
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    (a) Tier 1 tax In addition to other taxes, there is hereby imposed on the income
+    of each employee a tax equal to the applicable percentage of the compensation
+    received during any calendar year by such employee for services rendered.
+
+    (b) Tier 2 tax In addition to other taxes, there is hereby imposed on the income
+    of each employee a tax equal to the percentage determined under section 3241
+    for any calendar year of the compensation received during such calendar year.
+
+    (c) Cross reference For application of different contribution bases with respect
+    to the taxes imposed by subsections (a) and (b), see section 3231(e)(2).
+rules:
+  - name: tier_2_employee_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    source: 26 USC 3201(b)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: compensation_received_for_services * tier_2_rate
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_unapplied_cross_reference_base_mechanics(rules_file)
+
+    assert len(issues) == 1
+    assert "Cross-reference base mechanics omitted" in issues[0]
+    assert "tier_2_employee_tax" in issues[0]
+    assert "section 3231(e)(2)" in issues[0]
+
+
+def test_cross_reference_base_mechanics_allows_cited_base_formula(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "3201.yaml"
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+imports:
+  - us:statutes/26/3231/e/2#remaining_applicable_base_before_payment
+module:
+  summary: |-
+    (a) Tier 1 tax In addition to other taxes, there is hereby imposed on the income
+    of each employee a tax equal to the applicable percentage of the compensation
+    received during any calendar year by such employee for services rendered.
+
+    (c) Cross reference For application of different contribution bases with respect
+    to the taxes imposed by subsection (a), see section 3231(e)(2).
+rules:
+  - name: tier_1_employee_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    source: 26 USC 3201(a)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(compensation_received_for_services, remaining_applicable_base_before_payment) * tier_1_rate
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_unapplied_cross_reference_base_mechanics(rules_file)
+
+    assert issues == []
+
+
 def test_cross_reference_numeric_placeholder_does_not_infer_named_act_title(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.287"
+version = "0.2.288"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- reject generated raw-base tax formulas when source text says cited base mechanics apply
- auto-defer unsafe generated formula outputs during signed apply, including dependent generated tests
- refresh dependent proof import hashes after target repairs mutate the overlay target

## Tests
- uv run --extra dev ruff format --check src/axiom_encode/cli.py src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/prompts/encoder.py tests/test_cli.py tests/test_rulespec_validation.py
- uv run --extra dev ruff check src/axiom_encode/cli.py src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/prompts/encoder.py tests/test_cli.py tests/test_rulespec_validation.py
- uv run --extra dev python -m pytest