### PR TITLE
Classify section 3403 withholding liability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.300"
+version = "0.2.301"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.300"
+__version__ = "0.2.301"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1159,6 +1159,18 @@ mappings:
     mapping_type: not_comparable
     rationale: Section 3401(c) defines employee status for chapter 24 withholding; PolicyEngine models income and payroll tax amounts, not this legal status predicate as a separate output.
 
+  - legal_id: us:statutes/26/3403#employer_liability_for_chapter_withholding_tax_payment
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3403 assigns employer liability for chapter 24 withheld tax payments; PolicyEngine computes tax liabilities, not employer withholding-payment liability as a separate output.
+
+  - legal_id: us:statutes/26/3403#employer_liability_to_any_person_for_chapter_withholding_tax_payment
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3403 shields the employer from liability to other persons for withheld-tax payments; PolicyEngine does not expose this non-tax-due legal liability shield as a variable.
+
   - legal_id: us:statutes/26/3301#federal_unemployment_excise_tax_rate
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2747,6 +2747,31 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3403.yaml",
+        """format: rulespec/v1
+rules:
+  - name: employer_liability_for_chapter_withholding_tax_payment
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: tax_required_to_be_deducted_and_withheld_under_this_chapter
+  - name: employer_liability_to_any_person_for_chapter_withholding_tax_payment
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3231_c_employee_representative_outputs(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3403 employer withholding-liability outputs as PolicyEngine non-comparable
- add regression coverage for the two 3403 outputs
- bump axiom-encode to 0.2.301

## Tests
- uv run ruff format tests/test_policyengine_coverage.py
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/registry.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50