### PR TITLE
Classify section 3127 religious exemption outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.301"
+version = "0.2.302"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.301"
+__version__ = "0.2.302"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1141,6 +1141,48 @@ mappings:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose the section 3111(c) foreign-social-security agreement wage exemption as a separate variable.
 
+  - legal_id: us:statutes/26/3127#employer_application_meets_statutory_approval_prerequisites
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3127(b) encodes IRS/SSA approval prerequisites for a religious-sect payroll-tax exemption application; PolicyEngine does not expose this administrative approval predicate.
+
+  - legal_id: us:statutes/26/3127#employee_application_meets_statutory_approval_prerequisites
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3127(b) encodes IRS/SSA approval prerequisites for an employee religious-sect payroll-tax exemption application; PolicyEngine does not expose this administrative approval predicate.
+
+  - legal_id: us:statutes/26/3127#employer_meets_religious_exemption_requirements
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3127(a) classifies employers and partners by religious-sect membership, adherence, and approved application status; PolicyEngine does not model these exemption-status inputs.
+
+  - legal_id: us:statutes/26/3127#employee_meets_religious_exemption_requirements
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3127(a) classifies employees by religious-sect membership, adherence, and approved application status; PolicyEngine does not model these exemption-status inputs.
+
+  - legal_id: us:statutes/26/3127#wages_paid_during_section_3127_effective_period
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3127(c) defines the effective period for approved religious-sect payroll-tax exemptions; PolicyEngine does not expose this application-effective-period predicate.
+
+  - legal_id: us:statutes/26/3127#wages_exempt_from_section_3111_taxes_under_section_3127
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3127 exempts qualified wages from employer FICA taxes only when religious-sect exemption status and effective-period facts are present; PolicyEngine does not model those facts or expose the exempt-wage amount separately.
+
+  - legal_id: us:statutes/26/3127#wages_exempt_from_section_3101_taxes_under_section_3127
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3127 exempts qualified wages from employee FICA taxes only when religious-sect exemption status and effective-period facts are present; PolicyEngine does not model those facts or expose the exempt-wage amount separately.
+
   - legal_id: us:statutes/26/3401/b#payroll_period
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2772,6 +2772,58 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3127_religious_exemption_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3127.yaml",
+        """format: rulespec/v1
+rules:
+  - name: employer_application_meets_statutory_approval_prerequisites
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: employer_application_contains_required_evidence
+  - name: employee_application_meets_statutory_approval_prerequisites
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: employee_application_contains_required_evidence
+  - name: employer_meets_religious_exemption_requirements
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: employer_application_meets_statutory_approval_prerequisites
+  - name: employee_meets_religious_exemption_requirements
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: employee_application_meets_statutory_approval_prerequisites
+  - name: wages_paid_during_section_3127_effective_period
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: wages_paid_after_application_effective_date
+  - name: wages_exempt_from_section_3111_taxes_under_section_3127
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: wages_paid_to_employee_by_employer
+  - name: wages_exempt_from_section_3101_taxes_under_section_3127
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: wages_paid_to_employee_by_employer
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 7}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3231_c_employee_representative_outputs(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3127 religious-sect payroll-tax exemption outputs as PolicyEngine non-comparable
- add regression coverage for the seven 3127 outputs
- bump axiom-encode to 0.2.302

## Rationale
PolicyEngine computes payroll-tax amounts from modeled employment income, rates, and caps, but does not expose section 3127 religious-sect exemption application predicates, effective-period predicates, or exempt-wage amounts as separate oracle outputs.

## Tests
- uv run ruff format tests/test_policyengine_coverage.py
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/registry.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50