### PR TITLE
Defer unused source modifier outputs during apply

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.295"
+version = "0.2.296"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.295"
+__version__ = "0.2.296"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -11936,6 +11936,7 @@ def _try_repair_generated_unsafe_formula_outputs_for_apply(
     """Defer generated outputs that validation proved use unsafe formulas."""
     seed_rules: set[str] = set()
     issue_reasons: dict[str, list[str]] = defaultdict(list)
+    issue_source_values: dict[str, set[str]] = defaultdict(set)
     for issue in issues:
         issue_text = str(issue)
         flattened_match = _FLATTENED_THRESHOLDED_RATE_ISSUE_PATTERN.search(issue_text)
@@ -11974,6 +11975,17 @@ def _try_repair_generated_unsafe_formula_outputs_for_apply(
             rule_name = sibling_match.group(1)
             seed_rules.add(rule_name)
             issue_reasons[rule_name].append("sibling_rule_name_collision")
+        unused_modifier_match = _UNUSED_SOURCE_MODIFIER_ISSUE_PATTERN.search(issue_text)
+        if unused_modifier_match:
+            source_value_rule = unused_modifier_match.group("source_value")
+            affected_rule_names = re.findall(
+                r"`([^`]+)`",
+                unused_modifier_match.group("affected"),
+            )
+            for rule_name in affected_rule_names:
+                seed_rules.add(rule_name)
+                issue_reasons[rule_name].append("unused_source_modifier")
+                issue_source_values[rule_name].add(source_value_rule)
     if not seed_rules:
         return []
 
@@ -12082,6 +12094,13 @@ def _try_repair_generated_unsafe_formula_outputs_for_apply(
                 "encoded with a semantic branch-specific name without creating "
                 "ambiguous sibling imports."
             )
+        elif "unused_source_modifier" in reasons:
+            reason = (
+                "Generated rule ignored a source-stated substitution, "
+                "modification, or limitation parameter. This output is deferred "
+                "until the upstream cross-referenced mechanics can be imported "
+                "or composed without stranding the modifier."
+            )
         else:
             reason = (
                 "Generated rule used a thresholded, capped, base-limited, or "
@@ -12090,7 +12109,15 @@ def _try_repair_generated_unsafe_formula_outputs_for_apply(
                 "flattening the imported rate."
             )
         if output not in existing_outputs:
-            deferred_outputs.append({"output": output, "reason": reason})
+            deferred_record = {"output": output, "reason": reason}
+            source_value_targets = _source_value_targets_for_generated_rule_names(
+                rule_names=issue_source_values.get(rule_name, set()),
+                rules_by_name=rules_by_name,
+                base_anchor=base_anchor,
+            )
+            if source_value_targets:
+                deferred_record["source_values"] = source_value_targets
+            deferred_outputs.append(deferred_record)
             existing_outputs.add(output)
         deferred_targets.append(output)
 
@@ -12162,6 +12189,27 @@ def _deferred_output_target_for_generated_rule(
     return f"{base_anchor}{path_suffix}#{rule_name}"
 
 
+def _source_value_targets_for_generated_rule_names(
+    *,
+    rule_names: set[str],
+    rules_by_name: dict[str, dict[str, Any]],
+    base_anchor: str,
+) -> list[str]:
+    targets: list[str] = []
+    for rule_name in sorted(rule_names):
+        rule = rules_by_name.get(rule_name)
+        if not isinstance(rule, dict):
+            continue
+        target = _deferred_output_target_for_generated_rule(
+            rule_name=rule_name,
+            rule=rule,
+            base_anchor=base_anchor,
+        )
+        if target and target not in targets:
+            targets.append(target)
+    return targets
+
+
 def _top_level_source_suffix_from_rule_source(source: str) -> str:
     match = re.search(
         r"\b[0-9A-Za-z]+\s+USC\s+[0-9A-Za-z.-]+"
@@ -12193,6 +12241,7 @@ def _remove_generated_test_outputs_for_deferred_rules(
 
     removed_cases: list[str] = []
     repaired_cases: list[Any] = []
+    changed = False
     for index, case in enumerate(test_cases):
         if not isinstance(case, dict):
             repaired_cases.append(case)
@@ -12213,6 +12262,7 @@ def _remove_generated_test_outputs_for_deferred_rules(
         if repaired_outputs == outputs:
             repaired_cases.append(case)
             continue
+        changed = True
         case_name = str(case.get("name") or f"case[{index}]")
         if repaired_outputs:
             repaired_case = dict(case)
@@ -12221,7 +12271,7 @@ def _remove_generated_test_outputs_for_deferred_rules(
         else:
             removed_cases.append(case_name)
 
-    if len(repaired_cases) == len(test_cases) and not removed_cases:
+    if not changed and not removed_cases:
         return []
     test_file.write_text(yaml.safe_dump(repaired_cases, sort_keys=False))
     return removed_cases
@@ -12360,6 +12410,10 @@ _GENERIC_DEFERRED_PURPOSE_LIMITATION_ISSUE_PATTERN = re.compile(
 )
 _SIBLING_RULE_NAME_COLLISION_ISSUE_PATTERN = re.compile(
     r"Sibling rule name collision: rule `([^`]+)`"
+)
+_UNUSED_SOURCE_MODIFIER_ISSUE_PATTERN = re.compile(
+    r"Source-stated modifier parameter is not used by any numeric derived output: "
+    r"`(?P<source_value>[^`]+)`.+?but (?P<affected>.+?) ignores it\.",
 )
 _UNRESOLVED_TEST_OUTPUT_ISSUE_PATTERN = re.compile(
     r"Test case `[^`]+` output `([^`]+)` does not resolve"

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9576,6 +9576,12 @@ mappings:
     rationale: Same statutory percentage of adjusted gross income that floors deductible medical-care expenses.
 
 prefixes:
+  - legal_id_prefix: us:statutes/26/3111/e#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3111(e) defines the qualified tax-exempt organization qualified-veteran employment credit against employer OASDI tax, including modified section 51 rates, applicable-period, qualified-veteran, exempt-purpose wage, and credit-limitation intermediates; PolicyEngine does not expose this credit or its section 51 modification surfaces as one-to-one payroll-tax outputs.
+
   - legal_id_prefix: us:statutes/26/3202#
     country: us
     program: tax

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6808,6 +6808,120 @@ rules:
         ]
         assert test_cases == []
 
+    def test_unsafe_formula_output_repair_defers_unused_source_modifiers(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "openai-gpt-5.5" / "statutes/26/3111/e.yaml"
+        test_file = output_root / "openai-gpt-5.5" / "statutes/26/3111/e.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        policy_repo = tmp_path / "rulespec-us"
+        policy_repo.mkdir()
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: qualified_veteran_credit_substituted_section_51_a_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3111(e)(3)(A)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: '0.26'
+  - name: qualified_veteran_wages_taken_into_account_for_credit
+    kind: derived
+    entity: Employer
+    dtype: Money
+    source: 26 USC 3111(e)(3)(C)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: wages_paid_to_qualified_veteran_during_applicable_period
+  - name: qualified_veteran_employment_credit_against_subsection_a_tax
+    kind: derived
+    entity: Employer
+    dtype: Money
+    source: 26 USC 3111(e)(1)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: min(credit_determined_under_section_51_after_application_of_subsection_e_modifications, employer_oasdi_excise_tax)
+"""
+        )
+        test_file.write_text(
+            """- name: unused_source_modifier
+  output:
+    us:statutes/26/3111/e#qualified_veteran_credit_substituted_section_51_a_rate: 0.26
+    us:statutes/26/3111/e#qualified_veteran_wages_taken_into_account_for_credit: 12000
+    us:statutes/26/3111/e#qualified_veteran_employment_credit_against_subsection_a_tax: 5000
+"""
+        )
+        result = SimpleNamespace(
+            runner="openai-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = _try_repair_generated_unsafe_formula_outputs_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "statutes/26/3111/e.yaml: ci: Source-stated modifier parameter "
+                "is not used by any numeric derived output: "
+                "`qualified_veteran_credit_substituted_section_51_a_rate` "
+                "appears to encode a substitution/modification amount, but "
+                "`qualified_veteran_employment_credit_against_subsection_a_tax`, "
+                "`qualified_veteran_wages_taken_into_account_for_credit` ignores it. "
+                "Use the modifier in the affected formula or defer the affected "
+                "output until the upstream branching condition is encoded and list "
+                "this source value under `module.deferred_outputs[].source_values`."
+            ],
+        )
+
+        payload = yaml.safe_load(rules_file.read_text())
+        test_cases = yaml.safe_load(test_file.read_text())
+        assert repaired == [
+            "us:statutes/26/3111/e#qualified_veteran_employment_credit_against_subsection_a_tax",
+            "us:statutes/26/3111/e#qualified_veteran_wages_taken_into_account_for_credit",
+        ]
+        assert [rule["name"] for rule in payload["rules"]] == [
+            "qualified_veteran_credit_substituted_section_51_a_rate"
+        ]
+        assert payload["module"]["deferred_outputs"] == [
+            {
+                "output": "us:statutes/26/3111/e#qualified_veteran_employment_credit_against_subsection_a_tax",
+                "reason": (
+                    "Generated rule ignored a source-stated substitution, "
+                    "modification, or limitation parameter. This output is "
+                    "deferred until the upstream cross-referenced mechanics can "
+                    "be imported or composed without stranding the modifier."
+                ),
+                "source_values": [
+                    "us:statutes/26/3111/e#qualified_veteran_credit_substituted_section_51_a_rate"
+                ],
+            },
+            {
+                "output": "us:statutes/26/3111/e#qualified_veteran_wages_taken_into_account_for_credit",
+                "reason": (
+                    "Generated rule ignored a source-stated substitution, "
+                    "modification, or limitation parameter. This output is "
+                    "deferred until the upstream cross-referenced mechanics can "
+                    "be imported or composed without stranding the modifier."
+                ),
+                "source_values": [
+                    "us:statutes/26/3111/e#qualified_veteran_credit_substituted_section_51_a_rate"
+                ],
+            },
+        ]
+        assert test_cases == [
+            {
+                "name": "unused_source_modifier",
+                "output": {
+                    "us:statutes/26/3111/e#qualified_veteran_credit_substituted_section_51_a_rate": 0.26
+                },
+            }
+        ]
+
     def test_unresolved_local_test_output_repair_removes_stale_output(self, tmp_path):
         output_root = tmp_path / "out"
         rules_file = output_root / "openai-gpt-5.5" / "statutes/26/3221.yaml"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1826,6 +1826,12 @@ def test_policyengine_registry_is_legal_id_keyed():
         ).policyengine_variable
         == "employer_medicare_tax"
     )
+    qualified_veteran_credit_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/3111/e#veteran_employment_credit_against_subsection_a_tax",
+        country="us",
+    )
+    assert qualified_veteran_credit_mapping.mapping_type == "not_comparable"
+    assert qualified_veteran_credit_mapping.match_type == "prefix"
     assert (
         registry.mapping_for_legal_id(
             "us:policies/irs/rev-proc-2025-32/standard-deduction#basic_standard_deduction_amount",


### PR DESCRIPTION
## Summary
- defer generated numeric outputs when validation finds they ignored a source-stated modifier parameter
- preserve the stranded modifier under module.deferred_outputs[].source_values
- repair generated test files when deferred outputs are removed from only part of a case
- classify section 3111(e) payroll credit outputs as PolicyEngine not-comparable for oracle coverage
- bump axiom-encode to 0.2.296

## Tests
- uv run pytest tests/test_cli.py -k 'unsafe_formula_output_repair'
- uv run pytest tests/test_rulespec_validation.py -k policyengine_registry_is_legal_id_keyed
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check
- uv run python -c 'import axiom_encode; print(axiom_encode.__version__)'
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-rulespec-3111e-generated-20260526 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20