### PR TITLE
Classify section 3310 oracle outputs

### DIFF
--- a/changelog.d/section-3310-policyengine-coverage.changed.md
+++ b/changelog.d/section-3310-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify 26 USC 3310 certification-review timing outputs as not comparable to PolicyEngine tax outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.339"
+version = "0.2.340"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.339"
+__version__ = "0.2.340"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10599,6 +10599,12 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3308 limits United States instrumentality exemptions from section 3301 FUTA tax unless another law specifically references section 3301 or prior law; PolicyEngine exposes final employer FUTA tax, not this legal exemption-preclusion predicate separately.
 
+  - legal_id_prefix: us:statutes/26/3310#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3310 sets procedural deadlines and stays for State judicial review of Secretary of Labor certification actions; PolicyEngine does not expose these FUTA administration timing rules as tax calculation outputs.
+
   - legal_id_prefix: us:statutes/26/3311#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2870,6 +2870,45 @@ rules:
     assert "short-title" in item["rationale"]
 
 
+def test_policyengine_coverage_classifies_3310_review_deadlines(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3310.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3310
+rules:
+  - name: state_petition_for_review_deadline_days
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1990-01-01'
+        formula: '60'
+  - name: secretary_certification_withholding_notice_period_days
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1990-01-01'
+        formula: '60'
+  - name: judicial_proceedings_stay_period_days
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1990-01-01'
+        formula: '30'
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+    assert all("timing rules" in item["rationale"] for item in report["items"])
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify 26 USC 3310 FUTA certification-review timing outputs as PolicyEngine known-not-comparable
- add coverage regression and bump encoder version to 0.2.340
- add changelog fragment

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k '3310 or 3311 or 3308'
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py pyproject.toml
- uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run python - <<'PY'
import axiom_encode
print(axiom_encode.__version__)
PY
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py