### PR TITLE
Classify section 3402(t) oracle outputs

### DIFF
--- a/changelog.d/section-3402-t-policyengine-coverage.changed.md
+++ b/changelog.d/section-3402-t-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify Section 3402(t) qualified stock withholding outputs for PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.355"
+version = "0.2.356"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.355"
+__version__ = "0.2.356"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10467,6 +10467,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3402(s) governs employer elections not to withhold chapter 24 tax on vehicle fringe benefits, section 6051 wage-statement treatment, and the vehicle fringe benefit definition; PolicyEngine computes annual tax outcomes, not these employer paycheck withholding and reporting administration surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3402/t#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3402(t) sets withholding-rate floor and noncash fringe-benefit treatment rules for qualified stock with section 83(i) elections; PolicyEngine computes annual income tax outcomes, not this stock-specific withholding administration surface as a one-to-one output.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4132,6 +4132,38 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3402t_qualified_stock_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3402/t.yaml",
+        """format: rulespec/v1
+rules:
+  - name: qualified_stock_with_section_83_i_election
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: stock_is_qualified_stock and section_83_i_election_made
+  - name: section_1_maximum_rate_floor_applies_to_qualified_stock_with_section_83_i_election
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: qualified_stock_with_section_83_i_election
+  - name: qualified_stock_treated_as_noncash_fringe_benefit_for_section_3501_b
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: qualified_stock_with_section_83_i_election
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3403_withholding_liability(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3403.yaml",


### PR DESCRIPTION
## Summary
- Classify Section 3402(t) qualified stock withholding outputs as not comparable to PolicyEngine.
- Add a regression test for the PolicyEngine coverage registry.
- Bump axiom-encode to 0.2.356.

## Tests
- uv run pytest tests/test_policyengine_coverage.py -k 3402t
- uv run pytest tests/test_policyengine_coverage.py -q
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json