### PR TITLE
Classify section 3504 payroll agent outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.302"
+version = "0.2.303"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.302"
+__version__ = "0.2.303"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1213,6 +1213,24 @@ mappings:
     mapping_type: not_comparable
     rationale: Section 3403 shields the employer from liability to other persons for withheld-tax payments; PolicyEngine does not expose this non-tax-due legal liability shield as a variable.
 
+  - legal_id: us:statutes/26/3504#secretary_may_designate_wage_control_person_to_perform_employer_acts
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3504 authorizes Treasury to designate a fiduciary, agent, or other wage-control person to perform employer acts; PolicyEngine does not expose this designation-authority predicate.
+
+  - legal_id: us:statutes/26/3504#designated_person_subject_to_employer_law_provisions
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3504 applies employer legal provisions and penalties to designated payroll agents; PolicyEngine computes payroll tax amounts, not this legal-responsibility status.
+
+  - legal_id: us:statutes/26/3504#employer_remains_subject_to_employer_law_provisions
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3504 preserves employer legal responsibility except as Treasury provides otherwise; PolicyEngine does not expose this employer-responsibility status as a variable.
+
   - legal_id: us:statutes/26/3301#federal_unemployment_excise_tax_rate
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2824,6 +2824,38 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3504_payroll_agent_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3504.yaml",
+        """format: rulespec/v1
+rules:
+  - name: secretary_may_designate_wage_control_person_to_perform_employer_acts
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: person_has_control_receipt_custody_or_disposal_of_employee_wages
+  - name: designated_person_subject_to_employer_law_provisions
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: person_is_designated_by_secretary_under_section_3504
+  - name: employer_remains_subject_to_employer_law_provisions
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: designated_person_acts_for_employer
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3231_c_employee_representative_outputs(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3504 payroll-agent legal-responsibility outputs as PolicyEngine non-comparable
- add regression coverage for the three 3504 outputs
- bump axiom-encode to 0.2.303

## Rationale
PolicyEngine computes payroll tax amounts, but does not expose Treasury designation authority, payroll-agent legal-responsibility status, or preserved employer responsibility under section 3504 as separate oracle outputs.

## Tests
- uv run ruff format tests/test_policyengine_coverage.py
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/registry.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50