### PR TITLE
Classify section 3402(a) withholding table wages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.304"
+version = "0.2.305"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.304"
+__version__ = "0.2.305"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1201,6 +1201,12 @@ mappings:
     mapping_type: not_comparable
     rationale: Section 3401(c) defines employee status for chapter 24 withholding; PolicyEngine models income and payroll tax amounts, not this legal status predicate as a separate output.
 
+  - legal_id: us:statutes/26/3402/a#amount_of_wages_for_withholding_tables
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(a) defines the wage amount used for Secretary-prescribed withholding tables or computational procedures; PolicyEngine does not model paycheck withholding table inputs as separate outputs.
+
   - legal_id: us:statutes/26/3403#employer_liability_for_chapter_withholding_tax_payment
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2747,6 +2747,28 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402a_withholding_table_wages(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/a.yaml",
+        """format: rulespec/v1
+rules:
+  - name: amount_of_wages_for_withholding_tables
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: max(0, wages - taxpayer_withholding_allowance)
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3402(a) withholding-table wage amount as PolicyEngine non-comparable
- add regression coverage for the 3402(a) output
- bump axiom-encode to 0.2.305

## Rationale
PolicyEngine computes annual tax liabilities but does not model paycheck withholding table inputs or Secretary-prescribed withholding procedures as separate oracle outputs.

## Tests
- uv run ruff format tests/test_policyengine_coverage.py
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/registry.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50