### PR TITLE
Repair copied cross-reference summaries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.409"
+version = "0.2.410"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.409"
+__version__ = "0.2.410"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -71,6 +71,7 @@ from .validator_pipeline import (
     find_ungrounded_numeric_issues,
     find_unused_modifier_parameter_issues,
     numeric_value_is_grounded,
+    repair_copied_cross_reference_summary,
     repair_source_table_band_scalar_parameters,
     repair_source_table_interval_row_alignment,
     repair_source_table_interval_tests,
@@ -2548,6 +2549,16 @@ def _rulespec_validation_target(
                 shutil.copytree(sibling, sibling_target, dirs_exist_ok=True)
         overlay_repo = overlay_parent / policy_repo_root.name
         shutil.copytree(policy_repo_root, overlay_repo)
+        eval_workspaces_root = _nearby_eval_workspaces_root(rulespec_file)
+        if eval_workspaces_root is not None:
+            eval_overlay = overlay_parent / "_eval_workspaces"
+            try:
+                eval_overlay.symlink_to(
+                    eval_workspaces_root.resolve(),
+                    target_is_directory=True,
+                )
+            except OSError:
+                shutil.copytree(eval_workspaces_root, eval_overlay)
         validation_file = overlay_repo / relative
         validation_file.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(rulespec_file, validation_file)
@@ -2558,6 +2569,14 @@ def _rulespec_validation_target(
             )
             shutil.copy2(companion_test, validation_test)
         yield validation_file
+
+
+def _nearby_eval_workspaces_root(path: Path) -> Path | None:
+    for ancestor in path.parents:
+        candidate = ancestor / "_eval_workspaces"
+        if candidate.exists() and candidate.is_dir():
+            return candidate
+    return None
 
 
 def _relative_rulespec_source_path(path: Path) -> Path | None:
@@ -6724,6 +6743,10 @@ def _normalize_main_eval_content(
     normalized, _interval_repairs = repair_source_table_interval_row_alignment(
         normalized,
         source_text=source_text,
+    )
+    normalized, _summary_repairs = repair_copied_cross_reference_summary(
+        normalized,
+        rules_file=target_path,
     )
     normalized, _conditional_repairs = repair_unsupported_chained_conditionals(
         normalized

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -735,7 +735,7 @@ _MONTH_DAY_OF_MONTH_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _STRUCTURAL_SOURCE_SUBDIVISION_MARKER_PATTERN = re.compile(
-    r"(?<![A-Za-z0-9])\((?:[A-Za-z]|[ivxlcdmIVXLCDM]+|\d{1,2})\)"
+    r"(?<![A-Za-z0-9])\((?:[A-Za-z]|[ivxlcdmIVXLCDM]+|\d{1,2}(?:\.\d+)?)\)"
 )
 _TABLE_HEADING_PATTERN = re.compile(
     r"^\s*table\s+\d+[A-Za-z]?(?:\s*:.*)?$", re.IGNORECASE
@@ -3091,6 +3091,123 @@ def repair_source_table_interval_tests(
         return content, []
     repaired_content = yaml.safe_dump(cases, sort_keys=False).strip() + "\n"
     return repaired_content, changed_cases
+
+
+def repair_copied_cross_reference_summary(
+    content: str,
+    *,
+    rules_file: Path,
+    policy_repo_path: Path | None = None,
+) -> tuple[str, list[str]]:
+    """Remove copied same-section cross-reference bodies from module summaries."""
+    payload = _rulespec_payload(content)
+    if payload is None or payload.get("format") != "rulespec/v1":
+        return content, []
+
+    module = payload.get("module")
+    if not isinstance(module, dict):
+        return content, []
+    summary = module.get("summary")
+    if not isinstance(summary, str) or not summary.strip():
+        return content, []
+
+    statute_path = (
+        _statute_path_parts_for_file(rules_file, policy_repo_path)
+        if policy_repo_path is not None
+        else _statute_path_parts_for_any_file(rules_file)
+    )
+    if statute_path is None:
+        return content, []
+    title, section, current_fragments = statute_path
+
+    cited_subsections = _same_section_subsections_cited_by_summary(summary)
+    if not cited_subsections:
+        return content, []
+
+    repaired_summary = summary
+    repaired_imports: list[str] = []
+    for subsection in cited_subsections:
+        if subsection in current_fragments:
+            continue
+        repaired, changed = _remove_summary_subsection_body(
+            repaired_summary,
+            subsection=subsection,
+        )
+        if not changed:
+            continue
+        repaired_summary = repaired
+        repaired_imports.append("/".join(["statutes", title, section, subsection]))
+
+    if not repaired_imports:
+        return content, []
+
+    module["summary"] = repaired_summary.strip()
+    repaired_content = yaml.safe_dump(payload, sort_keys=False).strip() + "\n"
+    return repaired_content, repaired_imports
+
+
+def _same_section_subsections_cited_by_summary(summary: str) -> list[str]:
+    seen: set[str] = set()
+    subsections: list[str] = []
+    for match in re.finditer(
+        r"\bsubsection\s+\((?P<subsection>[A-Za-z0-9.]+)\)"
+        r"(?:\s+of\s+this\s+section)?(?=\W|$)",
+        summary,
+        flags=re.IGNORECASE,
+    ):
+        subsection = match.group("subsection")
+        if subsection in seen:
+            continue
+        seen.add(subsection)
+        subsections.append(subsection)
+    return subsections
+
+
+def _remove_summary_subsection_body(
+    summary: str,
+    *,
+    subsection: str,
+) -> tuple[str, bool]:
+    copied_body_pattern = re.compile(
+        rf"(?ms)(^|\n+)\({re.escape(subsection)}\)\s+[A-Z][\s\S]*?"
+        r"(?=\n+\([A-Za-z0-9.]+\)\s+[A-Z]|\Z)"
+    )
+
+    def remove_body(match: re.Match[str]) -> str:
+        prefix = match.group(1)
+        return "\n\n" if "\n\n" in prefix else prefix
+
+    repaired, count = copied_body_pattern.subn(remove_body, summary)
+    if count == 0:
+        return summary, False
+    repaired = re.sub(r"\n{3,}", "\n\n", repaired).strip()
+    return repaired, True
+
+
+def _statute_path_parts_for_any_file(
+    rules_file: Path,
+) -> tuple[str, str, tuple[str, ...]] | None:
+    parts = rules_file.resolve(strict=False).parts
+    for index, part in enumerate(parts):
+        if part != "statutes":
+            continue
+        return _statute_path_parts_from_relative_parts(tuple(parts[index:]))
+    return None
+
+
+def _statute_path_parts_from_relative_parts(
+    relative_parts: tuple[str, ...],
+) -> tuple[str, str, tuple[str, ...]] | None:
+    if not relative_parts or len(relative_parts) < 4 or relative_parts[0] != "statutes":
+        return None
+
+    title = relative_parts[1]
+    section = relative_parts[2]
+    fragments = list(relative_parts[3:-1])
+    stem = Path(relative_parts[-1]).stem
+    if stem not in {"index", "__init__"}:
+        fragments.append(stem)
+    return title, section, tuple(fragments)
 
 
 def _source_table_interval_alignment_specs(
@@ -12021,16 +12138,9 @@ def _statute_path_parts_for_file(
         with contextlib.suppress(ValueError):
             statutes_index = parts.index("statutes")
             relative_parts = tuple(parts[statutes_index:])
-    if not relative_parts or len(relative_parts) < 4 or relative_parts[0] != "statutes":
+    if relative_parts is None:
         return None
-
-    title = relative_parts[1]
-    section = relative_parts[2]
-    fragments = list(relative_parts[3:-1])
-    stem = Path(relative_parts[-1]).stem
-    if stem not in {"index", "__init__"}:
-        fragments.append(stem)
-    return title, section, tuple(fragments)
+    return _statute_path_parts_from_relative_parts(relative_parts)
 
 
 def _extract_import_items_from_content(content: str) -> list[str]:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -11,6 +11,7 @@ import pytest
 import requests
 import yaml
 
+from axiom_encode.harness import validator_pipeline
 from axiom_encode.harness.evals import (
     EvalArtifactMetrics,
     EvalContextFile,
@@ -34,6 +35,7 @@ from axiom_encode.harness.evals import (
     _normalize_nonannual_test_period_value,
     _normalize_test_periods_to_effective_dates,
     _post_openai_eval_request,
+    _rulespec_validation_target,
     _run_codex_prompt_eval,
     _select_cross_section_context_files,
     _source_identifier_to_relative_rulespec_path,
@@ -1020,6 +1022,75 @@ rules:
     assert output_file.exists()
     assert output_file.with_name("tn-snap.test.yaml").exists()
     assert output_file.read_text().startswith("format: rulespec/v1")
+
+
+def test_materialize_eval_artifact_repairs_copied_cross_reference_summary(tmp_path):
+    output_file = tmp_path / "runner" / "statutes" / "39" / "39-22-104" / "1.5.yaml"
+    llm_response = """=== FILE: 1.5.yaml ===
+format: rulespec/v1
+module:
+  summary: |-
+    (1.5) Subject to subsection (2) of this section, a tax of four and three-quarters percent is imposed.
+
+    (2) Prior to the application of the rate of tax prescribed in subsection (1), (1.5), or (1.7) of this section, federal taxable income shall be modified.
+rules:
+  - name: individual_estate_trust_income_tax_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '1999-01-01'
+        formula: '0.0475'
+"""
+
+    wrote = _materialize_eval_artifact(llm_response, output_file)
+
+    assert wrote is True
+    payload = yaml.safe_load(output_file.read_text())
+    summary = payload["module"]["summary"]
+    assert "four and three-quarters percent" in summary
+    assert "Prior to the application" not in summary
+
+
+def test_rulespec_validation_overlay_preserves_eval_source_metadata(tmp_path):
+    policy_repo = tmp_path / "rulespec-us-co"
+    policy_repo.mkdir()
+    output_file = (
+        tmp_path
+        / "out"
+        / "openai-gpt-5.5"
+        / "statutes"
+        / "39"
+        / "39-22-104"
+        / "1.5.yaml"
+    )
+    output_file.parent.mkdir(parents=True)
+    output_file.write_text("format: rulespec/v1\nrules: []\n")
+    workspace = (
+        tmp_path
+        / "out"
+        / "_eval_workspaces"
+        / "openai-gpt-5.5"
+        / "us-co-statute-39-39-22-104-1.5"
+        / "workspace"
+    )
+    workspace.mkdir(parents=True)
+    (workspace / "context-manifest.json").write_text(
+        json.dumps(
+            {
+                "citation": "us-co/statute/39/39-22-104/1.5",
+                "source_metadata": {
+                    "corpus_citation_path": "us-co/statute/39/39-22-104",
+                    "requested_source": "us-co/statute/39/39-22-104/1.5",
+                },
+            }
+        )
+    )
+
+    with _rulespec_validation_target(output_file, policy_repo) as validation_file:
+        metadata = validator_pipeline._load_nearby_eval_source_metadata(validation_file)
+
+    assert metadata is not None
+    assert metadata["requested_source"] == "us-co/statute/39/39-22-104/1.5"
 
 
 def test_materialize_eval_artifact_repairs_source_table_band_scalars(tmp_path):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -87,6 +87,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_upstream_placement_issues,
     find_versioned_derived_formula_issues,
     find_zero_branch_test_coverage_issues,
+    repair_copied_cross_reference_summary,
     repair_current_year_final_amount_tables,
     repair_nonnegative_amount_reductions,
     repair_source_table_band_scalar_parameters,
@@ -4816,6 +4817,15 @@ def test_numeric_occurrence_extraction_ignores_parenthetical_subdivision_labels(
     assert extract_numeric_occurrences_from_text(text) == [1.0]
 
 
+def test_numeric_occurrence_extraction_ignores_decimal_subsection_label():
+    text = (
+        "(1.5) Subject to subsection (2) of this section, a tax of four and "
+        "three-quarters percent is imposed."
+    )
+
+    assert extract_numeric_occurrences_from_text(text) == [0.0475]
+
+
 def test_broad_application_passthrough_rejects_furnishing_output():
     content = """format: rulespec/v1
 module:
@@ -6169,6 +6179,44 @@ rules:
     assert len(issues) == 1
     assert "Copied cross-reference source" in issues[0]
     assert "statutes/7/2015/e" in issues[0]
+
+
+def test_copied_cross_reference_summary_repair_removes_cited_body(tmp_path):
+    repo = tmp_path / "rulespec-us-co"
+    rules_file = repo / "statutes" / "39" / "39-22-104" / "1.5.yaml"
+    rules_file.parent.mkdir(parents=True)
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    (1.5) Subject to subsection (2) of this section, a tax of four and three-quarters percent is imposed.
+
+    (2) Prior to the application of the rate of tax prescribed in subsection (1), (1.5), or (1.7) of this section, federal taxable income shall be modified.
+rules:
+  - name: individual_estate_trust_income_tax_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '1999-01-01'
+        formula: '0.0475'
+"""
+
+    repaired, repairs = repair_copied_cross_reference_summary(
+        content,
+        rules_file=rules_file,
+    )
+
+    assert repairs == ["statutes/39/39-22-104/2"]
+    summary = yaml.safe_load(repaired)["module"]["summary"]
+    assert "four and three-quarters percent" in summary
+    assert "Prior to the application" not in summary
+    assert (
+        find_copied_cross_reference_source_issues(
+            repaired,
+            rules_file=rules_file,
+            policy_repo_path=repo,
+        )
+        == []
+    )
 
 
 def test_copied_cross_reference_source_allows_bare_subsection_citation(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.409"
+version = "0.2.410"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- remove copied same-section subsection bodies from generated module summaries during eval materialization
- preserve nearby eval workspace metadata when validating no-apply outputs in a temp rulespec overlay
- ignore decimal subsection labels like (1.5) when extracting source numeric occurrences

## Verification
- uv run --extra dev ruff check src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py tests/test_rulespec_validation.py
- uv run --extra dev ruff format --check src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py tests/test_rulespec_validation.py
- uv run --extra dev python -m pytest tests/test_evals.py -k 'copied_cross_reference_summary or validation_overlay_preserves_eval_source_metadata or source_identifier_handles_dotted_leaf_segments' tests/test_rulespec_validation.py -k 'copied_cross_reference or numeric_occurrence_extraction_ignores_decimal_subsection_label' -q
- uv run --extra dev python -m pytest tests/test_cli.py -k 'package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump' -q
- uv run --extra dev axiom-encode encode 'us-co/statute/39/39-22-104/1.5' --output /tmp/co-income-tax-1999-rate-branch-repair --policy-repo-path /Users/maxghenis/_axiom-worktrees/colorado-income-tax-1999-20260529/rulespec-us-co --corpus-path /Users/maxghenis/ssa-worktree/axiom-corpus --model gpt-5.5 --backend openai