### PR TITLE
Classify section 3402(m) oracle outputs

### DIFF
--- a/changelog.d/section-3402-m-policyengine-coverage.changed.md
+++ b/changelog.d/section-3402-m-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify section 3402(m) additional withholding allowance outputs as not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.348"
+version = "0.2.349"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.348"
+__version__ = "0.2.349"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10425,6 +10425,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3402(l) determines and discloses marital status for chapter 24 withholding certificates and paycheck withholding tables; PolicyEngine computes annual tax outcomes, not these employer certificate, marital-status disclosure, or withholding-table administration predicates as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3402/m#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(m) authorizes additional withholding allowances or reductions under Secretary-prescribed regulations and related certificate administration; PolicyEngine computes annual tax outcomes, not paycheck withholding allowance or reduction entitlement predicates as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3943,6 +3943,28 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402m_withholding_allowance_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/m.yaml",
+        """format: rulespec/v1
+rules:
+  - name: employee_entitled_to_additional_withholding_adjustment
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: employee and secretary_regulations_prescribe_adjustment
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- classify generated section 3402(m) withholding allowance outputs as PolicyEngine known-not-comparable
- add a regression test for the oracle coverage registry entry
- bump encoder provenance to 0.2.349 with a changelog fragment

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k '3402m'
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py pyproject.toml
- uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run python -c 'import axiom_encode; print(axiom_encode.__version__)'
- uv run towncrier build --draft --version 0.2.349
- uv run axiom-encode oracle-coverage --root /private/tmp/axiom-payroll-night-20260527103157 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20