### PR TITLE
Classify section 3402(r) oracle outputs

### DIFF
--- a/changelog.d/section-3402-r-policyengine-coverage.changed.md
+++ b/changelog.d/section-3402-r-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify Section 3402(r) Indian casino profit withholding outputs for PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.353"
+version = "0.2.354"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.353"
+__version__ = "0.2.354"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10455,6 +10455,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3402(q) extends chapter 24 withholding administration to certain gambling winnings, including wager-proceeds thresholds, 300-to-1 ratio tests, gambling-category predicates, and coordination/exemption rules; PolicyEngine computes annual income tax outcomes, not these payment-level gambling withholding administration surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3402/r#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(r) extends chapter 24 withholding administration to certain taxable payments of Indian casino profits, including payment-source predicates, annualized-payment exceptions, annualized tax, alternate Secretary procedures, and wage-treatment rules; PolicyEngine computes annual income tax outcomes, not these payment-level withholding administration surfaces as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4073,6 +4073,33 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402r_indian_casino_profit_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/r.yaml",
+        """format: rulespec/v1
+rules:
+  - name: indian_casino_profit_payment_withholding_predicate
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: payer_makes_payment and payment_is_to_member_of_indian_tribe
+  - name: tax_to_deduct_and_withhold_from_indian_casino_profit_payment
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: payment_proportionate_share_of_annualized_tax
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- classify Section 3402(r) Indian casino profit withholding outputs as not comparable to PolicyEngine
- add a regression test for the PolicyEngine coverage registry
- bump axiom-encode to 0.2.354

## Tests
- uv run pytest tests/test_policyengine_coverage.py -q
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run python - <<'PY'
from pathlib import Path
import yaml
with Path('src/axiom_encode/oracles/policyengine/mappings/us.yaml').open() as f:
    payload = yaml.safe_load(f)
print(len(payload.get('mappings', [])), len(payload.get('prefixes', [])))
PY
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json | jq '{status_counts, untested_comparable, unmapped: [.items[] | select(.status == "unmapped") | {legal_id,file,rule_name}]}'