### PR TITLE
Classify section 3402(l) oracle outputs

### DIFF
--- a/changelog.d/section-3402-l-policyengine-coverage.changed.md
+++ b/changelog.d/section-3402-l-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify section 3402(l) withholding marital-status outputs as not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.347"
+version = "0.2.348"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.347"
+__version__ = "0.2.348"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10419,6 +10419,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3402(k) applies chapter 24 withholding mechanics to tips, limits deduction and withholding to employer-controlled wages and employee-turned-over funds after section 3102(a) or 3202(a) collections, and allows special low-monthly-tip withholding for section 3401(a)(16)(B) tips; PolicyEngine does not expose paycheck tip-withholding administration surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3402/l#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(l) determines and discloses marital status for chapter 24 withholding certificates and paycheck withholding tables; PolicyEngine computes annual tax outcomes, not these employer certificate, marital-status disclosure, or withholding-table administration predicates as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3913,6 +3913,36 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402l_marital_status_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/l.yaml",
+        """format: rulespec/v1
+rules:
+  - name: employee_considered_not_married_for_married_certificate_disclosure
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: legally_separated or nonresident_alien_status
+  - name: employee_considered_married_after_current_year_spouse_death
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: spouse_died and not subparagraph_a_disqualified
+  - name: married_to_single_new_certificate_requirement_satisfied
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: not certificate_due or new_certificate_furnished
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- classify 26 USC 3402(l) withholding marital-status outputs as not comparable to PolicyEngine
- add coverage regression for generated 3402(l)-style outputs
- bump axiom-encode to 0.2.348 with a changelog fragment

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k '3402l'
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py pyproject.toml
- uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run python - <<'PY'
import axiom_encode
print(axiom_encode.__version__)
PY
- uv run towncrier build --draft --version 0.2.348 | rg '3402\(l\)|0.2.348'
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20