### PR TITLE
Repair generated subsection imports and exception outputs

### DIFF
--- a/changelog.d/missing-same-section-import-repair.fixed.md
+++ b/changelog.d/missing-same-section-import-repair.fixed.md
@@ -1,0 +1,1 @@
+Auto-repair generated RuleSpec files that omit validator-required same-section subsection imports.

--- a/changelog.d/unconsumed-exception-output.fixed.md
+++ b/changelog.d/unconsumed-exception-output.fixed.md
@@ -1,0 +1,1 @@
+Reject generated outputs that expose a local "shall not apply" exception without negating it in the matching `*_applies` rule.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.391"
+version = "0.2.392"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.391"
+__version__ = "0.2.392"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -11377,13 +11377,11 @@ def cmd_encode(args):
             )
             outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
-                repaired_same_section_imports = (
-                    _try_repair_generated_missing_same_section_subsection_imports_for_apply(
-                        result,
-                        output_root=args.output,
-                        policy_repo_path=policy_repo_path,
-                        issues=apply_issues,
-                    )
+                repaired_same_section_imports = _try_repair_generated_missing_same_section_subsection_imports_for_apply(
+                    result,
+                    output_root=args.output,
+                    policy_repo_path=policy_repo_path,
+                    issues=apply_issues,
                 )
                 if repaired_same_section_imports:
                     outcome["auto_repaired_missing_same_section_imports"] = (

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -11377,6 +11377,35 @@ def cmd_encode(args):
             )
             outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_same_section_imports = (
+                    _try_repair_generated_missing_same_section_subsection_imports_for_apply(
+                        result,
+                        output_root=args.output,
+                        policy_repo_path=policy_repo_path,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_same_section_imports:
+                    outcome["auto_repaired_missing_same_section_imports"] = (
+                        repaired_same_section_imports
+                    )
+                    print(
+                        "  apply=auto_repaired_missing_same_section_imports:"
+                        + ",".join(repaired_same_section_imports)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_table_relation_tests = (
                     _try_repair_generated_table_relation_tests_for_apply(
                         result,
@@ -14575,6 +14604,66 @@ def _try_repair_generated_import_output_inputs_for_apply(
         relative_output=relative_output,
         issues=issues,
     )
+
+
+_MISSING_SAME_SECTION_SUBSECTION_IMPORT_RE = re.compile(
+    r"Same-section subsection import missing: source text cites subsection "
+    r"`(?P<target>statutes/[^`]+)`"
+)
+
+
+def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+    issues: list[str],
+) -> list[str]:
+    """Add file-level imports for validator-proven same-section dependencies."""
+    if not issues:
+        return []
+
+    try:
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    if not rules_file.exists():
+        return []
+
+    content = rules_file.read_text()
+    repaired = content
+    jurisdiction = _repo_jurisdiction_prefix(policy_repo_path)
+    added: list[str] = []
+    for issue in issues:
+        match = _MISSING_SAME_SECTION_SUBSECTION_IMPORT_RE.search(str(issue))
+        if match is None:
+            continue
+        target = match.group("target").strip().strip("/")
+        if target.endswith((".yaml", ".yml")):
+            target = Path(target).with_suffix("").as_posix()
+        relative_target = Path(f"{target}.yaml")
+        if (
+            relative_target.is_absolute()
+            or any(part in {"", ".", ".."} for part in relative_target.parts)
+            or relative_target == relative_output
+        ):
+            continue
+        if not (policy_repo_path / relative_target).is_file():
+            continue
+        import_item = f"{jurisdiction}:{target}"
+        before = repaired
+        repaired = _ensure_rulespec_import(repaired, import_item)
+        if repaired != before:
+            added.append(import_item)
+
+    if not added:
+        return []
+    rules_file.write_text(repaired)
+    return added
 
 
 def _try_repair_generated_unreferenced_proof_imports_for_apply(

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3282,6 +3282,12 @@ Test file rules:
 - For every encoded `except`, `unless`, or `notwithstanding` carve-out, include
   companion tests for the positive path and the carve-out path so exclusions
   cannot be silently dropped.
+- When a source says a subsection, paragraph, payment, credit, benefit,
+  eligibility path, or other output "shall not apply" or "does not apply",
+  the exported rule that says that target applies, is allowed, is included, or
+  is eligible must negate the exception. Do not expose the exception only as a
+  standalone helper while leaving the affected `*_applies`, eligibility,
+  inclusion, exclusion, or amount output true under the exception.
 - For scoped exceptions, include a control case proving a non-excepted
   qualifying item is not reduced or blocked even when the exception amount or
   exception fact is positive/nonzero, plus a case where the same exception
@@ -3842,6 +3848,12 @@ RuleSpec requirements:
 - Represent every substantive source amount, rate, threshold, cap, or limit as a named `parameter` rule, then reference that parameter from derived formulas.
 - If the same numeric value appears twice in materially different legal roles, including separate numbered exceptions or subparagraphs, give those roles distinct named scalars; otherwise reuse that named scalar everywhere the rule compares against or computes with that number.
 - Adjacent bracket thresholds repeated as both an upper bound and the next bracket's lower bound are separate source-stated legal roles; define distinct semantic scalars for those occurrences and use them in the branch conditions.
+- When a source says a subsection, paragraph, payment, credit, benefit,
+  eligibility path, or other output "shall not apply" or "does not apply",
+  the exported rule that says that target applies, is allowed, is included, or
+  is eligible must negate the exception. Do not expose the exception only as a
+  standalone helper while leaving the affected `*_applies`, eligibility,
+  inclusion, exclusion, or amount output true under the exception.
 - For scoped exceptions, include a control case proving a non-excepted
   qualifying item is not reduced or blocked even when the exception amount or
   exception fact is positive/nonzero, plus a case where the same exception

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3288,6 +3288,9 @@ Test file rules:
   is eligible must negate the exception. Do not expose the exception only as a
   standalone helper while leaving the affected `*_applies`, eligibility,
   inclusion, exclusion, or amount output true under the exception.
+- When that exception is encoded as a local derived helper, include a blocking
+  companion test asserting both that helper as `holds` and the directly affected
+  Judgment output as `not_holds`.
 - For scoped exceptions, include a control case proving a non-excepted
   qualifying item is not reduced or blocked even when the exception amount or
   exception fact is positive/nonzero, plus a case where the same exception
@@ -3854,6 +3857,9 @@ RuleSpec requirements:
   is eligible must negate the exception. Do not expose the exception only as a
   standalone helper while leaving the affected `*_applies`, eligibility,
   inclusion, exclusion, or amount output true under the exception.
+- When that exception is encoded as a local derived helper, include a blocking
+  companion test asserting both that helper as `holds` and the directly affected
+  Judgment output as `not_holds`.
 - For scoped exceptions, include a control case proving a non-excepted
   qualifying item is not reduced or blocked even when the exception amount or
   exception fact is positive/nonzero, plus a case where the same exception

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -12502,6 +12502,145 @@ def find_aggregate_exception_predicate_issues(content: str) -> list[str]:
     return issues
 
 
+def find_unconsumed_local_exception_output_issues(content: str) -> list[str]:
+    """Require local exception outputs to block matching exported apply rules."""
+    try:
+        payload = yaml.safe_load(content)
+    except (yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    formulas_by_name: dict[str, list[str]] = {}
+    exception_names: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        name = str(rule.get("name") or "").strip()
+        if not name:
+            continue
+        formulas = _rule_formula_texts(rule)
+        if formulas:
+            formulas_by_name[name] = formulas
+        if "_exception_to_" in name and _rule_has_shall_not_apply_exception_atom(rule):
+            exception_names.append(name)
+
+    if not exception_names:
+        return []
+
+    issues: list[str] = []
+    for exception_name in exception_names:
+        target_fragments = _exception_output_target_fragments(exception_name)
+        if not target_fragments:
+            continue
+        for rule_name, formulas in sorted(formulas_by_name.items()):
+            if rule_name == exception_name or not rule_name.endswith("_applies"):
+                continue
+            if not _exception_fragments_match_rule_name(
+                target_fragments,
+                rule_name,
+            ):
+                continue
+            if any(
+                _formula_negates_identifier(formula, exception_name)
+                for formula in formulas
+            ):
+                continue
+            issues.append(
+                "Unconsumed local exception output: "
+                f"`{exception_name}` appears to carve out `{rule_name}`, but "
+                f"`{rule_name}` does not negate it. Compose the exception into "
+                "the affected exported rule instead of exposing both outputs "
+                "independently."
+            )
+    return issues
+
+
+def _rule_formula_texts(rule: dict[Any, Any]) -> list[str]:
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return []
+    formulas: list[str] = []
+    for version in versions:
+        if not isinstance(version, dict):
+            continue
+        formula = version.get("formula")
+        if isinstance(formula, str):
+            formulas.append(formula)
+    return formulas
+
+
+def _rule_has_shall_not_apply_exception_atom(rule: dict[Any, Any]) -> bool:
+    metadata = rule.get("metadata")
+    if not isinstance(metadata, dict):
+        return False
+    proof = metadata.get("proof")
+    if not isinstance(proof, dict):
+        return False
+    atoms = proof.get("atoms")
+    if not isinstance(atoms, list):
+        return False
+    for atom in atoms:
+        if not isinstance(atom, dict):
+            continue
+        if str(atom.get("kind") or "").strip().lower() != "exception":
+            continue
+        source = atom.get("source")
+        if not isinstance(source, dict):
+            continue
+        excerpt = str(source.get("excerpt") or "")
+        if re.search(
+            r"\b(?:shall|does)\s+not\s+(?:be\s+)?appl(?:y|icable)\b",
+            excerpt,
+            flags=re.IGNORECASE,
+        ):
+            return True
+    return False
+
+
+def _exception_output_target_fragments(exception_name: str) -> list[set[str]]:
+    _, _, suffix = exception_name.partition("_exception_to_")
+    if not suffix:
+        return []
+    fragments: list[set[str]] = []
+    for raw_fragment in suffix.split("_and_"):
+        fragment = re.sub(
+            r"^(?:subsection|section|paragraph|subparagraph|clause)_",
+            "",
+            raw_fragment,
+            flags=re.IGNORECASE,
+        )
+        tokens = _identifier_token_set(fragment)
+        if len(tokens) >= 2:
+            fragments.append(tokens)
+    return fragments
+
+
+def _exception_fragments_match_rule_name(
+    target_fragments: list[set[str]],
+    rule_name: str,
+) -> bool:
+    rule_tokens = _identifier_token_set(rule_name)
+    return any(fragment <= rule_tokens for fragment in target_fragments)
+
+
+def _identifier_token_set(identifier: str) -> set[str]:
+    return {token.lower() for token in re.findall(r"[A-Za-z0-9]+", identifier) if token}
+
+
+def _formula_negates_identifier(formula: str, identifier: str) -> bool:
+    return bool(
+        re.search(
+            rf"\bnot\s+{re.escape(identifier)}\b",
+            formula,
+        )
+    )
+
+
 def find_missing_child_exception_import_issues(
     content: str,
     *,
@@ -15771,6 +15910,7 @@ class ValidatorPipeline:
             )
         )
         issues.extend(find_aggregate_exception_predicate_issues(content))
+        issues.extend(find_unconsumed_local_exception_output_issues(content))
         issues.extend(self._check_cross_reference_exception_placeholders(rules_file))
         issues.extend(self._check_encoded_cross_reference_placeholders(rules_file))
         issues.extend(self._check_cross_reference_numeric_placeholders(rules_file))

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -12516,6 +12516,7 @@ def find_unconsumed_local_exception_output_issues(content: str) -> list[str]:
         return []
 
     formulas_by_name: dict[str, list[str]] = {}
+    imported_outputs_by_name: dict[str, set[str]] = {}
     exception_names: list[str] = []
     for rule in rules:
         if not isinstance(rule, dict):
@@ -12526,7 +12527,10 @@ def find_unconsumed_local_exception_output_issues(content: str) -> list[str]:
         formulas = _rule_formula_texts(rule)
         if formulas:
             formulas_by_name[name] = formulas
-        if "_exception_to_" in name and _rule_has_shall_not_apply_exception_atom(rule):
+        imported_outputs_by_name[name] = _rule_imported_outputs(rule)
+        if _is_exception_identifier(name) and _rule_has_shall_not_apply_exception_atom(
+            rule
+        ):
             exception_names.append(name)
 
     if not exception_names:
@@ -12535,15 +12539,22 @@ def find_unconsumed_local_exception_output_issues(content: str) -> list[str]:
     issues: list[str] = []
     for exception_name in exception_names:
         target_fragments = _exception_output_target_fragments(exception_name)
-        if not target_fragments:
-            continue
         for rule_name, formulas in sorted(formulas_by_name.items()):
-            if rule_name == exception_name or not rule_name.endswith("_applies"):
+            if rule_name == exception_name:
                 continue
-            if not _exception_fragments_match_rule_name(
-                target_fragments,
+            imports_exception = exception_name in imported_outputs_by_name.get(
                 rule_name,
-            ):
+                set(),
+            )
+            name_matches_exception_target = bool(
+                target_fragments
+                and rule_name.endswith("_applies")
+                and _exception_fragments_match_rule_name(
+                    target_fragments,
+                    rule_name,
+                )
+            )
+            if not imports_exception and not name_matches_exception_target:
                 continue
             if any(
                 _formula_negates_identifier(formula, exception_name)
@@ -12572,6 +12583,30 @@ def _rule_formula_texts(rule: dict[Any, Any]) -> list[str]:
         if isinstance(formula, str):
             formulas.append(formula)
     return formulas
+
+
+def _rule_imported_outputs(rule: dict[Any, Any]) -> set[str]:
+    metadata = rule.get("metadata")
+    if not isinstance(metadata, dict):
+        return set()
+    proof = metadata.get("proof")
+    if not isinstance(proof, dict):
+        return set()
+    atoms = proof.get("atoms")
+    if not isinstance(atoms, list):
+        return set()
+
+    outputs: set[str] = set()
+    for atom in atoms:
+        if not isinstance(atom, dict):
+            continue
+        imported = atom.get("import")
+        if not isinstance(imported, dict):
+            continue
+        output = str(imported.get("output") or "").strip()
+        if output:
+            outputs.add(output)
+    return outputs
 
 
 def _rule_has_shall_not_apply_exception_atom(rule: dict[Any, Any]) -> bool:
@@ -12635,7 +12670,7 @@ def _identifier_token_set(identifier: str) -> set[str]:
 def _formula_negates_identifier(formula: str, identifier: str) -> bool:
     return bool(
         re.search(
-            rf"\bnot\s+{re.escape(identifier)}\b",
+            rf"\bnot\s+(?:\(\s*)?{re.escape(identifier)}\b",
             formula,
         )
     )

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -657,6 +657,9 @@ Hard requirements:
   is eligible must negate the exception. Do not expose the exception only as a
   standalone helper while leaving the affected `*_applies`, eligibility,
   inclusion, exclusion, or amount output true under the exception.
+- When that exception is encoded as a local derived helper, include a blocking
+  companion test asserting both that helper as `holds` and the directly affected
+  Judgment output as `not_holds`.
 - For scoped exceptions, include a control case proving a non-excepted
   qualifying item is not reduced or blocked even when the exception amount or
   exception fact is positive/nonzero, plus a case where the same exception

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -651,6 +651,12 @@ Hard requirements:
 - For every encoded `except`, `unless`, or `notwithstanding` carve-out, include
   companion tests for the positive path and the carve-out path so exclusions
   cannot be silently dropped.
+- When a source says a subsection, paragraph, payment, credit, benefit,
+  eligibility path, or other output "shall not apply" or "does not apply",
+  the exported rule that says that target applies, is allowed, is included, or
+  is eligible must negate the exception. Do not expose the exception only as a
+  standalone helper while leaving the affected `*_applies`, eligibility,
+  inclusion, exclusion, or amount output true under the exception.
 - For scoped exceptions, include a control case proving a non-excepted
   qualifying item is not reduced or blocked even when the exception amount or
   exception fact is positive/nonzero, plus a case where the same exception

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,6 +67,7 @@ from axiom_encode.cli import (
     _split_table_row_relation_test_cases,
     _suppress_rulespec_ancestor_targets_for_subsection_overlay,
     _try_repair_generated_missing_deferred_outputs_for_apply,
+    _try_repair_generated_missing_same_section_subsection_imports_for_apply,
     _try_repair_generated_policyengine_oracle_inputs_for_apply,
     _try_repair_generated_section_1401_b_1_self_employment_income_for_apply,
     _try_repair_generated_source_table_band_scalars_for_apply,
@@ -7227,6 +7228,50 @@ rules: []
             }
         ]
         assert payload["rules"] == []
+
+    def test_missing_same_section_import_repair_adds_existing_file_import(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "openai-gpt-5.5" / "statutes/26/3406/d.yaml"
+        rules_file.parent.mkdir(parents=True)
+        policy_repo = tmp_path / "rulespec-us"
+        cited_file = policy_repo / "statutes" / "26" / "3406" / "a.yaml"
+        cited_file.parent.mkdir(parents=True)
+        cited_file.write_text("format: rulespec/v1\nrules: []\n")
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: Section 3406(d) certification failures.
+rules: []
+"""
+        )
+        result = SimpleNamespace(
+            runner="openai-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = (
+            _try_repair_generated_missing_same_section_subsection_imports_for_apply(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                issues=[
+                    "statutes/26/3406/d.yaml: ci: Same-section subsection import "
+                    "missing: source text cites subsection `statutes/26/3406/a` "
+                    "in an exception/cross-reference clause, but the file does "
+                    "not import it."
+                ],
+            )
+        )
+
+        assert repaired == ["us:statutes/26/3406/a"]
+        assert rules_file.read_text().startswith(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/3406/a
+"""
+        )
 
     def test_unsafe_formula_output_repair_defers_rules_and_tests(self, tmp_path):
         output_root = tmp_path / "out"

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3941,6 +3941,7 @@ class TestEvalPrompt:
             "For every encoded `except`, `unless`, or `notwithstanding` carve-out"
             in prompt
         )
+        assert 'shall not apply" or "does not apply"' in prompt
         assert "sets that exception input true" in prompt
         assert "Do not collapse a list of cited exceptions" in prompt
         assert "Do not create derived `dtype: Boolean` helper rules" in prompt

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3942,6 +3942,7 @@ class TestEvalPrompt:
             in prompt
         )
         assert 'shall not apply" or "does not apply"' in prompt
+        assert "that helper as `holds`" in prompt
         assert "sets that exception input true" in prompt
         assert "Do not collapse a list of cited exceptions" in prompt
         assert "Do not create derived `dtype: Boolean` helper rules" in prompt

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5332,6 +5332,98 @@ rules:
     assert find_unconsumed_local_exception_output_issues(content) == []
 
 
+def test_unconsumed_local_exception_output_flags_imported_exception_helper():
+    content = """format: rulespec/v1
+rules:
+  - name: existing_account_or_instrument_exception_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: This subsection and subsection (a)(1)(D) shall not apply.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: payment_paid_or_credited
+  - name: subsection_a_1_D_applies_to_readily_tradable_instrument_payment
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/d#existing_account_or_instrument_exception_applies
+              output: existing_account_or_instrument_exception_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          reportable_interest_or_dividend_payment
+          and payment_to_payee_on_readily_tradable_instrument
+"""
+
+    issues = find_unconsumed_local_exception_output_issues(content)
+
+    assert len(issues) == 1
+    assert "existing_account_or_instrument_exception_applies" in issues[0]
+    assert (
+        "subsection_a_1_D_applies_to_readily_tradable_instrument_payment" in issues[0]
+    )
+
+
+def test_unconsumed_local_exception_output_allows_imported_negated_helper():
+    content = """format: rulespec/v1
+rules:
+  - name: existing_brokerage_account_exception_to_broker_notice_applies
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: Subparagraph (B) of paragraph (2) shall not apply.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: broker_account_established_before_pre_cutoff_date
+  - name: broker_must_notify_payor_of_backup_withholding_status
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/d#existing_brokerage_account_exception_to_broker_notice_applies
+              output: existing_brokerage_account_exception_to_broker_notice_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          payee_acquires_readily_tradable_instrument_through_broker
+          and not existing_brokerage_account_exception_to_broker_notice_applies
+"""
+
+    assert find_unconsumed_local_exception_output_issues(content) == []
+
+
 def test_parent_exception_list_requires_child_exception_imports(tmp_path):
     repo = tmp_path / "rulespec-us"
     rules_file = repo / "statutes" / "26" / "163" / "h" / "4" / "B.yaml"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -77,6 +77,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_tax_status_component_local_input_issues,
     find_temporal_value_fact_name_issues,
     find_test_input_assignment_issues,
+    find_unconsumed_local_exception_output_issues,
     find_ungrounded_numeric_issues,
     find_unused_import_issues,
     find_unused_modifier_parameter_issues,
@@ -5255,6 +5256,80 @@ rules:
     assert (
         "section_2015_b_d_2_g_r_and_2012_m_4_do_not_preclude_eligibility" in issues[0]
     )
+
+
+def test_unconsumed_local_exception_output_flags_matching_applies_rule():
+    content = """format: rulespec/v1
+rules:
+  - name: readily_tradable_instrument_subsection_a_1_D_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          reportable_interest_or_dividend_payment
+          and payment_on_readily_tradable_instrument
+  - name: existing_account_exception_to_subsection_d_and_a_1_D
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: This subsection and subsection (a)(1)(D) shall not apply.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: account_established_before_transition_date
+"""
+
+    issues = find_unconsumed_local_exception_output_issues(content)
+
+    assert len(issues) == 1
+    assert "Unconsumed local exception output" in issues[0]
+    assert "existing_account_exception_to_subsection_d_and_a_1_D" in issues[0]
+    assert "readily_tradable_instrument_subsection_a_1_D_applies" in issues[0]
+
+
+def test_unconsumed_local_exception_output_allows_negated_exception():
+    content = """format: rulespec/v1
+rules:
+  - name: readily_tradable_instrument_subsection_a_1_D_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          reportable_interest_or_dividend_payment
+          and payment_on_readily_tradable_instrument
+          and not existing_account_exception_to_subsection_d_and_a_1_D
+  - name: existing_account_exception_to_subsection_d_and_a_1_D
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: This subsection and subsection (a)(1)(D) shall not apply.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: account_established_before_transition_date
+"""
+
+    assert find_unconsumed_local_exception_output_issues(content) == []
 
 
 def test_parent_exception_list_requires_child_exception_imports(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.391"
+version = "0.2.392"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- auto-repair generated RuleSpec files that cite same-section subsections but omit the file-level import
- reject generated outputs that import local "shall not apply" exception helpers without negating them, including both `*_exception_to_*` and `*_exception_applies` naming styles
- strengthen generation guidance for local derived exception-helper blocking tests and bump to 0.2.392

## Verification
- `uv run ruff check src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/harness/evals.py src/axiom_encode/prompts/encoder.py tests/test_evals.py tests/test_rulespec_validation.py`
- `uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/harness/evals.py src/axiom_encode/prompts/encoder.py tests/test_evals.py tests/test_rulespec_validation.py pyproject.toml src/axiom_encode/__init__.py`
- `uv run pytest tests/test_rulespec_validation.py -k 'unconsumed_local_exception_output or aggregate_exception_predicate' -q`
- `uv run pytest tests/test_evals.py -k broad_application_clause -q`
- `uv run pytest tests/test_cli.py -k missing_same_section_import_repair -q`
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/payroll-night-20260528/current/rulespec-us/statutes/26/3406/d.yaml --skip-reviewers`
- in-memory deletion check confirms the validator now catches both missing `and not existing_account_or_instrument_exception_applies` and missing `and not existing_brokerage_account_exception_to_broker_notice_applies`