### PR TITLE
Classify section 3404 oracle outputs

### DIFF
--- a/changelog.d/section-3404-policyengine-coverage.changed.md
+++ b/changelog.d/section-3404-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated section 3404 return-filing delegation outputs in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.356"
+version = "0.2.357"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.356"
+__version__ = "0.2.357"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10473,6 +10473,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3402(t) sets withholding-rate floor and noncash fringe-benefit treatment rules for qualified stock with section 83(i) elections; PolicyEngine computes annual income tax outcomes, not this stock-specific withholding administration surface as a one-to-one output.
 
+  - legal_id_prefix: us:statutes/26/3404#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3404 authorizes officers or employees of governmental employers to make returns of chapter 24 withheld wage amounts; PolicyEngine computes annual tax outcomes, not this return-filing delegation surface as a one-to-one output.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4189,6 +4189,30 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3404_government_return_maker(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3404.yaml",
+        """format: rulespec/v1
+rules:
+  - name: government_employer_withholding_return_maker_authorized
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: person_is_officer_or_employee and person_has_control_of_wages
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    [item] = report["items"]
+    assert item["status"] == "known_not_comparable"
+    assert item["policyengine_variable"] is None
+    assert "return-filing delegation" in item["rationale"]
+
+
 def test_policyengine_coverage_classifies_3127_religious_exemption_outputs(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3404 return-filing delegation outputs as PolicyEngine not_comparable
- add a regression test for the section 3404 coverage classification
- bump axiom-encode to 0.2.357 and add a changelog fragment

## Validation
- uv run pytest tests/test_policyengine_coverage.py -k 3404 -q
- uv run pytest tests/test_policyengine_coverage.py -q
- uv run ruff check tests/test_policyengine_coverage.py pyproject.toml src/axiom_encode/__init__.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json