### PR TITLE
Pin encoder version 0.2.375

### DIFF
--- a/changelog.d/pin-encoder-version-0-2-375.fixed.md
+++ b/changelog.d/pin-encoder-version-0-2-375.fixed.md
@@ -1,0 +1,1 @@
+Pin encoder provenance at version 0.2.375 after auto-repair changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.374"
+version = "0.2.375"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.374"
+__version__ = "0.2.375"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.374"
+version = "0.2.375"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- bump axiom-encode metadata to 0.2.375 after #403 changed encoder-affecting auto-repair code
- add changelog fragment so signed RuleSpec apply provenance can advance cleanly

## Validation
- env -u UV_FROZEN uv lock
- uv run ruff check pyproject.toml src/axiom_encode/__init__.py tests/test_concepts_auto_repair.py
- uv run ruff format --check src/axiom_encode/__init__.py tests/test_concepts_auto_repair.py
- uv run pytest tests/test_concepts_auto_repair.py -q
- uv run python -m towncrier build --draft --version 0.0.0