### PR TITLE
Classify Arizona SNAP oracle coverage

### DIFF
--- a/changelog.d/az-snap-policyengine-coverage.fixed.md
+++ b/changelog.d/az-snap-policyengine-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify Arizona SNAP child support and medical deduction outputs in the PolicyEngine coverage registry.

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -586,6 +586,38 @@ mappings:
     policyengine_variable: snap_excess_shelter_expense_deduction
     rationale: Colorado manual rule includes Colorado source inputs and reiterative USDA cap values; PE's federal shelter deduction is adjacent but requires PE-specific housing and utility inputs.
 
+  - legal_id: us-az:policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction#medical_expense_disregard
+    country: us
+    program: snap
+    mapping_type: parameter_value
+    policyengine_parameter: gov.usda.snap.income.deductions.excess_medical_expense.disregard
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Arizona SNAP medical expense disregard used before applying the standard or actual medical deduction.
+
+  - legal_id: us-az:policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction#standard_medical_deduction_net_amount
+    country: us
+    program: snap
+    mapping_type: parameter_value
+    policyengine_parameter: gov.usda.snap.income.deductions.excess_medical_expense.standard
+    parameter_key: AZ
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Arizona SNAP standard medical deduction net amount after the medical expense disregard.
+
+  - legal_id: us-az:policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction#medical_deduction
+    country: us
+    program: snap
+    mapping_type: direct_variable
+    policyengine_variable: snap_excess_medical_expense_deduction
+    entity: spm_unit
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Arizona SNAP excess medical expense deduction when PE-aligned medical expense and elderly or disabled inputs are supplied.
+
   - legal_id: us:statutes/7/2017/a#snap_allotment_before_minimum
     country: us
     program: snap
@@ -9826,6 +9858,18 @@ mappings:
     rationale: Same statutory percentage of adjusted gross income that floors deductible medical-care expenses.
 
 prefixes:
+  - legal_id_prefix: us-az:policies/des/faa5/na-child-support-expense/allowable-deductions#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Arizona manual child-support outputs are payment-level allowable expense determinations; PolicyEngine exposes household-level SNAP child support deductions rather than this source-specific payment boundary.
+
+  - legal_id_prefix: us-az:policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Arizona manual medical deduction helper outputs cover source-specific verification, eligibility, and gross-threshold predicates; exact PolicyEngine mappings are registered for the comparable disregard, standard amount, and deduction outputs.
+
   - legal_id_prefix: us:statutes/26/3102/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -146,6 +146,100 @@ rules:
     assert report["items"][0]["kind"] == "derived_relation"
 
 
+def test_policyengine_coverage_classifies_arizona_snap_medical_and_child_support(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/na-child-support-expense/allowable-deductions.yaml",
+        """format: rulespec/v1
+rules:
+  - name: allowable_child_support_expense_amount
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: verified_amount_paid
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction.yaml",
+        """format: rulespec/v1
+rules:
+  - name: medical_expense_disregard
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 35
+  - name: standard_medical_deduction_net_amount
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 145
+  - name: standard_medical_deduction_gross_amount
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 180
+  - name: medical_deduction
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(0, medical_expenses - medical_expense_disregard)
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction.test.yaml",
+        """- name: medical_outputs_are_tested
+  period: 2026-01
+  input: {}
+  output:
+    us-az:policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction#medical_expense_disregard: 35
+    us-az:policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction#standard_medical_deduction_net_amount: 145
+    us-az:policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction#medical_deduction: 145
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="snap")
+
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    child_support = items_by_id[
+        "us-az:policies/des/faa5/na-child-support-expense/allowable-deductions#allowable_child_support_expense_amount"
+    ]
+    disregard = items_by_id[
+        "us-az:policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction#medical_expense_disregard"
+    ]
+    standard = items_by_id[
+        "us-az:policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction#standard_medical_deduction_net_amount"
+    ]
+    gross = items_by_id[
+        "us-az:policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction#standard_medical_deduction_gross_amount"
+    ]
+    deduction = items_by_id[
+        "us-az:policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction#medical_deduction"
+    ]
+
+    assert child_support["status"] == "known_not_comparable"
+    assert disregard["status"] == "comparable"
+    assert (
+        disregard["policyengine_parameter"]
+        == "gov.usda.snap.income.deductions.excess_medical_expense.disregard"
+    )
+    assert standard["status"] == "comparable"
+    assert (
+        standard["policyengine_parameter"]
+        == "gov.usda.snap.income.deductions.excess_medical_expense.standard"
+    )
+    assert gross["status"] == "known_not_comparable"
+    assert deduction["status"] == "comparable"
+    assert deduction["policyengine_variable"] == "snap_excess_medical_expense_deduction"
+    assert deduction["tested"] is True
+
+
 def test_policyengine_coverage_classifies_tax_parameter_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3101/a.yaml",


### PR DESCRIPTION
## Summary
- map Arizona SNAP medical deduction outputs to PolicyEngine where the legal boundary is comparable
- classify Arizona child-support and medical helper outputs as known not comparable
- add coverage-registry test coverage for the new Arizona mappings

## Tests
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-az-snap-20260527071045 --oracle policyengine --json
- uv run --with towncrier towncrier build --draft