### PR TITLE
Classify section 3233 oracle output

### DIFF
--- a/changelog.d/section-3233-policyengine-coverage.changed.md
+++ b/changelog.d/section-3233-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify 26 USC 3233 short-title outputs as not comparable to PolicyEngine tax outputs.

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10059,6 +10059,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3232 defines federal district-court jurisdiction and nonexclusive enforcement jurisdiction for Railroad Retirement Tax Act obligations; PolicyEngine does not expose these court-jurisdiction enforcement predicates as one-to-one tax calculation outputs.
 
+  - legal_id_prefix: us:statutes/26/3233#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3233 is the Railroad Retirement Tax Act short-title provision; PolicyEngine does not expose statutory chapter citation titles as one-to-one tax calculation outputs.
+
   - legal_id_prefix: us-co:regulations/10-ccr-2506-1/
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4032,6 +4032,30 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3233_short_title_output(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3233.yaml",
+        """format: rulespec/v1
+rules:
+  - name: chapter_short_title
+    kind: parameter
+    dtype: String
+    versions:
+      - effective_from: '1990-01-01'
+        formula: '"Railroad Retirement Tax Act"'
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == "us:statutes/26/3233#chapter_short_title"
+    assert item["status"] == "known_not_comparable"
+    assert item["policyengine_variable"] is None
+    assert "short-title" in item["rationale"]
+
+
 def test_policyengine_coverage_classifies_3302_c_2_a_advance_reduction_outputs(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- classify 26 USC 3233 short-title outputs as known-not-comparable for the PolicyEngine tax oracle
- add a coverage regression test for the generated chapter_short_title output

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k '3233 or 3232'
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py
- uv run ruff check tests/test_policyengine_coverage.py
- uv run ruff format --check tests/test_policyengine_coverage.py
- uv run --extra dev python -m towncrier build --draft --version 0.0.0