### PR TITLE
Classify section 3402(e) wage deeming outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.308"
+version = "0.2.309"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.308"
+__version__ = "0.2.309"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1267,6 +1267,36 @@ mappings:
     mapping_type: not_comparable
     rationale: Section 3402(d) preserves employer liability for penalties or additions despite collection relief; PolicyEngine does not model employer withholding penalty-liability predicates as tax-calculation outputs.
 
+  - legal_id: us:statutes/26/3402/e#maximum_consecutive_days_for_payroll_period_deeming_rule
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(e) defines the 31-day payroll-period threshold for chapter 24 withholding wage-deeming administration; PolicyEngine does not expose this paycheck-period withholding threshold as a one-to-one output.
+
+  - legal_id: us:statutes/26/3402/e#payroll_period_within_deeming_rule_day_limit
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(e) classifies payroll periods within the 31-day wage-deeming threshold for chapter 24 withholding; PolicyEngine does not expose this paycheck-period withholding predicate as a one-to-one output.
+
+  - legal_id: us:statutes/26/3402/e#all_remuneration_deemed_wages_for_period
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(e) deems all remuneration wages for short payroll periods when one-half or more of service remuneration constitutes wages; PolicyEngine does not expose this paycheck-period wage-construction predicate.
+
+  - legal_id: us:statutes/26/3402/e#no_remuneration_deemed_wages_for_period
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(e) deems no remuneration wages for short payroll periods when more than one-half of service remuneration does not constitute wages; PolicyEngine does not expose this paycheck-period wage-construction predicate.
+
+  - legal_id: us:statutes/26/3402/e#remuneration_amount_deemed_wages_for_period
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(e) computes a deemed-wage amount for chapter 24 withholding administration; PolicyEngine does not expose paycheck-period deemed withholding wages as a one-to-one output.
+
   - legal_id: us:statutes/26/3403#employer_liability_for_chapter_withholding_tax_payment
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2870,6 +2870,48 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402e_wage_deeming_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/e.yaml",
+        """format: rulespec/v1
+rules:
+  - name: maximum_consecutive_days_for_payroll_period_deeming_rule
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 31
+  - name: payroll_period_within_deeming_rule_day_limit
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: payroll_period_consecutive_days <= maximum_consecutive_days_for_payroll_period_deeming_rule
+  - name: all_remuneration_deemed_wages_for_period
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: half_or_more_services_constitute_wages
+  - name: no_remuneration_deemed_wages_for_period
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: more_than_half_services_do_not_constitute_wages
+  - name: remuneration_amount_deemed_wages_for_period
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: remuneration_paid_by_employer_to_employee_for_period
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 5}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- Mark generated 26 USC 3402(e) payroll-period wage-deeming outputs as known-not-comparable to PolicyEngine.
- Add coverage regression for the 3402(e) output names.
- Bump axiom-encode to 0.2.309.

## Validation
- uv run ruff format src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run ruff check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50