### PR TITLE
Compose terminal child outputs in parent encodings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.323"
+version = "0.2.324"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.323"
+__version__ = "0.2.324"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3034,6 +3034,10 @@ import or re-export that exact canonical concept instead of duplicating it local
                 target_ref_prefix=target_ref_prefix,
             )
         )
+        parent_child_terminal_section = _format_parent_child_terminal_output_guidance(
+            context_files,
+            target_ref_prefix=target_ref_prefix,
+        )
         child_exception_import_section = _format_child_exception_import_guidance(
             source_text,
             context_files,
@@ -3072,6 +3076,7 @@ Context files are precedent and dependency context, not independent legal author
 {excluded_child_context_section}
 {unavailable_cited_context_section}
 {partial_extent_child_schema_section}
+{parent_child_terminal_section}
 {child_exception_import_section}
 {cycle_prone_context_import_section}
 Import and context rules:
@@ -4401,6 +4406,83 @@ Target-specific schema limit:
   `rules: []` and an empty companion test file. Do not create a
   `*_before_exemption` executable output or an adjusted local wage/base helper
   for this parent.
+"""
+
+
+def _format_parent_child_terminal_output_guidance(
+    context_files: list[EvalContextFile],
+    *,
+    target_ref_prefix: str | None,
+) -> str:
+    """Return concrete child-output imports for aggregate parent encodings."""
+    if not target_ref_prefix:
+        return ""
+    child_prefix = f"{target_ref_prefix.rstrip('/')}/"
+    lines: list[str] = []
+    local_inputs: set[str] = set()
+    for item in context_files:
+        if item.kind.endswith("_test_context"):
+            continue
+        if not item.import_path.startswith(child_prefix):
+            continue
+        terminal_exports = _context_file_terminal_exports(item.source_path)
+        if not terminal_exports:
+            continue
+        surfaces = _context_file_executable_surfaces(item.source_path)
+        export_details: list[str] = []
+        for name in terminal_exports:
+            surface = surfaces.get(name) or {}
+            dtype = str(surface.get("dtype") or "").strip()
+            kind = str(surface.get("kind") or "").strip()
+            entity = str(surface.get("entity") or "").strip()
+            annotations = ", ".join(part for part in (kind, dtype, entity) if part)
+            suffix = f" ({annotations})" if annotations else ""
+            export_details.append(f"`{item.import_path}#{name}`{suffix}")
+        inputs = sorted(_context_file_local_inputs(item.source_path))
+        local_inputs.update(inputs)
+        input_note = ""
+        if inputs:
+            visible_inputs = ", ".join(f"`{name}`" for name in inputs[:8])
+            if len(inputs) > 8:
+                visible_inputs += ", ..."
+            input_note = f"; child-local inputs: {visible_inputs}"
+        lines.append(
+            f"- `{item.import_path}` terminal exports: "
+            + ", ".join(export_details)
+            + input_note
+        )
+    if not lines:
+        return ""
+
+    input_guidance = ""
+    if local_inputs:
+        visible_inputs = ", ".join(f"`{name}`" for name in sorted(local_inputs)[:12])
+        if len(local_inputs) > 12:
+            visible_inputs += ", ..."
+        input_guidance = (
+            "\n- These child-local input names are already owned by child files: "
+            f"{visible_inputs}. Do not recreate a child branch by copying those "
+            "inputs into the parent when a terminal child output above is "
+            "available."
+        )
+
+    return f"""
+Aggregate parent child outputs detected:
+{chr(10).join(lines)}
+- For this aggregate parent, start from the terminal child outputs above.
+  Import each terminal child output needed by the parent and compose those
+  imported bare names directly. For numeric parent outputs, prefer terminal
+  `Money`, `Rate`, or `Count` child outputs over child predicates, rates, or raw
+  factual inputs.
+- Do not rebuild a child branch in the parent from the child's local facts,
+  helper predicates, or numeric literals. If a copied child already exports a
+  terminal numeric result, the parent formula should add, cap, select, subtract,
+  or otherwise compose that imported result.
+- If a copied child only exports a terminal `Judgment` and the source requires a
+  numeric parent amount for that branch, you may use a source-stated local
+  amount fact for that judgment-only branch, but still import all available
+  terminal numeric outputs for sibling child branches instead of recomputing
+  them locally.{input_guidance}
 """
 
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -10460,9 +10460,10 @@ def find_missing_same_section_subsection_import_issues(
     if statute_path is None:
         return []
     title, section, current_fragments = statute_path
+    import_items = _extract_import_items_from_content(content)
     imports = {
         _normalize_rulespec_import_path_static(import_path)
-        for import_path in _extract_import_paths_from_content(content)
+        for import_path in import_items
     }
 
     issues: list[str] = []
@@ -10995,9 +10996,10 @@ def find_child_fragment_reencoding_issues(
     except ValueError:
         return []
 
+    import_items = _extract_import_items_from_content(content)
     imports = {
         _normalize_rulespec_import_path_static(import_path)
-        for import_path in _extract_import_paths_from_content(content)
+        for import_path in import_items
     }
     parent_inputs = _rulespec_local_input_slots(
         payload,
@@ -11051,8 +11053,20 @@ def find_child_fragment_reencoding_issues(
         if parent_inputs:
             shared_inputs = sorted(parent_inputs & child_inputs)
             if shared_inputs:
+                terminal_child_names = _rulespec_terminal_executable_names_from_payload(
+                    child_payload
+                )
+                child_imports_terminal_output = (
+                    _imports_include_child_terminal_output_static(
+                        import_items,
+                        child_import_base=child_import_base,
+                        terminal_names=terminal_child_names,
+                    )
+                )
+                if child_imports_terminal_output:
+                    continue
                 child_exports = _rulespec_child_export_targets(
-                    _rulespec_terminal_executable_names_from_payload(child_payload),
+                    terminal_child_names,
                     child_import_base=child_import_base,
                     policy_repo_path=policy_repo_path,
                 )
@@ -11355,9 +11369,9 @@ def _statute_path_parts_for_file(
     return title, section, tuple(fragments)
 
 
-def _extract_import_paths_from_content(content: str) -> list[str]:
-    """Extract import file references from an imports block."""
-    paths: list[str] = []
+def _extract_import_items_from_content(content: str) -> list[str]:
+    """Extract raw import references from an imports block."""
+    items: list[str] = []
     in_imports = False
     imports_indent = 0
 
@@ -11390,6 +11404,17 @@ def _extract_import_paths_from_content(content: str) -> list[str]:
             if not mapping_match:
                 continue
             item = mapping_match.group(2).strip()
+        item = item.strip().strip("\"'")
+        if item:
+            items.append(item)
+
+    return items
+
+
+def _extract_import_paths_from_content(content: str) -> list[str]:
+    """Extract import file references from an imports block."""
+    paths: list[str] = []
+    for item in _extract_import_items_from_content(content):
         import_target = item.split("#", 1)[0].strip()
         if import_target:
             paths.append(import_target)
@@ -11418,16 +11443,46 @@ def _rulespec_import_path_aliases_static(import_path: str) -> set[str]:
 
 
 def _imports_cover_path_static(imports: set[str], expected_path: str) -> bool:
-    expected_aliases = _rulespec_import_path_aliases_static(expected_path)
     for import_path in imports:
-        for import_alias in _rulespec_import_path_aliases_static(import_path):
-            for expected in expected_aliases:
-                if import_alias == expected:
-                    return True
-                if import_alias.startswith(expected + "/"):
-                    return True
-                if expected.startswith(import_alias + "/"):
-                    return True
+        if _rulespec_import_path_matches_static(import_path, expected_path):
+            return True
+    return False
+
+
+def _rulespec_import_path_matches_static(
+    import_path: str,
+    expected_path: str,
+) -> bool:
+    expected_aliases = _rulespec_import_path_aliases_static(expected_path)
+    for import_alias in _rulespec_import_path_aliases_static(import_path):
+        for expected in expected_aliases:
+            if import_alias == expected:
+                return True
+            if import_alias.startswith(expected + "/"):
+                return True
+            if expected.startswith(import_alias + "/"):
+                return True
+    return False
+
+
+def _imports_include_child_terminal_output_static(
+    import_items: list[str],
+    *,
+    child_import_base: str,
+    terminal_names: list[str],
+) -> bool:
+    """Return true when imports include at least one terminal export from a child."""
+    terminal_set = {name for name in terminal_names if name}
+    if not terminal_set:
+        return False
+    for item in import_items:
+        import_base, separator, symbol = item.partition("#")
+        if not _rulespec_import_path_matches_static(import_base, child_import_base):
+            continue
+        if not separator:
+            return True
+        if symbol.strip() in terminal_set:
+            return True
     return False
 
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -5409,6 +5409,12 @@ rules:
             "terminal exports `us:statutes/26/3101/b/2#additional_medicare_tax`"
             in prompt
         )
+        assert "Aggregate parent child outputs detected" in prompt
+        assert (
+            "`us:statutes/26/3101/b/2#additional_medicare_tax`"
+            " (derived, Money, TaxUnit)" in prompt
+        )
+        assert "Do not rebuild a child branch in the parent" in prompt
 
     def test_build_eval_prompt_requires_child_exception_imports_for_parent_list(
         self, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5921,6 +5921,62 @@ rules:
     )
 
 
+def test_child_fragment_reencoding_allows_shared_input_with_terminal_child_import(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "3121" / "a" / "5.yaml"
+    child = repo / "statutes" / "26" / "3121" / "a" / "5" / "C.yaml"
+    child.parent.mkdir(parents=True)
+    child.write_text(
+        """format: rulespec/v1
+rules:
+  - name: simplified_employee_pension_payment_branch_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: payment_made_under_simplified_employee_pension
+
+  - name: simplified_employee_pension_payment_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if simplified_employee_pension_payment_branch_applies: payment_amount else: 0
+"""
+    )
+    content = """format: rulespec/v1
+imports:
+  - us:statutes/26/3121/a/5/C#simplified_employee_pension_payment_excluded_from_wages
+rules:
+  - name: executable_paragraph_5_branch_excluded_from_wages
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          simplified_employee_pension_payment_excluded_from_wages
+          + (if annuity_plan_403a_payment_exclusion_branch_applies: payment_amount else: 0)
+"""
+
+    assert (
+        find_child_fragment_reencoding_issues(
+            content,
+            rules_file=rules_file,
+            policy_repo_path=repo,
+        )
+        == []
+    )
+
+
 def test_child_fragment_reencoding_points_to_terminal_child_output(tmp_path):
     repo = tmp_path / "rulespec-us"
     rules_file = repo / "statutes" / "26" / "3101.yaml"


### PR DESCRIPTION
## Summary
- add aggregate-parent prompt guidance that lists terminal child exports with kind/dtype/entity metadata
- allow parent encodings to share a child-local input name when they import a terminal child output instead of rebuilding the child branch
- bump axiom-encode to 0.2.324

Fixes #341.

## Validation
- uv run --with pytest --with pytest-cov python -m pytest tests/test_rulespec_validation.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_evals.py
- uv run ruff check src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/harness/evals.py tests/test_rulespec_validation.py tests/test_evals.py
- uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/harness/evals.py tests/test_rulespec_validation.py tests/test_evals.py
- overlay validation of generated 26 USC 3121(a)(5) parent artifact: can_apply=True, issue_count=0
