### PR TITLE
Classify Arizona SNAP utility coverage

### DIFF
--- a/changelog.d/az-utility-coverage.changed.md
+++ b/changelog.d/az-utility-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify Arizona SNAP utility allowance eligibility outputs in the PolicyEngine coverage registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.327"
+version = "0.2.328"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.327"
+__version__ = "0.2.328"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -618,6 +618,64 @@ mappings:
     comparison: money
     rationale: Same Arizona SNAP excess medical expense deduction when PE-aligned medical expense and elderly or disabled inputs are supplied.
 
+  - legal_id: us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility#liheap_minimum_annual_payment_amount
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Arizona manual LIHEAP threshold parameter for standard utility allowance eligibility; PolicyEngine does not expose this LIHEAP-specific threshold as a SNAP utility parameter.
+
+  - legal_id: us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility#liheap_application_month_lookback_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Arizona manual LIHEAP lookback parameter for standard utility allowance eligibility; PolicyEngine does not expose this LIHEAP-specific lookback window as a SNAP utility parameter.
+
+  - legal_id: us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility#utility_allowance_prerequisites_met
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Arizona manual predicate requiring separately billed, obligated, and verified allowable utility expenses; PolicyEngine derives utility allowance type from its own utility-expense inputs rather than exposing this source-specific prerequisite.
+
+  - legal_id: us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility#qualifying_liheap_sua_condition
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_utility_allowance_type
+    candidate_priority: P4
+    rationale: Arizona manual predicate for LIHEAP-based standard utility allowance eligibility; PolicyEngine's utility allowance type is adjacent but does not expose this LIHEAP branch as a one-to-one output.
+
+  - legal_id: us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility#snap_standard_utility_allowance
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_standard_utility_allowance
+    candidate_priority: P4
+    rationale: Arizona manual output is a Judgment for standard utility allowance eligibility; PolicyEngine's same-named variable is a dollar amount conditional on its utility allowance type.
+
+  - legal_id: us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility#snap_limited_utility_allowance
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_limited_utility_allowance
+    candidate_priority: P4
+    rationale: Arizona manual output is a Judgment for limited utility allowance eligibility; PolicyEngine's same-named variable is a dollar amount conditional on its utility allowance type.
+
+  - legal_id: us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility#snap_telephone_utility_allowance_eligible
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_utility_allowance_type
+    candidate_priority: P4
+    rationale: Arizona manual output is a telephone-only eligibility predicate; PolicyEngine exposes the adjacent IUA utility allowance type and amount but not this source-specific predicate.
+
+  - legal_id: us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility#snap_individual_utility_allowance
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_individual_utility_allowance
+    candidate_priority: P4
+    rationale: Arizona manual output is a Judgment indicating telephone utility allowance eligibility; PolicyEngine's individual utility allowance variable is a dollar amount conditional on its utility allowance type.
+
   - legal_id: us:statutes/7/2017/a#snap_allotment_before_minimum
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -240,6 +240,114 @@ rules:
     assert deduction["tested"] is True
 
 
+def test_policyengine_coverage_classifies_arizona_snap_utility_eligibility(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility.yaml",
+        """format: rulespec/v1
+rules:
+  - name: liheap_minimum_annual_payment_amount
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 20
+  - name: liheap_application_month_lookback_months
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 12
+  - name: utility_allowance_prerequisites_met
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: billed_separately and obligated and verified
+  - name: qualifying_liheap_sua_condition
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: liheap_annual_payment_amount >= liheap_minimum_annual_payment_amount
+  - name: snap_standard_utility_allowance
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: utility_allowance_prerequisites_met and has_heating_or_cooling
+  - name: snap_limited_utility_allowance
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: utility_allowance_prerequisites_met and has_two_non_heating_utilities
+  - name: snap_telephone_utility_allowance_eligible
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: utility_allowance_prerequisites_met and has_only_telephone
+  - name: snap_individual_utility_allowance
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: snap_telephone_utility_allowance_eligible
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility.test.yaml",
+        """- name: utility_outputs_are_tested
+  period: 2026-01
+  input: {}
+  output:
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility#liheap_minimum_annual_payment_amount: 20
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility#snap_standard_utility_allowance: holds
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility#snap_limited_utility_allowance: not_holds
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility#snap_telephone_utility_allowance_eligible: not_holds
+    us-az:policies/des/faa5/na-utility-expenses-and-allowances/utility-allowance-eligibility#snap_individual_utility_allowance: not_holds
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="snap")
+
+    utility_items = {
+        item["rule_name"]: item
+        for item in report["items"]
+        if item["file"].endswith("utility-allowance-eligibility.yaml")
+    }
+    assert set(utility_items) == {
+        "liheap_minimum_annual_payment_amount",
+        "liheap_application_month_lookback_months",
+        "utility_allowance_prerequisites_met",
+        "qualifying_liheap_sua_condition",
+        "snap_standard_utility_allowance",
+        "snap_limited_utility_allowance",
+        "snap_telephone_utility_allowance_eligible",
+        "snap_individual_utility_allowance",
+    }
+    assert {item["status"] for item in utility_items.values()} == {
+        "known_not_comparable"
+    }
+    assert (
+        utility_items["snap_standard_utility_allowance"]["policyengine_variable"]
+        == "snap_standard_utility_allowance"
+    )
+    assert (
+        utility_items["snap_limited_utility_allowance"]["policyengine_variable"]
+        == "snap_limited_utility_allowance"
+    )
+    assert (
+        utility_items["snap_individual_utility_allowance"]["policyengine_variable"]
+        == "snap_individual_utility_allowance"
+    )
+    assert (
+        utility_items["snap_telephone_utility_allowance_eligible"][
+            "policyengine_variable"
+        ]
+        == "snap_utility_allowance_type"
+    )
+    assert utility_items["snap_standard_utility_allowance"]["tested"] is True
+
+
 def test_policyengine_coverage_classifies_tax_parameter_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3101/a.yaml",


### PR DESCRIPTION
## Summary
- classify Arizona SNAP utility allowance eligibility outputs in the PolicyEngine coverage registry
- mark source-specific LIHEAP/prerequisite/eligibility predicates as known-not-comparable to PE amount/type variables
- bump encoder provenance version to 0.2.328

## Validation
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run ruff check pyproject.toml src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run python - <<'PY' ... load_policyengine_registry() ... PY
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-az-snap-20260527071045 --oracle policyengine --json | jq ...
- uv run --with towncrier towncrier build --draft