### PR TITLE
Fix parent-fallback rate encodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.404"
+version = "0.2.405"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.404"
+__version__ = "0.2.405"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -79,6 +79,7 @@ from .harness.validator_pipeline import (
     _extract_source_verification_text,
     _filing_status_rule_source_context,
     _is_executable_rulespec_rule,
+    _load_nearby_eval_source_metadata,
     _rulespec_executable_index_for_roots,
     _rulespec_executable_signature,
     _rulespec_public_item_keys,
@@ -17809,6 +17810,11 @@ def _validate_generated_encoding_in_policy_overlay(
         overlay_repo_name = (
             canonical_rulespec_repo_name(policy_repo_path) or policy_repo_path.name
         )
+        _write_overlay_eval_source_metadata_for_generated_output(
+            output_file=output_file,
+            overlay_parent=overlay_parent,
+            relative_output=relative_output,
+        )
         for sibling in policy_repo_path.parent.glob("rulespec-*"):
             if sibling.resolve() == policy_repo_path.resolve() or not sibling.is_dir():
                 continue
@@ -18084,6 +18090,49 @@ def _validate_generated_encoding_in_policy_overlay(
                         f"{relative_file}: {validator_result.validator_name}: {validator_result.error}"
                     )
         return False, issues, {}
+
+
+def _write_overlay_eval_source_metadata_for_generated_output(
+    *,
+    output_file: Path,
+    overlay_parent: Path,
+    relative_output: Path,
+) -> Path | None:
+    """Preserve eval source metadata for temporary apply validation overlays.
+
+    Generated files can validate against a parent-fallback corpus source only
+    when the validator can see the original requested child source. The apply
+    overlay lives in a fresh temp directory, so copy the minimal manifest shape
+    read by `_load_nearby_eval_source_metadata`.
+    """
+    source_metadata = _load_nearby_eval_source_metadata(output_file)
+    if not source_metadata:
+        return None
+    requested_source = source_metadata.get("requested_source")
+    citation = (
+        requested_source.strip()
+        if isinstance(requested_source, str) and requested_source.strip()
+        else relative_output.with_suffix("").as_posix()
+    )
+    manifest_path = (
+        overlay_parent
+        / "_eval_workspaces"
+        / "apply"
+        / "workspace"
+        / "context-manifest.json"
+    )
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "citation": citation,
+                "source_metadata": source_metadata,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return manifest_path
 
 
 def _suppress_rulespec_ancestor_targets_for_subsection_overlay(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -920,6 +920,17 @@ _CARDINAL_VALUE_WORDS = {
     for word, value in _CARDINAL_WORD_VALUES.items()
     if float(value).is_integer()
 }
+_CARDINAL_WORD_SEQUENCE = (
+    r"(?:"
+    + "|".join(re.escape(word) for word in _CARDINAL_WORD_VALUES)
+    + r")(?:[-\s]+(?:"
+    + "|".join(
+        re.escape(word)
+        for word in _CARDINAL_WORD_VALUES
+        if 1 <= _CARDINAL_WORD_VALUES[word] <= 9
+    )
+    + r"))?"
+)
 _DATE_DECOMPOSITION_CUE_TOKENS = {
     "date",
     "birthday",
@@ -947,6 +958,7 @@ _PE_UNSUPPORTED_ERROR_PATTERNS = (
     re.compile(r"VariableNotFoundError"),
     re.compile(r"was not found in the .*tax and benefit system", re.IGNORECASE),
 )
+_APPLIED_ENCODING_MANIFEST_DIR = Path(".axiom") / "encoding-manifests"
 _DEFINITION_CROSS_REFERENCE_PATTERN = re.compile(
     r"(?:as defined in|defined in|meaning given in|within the meaning of|described in)\s+"
     r"section\s+(?P<section>[0-9A-Za-z.-]+(?:\([^)]+\))*)"
@@ -992,6 +1004,50 @@ def _load_nearby_eval_source_metadata(rulespec_file: Path) -> dict[str, object] 
             if manifest_norm == rulespec_norm:
                 return metadata
     return fallback
+
+
+def _load_applied_encoding_manifest_source_metadata(
+    rulespec_file: Path,
+    policy_repo_path: Path,
+) -> dict[str, object] | None:
+    """Load durable requested-source metadata from a generated apply manifest."""
+    try:
+        relative_rulespec = rulespec_file.resolve().relative_to(
+            policy_repo_path.resolve()
+        )
+    except (OSError, ValueError):
+        return None
+    manifest_path = (
+        policy_repo_path
+        / _APPLIED_ENCODING_MANIFEST_DIR
+        / relative_rulespec.with_suffix(".json")
+    )
+    if not manifest_path.exists():
+        return None
+    try:
+        payload = json.loads(manifest_path.read_text())
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    source_metadata = payload.get("source_metadata")
+    metadata: dict[str, object] = (
+        dict(source_metadata) if isinstance(source_metadata, dict) else {}
+    )
+    citation = payload.get("citation")
+    if isinstance(citation, str) and citation.strip():
+        metadata.setdefault("requested_source", citation.strip())
+    return metadata or None
+
+
+def _requested_source_from_metadata(metadata: dict[str, object] | None) -> str | None:
+    if not isinstance(metadata, dict):
+        return None
+    requested_source = metadata.get("requested_source")
+    if not isinstance(requested_source, str):
+        return None
+    requested_source = requested_source.strip()
+    return requested_source or None
 
 
 def _rulespec_file_normalized_target(rulespec_file: Path) -> tuple[str, ...] | None:
@@ -1758,6 +1814,20 @@ def _iter_normalized_special_numeric_matches(
     fraction_chars = "".join(re.escape(glyph) for glyph in _UNICODE_FRACTION_VALUES)
 
     for match in re.finditer(
+        rf"\b(?:(?P<whole>{_CARDINAL_WORD_SEQUENCE})\s+and\s+)?"
+        rf"(?P<numerator>{_CARDINAL_WORD_SEQUENCE})\s+"
+        r"one[-\s]+hundredths?\s+"
+        r"(?:percent|per\s*cent(?:um)?)\b",
+        text,
+        re.IGNORECASE,
+    ):
+        whole = _parse_cardinal_word_sequence(match.group("whole") or "")
+        numerator = _parse_cardinal_word_sequence(match.group("numerator"))
+        if numerator is None:
+            continue
+        matches.append((match.span(), ((whole or 0) + numerator / 100) / 100))
+
+    for match in re.finditer(
         rf"(-?[\d,]+)\s*([{fraction_chars}])(?:\s+|-)(?:percent|per\s*cent(?:um)?)",
         text,
         re.IGNORECASE,
@@ -1800,6 +1870,24 @@ def _iter_normalized_special_numeric_matches(
             matches.append((match.span(1), float(match.group(1).replace(",", ""))))
 
     return matches
+
+
+def _parse_cardinal_word_sequence(text: str) -> float | None:
+    """Parse a compact English cardinal phrase up to ninety-nine."""
+    words = [
+        token
+        for token in re.split(r"[-\s]+", text.strip().lower())
+        if token and token != "and"
+    ]
+    if not words:
+        return None
+    total = 0.0
+    for word in words:
+        value = _CARDINAL_WORD_VALUES.get(word)
+        if value is None:
+            return None
+        total += value
+    return total
 
 
 def _extract_percentage_context_values(text: str) -> set[float]:
@@ -16081,16 +16169,20 @@ class ValidatorPipeline:
         issues.extend(find_person_scoped_definition_unit_issues(content))
         issues.extend(find_helper_only_definition_issues(content))
         issues.extend(find_deferred_output_issues(content))
-        # Read the requested-source target from the nearby eval workspace
-        # so subparagraph-coverage scoping respects encoder intent even when
-        # the corpus served a parent-fallback source slice (issue #71).
-        nearby_metadata = _load_nearby_eval_source_metadata(rules_file)
-        requested_source = (
-            str(nearby_metadata.get("requested_source"))
-            if isinstance(nearby_metadata, dict)
-            and isinstance(nearby_metadata.get("requested_source"), str)
-            else None
+        # Read the requested-source target from the nearby eval workspace or
+        # the durable apply manifest so subparagraph-coverage scoping respects
+        # encoder intent even when the corpus served a parent-fallback source
+        # slice (issue #71).
+        requested_source = _requested_source_from_metadata(
+            _load_nearby_eval_source_metadata(rules_file)
         )
+        if requested_source is None:
+            requested_source = _requested_source_from_metadata(
+                _load_applied_encoding_manifest_source_metadata(
+                    rules_file,
+                    self.policy_repo_path,
+                )
+            )
         issues.extend(
             find_source_subparagraph_coverage_issues(
                 content,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,6 +82,7 @@ from axiom_encode.cli import (
     _try_repair_generated_unsafe_formula_outputs_for_apply,
     _validate_generated_encoding_in_policy_overlay,
     _write_applied_encoding_manifest,
+    _write_overlay_eval_source_metadata_for_generated_output,
     cmd_calibration,
     cmd_compile,
     cmd_encode,
@@ -131,6 +132,7 @@ from axiom_encode.harness.encoding_db import (
     ReviewResults,
 )
 from axiom_encode.harness.evals import EvalArtifactMetrics
+from axiom_encode.harness.validator_pipeline import _load_nearby_eval_source_metadata
 from axiom_encode.statute import citation_to_citation_path, parse_usc_citation
 
 TEST_APPLY_SIGNING_KEY = "test-apply-signing-key"
@@ -9783,6 +9785,57 @@ rules:
         assert len(issues) == 1
         assert issues[0].startswith("regulations/18-nycrr/387/12/f/3/v/c.yaml: ")
         assert "dropped existing source_relation" in issues[0]
+
+    def test_apply_overlay_preserves_requested_source_metadata_for_parent_fallback(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        output_file = (
+            output_root / "codex-test-model" / "statutes/39/39-22-104/1.7/c.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text("format: rulespec/v1\nrules: []\n")
+        manifest_path = (
+            output_root
+            / "_eval_workspaces"
+            / "codex-test-model"
+            / "us-co-statute-39-39-22-104-1.7-c"
+            / "workspace"
+            / "context-manifest.json"
+        )
+        manifest_path.parent.mkdir(parents=True)
+        manifest_path.write_text(
+            json.dumps(
+                {
+                    "citation": "us-co/statute/39/39-22-104/1.7/c",
+                    "source_metadata": {
+                        "corpus_citation_path": "us-co/statute/39/39-22-104",
+                        "corpus_source": "supabase",
+                        "requested_source": "us-co/statute/39/39-22-104/1.7/c",
+                    },
+                }
+            )
+        )
+
+        overlay_parent = tmp_path / "overlay"
+        overlay_target = (
+            overlay_parent / "rulespec-us-co" / "statutes/39/39-22-104/1.7/c.yaml"
+        )
+        overlay_target.parent.mkdir(parents=True)
+        overlay_target.write_text(output_file.read_text())
+
+        written = _write_overlay_eval_source_metadata_for_generated_output(
+            output_file=output_file,
+            overlay_parent=overlay_parent,
+            relative_output=Path("statutes/39/39-22-104/1.7/c.yaml"),
+        )
+
+        assert written is not None
+        assert _load_nearby_eval_source_metadata(overlay_target) == {
+            "corpus_citation_path": "us-co/statute/39/39-22-104",
+            "corpus_source": "supabase",
+            "requested_source": "us-co/statute/39/39-22-104/1.7/c",
+        }
 
     def test_apply_overlay_validation_allows_deferred_replacement_of_executable_file(
         self, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import math
 import os
 import subprocess
 from pathlib import Path
@@ -17,6 +18,7 @@ from axiom_encode.harness.validator_pipeline import (
     ValidatorPipeline,
     _extract_json_object,
     _infer_us_state_code_from_rulespec_path,
+    _load_applied_encoding_manifest_source_metadata,
     _normalize_us_tax_filing_status,
     _policyengine_expected_float,
     _policyengine_period_string,
@@ -12484,6 +12486,57 @@ rules: []
     )
 
 
+def test_source_subparagraph_coverage_uses_applied_manifest_requested_source(tmp_path):
+    source_text = """Eligibility disqualifications
+(a) Income standards. Households with income above thresholds are ineligible.
+(c) Gross income standard. Adjusted October 1 each year.
+(d) Exclusions from income. Various items excluded.
+(e) Deductions from income.
+    (1) Standard deduction.
+    (2) (B) Earned income deduction of 20 percent.
+(g) Allowable financial resources. Asset limits apply.
+"""
+    policy_repo = tmp_path / "rulespec-us"
+    rules_file = policy_repo / "statutes/7/2014/e/2/B.yaml"
+    rules_file.parent.mkdir(parents=True)
+    content = """format: rulespec/v1
+module:
+  status: deferred
+  source_verification:
+    corpus_citation_path: us/statute/7/2014
+  summary: Earned income deduction under 7 USC 2014(e)(2)(B).
+  deferred_outputs:
+    - output: us:statutes/7/2014/e/2/B#snap_earned_income_deduction
+      reason: Requires the (e)(2)(C) exception which is not in scope.
+rules: []
+"""
+    rules_file.write_text(content)
+    manifest_path = policy_repo / ".axiom/encoding-manifests/statutes/7/2014/e/2/B.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "citation": "us/statute/7/2014/e/2/B",
+                "schema_version": "axiom-encode/applied-rulespec/v1",
+            }
+        )
+    )
+
+    source_metadata = _load_applied_encoding_manifest_source_metadata(
+        rules_file,
+        policy_repo,
+    )
+    assert source_metadata is not None
+    issues = find_source_subparagraph_coverage_issues(
+        content,
+        rules_file=rules_file,
+        source_texts={"us/statute/7/2014": source_text},
+        requested_source=source_metadata["requested_source"],
+    )
+
+    assert issues == []
+
+
 def test_source_subparagraph_coverage_without_requested_source_keeps_strict_scope():
     """Sanity check: when no requested_source is supplied, behaviour is
     unchanged — the validator demands coverage of every top-level
@@ -16462,6 +16515,36 @@ rules:
 
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
     assert 0.075 in extract_numeric_occurrences_from_text(source_text)
+
+
+def test_ungrounded_numeric_accepts_spelled_hundredths_percentage():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-co/statute/39/39-22-104/1.7/c
+rules:
+  - name: individual_estate_trust_income_tax_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          0.044
+"""
+
+    source_text = (
+        "a tax of four and forty one-hundredths percent is imposed on the "
+        "federal taxable income"
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert any(
+        math.isclose(value, 0.044) for value in extract_numbers_from_text(source_text)
+    )
+    assert any(
+        math.isclose(value, 0.044)
+        for value in extract_numeric_occurrences_from_text(source_text)
+    )
 
 
 def test_non_rulespec_yaml_artifact_is_rejected(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.404"
+version = "0.2.405"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Accept spelled hundredths percentage phrases such as "four and forty one-hundredths percent" as grounded decimal rates.
- Preserve requested-source metadata inside temporary apply-validation overlays so parent-fallback corpus slices validate against the requested child scope.
- Add regressions for Colorado income tax rate wording and parent-fallback apply metadata.
- Bump axiom-encode to 0.2.405.

## Validation
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py -k "spelled_hundredths_percentage or mixed_unicode_fraction_percentage or decimal_percentage_float_noise" -q
- uv run --extra dev python -m pytest tests/test_cli.py -k "overlay_preserves_requested_source_metadata or package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump" -q
- uv run --extra dev axiom-encode validate /tmp/co-income-tax-rate-probe/codex-gpt-5.5/statutes/39/39-22-104/1.7/c.yaml --skip-reviewers