### PR TITLE
Bump axiom-encode to 0.2.297

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.296"
+version = "0.2.297"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.296"
+__version__ = "0.2.297"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9582,6 +9582,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3111(e) defines the qualified tax-exempt organization qualified-veteran employment credit against employer OASDI tax, including modified section 51 rates, applicable-period, qualified-veteran, exempt-purpose wage, and credit-limitation intermediates; PolicyEngine does not expose this credit or its section 51 modification surfaces as one-to-one payroll-tax outputs.
 
+  - legal_id_prefix: us:statutes/26/3111/f#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3111(f) defines section 41(h) research-credit offsets against employer OASDI and Medicare taxes, quarterly payroll-tax limitations, carryovers, and chapter 1 deduction coordination; PolicyEngine does not expose these employer payroll-credit allocation and carryover surfaces as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3202#
     country: us
     program: tax

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1832,6 +1832,12 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
     assert qualified_veteran_credit_mapping.mapping_type == "not_comparable"
     assert qualified_veteran_credit_mapping.match_type == "prefix"
+    research_payroll_credit_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/3111/f#research_credit_allowed_against_subsection_a_tax",
+        country="us",
+    )
+    assert research_payroll_credit_mapping.mapping_type == "not_comparable"
+    assert research_payroll_credit_mapping.match_type == "prefix"
     assert (
         registry.mapping_for_legal_id(
             "us:policies/irs/rev-proc-2025-32/standard-deduction#basic_standard_deduction_amount",


### PR DESCRIPTION
## Summary
- bump axiom-encode to 0.2.297 so payroll oracle mapping changes are included in the latest version marker
- classify section 3111(f) research payroll credit outputs as PolicyEngine not-comparable for oracle coverage

## Tests
- uv run python -c 'import axiom_encode; print(axiom_encode.__version__)'
- uv run pytest tests/test_rulespec_validation.py -k policyengine_registry_is_legal_id_keyed
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-rulespec-3111f-generated-20260526 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20