### PR TITLE
Prune out-of-scope deferred outputs before apply

### DIFF
--- a/changelog.d/prune-deferred-output-scope.fixed.md
+++ b/changelog.d/prune-deferred-output-scope.fixed.md
@@ -1,0 +1,1 @@
+Prune generated deferred outputs outside the requested RuleSpec target before signed apply.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.334"
+version = "0.2.335"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.334"
+__version__ = "0.2.335"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10624,6 +10624,21 @@ def cmd_encode(args):
                     "  apply=auto_repaired_nested_test_tables:"
                     + ",".join(repaired_nested_test_tables)
                 )
+            repaired_deferred_scope = (
+                _try_repair_generated_out_of_scope_deferred_outputs_for_apply(
+                    result,
+                    output_root=args.output,
+                    policy_repo_path=policy_repo_path,
+                )
+            )
+            if repaired_deferred_scope:
+                outcome["auto_repaired_out_of_scope_deferred_outputs"] = (
+                    repaired_deferred_scope
+                )
+                print(
+                    "  apply=auto_repaired_out_of_scope_deferred_outputs:"
+                    + ",".join(repaired_deferred_scope)
+                )
             can_apply, apply_issues, supplemental_files = (
                 _validate_generated_encoding_in_policy_overlay(
                     result,
@@ -11978,6 +11993,32 @@ def _try_repair_generated_invalid_deferred_source_values_for_apply(
     return _remove_invalid_deferred_source_values(rules_file=rules_file)
 
 
+def _try_repair_generated_out_of_scope_deferred_outputs_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+) -> list[str]:
+    """Remove deferred outputs outside the generated target file's scope."""
+    try:
+        relative_output = _relative_generated_output_path(
+            result,
+            output_root=output_root,
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    base_anchor = _relative_output_to_anchor(
+        relative_output,
+        policy_repo_path=policy_repo_path,
+    )
+    return _remove_out_of_scope_deferred_outputs(
+        rules_file=rules_file,
+        base_anchor=base_anchor,
+    )
+
+
 def _only_pending_empty_deferred_source_values_issues(issues: list[str]) -> bool:
     return bool(issues) and all(
         "module.deferred_outputs[" in str(issue)
@@ -12051,10 +12092,62 @@ def _remove_invalid_deferred_source_values(*, rules_file: Path) -> list[str]:
 
 def _looks_like_absolute_rulespec_output_target(value: Any) -> bool:
     text = str(value or "").strip()
-    if ":" not in text or "#" not in text:
+    if ":" not in text or text.count("#") != 1:
         return False
     path, symbol = text.rsplit("#", 1)
     return bool(path.strip()) and bool(symbol.strip())
+
+
+def _remove_out_of_scope_deferred_outputs(
+    *,
+    rules_file: Path,
+    base_anchor: str,
+) -> list[str]:
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    module = payload.get("module")
+    if not isinstance(module, dict):
+        return []
+    deferred_outputs = module.get("deferred_outputs")
+    if not isinstance(deferred_outputs, list):
+        return []
+
+    kept: list[Any] = []
+    removed: list[str] = []
+    for index, record in enumerate(deferred_outputs):
+        if not isinstance(record, dict):
+            kept.append(record)
+            continue
+        output = str(record.get("output") or "").strip()
+        if not _looks_like_absolute_rulespec_output_target(output):
+            kept.append(record)
+            continue
+        if _rulespec_target_within_anchor(output, base_anchor=base_anchor):
+            kept.append(record)
+            continue
+        removed.append(f"deferred_outputs[{index}]")
+
+    if not removed:
+        return []
+    if kept:
+        module["deferred_outputs"] = kept
+    else:
+        module.pop("deferred_outputs", None)
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return removed
+
+
+def _rulespec_target_within_anchor(target: str, *, base_anchor: str) -> bool:
+    if not _looks_like_absolute_rulespec_output_target(target):
+        return False
+    target_path = target.rsplit("#", 1)[0].strip()
+    return target_path == base_anchor or target_path.startswith(f"{base_anchor}/")
 
 
 def _try_repair_generated_deferred_output_subsection_paths_for_apply(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3543,6 +3543,70 @@ rules: []
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_prunes_out_of_scope_deferred_outputs(
+        self,
+        capsys,
+        tmp_path,
+    ):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(True)
+        output_file = (
+            tmp_path / "out" / "codex-test-model" / "statutes" / "26" / "3121/t.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  status: deferred
+  source_verification:
+    corpus_citation_path: us/statute/26/3121
+  deferred_outputs:
+    - output: us:statutes/26/3121/a#wages
+      reason: Outside subsection t.
+    - output: us:statutes/26/3121/t#repealed_subsection_t
+      reason: Current target deferred output.
+    - output: us:statutes/26/3121/t/1#child_output
+      reason: Current target child deferred output.
+rules: []
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/26/3121/t.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                return_value=(True, [], {}),
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert "apply=auto_repaired_out_of_scope_deferred_outputs:" in output
+        repaired = yaml.safe_load(output_file.read_text())
+        deferred_outputs = repaired["module"]["deferred_outputs"]
+        assert [record["output"] for record in deferred_outputs] == [
+            "us:statutes/26/3121/t#repealed_subsection_t",
+            "us:statutes/26/3121/t/1#child_output",
+        ]
+        assert mock_overlay.call_count == 1
+        mock_apply.assert_called_once()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_out_of_scope_deferred_outputs"] == [
+            "deferred_outputs[0]"
+        ]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_promotes_module_imports(self, capsys, tmp_path):
         args = self._make_args(tmp_path, backend="codex", sync=False)
         args.apply = True


### PR DESCRIPTION
## Summary
- remove generated deferred outputs whose targets are outside the requested RuleSpec file anchor before signed apply
- preserve same-file and descendant deferred targets; leave malformed targets for validation to reject
- bump encoder provenance version to 0.2.335

## Tests
- uv run --extra dev python -m pytest tests/test_cli.py -k 'out_of_scope_deferred_outputs or deferred_source_values'
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- uv run --extra dev python -m towncrier build --draft --version 0.0.0