### PR TITLE
Avoid employer scope for employee-paid tax residuals

### DIFF
--- a/changelog.d/employer-scope-employee-payment.fixed.md
+++ b/changelog.d/employer-scope-employee-payment.fixed.md
@@ -1,0 +1,1 @@
+Avoid rewriting employee-paid tax responsibilities to `Employer` scope merely because the tax was not collected by the employer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.320"
+version = "0.2.321"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.320"
+__version__ = "0.2.321"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -5052,7 +5052,12 @@ _UNIT_SOURCE_ENTITY_PATTERNS = (
 )
 _EMPLOYER_SCOPED_ENTITY_NAMES = {"business", "corporation", "taxunit"}
 _EMPLOYER_SCOPED_SOURCE_PATTERN = re.compile(
-    r"\b(?:each|every|any|an?|the)\s+employer\b"
+    r"\b(?:each|every|any|an?)\s+employer\b"
+    r"|"
+    r"\bthe\s+employer\s+(?:shall|must|is|are|pays?|collects?|withholds?|"
+    r"deducts?|responsible|liable|required)\b"
+    r"|"
+    r"\bimposed\s+on\s+(?:each|every|any|an?|the)\s+employer\b"
     r"|"
     r"\bwith\s+respect\s+to\s+(?:having\s+individuals\s+in\s+his\s+employ|"
     r"any\s+employer|an?\s+employer)\b",

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -10947,6 +10947,36 @@ rules:
     assert "TaxUnit" in issues[0]
 
 
+def test_employer_scoped_entity_ignores_employee_paid_tax_not_collected_by_employer():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    (2) Collection of amounts not withheld To the extent that the amount of any
+    tax imposed by section 3101(b)(2) is not collected by the employer, such tax
+    shall be paid by the employee.
+rules:
+  - name: employee_payment_responsibility_for_uncollected_additional_medicare_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3102(f)(2)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              excerpt: tax imposed by section 3101(b)(2) is not collected by the employer
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(0, additional_medicare_tax - additional_medicare_tax_collected_by_employer)
+"""
+
+    assert find_employer_scoped_entity_issues(content) == []
+
+
 def test_employer_scoped_entity_accepts_employer():
     content = """format: rulespec/v1
 module:


### PR DESCRIPTION
## Summary
- narrow employer-scope validation so employee-paid tax residuals are not rewritten to `Employer` merely because the employer failed to collect the tax
- add a regression test for 26 USC 3102(f)(2)-style language
- bump axiom-encode to 0.2.321

## Tests
- `uv run ruff format pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `uv run ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_rulespec_validation.py -q -k employer_scoped_entity`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_rulespec_validation.py -q`
