### PR TITLE
Classify section 3402(k) withholding outputs

### DIFF
--- a/changelog.d/section-3402-k-policyengine-coverage.fixed.md
+++ b/changelog.d/section-3402-k-policyengine-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify section 3402(k) tip-withholding outputs as known not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.316"
+version = "0.2.317"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.316"
+__version__ = "0.2.317"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10194,6 +10194,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3402(j) removes chapter 24 withholding requirements for certain noncash retail-salesman commission remuneration when the employer files prescribed information; PolicyEngine does not expose this paycheck withholding exemption predicate as a one-to-one output.
 
+  - legal_id_prefix: us:statutes/26/3402/k#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(k) applies chapter 24 withholding mechanics to tips, limits deduction and withholding to employer-controlled wages and employee-turned-over funds after section 3102(a) or 3202(a) collections, and allows special low-monthly-tip withholding for section 3401(a)(16)(B) tips; PolicyEngine does not expose paycheck tip-withholding administration surfaces as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3072,6 +3072,41 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402k_tip_withholding_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/k.yaml",
+        """format: rulespec/v1
+rules:
+  - name: monthly_tip_statement_threshold_for_paragraph_16_b_permission
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 20
+  - name: tips_withholding_under_subsection_a_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: tips_constitute_wages
+  - name: maximum_tip_tax_deduction_and_withholding_amount
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: max(0, employer_controlled_wages - section_3102_or_3202_tax)
+  - name: low_monthly_tip_statement_withholding_permitted_for_paragraph_16_b_tips
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: monthly_tips < monthly_tip_statement_threshold_for_paragraph_16_b_permission
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 4}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- classify 26 USC 3402(k) tip-withholding administration outputs as known not comparable to PolicyEngine
- add regression coverage for generated 3402(k) outputs
- bump axiom-encode to 0.2.317

## Validation
- `uv run ruff format tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- `uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q -k '3402k or 3402j or 3402h or 3402i'`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 100`