### PR TITLE
Classify 408(p) SIMPLE outputs for PE oracle

### DIFF
--- a/changelog.d/section-408-p-oracle.fixed.md
+++ b/changelog.d/section-408-p-oracle.fixed.md
@@ -1,0 +1,1 @@
+Classify section 408(p) SIMPLE retirement account intermediates as known-not-comparable in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.322"
+version = "0.2.323"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.322"
+__version__ = "0.2.323"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10134,6 +10134,18 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 224 qualified-tips deduction outputs are new statutory caps, phaseouts, eligibility predicates, and formula intermediates that PolicyEngine does not yet expose as one-to-one variables.
 
+  - legal_id_prefix: us:statutes/26/408/p#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 408(p) SIMPLE retirement account eligibility, election, contribution, or plan-definition intermediates as one-to-one payroll tax variables. These legal intermediates feed section 3121(a)(5) FICA wage construction before downstream payroll-tax comparisons.
+
+  - legal_id_prefix: us:statutes/26/408/p/
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose section 408(p) SIMPLE retirement account subpart eligibility, election, contribution, or plan-definition intermediates as one-to-one payroll tax variables. These legal intermediates feed section 3121(a)(5) FICA wage construction before downstream payroll-tax comparisons.
+
   - legal_id_prefix: us:statutes/26/3121/a/2#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4690,6 +4690,33 @@ rules:
     assert item["status"] == "known_not_comparable"
 
 
+def test_policyengine_coverage_classifies_408_p_subparts(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/408/p/2/A/i.yaml",
+        """format: rulespec/v1
+rules:
+  - name: employee_election_to_have_employer_make_payments_available
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: employee_eligible_to_participate_in_arrangement
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us:statutes/26/408/p/2/A/i#employee_election_to_have_employer_make_payments_available"
+    )
+    assert item["status"] == "known_not_comparable"
+
+
 def test_policyengine_coverage_classifies_3121_a_12_tip_threshold_parameter(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3121/a/12.yaml",


### PR DESCRIPTION
## Summary
- classify 26 USC 408(p) SIMPLE retirement account outputs as known-not-comparable in PolicyEngine tax oracle coverage
- add a regression for generated 408(p)(2)(A)(i) election outputs
- bump axiom-encode to 0.2.323 and add changelog entry

## Validation
- uv run ruff format pyproject.toml src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run ruff check pyproject.toml src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q -k 408_p
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-night-20260526190810 --oracle policyengine --program tax --fail-on-untested-comparable

Oracle coverage after the classification: executable outputs 1297; comparable 227; known_not_comparable 1070; untested comparable outputs 0.