### PR TITLE
Support annual SSA base outputs in payroll ECPS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.297"
+version = "0.2.298"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.297"
+__version__ = "0.2.298"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -20,6 +20,8 @@ from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 try:
     import numpy as np
 except ImportError:  # pragma: no cover - exercised only without optional oracle deps
@@ -90,6 +92,39 @@ def contribution_and_benefit_base_output(year: int) -> str:
         f"{contribution_and_benefit_base_base(year)}"
         "#contribution_and_benefit_base_under_section_230_of_social_security_act"
     )
+
+
+def contribution_and_benefit_base_output_candidates(year: int) -> tuple[str, ...]:
+    base = contribution_and_benefit_base_base(year)
+    return (
+        contribution_and_benefit_base_output(year),
+        f"{base}#contribution_and_benefit_base",
+    )
+
+
+def contribution_and_benefit_base_output_for_program(
+    program: Path,
+    *,
+    year: int,
+) -> str:
+    """Return the final contribution-and-benefit-base output exported by a file."""
+    try:
+        payload = yaml.safe_load(program.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return contribution_and_benefit_base_output(year)
+    rules = payload.get("rules") if isinstance(payload, dict) else None
+    if not isinstance(rules, list):
+        return contribution_and_benefit_base_output(year)
+    exported_names = {
+        rule.get("name")
+        for rule in rules
+        if isinstance(rule, dict) and isinstance(rule.get("name"), str)
+    }
+    for output in contribution_and_benefit_base_output_candidates(year):
+        local_name = output.rsplit("#", 1)[-1]
+        if local_name in exported_names:
+            return output
+    return contribution_and_benefit_base_output(year)
 
 
 CTC_OUTPUTS = {
@@ -537,16 +572,32 @@ def compare_tax_ecps(
                         "Contribution-and-benefit-base RuleSpec not found: "
                         f"{contribution_base_program}"
                     )
-                contribution_base_results = run_axiom_program(
-                    program=contribution_base_program,
-                    request=build_contribution_and_benefit_base_request(year=year),
-                    rulespec_root=resolved_rulespec_root,
-                    axiom_rules_path=resolved_axiom_rules_path,
+                contribution_base_output = (
+                    contribution_and_benefit_base_output_for_program(
+                        contribution_base_program,
+                        year=year,
+                    )
                 )
-                contribution_base = contribution_and_benefit_base_from_results(
-                    contribution_base_results,
+                contribution_base = contribution_and_benefit_base_from_rulespec_test(
+                    resolved_rulespec_root,
                     year=year,
+                    output=contribution_base_output,
                 )
+                if contribution_base is None:
+                    contribution_base_results = run_axiom_program(
+                        program=contribution_base_program,
+                        request=build_contribution_and_benefit_base_request(
+                            year=year,
+                            output=contribution_base_output,
+                        ),
+                        rulespec_root=resolved_rulespec_root,
+                        axiom_rules_path=resolved_axiom_rules_path,
+                    )
+                    contribution_base = contribution_and_benefit_base_from_results(
+                        contribution_base_results,
+                        year=year,
+                        output=contribution_base_output,
+                    )
             if oasdi_wage_base_results is None:
                 oasdi_program = resolved_rulespec_root / OASDI_WAGE_BASE_PROGRAM_PATH
                 if not oasdi_program.exists():
@@ -1167,12 +1218,17 @@ def build_payroll_request(
     }
 
 
-def build_contribution_and_benefit_base_request(*, year: int) -> dict[str, Any]:
+def build_contribution_and_benefit_base_request(
+    *,
+    year: int,
+    output: str | None = None,
+) -> dict[str, Any]:
     interval = {
         "period_kind": "tax_year",
         "start": f"{year:04d}-01-01",
         "end": f"{year:04d}-12-31",
     }
+    requested_output = output or contribution_and_benefit_base_output(year)
     return {
         "mode": "explain",
         "dataset": {"inputs": [], "relations": []},
@@ -1180,7 +1236,7 @@ def build_contribution_and_benefit_base_request(*, year: int) -> dict[str, Any]:
             {
                 "entity_id": f"tax_year_{year}",
                 "period": interval,
-                "outputs": [contribution_and_benefit_base_output(year)],
+                "outputs": [requested_output],
             }
         ],
     }
@@ -1190,8 +1246,9 @@ def contribution_and_benefit_base_from_results(
     results: list[dict[str, Any]],
     *,
     year: int,
+    output: str | None = None,
 ) -> float:
-    output = contribution_and_benefit_base_output(year)
+    output = output or contribution_and_benefit_base_output(year)
     if len(results) != 1:
         raise ValueError(
             "Expected exactly one contribution-and-benefit-base output result; "
@@ -1204,6 +1261,54 @@ def contribution_and_benefit_base_from_results(
             f"Axiom contribution-and-benefit-base output missing: {output}."
         )
     return contribution_base
+
+
+def contribution_and_benefit_base_from_rulespec_test(
+    rulespec_root: Path,
+    *,
+    year: int,
+    output: str | None = None,
+) -> float | None:
+    test_path = rulespec_root / contribution_and_benefit_base_program_path(
+        year
+    ).with_suffix(".test.yaml")
+    if not test_path.exists():
+        return None
+    try:
+        cases = yaml.safe_load(test_path.read_text()) or []
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(cases, list):
+        return None
+
+    outputs = (
+        (output,)
+        if output is not None
+        else contribution_and_benefit_base_output_candidates(year)
+    )
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        case_outputs = case.get("output")
+        if not isinstance(case_outputs, dict):
+            continue
+        for candidate_output in outputs:
+            if candidate_output not in case_outputs:
+                continue
+            return yaml_number(case_outputs[candidate_output])
+    return None
+
+
+def yaml_number(value: Any) -> float:
+    if isinstance(value, bool):
+        return float(value)
+    if isinstance(value, int | float):
+        return float(value)
+    if isinstance(value, str):
+        normalized = value.strip().replace(",", "").replace("$", "")
+        if normalized:
+            return float(normalized)
+    return math.nan
 
 
 def build_oasdi_wage_base_request(

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -35,7 +35,9 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     build_payroll_request,
     compare_tax_ecps,
     contribution_and_benefit_base_from_results,
+    contribution_and_benefit_base_from_rulespec_test,
     contribution_and_benefit_base_output,
+    contribution_and_benefit_base_output_for_program,
     contribution_and_benefit_base_program_path,
     ctc_h_filing_status_code,
     filing_status_code,
@@ -1149,6 +1151,52 @@ def test_build_contribution_and_benefit_base_request_queries_encoded_ssa_policy(
     }
 
 
+def test_build_contribution_and_benefit_base_request_accepts_selected_output():
+    output = "us:policies/ssa/contribution-and-benefit-base/2024#contribution_and_benefit_base"
+
+    request = build_contribution_and_benefit_base_request(year=2024, output=output)
+
+    assert request["queries"][0]["outputs"] == [output]
+
+
+def test_contribution_and_benefit_base_output_for_program_prefers_section_230(
+    tmp_path,
+):
+    program = tmp_path / "2026.yaml"
+    program.write_text(
+        """format: rulespec/v1
+rules:
+  - name: contribution_and_benefit_base
+    kind: parameter
+  - name: contribution_and_benefit_base_under_section_230_of_social_security_act
+    kind: parameter
+"""
+    )
+
+    assert contribution_and_benefit_base_output_for_program(program, year=2026) == (
+        "us:policies/ssa/contribution-and-benefit-base/2026"
+        "#contribution_and_benefit_base_under_section_230_of_social_security_act"
+    )
+
+
+def test_contribution_and_benefit_base_output_for_program_accepts_simple_base(
+    tmp_path,
+):
+    program = tmp_path / "2024.yaml"
+    program.write_text(
+        """format: rulespec/v1
+rules:
+  - name: contribution_and_benefit_base
+    kind: parameter
+"""
+    )
+
+    assert (
+        contribution_and_benefit_base_output_for_program(program, year=2024)
+        == "us:policies/ssa/contribution-and-benefit-base/2024#contribution_and_benefit_base"
+    )
+
+
 def test_contribution_and_benefit_base_comes_from_axiom_results():
     output = contribution_and_benefit_base_output(2026)
     results = [
@@ -1168,6 +1216,58 @@ def test_contribution_and_benefit_base_comes_from_axiom_results():
             year=2026,
         )
         == 184_500
+    )
+
+
+def test_contribution_and_benefit_base_comes_from_selected_axiom_result():
+    output = "us:policies/ssa/contribution-and-benefit-base/2024#contribution_and_benefit_base"
+    results = [
+        {
+            "outputs": {
+                output: {
+                    "kind": "scalar",
+                    "value": {"kind": "decimal", "value": "168600"},
+                }
+            }
+        }
+    ]
+
+    assert (
+        contribution_and_benefit_base_from_results(
+            results,
+            year=2024,
+            output=output,
+        )
+        == 168_600
+    )
+
+
+def test_contribution_and_benefit_base_can_come_from_rulespec_test(tmp_path):
+    test_path = tmp_path / contribution_and_benefit_base_program_path(2024).with_suffix(
+        ".test.yaml"
+    )
+    test_path.parent.mkdir(parents=True)
+    output = "us:policies/ssa/contribution-and-benefit-base/2024#contribution_and_benefit_base"
+    test_path.write_text(
+        f"""- name: base_for_2024
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {{}}
+  output:
+    {output}: "$168,600"
+"""
+    )
+
+    assert (
+        contribution_and_benefit_base_from_rulespec_test(
+            tmp_path,
+            year=2024,
+            output=output,
+        )
+        == 168_600
     )
 
 


### PR DESCRIPTION
## Summary
- select the contribution-and-benefit-base output exported by the RuleSpec file before payroll ECPS runs
- read scalar annual SSA base values from generated companion tests before falling back to rules-engine execution
- bump axiom-encode to 0.2.298

## Tests
- uv run ruff format src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py
- uv run ruff check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_ecps_tax.py -q
- uv run --with policyengine==4.11.0 --with policyengine-core==3.26.11 --with policyengine-us==1.705.16 axiom-encode tax-ecps-compare --rulespec-root /private/tmp/axiom-rulespec-ssa-cbb-2024-20260526/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 --year 2024 --sample-size 200 --surface employee-oasdi --fail-on-mismatch
- uv run --with policyengine==4.11.0 --with policyengine-core==3.26.11 --with policyengine-us==1.705.16 axiom-encode tax-ecps-compare --rulespec-root /private/tmp/axiom-rulespec-ssa-cbb-2024-20260526/rulespec-us --axiom-rules-engine-path /private/tmp/axiom-rules-engine-main-20260525 --year 2024 --sample-size 200 --surface employer-oasdi --fail-on-mismatch