### PR TITLE
Classify section 3405(b) oracle outputs

### DIFF
--- a/changelog.d/section-3405-b-policyengine-coverage.changed.md
+++ b/changelog.d/section-3405-b-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated section 3405(b) nonperiodic distribution withholding outputs in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.357"
+version = "0.2.358"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.357"
+__version__ = "0.2.358"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10479,6 +10479,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3404 authorizes officers or employees of governmental employers to make returns of chapter 24 withheld wage amounts; PolicyEngine computes annual tax outcomes, not this return-filing delegation surface as a one-to-one output.
 
+  - legal_id_prefix: us:statutes/26/3405/b#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3405(b) sets payment-level withholding and election-scope rules for nonperiodic pension and annuity distributions; PolicyEngine computes annual tax outcomes and pension income, not this distribution withholding administration surface as a one-to-one output.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4213,6 +4213,47 @@ rules:
     assert "return-filing delegation" in item["rationale"]
 
 
+def test_policyengine_coverage_classifies_3405b_nonperiodic_distribution_withholding(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3405/b.yaml",
+        """format: rulespec/v1
+rules:
+  - name: nonperiodic_distribution_withholding_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.10
+  - name: nonperiodic_distribution_withholding
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: nonperiodic_distribution_amount * nonperiodic_distribution_withholding_rate
+  - name: election_scope_for_current_nonperiodic_distribution
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: individual_elects_no_withholding_for_nonperiodic_distribution
+  - name: election_scope_for_subsequent_nonperiodic_distributions
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: election_scope_for_current_nonperiodic_distribution and same_arrangement
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 4}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+    assert all(
+        "distribution withholding administration" in item["rationale"]
+        for item in report["items"]
+    )
+
+
 def test_policyengine_coverage_classifies_3127_religious_exemption_outputs(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3405(b) nonperiodic distribution withholding outputs as PolicyEngine not_comparable
- add a regression test for the section 3405(b) coverage classification
- bump axiom-encode to 0.2.358 and add a changelog fragment

## Validation
- uv run pytest tests/test_policyengine_coverage.py -k 3405b -q
- uv run pytest tests/test_policyengine_coverage.py -q
- uv run ruff check tests/test_policyengine_coverage.py pyproject.toml src/axiom_encode/__init__.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json