### PR TITLE
Map 2024 SSA base to PolicyEngine payroll cap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.298"
+version = "0.2.299"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.298"
+__version__ = "0.2.299"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1735,6 +1735,16 @@ mappings:
     candidate_priority: P4
     rationale: PolicyEngine exposes taxable Social Security earnings after this exclusion, not the excluded-remuneration amount separately. The ECPS tax harness uses this Axiom output to stage OASDI wage inputs before comparing sections 3101(a) and 3111(a).
 
+  - legal_id: us:policies/ssa/contribution-and-benefit-base/2024#contribution_and_benefit_base
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.payroll.social_security.cap
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same final 2024 Social Security contribution-and-benefit base, stored in PolicyEngine as the Social Security payroll cap parameter.
+
   - legal_id: us:policies/ssa/contribution-and-benefit-base/2026#base_year_contribution_and_benefit_base
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3658,6 +3658,19 @@ def test_policyengine_coverage_treats_ssa_policy_parameters_as_tax(tmp_path):
     _write_rulespec_file(
         tmp_path
         / "rulespec-us"
+        / "policies/ssa/contribution-and-benefit-base/2024.yaml",
+        """format: rulespec/v1
+rules:
+  - name: contribution_and_benefit_base
+    kind: parameter
+    versions:
+      - effective_from: '2024-01-01'
+        formula: '168600'
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
         / "policies/ssa/contribution-and-benefit-base/2026.yaml",
         """format: rulespec/v1
 rules:
@@ -3676,8 +3689,21 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path, program="tax")
 
-    assert report["total_outputs"] == 2
+    assert report["total_outputs"] == 3
     statuses_by_id = {item["legal_id"]: item["status"] for item in report["items"]}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        statuses_by_id[
+            "us:policies/ssa/contribution-and-benefit-base/2024#contribution_and_benefit_base"
+        ]
+        == "comparable"
+    )
+    assert (
+        items_by_id[
+            "us:policies/ssa/contribution-and-benefit-base/2024#contribution_and_benefit_base"
+        ]["policyengine_parameter"]
+        == "gov.irs.payroll.social_security.cap"
+    )
     assert (
         statuses_by_id[
             "us:policies/ssa/contribution-and-benefit-base/2026#base_year_contribution_and_benefit_base"


### PR DESCRIPTION
## Summary
- map the generated 2024 SSA contribution-and-benefit-base RuleSpec output to `gov.irs.payroll.social_security.cap`
- add coverage regression for SSA policy parameters under the tax oracle
- bump axiom-encode to 0.2.299

## Validation
- `uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/registry.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-rulespec-ssa-cbb-2024-20260526/rulespec-us --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20`