### PR TITLE
Classify section 3401(h) oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.385"
+version = "0.2.386"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.385"
+__version__ = "0.2.386"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10422,6 +10422,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 3401(f) treats employee tips as wages for chapter 24 withholding and sets deemed-payment timing; PolicyEngine models annual income and payroll tax amounts, not this withholding-specific tip timing surface as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3401/h#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3401(h) defines differential wage payments and treats them as wages for chapter 24 withholding; PolicyEngine has military income variables but does not expose this employer-payment predicate, active-duty threshold, or withholding-specific wage-treatment surface as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3402/f#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3567,10 +3567,32 @@ rules:
         formula: tips_received_by_employee_in_course_of_employment and not written_statement_furnished
 """,
     )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3401/h.yaml",
+        """format: rulespec/v1
+rules:
+  - name: active_duty_period_minimum_days_for_differential_wage_payment
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 30
+  - name: differential_wage_payment
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: payment_is_made_by_employer and active_duty_period_days > active_duty_period_minimum_days_for_differential_wage_payment
+  - name: differential_wage_payment_treated_as_wages_for_subsection_a
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          if differential_wage_payment: differential_wage_payment_amount else: 0
+""",
+    )
 
     report = build_policyengine_coverage_report(tmp_path, program="tax")
 
-    assert report["status_counts"] == {"known_not_comparable": 6}
+    assert report["status_counts"] == {"known_not_comparable": 9}
     assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.385"
+version = "0.2.386"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 26 USC 3401(h) differential-wage withholding outputs as not comparable to PolicyEngine
- extend the 3401 withholding-definition coverage fixture
- bump axiom-encode to 0.2.386

## Tests
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run pytest tests/test_policyengine_coverage.py -k '3401_withholding_definitions' -q
- uv run pytest tests/test_cli.py -k version -q