### PR TITLE
Defer cross-reference placeholder outputs during apply

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.293"
+version = "0.2.294"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.293"
+__version__ = "0.2.294"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -11948,6 +11948,13 @@ def _try_repair_generated_unsafe_formula_outputs_for_apply(
             rule_name = base_match.group(1)
             seed_rules.add(rule_name)
             issue_reasons[rule_name].append("cross_reference_base_mechanics")
+        placeholder_match = _CROSS_REFERENCE_PLACEHOLDER_ISSUE_PATTERN.search(
+            issue_text
+        )
+        if placeholder_match:
+            rule_name = placeholder_match.group(1)
+            seed_rules.add(rule_name)
+            issue_reasons[rule_name].append("cross_reference_placeholder")
         numeric_match = _CROSS_REFERENCE_NUMERIC_PLACEHOLDER_ISSUE_PATTERN.search(
             issue_text
         )
@@ -12054,6 +12061,12 @@ def _try_repair_generated_unsafe_formula_outputs_for_apply(
                 "section. This output is deferred until the cited numeric "
                 "mechanics can be imported or composed without a local placeholder."
             )
+        elif "cross_reference_placeholder" in reasons:
+            reason = (
+                "Generated rule kept a local fact for a cited legal section. This "
+                "output is deferred until the cited source can be encoded or "
+                "imported without a local cross-reference placeholder."
+            )
         elif "generic_deferred_purpose_limitation" in reasons:
             reason = (
                 "Generated rule exported a broad amount, base, inclusion, or "
@@ -12144,6 +12157,8 @@ def _deferred_output_target_for_generated_rule(
 ) -> str:
     source = str(rule.get("source") or "")
     path_suffix = _top_level_source_suffix_from_rule_source(source)
+    if path_suffix and base_anchor.endswith(path_suffix):
+        path_suffix = ""
     return f"{base_anchor}{path_suffix}#{rule_name}"
 
 
@@ -12333,6 +12348,9 @@ _FLATTENED_THRESHOLDED_RATE_ISSUE_PATTERN = re.compile(
 )
 _CROSS_REFERENCE_BASE_MECHANICS_ISSUE_PATTERN = re.compile(
     r"Cross-reference base mechanics omitted: `([^`]+)`"
+)
+_CROSS_REFERENCE_PLACEHOLDER_ISSUE_PATTERN = re.compile(
+    r"(?:Encoded )?Cross-reference placeholder: `([^`]+)`"
 )
 _CROSS_REFERENCE_NUMERIC_PLACEHOLDER_ISSUE_PATTERN = re.compile(
     r"Cross-reference numeric placeholder: `([^`]+)`"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6742,6 +6742,72 @@ rules:
         ] == repaired
         assert test_cases == []
 
+    def test_unsafe_formula_output_repair_defers_cross_reference_placeholders(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "openai-gpt-5.5" / "statutes/26/3121/b.yaml"
+        test_file = output_root / "openai-gpt-5.5" / "statutes/26/3121/b.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        policy_repo = tmp_path / "rulespec-us"
+        policy_repo.mkdir()
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  summary: Section 3121(b) employment.
+rules:
+  - name: employment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    source: 26 USC 3121(b)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: service_designated_as_employment_under_section_233_social_security_act_agreement
+"""
+        )
+        test_file.write_text(
+            """- name: cross_reference_placeholder
+  output:
+    us:statutes/26/3121/b#employment: true
+"""
+        )
+        result = SimpleNamespace(
+            runner="openai-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = _try_repair_generated_unsafe_formula_outputs_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "statutes/26/3121/b.yaml: ci: Cross-reference placeholder: "
+                "`employment` uses local fact "
+                "`service_designated_as_employment_under_section_233_social_security_act_agreement` "
+                "for a cited legal section."
+            ],
+        )
+
+        payload = yaml.safe_load(rules_file.read_text())
+        test_cases = yaml.safe_load(test_file.read_text())
+        assert repaired == ["us:statutes/26/3121/b#employment"]
+        assert payload["module"]["status"] == "deferred"
+        assert payload["rules"] == []
+        assert payload["module"]["deferred_outputs"] == [
+            {
+                "output": "us:statutes/26/3121/b#employment",
+                "reason": (
+                    "Generated rule kept a local fact for a cited legal section. "
+                    "This output is deferred until the cited source can be encoded "
+                    "or imported without a local cross-reference placeholder."
+                ),
+            }
+        ]
+        assert test_cases == []
+
     def test_unresolved_local_test_output_repair_removes_stale_output(self, tmp_path):
         output_root = tmp_path / "out"
         rules_file = output_root / "openai-gpt-5.5" / "statutes/26/3221.yaml"


### PR DESCRIPTION
## Summary
- defer generated outputs that still rely on local facts for cited legal sections during apply-time repair
- avoid duplicating the source suffix when building deferred output targets
- bump axiom-encode to 0.2.294 for generated provenance

## Validation
- uv run pytest tests/test_cli.py -k 'unsafe_formula_output_repair'\n- uv run python -c 'import axiom_encode; print(axiom_encode.__version__)'