### PR TITLE
Classify Arizona SNAP dependent-care coverage

### DIFF
--- a/changelog.d/az-snap-dependent-care-coverage.changed.md
+++ b/changelog.d/az-snap-dependent-care-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify Arizona SNAP dependent-care outputs in the PolicyEngine coverage registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.330"
+version = "0.2.331"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.330"
+__version__ = "0.2.331"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -676,6 +676,14 @@ mappings:
     candidate_priority: P4
     rationale: Arizona manual output is a Judgment indicating telephone utility allowance eligibility; PolicyEngine's individual utility allowance variable is a dollar amount conditional on its utility allowance type.
 
+  - legal_id: us-az:policies/des/faa5/dependent-care-expense/na-dependent-care#snap_allowable_monthly_dependent_care_expenses
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_dependent_care_deduction
+    candidate_priority: P4
+    rationale: Arizona manual dependent-care output is a payment-level allowable expense after source-specific recipient, activity, expense-type, reimbursement, vendor-payment, parent-availability, and proration rules; PolicyEngine's dependent-care deduction is an adjacent SPM-unit childcare-expense aggregate.
+
   - legal_id: us-az:policies/des/faa5/shelter-expenses-and-deduction/shelter-deduction#shelter_deduction_net_income_share
     country: us
     program: snap
@@ -9944,6 +9952,12 @@ prefixes:
     program: snap
     mapping_type: not_comparable
     rationale: Arizona manual medical deduction helper outputs cover source-specific verification, eligibility, and gross-threshold predicates; exact PolicyEngine mappings are registered for the comparable disregard, standard amount, and deduction outputs.
+
+  - legal_id_prefix: us-az:policies/des/faa5/dependent-care-expense/na-dependent-care#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Arizona manual dependent-care helper outputs cover payment-level recipient qualification, allowable activity, allowable expense type, disallowed payment sources, parent-availability exceptions, and proration mechanics; PolicyEngine does not expose these source-specific branches as one-to-one outputs.
 
   - legal_id_prefix: us-az:policies/des/faa5/shelter-expenses-and-deduction/shelter-deduction#
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -434,6 +434,103 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_arizona_snap_dependent_care(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/dependent-care-expense/na-dependent-care.yaml",
+        """format: rulespec/v1
+rules:
+  - name: dependent_child_under_age_limit
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 18
+  - name: dependent_care_expense_recipient_qualifies
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: care_recipient_is_dependent_child and care_recipient_age < dependent_child_under_age_limit
+  - name: dependent_care_expense_necessary_for_allowable_activity
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: necessary_to_seek_accept_or_continue_employment
+  - name: dependent_care_expense_type_is_allowable
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: billed_for_dependent_care or required_registration_fee
+  - name: out_of_home_care_disallowed_due_to_available_parent
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: care_provided_out_of_home and parent_physically_capable_of_caring_for_dependent
+  - name: dependent_care_expense_not_disallowed
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: not cost_paid_by_reimbursement and not out_of_home_care_disallowed_due_to_available_parent
+  - name: dependent_care_expense_prorated_or_billed_amount
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: billed_dependent_care_expense_amount
+  - name: snap_allowable_monthly_dependent_care_expenses
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: dependent_care_expense_prorated_or_billed_amount
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/dependent-care-expense/na-dependent-care.test.yaml",
+        """- name: dependent_care_outputs_are_tested
+  period: 2026-01
+  input: {}
+  output:
+    us-az:policies/des/faa5/dependent-care-expense/na-dependent-care#dependent_child_under_age_limit: 18
+    us-az:policies/des/faa5/dependent-care-expense/na-dependent-care#dependent_care_expense_recipient_qualifies: holds
+    us-az:policies/des/faa5/dependent-care-expense/na-dependent-care#snap_allowable_monthly_dependent_care_expenses: 300
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="snap")
+
+    dependent_care_items = {
+        item["rule_name"]: item
+        for item in report["items"]
+        if item["file"].endswith("na-dependent-care.yaml")
+    }
+    assert set(dependent_care_items) == {
+        "dependent_care_expense_necessary_for_allowable_activity",
+        "dependent_care_expense_not_disallowed",
+        "dependent_care_expense_prorated_or_billed_amount",
+        "dependent_care_expense_recipient_qualifies",
+        "dependent_care_expense_type_is_allowable",
+        "dependent_child_under_age_limit",
+        "out_of_home_care_disallowed_due_to_available_parent",
+        "snap_allowable_monthly_dependent_care_expenses",
+    }
+    assert {item["status"] for item in dependent_care_items.values()} == {
+        "known_not_comparable"
+    }
+    assert (
+        dependent_care_items["snap_allowable_monthly_dependent_care_expenses"][
+            "policyengine_variable"
+        ]
+        == "snap_dependent_care_deduction"
+    )
+    assert (
+        dependent_care_items["snap_allowable_monthly_dependent_care_expenses"]["tested"]
+        is True
+    )
+
+
 def test_policyengine_coverage_classifies_tax_parameter_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3101/a.yaml",


### PR DESCRIPTION
## Summary
- classify Arizona SNAP dependent-care RuleSpec outputs in the PolicyEngine coverage registry
- map the final allowable monthly dependent-care expense to adjacent PE variable snap_dependent_care_deduction as not-comparable
- add coverage test and bump encoder provenance version to 0.2.331

## Validation
- uv run ruff check pyproject.toml src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run ruff format --check pyproject.toml src/axiom_encode/__init__.py tests/test_policyengine_coverage.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_arizona_snap_dependent_care -q
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run --with towncrier towncrier build --draft
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-az-snap-20260527071045 --program snap --json