### PR TITLE
Classify section 3241a oracle outputs

### DIFF
--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10418,6 +10418,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3241(b) Railroad Retirement Tax Act applicable-percentage schedule outputs are not exposed as one-to-one PolicyEngine variables or parameters.
 
+  - legal_id_prefix: us:statutes/26/3241/a#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3241(a) Railroad Retirement Tax Act applicable-percentage outputs route to the section 3241(b) schedule for sections 3201(b), 3211(b), and 3221(b), which PolicyEngine does not expose as one-to-one variables or parameters.
+
   - legal_id_prefix: us:statutes/26/63#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2609,6 +2609,33 @@ rules:
     assert item["policyengine_variable"] is None
 
 
+def test_policyengine_coverage_classifies_3241_a_applicable_percentage_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3241/a.yaml",
+        """format: rulespec/v1
+rules:
+  - name: applicable_percentage_for_section_3201_b_for_purposes_of_subsection_a
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: applicable_percentage_for_section_3201_b
+  - name: applicable_percentage_for_sections_3211_b_and_3221_b_for_purposes_of_subsection_a
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: applicable_percentage_for_sections_3211_b_and_3221_b
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3231_a_employer_definition_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3231/a.yaml",


### PR DESCRIPTION
## Summary
- classify 26 USC 3241(a) RRTA applicable-percentage alias outputs as known-not-comparable for the PolicyEngine tax oracle
- add coverage for the new prefix classification

## Validation
- uv run pytest tests/test_policyengine_coverage.py -k 3241_a
- uv run pytest tests/test_policyengine_coverage.py
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-rulespec-3241a-generated-20260526 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20