### PR TITLE
Preserve anaphoric predicate scope

### DIFF
--- a/changelog.d/preserve-anaphoric-scope.fixed.md
+++ b/changelog.d/preserve-anaphoric-scope.fixed.md
@@ -1,0 +1,1 @@
+Preserve same-object anaphoric scope such as "through such account" in generated predicates and companion tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.392"
+version = "0.2.393"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.392"
+__version__ = "0.2.393"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3295,6 +3295,11 @@ Test file rules:
   qualifying item is not reduced or blocked even when the exception amount or
   exception fact is positive/nonzero, plus a case where the same exception
   applies to the source-stated excepted category.
+- Preserve anaphoric scope in source predicates. If the source says "such
+  account", "such instrument", "through such account", "with respect to such
+  payment", or similar same-object language, the predicate name and companion
+  tests must keep that same-object relationship. Do not shorten it to broad
+  activity for the person, broker, household, or entity generally.
 - When a local formula has five or fewer independent source-stated boolean
   gates joined by `and`, include one all-gates-positive case and enough negative
   cases to toggle each gate at least once. Do not leave a source-stated gate
@@ -3864,6 +3869,11 @@ RuleSpec requirements:
   qualifying item is not reduced or blocked even when the exception amount or
   exception fact is positive/nonzero, plus a case where the same exception
   applies to the source-stated excepted category.
+- Preserve anaphoric scope in source predicates. If the source says "such
+  account", "such instrument", "through such account", "with respect to such
+  payment", or similar same-object language, the predicate name and companion
+  tests must keep that same-object relationship. Do not shorten it to broad
+  activity for the person, broker, household, or entity generally.
 - When a local formula has five or fewer independent source-stated boolean
   gates joined by `and`, include one all-gates-positive case and enough negative
   cases to toggle each gate at least once. Do not leave a source-stated gate

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -664,6 +664,11 @@ Hard requirements:
   qualifying item is not reduced or blocked even when the exception amount or
   exception fact is positive/nonzero, plus a case where the same exception
   applies to the source-stated excepted category.
+- Preserve anaphoric scope in source predicates. If the source says "such
+  account", "such instrument", "through such account", "with respect to such
+  payment", or similar same-object language, the predicate name and companion
+  tests must keep that same-object relationship. Do not shorten it to broad
+  activity for the person, broker, household, or entity generally.
 - When a local formula has five or fewer independent source-stated boolean
   gates joined by `and`, include one all-gates-positive case and enough negative
   cases to toggle each gate at least once. Do not leave a source-stated gate

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3943,6 +3943,7 @@ class TestEvalPrompt:
         )
         assert 'shall not apply" or "does not apply"' in prompt
         assert "that helper as `holds`" in prompt
+        assert '"through such account"' in prompt
         assert "sets that exception input true" in prompt
         assert "Do not collapse a list of cited exceptions" in prompt
         assert "Do not create derived `dtype: Boolean` helper rules" in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.392"
+version = "0.2.393"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add general encoder guidance to preserve same-object anaphoric scope such as "through such account" in predicates and tests
- mirror the guidance in eval prompts
- add a prompt-surface regression and bump to 0.2.393

## Motivation
A generated 26 USC 3406(d)(4) exception dropped the source's "through such account" limitation from the 1983 broker-activity predicate, making the exception over-broad. This keeps the rule general rather than policy-specific.

## Verification
- `uv run pytest tests/test_evals.py -k broad_application_clause -q`
- `uv run ruff check src/axiom_encode/harness/evals.py src/axiom_encode/prompts/encoder.py tests/test_evals.py`
- `uv run ruff format --check src/axiom_encode/harness/evals.py src/axiom_encode/prompts/encoder.py tests/test_evals.py pyproject.toml src/axiom_encode/__init__.py`
- `uv run python -c "import axiom_encode; print(axiom_encode.__version__)"`