### PR TITLE
Loop zero branch apply repairs

### DIFF
--- a/changelog.d/zero-branch-apply-repair-loop.fixed.md
+++ b/changelog.d/zero-branch-apply-repair-loop.fixed.md
@@ -1,0 +1,1 @@
+Loop generated zero-branch companion-test repairs during `encode --apply` until validation stops surfacing new zero-branch gaps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.311"
+version = "0.2.312"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.311"
+__version__ = "0.2.312"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10964,14 +10964,20 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
-                repaired_test_cases = _try_repair_generated_zero_branch_tests_for_apply(
-                    result,
-                    output_root=args.output,
-                    policy_repo_path=policy_repo_path,
-                    issues=apply_issues,
-                )
-                if repaired_test_cases:
-                    outcome["auto_repaired_zero_branch_tests"] = repaired_test_cases
+                repaired_zero_cases: list[str] = []
+                while not can_apply:
+                    repaired_test_cases = (
+                        _try_repair_generated_zero_branch_tests_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            issues=apply_issues,
+                        )
+                    )
+                    if not repaired_test_cases:
+                        break
+                    repaired_zero_cases.extend(repaired_test_cases)
+                    outcome["auto_repaired_zero_branch_tests"] = repaired_zero_cases
                     print(
                         "  apply=auto_repaired_zero_branch_tests:"
                         + ",".join(repaired_test_cases)
@@ -10988,6 +10994,8 @@ def cmd_encode(args):
                         )
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
+                if repaired_zero_cases:
+                    outcome["auto_repaired_zero_branch_tests"] = repaired_zero_cases
             if not can_apply:
                 repaired_test_cases = _try_repair_generated_exception_tests_for_apply(
                     result,
@@ -11228,20 +11236,23 @@ def cmd_encode(args):
                         repaired_output_cases
                     )
             if not can_apply:
-                repaired_test_cases = _try_repair_generated_zero_branch_tests_for_apply(
-                    result,
-                    output_root=args.output,
-                    policy_repo_path=policy_repo_path,
-                    issues=apply_issues,
-                )
-                if repaired_test_cases:
-                    prior_repairs = outcome.get("auto_repaired_zero_branch_tests")
-                    if not isinstance(prior_repairs, list):
-                        prior_repairs = []
-                    outcome["auto_repaired_zero_branch_tests"] = [
-                        *prior_repairs,
-                        *repaired_test_cases,
-                    ]
+                prior_repairs = outcome.get("auto_repaired_zero_branch_tests")
+                if not isinstance(prior_repairs, list):
+                    prior_repairs = []
+                repaired_zero_cases = list(prior_repairs)
+                while not can_apply:
+                    repaired_test_cases = (
+                        _try_repair_generated_zero_branch_tests_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            issues=apply_issues,
+                        )
+                    )
+                    if not repaired_test_cases:
+                        break
+                    repaired_zero_cases.extend(repaired_test_cases)
+                    outcome["auto_repaired_zero_branch_tests"] = repaired_zero_cases
                     print(
                         "  apply=auto_repaired_zero_branch_tests:"
                         + ",".join(repaired_test_cases)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4572,6 +4572,18 @@ rules:
               min(lodging_amount_paid, lodging_medical_care_nightly_cap * lodging_nights * lodging_individuals)
           else:
               0
+  - name: lodging_medical_care_secondary_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if secondary_lodging_condition:
+              secondary_lodging_amount
+          else:
+              0
 """
         )
         test_file = output_file.with_name("213.test.yaml")
@@ -4610,6 +4622,16 @@ rules:
                         ],
                         {},
                     ),
+                    (
+                        False,
+                        [
+                            "statutes/26/213.yaml: ci: "
+                            "Zero branch test coverage missing: "
+                            "`lodging_medical_care_secondary_amount` has a formula "
+                            "branch that returns 0."
+                        ],
+                        {},
+                    ),
                     (True, [], {}),
                 ],
             ) as mock_overlay,
@@ -4628,15 +4650,24 @@ rules:
             "apply=auto_repaired_zero_branch_tests:"
             "auto_zero_lodging_medical_care_amount"
         ) in output
-        assert mock_overlay.call_count == 2
+        assert (
+            "apply=auto_repaired_zero_branch_tests:"
+            "auto_zero_lodging_medical_care_secondary_amount"
+        ) in output
+        assert mock_overlay.call_count == 3
         mock_apply.assert_called_once()
         test_content = test_file.read_text()
         assert "auto_zero_lodging_medical_care_amount" in test_content
+        assert "auto_zero_lodging_medical_care_secondary_amount" in test_content
         assert (
             "us:statutes/26/213#input.lodging_not_lavish_or_extravagant: false"
             in test_content
         )
         assert "us:statutes/26/213#lodging_medical_care_amount: 0" in test_content
+        assert (
+            "us:statutes/26/213#lodging_medical_care_secondary_amount: 0"
+            in test_content
+        )
 
     def test_encode_apply_auto_repairs_exception_positive_companion(
         self, capsys, tmp_path


### PR DESCRIPTION
## Summary
- loop generated zero-branch companion-test repairs during encode --apply until validation no longer reports another zero-branch gap
- extend the CLI test to cover two sequential zero-branch validation failures
- bump version to 0.2.312 and add a changelog fragment

## Validation
- uv run ruff format src/axiom_encode/cli.py tests/test_cli.py pyproject.toml src/axiom_encode/__init__.py
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py pyproject.toml src/axiom_encode/__init__.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py -q