### PR TITLE
Repair invalid deferred source values before apply

### DIFF
--- a/changelog.d/deferred-source-values-apply.fixed.md
+++ b/changelog.d/deferred-source-values-apply.fixed.md
@@ -1,0 +1,1 @@
+Repair generated deferred outputs with prose `source_values` before signed apply validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.332"
+version = "0.2.333"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.332"
+__version__ = "0.2.333"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10729,6 +10729,34 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_deferred_source_values = (
+                    _try_repair_generated_invalid_deferred_source_values_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_deferred_source_values:
+                    outcome["auto_repaired_invalid_deferred_source_values"] = (
+                        repaired_deferred_source_values
+                    )
+                    print(
+                        "  apply=auto_repaired_invalid_deferred_source_values:"
+                        + ",".join(repaired_deferred_source_values)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_deferred_outputs = (
                     _try_repair_generated_deferred_output_subsection_paths_for_apply(
                         result,
@@ -11927,6 +11955,29 @@ def _try_repair_generated_empty_deferred_source_values_for_apply(
     return _remove_empty_deferred_source_values(rules_file=rules_file)
 
 
+def _try_repair_generated_invalid_deferred_source_values_for_apply(
+    result,
+    *,
+    output_root: Path,
+    issues: list[str],
+) -> list[str]:
+    """Remove optional prose source_values from deferred outputs."""
+    if not any(
+        "module.deferred_outputs[" in str(issue)
+        and ".source_values entry `" in str(issue)
+        and "must be an absolute RuleSpec target" in str(issue)
+        for issue in issues
+    ):
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    return _remove_invalid_deferred_source_values(rules_file=rules_file)
+
+
 def _only_pending_empty_deferred_source_values_issues(issues: list[str]) -> bool:
     return bool(issues) and all(
         "module.deferred_outputs[" in str(issue)
@@ -11957,6 +12008,53 @@ def _remove_empty_deferred_source_values(*, rules_file: Path) -> list[str]:
 
     rules_file.write_text("".join(repaired))
     return [f"source_values[{index}]" for index in range(removed)]
+
+
+def _remove_invalid_deferred_source_values(*, rules_file: Path) -> list[str]:
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    module = payload.get("module")
+    if not isinstance(module, dict):
+        return []
+    deferred_outputs = module.get("deferred_outputs")
+    if not isinstance(deferred_outputs, list):
+        return []
+
+    repaired: list[str] = []
+    for index, record in enumerate(deferred_outputs):
+        if not isinstance(record, dict):
+            continue
+        source_values = record.get("source_values")
+        if not isinstance(source_values, list):
+            continue
+        invalid_values = [
+            value
+            for value in source_values
+            if not _looks_like_absolute_rulespec_output_target(value)
+        ]
+        if not invalid_values:
+            continue
+        record.pop("source_values", None)
+        repaired.append(f"source_values[{index}]")
+
+    if not repaired:
+        return []
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repaired
+
+
+def _looks_like_absolute_rulespec_output_target(value: Any) -> bool:
+    text = str(value or "").strip()
+    if ":" not in text or "#" not in text:
+        return False
+    path, symbol = text.rsplit("#", 1)
+    return bool(path.strip()) and bool(symbol.strip())
 
 
 def _try_repair_generated_deferred_output_subsection_paths_for_apply(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3477,6 +3477,72 @@ rules: []
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_removes_prose_deferred_source_values(self, capsys, tmp_path):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path / "out" / "codex-test-model" / "statutes" / "26" / "3241/d.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  status: deferred
+  source_verification:
+    corpus_citation_path: us/statute/26/3241
+  deferred_outputs:
+    - output: us:statutes/26/3241/d#secretary_federal_register_notice
+      reason: Administrative publication duty, not an executable tax amount.
+      source_values:
+        - Notice must be published no later than December 1.
+rules: []
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/26/3241/d.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "statutes/26/3241/d.yaml: ci: "
+                            "module.deferred_outputs[0].source_values entry "
+                            "`Notice must be published no later than December 1.` "
+                            "must be an absolute RuleSpec target with a rule fragment."
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert "apply=auto_repaired_invalid_deferred_source_values:" in output
+        assert "source_values:" not in output_file.read_text()
+        assert mock_overlay.call_count == 2
+        mock_apply.assert_called_once()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_invalid_deferred_source_values"] == [
+            "source_values[0]"
+        ]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_promotes_module_imports(self, capsys, tmp_path):
         args = self._make_args(tmp_path, backend="codex", sync=False)
         args.apply = True


### PR DESCRIPTION
## Summary
- remove prose-only deferred output source_values during generated apply repair
- re-run overlay validation before signed apply proceeds
- bump encoder provenance version to 0.2.333

## Tests
- uv run --extra dev python -m pytest tests/test_cli.py -k 'deferred_source_values'
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- uv run --extra dev python -m towncrier build --draft --version 0.0.0