### PR TITLE
Handle Colorado base-rate oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.407"
+version = "0.2.408"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.407"
+__version__ = "0.2.408"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -579,6 +579,17 @@ _UNICODE_FRACTION_VALUES = {
     "⅝": 0.625,
     "⅞": 0.875,
 }
+_FRACTION_WORD_VALUES = {
+    "one half": 0.5,
+    "one third": 1 / 3,
+    "two thirds": 2 / 3,
+    "one quarter": 0.25,
+    "three quarters": 0.75,
+}
+_FRACTION_WORD_PATTERN = (
+    r"(?:one[-\s]+half|one[-\s]+third|two[-\s]+thirds|"
+    r"one[-\s]+quarter|three[-\s]+quarters)"
+)
 IMPORT_ITEM_PATTERN = re.compile(r"^\s*-\s*(['\"]?)([^'\"]+?)\1\s*$")
 IMPORT_MAPPING_PATTERN = re.compile(r"^\s*[A-Za-z_]\w*:\s*(['\"]?)([^'\"]+?)\1\s*$")
 _EMBEDDED_SCALAR_DIRECT_VALUE = re.compile(r"-?[\d,]+(?:\.\d+)?")
@@ -1771,21 +1782,11 @@ def extract_numbers_from_text(text: str) -> set[float]:
     for match in _ORDINAL_WORD_PATTERN.finditer(text):
         numbers.add(_ORDINAL_WORD_VALUES[match.group(1).lower()])
 
-    fraction_words = {
-        "one-half": 0.5,
-        "one half": 0.5,
-        "one-third": 1 / 3,
-        "one third": 1 / 3,
-        "two-thirds": 2 / 3,
-        "two thirds": 2 / 3,
-        "one-quarter": 0.25,
-        "one quarter": 0.25,
-        "three-quarters": 0.75,
-        "three quarters": 0.75,
-    }
     text_lower = text.lower()
-    for phrase, value in fraction_words.items():
+    for phrase, value in _FRACTION_WORD_VALUES.items():
         if phrase in text_lower:
+            numbers.add(value)
+        if phrase.replace(" ", "-") in text_lower:
             numbers.add(value)
 
     for glyph, value in _UNICODE_FRACTION_VALUES.items():
@@ -1812,6 +1813,19 @@ def _iter_normalized_special_numeric_matches(
     """Return normalized special-case numeric matches like percentages, pence, and table values."""
     matches: list[tuple[tuple[int, int], float]] = []
     fraction_chars = "".join(re.escape(glyph) for glyph in _UNICODE_FRACTION_VALUES)
+
+    for match in re.finditer(
+        rf"\b(?:(?P<whole>{_CARDINAL_WORD_SEQUENCE})\s+and\s+)?"
+        rf"(?P<fraction>{_FRACTION_WORD_PATTERN})\s+"
+        r"(?:percent|per\s*cent(?:um)?)\b",
+        text,
+        re.IGNORECASE,
+    ):
+        whole = _parse_cardinal_word_sequence(match.group("whole") or "") or 0
+        fraction = _parse_fraction_word(match.group("fraction"))
+        if fraction is None:
+            continue
+        matches.append((match.span(), (whole + fraction) / 100))
 
     for match in re.finditer(
         rf"\b(?:(?P<whole>{_CARDINAL_WORD_SEQUENCE})\s+and\s+)?"
@@ -1888,6 +1902,11 @@ def _parse_cardinal_word_sequence(text: str) -> float | None:
             return None
         total += value
     return total
+
+
+def _parse_fraction_word(text: str) -> float | None:
+    normalized = re.sub(r"[-\s]+", " ", text.strip().lower())
+    return _FRACTION_WORD_VALUES.get(normalized)
 
 
 def _extract_percentage_context_values(text: str) -> set[float]:

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -875,6 +875,18 @@ mappings:
     comparison: rate
     rationale: Same Colorado individual income tax flat rate, stored in PE as the Colorado income-tax rate parameter.
 
+  - legal_id: us-co:statutes/39/39-22-104/1.7/a#individual_estate_trust_income_tax_rate_before_2020
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: This generated output is the statutory 4.63% base rate before applying later TABOR/form-rate reductions; PolicyEngine exposes the final Colorado form rate for each tax year.
+
+  - legal_id: us-co:statutes/39/39-22-104/1.7/b#individual_estate_trust_income_tax_rate_before_2022
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: This generated output is the statutory 4.55% base rate before applying later TABOR/form-rate reductions; PolicyEngine exposes the final Colorado form rate for each tax year.
+
   - legal_id_prefix: us-ny:regulations/18-nycrr/387/14/a/1#
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -625,6 +625,67 @@ rules:
     assert item["test_output_count"] == 1
 
 
+def test_policyengine_coverage_classifies_colorado_base_rates_not_comparable(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/1.7/a.yaml",
+        """format: rulespec/v1
+rules:
+  - name: individual_estate_trust_income_tax_rate_before_2020
+    kind: parameter
+    versions:
+      - effective_from: '2000-01-01'
+        formula: '0.0463'
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/1.7/a.test.yaml",
+        """- name: rate for tax year beginning in 2019
+  period:
+    period_kind: tax_year
+    start: '2019-01-01'
+    end: '2019-12-31'
+  input: {}
+  output:
+    us-co:statutes/39/39-22-104/1.7/a#individual_estate_trust_income_tax_rate_before_2020: 0.0463
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/1.7/b.yaml",
+        """format: rulespec/v1
+rules:
+  - name: individual_estate_trust_income_tax_rate_before_2022
+    kind: parameter
+    versions:
+      - effective_from: '2020-01-01'
+        formula: '0.0455'
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/1.7/b.test.yaml",
+        """- name: rate for tax year beginning in 2021
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input: {}
+  output:
+    us-co:statutes/39/39-22-104/1.7/b#individual_estate_trust_income_tax_rate_before_2022: 0.0455
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["legal_id"] for item in report["items"]} == {
+        "us-co:statutes/39/39-22-104/1.7/a#individual_estate_trust_income_tax_rate_before_2020",
+        "us-co:statutes/39/39-22-104/1.7/b#individual_estate_trust_income_tax_rate_before_2022",
+    }
+    assert {item["program"] for item in report["items"]} == {"tax"}
+    assert {item["tested"] for item in report["items"]} == {True}
+
+
 def test_policyengine_coverage_classifies_3102a_collection_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3102/a.yaml",

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -16547,6 +16547,36 @@ rules:
     )
 
 
+def test_ungrounded_numeric_accepts_spelled_fractional_percentage():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-co/statute/39/39-22-104/1.5
+rules:
+  - name: individual_estate_trust_income_tax_rate_1999
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '1999-01-01'
+        formula: |-
+          0.0475
+"""
+
+    source_text = (
+        "a tax of four and three-quarters percent is imposed on the "
+        "federal taxable income"
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert any(
+        math.isclose(value, 0.0475) for value in extract_numbers_from_text(source_text)
+    )
+    assert any(
+        math.isclose(value, 0.0475)
+        for value in extract_numeric_occurrences_from_text(source_text)
+    )
+
+
 def test_non_rulespec_yaml_artifact_is_rejected(tmp_path):
     rules_file = tmp_path / "not-rulespec.yaml"
     rules_file.write_text("rules:\n  - name: missing_format_header\n")

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.407"
+version = "0.2.408"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- recognize spelled fractional percentages such as "four and three-quarters percent" as grounded numeric rates
- classify Colorado 39-22-104(1.7)(a)/(b) base-rate outputs as known not comparable to PolicyEngine final form-rate parameters
- bump axiom-encode to 0.2.408

## Validation
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py -k "spelled_hundredths_percentage or spelled_fractional_percentage" -q
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k "colorado_income_tax_rate_parameter or colorado_base_rates_not_comparable" -q
- uv run --extra dev python -m pytest tests/test_cli.py -k "package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump" -q
- uv run --extra dev pytest -q