### PR TITLE
Classify section 3303 oracle outputs

### DIFF
--- a/changelog.d/section-3303-oracle.fixed.md
+++ b/changelog.d/section-3303-oracle.fixed.md
@@ -1,0 +1,1 @@
+Classify section 3303 FUTA State-law reduced-rate and account-standard outputs as not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.342"
+version = "0.2.343"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.342"
+__version__ = "0.2.343"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10355,6 +10355,13 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3302(f) defines State-specific limitation and partial-limitation rules for subsection (c)(2) credit reductions, including benefit-cost ratios, State unemployment tax rates, and intermediate capped reduction amounts; PolicyEngine exposes final employer FUTA tax, not these statutory credit-reduction limitation components separately.
 
+  - legal_id_prefix: us:statutes/26/3303#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 3303 defines State-law reduced-rate standards, unemployment-fund account definitions, Secretary-of-Labor certification conditions, voluntary-contribution permissions, nonprofit reimbursement elections, and employer-fault noncharging predicates for FUTA additional-credit administration; PolicyEngine exposes final FUTA tax assumptions, not these State-law account and certification intermediates as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3402/f#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2909,6 +2909,45 @@ rules:
     assert all("timing rules" in item["rationale"] for item in report["items"])
 
 
+def test_policyengine_coverage_classifies_3303_state_reduced_rate_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3303.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3303
+rules:
+  - name: pooled_or_partially_pooled_minimum_experience_years
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1990-01-01'
+        formula: '3'
+  - name: pooled_fund
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: unemployment_fund and all_contributions_are_mingled
+  - name: employer_account_not_relieved_due_to_fault_pattern
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: employer_fault and pattern
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+    assert all("State-law" in item["rationale"] for item in report["items"])
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify section 3303 FUTA State-law reduced-rate/account-standard outputs as PolicyEngine known-not-comparable
- add focused coverage for representative 3303 parameters and judgment outputs
- bump encoder version to 0.2.343 and add changelog fragment

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k '3303 or 3310 or 3302_f'
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py pyproject.toml
- uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run python - <<'PY'
import axiom_encode
print(axiom_encode.__version__)
PY
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run axiom-encode validate --skip-reviewers --oracle policyengine --require-oracle-classification /private/tmp/axiom-payroll-night-20260527103157/rulespec-us/statutes/26/3303.yaml
