### PR TITLE
Scope subparagraph coverage to actual requested workspace

### DIFF
--- a/changelog.d/scope-subparagraph-coverage-to-requested-source.fixed.md
+++ b/changelog.d/scope-subparagraph-coverage-to-requested-source.fixed.md
@@ -1,0 +1,1 @@
+Scope source-subparagraph coverage to the actual requested workspace: pick the manifest matching the rules file (not first alphabetical) and accept human USC citations like `7 USC 2014(c)` in `requested_source`. Without this, validating sibling subsection encodes under a shared /tmp eval root silently loads the wrong workspace's metadata and rejects out-of-scope subparagraphs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.359"
+version = "0.2.361"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.359"
+__version__ = "0.2.361"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -61,6 +61,7 @@ from axiom_encode.repo_routing import (
     canonical_rulespec_repo_name,
     find_policy_repo_root,
 )
+from axiom_encode.statute import citation_to_citation_path, parse_usc_citation
 
 from .dependency_stubs import (
     has_corpus_provision_for_import_target,
@@ -916,7 +917,17 @@ _DEFINITION_CROSS_REFERENCE_PATTERN = re.compile(
 
 
 def _load_nearby_eval_source_metadata(rulespec_file: Path) -> dict[str, object] | None:
-    """Load source-metadata from a nearby eval workspace when present."""
+    """Load source-metadata from a nearby eval workspace when present.
+
+    When several workspaces share a parent directory (e.g. /tmp encode runs
+    for siblings a, c, d under one eval root), pick the manifest whose
+    citation maps to the same RuleSpec output path as `rulespec_file`. Falling
+    back to the first alphabetical manifest mixes up sibling subsections —
+    validate of c.yaml would silently load a/'s metadata and reject (c) for
+    not covering (a)'s siblings.
+    """
+    rulespec_norm = _rulespec_file_normalized_target(rulespec_file)
+    fallback: dict[str, object] | None = None
     for ancestor in rulespec_file.parents:
         eval_root = ancestor / "_eval_workspaces"
         if not eval_root.exists():
@@ -927,9 +938,41 @@ def _load_nearby_eval_source_metadata(rulespec_file: Path) -> dict[str, object] 
             except Exception:
                 continue
             metadata = payload.get("source_metadata")
-            if isinstance(metadata, dict):
+            if not isinstance(metadata, dict):
+                continue
+            if fallback is None:
+                fallback = metadata
+            if rulespec_norm is None:
+                continue
+            citation_raw = payload.get("citation")
+            manifest_norm = (
+                _citation_to_normalized_target(citation_raw)
+                if isinstance(citation_raw, str)
+                else None
+            )
+            if manifest_norm == rulespec_norm:
                 return metadata
+    return fallback
+
+
+def _rulespec_file_normalized_target(rulespec_file: Path) -> tuple[str, ...] | None:
+    """Best-effort tuple of statute/regulations path parts for matching."""
+    parts = list(rulespec_file.with_suffix("").parts)
+    for idx, part in enumerate(parts):
+        if part in {"statutes", "regulations", "policies"}:
+            return tuple(p.lower() for p in parts[idx:] if p)
     return None
+
+
+def _citation_to_normalized_target(citation: str) -> tuple[str, ...] | None:
+    try:
+        parts = parse_usc_citation(citation)
+    except Exception:
+        return None
+    if parts is None:
+        return None
+    pieces = ["statutes", parts.title, parts.section, *parts.fragments]
+    return tuple(p.lower() for p in pieces if p)
 
 
 def _source_metadata_sets_target_symbol(
@@ -6190,6 +6233,29 @@ def _source_subparagraph_coverage_scope_prefix(
     return _rulespec_file_subparagraph_scope(citation_path, rules_file)
 
 
+def _normalize_requested_source_to_corpus_path(requested_source: str) -> str:
+    """Return a corpus-path form for a requested_source string.
+
+    The eval workspace stores requested_source as the raw caller input —
+    typically the human USC citation (``7 USC 2014(c)``). Subparagraph-scope
+    matching needs the corpus-path form (``us/statute/7/2014/c``). If parsing
+    fails the input is returned unchanged so corpus-path inputs pass through.
+    """
+    candidate = requested_source.strip()
+    if not candidate or candidate.startswith(("us/", "us-")):
+        return candidate
+    try:
+        parts = parse_usc_citation(candidate)
+    except (ValueError, Exception):
+        return candidate
+    if parts is None:
+        return candidate
+    try:
+        return citation_to_citation_path(parts)
+    except (ValueError, Exception):
+        return candidate
+
+
 def _scope_prefix_from_requested_source(
     citation_path: str, requested_source: str | None
 ) -> tuple[str, ...]:
@@ -6198,16 +6264,23 @@ def _scope_prefix_from_requested_source(
     citation_path collapses to the parent while the requested source still
     names the encoder's actual target. The difference is the scope.
 
+    `requested_source` may be either a corpus-path form
+    (``us/statute/7/2014/e/2/B``) or the human USC form (``7 USC 2014(e)(2)(B)``)
+    — the eval workspace stores it as the raw caller input, which is usually
+    human form. Normalize both to corpus paths before comparing.
+
     Examples (citation_path → requested_source → scope):
       us/statute/7/2014 → us/statute/7/2014/e/2/B → ('e', '2', 'b')
+      us/statute/7/2014 → 7 USC 2014(e)(2)(B)    → ('e', '2', 'b')
       us/statute/7/2014 → us/statute/7/2014       → ()
       us/statute/7/2014 → us/statute/26/63        → ()  (unrelated)
     """
     if not requested_source:
         return ()
+    normalized_request = _normalize_requested_source_to_corpus_path(requested_source)
     citation_parts = tuple(part for part in citation_path.strip("/").split("/") if part)
     requested_parts = tuple(
-        part for part in requested_source.strip("/").split("/") if part
+        part for part in normalized_request.strip("/").split("/") if part
     )
     if not citation_parts or len(requested_parts) <= len(citation_parts):
         return ()

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -11819,6 +11819,47 @@ rules: []
     assert any("7 USC 2012(b)" in i for i in issues)
 
 
+def test_source_subparagraph_coverage_accepts_human_readable_requested_source():
+    """When the eval workspace writes requested_source in human form
+    ('7 USC 2014(c)') rather than corpus-path form ('us/statute/7/2014/c'),
+    the validator must still recognize it and scope subparagraph coverage to
+    the requested fragment. Surfaced live on 7 USC 2014(c) encode 2026-05-28:
+    workspace stored requested_source as the human form, scope function did
+    not match, and all six sibling subparagraphs were flagged as missing.
+    """
+    source_text = """Eligibility disqualifications
+(a) Income standards. Households with income above thresholds are ineligible.
+(c) Gross income standard. Adjusted October 1 each year.
+(d) Exclusions from income.
+(g) Allowable financial resources.
+"""
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/7/2014
+  summary: Gross and net income standards under 7 USC 2014(c).
+rules:
+  - name: snap_net_income_exceeds_income_standard
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 USC 2014(c)
+    versions:
+      - effective_from: '2008-10-01'
+        formula: "snap_net_income > applicable_poverty_line"
+"""
+
+    issues = find_source_subparagraph_coverage_issues(
+        content,
+        source_texts={"us/statute/7/2014": source_text},
+        requested_source="7 USC 2014(c)",
+    )
+    assert issues == [], (
+        f"Validator should scope to (c) but flagged out-of-scope siblings: {issues}"
+    )
+
+
 def test_source_subparagraph_coverage_matches_irc_section_citation(tmp_path):
     source_text = """Standard deduction
 (a) Rule for taxable years.

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.358"
+version = "0.2.361"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Two related fixes so source-subparagraph coverage validation actually targets the encoded fragment when the corpus serves a parent-fallback slice:

1. **Manifest matching** — when multiple encode workspaces share a parent dir (\`/tmp\` runs for sibling subsections a, c, d, g), \`_load_nearby_eval_source_metadata\` was picking the first manifest alphabetically. Validating \`c.yaml\` would silently load \`a/\`'s metadata and reject \`c\` for not covering \`a\`'s siblings. Now matches the manifest's \`citation\` to the rules file path.
2. **Human-citation normalization** — eval workspaces store \`requested_source\` as the raw caller input (\`7 USC 2014(c)\`), but \`_scope_prefix_from_requested_source\` only matched the corpus-path form. Normalize human USC citations via the existing \`citation_to_citation_path\` before comparing.

Surfaced live on \`7 USC 2014(c)\` encode 2026-05-28: both bugs combined to mis-scope every sibling subparagraph as a coverage gap, blocking every \`encode --apply\` for a 7 USC 2014 fragment.

Bumps to 0.2.361 (jumps past in-flight #399 at 0.2.360).

## Test plan
- [x] New test \`test_source_subparagraph_coverage_accepts_human_readable_requested_source\` — passes
- [x] Existing \`test_source_subparagraph_coverage_scopes_to_requested_source_under_parent_fallback\` — still passes
- [x] Existing \`test_source_subparagraph_coverage_without_requested_source_keeps_strict_scope\` — still passes
- [x] Full \`tests/test_rulespec_validation.py\` (419 passed, 28 skipped)
- [x] Live: \`axiom-encode validate\` on the \`/tmp\` (c) encode now passes the subparagraph check (separate test-input resolution issue remains but is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)