### PR TITLE
Bump axiom-encode to 0.2.293

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.292"
+version = "0.2.293"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.292"
+__version__ = "0.2.293"
 
 from .constants import (
     DEFAULT_CLI_MODEL,


### PR DESCRIPTION
## Summary
- bump axiom-encode package/version constants after oracle registry changes

## Validation
- uv run python -c 'import axiom_encode; print(axiom_encode.__version__)'