### PR TITLE
Classify section 3502 oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.382"
+version = "0.2.383"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.382"
+__version__ = "0.2.383"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10542,6 +10542,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3406 child subsections set backup withholding rules for reportable payments, TIN failures, underreporting notices, certifications, payor deductions, and withholding administration; PolicyEngine computes annual tax outcomes, not these payor-level backup withholding administration surfaces as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3502#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3502 disallows subtitle A deductions for chapter 21 and 22 employment taxes and chapter 24 withheld tax; PolicyEngine computes income-tax deductions and payroll taxes from modeled tax bases, not these legal disallowance outputs as one-to-one variables.
+
   - legal_id_prefix: us:statutes/26/3505#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4393,6 +4393,38 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3502_deduction_disallowance_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3502.yaml",
+        """format: rulespec/v1
+rules:
+  - name: chapter_21_and_22_employment_taxes_allowed_as_subtitle_a_deduction
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0
+  - name: employer_chapter_24_withheld_tax_allowed_as_subtitle_a_deduction
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0
+  - name: income_recipient_chapter_24_withheld_tax_allowed_as_subtitle_a_deduction
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3505_third_party_liability_outputs(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.382"
+version = "0.2.383"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Summary:
- classify 26 USC 3502 deduction disallowance outputs as PolicyEngine not-comparable
- add regression coverage for the generated output names
- bump encoder version to 0.2.383

Tests:
- uv run ruff check tests/test_policyengine_coverage.py pyproject.toml src/axiom_encode/__init__.py
- uv run ruff format --check tests/test_policyengine_coverage.py
- uv run pytest tests/test_policyengine_coverage.py -k '3502 or 3504' -q
- uv run pytest tests/test_cli.py -k version -q