### PR TITLE
Classify 3401(d) oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.387"
+version = "0.2.388"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.387"
+__version__ = "0.2.388"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10416,6 +10416,12 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3309 defines services covered for State unemployment-compensation purposes, source-specific exceptions, organization employee-count thresholds, and tribal delinquency predicates; PolicyEngine exposes final FUTA taxable earnings and tax assumptions, not these source-specific coverage thresholds and legal predicates as one-to-one outputs.
 
+  - legal_id_prefix: us:statutes/26/3401/d#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3401(d) defines employer status for chapter 24 withholding, including subsection-specific wage-payment-control exceptions; PolicyEngine computes annual income and payroll-tax amounts, not this withholding employer-definition surface as one-to-one outputs.
+
   - legal_id_prefix: us:statutes/26/3401/f#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3546,6 +3546,22 @@ rules:
 """,
     )
     _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3401/d.yaml",
+        """format: rulespec/v1
+rules:
+  - name: employer_for_subsection_a
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: person_for_whom_individual_performs_or_performed_service_as_employee
+  - name: employer
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: person_has_control_of_payment_of_wages_for_services
+""",
+    )
+    _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3401/f.yaml",
         """format: rulespec/v1
 rules:
@@ -3592,7 +3608,7 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path, program="tax")
 
-    assert report["status_counts"] == {"known_not_comparable": 9}
+    assert report["status_counts"] == {"known_not_comparable": 11}
     assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.387"
+version = "0.2.388"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- classify `26 USC 3401(d)` withholding employer-definition outputs as not comparable to PolicyEngine
- add a regression fixture to the 3401 withholding definitions oracle coverage test
- bump axiom-encode to 0.2.388

## Why

The generated 3401(d) RuleSpec now applies cleanly, but oracle coverage reports its two outputs as unmapped. These outputs define chapter 24 withholding employer status and a subsection-specific exception boundary; PolicyEngine computes annual income and payroll-tax amounts rather than exposing this employer-definition surface as one-to-one outputs.

## Validation

- `uv run pytest tests/test_policyengine_coverage.py -k '3401_withholding_definitions' -q`
- `uv run pytest tests/test_cli.py -k version -q`
- `uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- `uv run ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- registry smoke check for `us:statutes/26/3401/d#employer`
