### PR TITLE
Classify section 3308 oracle outputs

### DIFF
--- a/changelog.d/section-3308-policyengine-coverage.changed.md
+++ b/changelog.d/section-3308-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify 26 USC 3308 instrumentality exemption outputs as not comparable to PolicyEngine tax outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.337"
+version = "0.2.338"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.337"
+__version__ = "0.2.338"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10591,6 +10591,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3307 treats employee-remuneration deductions remitted to government as paid to the employee for chapter 23; PolicyEngine exposes final FUTA taxable earnings, not this payment-level paid-to-employee deeming rule separately.
 
+  - legal_id_prefix: us:statutes/26/3308#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: employer_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3308 limits United States instrumentality exemptions from section 3301 FUTA tax unless another law specifically references section 3301 or prior law; PolicyEngine exposes final employer FUTA tax, not this legal exemption-preclusion predicate separately.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2796,6 +2796,49 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3308_instrumentality_exemption(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3308.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3308
+rules:
+  - name: other_law_specific_section_3301_exemption_requirement_met
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: section_3301_specific_exemption or prior_law_specific_exemption
+  - name: united_states_instrumentality_section_3301_tax_exemption_precluded
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          employer_is_instrumentality_of_united_states
+          and general_instrumentality_tax_exemption
+          and not other_law_specific_section_3301_exemption_requirement_met
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {
+        "employer_federal_unemployment_tax"
+    }
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3308 outputs as known-not-comparable to PolicyEngine FUTA tax outputs
- add coverage regression for the generated instrumentality exemption predicates
- bump encoder provenance version to 0.2.338

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k '3308 or 3307'
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py pyproject.toml
- uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable