### PR TITLE
Repair double-hash deferred output paths

### DIFF
--- a/changelog.d/deferred-output-double-hash-paths.fixed.md
+++ b/changelog.d/deferred-output-double-hash-paths.fixed.md
@@ -1,0 +1,1 @@
+Repair generated deferred output targets that place subsection labels between two hash separators.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.340"
+version = "0.2.341"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.340"
+__version__ = "0.2.341"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -12204,6 +12204,18 @@ def _qualify_deferred_output_subsection_paths(
         if not isinstance(record, dict):
             continue
         output = str(record.get("output") or "").strip()
+        double_hash_prefix = f"{base_anchor}#"
+        if output.startswith(double_hash_prefix):
+            remainder = output[len(double_hash_prefix) :]
+            raw_subsection, separator, raw_symbol = remainder.partition("#")
+            subsection = raw_subsection.strip().strip("()")
+            symbol = raw_symbol.strip()
+            if separator and re.fullmatch(r"[A-Za-z0-9]+", subsection) and symbol:
+                qualified = f"{base_anchor}/{subsection}#{symbol}"
+                record["output"] = qualified
+                repaired.append(qualified)
+                continue
+
         if not output.startswith(f"{base_anchor}#"):
             continue
         reason = str(record.get("reason") or "")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,7 @@ from axiom_encode.cli import (
     _insert_false_input_default,
     _local_factual_input_names_from_rules_content,
     _person_scoped_definition_issue_names,
+    _qualify_deferred_output_subsection_paths,
     _remove_cross_module_dependent_test_outputs,
     _remove_invalid_dependent_test_inputs,
     _repair_employer_scoped_entities,
@@ -3944,6 +3945,37 @@ rules:
         ]
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
+
+    def test_repair_deferred_output_double_hash_subsection_path(self, tmp_path):
+        output_file = tmp_path / "3303.yaml"
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3303
+  deferred_outputs:
+    - output: us:statutes/26/3303#b#secretary_certification
+      reason: Section 3304 is not available as copied context.
+rules:
+  - name: minimum_experience_rating_years
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1990-01-01'
+        formula: '3'
+"""
+        )
+
+        repaired = _qualify_deferred_output_subsection_paths(
+            rules_file=output_file,
+            base_anchor="us:statutes/26/3303",
+        )
+
+        assert repaired == ["us:statutes/26/3303/b#secretary_certification"]
+        payload = yaml.safe_load(output_file.read_text())
+        assert payload["module"]["deferred_outputs"][0]["output"] == (
+            "us:statutes/26/3303/b#secretary_certification"
+        )
 
     def test_repair_person_scoped_definition_entities_moves_helpers(self, tmp_path):
         rules_file = tmp_path / "statutes/26/1402/b.yaml"


### PR DESCRIPTION
## Summary
- normalize generated deferred output targets like section#b#symbol to section/b#symbol
- add a focused CLI regression
- bump encoder version to 0.2.341 and add changelog fragment

## Tests
- uv run --extra dev python -m pytest tests/test_cli.py -k 'double_hash_subsection_path or deferred_output_paths'\n- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py src/axiom_encode/__init__.py pyproject.toml\n- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py src/axiom_encode/__init__.py\n- uv run python - <<'PY'\nimport axiom_encode\nprint(axiom_encode.__version__)\nPY\n- uv run --extra dev python -m towncrier build --draft --version 0.0.0