### PR TITLE
Classify section 3232 oracle outputs

### DIFF
--- a/changelog.d/section-3232-policyengine-coverage.changed.md
+++ b/changelog.d/section-3232-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated 26 USC 3232 court-jurisdiction outputs in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.333"
+version = "0.2.334"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.333"
+__version__ = "0.2.334"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10053,6 +10053,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3231(g) defines Railroad Retirement Tax Act carrier status; PolicyEngine does not expose RRTA carrier-definition surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3232#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3232 defines federal district-court jurisdiction and nonexclusive enforcement jurisdiction for Railroad Retirement Tax Act obligations; PolicyEngine does not expose these court-jurisdiction enforcement predicates as one-to-one tax calculation outputs.
+
   - legal_id_prefix: us-co:regulations/10-ccr-2506-1/
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4002,6 +4002,36 @@ rules:
     assert item["policyengine_variable"] is None
 
 
+def test_policyengine_coverage_classifies_3232_court_jurisdiction_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3232.yaml",
+        """format: rulespec/v1
+rules:
+  - name: district_court_jurisdiction_to_compel_employee_or_other_person
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: attorney_general_application and person_resides_in_jurisdiction
+  - name: district_court_jurisdiction_to_compel_employer
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: attorney_general_application and employer_subject_to_service
+  - name: conferred_federal_court_jurisdiction_not_exclusive
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: otherwise_possessed_jurisdiction and enforcement_civil_action
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3302_c_2_a_advance_reduction_outputs(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3232 court-jurisdiction outputs as known not comparable to PolicyEngine
- add coverage test for the three generated outputs
- bump encoder provenance version to 0.2.334

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k '3232 or 3231_g'
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run ruff format --check tests/test_policyengine_coverage.py
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --limit 10 --fail-on-unmapped --fail-on-untested-comparable

Note: I accidentally ran ruff check on the YAML mapping file first; ruff treats YAML as Python and emitted syntax noise, so I reran the applicable Python lint/format checks above.