### PR TITLE
Classify section 3402(c) wage bracket outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.306"
+version = "0.2.307"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.306"
+__version__ = "0.2.307"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1231,6 +1231,30 @@ mappings:
     mapping_type: not_comparable
     rationale: Section 3402(b) permits employer-elected rounding of wages for percentage-method withholding; PolicyEngine does not model paycheck withholding wage rounding as a separate output.
 
+  - legal_id: us:statutes/26/3402/c#wage_bracket_miscellaneous_period_days_for_nonpayroll_period_wages
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(c) defines miscellaneous payroll-period days for wage-bracket withholding tables; PolicyEngine does not model paycheck withholding table periods as separate outputs.
+
+  - legal_id: us:statutes/26/3402/c#wage_bracket_miscellaneous_period_days_for_wages_paid_without_regard_to_period
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(c) defines elapsed-day miscellaneous payroll periods for wages paid without regard to a period under wage-bracket withholding; PolicyEngine does not model paycheck withholding table periods as separate outputs.
+
+  - legal_id: us:statutes/26/3402/c#wage_bracket_weekly_aggregate_computation_authorized
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(c) authorizes weekly aggregate wage-bracket withholding computation for short periods; PolicyEngine does not expose this Treasury authorization predicate.
+
+  - legal_id: us:statutes/26/3402/c#wages_computed_for_wage_bracket_withholding
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(c) permits employer-elected rounding of wages for wage-bracket withholding tables; PolicyEngine does not model paycheck withholding wage rounding as a separate output.
+
   - legal_id: us:statutes/26/3403#employer_liability_for_chapter_withholding_tax_payment
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2806,6 +2806,43 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402c_wage_bracket_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/c.yaml",
+        """format: rulespec/v1
+rules:
+  - name: wage_bracket_miscellaneous_period_days_for_nonpayroll_period_wages
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: days_in_period_with_respect_to_which_wages_are_paid
+  - name: wage_bracket_miscellaneous_period_days_for_wages_paid_without_regard_to_period
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: days_elapsed_since_later_reference_date
+  - name: wage_bracket_weekly_aggregate_computation_authorized
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: period_is_less_than_one_week
+  - name: wages_computed_for_wage_bracket_withholding
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: wages_computed_to_nearest_dollar
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 4}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- Mark generated 26 USC 3402(c) wage-bracket withholding period and rounding outputs as known-not-comparable to PolicyEngine.
- Add coverage regression for the 3402(c) output names.
- Bump axiom-encode to 0.2.307.

## Validation
- uv run ruff format src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run ruff check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50