### PR TITLE
Classify section 3402(i) withholding outputs

### DIFF
--- a/changelog.d/section-3402-i-policyengine-coverage.fixed.md
+++ b/changelog.d/section-3402-i-policyengine-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classified section 3402(i) requested increased withholding outputs as PolicyEngine known-not-comparable oracle outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.313"
+version = "0.2.314"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.313"
+__version__ = "0.2.314"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10182,6 +10182,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3402(h) defines alternative paycheck withholding methods based on average, annualized, cumulative, or substantially equivalent wages, including timing and intermediate method calculations; PolicyEngine computes annual tax and payroll-tax amounts, not these chapter 24 withholding-method administration surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3402/i#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(i) authorizes employee-requested increased withholding under regulations and treats that additional withholding as required chapter 24 tax; PolicyEngine does not expose this paycheck withholding election authority or legal-treatment rule as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3023,6 +3023,33 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402i_requested_increased_withholding(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/i.yaml",
+        """format: rulespec/v1
+rules:
+  - name: employee_requested_increased_withholding_regulatory_authority
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: employee_requests_increased_withholding
+  - name: increased_withholding_treated_as_required_withholding_tax
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: increased_withholding_deducted_and_withheld
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3402(i) requested increased withholding outputs as PolicyEngine known-not-comparable
- add a coverage regression for 3402(i) outputs
- bump version to 0.2.314 and add a changelog fragment

## Validation
- uv run ruff format tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 100