### PR TITLE
Defer generic outputs with purpose-specific limits

### DIFF
--- a/changelog.d/deferred-purpose-generic-repair.fixed.md
+++ b/changelog.d/deferred-purpose-generic-repair.fixed.md
@@ -1,0 +1,1 @@
+Defer generated generic outputs during apply when validation finds they overlap deferred purpose-specific limitations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.289"
+version = "0.2.290"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.289"
+__version__ = "0.2.290"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -11926,6 +11926,13 @@ def _try_repair_generated_unsafe_formula_outputs_for_apply(
             rule_name = numeric_match.group(1)
             seed_rules.add(rule_name)
             issue_reasons[rule_name].append("cross_reference_numeric_placeholder")
+        generic_purpose_match = (
+            _GENERIC_DEFERRED_PURPOSE_LIMITATION_ISSUE_PATTERN.search(issue_text)
+        )
+        if generic_purpose_match:
+            rule_name = generic_purpose_match.group(1)
+            seed_rules.add(rule_name)
+            issue_reasons[rule_name].append("generic_deferred_purpose_limitation")
     if not seed_rules:
         return []
 
@@ -12012,6 +12019,14 @@ def _try_repair_generated_unsafe_formula_outputs_for_apply(
                 "base that the source sets by cross-reference to another legal "
                 "section. This output is deferred until the cited numeric "
                 "mechanics can be imported or composed without a local placeholder."
+            )
+        elif "generic_deferred_purpose_limitation" in reasons:
+            reason = (
+                "Generated rule exported a broad amount, base, inclusion, or "
+                "exclusion while a source-stated purpose-specific limitation was "
+                "deferred. This generic surface is deferred until the affected "
+                "purpose-specific outputs can be encoded or split without "
+                "applying the non-excepted rule too broadly."
             )
         else:
             reason = (
@@ -12190,6 +12205,9 @@ _CROSS_REFERENCE_BASE_MECHANICS_ISSUE_PATTERN = re.compile(
 )
 _CROSS_REFERENCE_NUMERIC_PLACEHOLDER_ISSUE_PATTERN = re.compile(
     r"Cross-reference numeric placeholder: `([^`]+)`"
+)
+_GENERIC_DEFERRED_PURPOSE_LIMITATION_ISSUE_PATTERN = re.compile(
+    r"Generic output with deferred purpose-specific limitation: `([^`]+)`"
 )
 _SHARED_STATUTORY_RATE_NAME_ISSUE_PATTERN = re.compile(
     r"Shared statutory rate name [^:]+: `([^`]+)`"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6679,6 +6679,15 @@ rules:
     versions:
       - effective_from: '2013-01-01'
         formula: compensation * tier_2_rate
+  - name: employer_section_3201_tax_payment_liability
+    kind: derived
+    entity: Employer
+    dtype: Money
+    source: 26 USC 3201(b)
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          if employer_required_to_deduct_tax: tax_required_to_deduct else: 0
 """
         )
         test_file.write_text(
@@ -6687,6 +6696,7 @@ rules:
     us:statutes/26/3201#tier_1_applicable_percentage: 0.0855
     us:statutes/26/3201#tier_1_employee_tax: 8550
     us:statutes/26/3201#tier_2_employee_tax: 4900
+    us:statutes/26/3201#employer_section_3201_tax_payment_liability: 1200
 """
         )
         result = SimpleNamespace(
@@ -6707,12 +6717,17 @@ rules:
                 "`additional_medicare_tax_rate` for `percentage`.",
                 "statutes/26/3201.yaml: ci: Cross-reference base mechanics omitted: "
                 "`tier_2_employee_tax` cites source child `(b)`.",
+                "statutes/26/3201.yaml: ci: Generic output with deferred "
+                "purpose-specific limitation: "
+                "`employer_section_3201_tax_payment_liability` overlaps deferred "
+                "purpose-specific output `tips_section_3201_tax_collectible_by_employer`.",
             ],
         )
 
         payload = yaml.safe_load(rules_file.read_text())
         test_cases = yaml.safe_load(test_file.read_text())
         assert repaired == [
+            "us:statutes/26/3201/b#employer_section_3201_tax_payment_liability",
             "us:statutes/26/3201/a#tier_1_applicable_percentage",
             "us:statutes/26/3201/a#tier_1_employee_tax",
             "us:statutes/26/3201/b#tier_2_employee_tax",


### PR DESCRIPTION
Summary
- Teach apply-time unsafe formula repair to defer broad generic outputs when validation finds they overlap deferred purpose-specific limitations.
- Extend the repair regression test and bump axiom-encode to 0.2.290.

Validation
- uv run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run --extra dev python -m pytest tests/test_cli.py::TestCmdEncode::test_unsafe_formula_output_repair_defers_rules_and_tests
- Scratch apply: axiom-encode encode "26 USC 3202" --apply against copied RuleSpec branch