### PR TITLE
Classify section 3401 withholding definitions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.299"
+version = "0.2.300"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.299"
+__version__ = "0.2.300"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1141,6 +1141,24 @@ mappings:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose the section 3111(c) foreign-social-security agreement wage exemption as a separate variable.
 
+  - legal_id: us:statutes/26/3401/b#payroll_period
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3401(b) defines payroll-period status for chapter 24 withholding mechanics; PolicyEngine does not expose this legal-period classification as a separate output.
+
+  - legal_id: us:statutes/26/3401/b#miscellaneous_payroll_period
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3401(b) defines a residual payroll-period classification for chapter 24 withholding; PolicyEngine does not expose this cadence classification as a separate variable.
+
+  - legal_id: us:statutes/26/3401/c#employee
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3401(c) defines employee status for chapter 24 withholding; PolicyEngine models income and payroll tax amounts, not this legal status predicate as a separate output.
+
   - legal_id: us:statutes/26/3301#federal_unemployment_excise_tax_rate
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2711,6 +2711,42 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3401_withholding_definitions(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3401/b.yaml",
+        """format: rulespec/v1
+rules:
+  - name: payroll_period
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: payment_of_wages_is_ordinarily_made_to_employee_by_employer_for_period
+  - name: miscellaneous_payroll_period
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: payroll_period and not payroll_period_is_daily
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3401/c.yaml",
+        """format: rulespec/v1
+rules:
+  - name: employee
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: person_is_officer_of_corporation
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3231_c_employee_representative_outputs(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- classify generated section 3401(b) payroll-period outputs as known not comparable to PolicyEngine
- classify generated section 3401(c) employee status as known not comparable to PolicyEngine
- bump axiom-encode to 0.2.300

## Validation
- `uv run ruff format tests/test_policyengine_coverage.py`
- `uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/registry.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`