### PR TITLE
Classify section 3406 oracle outputs

### DIFF
--- a/changelog.d/section-3406-policyengine-coverage.changed.md
+++ b/changelog.d/section-3406-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify section 3406 backup withholding outputs as not comparable to PolicyEngine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.360"
+version = "0.2.361"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.360"
+__version__ = "0.2.361"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10497,6 +10497,18 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3405 child subsections set payment-level withholding, election, notice, liability, and definition rules for pension and annuity distributions; PolicyEngine computes annual tax outcomes and pension income, not these withholding administration surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3406#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3406 sets backup withholding rules for reportable payments, TIN failures, underreporting notices, certifications, payor deductions, and withholding administration; PolicyEngine computes annual tax outcomes, not these payor-level backup withholding administration surfaces as one-to-one outputs.
+
+  - legal_id_prefix: us:statutes/26/3406/
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3406 child subsections set backup withholding rules for reportable payments, TIN failures, underreporting notices, certifications, payor deductions, and withholding administration; PolicyEngine computes annual tax outcomes, not these payor-level backup withholding administration surfaces as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4278,6 +4278,37 @@ rules:
     assert "withholding administration" in item["rationale"]
 
 
+def test_policyengine_coverage_classifies_3406_child_backup_withholding_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3406/a.yaml",
+        """format: rulespec/v1
+rules:
+  - name: backup_withholding_requirement_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: reportable_payment and payee_fails_to_furnish_tin_to_payor
+  - name: underreporting_or_certification_failure_applies_to_payment
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: reportable_interest_or_dividend_payment and notified_payee_underreporting
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+    assert all(
+        "backup withholding administration" in item["rationale"]
+        for item in report["items"]
+    )
+
+
 def test_policyengine_coverage_classifies_3127_religious_exemption_outputs(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary
- classify 26 USC 3406 backup withholding outputs as not comparable to PolicyEngine
- add regression coverage for child subsection outputs such as 3406(a)
- bump encoder version to 0.2.361

## Validation
- `uv run pytest tests/test_policyengine_coverage.py -k "3406_child or 3405_child" -q`
- `uv run ruff check tests/test_policyengine_coverage.py pyproject.toml src/axiom_encode/__init__.py`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`