### PR TITLE
Bump encoder version to 0.2.326

### DIFF
--- a/changelog.d/encoder-version-0.2.326.changed.md
+++ b/changelog.d/encoder-version-0.2.326.changed.md
@@ -1,0 +1,1 @@
+Pinned encoder provenance at version 0.2.326 after manual corpus path routing changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.325"
+version = "0.2.326"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.325"
+__version__ = "0.2.326"
 
 from .constants import (
     DEFAULT_CLI_MODEL,


### PR DESCRIPTION
## Summary
- bump axiom-encode provenance to 0.2.326 after the manual corpus routing fix
- keep pyproject and package runtime version in sync

## Validation
- `uv run ruff check pyproject.toml src/axiom_encode/__init__.py`
- `uv run ruff format --check src/axiom_encode/__init__.py`
- `uv run --with towncrier python -m towncrier build --draft --version 0.0.0`
- inline Python assertion that pyproject version equals `axiom_encode.__version__`
