### PR TITLE
Classify section 3402(j) withholding output

### DIFF
--- a/changelog.d/section-3402-j-policyengine-coverage.fixed.md
+++ b/changelog.d/section-3402-j-policyengine-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classified section 3402(j) retail commission noncash remuneration withholding output as a PolicyEngine known-not-comparable oracle output.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.314"
+version = "0.2.315"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.314"
+__version__ = "0.2.315"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10188,6 +10188,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3402(i) authorizes employee-requested increased withholding under regulations and treats that additional withholding as required chapter 24 tax; PolicyEngine does not expose this paycheck withholding election authority or legal-treatment rule as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3402/j#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(j) removes chapter 24 withholding requirements for certain noncash retail-salesman commission remuneration when the employer files prescribed information; PolicyEngine does not expose this paycheck withholding exemption predicate as a one-to-one output.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3050,6 +3050,28 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402j_retail_commission_output(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/j.yaml",
+        """format: rulespec/v1
+rules:
+  - name: retail_commission_noncash_remuneration_withholding_not_required
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: noncash_remuneration and retail_salesman_commission_service
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3402(j) retail commission noncash remuneration withholding output as PolicyEngine known-not-comparable
- add a coverage regression for the 3402(j) output
- bump version to 0.2.315 and add a changelog fragment

## Validation
- uv run ruff format tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 100