### PR TITLE
Classify section 3304 oracle output

### DIFF
--- a/changelog.d/section-3304-policyengine-coverage.changed.md
+++ b/changelog.d/section-3304-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify section 3304 FUTA State-law approval outputs as known non-comparable PolicyEngine tax oracle outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.343"
+version = "0.2.344"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.343"
+__version__ = "0.2.344"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10362,6 +10362,13 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3303 defines State-law reduced-rate standards, unemployment-fund account definitions, Secretary-of-Labor certification conditions, voluntary-contribution permissions, nonprofit reimbursement elections, and employer-fault noncharging predicates for FUTA additional-credit administration; PolicyEngine exposes final FUTA tax assumptions, not these State-law account and certification intermediates as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3304#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 3304 defines State-law approval requirements and institutional legal-status predicates for unemployment-compensation administration; PolicyEngine exposes final FUTA tax assumptions, not these State-law approval and institution-definition outputs as one-to-one variables or parameters.
+
   - legal_id_prefix: us:statutes/26/3402/f#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2948,6 +2948,35 @@ rules:
     assert all("State-law" in item["rationale"] for item in report["items"])
 
 
+def test_policyengine_coverage_classifies_3304_state_law_approval_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3304.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3304
+rules:
+  - name: institution_of_higher_education
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: educational_institution and nonprofit
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == ("us:statutes/26/3304#institution_of_higher_education")
+    assert item["status"] == "known_not_comparable"
+    assert item["policyengine_variable"] is None
+    assert "State-law approval" in item["rationale"]
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify 26 USC 3304 FUTA State-law approval and institution-definition outputs as known non-comparable to PolicyEngine tax outputs
- add a regression test for the generated `institution_of_higher_education` output
- bump encoder version to 0.2.344 for provenance on downstream RuleSpec validation

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k '3304 or 3303 or 3310 or 3302_f'`
- `uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py pyproject.toml`
- `uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- YAML parse check for `src/axiom_encode/oracles/policyengine/mappings/us.yaml`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable`
