### PR TITLE
Map Colorado income tax rate oracle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.405"
+version = "0.2.406"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.405"
+__version__ = "0.2.406"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -866,6 +866,15 @@ mappings:
     mapping_type: not_comparable
     rationale: Colorado initial-month proration output; PolicyEngine SNAP does not expose Colorado initial-month proration.
 
+  - legal_id: us-co:statutes/39/39-22-104/1.7/c#individual_estate_trust_income_tax_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.rate
+    period: year
+    comparison: rate
+    rationale: Same Colorado individual income tax flat rate, stored in PE as the Colorado income-tax rate parameter.
+
   - legal_id_prefix: us-ny:regulations/18-nycrr/387/14/a/1#
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -587,6 +587,44 @@ rules:
     )
 
 
+def test_policyengine_coverage_maps_colorado_income_tax_rate_parameter(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/1.7/c.yaml",
+        """format: rulespec/v1
+rules:
+  - name: individual_estate_trust_income_tax_rate
+    kind: parameter
+    versions:
+      - effective_from: '2022-01-01'
+        formula: '0.044'
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/1.7/c.test.yaml",
+        """- name: rate for tax year beginning after january 2022
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  output:
+    us-co:statutes/39/39-22-104/1.7/c#individual_estate_trust_income_tax_rate: 0.044
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us-co:statutes/39/39-22-104/1.7/c#individual_estate_trust_income_tax_rate"
+    )
+    assert item["policyengine_parameter"] == "gov.states.co.tax.income.rate"
+    assert item["tested"] is True
+    assert item["test_output_count"] == 1
+
+
 def test_policyengine_coverage_classifies_3102a_collection_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3102/a.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.405"
+version = "0.2.406"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map the generated Colorado 39-22-104(1.7)(c) income tax rate output to PolicyEngine parameter `gov.states.co.tax.income.rate`
- add a coverage regression showing a rulespec-us-co companion test satisfies the oracle coverage gate

## Validation
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k "colorado_income_tax_rate_parameter or tax_parameter_outputs" -q`
- `uv run --extra dev python -m pytest tests/test_cli.py -k "package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump" -q`
- `uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/colorado-income-tax-20260529 --json`