### PR TITLE
Classify section 3506 oracle outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.362"
+version = "0.2.363"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.362"
+__version__ = "0.2.363"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10515,6 +10515,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3505 assigns third-party liability to lenders, sureties, and other non-employer persons that directly pay wages or supply funds for wage payments, and credits resulting payments against employer liability; PolicyEngine computes payroll tax amounts, not this third-party legal-liability and credit-allocation surface as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3506#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3506 defines sitter-placement businesses and excludes qualifying placement persons from employer treatment for sitters; PolicyEngine computes employment taxes from modeled employer and wage facts, not this placement-service employer-status classification as a one-to-one output.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4453,6 +4453,42 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3506_sitter_placement_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3506.yaml",
+        """format: rulespec/v1
+rules:
+  - name: sitters
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: individual_furnishes_personal_attendance_companionship_or_household_care_services
+  - name: sitter_placement_person_not_treated_as_employer
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: person_engaged_in_trade_or_business_of_putting_sitters_in_touch_with_individuals_who_wish_to_employ_them
+  - name: sitter_not_treated_as_employee_of_placement_person
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: sitters and not placement_person_pays_or_receives_salary_or_wages_of_sitters
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+    assert all(
+        "placement-service employer-status classification" in item["rationale"]
+        for item in report["items"]
+    )
+
+
 def test_policyengine_coverage_classifies_3511_cpeo_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3511.yaml",


### PR DESCRIPTION
Adds PolicyEngine oracle coverage classification for generated 26 USC 3506 sitter-placement employer-status outputs and bumps axiom-encode to 0.2.363.\n\nValidation:\n- `uv run ruff check src/ tests/`\n- `uv run ruff format --check src/ tests/`\n- `uv run pytest tests/test_policyengine_coverage.py -k '3506'`\n- Tax oracle coverage on the 3506 RuleSpec branch now reports `227 comparable`, `1239 known_not_comparable`, `0 unmapped`, `0 untested_comparable`.