### PR TITLE
Guide cap alternatives to preserve uncapped bases

### DIFF
--- a/changelog.d/cap-alternative-boundaries.fixed.md
+++ b/changelog.d/cap-alternative-boundaries.fixed.md
@@ -1,0 +1,1 @@
+Guide the encoder to apply alternative cap amounts to an uncapped base instead of substituting one cap branch for the base computation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.328"
+version = "0.2.329"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.328"
+__version__ = "0.2.329"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -795,6 +795,15 @@ Hard requirements:
   `min(source_amount, cap)`. The excluded excess is
   `max(0, source_amount - cap)`, but do not return `source_amount - cap` or
   `source_amount - remaining_cap` as the included amount.
+- When a source says an already-computed deduction, allowance, credit, benefit,
+  or other amount "cannot exceed", is "limited to", or is capped by "the higher
+  of", "the greater of", "the lesser of", or "the lower of" several cap
+  amounts, compute the uncapped base amount separately and apply the selected
+  cap only at the final capped output, e.g. `min(uncapped_amount, max(cap_a,
+  cap_b))`. Do not replace the uncapped base with one cap alternative such as
+  `if condition: cap_b else: uncapped_amount` unless the source expressly says
+  the alternative amount is used "instead of", "in lieu of", or as a
+  substitution for the base computation.
 - Formula strings must use bare identifiers only. If an imported rule is listed
   as `us:statutes/...#example_rule`, add that exact target to `imports:` but
   reference `example_rule` inside formula text.

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -74,6 +74,9 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "Axiom formulas have no date literal type" in ENCODER_PROMPT
     assert 'excess of" a cap' in ENCODER_PROMPT
     assert "min(source_amount, cap)" in ENCODER_PROMPT
+    assert "compute the uncapped base amount separately" in ENCODER_PROMPT
+    assert "min(uncapped_amount, max(cap_a," in ENCODER_PROMPT
+    assert "unless the source expressly says" in ENCODER_PROMPT
     assert (
         "Never use `post_YYYY`, `pre_YYYY`, `after_YYYY`, `before_YYYY`"
         in ENCODER_PROMPT


### PR DESCRIPTION
## Summary
- add generic encoder guidance that cap alternatives apply to an uncapped base instead of replacing it
- cover the prompt guardrail in encoder backend tests
- bump encoder provenance to 0.2.329 and add a Towncrier fragment

## Validation
- uv run ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/prompts/encoder.py tests/test_encoder_backend.py
- uv run --with towncrier towncrier build --draft
- uv run --with pytest --with pytest-cov --with pytest-asyncio python -m pytest tests/test_encoder_backend.py -q