### PR TITLE
Ground ordinal number words

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.366"
+version = "0.2.367"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.366"
+__version__ = "0.2.367"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -729,6 +729,39 @@ _TABLE_HEADING_PATTERN = re.compile(
     r"^\s*table\s+\d+[A-Za-z]?(?:\s*:.*)?$", re.IGNORECASE
 )
 _ORDINAL_NUMBER_PATTERN = re.compile(r"\b(\d+)(?:st|nd|rd|th)\b", re.IGNORECASE)
+_ORDINAL_WORD_VALUES = {
+    "first": 1.0,
+    "second": 2.0,
+    "third": 3.0,
+    "fourth": 4.0,
+    "fifth": 5.0,
+    "sixth": 6.0,
+    "seventh": 7.0,
+    "eighth": 8.0,
+    "ninth": 9.0,
+    "tenth": 10.0,
+    "eleventh": 11.0,
+    "twelfth": 12.0,
+    "thirteenth": 13.0,
+    "fourteenth": 14.0,
+    "fifteenth": 15.0,
+    "sixteenth": 16.0,
+    "seventeenth": 17.0,
+    "eighteenth": 18.0,
+    "nineteenth": 19.0,
+    "twentieth": 20.0,
+    "thirtieth": 30.0,
+    "fortieth": 40.0,
+    "fiftieth": 50.0,
+    "sixtieth": 60.0,
+    "seventieth": 70.0,
+    "eightieth": 80.0,
+    "ninetieth": 90.0,
+}
+_ORDINAL_WORD_PATTERN = re.compile(
+    r"\b(" + "|".join(re.escape(word) for word in _ORDINAL_WORD_VALUES) + r")\b",
+    re.IGNORECASE,
+)
 _SCHEDULE_BLOCK_HEADING_PATTERN = re.compile(r"^[A-Z][A-Z0-9_ ]+:\s*$")
 _SCHEDULE_SIZE_ROW_PATTERN = re.compile(
     r"^\s*[-*]?\s*(?:size|household size|unit size)(?:\s+\d+(?:\s+or\s+more)?)?\s*:\s*"
@@ -1630,6 +1663,9 @@ def extract_numbers_from_text(text: str) -> set[float]:
         with contextlib.suppress(ValueError):
             numbers.add(float(match.group(1)))
 
+    for match in _ORDINAL_WORD_PATTERN.finditer(text):
+        numbers.add(_ORDINAL_WORD_VALUES[match.group(1).lower()])
+
     fraction_words = {
         "one-half": 0.5,
         "one half": 0.5,
@@ -1890,6 +1926,11 @@ def extract_numeric_occurrences_from_text(text: str) -> list[float]:
                 continue
             if _ordinal_is_calendar_day_reference(cleaned, match.end(), value):
                 continue
+            occurrences.append(value)
+
+    for match in _ORDINAL_WORD_PATTERN.finditer(cleaned):
+        value = _ORDINAL_WORD_VALUES[match.group(1).lower()]
+        if value not in GROUNDING_ALLOWED_VALUES:
             occurrences.append(value)
 
     for glyph, value in _UNICODE_FRACTION_VALUES.items():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -15544,6 +15544,29 @@ rules:
     assert 0.5 in extract_numeric_occurrences_from_text("The amount is ½.")
 
 
+def test_ungrounded_numeric_accepts_source_ordinal_word():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3510
+rules:
+  - name: return_filing_deadline_months_after_employer_taxable_year_close
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          4
+"""
+    source_text = (
+        "The return shall be filed on or before the 15th day of the "
+        "fourth month following the close of the employer's taxable year."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 4 in extract_numeric_occurrences_from_text(source_text)
+
+
 def test_ungrounded_numeric_accepts_source_mixed_unicode_fraction_percentage():
     content = """format: rulespec/v1
 module:


### PR DESCRIPTION
## Summary
- recognize ordinal words such as `fourth` as numeric grounding values
- keep allowed structural ordinal words like `first` out of required numeric-occurrence extraction
- add a 3510-style regression for the `fourth month` filing deadline
- bump axiom-encode to 0.2.367

## Tests
- `uv run pytest tests/test_rulespec_validation.py -k 'ungrounded_numeric_accepts_source_ordinal_word or ungrounded_numeric_accepts_source_unicode_fraction or numeric_occurrence_extraction_ignores_parenthetical_subdivision_labels'`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`