### PR TITLE
Classify SNAP income-standard oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.403"
+version = "0.2.404"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.403"
+__version__ = "0.2.404"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1,4 +1,42 @@
 mappings:
+  - legal_id: us:statutes/7/2014/c#snap_gross_income_excess_rate_over_poverty_line
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: PolicyEngine represents the federal SNAP gross-income limit as a 130 percent FPG threshold or eligibility test, not as the standalone statutory 30 percent excess-over-poverty rate.
+
+  - legal_id: us:statutes/7/2014/c#snap_income_standard_poverty_line_with_territory_cap
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_fpg
+    candidate_priority: P4
+    rationale: PolicyEngine exposes SNAP FPG and threshold surfaces, but not this 7 USC 2014(c) intermediate that caps Virgin Islands and Guam standards to the forty-eight-state standard.
+
+  - legal_id: us:statutes/7/2014/c#snap_net_income_exceeds_poverty_line
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: meets_snap_net_income_test
+    candidate_priority: P4
+    rationale: PolicyEngine exposes the positive SNAP net-income eligibility test, while this output is the statutory failure predicate after subsection (e) deductions.
+
+  - legal_id: us:statutes/7/2014/c#household_fails_gross_income_standard
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: meets_snap_gross_income_test
+    candidate_priority: P4
+    rationale: PolicyEngine exposes the positive SNAP gross-income eligibility test, while this output is the statutory failure predicate and excludes households with elderly or disabled members.
+
+  - legal_id: us:statutes/7/2014/c#household_ineligible_to_participate_due_to_income_standards
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: is_snap_eligible
+    candidate_priority: P4
+    rationale: PolicyEngine exposes final SNAP eligibility including categorical, resource, and other conditions; this output is limited to the 7 USC 2014(c) income-standard ineligibility predicate.
+
   - legal_id: us:statutes/7/2014/e/2#snap_earned_income_deduction
     country: us
     program: snap

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2041,6 +2041,44 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
     assert gross_income_limit_mapping.policyengine_variable == "snap_fpg"
     assert gross_income_limit_mapping.result_multiplier == 1.3
+    section_2014c_net_failure_mapping = registry.mapping_for_legal_id(
+        "us:statutes/7/2014/c#snap_net_income_exceeds_poverty_line",
+        country="us",
+    )
+    assert section_2014c_net_failure_mapping.mapping_type == "not_comparable"
+    assert (
+        section_2014c_net_failure_mapping.policyengine_variable
+        == "meets_snap_net_income_test"
+    )
+    section_2014c_gross_failure_mapping = registry.mapping_for_legal_id(
+        "us:statutes/7/2014/c#household_fails_gross_income_standard",
+        country="us",
+    )
+    assert section_2014c_gross_failure_mapping.mapping_type == "not_comparable"
+    assert (
+        section_2014c_gross_failure_mapping.policyengine_variable
+        == "meets_snap_gross_income_test"
+    )
+    section_2014c_income_ineligible_mapping = registry.mapping_for_legal_id(
+        "us:statutes/7/2014/c#household_ineligible_to_participate_due_to_income_standards",
+        country="us",
+    )
+    assert section_2014c_income_ineligible_mapping.mapping_type == "not_comparable"
+    assert (
+        section_2014c_income_ineligible_mapping.policyengine_variable
+        == "is_snap_eligible"
+    )
+    section_2014c_rate_mapping = registry.mapping_for_legal_id(
+        "us:statutes/7/2014/c#snap_gross_income_excess_rate_over_poverty_line",
+        country="us",
+    )
+    assert section_2014c_rate_mapping.mapping_type == "not_comparable"
+    section_2014c_poverty_line_mapping = registry.mapping_for_legal_id(
+        "us:statutes/7/2014/c#snap_income_standard_poverty_line_with_territory_cap",
+        country="us",
+    )
+    assert section_2014c_poverty_line_mapping.mapping_type == "not_comparable"
+    assert section_2014c_poverty_line_mapping.policyengine_variable == "snap_fpg"
     shelter_cap_mapping = registry.mapping_for_legal_id(
         "us:policies/usda/snap/fy-2026-cola/deductions#snap_maximum_excess_shelter_deduction_alaska",
         country="us",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.403"
+version = "0.2.404"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 7 USC 2014(c) SNAP income-standard outputs in the PolicyEngine oracle registry
- mark statutory failure/intermediate predicates as known not comparable against adjacent PE variables
- bump axiom-encode to 0.2.404

## Tests
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py -k policyengine_registry_is_legal_id_keyed -q
- uv run --extra dev python -m pytest tests/test_cli.py -k "package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump" -q
- uv run --extra dev ruff check tests/test_rulespec_validation.py src/axiom_encode/__init__.py
- uv run --extra dev ruff format --check tests/test_rulespec_validation.py src/axiom_encode/__init__.py
- uv run --extra dev axiom-encode oracle-coverage --root /tmp/axiom-coverage-root-pr303 --program snap --fail-on-unmapped --fail-on-untested-comparable --json