### PR TITLE
Classify section 3401(f) oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.384"
+version = "0.2.385"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.384"
+__version__ = "0.2.385"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10416,6 +10416,12 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3309 defines services covered for State unemployment-compensation purposes, source-specific exceptions, organization employee-count thresholds, and tribal delinquency predicates; PolicyEngine exposes final FUTA taxable earnings and tax assumptions, not these source-specific coverage thresholds and legal predicates as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3401/f#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3401(f) treats employee tips as wages for chapter 24 withholding and sets deemed-payment timing; PolicyEngine models annual income and payroll tax amounts, not this withholding-specific tip timing surface as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3402/f#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3545,10 +3545,32 @@ rules:
         formula: person_is_officer_of_corporation
 """,
     )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3401/f.yaml",
+        """format: rulespec/v1
+rules:
+  - name: tips_included_in_wages_for_subsection_a
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if tips_received_by_employee_in_course_of_employment: tips_received_amount else: 0
+  - name: tips_deemed_paid_when_written_statement_furnished
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: tips_received_by_employee_in_course_of_employment and written_statement_furnished
+  - name: tips_deemed_paid_when_received
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: tips_received_by_employee_in_course_of_employment and not written_statement_furnished
+""",
+    )
 
     report = build_policyengine_coverage_report(tmp_path, program="tax")
 
-    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert report["status_counts"] == {"known_not_comparable": 6}
     assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.384"
+version = "0.2.385"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3401(f) tip-withholding outputs as not comparable to PolicyEngine
- extend the 3401 withholding-definition coverage fixture
- bump axiom-encode to 0.2.385

## Tests
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run pytest tests/test_policyengine_coverage.py -q
- uv run pytest tests/test_cli.py -k version -q