### PR TITLE
Classify section 3241(c) oracle outputs

### DIFF
--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10895,6 +10895,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3241(b) Railroad Retirement Tax Act applicable-percentage schedule outputs are not exposed as one-to-one PolicyEngine variables or parameters.
 
+  - legal_id_prefix: us:statutes/26/3241/c#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3241(c) defines Railroad Retirement Tax Act average account benefits ratio and account benefits ratio trust-accounting intermediates; PolicyEngine does not expose these RRTA rate-setting accounting surfaces as one-to-one variables or parameters.
+
   - legal_id_prefix: us:statutes/26/3241/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3087,6 +3087,48 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3241_c_account_ratio_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3241/c.yaml",
+        """format: rulespec/v1
+rules:
+  - name: most_recent_fiscal_year_count_for_average_account_benefits_ratio
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 10
+  - name: average_account_benefits_ratio_rounding_multiple
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.1
+  - name: unrounded_average_account_benefits_ratio
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: sum_of_account_benefits_ratios / 10
+  - name: average_account_benefits_ratio
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: ceil(unrounded_average_account_benefits_ratio / 0.1) * 0.1
+  - name: account_benefits_ratio
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: assets / benefits_and_administrative_expenses
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 5}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3231_a_employer_definition_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3231/a.yaml",


### PR DESCRIPTION
## Summary
- classify 26 USC 3241(c) RRTA account-benefits ratio outputs as known not comparable to PolicyEngine
- add coverage regression for the new prefix

## Checks
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k '3241_c or 3241_a'
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --json