### PR TITLE
Bump encoder version to 0.2.360

### DIFF
--- a/changelog.d/bump-0-2-360.changed.md
+++ b/changelog.d/bump-0-2-360.changed.md
@@ -1,0 +1,1 @@
+Bump encoder version to 0.2.360 so apply-time manifest recognizes the auto-repair gate landed in #383 against #385's prior version bump.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.359"
+version = "0.2.360"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.359"
+__version__ = "0.2.360"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.358"
+version = "0.2.360"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
PR #383 (auto-repair test-yaml canonical refs) landed after #385's prior version bump, so the apply-time manifest sees encoder-affecting files changed without a corresponding bump and refuses to apply. This bump recognizes the new encoder files.

Also syncs uv.lock (was stale at 0.2.358).

🤖 Generated with [Claude Code](https://claude.com/claude-code)