### PR TITLE
Classify Arizona SNAP shelter coverage

### DIFF
--- a/changelog.d/az-snap-shelter-coverage.changed.md
+++ b/changelog.d/az-snap-shelter-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify Arizona SNAP shelter deduction outputs in the PolicyEngine coverage registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.329"
+version = "0.2.330"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.329"
+__version__ = "0.2.330"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -676,6 +676,23 @@ mappings:
     candidate_priority: P4
     rationale: Arizona manual output is a Judgment indicating telephone utility allowance eligibility; PolicyEngine's individual utility allowance variable is a dollar amount conditional on its utility allowance type.
 
+  - legal_id: us-az:policies/des/faa5/shelter-expenses-and-deduction/shelter-deduction#shelter_deduction_net_income_share
+    country: us
+    program: snap
+    mapping_type: parameter_value
+    policyengine_parameter: gov.usda.snap.income.deductions.excess_shelter_expense.income_share_disregard
+    period: month
+    comparison: rate
+    rationale: Same Arizona SNAP excess-shelter income-share disregard used to compute the uncapped shelter deduction.
+
+  - legal_id: us-az:policies/des/faa5/shelter-expenses-and-deduction/shelter-deduction#shelter_deduction
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_excess_shelter_expense_deduction
+    candidate_priority: P4
+    rationale: Arizona manual shelter deduction output uses source-specific allowable shelter and utility inputs and cap-oriented homeless-deduction wording; PolicyEngine's final excess shelter deduction is adjacent but not a one-to-one output for this source boundary.
+
   - legal_id: us:statutes/7/2017/a#snap_allotment_before_minimum
     country: us
     program: snap
@@ -9927,6 +9944,12 @@ prefixes:
     program: snap
     mapping_type: not_comparable
     rationale: Arizona manual medical deduction helper outputs cover source-specific verification, eligibility, and gross-threshold predicates; exact PolicyEngine mappings are registered for the comparable disregard, standard amount, and deduction outputs.
+
+  - legal_id_prefix: us-az:policies/des/faa5/shelter-expenses-and-deduction/shelter-deduction#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Arizona manual shelter deduction helper outputs cover source-specific allowable shelter expenses, utility composition, uncapped excess amounts, and state manual cap mechanics; exact PolicyEngine mappings are registered only where the output boundary is comparable.
 
   - legal_id_prefix: us:statutes/26/3102/a#
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -348,6 +348,92 @@ rules:
     assert utility_items["snap_standard_utility_allowance"]["tested"] is True
 
 
+def test_policyengine_coverage_classifies_arizona_snap_shelter_deduction(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/shelter-expenses-and-deduction/shelter-deduction.yaml",
+        """format: rulespec/v1
+rules:
+  - name: shelter_deduction_net_income_share
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.50
+  - name: allowable_shelter_expense
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(0, shelter_expense - vendor_payment)
+  - name: shelter_costs_with_utility_allowance
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: allowable_shelter_expense + utility_allowance
+  - name: uncapped_shelter_deduction
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(0, shelter_costs_with_utility_allowance - shelter_deduction_net_income_share * net_income)
+  - name: shelter_deduction_limit_for_budgetary_unit_without_elderly_or_disabled_participant
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(maximum_shelter_deduction_amount, homeless_shelter_deduction)
+  - name: shelter_deduction
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(uncapped_shelter_deduction, shelter_deduction_limit_for_budgetary_unit_without_elderly_or_disabled_participant)
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/shelter-expenses-and-deduction/shelter-deduction.test.yaml",
+        """- name: shelter_outputs_are_tested
+  period: 2026-01
+  input: {}
+  output:
+    us-az:policies/des/faa5/shelter-expenses-and-deduction/shelter-deduction#shelter_deduction_net_income_share: 0.5
+    us-az:policies/des/faa5/shelter-expenses-and-deduction/shelter-deduction#allowable_shelter_expense: 800
+    us-az:policies/des/faa5/shelter-expenses-and-deduction/shelter-deduction#shelter_deduction: 500
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="snap")
+
+    shelter_items = {
+        item["rule_name"]: item
+        for item in report["items"]
+        if item["file"].endswith("shelter-deduction.yaml")
+    }
+    assert set(shelter_items) == {
+        "allowable_shelter_expense",
+        "shelter_costs_with_utility_allowance",
+        "shelter_deduction",
+        "shelter_deduction_limit_for_budgetary_unit_without_elderly_or_disabled_participant",
+        "shelter_deduction_net_income_share",
+        "uncapped_shelter_deduction",
+    }
+    assert shelter_items["shelter_deduction_net_income_share"]["status"] == "comparable"
+    assert (
+        shelter_items["shelter_deduction_net_income_share"]["policyengine_parameter"]
+        == "gov.usda.snap.income.deductions.excess_shelter_expense.income_share_disregard"
+    )
+    assert shelter_items["shelter_deduction_net_income_share"]["tested"] is True
+    assert shelter_items["shelter_deduction"]["status"] == "known_not_comparable"
+    assert (
+        shelter_items["shelter_deduction"]["policyengine_variable"]
+        == "snap_excess_shelter_expense_deduction"
+    )
+    assert (
+        shelter_items["allowable_shelter_expense"]["status"] == "known_not_comparable"
+    )
+
+
 def test_policyengine_coverage_classifies_tax_parameter_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3101/a.yaml",


### PR DESCRIPTION
## Summary
- classify Arizona SNAP shelter deduction outputs in the PolicyEngine coverage registry
- map the shelter 50% income-share rate to the PolicyEngine parameter
- mark source-specific shelter helpers and the final shelter output as known-not-comparable, with final PE adjacency noted
- bump encoder provenance to 0.2.330

## Validation
- uv run ruff check pyproject.toml src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_arizona_snap_shelter_deduction -q
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run --with towncrier towncrier build --draft
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-az-snap-20260527071045 --program snap --json