### PR TITLE
Respect requested source target in subparagraph-coverage scope

### DIFF
--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -6205,9 +6205,7 @@ def _scope_prefix_from_requested_source(
     """
     if not requested_source:
         return ()
-    citation_parts = tuple(
-        part for part in citation_path.strip("/").split("/") if part
-    )
+    citation_parts = tuple(part for part in citation_path.strip("/").split("/") if part)
     requested_parts = tuple(
         part for part in requested_source.strip("/").split("/") if part
     )
@@ -6215,7 +6213,7 @@ def _scope_prefix_from_requested_source(
         return ()
     if requested_parts[: len(citation_parts)] != citation_parts:
         return ()
-    return tuple(part.lower() for part in requested_parts[len(citation_parts):])
+    return tuple(part.lower() for part in requested_parts[len(citation_parts) :])
 
 
 def _rulespec_file_subparagraph_scope(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -5984,8 +5984,18 @@ def find_source_subparagraph_coverage_issues(
     *,
     rules_file: Path | None = None,
     source_texts: dict[str, str] | None = None,
+    requested_source: str | None = None,
 ) -> list[str]:
-    """Require high-signal source children to be encoded or explicitly deferred."""
+    """Require high-signal source children to be encoded or explicitly deferred.
+
+    ``requested_source`` lets the caller declare which subsection the encoder
+    was *asked* to produce, even when the corpus served a parent-fallback
+    source slice. Without it, a benchmark targeting `us/statute/7/2014/e/2/B`
+    that gets served the whole § 2014 text triggers spurious "missing
+    coverage" errors for every sibling subparagraph — the encoder was only
+    responsible for (e)(2)(B). The pipeline reads this from the nearby eval
+    workspace's ``source-metadata.json``; tests can pass it directly.
+    """
     payload = _rulespec_payload(content)
     if payload is None or payload.get("format") != "rulespec/v1":
         return []
@@ -6011,7 +6021,13 @@ def find_source_subparagraph_coverage_issues(
         return []
 
     source_children = _high_signal_top_level_subparagraphs(source_text)
-    coverage_scope_prefix = _source_subparagraph_coverage_scope_prefix(
+    # The requested-source scope takes precedence over the rules_file-derived
+    # one because it captures encoder intent precisely; the rules_file path
+    # only tells us where the artifact landed (which can collapse to the
+    # parent under corpus fallback, see issue #71).
+    coverage_scope_prefix = _scope_prefix_from_requested_source(
+        citation_path, requested_source
+    ) or _source_subparagraph_coverage_scope_prefix(
         citation_path,
         rules_file=rules_file,
     )
@@ -6172,6 +6188,34 @@ def _source_subparagraph_coverage_scope_prefix(
     rules_file: Path | None,
 ) -> tuple[str, ...]:
     return _rulespec_file_subparagraph_scope(citation_path, rules_file)
+
+
+def _scope_prefix_from_requested_source(
+    citation_path: str, requested_source: str | None
+) -> tuple[str, ...]:
+    """Derive a subparagraph scope from a requested source vs the resolved
+    citation_path. When the corpus serves a parent-fallback slice, the
+    citation_path collapses to the parent while the requested source still
+    names the encoder's actual target. The difference is the scope.
+
+    Examples (citation_path → requested_source → scope):
+      us/statute/7/2014 → us/statute/7/2014/e/2/B → ('e', '2', 'b')
+      us/statute/7/2014 → us/statute/7/2014       → ()
+      us/statute/7/2014 → us/statute/26/63        → ()  (unrelated)
+    """
+    if not requested_source:
+        return ()
+    citation_parts = tuple(
+        part for part in citation_path.strip("/").split("/") if part
+    )
+    requested_parts = tuple(
+        part for part in requested_source.strip("/").split("/") if part
+    )
+    if not citation_parts or len(requested_parts) <= len(citation_parts):
+        return ()
+    if requested_parts[: len(citation_parts)] != citation_parts:
+        return ()
+    return tuple(part.lower() for part in requested_parts[len(citation_parts):])
 
 
 def _rulespec_file_subparagraph_scope(
@@ -15302,8 +15346,22 @@ class ValidatorPipeline:
         issues.extend(find_person_scoped_definition_unit_issues(content))
         issues.extend(find_helper_only_definition_issues(content))
         issues.extend(find_deferred_output_issues(content))
+        # Read the requested-source target from the nearby eval workspace
+        # so subparagraph-coverage scoping respects encoder intent even when
+        # the corpus served a parent-fallback source slice (issue #71).
+        nearby_metadata = _load_nearby_eval_source_metadata(rules_file)
+        requested_source = (
+            str(nearby_metadata.get("requested_source"))
+            if isinstance(nearby_metadata, dict)
+            and isinstance(nearby_metadata.get("requested_source"), str)
+            else None
+        )
         issues.extend(
-            find_source_subparagraph_coverage_issues(content, rules_file=rules_file)
+            find_source_subparagraph_coverage_issues(
+                content,
+                rules_file=rules_file,
+                requested_source=requested_source,
+            )
         )
         issues.extend(find_tax_status_component_local_input_issues(content))
         issues.extend(find_unused_modifier_parameter_issues(content))

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -11743,6 +11743,82 @@ rules:
     )
 
 
+def test_source_subparagraph_coverage_scopes_to_requested_source_under_parent_fallback(
+    tmp_path,
+):
+    """When the corpus serves a parent-fallback source slice for a sub-subsection
+    encoding target, the validator must scope subparagraph coverage to the
+    *requested* target rather than the entire parent statute. Otherwise an
+    encoder asked to produce a rule for `7 USC 2014(e)(2)(B)` would have to
+    defer or encode every top-level subparagraph of § 2014, which is out of
+    its scope.
+
+    Surfaced live by us_snap_earned_income_deduction_refresh.yaml on
+    2026-05-27: corpus lacked the (e)(2)(B) slice, so it served the whole
+    § 2014; validator then demanded coverage for (a), (c), (d), (g), (h),
+    (k), (l) — none of which the encoder was asked to touch.
+    """
+    source_text = """Eligibility disqualifications
+(a) Income standards. Households with income above thresholds are ineligible.
+(c) Gross income standard. Adjusted October 1 each year.
+(d) Exclusions from income. Various items excluded.
+(e) Deductions from income.
+    (1) Standard deduction.
+    (2) (B) Earned income deduction of 20 percent.
+(g) Allowable financial resources. Asset limits apply.
+"""
+    content = """format: rulespec/v1
+module:
+  status: deferred
+  source_verification:
+    corpus_citation_path: us/statute/7/2014
+  summary: Earned income deduction under 7 USC 2014(e)(2)(B).
+  deferred_outputs:
+    - output: us:statutes/7/2014/e/2/B#snap_earned_income_deduction
+      reason: Requires the (e)(2)(C) exception which is not in scope.
+rules: []
+"""
+
+    issues = find_source_subparagraph_coverage_issues(
+        content,
+        source_texts={"us/statute/7/2014": source_text},
+        requested_source="us/statute/7/2014/e/2/B",
+    )
+
+    # All seven sibling subparagraphs (a, c, d, g) are out of scope when the
+    # request targets (e)(2)(B). The encoder must not be held responsible
+    # for them.
+    assert issues == [], (
+        "Validator complained about subparagraphs the encoder was never "
+        f"asked to cover: {issues}"
+    )
+
+
+def test_source_subparagraph_coverage_without_requested_source_keeps_strict_scope():
+    """Sanity check: when no requested_source is supplied, behaviour is
+    unchanged — the validator demands coverage of every top-level
+    subparagraph as before."""
+    source_text = """Definitions
+(a) Benefit means the amount payable.
+(b) Household means an individual or group.
+"""
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/7/2012
+  summary: Definitions
+rules: []
+"""
+
+    issues = find_source_subparagraph_coverage_issues(
+        content,
+        source_texts={"us/statute/7/2012": source_text},
+    )
+    assert len(issues) == 2
+    assert any("7 USC 2012(a)" in i for i in issues)
+    assert any("7 USC 2012(b)" in i for i in issues)
+
+
 def test_source_subparagraph_coverage_matches_irc_section_citation(tmp_path):
     source_text = """Standard deduction
 (a) Rule for taxable years.


### PR DESCRIPTION
## Summary
Fixes the source-subparagraph-coverage validator demanding coverage of out-of-scope sibling subparagraphs when the corpus serves a parent-fallback source slice. Surfaced live by \`benchmarks/us_snap_earned_income_deduction_refresh.yaml\`: encoder asked to produce \`7 USC 2014(e)(2)(B)\`, corpus served the whole § 2014 (subsection slice missing — issue #71), validator then demanded coverage for (a), (c), (d), (g), (h), (k), (l), none of which the encoder was responsible for.

The harness already records the requested target separately from the resolved corpus_citation_path (in the workspace's \`source-metadata.json\`, also for issue #71 reasons). This change reads that field and scopes the validator accordingly.

## TDD
- \`test_source_subparagraph_coverage_scopes_to_requested_source_under_parent_fallback\` — captures the bug. Fails without the fix, passes with it.
- \`test_source_subparagraph_coverage_without_requested_source_keeps_strict_scope\` — pins existing baseline so the change doesn't accidentally loosen strict-coverage checks on broad-target encodings.

## Live result on us_snap_earned_income_deduction_refresh.yaml

| Gate | v1 (no fix) | v2 (this fix) |
|---|---|---|
| success | 0% | **100%** |
| CI | 0% | **100%** |
| compile | 100% | 100% |
| generalist | 7.5/10 | **8.0/10** |
| cost | \$0.18 | \$0.27 |

Only \`min_policyengine_pass_rate: n/a\` still fails — same benchmark-config issue as the eligibility benchmark (PE gate has nothing to score when module is honestly deferred). Not an encoder failure.

## Regression
- 417 validator tests pass; my 2 new tests pass.
- Full encoder suite: 1299 pass. 8 pre-existing failures (test_encoder_backend, test_repo_cross_statute_imports) unchanged — verified by stash-and-rerun on main.

## Unblocks
- Task axiom-oracles#66 (encoding federal SNAP subsection slices). Each subsection benchmark can now produce honest deferred modules without spurious coverage errors.
- Task axiom-oracles#62 (CA SNAP composition encoding), downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)