### PR TITLE
Classify section 3402(d) withholding liability outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.307"
+version = "0.2.308"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.307"
+__version__ = "0.2.308"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1255,6 +1255,18 @@ mappings:
     mapping_type: not_comparable
     rationale: Section 3402(c) permits employer-elected rounding of wages for wage-bracket withholding tables; PolicyEngine does not model paycheck withholding wage rounding as a separate output.
 
+  - legal_id: us:statutes/26/3402/d#required_withholding_tax_not_collected_from_employer
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(d) limits IRS collection of required withholding tax from an employer after the recipient pays the credited tax; PolicyEngine does not expose employer collection-relief predicates.
+
+  - legal_id: us:statutes/26/3402/d#employer_remains_liable_for_penalties_or_additions_for_withholding_failure
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(d) preserves employer liability for penalties or additions despite collection relief; PolicyEngine does not model employer withholding penalty-liability predicates as tax-calculation outputs.
+
   - legal_id: us:statutes/26/3403#employer_liability_for_chapter_withholding_tax_payment
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2843,6 +2843,33 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402d_withholding_liability_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/d.yaml",
+        """format: rulespec/v1
+rules:
+  - name: required_withholding_tax_not_collected_from_employer
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: recipient_tax_paid
+  - name: employer_remains_liable_for_penalties_or_additions_for_withholding_failure
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: penalties_or_additions_apply
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- Mark generated 26 USC 3402(d) employer collection-relief and penalty-liability outputs as known-not-comparable to PolicyEngine.
- Add coverage regression for the 3402(d) output names.
- Bump axiom-encode to 0.2.308.

## Validation
- uv run ruff format src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run ruff check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50