### PR TITLE
Preserve Colorado statute decimal paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.408"
+version = "0.2.409"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.408"
+__version__ = "0.2.409"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3011,6 +3011,8 @@ def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
             if parts[0] == "us" and parts[1] in {"regulation", "regulations"}:
                 tail = _canonical_us_regulation_tail(tail)
             if tail:
+                if _preserve_state_statute_dotted_leaf(parts[0], root, tail):
+                    return Path(root) / Path(*tail[:-1]) / f"{tail[-1]}.yaml"
                 return Path(root) / _dotted_leaf_to_nested_yaml_path(tail)
     return Path("source") / f"{_slugify(source_id)}.yaml"
 
@@ -3041,6 +3043,21 @@ def _preserve_dotted_leaf_filename(tail: list[str]) -> bool:
         re.fullmatch(r"\d+-ccr-\d+-\d+", tail[0], flags=re.IGNORECASE)
         and re.fullmatch(r"\d+(?:\.\d+)+", tail[-1])
     )
+
+
+def _preserve_state_statute_dotted_leaf(
+    jurisdiction: str,
+    root: str,
+    tail: list[str],
+) -> bool:
+    """Return true when a dotted state statute segment is a legal citation label."""
+    if jurisdiction != "us-co" or root != "statutes" or len(tail) < 2:
+        return False
+    if len(tail) == 2 and tail[0].isdigit():
+        return bool(re.fullmatch(r"\d+(?:-\d+)+(?:\.\d+)+", tail[-1]))
+    if not re.fullmatch(r"\d+(?:\.\d+)+", tail[-1]):
+        return False
+    return bool(re.fullmatch(r"\d+(?:-\d+)+(?:\.\d+)?", tail[-2]))
 
 
 def _canonical_us_regulation_tail(tail: list[str]) -> list[str]:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -147,6 +147,16 @@ def test_source_identifier_maps_federal_regulation_to_cfr_repo_path():
             "us-co/regulation/10-ccr-2506-1/4.403.11/b/c/3",
             "regulations/10-ccr-2506-1/4.403.11/b/c/3.yaml",
         ),
+        # Colorado statutes also use dotted legal labels for sections and
+        # subsections; those labels are file stems, not nested MPP-style parts.
+        (
+            "us-co/statute/39/39-22-104.5",
+            "statutes/39/39-22-104.5.yaml",
+        ),
+        (
+            "us-co/statute/39/39-22-104/1.5",
+            "statutes/39/39-22-104/1.5.yaml",
+        ),
         # Slash-separated citations (USC, NYCRR, CFR) are unaffected — these
         # are regression cases for the dot-stripping fix.
         (

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.408"
+version = "0.2.409"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Preserve Colorado dotted statute leaves such as 39-22-104.5 and subsection labels like 1.5 when deriving RuleSpec paths.
- Add regression coverage for state statute decimal section and subsection identifiers.
- Bump encoder version to 0.2.409.

## Validation
- uv run --extra dev python -m pytest tests/test_evals.py -k 'source_identifier_handles_dotted_leaf_segments' -q
- uv run --extra dev python -m pytest tests/test_cli.py -k 'package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump' -q