### PR TITLE
Repair multiline nonnegative income-base floors

### DIFF
--- a/changelog.d/multiline-nonnegative-floor.fixed.md
+++ b/changelog.d/multiline-nonnegative-floor.fixed.md
@@ -1,0 +1,1 @@
+Repair generated multiline `min(...)` income-base caps by inserting nonnegative floors before applying RuleSpec artifacts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.369"
+version = "0.2.370"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.369"
+__version__ = "0.2.370"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -6955,6 +6955,11 @@ def _taxable_income_expression_has_zero_floor(expression: str) -> bool:
 
 
 def _repair_nonnegative_amount_reduction_formula(formula: str) -> str:
+    if _nonnegative_income_base_missing_zero_floor(formula):
+        repaired_formula = _repair_nonnegative_income_base_expression(formula.strip())
+        if repaired_formula != formula.strip():
+            return repaired_formula
+
     repaired_lines: list[str] = []
     changed = False
     for line in formula.splitlines() or [formula]:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -12869,6 +12869,34 @@ rules:
     assert find_nonnegative_amount_reduction_issues(repaired) == []
 
 
+def test_repair_nonnegative_amount_reductions_floors_multiline_income_base_in_credit():
+    content = """format: rulespec/v1
+rules:
+  - name: qualified_family_leave_wages_credit_limited_to_employment_taxes
+    kind: derived
+    entity: Employer
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          min(
+            qualified_family_leave_wages_credit_against_applicable_employment_taxes,
+            applicable_employment_taxes_after_section_3131_credits
+          )
+"""
+
+    repaired, rules = repair_nonnegative_amount_reductions(content)
+
+    assert rules == ["qualified_family_leave_wages_credit_limited_to_employment_taxes"]
+    assert (
+        "min(max(0, "
+        "qualified_family_leave_wages_credit_against_applicable_employment_taxes),"
+        in repaired
+    )
+    assert find_nonnegative_amount_reduction_issues(repaired) == []
+
+
 def test_current_year_final_amount_table_rejects_recomputed_maximum(tmp_path):
     repo = tmp_path / "rulespec-us"
     imported = repo / "policies/irs/rev-proc-2025-32/earned-income-credit.yaml"


### PR DESCRIPTION
## Summary
- Repairs generated multiline `min(...)` income-base caps before applying RuleSpec artifacts.
- Adds a regression test covering the 3132(b)(2)-style generated credit cap.
- Bumps `axiom-encode` to 0.2.370 and adds a Towncrier fragment.

## Validation
- `uv run pytest tests/test_rulespec_validation.py -k "nonnegative_amount_reduction"`
- `uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py pyproject.toml src/axiom_encode/__init__.py`
