### PR TITLE
Fix manual corpus path routing

### DIFF
--- a/changelog.d/manual-corpus-routing.fixed.md
+++ b/changelog.d/manual-corpus-routing.fixed.md
@@ -1,0 +1,1 @@
+Recognize state manual corpus citation paths during source resolution and map them to policy RuleSpec output paths.

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1824,6 +1824,8 @@ def _looks_like_corpus_citation_path(identifier: str) -> bool:
     parts = identifier.split("/")
     return len(parts) >= 3 and parts[1] in {
         "guidance",
+        "manual",
+        "manuals",
         "policy",
         "regulation",
         "statute",
@@ -2871,6 +2873,8 @@ def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
     if len(parts) >= 3:
         document_roots = {
             "guidance": "guidance",
+            "manual": "policies",
+            "manuals": "policies",
             "policies": "policies",
             "policy": "policies",
             "regulation": "regulations",

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -107,6 +107,12 @@ def test_source_identifier_maps_corpus_regulation_to_repo_path():
     ) == Path("regulations/18-nycrr/387/12/f/3/v/c.yaml")
 
 
+def test_source_identifier_maps_state_manual_to_policies_repo_path():
+    assert _source_identifier_to_relative_rulespec_path(
+        "us-az/manual/des/faa5/na-child-support-expense/block-2"
+    ) == Path("policies/des/faa5/na-child-support-expense/block-2.yaml")
+
+
 def test_source_identifier_maps_federal_regulation_to_cfr_repo_path():
     assert _source_identifier_to_relative_rulespec_path(
         "us/regulation/7/273/10"
@@ -145,6 +151,24 @@ def test_source_identifier_handles_dotted_leaf_segments(citation, expected):
 
 
 class TestCorpusSourceResolution:
+    def test_resolves_state_manual_corpus_path_without_statute_rewrite(self, tmp_path):
+        corpus_path = _write_test_corpus_provision(
+            tmp_path,
+            citation_path="us-az/manual/des/faa5/na-child-support-expense/block-2",
+            body="manual child support text",
+        )
+
+        source = resolve_corpus_source_unit(
+            "us-az/manual/des/faa5/na-child-support-expense/block-2",
+            corpus_path,
+        )
+
+        assert source.citation_path == (
+            "us-az/manual/des/faa5/na-child-support-expense/block-2"
+        )
+        assert source.body == "manual child support text"
+        assert source.source == "local"
+
     def test_resolves_usc_child_citation_to_sliced_section_provision(self, tmp_path):
         corpus_path = tmp_path / "axiom-corpus"
         provisions_dir = (


### PR DESCRIPTION
## Summary
- recognize `manual` and `manuals` as corpus citation roots
- map state manual source identifiers into `policies/...` RuleSpec output paths
- add regression coverage for Arizona manual source resolution without USC/statute rewriting

## Why
Arizona SNAP manual provisions use paths like `us-az/manual/des/faa5/...`. The encoder was treating those as free-form statute citations and trying `us/statute/us-az/...`, which blocks generated `--apply` encodes for state manuals.

## Validation
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_evals.py -k 'state_manual or source_identifier_maps_state_manual'`
- `uv run ruff check src/axiom_encode/harness/evals.py tests/test_evals.py`
- `uv run ruff format --check src/axiom_encode/harness/evals.py tests/test_evals.py`
- `uv run --with towncrier python -m towncrier build --draft --version 0.0.0`
