### PR TITLE
Map Colorado 1999 income tax oracle outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.410"
+version = "0.2.411"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.410"
+__version__ = "0.2.411"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -875,6 +875,26 @@ mappings:
     comparison: rate
     rationale: Same Colorado individual income tax flat rate, stored in PE as the Colorado income-tax rate parameter.
 
+  - legal_id: us-co:statutes/39/39-22-104/1.5#subsection_1_5_individual_income_tax_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.rate
+    period: year
+    comparison: rate
+    rationale: Same Colorado individual income tax flat rate for 1999, stored in PE as the Colorado income-tax rate parameter.
+
+  - legal_id: us-co:statutes/39/39-22-104/1.5#subsection_1_5_individual_income_tax
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: co_income_tax_before_non_refundable_credits
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same pre-credit Colorado income tax on the subsection (2)-modified tax base; PE computes co_taxable_income times the Colorado income-tax rate before nonrefundable credits.
+
   - legal_id: us-co:statutes/39/39-22-104/1.7/a#individual_estate_trust_income_tax_rate_before_2020
     country: us
     program: tax
@@ -12553,4 +12573,3 @@ prefixes:
     program: snap
     mapping_type: not_comparable
     rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -625,6 +625,61 @@ rules:
     assert item["test_output_count"] == 1
 
 
+def test_policyengine_coverage_maps_colorado_1999_income_tax_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/1.5.yaml",
+        """format: rulespec/v1
+rules:
+  - name: subsection_1_5_individual_income_tax_rate
+    kind: parameter
+    versions:
+      - effective_from: '1999-01-01'
+        formula: '0.0475'
+  - name: subsection_1_5_individual_income_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1999-01-01'
+        formula: 'if taxable_year_commences_in_subsection_1_5_window: max(0, federal_taxable_income_after_subsection_2_modifications) * subsection_1_5_individual_income_tax_rate else: 0'
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/1.5.test.yaml",
+        """- name: rate applies to positive modified income
+  period:
+    period_kind: tax_year
+    start: '1999-01-01'
+    end: '1999-12-31'
+  input:
+    us-co:statutes/39/39-22-104/1.5#input.taxable_year_commences_in_subsection_1_5_window: true
+    us-co:statutes/39/39-22-104/1.5#input.federal_taxable_income_after_subsection_2_modifications: 100000
+  output:
+    us-co:statutes/39/39-22-104/1.5#subsection_1_5_individual_income_tax_rate: 0.0475
+    us-co:statutes/39/39-22-104/1.5#subsection_1_5_individual_income_tax: 4750
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    rate = items_by_id[
+        "us-co:statutes/39/39-22-104/1.5#subsection_1_5_individual_income_tax_rate"
+    ]
+    tax = items_by_id[
+        "us-co:statutes/39/39-22-104/1.5#subsection_1_5_individual_income_tax"
+    ]
+    assert rate["policyengine_parameter"] == "gov.states.co.tax.income.rate"
+    assert rate["tested"] is True
+    assert rate["test_output_count"] == 1
+    assert tax["policyengine_variable"] == "co_income_tax_before_non_refundable_credits"
+    assert tax["tested"] is True
+    assert tax["test_output_count"] == 1
+
+
 def test_policyengine_coverage_classifies_colorado_base_rates_not_comparable(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.410"
+version = "0.2.411"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map Colorado 1999 income-tax rate output to PE `gov.states.co.tax.income.rate` parameter
- map the generated pre-credit 1999 income tax output to PE `co_income_tax_before_non_refundable_credits`
- bump axiom-encode to 0.2.411

## Verification
- uv run --extra dev ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run --extra dev ruff format --check tests/test_policyengine_coverage.py
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k 'colorado_income_tax_rate_parameter or colorado_1999_income_tax_outputs' -q
- uv run --extra dev python -m pytest tests/test_cli.py -k 'package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump' -q
- uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/colorado-income-tax-1999-20260529 --json