### PR TITLE
Classify section 3510 oracle outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.367"
+version = "0.2.368"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.367"
+__version__ = "0.2.368"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10533,6 +10533,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3509 sets substitute employer liability rates and collection rules for employee misclassification withholding failures; PolicyEngine computes regular payroll taxes from modeled employment and wages, not this reduced-liability misclassification assessment surface as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3510#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3510 sets administrative return, deposit, estimated-tax, and domestic-service voluntary withholding treatment rules for household employers; PolicyEngine computes annual tax outcomes and regular payroll taxes, not this domestic-service withholding-administration component as a one-to-one output.
+
   - legal_id_prefix: us:statutes/26/3306/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4596,6 +4596,30 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3510_domestic_service_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3510.yaml",
+        """format: rulespec/v1
+rules:
+  - name: amount_withheld_from_domestic_service_remuneration_under_section_3402_p_agreement
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: max(0, amount_withheld_from_remuneration_for_domestic_service_in_private_home_pursuant_to_section_3402_p_agreement)
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+    assert all(
+        "domestic-service withholding-administration component" in item["rationale"]
+        for item in report["items"]
+    )
+
+
 def test_policyengine_coverage_classifies_3511_cpeo_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3511.yaml",


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3510 domestic-service withholding-administration outputs as not comparable to PolicyEngine
- add a targeted oracle coverage regression
- bump axiom-encode to 0.2.368

## Tests
- `uv run pytest tests/test_policyengine_coverage.py -k '3510_domestic_service_outputs or 3509_misclassification_liability_outputs'`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`