### PR TITLE
Repair generated auto output test mismatches

### DIFF
--- a/changelog.d/auto-output-test-mismatch-repair.fixed.md
+++ b/changelog.d/auto-output-test-mismatch-repair.fixed.md
@@ -1,0 +1,1 @@
+Repair mismatched expectations in deterministic `auto_output_*` companion tests during `encode --apply`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.315"
+version = "0.2.316"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.315"
+__version__ = "0.2.316"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -11236,6 +11236,39 @@ def cmd_encode(args):
                         repaired_output_cases
                     )
             if not can_apply:
+                repaired_output_cases = []
+                while not can_apply:
+                    repaired_test_cases = (
+                        _try_repair_generated_auto_output_test_mismatches_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            issues=apply_issues,
+                        )
+                    )
+                    if not repaired_test_cases:
+                        break
+                    repaired_output_cases.extend(repaired_test_cases)
+                    outcome["auto_repaired_auto_output_tests"] = repaired_output_cases
+                    print(
+                        "  apply=auto_repaired_auto_output_tests:"
+                        + ",".join(repaired_test_cases)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+                if repaired_output_cases:
+                    outcome["auto_repaired_auto_output_tests"] = repaired_output_cases
+            if not can_apply:
                 prior_repairs = outcome.get("auto_repaired_zero_branch_tests")
                 if not isinstance(prior_repairs, list):
                     prior_repairs = []
@@ -13892,6 +13925,34 @@ def _try_repair_generated_imported_output_test_mismatches_for_apply(
     )
 
 
+def _try_repair_generated_auto_output_test_mismatches_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+    issues: list[str],
+) -> list[str]:
+    """Update expectations for deterministic auto-generated output tests."""
+    if not issues:
+        return []
+
+    try:
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    test_file = _rulespec_test_path(rules_file)
+    return _repair_auto_output_test_mismatches(
+        test_file=test_file,
+        policy_repo_path=policy_repo_path,
+        relative_output=relative_output,
+        issues=issues,
+    )
+
+
 def _repair_imported_output_test_mismatches(
     *,
     test_file: Path,
@@ -13959,6 +14020,70 @@ def _repair_imported_output_test_mismatches(
     return repaired_cases
 
 
+def _repair_auto_output_test_mismatches(
+    *,
+    test_file: Path,
+    policy_repo_path: Path,
+    relative_output: Path,
+    issues: list[str],
+) -> list[str]:
+    if not test_file.exists():
+        return []
+
+    try:
+        test_payload = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, yaml.YAMLError):
+        return []
+    if not isinstance(test_payload, list):
+        return []
+
+    anchor = _relative_output_to_anchor(
+        relative_output, policy_repo_path=policy_repo_path
+    )
+    repairs_by_case: dict[str, dict[str, object]] = {}
+    for issue in issues:
+        parsed = _parse_generated_test_output_mismatch(str(issue))
+        if parsed is None:
+            continue
+        case_name, output_ref, actual_value = parsed
+        if not case_name.startswith("auto_output_"):
+            continue
+        if not _rulespec_ref_matches_base(output_ref, anchor):
+            continue
+        repairs_by_case.setdefault(case_name, {})[output_ref] = actual_value
+    if not repairs_by_case:
+        return []
+
+    repaired_cases: list[str] = []
+    for test_case in test_payload:
+        if not isinstance(test_case, dict):
+            continue
+        case_name = str(test_case.get("name") or "").strip()
+        replacements = repairs_by_case.get(case_name)
+        if not replacements:
+            continue
+        outputs = test_case.get("output")
+        if not isinstance(outputs, dict):
+            return []
+        changed = False
+        for output_ref, actual_value in replacements.items():
+            output_key = _matching_mapping_key_by_rulespec_ref(outputs, output_ref)
+            if output_key is None:
+                return []
+            if outputs[output_key] != actual_value:
+                outputs[output_key] = actual_value
+                changed = True
+        if changed:
+            repaired_cases.append(case_name)
+
+    if not repaired_cases:
+        return []
+    test_file.write_text(
+        yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
+    )
+    return repaired_cases
+
+
 def _parse_generated_test_output_mismatch(
     issue: str,
 ) -> tuple[str, str, object] | None:
@@ -13970,13 +14095,27 @@ def _parse_generated_test_output_mismatch(
         issue,
         flags=re.IGNORECASE,
     )
-    if not match:
-        return None
-    try:
-        value = _rulespec_mismatch_actual_value(match["kind"], match["value"])
-    except (InvalidOperation, ValueError):
-        return None
-    return match["case"].strip(), match["output"].strip(), value
+    if match:
+        try:
+            value = _rulespec_mismatch_actual_value(match["kind"], match["value"])
+        except (InvalidOperation, ValueError):
+            return None
+        return match["case"].strip(), match["output"].strip(), value
+
+    judgment_match = re.search(
+        r"Test case\s+`?(?P<case>[^\s`]+)`?\s+"
+        r"output\s+`?(?P<output>[^\s`]+)`?\s+"
+        r"expected\s+\w+,\s+got\s+(?P<value>holds|not_holds)\.?$",
+        issue,
+        flags=re.IGNORECASE,
+    )
+    if judgment_match:
+        return (
+            judgment_match["case"].strip(),
+            judgment_match["output"].strip(),
+            judgment_match["value"].strip().lower(),
+        )
+    return None
 
 
 def _rulespec_mismatch_actual_value(kind: str, raw_value: str) -> object:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5337,6 +5337,115 @@ rules:
             "us:statutes/26/3241/b#average_account_benefits_ratio_bracket": 1
         }
 
+    def test_encode_apply_auto_repairs_auto_output_test_mismatches(
+        self, capsys, tmp_path
+    ):
+        args = self._make_args(
+            tmp_path, backend="codex", citation="26 USC 3402(k)", sync=False
+        )
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path
+            / "out"
+            / "codex-test-model"
+            / "statutes"
+            / "26"
+            / "3402"
+            / "k.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: low_monthly_reported_tip_amount_threshold
+    kind: parameter
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 20
+  - name: monthly_reported_tips_below_low_tip_threshold
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: total_tips_in_employee_statements < low_monthly_reported_tip_amount_threshold
+"""
+        )
+        test_file = output_file.with_name("k.test.yaml")
+        test_file.write_text("[]\n")
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/26/3402/k.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "statutes/26/3402/k.yaml: ci: "
+                            "Derived rule missing companion output coverage: "
+                            "`us:statutes/26/3402/k#monthly_reported_tips_below_low_tip_threshold` "
+                            "is not asserted by the companion `.test.yaml` file."
+                        ],
+                        {},
+                    ),
+                    (
+                        False,
+                        [
+                            "statutes/26/3402/k.yaml: ci: "
+                            "Test case `auto_output_monthly_reported_tips_below_low_tip_threshold` "
+                            "output `us:statutes/26/3402/k#monthly_reported_tips_below_low_tip_threshold` "
+                            "expected not_holds, got holds."
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert (
+            "apply=auto_repaired_derived_output_tests:"
+            "auto_output_monthly_reported_tips_below_low_tip_threshold"
+        ) in output
+        assert (
+            "apply=auto_repaired_auto_output_tests:"
+            "auto_output_monthly_reported_tips_below_low_tip_threshold"
+        ) in output
+        assert mock_overlay.call_count == 3
+        mock_apply.assert_called_once()
+        test_payload = yaml.safe_load(test_file.read_text())
+        assert test_payload[0]["output"] == {
+            "us:statutes/26/3402/k#monthly_reported_tips_below_low_tip_threshold": "holds"
+        }
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_derived_output_tests"] == [
+            "auto_output_monthly_reported_tips_below_low_tip_threshold"
+        ]
+        assert run.outcome["auto_repaired_auto_output_tests"] == [
+            "auto_output_monthly_reported_tips_below_low_tip_threshold"
+        ]
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_removes_local_import_output_input_placeholders(
         self, capsys, tmp_path
     ):


### PR DESCRIPTION
## Summary
- repair deterministic generated `auto_output_*` companion tests when validation reports their expected output differs from the actual result
- parse judgment output mismatches like `expected not_holds, got holds`
- add regression coverage for the 26 USC 3402(k) apply blocker

## Validation
- `uv run ruff format src/axiom_encode/cli.py tests/test_cli.py pyproject.toml src/axiom_encode/__init__.py`
- `uv run ruff check src/axiom_encode/cli.py tests/test_cli.py pyproject.toml src/axiom_encode/__init__.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py -q -k 'auto_output_test_mismatches or missing_derived_output_coverage or imported_output_test_mismatches'`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py -q`