### PR TITLE
Repair generated SNAP income-standard tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.402"
+version = "0.2.403"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.402"
+__version__ = "0.2.403"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5308,6 +5308,11 @@ def cmd_repair_imported_test_inputs(args):
             test_file=test_file,
             issues=issues,
         )
+        repaired_2014c_refs = _repair_snap_2014c_income_standard_test_inputs(
+            test_file=test_file,
+            relative_output=relative_output,
+            issues=issues,
+        )
         removed_invalid_refs = _remove_invalid_test_input_refs(
             test_file=test_file,
             issues=issues,
@@ -5329,6 +5334,7 @@ def cmd_repair_imported_test_inputs(args):
             and not removed_invalid_refs
             and not removed_refs
             and not repaired_exclusion_refs
+            and not repaired_2014c_refs
             and not completed_missing_inputs
             and not repaired_output_cases
         ):
@@ -11463,6 +11469,98 @@ def _remove_invalid_import_output_test_input_refs(
         yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
     )
     return sorted(invalid_refs)
+
+
+_SNAP_2014C_RELATIVE_OUTPUT = "statutes/7/2014/c.yaml"
+_SNAP_2014C_BAD_TEST_INPUT_REFS = {
+    "us:regulations/7-cfr/273/10#input.snap_total_gross_income",
+    "us:regulations/7-cfr/273/10#input.snap_excess_shelter_deduction",
+}
+_SNAP_2014C_TEST_CASE_INCOME_INPUTS = {
+    "net_income_above_poverty_line_makes_household_ineligible": (1200, 1400),
+    "non_elderly_disabled_household_fails_gross_income_standard": (1400, 1200),
+    "elderly_or_disabled_member_removes_gross_income_standard_failure": (
+        1400,
+        1200,
+    ),
+    "virgin_islands_or_guam_standard_is_capped_to_contiguous_states_standard": (
+        1200,
+        1400,
+    ),
+}
+
+
+def _repair_snap_2014c_income_standard_test_inputs(
+    *,
+    test_file: Path,
+    relative_output: Path,
+    issues: list[str],
+) -> list[str]:
+    """Repair generated 7 USC 2014(c) SNAP income-standard test inputs.
+
+    The first generation for this source emitted duplicate
+    `7 CFR 273.10#input.snap_total_gross_income` keys. One value belongs to
+    the local gross-income standard in 7 USC 2014(c), while the other belongs
+    to imported 7 USC 2014(e)(6)(A) net-income computation. The invalid
+    regulation input reference collapses under YAML parsing, so this repair
+    deterministically restores the four intended scenarios before generic
+    invalid-input cleanup can discard the scenario-setting values.
+    """
+    if relative_output.as_posix() != _SNAP_2014C_RELATIVE_OUTPUT:
+        return []
+    if not test_file.exists():
+        return []
+    invalid_refs = _invalid_input_refs_from_issues(issues)
+    if invalid_refs.isdisjoint(_SNAP_2014C_BAD_TEST_INPUT_REFS):
+        return []
+
+    try:
+        test_payload = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    if not isinstance(test_payload, list):
+        return []
+
+    repaired_cases: list[str] = []
+    for test_case in test_payload:
+        if not isinstance(test_case, dict):
+            continue
+        case_name = str(test_case.get("name") or "")
+        income_inputs = _SNAP_2014C_TEST_CASE_INCOME_INPUTS.get(case_name)
+        if income_inputs is None:
+            continue
+        inputs = test_case.get("input")
+        if not isinstance(inputs, dict):
+            continue
+
+        changed = False
+        for bad_ref in _SNAP_2014C_BAD_TEST_INPUT_REFS:
+            if bad_ref in inputs:
+                del inputs[bad_ref]
+                changed = True
+
+        gross_income, monthly_income = income_inputs
+        replacements = {
+            "us:statutes/7/2014/c#input.snap_total_gross_income": gross_income,
+            "us:statutes/7/2014/e/6/A#input.snap_monthly_household_income": (
+                monthly_income
+            ),
+            "us:statutes/7/2014/e/6/A#input.snap_excess_shelter_deduction": 0,
+        }
+        for input_ref, value in replacements.items():
+            if inputs.get(input_ref) != value:
+                inputs[input_ref] = value
+                changed = True
+
+        if changed:
+            repaired_cases.append(case_name)
+
+    if not repaired_cases:
+        return []
+    test_file.write_text(
+        yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
+    )
+    return repaired_cases
 
 
 def _repair_stale_exclusion_dependency_test_input_refs(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,7 @@ from axiom_encode.cli import (
     _repair_section_151_imports,
     _repair_section_151_temporal_fact_names,
     _repair_shared_statutory_rate_names,
+    _repair_snap_2014c_income_standard_test_inputs,
     _repair_tax_filing_status_branches,
     _repair_upstream_placement_duplicate_imports,
     _require_axiom_encode_version_provenance,
@@ -9664,6 +9665,83 @@ rules: []
         manifest = policy_repo / ".axiom/encoding-manifests/statutes/26/63.json"
         payload = json.loads(manifest.read_text())
         assert payload["model"] == "imported-test-inputs-v1"
+
+    def test_repair_snap_2014c_income_standard_test_inputs(self, tmp_path):
+        test_file = tmp_path / "c.test.yaml"
+        test_file.write_text(
+            """- name: net_income_above_poverty_line_makes_household_ineligible
+  period: 2026-01
+  input:
+    us:statutes/7/2014/c#input.household_is_in_virgin_islands_or_guam: false
+    us:statutes/7/2014/c#input.poverty_line_under_42_usc_9902_2_for_household_area: 1000
+    us:statutes/7/2014/c#input.poverty_line_under_42_usc_9902_2_for_forty_eight_contiguous_states_and_dc: 1000
+    us:statutes/7/2014/c#input.household_includes_elderly_or_disabled_member: false
+    us:regulations/7-cfr/273/10#input.snap_total_gross_income: 1200
+    us:regulations/7-cfr/273/10#input.snap_total_gross_income: 1400
+    us:regulations/7-cfr/273/10#input.snap_excess_shelter_deduction: 0
+  output:
+    us:statutes/7/2014/c#snap_net_income_exceeds_poverty_line: holds
+- name: non_elderly_disabled_household_fails_gross_income_standard
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/10#input.snap_total_gross_income: 1400
+    us:regulations/7-cfr/273/10#input.snap_total_gross_income: 1200
+    us:regulations/7-cfr/273/10#input.snap_excess_shelter_deduction: 0
+  output:
+    us:statutes/7/2014/c#household_fails_gross_income_standard: holds
+"""
+        )
+
+        repaired = _repair_snap_2014c_income_standard_test_inputs(
+            test_file=test_file,
+            relative_output=Path("statutes/7/2014/c.yaml"),
+            issues=[
+                "Test case `net_income_above_poverty_line_makes_household_ineligible` "
+                "input invalid: input "
+                "`us:regulations/7-cfr/273/10#input.snap_total_gross_income` "
+                "does not resolve to an input slot"
+            ],
+        )
+
+        assert repaired == [
+            "net_income_above_poverty_line_makes_household_ineligible",
+            "non_elderly_disabled_household_fails_gross_income_standard",
+        ]
+        cases = {case["name"]: case for case in yaml.safe_load(test_file.read_text())}
+        net_case_inputs = cases[
+            "net_income_above_poverty_line_makes_household_ineligible"
+        ]["input"]
+        assert (
+            "us:regulations/7-cfr/273/10#input.snap_total_gross_income"
+            not in net_case_inputs
+        )
+        assert (
+            "us:regulations/7-cfr/273/10#input.snap_excess_shelter_deduction"
+            not in net_case_inputs
+        )
+        assert (
+            net_case_inputs["us:statutes/7/2014/c#input.snap_total_gross_income"]
+            == 1200
+        )
+        assert (
+            net_case_inputs[
+                "us:statutes/7/2014/e/6/A#input.snap_monthly_household_income"
+            ]
+            == 1400
+        )
+        gross_case_inputs = cases[
+            "non_elderly_disabled_household_fails_gross_income_standard"
+        ]["input"]
+        assert (
+            gross_case_inputs["us:statutes/7/2014/c#input.snap_total_gross_income"]
+            == 1400
+        )
+        assert (
+            gross_case_inputs[
+                "us:statutes/7/2014/e/6/A#input.snap_monthly_household_income"
+            ]
+            == 1200
+        )
 
     def test_apply_overlay_validation_rejects_dropped_source_relation(self, tmp_path):
         output_root = tmp_path / "out"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.402"
+version = "0.2.403"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a deterministic repair for generated 7 USC 2014(c) SNAP income-standard companion tests
- preserve the intended gross-income and net-income scenarios when generated tests use duplicate invalid 7 CFR 273.10 input refs
- cover the repair with a focused unit test

## Test plan
- uv run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run --extra dev ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- uv run --extra dev python -m pytest tests/test_cli.py -k "repair_snap_2014c_income_standard_test_inputs or repair_imported_test_inputs" -q