### PR TITLE
Repeat unsafe payroll formula repair during apply

### DIFF
--- a/changelog.d/payroll-unsafe-repair-loop.fixed.md
+++ b/changelog.d/payroll-unsafe-repair-loop.fixed.md
@@ -1,0 +1,1 @@
+Repeat apply-time unsafe formula deferral until overlay validation stops surfacing newly exposed payroll cross-reference issues.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.288"
+version = "0.2.289"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.288"
+__version__ = "0.2.289"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10649,21 +10649,32 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
-                repaired_deferred_rules = (
-                    _try_repair_generated_unsafe_formula_outputs_for_apply(
-                        result,
-                        output_root=args.output,
-                        policy_repo_path=policy_repo_path,
-                        issues=apply_issues,
+                repaired_deferred_rules: list[str] = []
+                seen_deferred_rules: set[str] = set()
+                for _repair_attempt in range(5):
+                    repaired_batch = (
+                        _try_repair_generated_unsafe_formula_outputs_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            issues=apply_issues,
+                        )
                     )
-                )
-                if repaired_deferred_rules:
+                    if not repaired_batch:
+                        break
+                    new_repairs = [
+                        repair
+                        for repair in repaired_batch
+                        if repair not in seen_deferred_rules
+                    ]
+                    seen_deferred_rules.update(repaired_batch)
+                    repaired_deferred_rules.extend(new_repairs)
                     outcome["auto_deferred_unsafe_formula_outputs"] = (
                         repaired_deferred_rules
                     )
                     print(
                         "  apply=auto_deferred_unsafe_formula_outputs:"
-                        + ",".join(repaired_deferred_rules)
+                        + ",".join(repaired_batch)
                     )
                     can_apply, apply_issues, supplemental_files = (
                         _validate_generated_encoding_in_policy_overlay(
@@ -10677,6 +10688,8 @@ def cmd_encode(args):
                         )
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
+                    if can_apply:
+                        break
             if not can_apply:
                 repaired_employer_scoped_rules = (
                     _try_repair_generated_employer_scope_for_apply(


### PR DESCRIPTION
Summary
- Repeat apply-time unsafe formula deferral until overlay validation stops surfacing newly exposed issues.
- Bump axiom-encode to 0.2.289 and add changelog entry.

Validation
- uv run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run --extra dev python -m pytest tests/test_cli.py::TestCmdEncode::test_unsafe_formula_output_repair_defers_rules_and_tests
- Scratch apply: axiom-encode encode "26 USC 3211" --apply against copied RuleSpec branch