### PR TITLE
Classify payroll rate oracle outputs

### DIFF
--- a/changelog.d/payroll-oracle-rate-coverage.fixed.md
+++ b/changelog.d/payroll-oracle-rate-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify generated railroad payroll applicable-percentage helper outputs as not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.291"
+version = "0.2.292"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.291"
+__version__ = "0.2.292"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1059,6 +1059,12 @@ mappings:
     mapping_type: not_comparable
     rationale: PolicyEngine models employee FICA payroll taxes and excess payroll tax withheld, but not Railroad Retirement Tax Act section 3201(b) tier 2 employee tax or the section 3241 applicable percentage as a comparable output.
 
+  - legal_id: us:statutes/26/3201#tier_2_applicable_percentage
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine models employee FICA payroll taxes and excess payroll tax withheld, but not the Railroad Retirement Tax Act section 3201(b) tier 2 applicable-percentage helper as a one-to-one output.
+
   - legal_id: us:statutes/26/3211#tier_2_employee_representative_tax
     country: us
     program: tax
@@ -1070,6 +1076,12 @@ mappings:
     program: tax
     mapping_type: not_comparable
     rationale: PolicyEngine models employer FICA payroll taxes, but not Railroad Retirement Tax Act section 3221(b) tier 2 employer tax or the section 3241 applicable percentage as a comparable output.
+
+  - legal_id: us:statutes/26/3221#tier_1_applicable_percentage
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine exposes component employer OASDI and Medicare payroll tax rates, but not the section 3221(a) Railroad Retirement Tax Act tier 1 applicable-percentage helper as a one-to-one output.
 
   - legal_id: us:statutes/26/3111/a#employer_oasdi_excise_tax_rate
     country: us


### PR DESCRIPTION
Summary
- Mark generated railroad payroll applicable-percentage helper outputs as not comparable to PolicyEngine.
- Bump axiom-encode to 0.2.292 and add changelog entry.

Validation
- uv run --extra dev ruff check src/axiom_encode/__init__.py
- uv run python -c "import yaml; yaml.safe_load(open('src/axiom_encode/oracles/policyengine/mappings/us.yaml'))"
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-rulespec-3201-generated-20260526 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20