### PR TITLE
Classify section 3402(g) special wage withholding output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.310"
+version = "0.2.311"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.310"
+__version__ = "0.2.311"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10170,6 +10170,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3402(f) defines withholding allowance certificates, certificate effective dates, nonresident alien exemption limits, and duplicate allowance-claim restrictions for chapter 24 withholding administration; PolicyEngine does not expose these paycheck withholding certificate administration surfaces as one-to-one outputs.
 
+  - legal_id: us:statutes/26/3402/g#special_wage_payment_regulatory_withholding_rule_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(g) identifies special wage-payment situations where withholding manner and amount are determined under Secretary regulations; PolicyEngine does not expose this regulatory-applicability predicate as a separate tax output.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2959,6 +2959,28 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402g_special_wage_withholding_output(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/g.yaml",
+        """format: rulespec/v1
+rules:
+  - name: special_wage_payment_regulatory_withholding_rule_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: supplemental_wage_payment_condition
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- Mark generated 26 USC 3402(g) special wage-payment regulatory withholding predicate as known-not-comparable to PolicyEngine.
- Add coverage regression for the 3402(g) output name.
- Bump axiom-encode to 0.2.311.

## Validation
- uv run ruff format src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run ruff check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 100