### PR TITLE
Bump encoder version to 0.2.376

### DIFF
--- a/changelog.d/bump-0-2-376.changed.md
+++ b/changelog.d/bump-0-2-376.changed.md
@@ -1,0 +1,1 @@
+Bump encoder version to 0.2.376 so apply-time manifest recognizes the cli.py changes from #405 against #404's prior version bump.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.375"
+version = "0.2.376"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.375"
+__version__ = "0.2.376"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.375"
+version = "0.2.376"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
PR #405 (rewrite #input.X repair) changed cli.py after #404's version bump. This bump pins the new files.