### PR TITLE
Inject pre-computed subparagraph checklist into encoder prompt

### DIFF
--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3258,7 +3258,7 @@ Preferred principal output:
 === BEGIN SOURCE.TXT ===
 {source_text}
 === END SOURCE.TXT ===
-"""
+{_format_subparagraph_coverage_checklist(source_text, corpus_citation_path)}"""
     corpus_source_section = ""
     corpus_rulespec_requirement = ""
     if corpus_citation_path:
@@ -3964,6 +3964,67 @@ def _source_identifier_requests_percentage_rate_boundary(
     if not parts or parts[-1].lower() != "rate":
         return False
     return bool(re.search(r"(?i)(?:\bper\s+cent\b|\bpercent(?:age)?\b|%)", source_text))
+
+
+def _format_subparagraph_coverage_checklist(
+    source_text: str, corpus_citation_path: str | None
+) -> str:
+    """Pre-compute the validator's subparagraph coverage list and inject it as a
+    structured checklist the model must satisfy.
+
+    The source-subparagraph-coverage validator (validator_pipeline.py) flags
+    every high-signal top-level subparagraph that the encoded artifact neither
+    cites in a rule's ``source:`` nor lists in ``module.deferred_outputs``.
+    Adding more abstract instructions to the prompt failed to make gpt-class
+    models comply (two prior iterations either ignored the directive or
+    omitted more subparagraphs). The structural fix is to do the enumeration
+    deterministically here, render it next to the source text, and force the
+    model to acknowledge each subparagraph by name. Same data the validator
+    uses, same expectation, no model-side enumeration discretion.
+    """
+    if not corpus_citation_path:
+        return ""
+    try:
+        from .validator_pipeline import (
+            _compact_source_excerpt,
+            _format_source_subparagraph_citation,
+            _high_signal_top_level_subparagraphs,
+        )
+    except ImportError:
+        return ""
+    subparagraphs = _high_signal_top_level_subparagraphs(source_text)
+    if not subparagraphs:
+        return ""
+    rows = []
+    for label, text in subparagraphs:
+        citation = _format_source_subparagraph_citation(corpus_citation_path, label)
+        excerpt = _compact_source_excerpt(text, limit=100)
+        rows.append(f"  - {citation}: {excerpt}")
+    rows_text = "\n".join(rows)
+    return f"""
+=== BEGIN SUBPARAGRAPH COVERAGE CHECKLIST ===
+The source text above contains {len(subparagraphs)} high-signal top-level
+subparagraphs. Your output MUST account for every one. For each subparagraph
+below, the encoded artifact must contain EITHER:
+  (a) An executable rule whose `source:` field cites that subparagraph
+      (e.g. `source: 7 USC 2014(d)`), OR
+  (b) An entry under `module.deferred_outputs[]` whose `output:` target path
+      includes that subparagraph segment (e.g.
+      `us:statutes/7/2014/d#unspecified_output`) and whose `reason:` names
+      the legal dependency or scope reason blocking encoding.
+
+Subparagraphs without (a) or (b) are an automatic CI failure under the
+source-subparagraph-coverage validator. There is no implicit "covered by
+the umbrella rule" path — composite rules cite the parent section, not
+the children.
+
+Subparagraphs requiring action:
+{rows_text}
+
+When in doubt, prefer (b): a `deferred_outputs` entry with a clear
+`reason` is honest and cheap to refine later. Silent omission is not.
+=== END SUBPARAGRAPH COVERAGE CHECKLIST ===
+"""
 
 
 def render_rate_only_source_boundary_guidance() -> str:


### PR DESCRIPTION
## Summary
Closes the silent-omission gap that the source-subparagraph-coverage validator was catching at the end of encoding sessions. Two prior prose-only fixes (this session) didn't move the gate and one made it worse — adding more instructions to a 979-line prompt full of 40KB+ source text just gets diluted.

Structural fix: the validator already knows which subparagraphs it requires coverage for. Run the same enumeration at prompt-build time and inject the result as a concrete checklist right after the source text. The model no longer has to scan the source itself — every subparagraph is named with its full citation, short excerpt, and the two acceptable response forms.

The validator and the prompt now share the same helpers (\`_high_signal_top_level_subparagraphs\`, \`_format_source_subparagraph_citation\`, \`_compact_source_excerpt\`), so they cannot drift.

## Live result on benchmarks/us_snap_eligibility_refresh.yaml

| Gate | v1 baseline | v2 (prose) | v3 (this) |
|---|---|---|---|
| success | 0% | 0% | **100%** |
| CI | 0% | 0% | **100%** |
| compile | 100% | 100% | 100% |
| zero ungrounded | 100% | 100% | 100% |
| generalist review | 8.0 | 7.5 | **8.5** |
| cost | \$0.70 | \$0.48 | **\$0.30** |

CI was the blocking gate; now passes cleanly. Generalist review score went up, cost went down — the model spent less on inventing structure because the structure was provided.

The encoder correctly produced a fully-deferred module (\`module.status: deferred\`) with 9 \`deferred_outputs\` entries, one per subparagraph. That's the honest answer for the umbrella \`7 USC 2014\` source slice — sub-source slices for (a)/(c)/(d)/(e)/(g)/(h)/(k)/(l) aren't in scope, so dependencies can't be resolved yet. Subsequent encoding sessions targeting those slices fill the deferred outputs.

## Why this works where prose didn't

| Prior attempts | This change |
|---|---|
| Model had to find high-signal subparagraphs in 47KB source | Enumerated **for** the model, same helper as validator |
| Abstract "either encode or defer" instruction | Concrete: each row asks model to pick one of two responses |
| Buried at line ~80 of a 979-line prompt | Injected **immediately after** \`=== END SOURCE.TXT ===\` |
| Iteration cost: \$0.50/run | Deterministic — fix lands per-source automatically |

## Test plan
- [x] 204 existing tests pass (\`pytest tests/test_evals.py\`)
- [x] \`_format_subparagraph_coverage_checklist\` reused validator helpers — they cannot diverge
- [x] Live benchmark: CI 0%→100% on \`us_snap_eligibility_refresh\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)