### PR TITLE
Classify section 3405 oracle outputs

### DIFF
--- a/changelog.d/section-3405-policyengine-coverage.changed.md
+++ b/changelog.d/section-3405-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated section 3405 pension and annuity distribution withholding outputs in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.358"
+version = "0.2.359"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.358"
+__version__ = "0.2.359"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10485,6 +10485,18 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3405(b) sets payment-level withholding and election-scope rules for nonperiodic pension and annuity distributions; PolicyEngine computes annual tax outcomes and pension income, not this distribution withholding administration surface as a one-to-one output.
 
+  - legal_id_prefix: us:statutes/26/3405#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3405 sets payment-level withholding, election, notice, liability, and definition rules for pension and annuity distributions; PolicyEngine computes annual tax outcomes and pension income, not this withholding administration surface as a one-to-one output.
+
+  - legal_id_prefix: us:statutes/26/3405/
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3405 child subsections set payment-level withholding, election, notice, liability, and definition rules for pension and annuity distributions; PolicyEngine computes annual tax outcomes and pension income, not these withholding administration surfaces as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4254,6 +4254,30 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3405_child_withholding_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3405/c.yaml",
+        """format: rulespec/v1
+rules:
+  - name: eligible_rollover_distribution_withholding_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.20
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    [item] = report["items"]
+    assert item["status"] == "known_not_comparable"
+    assert item["policyengine_variable"] is None
+    assert "withholding administration" in item["rationale"]
+
+
 def test_policyengine_coverage_classifies_3127_religious_exemption_outputs(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3405 pension and annuity distribution withholding outputs as PolicyEngine not_comparable
- add a child-subsection regression test covering 3405(c) eligible rollover withholding-rate output
- bump axiom-encode to 0.2.359 and add a changelog fragment

## Validation
- uv run pytest tests/test_policyengine_coverage.py -k "3405_child or 3405b" -q
- uv run pytest tests/test_policyengine_coverage.py -q
- uv run ruff check tests/test_policyengine_coverage.py pyproject.toml src/axiom_encode/__init__.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json