### PR TITLE
Repair missing positive judgment tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.319"
+version = "0.2.320"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.319"
+__version__ = "0.2.320"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -9218,6 +9218,143 @@ def _append_generated_derived_output_tests_if_missing(
     return repaired
 
 
+def _append_generated_judgment_positive_tests_if_missing(
+    *,
+    test_file: Path,
+    repo_path: Path,
+    axiom_rules_path: Path,
+    relative_output: Path,
+    issues: list[str],
+    test_failure_checker=None,
+) -> list[str]:
+    """Clone existing scenarios into positive Judgment companion tests."""
+    if not issues or not test_file.exists():
+        return []
+    output_targets = _judgment_positive_output_targets_from_issues(issues)
+    if not output_targets:
+        return []
+
+    try:
+        test_payload = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    if not isinstance(test_payload, list):
+        return []
+
+    target_base = (
+        f"{_repo_jurisdiction_prefix(repo_path)}:"
+        f"{_relative_rulespec_import_target(relative_output)}"
+    )
+    existing_case_names = {
+        str(test_case.get("name") or "").strip()
+        for test_case in test_payload
+        if isinstance(test_case, dict)
+    }
+    repaired: list[str] = []
+    for target in output_targets:
+        rule_name = target.rsplit("#", 1)[-1]
+        if _test_payload_has_rule_output_value(
+            test_payload, rule_name=rule_name, normalized_value="holds"
+        ):
+            continue
+        case_name = _unique_generated_test_name(
+            f"auto_positive_{_safe_test_name(rule_name)}",
+            existing_case_names,
+        )
+        candidate_payload: list[object] | None = None
+        for test_case in test_payload:
+            if not isinstance(test_case, dict):
+                continue
+            outputs = test_case.get("output")
+            if not isinstance(outputs, dict):
+                continue
+            if _case_asserts_rule_value(
+                outputs, rule_name=rule_name, normalized_value="not_holds"
+            ):
+                continue
+            companion = copy.deepcopy(test_case)
+            companion["name"] = case_name
+            companion["output"] = {f"{target_base}#{rule_name}": "holds"}
+            trial_payload = list(test_payload)
+            trial_payload.append(companion)
+            if test_failure_checker is not None:
+                test_file.write_text(
+                    yaml.safe_dump(trial_payload, sort_keys=False, allow_unicode=False)
+                )
+                failures = test_failure_checker(
+                    test_file,
+                    root=repo_path,
+                    axiom_rules_path=axiom_rules_path,
+                )
+                if failures:
+                    continue
+            candidate_payload = trial_payload
+            break
+
+        if candidate_payload is None:
+            test_file.write_text(
+                yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
+            )
+            continue
+        test_payload = candidate_payload
+        existing_case_names.add(case_name)
+        repaired.append(case_name)
+
+    if not repaired:
+        return []
+    test_file.write_text(
+        yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
+    )
+    return repaired
+
+
+def _judgment_positive_output_targets_from_issues(issues: list[str]) -> list[str]:
+    targets: list[str] = []
+    seen: set[str] = set()
+    for issue in issues:
+        match = re.search(
+            r"Judgment rule missing positive companion output coverage:"
+            r"\s*`(?P<target>[^`]+)`",
+            str(issue),
+        )
+        if not match:
+            continue
+        target = match["target"].strip()
+        if not target or target in seen:
+            continue
+        seen.add(target)
+        targets.append(target)
+    return targets
+
+
+def _test_payload_has_rule_output_value(
+    test_payload: list[object],
+    *,
+    rule_name: str,
+    normalized_value: str,
+) -> bool:
+    for test_case in test_payload:
+        if not isinstance(test_case, dict):
+            continue
+        outputs = test_case.get("output")
+        if not isinstance(outputs, dict):
+            continue
+        if _case_asserts_rule_value(
+            outputs, rule_name=rule_name, normalized_value=normalized_value
+        ):
+            return True
+    return False
+
+
+def _unique_generated_test_name(base_name: str, existing_case_names: set[str]) -> str:
+    if base_name not in existing_case_names:
+        return base_name
+    index = 2
+    while f"{base_name}_{index}" in existing_case_names:
+        index += 1
+    return f"{base_name}_{index}"
+
+
 def _missing_derived_output_targets_from_issues(issues: list[str]) -> list[str]:
     targets: list[str] = []
     seen: set[str] = set()
@@ -11093,6 +11230,44 @@ def cmd_encode(args):
                 if repaired_derived_cases:
                     outcome["auto_repaired_derived_output_tests"] = (
                         repaired_derived_cases
+                    )
+            if not can_apply:
+                repaired_positive_cases: list[str] = []
+                while not can_apply:
+                    repaired_test_cases = (
+                        _try_repair_generated_judgment_positive_tests_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            issues=apply_issues,
+                        )
+                    )
+                    if not repaired_test_cases:
+                        break
+                    repaired_positive_cases.extend(repaired_test_cases)
+                    outcome["auto_repaired_judgment_positive_tests"] = (
+                        repaired_positive_cases
+                    )
+                    print(
+                        "  apply=auto_repaired_judgment_positive_tests:"
+                        + ",".join(repaired_test_cases)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+                if repaired_positive_cases:
+                    outcome["auto_repaired_judgment_positive_tests"] = (
+                        repaired_positive_cases
                     )
             if not can_apply:
                 repaired_input_refs: list[str] = []
@@ -13294,6 +13469,45 @@ def _only_pending_missing_derived_output_coverage_issues(
 ) -> bool:
     return bool(issues) and all(
         "Derived rule missing companion output coverage:" in str(issue)
+        for issue in issues
+    )
+
+
+def _try_repair_generated_judgment_positive_tests_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+    axiom_rules_path: Path,
+    issues: list[str],
+) -> list[str]:
+    """Append deterministic positive companion tests for Judgment outputs."""
+    if not _only_pending_judgment_positive_output_coverage_issues(issues):
+        return []
+
+    try:
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    test_file = _rulespec_test_path(rules_file)
+    return _append_generated_judgment_positive_tests_if_missing(
+        test_file=test_file,
+        repo_path=policy_repo_path,
+        axiom_rules_path=axiom_rules_path,
+        relative_output=relative_output,
+        issues=issues,
+    )
+
+
+def _only_pending_judgment_positive_output_coverage_issues(
+    issues: list[str],
+) -> bool:
+    return bool(issues) and all(
+        "Judgment rule missing positive companion output coverage:" in str(issue)
         for issue in issues
     )
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -4418,6 +4418,72 @@ def find_missing_derived_companion_output_issues(
     return issues
 
 
+def find_judgment_positive_companion_output_issues(
+    content: str,
+    cases: list[Any],
+    *,
+    rules_file: Path,
+    policy_repo_path: Path | None = None,
+) -> list[str]:
+    """Require local Judgment outputs to have at least one positive case."""
+    try:
+        payload = yaml.safe_load(content)
+    except (yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict) or payload.get("format") != "rulespec/v1":
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    positive_outputs: set[str] = set()
+    positive_fragments: set[str] = set()
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        outputs = case.get("output")
+        if not isinstance(outputs, dict):
+            continue
+        for key, value in outputs.items():
+            if not _is_positive_judgment_value(value):
+                continue
+            key_text = str(key).strip()
+            positive_outputs.add(key_text)
+            positive_fragments.add(_test_reference_fragment(key_text))
+
+    issues: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict) or rule.get("kind") != "derived":
+            continue
+        if str(rule.get("dtype") or "").strip().lower() != "judgment":
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list) or not any(
+            isinstance(version, dict)
+            and isinstance(version.get("formula"), str)
+            and version["formula"].strip()
+            for version in versions
+        ):
+            continue
+        name = _rulespec_rule_name(rule)
+        target = _canonical_rulespec_file_target(
+            policy_repo_path=policy_repo_path,
+            rules_file=rules_file,
+            symbol=name,
+        )
+        if target is None:
+            continue
+        if target in positive_outputs or name in positive_fragments:
+            continue
+        issues.append(
+            "Judgment rule missing positive companion output coverage: "
+            f"`{target}` is not asserted as `holds` by the companion "
+            "`.test.yaml` file."
+        )
+
+    return issues
+
+
 def _rulespec_executable_signature(rule: dict[str, Any]) -> str | None:
     versions = rule.get("versions")
     if not isinstance(versions, list):
@@ -15292,6 +15358,14 @@ class ValidatorPipeline:
                     if strict_layout_checks:
                         issues.extend(
                             find_missing_derived_companion_output_issues(
+                                content,
+                                payload,
+                                rules_file=rules_file,
+                                policy_repo_path=self.policy_repo_path,
+                            )
+                        )
+                        issues.extend(
+                            find_judgment_positive_companion_output_issues(
                                 content,
                                 payload,
                                 rules_file=rules_file,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ from axiom_encode.cli import (
     APPLIED_ENCODING_MANIFEST_SCHEMA,
     APPLIED_ENCODING_SIGNING_KEY_ENV,
     _append_generated_derived_output_tests_if_missing,
+    _append_generated_judgment_positive_tests_if_missing,
     _apply_generated_encoding_result,
     _complete_missing_dependent_test_inputs,
     _complete_missing_imported_test_inputs,
@@ -5336,6 +5337,49 @@ rules:
         assert test_payload[0]["output"] == {
             "us:statutes/26/3241/b#average_account_benefits_ratio_bracket": 1
         }
+
+    def test_judgment_positive_test_repair_clones_existing_scenario(self, tmp_path):
+        repo_path = tmp_path / "rulespec-us"
+        test_file = repo_path / "statutes" / "26" / "3102" / "f" / "1.test.yaml"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text(
+            """- name: above_threshold_parameter_only
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  tables:
+    Payment:
+    - us:statutes/26/3102/f/1#input.tax_is_imposed_by_section_3101_b_2: true
+      us:statutes/26/3102/f/1#input.taxpayer_wages_received_from_employer: 250000
+  output:
+    us:statutes/26/3102/f/1#additional_medicare_employer_wage_collection_threshold: 200000
+"""
+        )
+
+        repaired = _append_generated_judgment_positive_tests_if_missing(
+            test_file=test_file,
+            repo_path=repo_path,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            relative_output=Path("statutes/26/3102/f/1.yaml"),
+            issues=[
+                "Judgment rule missing positive companion output coverage: "
+                "`us:statutes/26/3102/f/1#subsection_a_applies_to_additional_medicare_tax_wages_above_employer_threshold` "
+                "is not asserted as `holds` by the companion `.test.yaml` file."
+            ],
+        )
+
+        assert repaired == [
+            "auto_positive_subsection_a_applies_to_additional_medicare_tax_wages_above_employer_threshold"
+        ]
+        test_payload = yaml.safe_load(test_file.read_text())
+        assert test_payload[0]["name"] == "above_threshold_parameter_only"
+        assert test_payload[1]["name"] == repaired[0]
+        assert test_payload[1]["output"] == {
+            "us:statutes/26/3102/f/1#subsection_a_applies_to_additional_medicare_tax_wages_above_employer_threshold": "holds"
+        }
+        assert test_payload[1]["tables"] == test_payload[0]["tables"]
 
     def test_encode_apply_auto_repairs_auto_output_test_mismatches(
         self, capsys, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -46,6 +46,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_helper_only_definition_issues,
     find_import_shape_issues,
     find_judgment_conditional_formula_issues,
+    find_judgment_positive_companion_output_issues,
     find_missing_child_exception_import_issues,
     find_missing_derived_companion_output_issues,
     find_missing_same_section_subsection_import_issues,
@@ -556,6 +557,89 @@ rules:
         "`us:statutes/26/63/f#blind_under_subsection_f` "
         "is not asserted by the companion `.test.yaml` file."
     ]
+
+
+def test_judgment_positive_companion_output_rejects_never_holds(tmp_path):
+    policy_repo = tmp_path / "rulespec-us"
+    rules_file = policy_repo / "statutes" / "26" / "3102" / "f" / "1.yaml"
+    rules_file.parent.mkdir(parents=True)
+    content = """format: rulespec/v1
+rules:
+  - name: subsection_a_applies_to_additional_medicare_tax_wages_above_employer_threshold
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(f)(1)
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          tax_is_imposed_by_section_3101_b_2
+          and wages_from_employer_in_excess_of_additional_medicare_collection_threshold > 0
+"""
+    cases = [
+        {
+            "name": "below_threshold",
+            "period": "2026",
+            "input": {},
+            "output": {
+                "us:statutes/26/3102/f/1#subsection_a_applies_to_additional_medicare_tax_wages_above_employer_threshold": "not_holds"
+            },
+        }
+    ]
+
+    issues = find_judgment_positive_companion_output_issues(
+        content,
+        cases,
+        rules_file=rules_file,
+        policy_repo_path=policy_repo,
+    )
+
+    assert issues == [
+        "Judgment rule missing positive companion output coverage: "
+        "`us:statutes/26/3102/f/1#subsection_a_applies_to_additional_medicare_tax_wages_above_employer_threshold` "
+        "is not asserted as `holds` by the companion `.test.yaml` file."
+    ]
+
+
+def test_judgment_positive_companion_output_allows_holds_case(tmp_path):
+    policy_repo = tmp_path / "rulespec-us"
+    rules_file = policy_repo / "statutes" / "26" / "3102" / "f" / "1.yaml"
+    rules_file.parent.mkdir(parents=True)
+    content = """format: rulespec/v1
+rules:
+  - name: additional_medicare_collection_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3102(f)(1)
+    versions:
+      - effective_from: '2013-01-01'
+        formula: wages_above_threshold > 0
+"""
+    cases = [
+        {
+            "name": "above_threshold",
+            "period": "2026",
+            "input": {},
+            "output": {
+                "us:statutes/26/3102/f/1#additional_medicare_collection_applies": [
+                    "holds"
+                ]
+            },
+        }
+    ]
+
+    assert (
+        find_judgment_positive_companion_output_issues(
+            content,
+            cases,
+            rules_file=rules_file,
+            policy_repo_path=policy_repo,
+        )
+        == []
+    )
 
 
 def test_test_input_assignment_scopes_inputs_to_asserted_outputs():


### PR DESCRIPTION
## Summary
- add strict validation requiring local derived Judgment rules to have a positive `holds` companion test
- add deterministic apply repair that clones an existing generated scenario into an `auto_positive_*` companion test
- bump axiom-encode to 0.2.320

## Tests
- `uv run ruff format pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/cli.py tests/test_rulespec_validation.py tests/test_cli.py`
- `uv run ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/cli.py tests/test_rulespec_validation.py tests/test_cli.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py -q`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_rulespec_validation.py -q`
