### PR TITLE
Bump encoder version to 0.2.327

### DIFF
--- a/changelog.d/bump-0-2-327.changed.md
+++ b/changelog.d/bump-0-2-327.changed.md
@@ -1,0 +1,1 @@
+Pin encoder provenance at version 0.2.327 after Arizona SNAP PolicyEngine coverage registry changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.326"
+version = "0.2.327"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.326"
+__version__ = "0.2.327"
 
 from .constants import (
     DEFAULT_CLI_MODEL,


### PR DESCRIPTION
## Summary
- bump axiom-encode provenance version to 0.2.327 after the Arizona SNAP PolicyEngine coverage registry change
- add a changelog fragment for the bump

## Tests
- uv run ruff check pyproject.toml src/axiom_encode/__init__.py
- uv run --with towncrier towncrier build --draft