### PR TITLE
Complete imported row inputs during apply repair

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.294"
+version = "0.2.295"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.294"
+__version__ = "0.2.295"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -16194,15 +16194,21 @@ def _complete_missing_imported_test_inputs(
         entity_id = assignment.get("entity")
         if not entity_id:
             continue
-        input_name = assignment["input"]
-        for input_ref in imported_inputs.get(input_name, []):
-            updated = _insert_input_default_in_table_entity_rows(
-                updated,
-                input_ref=input_ref,
-                value=_infer_missing_input_default(input_name),
-                case_name=assignment["case"],
-                entity_id=entity_id,
-            )
+        input_names = [assignment["input"]]
+        if assignment["input"] in imported_inputs:
+            # The validator reports the first missing row input it encounters.
+            # Imported aggregate rules can require many defaults, so complete the
+            # whole imported input surface for that row in one repair pass.
+            input_names = sorted(imported_inputs)
+        for input_name in input_names:
+            for input_ref in imported_inputs.get(input_name, []):
+                updated = _insert_input_default_in_table_entity_rows(
+                    updated,
+                    input_ref=input_ref,
+                    value=_infer_missing_input_default(input_name),
+                    case_name=assignment["case"],
+                    entity_id=entity_id,
+                )
     if updated == content:
         return False
     test_file.write_text(updated)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7714,6 +7714,7 @@ rules:
       - effective_from: '2026-01-01'
         formula: |-
           service_performed_in_employ_of_international_organization_within_meaning_of_section_3581_3_of_title_5
+          and worker_is_transferred_federal_employee
 """
         )
         dependent.write_text(
@@ -7772,6 +7773,12 @@ rules:
         payload = yaml.safe_load(dependent_test.read_text())
         payment_row = payload[0]["tables"]["Payment"][0]
         assert payment_row[imported_ref] is True
+        assert (
+            payment_row[
+                "us:statutes/26/3121/y#input.worker_is_transferred_federal_employee"
+            ]
+            is False
+        )
 
     def test_repair_imported_test_inputs_writes_signed_manifest(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"


### PR DESCRIPTION
## Summary
- when a generated table-row test is missing one imported input, fill the imported dependency inputs for that affected row in one repair pass
- preserve explicit test inputs already provided by the generated case
- bump axiom-encode to 0.2.295 for generated provenance

## Validation
- uv run pytest tests/test_cli.py -k 'complete_missing_imported_test_inputs or apply_overlay_validation_fills_target_imported_relation_row_inputs or unsafe_formula_output_repair'\n- uv run ruff check src/ tests/\n- uv run ruff format --check src/ tests/\n- git diff --check\n- uv run python -c 'import axiom_encode; print(axiom_encode.__version__)'\n- replayed overlay validation for the failed 26 USC 3121(b) candidate; it now passes with supplemental statutes/26/3121/b.test.yaml