### PR TITLE
Classify 3121(a)(5) payroll exclusions for PE oracle

### DIFF
--- a/changelog.d/section-3121-a-5-oracle.fixed.md
+++ b/changelog.d/section-3121-a-5-oracle.fixed.md
@@ -1,0 +1,1 @@
+Classify section 3121(a)(5) FICA wage-exclusion fragments as known-not-comparable in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.321"
+version = "0.2.322"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.321"
+__version__ = "0.2.322"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10146,6 +10146,18 @@ prefixes:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose section 3121(a)(4) post-work sickness, disability, or medical payment wage-exclusion predicates and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
 
+  - legal_id_prefix: us:statutes/26/3121/a/5#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(5) retirement-plan, annuity-plan, cafeteria-plan, SEP, SIMPLE, or governmental deferred-compensation wage-exclusion predicates and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
+  - legal_id_prefix: us:statutes/26/3121/a/5/
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 3121(a)(5) retirement-plan, annuity-plan, cafeteria-plan, SEP, SIMPLE, or governmental deferred-compensation wage-exclusion subpart predicates and amounts as one-to-one variables. These legal intermediates are inputs to FICA wage construction before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/a/6#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4661,6 +4661,35 @@ rules:
     assert item["status"] == "known_not_comparable"
 
 
+def test_policyengine_coverage_classifies_3121_a_5_subparts(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3121/a/5/D.yaml",
+        """format: rulespec/v1
+rules:
+  - name: section_403_b_annuity_contract_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |
+          if section_403_b_annuity_contract_payment_exclusion_applies: payment_amount else: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us:statutes/26/3121/a/5/D#section_403_b_annuity_contract_payment_excluded_from_wages"
+    )
+    assert item["status"] == "known_not_comparable"
+
+
 def test_policyengine_coverage_classifies_3121_a_12_tip_threshold_parameter(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3121/a/12.yaml",


### PR DESCRIPTION
## Summary
- classify 26 USC 3121(a)(5) parent and subpart outputs as known-not-comparable in PolicyEngine tax oracle coverage
- add a regression for generated 3121(a)(5)(D) wage-exclusion subpart outputs
- bump axiom-encode to 0.2.322 and add changelog entry

## Validation
- uv run ruff format pyproject.toml src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run ruff check pyproject.toml src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q -k 3121_a_5
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable

Oracle coverage after the classification: executable outputs 1293; comparable 227; known_not_comparable 1066; untested comparable outputs 0.