### PR TITLE
Classify section 3402(b) withholding period outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.305"
+version = "0.2.306"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.305"
+__version__ = "0.2.306"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1207,6 +1207,30 @@ mappings:
     mapping_type: not_comparable
     rationale: Section 3402(a) defines the wage amount used for Secretary-prescribed withholding tables or computational procedures; PolicyEngine does not model paycheck withholding table inputs as separate outputs.
 
+  - legal_id: us:statutes/26/3402/b#miscellaneous_allowance_period_days_for_nonpayroll_period_wages
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(b) defines miscellaneous payroll-period days for withholding allowance calculations; PolicyEngine does not model paycheck withholding allowance periods as separate outputs.
+
+  - legal_id: us:statutes/26/3402/b#miscellaneous_allowance_period_days_for_wages_paid_without_regard_to_period
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(b) defines elapsed-day miscellaneous payroll periods for wages paid without regard to a period; PolicyEngine does not model paycheck withholding allowance periods as separate outputs.
+
+  - legal_id: us:statutes/26/3402/b#secretary_may_authorize_weekly_aggregate_computation
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(b) authorizes weekly aggregate withholding computation for short periods; PolicyEngine does not expose this Treasury authorization predicate.
+
+  - legal_id: us:statutes/26/3402/b#wages_computed_for_withholding_under_percentage_method
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(b) permits employer-elected rounding of wages for percentage-method withholding; PolicyEngine does not model paycheck withholding wage rounding as a separate output.
+
   - legal_id: us:statutes/26/3403#employer_liability_for_chapter_withholding_tax_payment
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2769,6 +2769,43 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402b_withholding_period_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/b.yaml",
+        """format: rulespec/v1
+rules:
+  - name: miscellaneous_allowance_period_days_for_nonpayroll_period_wages
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: days_in_period_with_respect_to_which_wages_are_paid
+  - name: miscellaneous_allowance_period_days_for_wages_paid_without_regard_to_period
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: days_elapsed_since_later_reference_date
+  - name: secretary_may_authorize_weekly_aggregate_computation
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: period_is_less_than_one_week
+  - name: wages_computed_for_withholding_under_percentage_method
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: wages_computed_to_nearest_dollar
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 4}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3402(b) withholding-period and percentage-method wage outputs as PolicyEngine non-comparable
- add regression coverage for the four 3402(b) outputs
- bump axiom-encode to 0.2.306

## Rationale
PolicyEngine computes annual tax liabilities but does not model paycheck withholding allowance periods, Treasury weekly aggregate authorization, or percentage-method wage rounding as separate oracle outputs.

## Tests
- uv run ruff format tests/test_policyengine_coverage.py
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/registry.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50