### PR TITLE
Repair Colorado SNAP separate household scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.397"
+version = "0.2.399"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.397"
+__version__ = "0.2.399"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3134,6 +3134,7 @@ def cmd_repair_colorado_snap_federal_refs(args):
             repo_path / COLORADO_SNAP_PROGRAM_RELATIVE
         )
         _repair_colorado_snap_2072(repo_path / COLORADO_SNAP_CCR_ROOT / "4.207.2.yaml")
+        _repair_colorado_snap_401(repo_path / COLORADO_SNAP_CCR_ROOT / "4.401.yaml")
         _repair_colorado_snap_4073(repo_path / COLORADO_SNAP_CCR_ROOT / "4.407.3.yaml")
         _repair_colorado_snap_program_tests(
             _rulespec_test_path(repo_path / COLORADO_SNAP_PROGRAM_RELATIVE)
@@ -3349,6 +3350,56 @@ def _repair_colorado_snap_2072(path: Path) -> None:
             ),
             source="10 CCR 2506-1 sections 4.207.2 and 4.207.3(B)",
         ),
+    )
+    path.write_text(content)
+
+
+def _repair_colorado_snap_401(path: Path) -> None:
+    content = path.read_text()
+    content = _upsert_rule_text(
+        content,
+        {
+            "name": "co_resident_gross_income_limit_165_percent_fpl_48_states_dc",
+            "kind": "derived",
+            "entity": "Household",
+            "dtype": "Money",
+            "period": "Month",
+            "unit": "USD",
+            "source": "10 CCR 2506-1 section 4.401(A)(4)",
+            "versions": [
+                {
+                    "effective_from": "2025-10-01",
+                    "formula": (
+                        "snap_gross_income_limit_165_percent_fpl_48_states_dc_table"
+                        "[max(min(co_resident_group_size, 8), 1)]\n"
+                        "+ (max(co_resident_group_size - 8, 0) * "
+                        "snap_gross_income_limit_165_percent_fpl_48_states_dc_additional_member)"
+                    ),
+                }
+            ],
+        },
+        before_rule="snap_elderly_disabled_separate_household_allowed",
+    )
+    content = _upsert_rule_text(
+        content,
+        {
+            "name": "snap_elderly_disabled_separate_household_allowed",
+            "kind": "derived",
+            "entity": "Household",
+            "dtype": "Judgment",
+            "period": "Month",
+            "source": "10 CCR 2506-1 section 4.401(A)(4)",
+            "versions": [
+                {
+                    "effective_from": "2025-10-01",
+                    "formula": (
+                        "elderly_disabled_person_unable_to_purchase_and_prepare_meals\n"
+                        "and co_resident_gross_income <= "
+                        "co_resident_gross_income_limit_165_percent_fpl_48_states_dc"
+                    ),
+                }
+            ],
+        },
     )
     path.write_text(content)
 
@@ -3964,7 +4015,91 @@ def _repair_colorado_snap_401_tests(path: Path) -> None:
                 0,
                 gross - _numeric_test_value(shelter),
             )
+        outputs = case.get("output")
+        if (
+            isinstance(outputs, dict)
+            and (
+                "us-co:regulations/10-ccr-2506-1/4.401"
+                "#snap_elderly_disabled_separate_household_allowed"
+            )
+            in outputs
+        ):
+            group_size_key = (
+                "us-co:regulations/10-ccr-2506-1/4.401#input.co_resident_group_size"
+            )
+            inputs.setdefault(
+                group_size_key,
+                inputs.get(
+                    "us:policies/usda/snap/fy-2026-cola/income-eligibility-standards"
+                    "#input.household_size",
+                    1,
+                ),
+            )
+            outputs.setdefault(
+                "us-co:regulations/10-ccr-2506-1/4.401"
+                "#co_resident_gross_income_limit_165_percent_fpl_48_states_dc",
+                _snap_fy2026_165_percent_fpl_limit(inputs[group_size_key]),
+            )
+    _upsert_test_case(
+        cases,
+        {
+            "name": "separate_household_allowed_uses_co_resident_group_size",
+            "period": "2026-01",
+            "input": {
+                "us:policies/usda/snap/fy-2026-cola/income-eligibility-standards"
+                "#input.household_size": 1,
+                "us-co:regulations/10-ccr-2506-1/4.401#input.co_resident_group_size": 3,
+                "us-co:regulations/10-ccr-2506-1/4.401"
+                "#input.elderly_disabled_person_unable_to_purchase_and_prepare_meals": True,
+                "us-co:regulations/10-ccr-2506-1/4.401"
+                "#input.co_resident_gross_income": 3000,
+            },
+            "output": {
+                "us-co:regulations/10-ccr-2506-1/4.401"
+                "#co_resident_gross_income_limit_165_percent_fpl_48_states_dc": 3665,
+                "us-co:regulations/10-ccr-2506-1/4.401"
+                "#snap_elderly_disabled_separate_household_allowed": "holds",
+            },
+        },
+    )
+    _upsert_test_case(
+        cases,
+        {
+            "name": "separate_household_denied_when_co_resident_group_income_exceeds_limit",
+            "period": "2026-01",
+            "input": {
+                "us:policies/usda/snap/fy-2026-cola/income-eligibility-standards"
+                "#input.household_size": 1,
+                "us-co:regulations/10-ccr-2506-1/4.401#input.co_resident_group_size": 3,
+                "us-co:regulations/10-ccr-2506-1/4.401"
+                "#input.elderly_disabled_person_unable_to_purchase_and_prepare_meals": True,
+                "us-co:regulations/10-ccr-2506-1/4.401"
+                "#input.co_resident_gross_income": 3666,
+            },
+            "output": {
+                "us-co:regulations/10-ccr-2506-1/4.401"
+                "#co_resident_gross_income_limit_165_percent_fpl_48_states_dc": 3665,
+                "us-co:regulations/10-ccr-2506-1/4.401"
+                "#snap_elderly_disabled_separate_household_allowed": "not_holds",
+            },
+        },
+    )
     _write_yaml_payload(path, cases)
+
+
+def _snap_fy2026_165_percent_fpl_limit(group_size: object) -> int:
+    size = int(_numeric_test_value(group_size))
+    table = {
+        1: 2152,
+        2: 2909,
+        3: 3665,
+        4: 4421,
+        5: 5177,
+        6: 5934,
+        7: 6690,
+        8: 7446,
+    }
+    return table[max(min(size, 8), 1)] + (max(size - 8, 0) * 757)
 
 
 def _repair_colorado_snap_4073_tests(path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,6 +43,8 @@ from axiom_encode.cli import (
     _remove_cross_module_dependent_test_outputs,
     _remove_invalid_dependent_test_inputs,
     _repair_anaphoric_scope_identifiers,
+    _repair_colorado_snap_401,
+    _repair_colorado_snap_401_tests,
     _repair_colorado_snap_2072,
     _repair_colorado_snap_2072_tests,
     _repair_colorado_snap_program_tests,
@@ -4985,6 +4987,130 @@ rules:
         assert rule["versions"][0]["formula"] == "false"
         assert rule["entity"] == "Household"
         assert rule["period"] == "Month"
+
+    def test_repair_colorado_snap_401_uses_household_scope_for_separate_household(
+        self, tmp_path
+    ):
+        rules_file = tmp_path / "4.401.yaml"
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards
+rules:
+  - name: snap_elderly_disabled_separate_household_allowed
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 10 CCR 2506-1 section 4.401(A)(4)
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          elderly_disabled_person_unable_to_purchase_and_prepare_meals
+          and co_resident_gross_income <= snap_gross_income_limit_165_percent_fpl_48_states_dc
+"""
+        )
+
+        _repair_colorado_snap_401(rules_file)
+
+        payload = yaml.safe_load(rules_file.read_text())
+        limit_rule = next(
+            item
+            for item in payload["rules"]
+            if item["name"]
+            == "co_resident_gross_income_limit_165_percent_fpl_48_states_dc"
+        )
+        assert limit_rule["entity"] == "Household"
+        assert limit_rule["kind"] == "derived"
+        assert limit_rule["dtype"] == "Money"
+        assert limit_rule["period"] == "Month"
+        assert limit_rule["unit"] == "USD"
+        assert (
+            limit_rule["versions"][0]["formula"]
+            == "snap_gross_income_limit_165_percent_fpl_48_states_dc_table"
+            "[max(min(co_resident_group_size, 8), 1)]\n"
+            "+ (max(co_resident_group_size - 8, 0) * "
+            "snap_gross_income_limit_165_percent_fpl_48_states_dc_additional_member)"
+        )
+        eligibility_rule = next(
+            item
+            for item in payload["rules"]
+            if item["name"] == "snap_elderly_disabled_separate_household_allowed"
+        )
+        assert eligibility_rule["entity"] == "Household"
+        assert eligibility_rule["kind"] == "derived"
+        assert eligibility_rule["dtype"] == "Judgment"
+        assert eligibility_rule["period"] == "Month"
+        assert (
+            eligibility_rule["versions"][0]["formula"]
+            == "elderly_disabled_person_unable_to_purchase_and_prepare_meals\n"
+            "and co_resident_gross_income <= "
+            "co_resident_gross_income_limit_165_percent_fpl_48_states_dc"
+        )
+
+    def test_repair_colorado_snap_401_tests_uses_co_resident_group_size(self, tmp_path):
+        test_file = tmp_path / "4.401.test.yaml"
+        test_file.write_text(
+            """- name: separate_household_allowed_when_co_resident_income_is_within_limit
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us-co:regulations/10-ccr-2506-1/4.401#input.elderly_disabled_person_unable_to_purchase_and_prepare_meals: true
+    us-co:regulations/10-ccr-2506-1/4.401#input.co_resident_gross_income: 2152
+  output:
+    us-co:regulations/10-ccr-2506-1/4.401#snap_elderly_disabled_separate_household_allowed: holds
+"""
+        )
+
+        _repair_colorado_snap_401_tests(test_file)
+
+        cases = yaml.safe_load(test_file.read_text())
+        original = cases[0]
+        assert (
+            original["input"][
+                "us-co:regulations/10-ccr-2506-1/4.401#input.co_resident_group_size"
+            ]
+            == 1
+        )
+        assert (
+            original["output"][
+                "us-co:regulations/10-ccr-2506-1/4.401"
+                "#co_resident_gross_income_limit_165_percent_fpl_48_states_dc"
+            ]
+            == 2152
+        )
+        allowed = next(
+            item
+            for item in cases
+            if item["name"] == "separate_household_allowed_uses_co_resident_group_size"
+        )
+        assert (
+            allowed["input"][
+                "us:policies/usda/snap/fy-2026-cola/income-eligibility-standards"
+                "#input.household_size"
+            ]
+            == 1
+        )
+        assert (
+            allowed["input"][
+                "us-co:regulations/10-ccr-2506-1/4.401#input.co_resident_group_size"
+            ]
+            == 3
+        )
+        assert (
+            allowed["output"][
+                "us-co:regulations/10-ccr-2506-1/4.401"
+                "#co_resident_gross_income_limit_165_percent_fpl_48_states_dc"
+            ]
+            == 3665
+        )
+        assert (
+            allowed["output"][
+                "us-co:regulations/10-ccr-2506-1/4.401"
+                "#snap_elderly_disabled_separate_household_allowed"
+            ]
+            == "holds"
+        )
 
     def test_repair_employer_scoped_entities_sets_rate_helpers(self, tmp_path):
         rules_file = tmp_path / "3221.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.397"
+version = "0.2.399"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- update the Colorado SNAP deterministic repair to regenerate 4.401 separate-household eligibility at Household scope
- compute the 165% FPL threshold from a dedicated co-resident group size instead of the SNAP household size
- add CLI regression tests for the 4.401 source-scope and co-resident-size repairs
- bump axiom-encode to 0.2.399 for signed generated-artifact provenance

## Tests
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py -k "package_version_metadata_matches_pyproject or colorado_snap_401 or colorado_snap_2072_uses_parameter or colorado_snap_program_tests" -q