### PR TITLE
Classify section 3505 oracle outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.361"
+version = "0.2.362"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.361"
+__version__ = "0.2.362"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10509,6 +10509,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3406 child subsections set backup withholding rules for reportable payments, TIN failures, underreporting notices, certifications, payor deductions, and withholding administration; PolicyEngine computes annual tax outcomes, not these payor-level backup withholding administration surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3505#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3505 assigns third-party liability to lenders, sureties, and other non-employer persons that directly pay wages or supply funds for wage payments, and credits resulting payments against employer liability; PolicyEngine computes payroll tax amounts, not this third-party legal-liability and credit-allocation surface as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4393,6 +4393,66 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3505_third_party_liability_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3505.yaml",
+        """format: rulespec/v1
+rules:
+  - name: supplied_funds_liability_limit_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.25
+  - name: direct_wage_payment_third_party_liability_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: third_party_pays_wages_directly_to_employee_group_or_agent
+  - name: direct_wage_payment_third_party_liability
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: taxes_together_with_interest_required_to_be_deducted_and_withheld_from_directly_paid_wages
+  - name: supplied_funds_third_party_liability_applies
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: funds_supplied_for_specific_purpose_of_paying_employer_wages
+  - name: supplied_funds_third_party_liability_before_limit
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: taxes_together_with_interest_not_paid_over_by_employer
+  - name: supplied_funds_third_party_liability_limit
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: supplied_funds_liability_limit_rate * amount_supplied
+  - name: supplied_funds_third_party_liability
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: min(supplied_funds_third_party_liability_before_limit, supplied_funds_third_party_liability_limit)
+  - name: employer_liability_credit_for_section_3505_payments
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: amounts_paid_to_united_states_pursuant_to_section_3505
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 8}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+    assert all(
+        "third-party legal-liability" in item["rationale"] for item in report["items"]
+    )
+
+
 def test_policyengine_coverage_classifies_3511_cpeo_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3511.yaml",


### PR DESCRIPTION
Adds PolicyEngine oracle coverage classification for generated 26 USC 3505 third-party employment-tax liability outputs and bumps axiom-encode to 0.2.362.\n\nValidation:\n- `uv run pytest tests/test_policyengine_coverage.py`\n- `uv run pytest tests/test_policyengine_coverage.py -k '3505'`\n- `uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`\n- Tax oracle coverage on the 3505 RuleSpec branch now reports `227 comparable`, `1236 known_not_comparable`, `0 unmapped`, `0 untested_comparable`.