### PR TITLE
Classify section 3102(a) collection outputs

### DIFF
--- a/changelog.d/section-3102-a-policyengine-coverage.fixed.md
+++ b/changelog.d/section-3102-a-policyengine-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify section 3102(a) payroll-tax collection outputs as known not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.317"
+version = "0.2.318"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.317"
+__version__ = "0.2.318"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9826,6 +9826,14 @@ mappings:
     rationale: Same statutory percentage of adjusted gross income that floors deductible medical-care expenses.
 
 prefixes:
+  - legal_id_prefix: us:statutes/26/3102/a#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employee_payroll_tax
+    candidate_priority: P4
+    rationale: Section 3102(a) governs employer collection of section 3101 tax by wage deduction and special collection permissions for small cash remuneration and tips; PolicyEngine exposes final employee payroll tax amounts, not these collection-administration predicates and thresholds as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3111/e#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -202,6 +202,43 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3102a_collection_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3102/a.yaml",
+        """format: rulespec/v1
+rules:
+  - name: paragraph_7C_or_10_cash_remuneration_deduction_threshold
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 100
+  - name: paragraph_8B_cash_remuneration_deduction_threshold
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 150
+  - name: employer_required_to_collect_section_3101_tax_by_wage_deduction
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: employer_is_employer_of_taxpayer and wages_are_paid
+  - name: paragraph_7B_cash_remuneration_tax_deduction_permitted_when_below_applicable_threshold
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: cash_remuneration < applicable_dollar_threshold
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 4}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {
+        "employee_payroll_tax"
+    }
+
+
 def test_policyengine_coverage_maps_3306_b_1_futa_wage_base(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3306/b/1.yaml",


### PR DESCRIPTION
## Summary
- classify 26 USC 3102(a) employee payroll-tax collection outputs as known not comparable to PolicyEngine
- add regression coverage for generated 3102(a) outputs
- bump axiom-encode to 0.2.318

## Validation
- `uv run ruff format tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- `uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q -k '3102a or tax_parameter_outputs'`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 100`