### PR TITLE
Defer tax status placeholder outputs during apply

### DIFF
--- a/changelog.d/tax-status-output-deferral.fixed.md
+++ b/changelog.d/tax-status-output-deferral.fixed.md
@@ -1,0 +1,1 @@
+Defer generated outputs that treat tax-status or marital-status legal classifications as local factual inputs during signed apply.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.346"
+version = "0.2.347"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.346"
+__version__ = "0.2.347"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -12608,6 +12608,11 @@ def _try_repair_generated_unsafe_formula_outputs_for_apply(
                 seed_rules.add(rule_name)
                 issue_reasons[rule_name].append("unused_source_modifier")
                 issue_source_values[rule_name].add(source_value_rule)
+        tax_status_component_match = _TAX_STATUS_COMPONENT_ISSUE_RE.search(issue_text)
+        if tax_status_component_match:
+            rule_name = tax_status_component_match.group("rule")
+            seed_rules.add(rule_name)
+            issue_reasons[rule_name].append("tax_status_component_placeholder")
     if not seed_rules:
         return []
 
@@ -12722,6 +12727,13 @@ def _try_repair_generated_unsafe_formula_outputs_for_apply(
                 "modification, or limitation parameter. This output is deferred "
                 "until the upstream cross-referenced mechanics can be imported "
                 "or composed without stranding the modifier."
+            )
+        elif "tax_status_component_placeholder" in reasons:
+            reason = (
+                "Generated rule treated a filing-status or marital-status legal "
+                "classification as a local fact. This output is deferred until "
+                "the upstream status source can be encoded or imported without "
+                "inventing local tax-status component inputs."
             )
         else:
             reason = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7364,6 +7364,98 @@ rules:
             }
         ]
 
+    def test_unsafe_formula_output_repair_defers_tax_status_components(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "openai-gpt-5.5" / "statutes/26/3402/l.yaml"
+        test_file = output_root / "openai-gpt-5.5" / "statutes/26/3402/l.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        policy_repo = tmp_path / "rulespec-us"
+        policy_repo.mkdir()
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: employer_must_treat_employee_as_single_for_withholding_tables
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    source: 26 USC 3402(l)(1)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: not withholding_allowance_certificate_indicating_employee_is_married
+  - name: employee_considered_not_married_for_withholding_certificate
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    source: 26 USC 3402(l)(2)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: employee_legally_separated_from_spouse
+"""
+        )
+        test_file.write_text(
+            """- name: status_component_placeholder
+  output:
+    us:statutes/26/3402/l#employer_must_treat_employee_as_single_for_withholding_tables: true
+- name: retained_local_rule
+  output:
+    us:statutes/26/3402/l#employee_considered_not_married_for_withholding_certificate: true
+"""
+        )
+        result = SimpleNamespace(
+            runner="openai-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = _try_repair_generated_unsafe_formula_outputs_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "statutes/26/3402/l.yaml: ci: Tax filing-status component is a "
+                "derived legal classification, not a local factual input: "
+                "`employer_must_treat_employee_as_single_for_withholding_tables` "
+                "references "
+                "`withholding_allowance_certificate_indicating_employee_is_married` "
+                "without defining or importing its absolute upstream RuleSpec "
+                "output."
+            ],
+        )
+
+        payload = yaml.safe_load(rules_file.read_text())
+        test_cases = yaml.safe_load(test_file.read_text())
+        assert repaired == [
+            "us:statutes/26/3402/l#employer_must_treat_employee_as_single_for_withholding_tables"
+        ]
+        assert [rule["name"] for rule in payload["rules"]] == [
+            "employee_considered_not_married_for_withholding_certificate"
+        ]
+        assert payload["module"]["deferred_outputs"] == [
+            {
+                "output": (
+                    "us:statutes/26/3402/l#"
+                    "employer_must_treat_employee_as_single_for_withholding_tables"
+                ),
+                "reason": (
+                    "Generated rule treated a filing-status or marital-status "
+                    "legal classification as a local fact. This output is "
+                    "deferred until the upstream status source can be encoded "
+                    "or imported without inventing local tax-status component "
+                    "inputs."
+                ),
+            }
+        ]
+        assert test_cases == [
+            {
+                "name": "retained_local_rule",
+                "output": {
+                    "us:statutes/26/3402/l#employee_considered_not_married_for_withholding_certificate": True
+                },
+            }
+        ]
+
     def test_unresolved_local_test_output_repair_removes_stale_output(self, tmp_path):
         output_root = tmp_path / "out"
         rules_file = output_root / "openai-gpt-5.5" / "statutes/26/3221.yaml"


### PR DESCRIPTION
## Summary
- defer generated outputs that validation flags as local filing-status or marital-status placeholders
- keep safe sibling outputs and companion tests when only one generated output is deferred
- bump axiom-encode to 0.2.347 with a changelog fragment

## Tests
- uv run --extra dev python -m pytest tests/test_cli.py -k 'unsafe_formula_output_repair'
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py src/axiom_encode/__init__.py pyproject.toml
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py src/axiom_encode/__init__.py
- uv run python - <<'PY'
import axiom_encode
print(axiom_encode.__version__)
PY
- uv run towncrier build --draft --version 0.2.347 | rg 'tax-status|0.2.347'