### PR TITLE
Classify section 3311 oracle output

### DIFF
--- a/changelog.d/section-3311-policyengine-coverage.changed.md
+++ b/changelog.d/section-3311-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify 26 USC 3311 short-title outputs as not comparable to PolicyEngine tax outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.338"
+version = "0.2.339"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.338"
+__version__ = "0.2.339"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10599,6 +10599,12 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3308 limits United States instrumentality exemptions from section 3301 FUTA tax unless another law specifically references section 3301 or prior law; PolicyEngine exposes final employer FUTA tax, not this legal exemption-preclusion predicate separately.
 
+  - legal_id_prefix: us:statutes/26/3311#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3311 is the Federal Unemployment Tax Act short-title provision; PolicyEngine does not expose statutory chapter citation titles as one-to-one tax calculation outputs.
+
   - legal_id_prefix: us:statutes/26/3121/a/10#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2839,6 +2839,37 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3311_short_title_output(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3311.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3311
+rules:
+  - name: federal_unemployment_tax_act_short_title
+    kind: parameter
+    dtype: String
+    versions:
+      - effective_from: '1990-01-01'
+        formula: '"Federal Unemployment Tax Act"'
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == (
+        "us:statutes/26/3311#federal_unemployment_tax_act_short_title"
+    )
+    assert item["status"] == "known_not_comparable"
+    assert item["policyengine_variable"] is None
+    assert "short-title" in item["rationale"]
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3311 short-title output as known-not-comparable to PolicyEngine tax outputs
- add coverage regression for the Federal Unemployment Tax Act short-title output
- bump encoder provenance version to 0.2.339

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k '3311 or 3308 or 3233'
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py pyproject.toml
- uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run python - <<'PY'
import axiom_encode
print(axiom_encode.__version__)
PY
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable