### PR TITLE
Include ancestor context for cited provisions

### DIFF
--- a/changelog.d/cross-section-ancestor-context.fixed.md
+++ b/changelog.d/cross-section-ancestor-context.fixed.md
@@ -1,0 +1,1 @@
+Include ancestor RuleSpec files when an explicit cross-section citation points to a deeper provision whose exact file does not exist.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.376"
+version = "0.2.377"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.376"
+__version__ = "0.2.377"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2043,15 +2043,32 @@ def _select_cross_section_context_files(
         cited_parts = CitationParts(
             parts.title, cited_parts.section, cited_parts.fragments
         )
-        candidate_rel = citation_to_relative_rulespec_path(cited_parts)
-        if candidate_rel == target_rel:
-            continue
-        for candidate in _cited_context_candidates(policy_root, candidate_rel):
-            resolved = candidate.resolve()
-            if resolved not in seen:
-                selected.append(candidate)
-                seen.add(resolved)
+        for candidate_rel in _cited_context_candidate_paths(cited_parts):
+            if candidate_rel == target_rel:
+                continue
+            candidates = _cited_context_candidates(policy_root, candidate_rel)
+            if not candidates:
+                continue
+            for candidate in candidates:
+                resolved = candidate.resolve()
+                if resolved not in seen:
+                    selected.append(candidate)
+                    seen.add(resolved)
+            break
     return selected
+
+
+def _cited_context_candidate_paths(cited_parts: CitationParts) -> list[Path]:
+    """Return exact and ancestor RuleSpec paths for a cited USC provision."""
+    paths: list[Path] = []
+    for length in range(len(cited_parts.fragments), -1, -1):
+        candidate_parts = CitationParts(
+            cited_parts.title,
+            cited_parts.section,
+            cited_parts.fragments[:length],
+        )
+        paths.append(citation_to_relative_rulespec_path(candidate_parts))
+    return paths
 
 
 def _iter_cited_usc_sections(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -7096,6 +7096,58 @@ rules:
         assert copied_sources[str(section_931)]["import_path"] == "us:statutes/26/931"
         assert copied_sources[str(section_933)]["import_path"] == "us:statutes/26/933"
 
+    def test_prepare_eval_workspace_adds_cross_section_ancestor_context_for_deep_citation(
+        self, tmp_path
+    ):
+        repo_root = tmp_path / "repos"
+        policy_repo_root = repo_root / "axiom-rules-engine"
+        policy_repo_root.mkdir(parents=True)
+        section_3511 = repo_root / "rulespec-us" / "statutes" / "26" / "3511.yaml"
+        section_3511.parent.mkdir(parents=True)
+        section_3511.write_text(
+            "format: rulespec/v1\n"
+            "rules:\n"
+            "  - name: specified_credit_applies_to_customer_not_cpeo\n"
+            "    kind: derived\n"
+            "    entity: Employer\n"
+            "    dtype: Judgment\n"
+            "    period: Year\n"
+        )
+        source_text = (
+            "Any credit allowed under this section shall be treated as a "
+            "credit described in section 3511(d)(2)."
+        )
+
+        selected = _select_cross_section_context_files(
+            "26 USC 3134(i)",
+            source_text,
+            repo_root / "rulespec-us",
+        )
+
+        assert selected == [section_3511]
+
+        runner = parse_runner_spec("codex:gpt-5.5")
+        with patch(
+            "axiom_encode.harness.evals.select_context_files",
+            return_value=[],
+        ):
+            workspace = prepare_eval_workspace(
+                citation="26 USC 3134(i)",
+                runner=runner,
+                output_root=tmp_path / "out",
+                source_text=source_text,
+                axiom_rules_path=policy_repo_root,
+                mode="repo-augmented",
+                extra_context_paths=[],
+            )
+
+        manifest = json.loads(workspace.manifest_file.read_text())
+        copied_sources = {
+            item["source_path"]: item for item in manifest["context_files"]
+        }
+        assert copied_sources[str(section_3511)]["kind"] == "implementation_precedent"
+        assert copied_sources[str(section_3511)]["import_path"] == "us:statutes/26/3511"
+
     def test_build_eval_prompt_warns_on_unavailable_cited_context(self, tmp_path):
         repo_root = tmp_path / "repos"
         policy_repo_root = repo_root / "rulespec-us"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.376"
+version = "0.2.377"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add ancestor fallback when repo-augmented context selection sees an explicit cross-section citation whose exact deep RuleSpec file is absent
- add a regression for 26 USC 3134(i) citing section 3511(d)(2), where the available executable context is statutes/26/3511.yaml
- bump axiom-encode to 0.2.377 and add a Towncrier fragment

## Validation
- uv run ruff check src/axiom_encode/harness/evals.py tests/test_evals.py src/axiom_encode/__init__.py
- uv run ruff format --check src/axiom_encode/harness/evals.py tests/test_evals.py src/axiom_encode/__init__.py
- uv run pytest tests/test_evals.py -k "cross_section_ancestor_context or cross_section_context or cross_section_list"
- uv run pytest tests/test_cli.py -k "version or provenance"