### PR TITLE
Warn on unavailable cited ancestor placeholders

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.324"
+version = "0.2.325"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.324"
+__version__ = "0.2.325"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -4788,13 +4788,17 @@ def _format_unavailable_cited_context_guidance(
         if item.import_path in seen:
             continue
         seen.add(item.import_path)
-        suffix = _citation_example_suffix(item.import_path)
+        suffixes = _citation_example_suffixes(item.import_path)
+        suffix_list = ", ".join(f"`{suffix}`" for suffix in suffixes)
+        example_suffix = suffixes[-1]
         lines.append(
             f"- Source cites `{citation.label}`; copied context target "
             f"`{item.import_path}` has {reason}. For this cited target, do not "
-            f"create local `_under_section_{suffix}`, `section_{suffix}_...`, "
-            f"`*_provided_in_section_{suffix}`, or similar cross-reference "
-            "facts."
+            f"create local cross-reference facts using suffixes {suffix_list}. "
+            f"That includes `_under_section_{example_suffix}`, "
+            f"`section_{example_suffix}_...`, "
+            f"`*_provided_in_section_{example_suffix}`, "
+            f"`*_to_which_section_{example_suffix}_applies`, or similar facts."
         )
     if not lines:
         return ""
@@ -4960,6 +4964,25 @@ def _citation_example_suffix(import_target: str) -> str:
     if len(parts) >= 3 and parts[0] == "statutes":
         return "_".join(parts[2:])
     return "_".join(parts[-2:]) if len(parts) >= 2 else "cited"
+
+
+def _citation_example_suffixes(import_target: str) -> list[str]:
+    """Return exact and ancestor identifier suffixes for a cited import target."""
+    normalized = _normalize_prompt_import_target(import_target)
+    parts = [part for part in normalized.split("/") if part]
+    if len(parts) < 3 or parts[0] != "statutes":
+        return [_citation_example_suffix(import_target)]
+
+    citation_parts = parts[2:]
+    suffixes: list[str] = []
+    # A bare section ancestor is usually too broad for prompt guidance, but
+    # subsection ancestors are exactly how models phrase local placeholders.
+    minimum_length = 2 if len(citation_parts) > 1 else 1
+    for length in range(len(citation_parts), minimum_length - 1, -1):
+        suffix = "_".join(citation_parts[:length])
+        if suffix not in suffixes:
+            suffixes.append(suffix)
+    return suffixes or [_citation_example_suffix(import_target)]
 
 
 def _format_proration_test_guidance(source_text: str) -> str:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -7063,8 +7063,49 @@ rules:
         assert (
             "`us:statutes/26/152` has `module.status: entity_not_supported`" in prompt
         )
-        assert "do not create local `_under_section_152`" in prompt
+        assert "`_under_section_152`" in prompt
         assert "omit or defer only the affected executable surface" in prompt
+
+    def test_build_eval_prompt_warns_on_unavailable_cited_context_ancestors(
+        self, tmp_path
+    ):
+        repo_root = tmp_path / "repos"
+        policy_repo_root = repo_root / "rulespec-us"
+        section_408_p_2_a = (
+            policy_repo_root / "statutes" / "26" / "408" / "p" / "2" / "A.yaml"
+        )
+        section_408_p_2_a.parent.mkdir(parents=True)
+        section_408_p_2_a.write_text(
+            "format: rulespec/v1\nmodule:\n  status: entity_not_supported\nrules: []\n"
+        )
+
+        workspace = prepare_eval_workspace(
+            citation="26 USC 3121(a)(5)(H)",
+            runner=parse_runner_spec("openai:gpt-5.5"),
+            output_root=tmp_path / "out",
+            source_text=(
+                "under an arrangement to which section 408(p) applies, "
+                "other than elective contributions under paragraph (2)(A)(i) thereof"
+            ),
+            axiom_rules_path=policy_repo_root,
+            mode="repo-augmented",
+            extra_context_paths=[],
+        )
+
+        prompt = _build_eval_prompt(
+            "26 USC 3121(a)(5)(H)",
+            "repo-augmented",
+            workspace,
+            workspace.context_files,
+            target_file_name="H.yaml",
+            target_ref_prefix="us:statutes/26/3121/a/5/H",
+            include_tests=True,
+            runner_backend="openai",
+        )
+
+        assert "Unavailable cited RuleSpec context detected" in prompt
+        assert "`408_p_2_A`, `408_p_2`, `408_p`" in prompt
+        assert "`*_to_which_section_408_p_applies`" in prompt
 
     def test_prepare_eval_workspace_adds_child_fragment_context(self, tmp_path):
         repo_root = tmp_path / "repos"


### PR DESCRIPTION
## Summary
- expand unavailable cited-context prompt guidance to include ancestor suffixes such as `408_p` when only a descendant context file is present
- explicitly warn against `*_to_which_section_*_applies` local placeholders
- bump axiom-encode to 0.2.325

## Validation
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_evals.py -k 'unavailable_cited_context'`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_evals.py`
- `uv run ruff check src/axiom_encode/harness/evals.py tests/test_evals.py`
- `uv run ruff format --check src/axiom_encode/harness/evals.py tests/test_evals.py`
