### PR TITLE
Repair joint-only filing status branches

### DIFF
--- a/changelog.d/joint-only-filing-status-repair.fixed.md
+++ b/changelog.d/joint-only-filing-status-repair.fixed.md
@@ -1,0 +1,1 @@
+Repair joint-return-only filing-status thresholds by routing surviving-spouse status through the any-other-case branch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.378"
+version = "0.2.379"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.378"
+__version__ = "0.2.379"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -69,16 +69,22 @@ from .harness.evals import (
 )
 from .harness.proof_validator import validate_rulespec_proofs
 from .harness.validator_pipeline import (
+    _US_TAX_JOINT_ONLY_ANY_OTHER_CASE_TEXT_PATTERN,
+    _US_TAX_JOINT_SURVIVING_SPOUSE_GROUP_TEXT_PATTERN,
     ValidatorPipeline,
     _candidate_upstream_rulespec_roots,
     _canonical_rulespec_compile_path,
     _canonical_rulespec_target,
+    _extract_source_verification_text,
+    _filing_status_rule_source_context,
     _is_executable_rulespec_rule,
     _rulespec_executable_index_for_roots,
     _rulespec_executable_signature,
     _rulespec_public_item_keys,
     _rulespec_repo_prefix,
+    _rulespec_rule_formula_rule_records,
     _rulespec_target_is_descendant_of,
+    extract_embedded_source_text,
     find_proof_import_reference_issues,
     find_tax_filing_status_local_input_issues,
     find_tax_status_component_local_input_issues,
@@ -6851,10 +6857,16 @@ def _repair_tax_filing_status_branches(content: str) -> tuple[str, list[str]]:
     lines = content.splitlines(keepends=True)
     repaired: list[str] = []
     repaired_rules: list[str] = []
-    needs_surviving_spouse = (
-        "surviving spouse" in content.lower() or "qualifying widow" in content.lower()
+    fallback_mode = (
+        "surviving_joint"
+        if (
+            "surviving spouse" in content.lower()
+            or "qualifying widow" in content.lower()
+        )
+        else None
     )
-    needs_other_case = "any other case" in content.lower()
+    fallback_needs_other_case = "any other case" in content.lower()
+    repair_modes = _tax_filing_status_branch_repair_modes(content)
     current_rule_name: str | None = None
     index = 0
 
@@ -6875,12 +6887,15 @@ def _repair_tax_filing_status_branches(content: str) -> tuple[str, list[str]]:
                 index += 1
             repaired_block, block_repairs = _repair_tax_filing_status_match_block(
                 match_block,
-                needs_surviving_spouse=needs_surviving_spouse,
-                needs_other_case=needs_other_case,
+                repair_mode=repair_modes.get(current_rule_name or "") or fallback_mode,
+                needs_other_case=repair_modes.get(current_rule_name or "")
+                == "joint_only_other"
+                or fallback_needs_other_case,
             )
             repaired.extend(repaired_block)
             repaired_rules.extend(
-                current_rule_name or "<unknown>" for _ in block_repairs
+                f"{current_rule_name or '<unknown>'}:{repair}"
+                for repair in block_repairs
             )
             continue
 
@@ -6890,10 +6905,42 @@ def _repair_tax_filing_status_branches(content: str) -> tuple[str, list[str]]:
     return "".join(repaired), repaired_rules
 
 
+def _tax_filing_status_branch_repair_modes(content: str) -> dict[str, str]:
+    try:
+        payload = yaml.safe_load(content)
+    except (yaml.YAMLError, ValueError):
+        return {}
+    if not isinstance(payload, dict) or payload.get("format") != "rulespec/v1":
+        return {}
+
+    module_source_text = (
+        _extract_source_verification_text(content)
+        or extract_embedded_source_text(content)
+        or content
+    )
+    modes: dict[str, str] = {}
+    for name, kind, formula, source, rule in _rulespec_rule_formula_rule_records(
+        payload
+    ):
+        if kind != "derived" or "filing_status" not in formula:
+            continue
+        source_context = _filing_status_rule_source_context(
+            content=content,
+            module_source_text=module_source_text,
+            rule=rule,
+            source=source,
+        )
+        if _US_TAX_JOINT_SURVIVING_SPOUSE_GROUP_TEXT_PATTERN.search(source_context):
+            modes[name] = "surviving_joint"
+        elif _US_TAX_JOINT_ONLY_ANY_OTHER_CASE_TEXT_PATTERN.search(source_context):
+            modes[name] = "joint_only_other"
+    return modes
+
+
 def _repair_tax_filing_status_match_block(
     block: list[str],
     *,
-    needs_surviving_spouse: bool,
+    repair_mode: str | None,
     needs_other_case: bool,
 ) -> tuple[list[str], list[str]]:
     arms: dict[int, tuple[str, str]] = {}
@@ -6904,20 +6951,51 @@ def _repair_tax_filing_status_match_block(
         indent, code, expression = arm_match.groups()
         arms[int(code)] = (indent, expression)
 
-    should_add_surviving_spouse = needs_surviving_spouse and 1 in arms and 4 not in arms
+    other_case_expression = None
+    if 0 in arms:
+        other_case_expression = arms[0][1]
+    elif 3 in arms:
+        other_case_expression = arms[3][1]
+
+    should_add_surviving_spouse = (
+        repair_mode == "surviving_joint" and 1 in arms and 4 not in arms
+    )
+    should_add_surviving_spouse_to_other = (
+        repair_mode == "joint_only_other"
+        and 1 in arms
+        and 4 not in arms
+        and other_case_expression is not None
+    )
+    should_route_surviving_spouse_to_other = (
+        repair_mode == "joint_only_other"
+        and 1 in arms
+        and 4 in arms
+        and other_case_expression is not None
+        and arms[4][1].strip() == arms[1][1].strip()
+    )
     should_add_other_case = needs_other_case and 0 in arms and 3 not in arms
 
     repaired: list[str] = []
     repairs: list[str] = []
     for line in block:
-        repaired.append(line)
         arm_match = re.match(r"(\s*)(\d+)\s*=>\s*(.+)$", line.rstrip("\n"))
+        if arm_match is not None:
+            indent, code, expression = arm_match.groups()
+            if code == "4" and should_route_surviving_spouse_to_other:
+                repaired.append(f"{indent}4 => {other_case_expression}\n")
+                repairs.append("surviving_spouse_to_other_case")
+                continue
+
+        repaired.append(line)
         if arm_match is None:
             continue
         indent, code, expression = arm_match.groups()
         if code == "1" and should_add_surviving_spouse:
             repaired.append(f"{indent}4 => {expression}\n")
             repairs.append("surviving_spouse")
+        if code == "1" and should_add_surviving_spouse_to_other:
+            repaired.append(f"{indent}4 => {other_case_expression}\n")
+            repairs.append("surviving_spouse_to_other_case")
         if code == "0" and should_add_other_case:
             repaired.append(f"{indent}3 => {expression}\n")
             repairs.append("other_case")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,7 @@ from axiom_encode.cli import (
     _repair_section_151_imports,
     _repair_section_151_temporal_fact_names,
     _repair_shared_statutory_rate_names,
+    _repair_tax_filing_status_branches,
     _repair_upstream_placement_duplicate_imports,
     _require_axiom_encode_version_provenance,
     _rewrite_gpt_runner_backend,
@@ -9739,6 +9740,50 @@ rules:
         assert payload["tool"] == "axiom-encode repair-tax-filing-status-branches"
         assert [applied_file["path"] for applied_file in payload["applied_files"]] == [
             "statutes/26/3101/b/2.yaml"
+        ]
+
+    def test_repair_tax_filing_status_branches_routes_joint_only_status_four_to_other(
+        self,
+    ):
+        content = """format: rulespec/v1
+module:
+  summary: joint / surviving spouse and any other case
+  source_verification:
+    corpus_citation_path: us/statute/26/3101
+rules:
+  - name: additional_medicare_wage_tax_threshold
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    source: 26 USC 3101(b)(2)(A)-(C)
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          match filing_status:
+              1 => additional_medicare_wage_tax_joint_threshold
+              4 => additional_medicare_wage_tax_joint_threshold
+              2 => additional_medicare_wage_tax_joint_threshold / 2
+              0 => additional_medicare_wage_tax_other_threshold
+              3 => additional_medicare_wage_tax_other_threshold
+"""
+
+        with patch(
+            "axiom_encode.cli._extract_source_verification_text",
+            return_value=(
+                "(2) Additional tax ... in excess of-- "
+                "(A) in the case of a joint return, $250,000, "
+                "(B) in the case of a married taxpayer filing a separate return, "
+                "1/2 of the dollar amount determined under subparagraph (A), and "
+                "(C) in any other case, $200,000."
+            ),
+        ):
+            repaired, repairs = _repair_tax_filing_status_branches(content)
+
+        assert "4 => additional_medicare_wage_tax_joint_threshold" not in repaired
+        assert "4 => additional_medicare_wage_tax_other_threshold" in repaired
+        assert repairs == [
+            "additional_medicare_wage_tax_threshold:surviving_spouse_to_other_case"
         ]
 
     def test_repair_tax_filing_status_branches_does_not_mutate_without_signing_key(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.378"
+version = "0.2.379"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- extend the signed filing-status branch repair tool to use verified source text per rule
- route surviving-spouse status 4 through the any-other-case branch when the source says only joint return plus any other case
- bump axiom-encode to 0.2.379

## Tests
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- uv run pytest tests/test_cli.py -k 'repair_tax_filing_status_branches or version or provenance' -q
- uv run pytest tests/test_rulespec_validation.py -k filing_status_branch -q
- dry check against rulespec-us statutes/26/3101/b/2.yaml: repairs status 4 from joint threshold to other threshold