### PR TITLE
Classify section 3309 oracle outputs

### DIFF
--- a/changelog.d/section-3309-policyengine-coverage.changed.md
+++ b/changelog.d/section-3309-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify section 3309 FUTA coverage thresholds and predicates as known non-comparable PolicyEngine tax oracle outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.345"
+version = "0.2.346"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.345"
+__version__ = "0.2.346"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10376,6 +10376,13 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3305 preserves State unemployment-law compliance duties against interstate-commerce and federal-property objections and denies section 3302 credits after Labor certification failures; PolicyEngine exposes final FUTA tax assumptions, not these State-law compliance and administrative credit-denial predicates as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3309#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 3309 defines services covered for State unemployment-compensation purposes, source-specific exceptions, organization employee-count thresholds, and tribal delinquency predicates; PolicyEngine exposes final FUTA taxable earnings and tax assumptions, not these source-specific coverage thresholds and legal predicates as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3402/f#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3016,6 +3016,57 @@ rules:
     assert all("State-law compliance" in item["rationale"] for item in report["items"])
 
 
+def test_policyengine_coverage_classifies_3309_coverage_predicate_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3309.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3309
+rules:
+  - name: policymaking_advisory_position_weekly_hours_limit
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 8
+  - name: election_official_worker_remuneration_annual_limit
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 1000
+  - name: service_category_excludes_section_application
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: religious_service or inmate_service
+  - name: organization_has_minimum_employment_for_section_application
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: counted_days >= 20 and workers >= 4
+  - name: tribal_uncorrected_failure_prevents_governmental_service_exception
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: tribal_delinquency and not corrected
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 5}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+    assert all("coverage thresholds" in item["rationale"] for item in report["items"])
+
+
 def test_policyengine_coverage_classifies_3301_gross_futa_tax(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3301.yaml",


### PR DESCRIPTION
## Summary
- classify 26 USC 3309 FUTA coverage thresholds and service-category predicates as known non-comparable to PolicyEngine tax outputs
- add a regression test for generated 3309 parameter and derived outputs
- bump encoder version to 0.2.346 for downstream provenance

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k '3309 or 3305 or 3304 or 3303 or 3310 or 3302_f'`
- `uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py pyproject.toml`
- `uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- YAML parse check for `src/axiom_encode/oracles/policyengine/mappings/us.yaml`
- `uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --program tax --fail-on-unmapped --fail-on-untested-comparable`
