### PR TITLE
Classify section 3402(f) withholding certificate outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.309"
+version = "0.2.310"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.309"
+__version__ = "0.2.310"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10164,6 +10164,12 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3302(f) defines State-specific limitation and partial-limitation rules for subsection (c)(2) credit reductions, including benefit-cost ratios, State unemployment tax rates, and intermediate capped reduction amounts; PolicyEngine exposes final employer FUTA tax, not these statutory credit-reduction limitation components separately.
 
+  - legal_id_prefix: us:statutes/26/3402/f#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(f) defines withholding allowance certificates, certificate effective dates, nonresident alien exemption limits, and duplicate allowance-claim restrictions for chapter 24 withholding administration; PolicyEngine does not expose these paycheck withholding certificate administration surfaces as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2912,6 +2912,53 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402f_withholding_certificate_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/f.yaml",
+        """format: rulespec/v1
+rules:
+  - name: change_status_new_certificate_due_days
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 10
+  - name: replacement_certificate_default_wait_days
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 30
+  - name: nonresident_alien_withholding_exemption_limit
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 1
+  - name: commencement_certificate_requirement_satisfied
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: signed_certificate_furnished
+  - name: excess_allowance_new_certificate_violation
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: not new_certificate_furnished
+  - name: first_certificate_effective_for_payment
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: first_payroll_period_after_certificate
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 6}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- Mark generated 26 USC 3402(f) withholding allowance certificate outputs as known-not-comparable to PolicyEngine.
- Add coverage regression for the 3402(f) certificate output prefix.
- Bump axiom-encode to 0.2.310.

## Validation
- uv run ruff format src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run ruff check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 100