### PR TITLE
Classify section 3307 oracle outputs

### DIFF
--- a/changelog.d/section-3307-policyengine-coverage.changed.md
+++ b/changelog.d/section-3307-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify 26 USC 3307 deduction-payment treatment outputs as not comparable to PolicyEngine tax outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.336"
+version = "0.2.337"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.336"
+__version__ = "0.2.337"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10583,6 +10583,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(g) defines payment-level State-law unemployment fund contributions for chapter 23 credit calculations; PolicyEngine exposes final employer FUTA tax, not these State contribution amounts separately.
 
+  - legal_id_prefix: us:statutes/26/3307#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3307 treats employee-remuneration deductions remitted to government as paid to the employee for chapter 23; PolicyEngine exposes final FUTA taxable earnings, not this payment-level paid-to-employee deeming rule separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2754,6 +2754,48 @@ rules:
     assert item["policyengine_variable"] == "employer_federal_unemployment_tax"
 
 
+def test_policyengine_coverage_classifies_3307_deduction_payment_treatment(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3307.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3307
+rules:
+  - name: remuneration_deduction_payment_treatment_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: employer_required_to_deduct and amount_paid_to_government
+  - name: remuneration_deduction_considered_paid_to_employee_for_chapter
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if remuneration_deduction_payment_treatment_applies: amount_deducted else: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {
+        "taxable_earnings_for_federal_unemployment_tax"
+    }
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify 26 USC 3307 deduction-payment treatment outputs as known-not-comparable for the PolicyEngine tax oracle
- add a regression test covering the generated 3307 outputs
- bump axiom-encode to 0.2.337 so generated apply manifests can reference this registry state

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k '3307 or 3306_g'
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py pyproject.toml
- uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run python - <<'PY'
import axiom_encode
print(axiom_encode.__version__)
PY
- uv run --extra dev python -m towncrier build --draft --version 0.0.0