### PR TITLE
Preserve parenthetical numeric grounding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.388"
+version = "0.2.389"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.388"
+__version__ = "0.2.389"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -665,7 +665,7 @@ _SYNTHETIC_STATEWIDE_ALLOWANCE_RESTATEMENT_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _SOURCE_REFERENCE_TARGET_PATTERN = (
-    r"(?:(?:\([^)]+\))+|"
+    r"(?:(?:\([A-Za-z0-9ivxlcdmIVXLCDM]+\))+|"
     r"\d+[A-Za-z./-]*(?:\([^)]+\))*(?=$|[\s,.;:])"
     r"(?!\s*(?:percent|per\s*cent(?:um)?))|"
     r"[ivxlcdm]+\b|[A-Z]{1,4}\b|[a-z]\b)"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -16085,6 +16085,30 @@ rules:
     assert 4 in extract_numeric_occurrences_from_text(source_text)
 
 
+def test_ungrounded_numeric_preserves_substantive_parenthetical_days():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3406
+rules:
+  - name: broker_notice_deadline_days
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          15
+"""
+    source_text = (
+        "such broker shall, within such period as the Secretary may prescribe by "
+        "regulations (but not later than 15 days after such acquisition), notify "
+        "the payor"
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 15 in extract_numeric_occurrences_from_text(source_text)
+
+
 def test_ungrounded_numeric_accepts_source_mixed_unicode_fraction_percentage():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.388"
+version = "0.2.389"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- keep substantive prose parentheticals such as `(but not later than 15 days...)` in numeric grounding source text
- still strip structural source references like `(B)` and `(iv)`
- add a regression test covering the 3406(d) backup-withholding deadline phrasing
- bump axiom-encode to 0.2.389

## Why

Generated `26 USC 3406(d)` correctly encoded the source-stated `15` day broker notice deadline, but apply validation rejected it as ungrounded. The source cleaner was treating the parenthetical after `regulations` as a structural regulation reference and deleting the substantive `15 days` phrase before numeric grounding ran.

## Validation

- `uv run pytest tests/test_rulespec_validation.py -k 'parenthetical_days or unicode_fraction or ordinal_word' -q`
- `uv run pytest tests/test_cli.py -k version -q`
- `uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py src/axiom_encode/__init__.py`
- `uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py src/axiom_encode/__init__.py`
