### PR TITLE
Classify section 3511 CPEO outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.303"
+version = "0.2.304"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.303"
+__version__ = "0.2.304"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1231,6 +1231,60 @@ mappings:
     mapping_type: not_comparable
     rationale: Section 3504 preserves employer legal responsibility except as Treasury provides otherwise; PolicyEngine does not expose this employer-responsibility status as a variable.
 
+  - legal_id: us:statutes/26/3511#related_party_nonapplication_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3511(e) makes CPEO treatment inapplicable for related customers under modified section 267(b) or 707(b) relationships; PolicyEngine does not expose this related-party nonapplication predicate.
+
+  - legal_id: us:statutes/26/3511#cpeo_exclusive_employer_for_work_site_employee_remuneration
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3511(a) treats a CPEO as the exclusive employer for specified work-site employee remuneration; PolicyEngine does not model CPEO/customer employer identity as a separate output.
+
+  - legal_id: us:statutes/26/3511#employer_type_based_rules_apply_to_cpeo_remitted_work_site_remuneration
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3511(a)(2) applies employer-type exemptions, exclusions, definitions, and rules to CPEO-remitted remuneration; PolicyEngine does not expose this legal-rule-application status.
+
+  - legal_id: us:statutes/26/3511#cpeo_successor_customer_predecessor_during_service_contract
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3511(b)(1) gives CPEO/customer successor-predecessor treatment for wage-base purposes during service contracts; PolicyEngine does not expose this CPEO succession status.
+
+  - legal_id: us:statutes/26/3511#customer_successor_cpeo_predecessor_after_service_contract_termination
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3511(b)(2) gives customer/CPEO successor-predecessor treatment after service-contract termination; PolicyEngine does not expose this CPEO succession status.
+
+  - legal_id: us:statutes/26/3511#individual_not_work_site_employee_due_to_self_employment
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3511(f) excludes individuals with self-employment earnings from the customer trade or business from work-site employee status; PolicyEngine does not expose this CPEO work-site status predicate.
+
+  - legal_id: us:statutes/26/3511#specified_credit_applies_to_customer_not_cpeo
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3511(d) allocates specified employment credits to the customer rather than the CPEO; PolicyEngine does not expose this CPEO/customer credit-allocation predicate.
+
+  - legal_id: us:statutes/26/3511#customer_takes_cpeo_paid_wages_and_employment_taxes_into_account_for_specified_credit
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3511(d) tells the customer to account for CPEO-paid wages and employment taxes for specified credits; PolicyEngine does not expose this credit-input allocation status.
+
+  - legal_id: us:statutes/26/3511#cpeo_information_furnishing_required_for_customer_credit
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3511(d) requires the CPEO to furnish information needed for customer specified credits; PolicyEngine does not expose this information-reporting obligation.
+
   - legal_id: us:statutes/26/3301#federal_unemployment_excise_tax_rate
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2856,6 +2856,66 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3511_cpeo_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3511.yaml",
+        """format: rulespec/v1
+rules:
+  - name: related_party_nonapplication_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: customer_bears_relationship_to_cpeo
+  - name: cpeo_exclusive_employer_for_work_site_employee_remuneration
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: organization_is_certified_professional_employer_organization
+  - name: employer_type_based_rules_apply_to_cpeo_remitted_work_site_remuneration
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: cpeo_exclusive_employer_for_work_site_employee_remuneration
+  - name: cpeo_successor_customer_predecessor_during_service_contract
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: organization_entering_into_service_contract_with_customer
+  - name: customer_successor_cpeo_predecessor_after_service_contract_termination
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: customer_service_contract_with_cpeo_terminated
+  - name: individual_not_work_site_employee_due_to_self_employment
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: individual_has_net_earnings_from_self_employment
+  - name: specified_credit_applies_to_customer_not_cpeo
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: credit_is_specified_in_subsection_d
+  - name: customer_takes_cpeo_paid_wages_and_employment_taxes_into_account_for_specified_credit
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: specified_credit_applies_to_customer_not_cpeo
+  - name: cpeo_information_furnishing_required_for_customer_credit
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: specified_credit_applies_to_customer_not_cpeo
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 9}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3231_c_employee_representative_outputs(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3511 CPEO employer-identity, successor, related-party, self-employment, and credit-allocation outputs as PolicyEngine non-comparable
- add regression coverage for the nine 3511 outputs
- bump axiom-encode to 0.2.304

## Rationale
PolicyEngine computes payroll tax amounts, but does not expose CPEO/customer legal status, successor/predecessor wage-base status, or specified-credit allocation/reporting predicates from section 3511 as separate oracle outputs.

## Tests
- uv run ruff format tests/test_policyengine_coverage.py
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/registry.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50