### PR TITLE
Bump encoder version to 0.2.336

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.335"
+version = "0.2.336"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.335"
+__version__ = "0.2.336"
 
 from .constants import (
     DEFAULT_CLI_MODEL,


### PR DESCRIPTION
## Summary
- bump axiom-encode to 0.2.336 so generated apply manifests can reference the current encoder state after recent validator and oracle registry changes

## Tests
- uv run python - <<'PY'
import axiom_encode
print(axiom_encode.__version__)
PY
- uv run ruff check pyproject.toml src/axiom_encode/__init__.py