### PR TITLE
Clarify same-section deferred imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.386"
+version = "0.2.387"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.386"
+__version__ = "0.2.387"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3891,7 +3891,7 @@ RuleSpec requirements:
 - A pure `notwithstanding subsection ...` override does not require importing
   the overridden subsection unless the formula actually needs that cited
   subsection's computed output.
-- If the cited same-section subsection is supplied in context as a RuleSpec file, add an `imports:` entry for that file and reference its exported rule; do not summarize the cited subsection into a local fact like `person_meets_...requirements`.
+- If the cited same-section subsection is supplied in context as a RuleSpec file, add an `imports:` entry for that file; do not summarize the cited subsection into a local fact like `person_meets_...requirements`. If the cited file has an exported executable rule that the formula needs, import and reference that exported rule. If the cited file is deferred or the current source only needs to preserve an exception boundary such as `except for purposes of subsection (a)`, use a file-level import without a `#symbol` fragment, such as `us:statutes/26/3401/a`, and encode the local source-stated override directly. Do not add a fragment import only for proof when the formula does not reference that symbol.
 - Do not copy the body of a cited cross-reference provision into this module's `summary` or re-encode that cited provision locally. Keep this module scoped to the requested citation and import the cited provision instead.
 - Do not fabricate sibling-file imports, do not guess unavailable import targets, and do not invent `import` statements or `imports:` blocks for uncopied same-instrument provisions.
 - Before using any imported output in arithmetic, check the copied context

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -682,9 +682,15 @@ Hard requirements:
   the overridden subsection unless the formula actually needs that cited
   subsection's computed output.
 - If the cited same-section subsection is supplied in context as a RuleSpec
-  file, add an `imports:` entry for that file and reference its exported rule;
-  do not summarize the cited subsection into a local fact like
-  `person_meets_...requirements`.
+  file, add an `imports:` entry for that file; do not summarize the cited
+  subsection into a local fact like `person_meets_...requirements`.
+  If the cited file has an exported executable rule that the formula needs,
+  import and reference that exported rule. If the cited file is deferred or the
+  current source only needs to preserve an exception boundary such as
+  `except for purposes of subsection (a)`, use a file-level import without a
+  `#symbol` fragment, such as `us:statutes/26/3401/a`, and encode the local
+  source-stated override directly. Do not add a fragment import only for proof
+  when the formula does not reference that symbol.
 - Do not copy the body of a cited cross-reference provision into this module's
   `summary` or re-encode that cited provision locally. Keep this module scoped
   to the requested citation and import the cited provision instead.

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3885,6 +3885,9 @@ class TestEvalPrompt:
         assert "Never drop the jurisdiction prefix" in prompt
         assert "listed under invalid copied local inputs" in prompt
         assert "do not preserve, rename, or recreate" in prompt
+        assert "file-level import without a `#symbol` fragment" in prompt
+        assert "except for purposes of subsection (a)" in prompt
+        assert "Do not add a fragment import only for proof" in prompt
         assert "treated as attributable to" in prompt
         assert "amount-level" in prompt
         assert "boolean or `dtype: Judgment` predicate" in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.386"
+version = "0.2.387"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- clarify that same-section exception/cross-reference clauses should import the cited sibling RuleSpec file instead of summarizing it as a local fact
- document when to use a file-level import without a `#symbol` fragment for deferred sibling subsections
- mirror the guidance in eval prompt generation and cover it with a schema guardrail test
- bump axiom-encode to 0.2.387

## Why

Generated `26 USC 3401(d)` was correctly blocked by RuleSpec validation because it cited subsection 3401(a) in an exception boundary but emitted no same-section import. A fragment import is also wrong when the formula does not reference the imported executable symbol. This prompt change teaches the generic pattern without hard-coding 3401(d).

## Validation

- `uv run pytest tests/test_evals.py -k 'schema_guardrails' -q`
- `uv run ruff check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py src/axiom_encode/__init__.py tests/test_evals.py`
- `uv run ruff format --check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py src/axiom_encode/__init__.py tests/test_evals.py`
- `uv run pytest tests/test_rulespec_validation.py -k 'same_section' -q`
- `uv run pytest tests/test_cli.py -k version -q`
