### PR TITLE
Polish filing status branch repair output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.381"
+version = "0.2.382"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.381"
+__version__ = "0.2.382"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -6433,6 +6433,27 @@ def cmd_repair_tax_filing_status_branches(args):
         test_file.write_text(repaired_test_content)
         validation = validation_pipeline.validate(rules_file, skip_reviewers=True)
 
+    if (
+        validation.all_passed
+        and repaired_test_content is not None
+        and repaired_test_rules
+        and any(
+            repair.endswith(":surviving_spouse_to_other_case")
+            for repair in repaired_rules
+        )
+    ):
+        next_test_content, rename_repairs = _rename_tax_filing_status_branch_test_cases(
+            repaired_test_content
+        )
+        if rename_repairs:
+            repaired_test_content = next_test_content
+            repaired_test_rules.extend(rename_repairs)
+            test_file.write_text(repaired_test_content)
+            validation = validation_pipeline.validate(
+                rules_file,
+                skip_reviewers=True,
+            )
+
     if not validation.all_passed:
         rules_file.write_text(original_content)
         if original_test_content is not None:
@@ -6987,6 +7008,13 @@ def _repair_tax_filing_status_branch_summary(
     )
     for old, new in [
         (
+            "$250,000 for a joint return or surviving\n"
+            "    spouse, one-half of that amount for a married individual filing\n"
+            "    separately, and $200,000 in any other case.",
+            "$250,000 for a joint return, one-half of that amount for a married\n"
+            "    individual filing separately, and $200,000 in any other case.",
+        ),
+        (
             "$250,000 for a joint return or surviving\n    spouse, ",
             "$250,000 for a joint return, ",
         ),
@@ -7012,6 +7040,9 @@ def _repair_tax_filing_status_branch_summary(
 _FILING_STATUS_SUMMARY_JOINT_SURVIVING_PATTERN = re.compile(
     r"(?m)^(?P<indent>[ \t]*)1\s*=\s*joint\s*/\s*surviving spouse"
     r"(?P<newline>\r?\n)(?P=indent)2\s*=\s*married filing separately"
+    r"(?P<line2_tail>[^\r\n]*)"
+    r"(?:(?P=newline)(?P=indent)3\s*=\s*head of household"
+    r"(?P<line3_tail>[^\r\n]*))?"
 )
 _FILING_STATUS_SUMMARY_ENUM_LINE_PATTERN = re.compile(r"^[ \t]*\d+\s*=")
 
@@ -7021,11 +7052,15 @@ def _repair_tax_filing_status_branch_summary_enum_match(
 ) -> str:
     indent = match.group("indent")
     newline = match.group("newline")
-    return (
-        f"{indent}1 = joint{newline}"
-        f"{indent}2 = married filing separately{newline}"
-        f"{indent}4 = surviving spouse / qualifying widow(er)"
-    )
+    lines = [
+        f"{indent}1 = joint",
+        f"{indent}2 = married filing separately{match.group('line2_tail') or ''}",
+    ]
+    line3_tail = match.group("line3_tail")
+    if line3_tail is not None:
+        lines.append(f"{indent}3 = head of household{line3_tail}")
+    lines.append(f"{indent}4 = surviving spouse / qualifying widow(er)")
+    return newline.join(lines)
 
 
 def _replace_tax_filing_status_summary_phrase(text: str, old: str, new: str) -> str:
@@ -7113,6 +7148,39 @@ def _repair_tax_filing_status_branch_test_output_mismatches(
             continue
         outputs[output_name] = actual_value
         repairs.append(f"test:{case_name}:{output_name}")
+
+    if not repairs:
+        return test_content, []
+    return yaml.safe_dump(payload, sort_keys=False), repairs
+
+
+def _rename_tax_filing_status_branch_test_cases(
+    test_content: str,
+) -> tuple[str, list[str]]:
+    try:
+        payload = yaml.safe_load(test_content)
+    except (yaml.YAMLError, ValueError):
+        return test_content, []
+    if not isinstance(payload, list):
+        return test_content, []
+
+    repairs: list[str] = []
+    for case in payload:
+        if not isinstance(case, dict) or not _test_case_has_filing_status(case, 4):
+            continue
+        case_name = str(case.get("name") or "")
+        if (
+            "surviving_spouse" not in case_name and "qualifying_widow" not in case_name
+        ) or "joint_threshold" not in case_name:
+            continue
+        new_case_name = case_name.replace(
+            "uses_joint_threshold",
+            "uses_other_threshold",
+        ).replace("joint_threshold", "other_threshold")
+        if new_case_name == case_name:
+            continue
+        case["name"] = new_case_name
+        repairs.append(f"test:{case_name}->{new_case_name}")
 
     if not repairs:
         return test_content, []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9751,6 +9751,7 @@ module:
     Filing-status encoding convention:
       1 = joint / surviving spouse
       2 = married filing separately
+      3 = head of household
 
     Any other case uses the other threshold.
   source_verification:
@@ -9788,8 +9789,12 @@ rules:
         assert "4 => additional_medicare_wage_tax_joint_threshold" not in repaired
         assert "4 => additional_medicare_wage_tax_other_threshold" in repaired
         assert "joint / surviving spouse" not in repaired
-        assert "      1 = joint\n      2 = married filing separately\n" in repaired
-        assert "      4 = surviving spouse / qualifying widow(er)" in repaired
+        assert (
+            "      1 = joint\n"
+            "      2 = married filing separately\n"
+            "      3 = head of household\n"
+            "      4 = surviving spouse / qualifying widow(er)"
+        ) in repaired
         assert repairs == [
             "summary:surviving_spouse_to_other_case",
             "additional_medicare_wage_tax_threshold:surviving_spouse_to_other_case",
@@ -9936,7 +9941,13 @@ rules:
         assert "4 = surviving spouse / qualifying widow(er)" in content
         assert "$250,000 for a joint return or surviving" not in content
         assert "$250,000 for a joint return, one-half" in content
+        assert (
+            "$250,000 for a joint return, one-half of that amount for a married "
+            "individual filing" not in content
+        )
+        assert "surviving_spouse_uses_joint_threshold" not in test_file.read_text()
         repaired_test = yaml.safe_load(test_file.read_text())
+        assert repaired_test[0]["name"] == "surviving_spouse_uses_other_threshold"
         outputs = repaired_test[0]["output"]
         assert (
             outputs["us:statutes/26/3101/b/2#additional_medicare_wage_tax_threshold"]

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.381"
+version = "0.2.382"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- keep repaired filing-status enum summaries in stable status order
- rename repaired status-4 threshold test cases from joint-threshold to other-threshold wording
- bump axiom-encode to 0.2.382 for generated RuleSpec provenance

## Tests
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- uv run pytest tests/test_cli.py -k 'repair_tax_filing_status_branches or version' -q