### PR TITLE
Guard joint-only filing status thresholds

### DIFF
--- a/changelog.d/filing-status-joint-only.fixed.md
+++ b/changelog.d/filing-status-joint-only.fixed.md
@@ -1,0 +1,1 @@
+Prevent joint-return-only threshold branches from treating surviving-spouse status as joint.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.377"
+version = "0.2.378"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.377"
+__version__ = "0.2.378"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3775,10 +3775,15 @@ RuleSpec requirements:
   `surviving_spouse`. If a source provision itself defines a legal status or
   return category, encode that source-backed output at its absolute RuleSpec
   path and import it downstream. If a shared numeric filing-status output is
-  available, import it and use the structural enum in formulas, e.g.
+  available, import it and use the structural enum in formulas when the source
+  supports that grouping, e.g.
   `match filing_status: 1 => joint_amount; 4 => joint_amount; ...`. If the source
   groups surviving spouse with joint return, every branch or match that handles
   status 1 must also handle status 4 in that same branch with the same result.
+  If the source says only "joint return" without also naming surviving spouse
+  or qualifying widow(er), do not route status 4 to the joint-return branch;
+  status 4 falls under any "other case" branch unless the source states
+  otherwise.
 - Do not replace filing-status components with local status inputs such as
   `taxpayer_is_surviving_spouse`, `surviving_spouse`, or `head_of_household`.
   This also prohibits compound status predicates such as

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -818,6 +818,12 @@ _US_TAX_JOINT_SURVIVING_SPOUSE_GROUP_TEXT_PATTERN = re.compile(
     r")",
     flags=re.IGNORECASE,
 )
+_US_TAX_JOINT_ONLY_ANY_OTHER_CASE_TEXT_PATTERN = re.compile(
+    r"\b(?:joint(?:[\s_-]+return)?|married[\s_-]+filing[\s_-]+jointly)\b"
+    r"(?:(?!surviving[\s_-]+spouse|qualifying[\s_-]+widow(?:er)?).){0,500}?"
+    r"\bany\s+other\s+case\b",
+    flags=re.IGNORECASE | re.DOTALL,
+)
 _US_TAX_FILING_STATUS_NAME_PATTERN = re.compile(
     rf"\b{_STRUCTURAL_ENUM_INDEX_NAME_PATTERN}\b",
     flags=re.IGNORECASE,
@@ -5688,7 +5694,11 @@ def find_tax_filing_status_surviving_spouse_issues(content: str) -> list[str]:
     if payload is None:
         return []
 
-    module_source_text = extract_embedded_source_text(content) or content
+    module_source_text = (
+        _extract_source_verification_text(content)
+        or extract_embedded_source_text(content)
+        or content
+    )
     issues: list[str] = []
     for name, kind, formula, source, rule in _rulespec_rule_formula_rule_records(
         payload
@@ -5701,6 +5711,12 @@ def find_tax_filing_status_surviving_spouse_issues(content: str) -> list[str]:
             rule=rule,
             source=source,
         )
+        joint_only_issue = _filing_status_joint_only_any_other_case_branch_issue(
+            name, formula, source_context
+        )
+        if joint_only_issue is not None:
+            issues.append(joint_only_issue)
+            continue
         if not _US_TAX_JOINT_SURVIVING_SPOUSE_GROUP_TEXT_PATTERN.search(source_context):
             continue
         branch_issue = _filing_status_surviving_spouse_branch_issue(name, formula)
@@ -6724,6 +6740,50 @@ def _filing_status_surviving_spouse_branch_issue(
             "mentions surviving spouse or qualifying widow(er), but the formula "
             "does not handle status code 4. Include code 4 when the source groups "
             "surviving spouse with joint return, or encode a separate explicit branch."
+        )
+    return None
+
+
+def _filing_status_joint_only_any_other_case_branch_issue(
+    rule_name: str,
+    formula: str,
+    source_context: str,
+) -> str | None:
+    if _US_TAX_JOINT_SURVIVING_SPOUSE_GROUP_TEXT_PATTERN.search(source_context):
+        return None
+    if not _US_TAX_JOINT_ONLY_ANY_OTHER_CASE_TEXT_PATTERN.search(source_context):
+        return None
+
+    match_blocks = _filing_status_match_blocks(formula)
+    for arms in match_blocks:
+        if 1 not in arms or 4 not in arms:
+            continue
+        if _normalize_branch_result(arms[1]) == _normalize_branch_result(arms[4]):
+            return (
+                "Filing status branch incorrectly treats surviving spouse as joint "
+                "return: "
+                f"`{rule_name}` routes status code 4 to the same result as "
+                "joint-return status code 1, but this source states a joint-return "
+                "branch and an any-other-case branch without grouping surviving "
+                "spouse or qualifying widow(er) with joint returns. Route status "
+                "code 4 through the any-other-case branch unless the source "
+                "explicitly states otherwise."
+            )
+
+    conditional_results = _filing_status_conditional_branch_results(formula)
+    if (
+        1 in conditional_results
+        and 4 in conditional_results
+        and conditional_results[1] == conditional_results[4]
+    ) or _filing_status_has_grouped_joint_surviving_spouse_condition(formula):
+        return (
+            "Filing status branch incorrectly treats surviving spouse as joint "
+            "return: "
+            f"`{rule_name}` groups status code 4 with joint-return status code 1, "
+            "but this source states a joint-return branch and an any-other-case "
+            "branch without grouping surviving spouse or qualifying widow(er) with "
+            "joint returns. Route status code 4 through the any-other-case branch "
+            "unless the source explicitly states otherwise."
         )
     return None
 
@@ -8000,6 +8060,34 @@ def _rule_source_subsection_tokens(source: Any) -> tuple[str, ...]:
     )
 
 
+def _rule_source_subsection_selectors(
+    source: Any,
+) -> tuple[tuple[str, str | None], ...]:
+    if isinstance(source, dict):
+        source_text = " ".join(
+            str(value) for value in source.values() if isinstance(value, str)
+        )
+    elif isinstance(source, str):
+        source_text = source
+    else:
+        return ()
+
+    selectors: list[tuple[str, str | None]] = []
+    for match in re.finditer(
+        r"\(([A-Za-z0-9]+)\)"
+        r"(?:\s*(?:-|\u2013|\u2014|to)\s*\(([A-Za-z0-9]+)\))?",
+        source_text,
+    ):
+        start = match.group(1)
+        end = match.group(2)
+        if not 1 <= len(start) <= 4:
+            continue
+        if end is not None and not 1 <= len(end) <= 4:
+            continue
+        selectors.append((start, end))
+    return tuple(selectors)
+
+
 def _slice_source_text_at_marker(source_text: str, token: str) -> str:
     marker_flags = 0 if token.isalpha() else re.IGNORECASE
     marker = re.compile(rf"\({re.escape(token)}\)", flags=marker_flags)
@@ -8022,26 +8110,72 @@ def _slice_source_text_at_marker(source_text: str, token: str) -> str:
         flags=marker_flags,
     )
     if next_match is None:
-        sibling_marker_pattern = ""
         if token.isdigit():
-            sibling_marker_pattern = r"\(\d+\)"
+            for sibling_match in re.finditer(
+                r"\((\d+)\)",
+                source_text[match.end() :],
+                flags=marker_flags,
+            ):
+                if int(sibling_match.group(1)) > int(token):
+                    next_match = sibling_match
+                    break
         elif len(token) == 1 and token.isalpha():
-            sibling_marker_pattern = r"\([a-z]\)" if token.islower() else r"\([A-Z]\)"
-        if sibling_marker_pattern:
-            next_match = re.search(
+            sibling_marker_pattern = (
+                r"\(([a-z])\)" if token.islower() else r"\(([A-Z])\)"
+            )
+            for sibling_match in re.finditer(
                 sibling_marker_pattern,
                 source_text[match.end() :],
                 flags=marker_flags,
-            )
+            ):
+                if ord(sibling_match.group(1)) > ord(token):
+                    next_match = sibling_match
+                    break
     if next_match is None:
         return source_text[match.start() :].strip()
     return source_text[match.start() : match.end() + next_match.start()].strip()
 
 
+def _slice_source_text_at_marker_range(
+    source_text: str,
+    start_token: str,
+    end_token: str,
+) -> str:
+    start_flags = 0 if start_token.isalpha() else re.IGNORECASE
+    start_marker = re.compile(rf"\({re.escape(start_token)}\)", flags=start_flags)
+    start_match = start_marker.search(source_text)
+    if start_match is None:
+        return ""
+
+    end_flags = 0 if end_token.isalpha() else re.IGNORECASE
+    end_marker = re.compile(rf"\({re.escape(end_token)}\)", flags=end_flags)
+    end_match = end_marker.search(source_text, start_match.end())
+    if end_match is None:
+        return _slice_source_text_at_marker(source_text, start_token)
+
+    end_segment = _slice_source_text_at_marker(
+        source_text[end_match.start() :], end_token
+    )
+    if not end_segment:
+        return _slice_source_text_at_marker(source_text, start_token)
+    return source_text[
+        start_match.start() : end_match.start() + len(end_segment)
+    ].strip()
+
+
 def _source_text_for_rule_source(source_text: str, source: Any) -> str:
     scoped_source = source_text
-    for token in _rule_source_subsection_tokens(source):
-        next_scoped_source = _slice_source_text_at_marker(scoped_source, token)
+    for start_token, end_token in _rule_source_subsection_selectors(source):
+        if end_token is None:
+            next_scoped_source = _slice_source_text_at_marker(
+                scoped_source, start_token
+            )
+        else:
+            next_scoped_source = _slice_source_text_at_marker_range(
+                scoped_source,
+                start_token,
+                end_token,
+            )
         if not next_scoped_source:
             return scoped_source
         scoped_source = next_scoped_source

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -841,13 +841,17 @@ Hard requirements:
   4 surviving spouse / qualifying widow(er). If the source groups surviving
   spouse with joint return, every filing-status branch or match that handles
   status 1 must also handle status 4 in that same branch.
+  If the source says only "joint return" without also naming surviving spouse
+  or qualifying widow(er), do not route status 4 to the joint-return branch;
+  status 4 falls under any "other case" branch unless the source states
+  otherwise.
 - Never encode US tax filing status as string literals such as
   `"married_filing_jointly"` or as unbacked local boolean facts such as
   `married_filing_jointly`, `head_of_household`, or `surviving_spouse`. If a
   source provision itself defines a legal status or return category, encode that
   source-backed output at its absolute RuleSpec path and import it downstream.
   If a shared numeric filing-status output is available, import it and use the
-  structural enum in formulas, e.g.
+  structural enum in formulas when the source supports that grouping, e.g.
   `match filing_status: 1 => joint_amount; 4 => joint_amount; ...`.
 - Do not replace filing-status components with local status inputs such as
   `taxpayer_is_surviving_spouse`, `surviving_spouse`, or `head_of_household`.

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -540,6 +540,8 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "period: Day" in prompt
     assert "never use bare `YYYY-MM-DD` shorthand" in prompt
     assert "Do not preserve existing `#input.filing_status`" in prompt
+    assert 'If the source says only "joint return"' in prompt
+    assert 'status 4 falls under any "other case" branch' in prompt
     assert "Existing executable output names are public API contracts" not in prompt
     assert "applicable_amount_in_effect_under_section_<section>" not in prompt
     assert "Do not put the date or year value in the fact name" in prompt
@@ -3873,6 +3875,8 @@ class TestEvalPrompt:
         assert "Do not use bare year periods like `2024`" in prompt
         assert "Never encode US tax filing status" in prompt
         assert "Do not create local `#input.filing_status` facts" in prompt
+        assert 'If the source says only "joint return"' in prompt
+        assert 'status 4 falls under any "other case" branch' in prompt
         assert "Hard requirement for IRC section 151(d)" not in prompt
         assert "must use the numeric `filing_status` enum input directly" not in prompt
         assert "Importing an adjacent upstream output only as proof" in prompt

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -12725,6 +12725,99 @@ rules:
     assert find_tax_filing_status_surviving_spouse_issues(content) == []
 
 
+def test_filing_status_branch_rejects_surviving_spouse_for_joint_only_any_other_case():
+    content = """format: rulespec/v1
+module:
+  summary: The threshold is $250,000 in the case of a joint return and $200,000 in any other case.
+rules:
+  - name: additional_medicare_wage_tax_threshold
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    source: 26 USC 3101(b)(2)(A)-(C)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          match filing_status:
+              1 => joint_threshold
+              4 => joint_threshold
+              2 => separate_threshold
+              3 => other_threshold
+              0 => other_threshold
+"""
+
+    issues = find_tax_filing_status_surviving_spouse_issues(content)
+
+    assert any(
+        "incorrectly treats surviving spouse as joint return" in issue
+        for issue in issues
+    )
+
+
+def test_filing_status_branch_uses_subparagraph_range_source_context():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    (a) Old-age, survivors, and disability insurance.
+    (b) Hospital insurance (1) In general. (2) Additional tax
+    The tax applies to wages which are in excess of--
+    (A) in the case of a joint return, $250,000,
+    (B) in the case of a married taxpayer filing a separate return, one-half
+    of the dollar amount determined under subparagraph (A), and
+    (C) in any other case, $200,000.
+    (c) Relief from taxes.
+rules:
+  - name: additional_medicare_wage_tax_threshold
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    source: 26 USC 3101(b)(2)(A)-(C)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          match filing_status:
+              1 => joint_threshold
+              4 => joint_threshold
+              2 => separate_threshold
+              3 => other_threshold
+              0 => other_threshold
+"""
+
+    issues = find_tax_filing_status_surviving_spouse_issues(content)
+
+    assert any(
+        "incorrectly treats surviving spouse as joint return" in issue
+        for issue in issues
+    )
+
+
+def test_filing_status_branch_allows_surviving_spouse_as_other_case_for_joint_only():
+    content = """format: rulespec/v1
+module:
+  summary: The threshold is $250,000 in the case of a joint return and $200,000 in any other case.
+rules:
+  - name: additional_medicare_wage_tax_threshold
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    source: 26 USC 3101(b)(2)(A)-(C)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          match filing_status:
+              1 => joint_threshold
+              4 => other_threshold
+              2 => separate_threshold
+              3 => other_threshold
+              0 => other_threshold
+"""
+
+    assert find_tax_filing_status_surviving_spouse_issues(content) == []
+
+
 def test_filing_status_branch_rejects_unrelated_surviving_spouse_code():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.377"
+version = "0.2.378"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- teach encoder/eval prompts that joint-return-only sources should not group surviving spouse unless the source says so
- validate joint-return plus any-other-case source text and flag status 4 routed to the joint branch
- preserve subparagraph range source context like 26 USC 3101(b)(2)(A)-(C), and avoid cutting source text at backward cross-references

## Tests
- uv run ruff format --check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py tests/test_rulespec_validation.py
- uv run ruff check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py tests/test_rulespec_validation.py
- uv run pytest tests/test_rulespec_validation.py -k filing_status_branch -q
- uv run pytest tests/test_evals.py -k 'filing_status or prompt' -q
- uv run pytest tests/test_cli.py -k 'version or provenance' -q
- AXIOM_CORPUS_REPO=/Users/maxghenis/_axiom-worktrees/payroll-night-20260528/axiom-corpus uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3101/b/2.yaml --skip-reviewers (expected failure on current bad artifact)