### PR TITLE
Classify section 3102 collection outputs

### DIFF
--- a/changelog.d/section-3102-collection-coverage.fixed.md
+++ b/changelog.d/section-3102-collection-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify remaining section 3102 payroll-tax collection administration outputs as known not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.318"
+version = "0.2.319"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.318"
+__version__ = "0.2.319"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9834,6 +9834,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3102(a) governs employer collection of section 3101 tax by wage deduction and special collection permissions for small cash remuneration and tips; PolicyEngine exposes final employee payroll tax amounts, not these collection-administration predicates and thresholds as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3102/
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employee_payroll_tax
+    candidate_priority: P4
+    rationale: Section 3102 subsections after subsection (a) govern employer liability, indemnification, tip-tax collection, and reporting administration for section 3101 tax; PolicyEngine exposes final employee payroll tax amounts, not these collection and employer-liability administration surfaces as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3111/e#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -239,6 +239,35 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3102b_collection_liability_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3102/b.yaml",
+        """format: rulespec/v1
+rules:
+  - name: employer_liable_for_payment_of_deducted_tax
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: tax_deducted_under_section_3102
+  - name: employer_indemnified_against_claims_for_deducted_tax_payment
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: employer_paid_tax_deducted_under_section_3102
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {
+        "employee_payroll_tax"
+    }
+
+
 def test_policyengine_coverage_maps_3306_b_1_futa_wage_base(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3306/b/1.yaml",


### PR DESCRIPTION
## Summary
- classify remaining 26 USC 3102 collection-administration outputs as known not comparable to PolicyEngine
- keep the specific 3102(a) mapping while covering later 3102 subsections
- add regression coverage for generated 3102(b) outputs
- bump axiom-encode to 0.2.319

## Validation
- `uv run ruff format tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- `uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q -k '3102a or 3102b or tax_parameter_outputs'`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 100`