### PR TITLE
Require version bump for encoder changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.1.0

--- a/changelog.d/require-version-bump-for-encoder-affecting-changes.fixed.md
+++ b/changelog.d/require-version-bump-for-encoder-affecting-changes.fixed.md
@@ -1,0 +1,1 @@
+Fail CI when encoder-affecting changes are not behind an axiom-encode version bump.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.375"
+version = "0.2.376"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.375"
+__version__ = "0.2.376"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10639,6 +10639,7 @@ def _git_repo_provenance(path: Path) -> dict[str, object] | None:
 _AXIOM_ENCODE_VERSION_FILES = (
     "pyproject.toml",
     "src/axiom_encode/__init__.py",
+    "uv.lock",
 )
 _AXIOM_ENCODE_VERSIONED_PREFIXES = ("src/axiom_encode/",)
 _AXIOM_ENCODE_VERSIONED_FILES = {
@@ -10655,17 +10656,23 @@ def _require_axiom_encode_version_provenance(
     current_versions = _axiom_encode_versions_at_ref(repo, "HEAD")
     pyproject_version = current_versions.get("pyproject")
     package_version = current_versions.get("package")
-    if not pyproject_version or not package_version:
+    lock_version = current_versions.get("lock")
+    if not pyproject_version or not package_version or not lock_version:
         raise RuntimeError(
             "Cannot apply generated RuleSpec: axiom-encode version metadata is "
-            "incomplete; pyproject.toml and src/axiom_encode/__init__.py must "
-            "both declare the encoder version."
+            "incomplete; pyproject.toml, src/axiom_encode/__init__.py, and "
+            "uv.lock must declare the encoder version."
         )
-    if pyproject_version != package_version or pyproject_version != __version__:
+    if (
+        pyproject_version != package_version
+        or pyproject_version != lock_version
+        or pyproject_version != __version__
+    ):
         raise RuntimeError(
             "Cannot apply generated RuleSpec: axiom-encode version metadata is "
             f"inconsistent (pyproject={pyproject_version}, "
-            f"package={package_version}, runtime={__version__})."
+            f"package={package_version}, lock={lock_version}, "
+            f"runtime={__version__})."
         )
 
     version_commit = _latest_axiom_encode_version_commit(repo)
@@ -10718,9 +10725,33 @@ def _latest_axiom_encode_version_commit(repo: Path) -> str | None:
         if parent is None:
             return commit
         previous = _axiom_encode_versions_at_ref(repo, parent)
-        if current != previous:
+        if _axiom_encode_version_increased(current, previous):
             return commit
     return None
+
+
+def _axiom_encode_version_increased(
+    current: dict[str, str | None],
+    previous: dict[str, str | None],
+) -> bool:
+    current_version = current.get("pyproject")
+    previous_version = previous.get("pyproject")
+    if not current_version:
+        return False
+    if not previous_version:
+        return True
+    current_key = _parse_numeric_version(current_version)
+    previous_key = _parse_numeric_version(previous_version)
+    if current_key is None or previous_key is None:
+        return current_version > previous_version
+    return current_key > previous_key
+
+
+def _parse_numeric_version(version: str) -> tuple[int, ...] | None:
+    parts = version.split(".")
+    if not parts or any(not re.fullmatch(r"\d+", part) for part in parts):
+        return None
+    return tuple(int(part) for part in parts)
 
 
 def _git_first_parent(repo: Path, commit: str) -> str | None:
@@ -10745,6 +10776,7 @@ def _axiom_encode_versions_at_ref(repo: Path, ref: str) -> dict[str, str | None]
         "package": _extract_package_init_version(
             _git_show_text(repo, ref, "src/axiom_encode/__init__.py") or ""
         ),
+        "lock": _extract_uv_lock_version(_git_show_text(repo, ref, "uv.lock") or ""),
     }
 
 
@@ -10782,6 +10814,14 @@ def _extract_pyproject_version(content: str) -> str | None:
 def _extract_package_init_version(content: str) -> str | None:
     match = re.search(r'(?m)^__version__\s*=\s*"([^"]+)"\s*$', content)
     return match.group(1) if match else None
+
+
+def _extract_uv_lock_version(content: str) -> str | None:
+    package_block = re.search(
+        r'(?ms)^\[\[package\]\]\s*^name\s*=\s*"axiom-encode"\s*^version\s*=\s*"([^"]+)"',
+        content,
+    )
+    return package_block.group(1) if package_block else None
 
 
 def _is_axiom_encode_versioned_path(path: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -131,8 +131,27 @@ def test_package_version_metadata_matches_pyproject():
     pyproject = tomllib.loads(
         (Path(__file__).parents[1] / "pyproject.toml").read_text()
     )
+    lockfile = tomllib.loads((Path(__file__).parents[1] / "uv.lock").read_text())
+    lock_version = next(
+        package["version"]
+        for package in lockfile["package"]
+        if package["name"] == "axiom-encode"
+    )
 
     assert pyproject["project"]["version"] == AXIOM_ENCODE_TEST_VERSION
+    assert lock_version == AXIOM_ENCODE_TEST_VERSION
+
+
+def test_current_encoder_affecting_changes_are_behind_version_bump():
+    repo = Path(__file__).parents[1]
+    try:
+        _git(repo, "rev-parse", "--is-inside-work-tree")
+    except subprocess.CalledProcessError:
+        pytest.skip("version provenance check requires a git checkout")
+
+    provenance = _require_axiom_encode_version_provenance(repo)
+
+    assert provenance["version"] == AXIOM_ENCODE_TEST_VERSION
 
 
 def _signed_manifest_payload(payload: dict) -> dict:
@@ -3266,6 +3285,40 @@ class TestCmdEncode:
         _write_test_encoder_source(repo, "unversioned guard")
         _git(repo, "add", "src/axiom_encode/prompts/encoder.py")
         _git(repo, "commit", "-m", "Change encoder without version")
+
+        with pytest.raises(RuntimeError, match="encoder-affecting files changed"):
+            _require_axiom_encode_version_provenance(repo)
+
+    def test_apply_version_provenance_rejects_stale_lockfile(self, tmp_path):
+        repo = tmp_path / "axiom-encode"
+        _init_test_git_repo(repo)
+        _write_test_encoder_version(repo, "0.2.68")
+        _write_test_encoder_source(repo, "old guard")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "Initial encoder version")
+
+        _write_test_encoder_version(repo, AXIOM_ENCODE_TEST_VERSION)
+        (repo / "uv.lock").write_text(
+            '[[package]]\nname = "axiom-encode"\nversion = "0.2.68"\n'
+        )
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "Leave lockfile stale")
+
+        with pytest.raises(RuntimeError, match="lock=0.2.68"):
+            _require_axiom_encode_version_provenance(repo)
+
+    def test_apply_version_provenance_rejects_version_downgrade(self, tmp_path):
+        repo = tmp_path / "axiom-encode"
+        _init_test_git_repo(repo)
+        _write_test_encoder_version(repo, "99.0.0")
+        _write_test_encoder_source(repo, "future guard")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "Initial future encoder version")
+
+        _write_test_encoder_version(repo, AXIOM_ENCODE_TEST_VERSION)
+        _write_test_encoder_source(repo, "downgraded guard")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "Downgrade encoder version")
 
         with pytest.raises(RuntimeError, match="encoder-affecting files changed"):
             _require_axiom_encode_version_provenance(repo)

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.375"
+version = "0.2.376"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a repo-level test that fails when encoder-affecting changes exist after the latest axiom-encode version bump
- fetch full history in the test CI job so version-provenance checks can find the latest version bump commit
- require pyproject, package version metadata, and uv.lock to agree, and treat only monotonic numeric version increases as valid bump commits
- bump axiom-encode to 0.2.376 after #405 changed CLI repair behavior without advancing provenance

## Validation
- env -u UV_FROZEN uv lock
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run python workflow YAML parse check
- uv run pytest tests/test_cli.py -k current_encoder_affecting_changes_are_behind_version_bump_or_apply_version_provenance_or_package_version_metadata_matches_pyproject -q
- uv run python -m towncrier build --draft --version 0.0.0
- subagent read-only review findings addressed: stale uv.lock, version downgrade