### PR TITLE
Classify section 3305 oracle outputs

### DIFF
--- a/changelog.d/section-3305-policyengine-coverage.changed.md
+++ b/changelog.d/section-3305-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify section 3305 FUTA State-law compliance and credit-denial outputs as known non-comparable PolicyEngine tax oracle outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.344"
+version = "0.2.345"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.344"
+__version__ = "0.2.345"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10369,6 +10369,13 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3304 defines State-law approval requirements and institutional legal-status predicates for unemployment-compensation administration; PolicyEngine exposes final FUTA tax assumptions, not these State-law approval and institution-definition outputs as one-to-one variables or parameters.
 
+  - legal_id_prefix: us:statutes/26/3305#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 3305 preserves State unemployment-law compliance duties against interstate-commerce and federal-property objections and denies section 3302 credits after Labor certification failures; PolicyEngine exposes final FUTA tax assumptions, not these State-law compliance and administrative credit-denial predicates as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3402/f#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2977,6 +2977,45 @@ rules:
     assert "State-law approval" in item["rationale"]
 
 
+def test_policyengine_coverage_classifies_3305_state_law_compliance_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3305.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3305
+rules:
+  - name: state_unemployment_fund_payment_compliance_not_relieved_by_commerce_ground
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: required_to_pay and interstate_commerce
+  - name: state_unemployment_compensation_compliance_not_relieved_by_federal_property_services
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: subject_to_state_law and federal_property_services
+  - name: state_unemployment_contribution_credits_denied_for_permission_condition_failure
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: required_to_contribute and certified_failure
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+    assert all("State-law compliance" in item["rationale"] for item in report["items"])
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify 26 USC 3305 FUTA State-law compliance and Labor-certified credit-denial outputs as known non-comparable to PolicyEngine tax outputs
- add a regression test for the three generated 3305 outputs
- bump encoder version to 0.2.345 for downstream provenance

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k '3305 or 3304 or 3303 or 3310 or 3302_f'`
- `uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py pyproject.toml`
- `uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- YAML parse check for `src/axiom_encode/oracles/policyengine/mappings/us.yaml`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable`
