### PR TITLE
Classify COVID payroll credit outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.368"
+version = "0.2.369"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.368"
+__version__ = "0.2.369"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -9993,6 +9993,30 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3111(f) defines section 41(h) research-credit offsets against employer OASDI and Medicare taxes, quarterly payroll-tax limitations, carryovers, and chapter 1 deduction coordination; PolicyEngine does not expose these employer payroll-credit allocation and carryover surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3131
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3131 defines temporary COVID qualified sick leave employer credits against applicable employment taxes; PolicyEngine computes regular payroll taxes from wages and does not expose these employer paid-leave credit surfaces as one-to-one outputs.
+
+  - legal_id_prefix: us:statutes/26/3132
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3132 defines temporary COVID qualified family leave employer credits against applicable employment taxes; PolicyEngine computes regular payroll taxes from wages and does not expose these employer paid-leave credit surfaces as one-to-one outputs.
+
+  - legal_id_prefix: us:statutes/26/3133
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3133 increases temporary COVID paid-leave credits by employer payroll taxes on qualified leave wages; PolicyEngine computes regular payroll taxes from wages and does not expose these credit-increase surfaces as one-to-one outputs.
+
+  - legal_id_prefix: us:statutes/26/3134
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3134 defines the temporary COVID employee retention credit against applicable employment taxes; PolicyEngine computes regular payroll taxes from wages and does not expose this employer retention-credit surface as a one-to-one output.
+
   - legal_id_prefix: us:statutes/26/3202#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4530,6 +4530,37 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3131_paid_leave_credit_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3131/a.yaml",
+        """format: rulespec/v1
+rules:
+  - name: qualified_sick_leave_wages_credit_rate
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 1
+  - name: qualified_sick_leave_wages_credit_against_applicable_employment_taxes
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: qualified_sick_leave_wages_credit_rate * qualified_sick_leave_wages
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+    assert all(
+        "employer paid-leave credit surfaces" in item["rationale"]
+        for item in report["items"]
+    )
+
+
 def test_policyengine_coverage_classifies_3509_misclassification_liability_outputs(
     tmp_path,
 ):


### PR DESCRIPTION
## Summary\n- classify 26 USC 3131-3134 COVID employer payroll credit outputs as known not comparable to PolicyEngine\n- add a regression for generated 3131(a) paid sick leave credit outputs\n- bump axiom-encode to 0.2.369\n\n## Tests\n- uv run pytest tests/test_policyengine_coverage.py -k '3131_paid_leave_credit_outputs or 3510_domestic_service_outputs'\n- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current --json > /tmp/oracle-coverage-3131a-after-map.json\n- uv run ruff check src/ tests/\n- uv run ruff format --check src/ tests/