### PR TITLE
Repair deferred source value target checks

### DIFF
--- a/changelog.d/deferred-source-value-targets.fixed.md
+++ b/changelog.d/deferred-source-value-targets.fixed.md
@@ -1,0 +1,1 @@
+Reject dict-shaped deferred `source_values` entries so apply-time repair removes malformed generated metadata.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.370"
+version = "0.2.371"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.370"
+__version__ = "0.2.371"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -12292,6 +12292,8 @@ def _remove_invalid_deferred_source_values(*, rules_file: Path) -> list[str]:
 
 
 def _looks_like_absolute_rulespec_output_target(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
     text = str(value or "").strip()
     if ":" not in text or text.count("#") != 1:
         return False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,6 +37,7 @@ from axiom_encode.cli import (
     _infer_missing_input_default,
     _insert_false_input_default,
     _local_factual_input_names_from_rules_content,
+    _looks_like_absolute_rulespec_output_target,
     _person_scoped_definition_issue_names,
     _qualify_deferred_output_subsection_paths,
     _remove_cross_module_dependent_test_outputs,
@@ -3543,6 +3544,21 @@ rules: []
         ]
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
+
+    def test_rulespec_output_target_check_rejects_dict_source_values(self):
+        assert _looks_like_absolute_rulespec_output_target(
+            "us:statutes/26/3132/c#modified_section_110_b_aggregate_limit_amount"
+        )
+        assert not _looks_like_absolute_rulespec_output_target(
+            {
+                "output": (
+                    "us:statutes/26/3132/c#"
+                    "modified_section_110_b_aggregate_limit_amount"
+                ),
+                "value": 12000,
+                "source": "26 USC 3132(c)(2)(A)(ii)(III)",
+            }
+        )
 
     def test_encode_apply_prunes_out_of_scope_deferred_outputs(
         self,


### PR DESCRIPTION
## Summary
- Rejects non-string candidates in the absolute RuleSpec output-target check.
- Lets apply-time repair remove dict-shaped generated `module.deferred_outputs[].source_values` entries instead of treating their stringification as a valid target.
- Bumps `axiom-encode` to 0.2.371 and adds a Towncrier fragment.

## Validation
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run pytest tests/test_cli.py -k "deferred_source_values or output_target_check_rejects_dict_source_values"`
