### PR TITLE
Auto-repair preserves consumer anchor on input.X refs

### DIFF
--- a/changelog.d/auto-repair-preserve-consumer-anchor.fixed.md
+++ b/changelog.d/auto-repair-preserve-consumer-anchor.fixed.md
@@ -1,0 +1,1 @@
+Auto-repair preserves the consumer anchor when rewriting blocked synonyms on `#input.X` references in test YAML. Previously the repair unconditionally swapped the anchor to the canonical producer's location, corrupting input slot declarations by pointing them at the wrong file. Output (non-input) refs still get the anchor redirected to the canonical producer as before.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.373"
+version = "0.2.374"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.373"
+__version__ = "0.2.374"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/concepts/auto_repair.py
+++ b/src/axiom_encode/concepts/auto_repair.py
@@ -8,8 +8,16 @@ mechanically against the registry, so a clean encode --apply isn't blocked by
 drift that only shows up in test cases.
 
 The rewrite is intentionally surgical: it operates on anchored references of
-the form `<jurisdiction>:<path>#[input.]<name>` and only swaps the synonym for
-its canonical, or the anchor for the canonical's producer_anchor.
+the form `<jurisdiction>:<path>#[input.]<name>`.
+
+Input refs are special. `<anchor>#input.X` declares an input slot on the
+consumer at `<anchor>` — `<anchor>` names the file that *reads* X, not the
+canonical producer of X. Rewriting the anchor on an input ref would move the
+slot to the producer's file, which is nonsense (a file does not consume its
+own output). For input refs we only rename the synonym; the consumer anchor
+is preserved. For non-input (output) refs the anchor is the consumer's
+reference to a producer, so we also redirect the anchor to the canonical
+producer.
 """
 
 from __future__ import annotations
@@ -59,15 +67,17 @@ def _rewrite_anchored_refs(text: str, registry: ConceptRegistry) -> str:
             match.group(2) or "",
             match.group(3),
         )
+        is_input_ref = bool(input_prefix)
         blocked = registry.lookup_synonym(name)
         if blocked is not None:
-            new_anchor = blocked.producer_anchor or anchor
+            new_anchor = anchor if is_input_ref else (blocked.producer_anchor or anchor)
             return f"{new_anchor}#{input_prefix}{blocked.canonical_name}"
         canonical = registry.lookup_canonical(name)
         if (
             canonical is not None
             and canonical.has_producer
             and canonical.producer_anchor != anchor
+            and not is_input_ref
         ):
             return f"{canonical.producer_anchor}#{input_prefix}{name}"
         return match.group(0)

--- a/tests/test_concepts_auto_repair.py
+++ b/tests/test_concepts_auto_repair.py
@@ -85,6 +85,36 @@ def test_repair_handles_input_dot_prefixed_uppercase_paths(tmp_path: Path):
     assert "#input.snap_total_gross_income" in text
 
 
+def test_repair_preserves_consumer_anchor_on_input_refs(tmp_path: Path):
+    """For `#input.X` refs the anchor names the consumer file (where X is read
+    as an input slot), not the canonical producer. Rewriting the anchor to the
+    producer would point the input slot at the wrong file. Surfaced live on
+    7 USC 2014(c) test cases 2026-05-28: encoder wrote
+    `us:statutes/7/2014/e/6/A#input.snap_monthly_household_income` (legit:
+    `(e)(6)(A)` is the consumer, gross income is an input to net income).
+    The repair swapped the anchor to `us:regulations/7-cfr/273/10` (the
+    canonical producer of gross income), corrupting the test.
+    """
+    registry = load_concept_registry()
+    drift = _write(
+        tmp_path,
+        "drift.test.yaml",
+        """
+        format: rulespec/v1
+        cases:
+          - inputs:
+              us:statutes/7/2014/e/6/A#input.snap_monthly_household_income: 1000
+        """,
+    )
+    auto_repair_test_yaml_canonical_violations([drift], registry)
+    text = drift.read_text()
+    assert "snap_monthly_household_income" not in text
+    assert "snap_total_gross_income" in text
+    # Consumer anchor preserved — the input slot still belongs to (e)(6)(A).
+    assert "us:statutes/7/2014/e/6/A#input.snap_total_gross_income" in text
+    assert "us:regulations/7-cfr/273/10#input." not in text
+
+
 def test_repair_skips_non_test_files(tmp_path: Path):
     """Producer/source YAML must fail loudly — never silently rewritten."""
     registry = load_concept_registry()

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.373"
+version = "0.2.374"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

PR #383's auto-repair unconditionally redirected the anchor to the canonical producer's location whenever it rewrote a blocked synonym. For \`#input.X\` references that declare an input slot on the *consumer*, that move corrupted the slot: pointed it at the producer file (which doesn't consume its own output) instead of the consumer file that actually reads X.

Surfaced live on 7 USC 2014(c) test cases: encoder wrote \`us:statutes/7/2014/e/6/A#input.snap_monthly_household_income\` (correct — (e)(6)(A) is the net-income consumer, and gross income is an input to it). Repair swapped the anchor to \`us:regulations/7-cfr/273/10\` (the canonical producer of gross income), and rulespec-us CI rejected with "input does not resolve to an input slot in regulations/7-cfr/273/10.yaml".

## Fix

- For \`#input.X\` refs: rewrite the synonym name only, preserve the consumer anchor.
- For non-input (output) refs: redirect the anchor to the canonical producer as before — that's the consumer reaching back to the canonical producer's output.

## Test plan
- [x] New test \`test_repair_preserves_consumer_anchor_on_input_refs\` — passes
- [x] 5 existing auto-repair tests — still pass
- [x] CLI integration test (\`test_apply_hook_auto_repairs_test_yaml_blocked_synonym\`) — still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)