### PR TITLE
Classify section 3503 oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.383"
+version = "0.2.384"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.383"
+__version__ = "0.2.384"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10548,6 +10548,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3502 disallows subtitle A deductions for chapter 21 and 22 employment taxes and chapter 24 withheld tax; PolicyEngine computes income-tax deductions and payroll taxes from modeled tax bases, not these legal disallowance outputs as one-to-one variables.
 
+  - legal_id_prefix: us:statutes/26/3503#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3503 credits or refunds tax paid under chapter 21 or 22 for periods without liability under that chapter; PolicyEngine computes payroll tax liabilities from modeled facts, not this cross-chapter refund and credit administration surface as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3505#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4425,6 +4425,38 @@ rules:
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
+def test_policyengine_coverage_classifies_3503_cross_chapter_refund_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3503.yaml",
+        """format: rulespec/v1
+rules:
+  - name: chapter_21_or_22_tax_paid_for_period_without_liability
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: if tax_paid_under_chapter_21_or_22_for_period_with_no_liability_under_that_chapter then max(0, tax_paid_under_chapter_21_or_22_for_period) else 0
+  - name: credit_against_tax_imposed_by_other_chapter
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: min(chapter_21_or_22_tax_paid_for_period_without_liability, max(0, tax_imposed_by_other_chapter_on_taxpayer))
+  - name: refund_balance_after_other_chapter_credit
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: max(0, chapter_21_or_22_tax_paid_for_period_without_liability - credit_against_tax_imposed_by_other_chapter)
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3505_third_party_liability_outputs(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.383"
+version = "0.2.384"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Summary:
- classify 26 USC 3503 cross-chapter payroll tax refund and credit outputs as PolicyEngine not-comparable
- add regression coverage for the generated output names
- bump encoder version to 0.2.384

Tests:
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run python YAML load for src/axiom_encode/oracles/policyengine/mappings/us.yaml
- uv run pytest tests/test_policyengine_coverage.py -k '3503 or 3502 or 3504' -q
- uv run pytest tests/test_cli.py -k version -q