### PR TITLE
Classify section 3402(s) oracle outputs

### DIFF
--- a/changelog.d/section-3402-s-policyengine-coverage.changed.md
+++ b/changelog.d/section-3402-s-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify Section 3402(s) vehicle fringe benefit withholding outputs for PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.354"
+version = "0.2.355"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.354"
+__version__ = "0.2.355"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10461,6 +10461,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3402(r) extends chapter 24 withholding administration to certain taxable payments of Indian casino profits, including payment-source predicates, annualized-payment exceptions, annualized tax, alternate Secretary procedures, and wage-treatment rules; PolicyEngine computes annual income tax outcomes, not these payment-level withholding administration surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3402/s#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(s) governs employer elections not to withhold chapter 24 tax on vehicle fringe benefits, section 6051 wage-statement treatment, and the vehicle fringe benefit definition; PolicyEngine computes annual tax outcomes, not these employer paycheck withholding and reporting administration surfaces as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4100,6 +4100,38 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402s_vehicle_fringe_benefit_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/s.yaml",
+        """format: rulespec/v1
+rules:
+  - name: vehicle_fringe_benefit
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: payment_is_fringe_benefit and fringe_benefit_constitutes_wages
+  - name: vehicle_fringe_benefit_treated_as_wages_for_section_6051
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: vehicle_fringe_benefit
+  - name: employer_vehicle_fringe_benefit_nonwithholding_election_available
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: vehicle_fringe_benefit and employee_notified_by_employer
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- Classify Section 3402(s) vehicle fringe benefit withholding outputs as not comparable to PolicyEngine.
- Add a regression test for the PolicyEngine coverage registry.
- Bump axiom-encode to 0.2.355.

## Tests
- uv run pytest tests/test_policyengine_coverage.py -k 3402s
- uv run pytest tests/test_policyengine_coverage.py -q
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json