### PR TITLE
Classify section 3509 oracle outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.364"
+version = "0.2.365"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.364"
+__version__ = "0.2.365"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10527,6 +10527,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3508 classifies qualified real estate agents and direct sellers and excludes qualifying services from employee and employer treatment; PolicyEngine computes payroll taxes from modeled employer and wage facts, not these worker-classification predicates as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3509#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3509 sets substitute employer liability rates and collection rules for employee misclassification withholding failures; PolicyEngine computes regular payroll taxes from modeled employment and wages, not this reduced-liability misclassification assessment surface as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4530,6 +4530,72 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3509_misclassification_liability_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3509.yaml",
+        """format: rulespec/v1
+rules:
+  - name: default_withholding_liability_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.015
+  - name: default_employee_social_security_tax_liability_percentage
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.20
+  - name: increased_withholding_liability_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.03
+  - name: increased_employee_social_security_tax_liability_percentage
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.40
+  - name: section_applies_to_misclassified_employee_withholding_failure
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: employer_failed_to_deduct_and_withhold_tax
+  - name: section_applies_to_employee_social_security_tax
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: section_applies_to_misclassified_employee_withholding_failure
+  - name: employee_tax_liability_unaffected_by_section_assessment_or_collection
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: amount_of_liability_for_tax_determined_under_this_section
+  - name: employer_not_entitled_to_recover_section_tax_from_employee
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: amount_of_liability_for_tax_determined_under_this_section
+  - name: section_3402_d_and_section_6521_do_not_apply_to_section_determined_tax
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: amount_of_liability_for_tax_determined_under_this_section
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 9}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+    assert all(
+        "misclassification assessment surface" in item["rationale"]
+        for item in report["items"]
+    )
+
+
 def test_policyengine_coverage_classifies_3511_cpeo_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3511.yaml",


### PR DESCRIPTION
## Summary
- Classify 26 USC 3509 misclassification-liability outputs as known not comparable to PolicyEngine.
- Add a focused coverage regression for substitute withholding/FICA liability rates and collection predicates.
- Bump axiom-encode to `0.2.365`.

## Validation
- `uv run ruff format tests/test_policyengine_coverage.py`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run pytest tests/test_policyengine_coverage.py -k '3509'`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --oracle policyengine --program tax --fail-on-unmapped --fail-on-untested-comparable --json`