### PR TITLE
Classify section 3508 oracle outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.363"
+version = "0.2.364"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.363"
+__version__ = "0.2.364"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10521,6 +10521,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3506 defines sitter-placement businesses and excludes qualifying placement persons from employer treatment for sitters; PolicyEngine computes employment taxes from modeled employer and wage facts, not this placement-service employer-status classification as a one-to-one output.
 
+  - legal_id_prefix: us:statutes/26/3508#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3508 classifies qualified real estate agents and direct sellers and excludes qualifying services from employee and employer treatment; PolicyEngine computes payroll taxes from modeled employer and wage facts, not these worker-classification predicates as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4489,6 +4489,47 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3508_worker_classification_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3508.yaml",
+        """format: rulespec/v1
+rules:
+  - name: qualified_real_estate_agent
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: individual_is_licensed_real_estate_agent
+  - name: direct_seller_engaged_trade_or_business
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: engaged_in_consumer_products_home_or_nonpermanent_retail_trade_or_business
+  - name: direct_seller
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: direct_seller_engaged_trade_or_business
+  - name: services_performed_as_qualified_real_estate_agent_or_direct_seller
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: qualified_real_estate_agent or direct_seller
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 4}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+    assert all(
+        "worker-classification predicates" in item["rationale"]
+        for item in report["items"]
+    )
+
+
 def test_policyengine_coverage_classifies_3511_cpeo_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3511.yaml",


### PR DESCRIPTION
## Summary
- Classify 26 USC 3508 worker-classification outputs as known not comparable to PolicyEngine.
- Add a focused coverage regression for real estate agent/direct seller outputs.
- Bump axiom-encode to `0.2.364`.

## Validation
- `uv run ruff format tests/test_policyengine_coverage.py`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run pytest tests/test_policyengine_coverage.py -k '3508'`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`