### PR TITLE
Classify section 3402(q) oracle outputs

### DIFF
--- a/changelog.d/3402q-oracle-classification.changed.md
+++ b/changelog.d/3402q-oracle-classification.changed.md
@@ -1,0 +1,1 @@
+Classify generated 26 USC 3402(q) gambling withholding outputs as PolicyEngine-known non-comparable tax surfaces.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.352"
+version = "0.2.353"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.352"
+__version__ = "0.2.353"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10449,6 +10449,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3402(p) provides voluntary chapter 24 withholding rules for specified Federal payments, unemployment compensation, and other agreed non-wage payments; PolicyEngine computes annual tax outcomes, not these payment-level voluntary withholding request predicates, rates, and amount intermediates as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3402/q#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(q) extends chapter 24 withholding administration to certain gambling winnings, including wager-proceeds thresholds, 300-to-1 ratio tests, gambling-category predicates, and coordination/exemption rules; PolicyEngine computes annual income tax outcomes, not these payment-level gambling withholding administration surfaces as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4041,6 +4041,38 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402q_gambling_withholding_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/q.yaml",
+        """format: rulespec/v1
+rules:
+  - name: withholding_winnings_proceeds_threshold
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 5000
+  - name: winnings_subject_to_withholding
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: wager_proceeds > withholding_winnings_proceeds_threshold
+  - name: payment_of_winnings_treated_as_wages_for_section_3403
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: winnings_subject_to_withholding
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- Classify generated 26 USC 3402(q) gambling withholding outputs as PolicyEngine-known non-comparable tax surfaces
- Add a focused coverage regression test
- Bump axiom-encode to 0.2.353 with a changelog fragment

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k '3402q'`
- `uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- `uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- `uv run python -c 'import axiom_encode; print(axiom_encode.__version__)'`
- `uv run towncrier build --draft --version 0.2.353 | rg '3402\(q\)|0.2.353'`
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/rulespec-us-3402p/statutes/26/3402/q.yaml --skip-reviewers --oracle policyengine --require-oracle-classification --json`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528 --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20`