### PR TITLE
Repair encoded cross-reference placeholder detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.365"
+version = "0.2.366"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.365"
+__version__ = "0.2.366"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -13035,7 +13035,7 @@ _CROSS_REFERENCE_BASE_MECHANICS_ISSUE_PATTERN = re.compile(
     r"Cross-reference base mechanics omitted: `([^`]+)`"
 )
 _CROSS_REFERENCE_PLACEHOLDER_ISSUE_PATTERN = re.compile(
-    r"(?:Encoded )?Cross-reference placeholder: `([^`]+)`"
+    r"(?:Encoded )?[Cc]ross-reference placeholder: `([^`]+)`"
 )
 _CROSS_REFERENCE_NUMERIC_PLACEHOLDER_ISSUE_PATTERN = re.compile(
     r"Cross-reference numeric placeholder: `([^`]+)`"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7250,6 +7250,74 @@ rules:
         ]
         assert test_cases == []
 
+    def test_unsafe_formula_output_repair_defers_encoded_cross_reference_placeholders(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "openai-gpt-5.5" / "statutes/26/3510.yaml"
+        test_file = output_root / "openai-gpt-5.5" / "statutes/26/3510.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        policy_repo = tmp_path / "rulespec-us"
+        policy_repo.mkdir()
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  summary: Section 3510 domestic service employment taxes.
+rules:
+  - name: domestic_service_employment_taxes
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    source: 26 USC 3510
+    versions:
+      - effective_from: '1990-01-01'
+        formula: amount_withheld_from_domestic_service_private_home_remuneration_under_section_3402_p_agreement
+"""
+        )
+        test_file.write_text(
+            """- name: encoded_cross_reference_placeholder
+  output:
+    us:statutes/26/3510#domestic_service_employment_taxes: 100
+"""
+        )
+        result = SimpleNamespace(
+            runner="openai-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = _try_repair_generated_unsafe_formula_outputs_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "statutes/26/3510.yaml: ci: Encoded cross-reference placeholder: "
+                "`domestic_service_employment_taxes` uses local "
+                "`amount_withheld_from_domestic_service_private_home_remuneration_under_section_3402_p_agreement` "
+                "for an already encoded or required cited source. Import "
+                "`statutes/26/3402/p` and reference the upstream output instead "
+                "of keeping a local cross-reference input."
+            ],
+        )
+
+        payload = yaml.safe_load(rules_file.read_text())
+        test_cases = yaml.safe_load(test_file.read_text())
+        assert repaired == ["us:statutes/26/3510#domestic_service_employment_taxes"]
+        assert payload["module"]["status"] == "deferred"
+        assert payload["rules"] == []
+        assert payload["module"]["deferred_outputs"] == [
+            {
+                "output": "us:statutes/26/3510#domestic_service_employment_taxes",
+                "reason": (
+                    "Generated rule kept a local fact for a cited legal section. "
+                    "This output is deferred until the cited source can be encoded "
+                    "or imported without a local cross-reference placeholder."
+                ),
+            }
+        ]
+        assert test_cases == []
+
     def test_unsafe_formula_output_repair_defers_unused_source_modifiers(
         self, tmp_path
     ):


### PR DESCRIPTION
## Summary
- recognize validator diagnostics beginning with `Encoded cross-reference placeholder`
- add a 3510-shaped regression test for generated unsafe formula repair
- bump axiom-encode to 0.2.366

## Tests
- `uv run pytest tests/test_cli.py -k 'unsafe_formula_output_repair_defers_cross_reference_placeholders or unsafe_formula_output_repair_defers_encoded_cross_reference_placeholders'`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`