### PR TITLE
Bump encoder version to 0.2.360

### DIFF
--- a/changelog.d/bump-encoder-0-2-360.changed.md
+++ b/changelog.d/bump-encoder-0-2-360.changed.md
@@ -1,0 +1,1 @@
+Bump encoder version to 0.2.360 after canonical-ref auto-repair changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.359"
+version = "0.2.360"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.359"
+__version__ = "0.2.360"
 
 from .constants import (
     DEFAULT_CLI_MODEL,


### PR DESCRIPTION
## Summary
- bump `axiom-encode` package version from 0.2.359 to 0.2.360
- add changelog entry for the bump after canonical-ref auto-repair changes

## Validation
- `uv run ruff check pyproject.toml src/axiom_encode/__init__.py`
- `uv run pytest tests/test_concepts_auto_repair.py tests/test_concepts_cli.py -q`