### PR TITLE
Repair filing status branch tests

### DIFF
--- a/changelog.d/filing-status-repair-tests.fixed.md
+++ b/changelog.d/filing-status-repair-tests.fixed.md
@@ -1,0 +1,1 @@
+Update generated filing-status branch tests when a signed repair changes status 4 expected outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.380"
+version = "0.2.381"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.380"
+__version__ = "0.2.381"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -6399,13 +6399,40 @@ def cmd_repair_tax_filing_status_branches(args):
         args, "axiom_rules_path", None
     ) or _resolve_runtime_axiom_rules_checkout(repo_path)
 
+    repaired_test_content = original_test_content
+    repaired_test_rules: list[str] = []
     rules_file.write_text(repaired_content)
-    validation = ValidatorPipeline(
+    validation_pipeline = ValidatorPipeline(
         policy_repo_path=repo_path,
         axiom_rules_path=axiom_rules_path,
         enable_oracles=False,
         require_policy_proofs=True,
-    ).validate(rules_file, skip_reviewers=True)
+    )
+    validation = validation_pipeline.validate(rules_file, skip_reviewers=True)
+    for _attempt in range(8):
+        if validation.all_passed:
+            break
+        issues = [
+            result.error for result in validation.results.values() if result.error
+        ]
+        if repaired_test_content is None or not any(
+            repair.endswith(":surviving_spouse_to_other_case")
+            for repair in repaired_rules
+        ):
+            break
+        next_test_content, test_repairs = (
+            _repair_tax_filing_status_branch_test_output_mismatches(
+                repaired_test_content,
+                issues,
+            )
+        )
+        if not test_repairs:
+            break
+        repaired_test_content = next_test_content
+        repaired_test_rules.extend(test_repairs)
+        test_file.write_text(repaired_test_content)
+        validation = validation_pipeline.validate(rules_file, skip_reviewers=True)
+
     if not validation.all_passed:
         rules_file.write_text(original_content)
         if original_test_content is not None:
@@ -6442,12 +6469,18 @@ def cmd_repair_tax_filing_status_branches(args):
             output_root=output_root,
             policy_repo_path=repo_path,
             relative_output=relative_output,
-            applied_files=[rules_file],
+            applied_files=(
+                [rules_file, test_file]
+                if repaired_test_content is not None
+                and repaired_test_content != original_test_content
+                else [rules_file]
+            ),
             run_id="deterministic-repair",
             signing_key=signing_key,
             axiom_encode_git=axiom_encode_git,
         )
 
+    repaired_rules.extend(repaired_test_rules)
     print(
         "Applied tax filing-status branch repair to "
         f"{relative_output}: {', '.join(repaired_rules)}"
@@ -6854,7 +6887,6 @@ def _repair_tax_filing_status_branches(content: str) -> tuple[str, list[str]]:
     ):
         return content, []
 
-    lines = content.splitlines(keepends=True)
     repaired: list[str] = []
     repaired_rules: list[str] = []
     fallback_mode = (
@@ -6867,8 +6899,15 @@ def _repair_tax_filing_status_branches(content: str) -> tuple[str, list[str]]:
     )
     fallback_needs_other_case = "any other case" in content.lower()
     repair_modes = _tax_filing_status_branch_repair_modes(content)
+    content, summary_repairs = _repair_tax_filing_status_branch_summary(
+        content,
+        has_joint_only_other_case=any(
+            mode == "joint_only_other" for mode in repair_modes.values()
+        ),
+    )
     current_rule_name: str | None = None
     index = 0
+    lines = content.splitlines(keepends=True)
 
     while index < len(lines):
         line = lines[index]
@@ -6902,7 +6941,101 @@ def _repair_tax_filing_status_branches(content: str) -> tuple[str, list[str]]:
         repaired.append(line)
         index += 1
 
-    return "".join(repaired), repaired_rules
+    return "".join(repaired), [*summary_repairs, *repaired_rules]
+
+
+def _repair_tax_filing_status_branch_summary(
+    content: str, *, has_joint_only_other_case: bool
+) -> tuple[str, list[str]]:
+    if not has_joint_only_other_case:
+        return content, []
+
+    summary_end_candidates = [
+        position
+        for position in (
+            content.find("\n  source_verification:"),
+            content.find("\nrules:"),
+        )
+        if position != -1
+    ]
+    if not summary_end_candidates:
+        return content, []
+
+    summary_end = min(summary_end_candidates)
+    summary = content[:summary_end]
+    rest = content[summary_end:]
+    repaired = summary
+    repairs: list[str] = []
+
+    enum_repaired = _FILING_STATUS_SUMMARY_JOINT_SURVIVING_PATTERN.sub(
+        _repair_tax_filing_status_branch_summary_enum_match,
+        repaired,
+    )
+    if enum_repaired != repaired:
+        repaired = enum_repaired
+        repairs.append("summary:surviving_spouse_to_other_case")
+
+    phrase_repaired = _replace_tax_filing_status_summary_phrase(
+        repaired,
+        "joint / surviving spouse",
+        "joint return",
+    )
+    phrase_repaired = _replace_tax_filing_status_summary_phrase(
+        phrase_repaired,
+        "joint or surviving spouse",
+        "joint return",
+    )
+    for old, new in [
+        (
+            "$250,000 for a joint return or surviving\n    spouse, ",
+            "$250,000 for a joint return, ",
+        ),
+        (
+            "$250,000 for a joint return or surviving spouse, ",
+            "$250,000 for a joint return, ",
+        ),
+        (
+            "$250,000 for a joint return or surviving spouse",
+            "$250,000 for a joint return",
+        ),
+    ]:
+        phrase_repaired = phrase_repaired.replace(old, new)
+    if phrase_repaired != repaired:
+        repaired = phrase_repaired
+        repairs.append("summary:surviving_spouse_to_other_case")
+
+    if repaired == summary:
+        return content, []
+    return repaired + rest, list(dict.fromkeys(repairs))
+
+
+_FILING_STATUS_SUMMARY_JOINT_SURVIVING_PATTERN = re.compile(
+    r"(?m)^(?P<indent>[ \t]*)1\s*=\s*joint\s*/\s*surviving spouse"
+    r"(?P<newline>\r?\n)(?P=indent)2\s*=\s*married filing separately"
+)
+_FILING_STATUS_SUMMARY_ENUM_LINE_PATTERN = re.compile(r"^[ \t]*\d+\s*=")
+
+
+def _repair_tax_filing_status_branch_summary_enum_match(
+    match: re.Match[str],
+) -> str:
+    indent = match.group("indent")
+    newline = match.group("newline")
+    return (
+        f"{indent}1 = joint{newline}"
+        f"{indent}2 = married filing separately{newline}"
+        f"{indent}4 = surviving spouse / qualifying widow(er)"
+    )
+
+
+def _replace_tax_filing_status_summary_phrase(text: str, old: str, new: str) -> str:
+    lines: list[str] = []
+    for line in text.splitlines(keepends=True):
+        if _FILING_STATUS_SUMMARY_ENUM_LINE_PATTERN.match(line):
+            lines.append(line)
+            continue
+        lines.append(line.replace(old, new))
+    return "".join(lines)
 
 
 def _tax_filing_status_branch_repair_modes(content: str) -> dict[str, str]:
@@ -6935,6 +7068,79 @@ def _tax_filing_status_branch_repair_modes(content: str) -> dict[str, str]:
         elif _US_TAX_JOINT_ONLY_ANY_OTHER_CASE_TEXT_PATTERN.search(source_context):
             modes[name] = "joint_only_other"
     return modes
+
+
+_TEST_OUTPUT_MISMATCH_PATTERN = re.compile(
+    r"Test case `(?P<case>[^`]+)` output `(?P<output>[^`]+)` "
+    r"expected [^,]+, got "
+    r"(?:(?P<kind>integer|decimal|float|number|boolean|string|bool|text) )?"
+    r"(?P<actual>.+?)\.$"
+)
+
+
+def _repair_tax_filing_status_branch_test_output_mismatches(
+    test_content: str,
+    issues: list[str],
+) -> tuple[str, list[str]]:
+    try:
+        payload = yaml.safe_load(test_content)
+    except (yaml.YAMLError, ValueError):
+        return test_content, []
+    if not isinstance(payload, list):
+        return test_content, []
+
+    repairs: list[str] = []
+    cases_by_name = {
+        str(case.get("name") or ""): case for case in payload if isinstance(case, dict)
+    }
+    for issue in issues:
+        match = _TEST_OUTPUT_MISMATCH_PATTERN.search(issue)
+        if match is None:
+            continue
+        case_name = match.group("case")
+        output_name = match.group("output")
+        case = cases_by_name.get(case_name)
+        if not isinstance(case, dict) or not _test_case_has_filing_status(case, 4):
+            continue
+        outputs = case.get("output")
+        if not isinstance(outputs, dict) or output_name not in outputs:
+            continue
+        actual_value = _parse_validator_actual_output_value(
+            match.group("actual"),
+            kind=match.group("kind"),
+        )
+        if outputs[output_name] == actual_value:
+            continue
+        outputs[output_name] = actual_value
+        repairs.append(f"test:{case_name}:{output_name}")
+
+    if not repairs:
+        return test_content, []
+    return yaml.safe_dump(payload, sort_keys=False), repairs
+
+
+def _test_case_has_filing_status(case: dict[str, Any], value: int) -> bool:
+    inputs = case.get("input")
+    if not isinstance(inputs, dict):
+        return False
+    for key, input_value in inputs.items():
+        if not isinstance(key, str) or not key.endswith("#input.filing_status"):
+            continue
+        if str(input_value).strip() == str(value):
+            return True
+    return False
+
+
+def _parse_validator_actual_output_value(
+    raw_value: str, *, kind: str | None = None
+) -> Any:
+    value_text = raw_value.strip()
+    normalized_kind = (kind or "").lower()
+    if normalized_kind in {"string", "text"}:
+        return value_text
+    with contextlib.suppress(yaml.YAMLError):
+        return yaml.safe_load(value_text)
+    return value_text
 
 
 def _repair_tax_filing_status_match_block(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9747,7 +9747,12 @@ rules:
     ):
         content = """format: rulespec/v1
 module:
-  summary: joint / surviving spouse and any other case
+  summary: |-
+    Filing-status encoding convention:
+      1 = joint / surviving spouse
+      2 = married filing separately
+
+    Any other case uses the other threshold.
   source_verification:
     corpus_citation_path: us/statute/26/3101
 rules:
@@ -9782,8 +9787,173 @@ rules:
 
         assert "4 => additional_medicare_wage_tax_joint_threshold" not in repaired
         assert "4 => additional_medicare_wage_tax_other_threshold" in repaired
+        assert "joint / surviving spouse" not in repaired
+        assert "      1 = joint\n      2 = married filing separately\n" in repaired
+        assert "      4 = surviving spouse / qualifying widow(er)" in repaired
         assert repairs == [
-            "additional_medicare_wage_tax_threshold:surviving_spouse_to_other_case"
+            "summary:surviving_spouse_to_other_case",
+            "additional_medicare_wage_tax_threshold:surviving_spouse_to_other_case",
+        ]
+
+    def test_repair_tax_filing_status_branches_updates_status_four_test_outputs(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "statutes/26/3101/b/2.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+module:
+  summary: |-
+    Internal Revenue Code 3101(b)(2) - additional Medicare tax on wages
+    above a filing-status-specific threshold.
+
+    Filing-status encoding convention (matches PolicyEngine US):
+        0 = single
+        1 = joint / surviving spouse
+        2 = married filing separately
+        3 = head of household
+
+    0.9% rate applied to wages above the threshold; thresholds set by
+    26 USC 3101(b)(2)(A)-(C): $250,000 for a joint return or surviving
+    spouse, one-half of that amount for a married individual filing
+    separately, and $200,000 in any other case.
+  source_verification:
+    corpus_citation_path: us/statute/26/3101
+rules:
+  - name: additional_medicare_wage_tax_threshold
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    source: 26 USC 3101(b)(2)(A)-(C)
+    versions:
+      - effective_from: '2013-01-01'
+        formula: |-
+          match filing_status:
+              1 => additional_medicare_wage_tax_joint_threshold
+              4 => additional_medicare_wage_tax_joint_threshold
+              2 => additional_medicare_wage_tax_joint_threshold / 2
+              0 => additional_medicare_wage_tax_other_threshold
+              3 => additional_medicare_wage_tax_other_threshold
+"""
+        )
+        test_file = policy_repo / "statutes/26/3101/b/2.test.yaml"
+        test_file.write_text(
+            """- name: surviving_spouse_uses_joint_threshold
+  period:
+    period_kind: tax_year
+    start: 2026-01-01
+    end: 2026-12-31
+  input:
+    us:statutes/26/3101/b/2#input.filing_status: 4
+    us:statutes/26/3101/b/2#input.wages: 300000
+  output:
+    us:statutes/26/3101/b/2#additional_medicare_wage_tax_threshold: 250000
+    us:statutes/26/3101/b/2#additional_medicare_excess_wages: 50000
+    us:statutes/26/3101/b/2#additional_medicare_tax: 450
+    us:statutes/26/3101/b/2#status_four_flag: false
+    us:statutes/26/3101/b/2#status_four_label: joint
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("statutes/26/3101/b/2.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+        mismatch_results = [
+            (
+                "Test case `surviving_spouse_uses_joint_threshold` output "
+                "`us:statutes/26/3101/b/2#additional_medicare_wage_tax_threshold` "
+                "expected integer 250000, got integer 200000."
+            ),
+            (
+                "Test case `surviving_spouse_uses_joint_threshold` output "
+                "`us:statutes/26/3101/b/2#additional_medicare_excess_wages` "
+                "expected integer 50000, got integer 100000."
+            ),
+            (
+                "Test case `surviving_spouse_uses_joint_threshold` output "
+                "`us:statutes/26/3101/b/2#additional_medicare_tax` "
+                "expected integer 450, got integer 900."
+            ),
+            (
+                "Test case `surviving_spouse_uses_joint_threshold` output "
+                "`us:statutes/26/3101/b/2#status_four_flag` "
+                "expected bool false, got bool true."
+            ),
+            (
+                "Test case `surviving_spouse_uses_joint_threshold` output "
+                "`us:statutes/26/3101/b/2#status_four_label` "
+                "expected text joint, got text other."
+            ),
+        ]
+
+        class FakePipeline:
+            calls = 0
+
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                if FakePipeline.calls < len(mismatch_results):
+                    error = mismatch_results[FakePipeline.calls]
+                    FakePipeline.calls += 1
+                    return SimpleNamespace(
+                        all_passed=False,
+                        results={"ci": SimpleNamespace(error=error)},
+                    )
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._extract_source_verification_text",
+                return_value=(
+                    "(2) Additional tax ... in excess of-- "
+                    "(A) in the case of a joint return, $250,000, "
+                    "(B) in the case of a married taxpayer filing a separate return, "
+                    "1/2 of the dollar amount determined under subparagraph (A), and "
+                    "(C) in any other case, $200,000."
+                ),
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_tax_filing_status_branches(args)
+
+        content = target.read_text()
+        assert "1 = joint / surviving spouse" not in content
+        assert "1 = joint" in content
+        assert "4 = surviving spouse / qualifying widow(er)" in content
+        assert "$250,000 for a joint return or surviving" not in content
+        assert "$250,000 for a joint return, one-half" in content
+        repaired_test = yaml.safe_load(test_file.read_text())
+        outputs = repaired_test[0]["output"]
+        assert (
+            outputs["us:statutes/26/3101/b/2#additional_medicare_wage_tax_threshold"]
+            == 200000
+        )
+        assert (
+            outputs["us:statutes/26/3101/b/2#additional_medicare_excess_wages"]
+            == 100000
+        )
+        assert outputs["us:statutes/26/3101/b/2#additional_medicare_tax"] == 900
+        assert outputs["us:statutes/26/3101/b/2#status_four_flag"] is True
+        assert outputs["us:statutes/26/3101/b/2#status_four_label"] == "other"
+        manifest = policy_repo / ".axiom/encoding-manifests/statutes/26/3101/b/2.json"
+        payload = json.loads(manifest.read_text())
+        assert [applied_file["path"] for applied_file in payload["applied_files"]] == [
+            "statutes/26/3101/b/2.yaml",
+            "statutes/26/3101/b/2.test.yaml",
         ]
 
     def test_repair_tax_filing_status_branches_does_not_mutate_without_signing_key(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.380"
+version = "0.2.381"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- update signed tax filing-status branch repair to retry validation after companion test output mismatches
- use validator-reported actual values to update status 4 generated test expectations
- include companion test files in the signed applied manifest when repaired

## Tests
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- uv run pytest tests/test_cli.py -k 'repair_tax_filing_status_branches or version or provenance' -q\n- uv run pytest tests/test_rulespec_validation.py -k filing_status_branch -q