### PR TITLE
Classify section 3402(p) oracle outputs

### DIFF
--- a/changelog.d/section-3402-p-policyengine-coverage.changed.md
+++ b/changelog.d/section-3402-p-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify section 3402(p) voluntary withholding outputs as not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.351"
+version = "0.2.352"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.351"
+__version__ = "0.2.352"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10443,6 +10443,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3402(o) extends chapter 24 paycheck withholding treatment to supplemental unemployment compensation, requested annuity withholding, requested non-wage sick pay, and related request or collective-bargaining administration rules; PolicyEngine computes annual tax outcomes, not these payment-level withholding-administration predicates or request amount intermediates as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3402/p#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(p) provides voluntary chapter 24 withholding rules for specified Federal payments, unemployment compensation, and other agreed non-wage payments; PolicyEngine computes annual tax outcomes, not these payment-level voluntary withholding request predicates, rates, and amount intermediates as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4014,6 +4014,33 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402p_voluntary_withholding_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/p.yaml",
+        """format: rulespec/v1
+rules:
+  - name: unemployment_compensation_voluntary_withholding_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.10
+  - name: specified_federal_payment_voluntary_withholding_amount
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: payment_amount * requested_rate
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- classify section 3402(p) voluntary withholding outputs as PolicyEngine known-not-comparable
- add a regression test for the oracle coverage registry entry
- bump encoder provenance to 0.2.352 with a changelog fragment

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k '3402p'
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py pyproject.toml
- uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run python -c 'import axiom_encode; print(axiom_encode.__version__)'
- uv run towncrier build --draft --version 0.2.352 | rg '3402\(p\)|0.2.352'
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20