### PR TITLE
Ground spelled large numeric values

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.411"
+version = "0.2.412"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.411"
+__version__ = "0.2.412"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -922,8 +922,28 @@ _CARDINAL_WORD_VALUES = {
     "eighty": 80.0,
     "ninety": 90.0,
 }
+_CARDINAL_SCALE_WORD_VALUES = {
+    "hundred": 100.0,
+    "thousand": 1_000.0,
+    "million": 1_000_000.0,
+    "billion": 1_000_000_000.0,
+}
 _CARDINAL_WORD_PATTERN = re.compile(
     r"\b(" + "|".join(re.escape(word) for word in _CARDINAL_WORD_VALUES) + r")\b",
+    re.IGNORECASE,
+)
+_CARDINAL_NUMBER_WORD_PATTERN = re.compile(
+    r"\b(?:"
+    + "|".join(
+        re.escape(word)
+        for word in list(_CARDINAL_WORD_VALUES) + list(_CARDINAL_SCALE_WORD_VALUES)
+    )
+    + r")(?:[-\s]+(?:and[-\s]+)?(?:"
+    + "|".join(
+        re.escape(word)
+        for word in list(_CARDINAL_WORD_VALUES) + list(_CARDINAL_SCALE_WORD_VALUES)
+    )
+    + r"))*\b",
     re.IGNORECASE,
 )
 _CARDINAL_VALUE_WORDS = {
@@ -1767,6 +1787,10 @@ def extract_numbers_from_text(text: str) -> set[float]:
         numbers.add(value)
         occupied_spans.append(span)
     numbers.update(_extract_percentage_context_values(text))
+    for span, value in _iter_cardinal_word_number_matches(text):
+        if _span_overlaps(span, occupied_spans):
+            continue
+        numbers.add(value)
 
     for match in SOURCE_TEXT_NUMBER_PATTERN.finditer(text):
         if _span_overlaps(match.span(1), occupied_spans):
@@ -1902,6 +1926,58 @@ def _parse_cardinal_word_sequence(text: str) -> float | None:
             return None
         total += value
     return total
+
+
+def _iter_cardinal_word_number_matches(
+    text: str,
+) -> list[tuple[tuple[int, int], float]]:
+    """Return English cardinal number phrases such as "five hundred thousand"."""
+    matches: list[tuple[tuple[int, int], float]] = []
+    for match in _CARDINAL_NUMBER_WORD_PATTERN.finditer(text):
+        value = _parse_cardinal_number_words(match.group(0))
+        if value is None:
+            continue
+        matches.append((match.span(), value))
+    return matches
+
+
+def _parse_cardinal_number_words(text: str) -> float | None:
+    """Parse an English cardinal phrase with hundred/thousand/million scales."""
+    tokens = [
+        token
+        for token in re.split(r"[-\s]+", text.strip().lower())
+        if token and token != "and"
+    ]
+    if not tokens:
+        return None
+
+    total = 0.0
+    current = 0.0
+    seen_number = False
+    seen_scale = False
+    for token in tokens:
+        if token in _CARDINAL_WORD_VALUES:
+            current += _CARDINAL_WORD_VALUES[token]
+            seen_number = True
+            continue
+        scale = _CARDINAL_SCALE_WORD_VALUES.get(token)
+        if scale is None:
+            return None
+        seen_scale = True
+        if scale == 100:
+            current = (current or 1) * scale
+            seen_number = True
+            continue
+        total += (current or 1) * scale
+        current = 0.0
+        seen_number = True
+
+    if not seen_number:
+        return None
+    value = total + current
+    if not seen_scale and len(tokens) == 1:
+        return _CARDINAL_WORD_VALUES.get(tokens[0])
+    return value
 
 
 def _parse_fraction_word(text: str) -> float | None:
@@ -2091,6 +2167,12 @@ def extract_numeric_occurrences_from_text(text: str) -> list[float]:
 
     for glyph, value in _UNICODE_FRACTION_VALUES.items():
         occurrences.extend(value for _ in re.finditer(re.escape(glyph), cleaned))
+
+    for span, value in _iter_cardinal_word_number_matches(cleaned):
+        if _span_overlaps(span, spans):
+            continue
+        if value not in GROUNDING_ALLOWED_VALUES:
+            occurrences.append(value)
 
     occurrence_counts = Counter(occurrences)
     normalized: list[float] = []

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -4681,6 +4681,41 @@ rules:
     )
 
 
+def test_rulespec_grounding_accepts_large_cardinal_word_amounts():
+    content = """format: rulespec/v1
+rules:
+  - name: single_return_adjusted_gross_income_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2021-01-01'
+        formula: '500000'
+  - name: joint_return_adjusted_gross_income_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2021-01-01'
+        formula: '1000000'
+"""
+
+    source_text = (
+        "for a taxpayer who files a single return and whose adjusted gross income "
+        "is greater than five hundred thousand dollars, and for taxpayers who file "
+        "a joint return and whose adjusted gross income is greater than one million "
+        "dollars"
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    source_values = extract_numbers_from_text(source_text)
+    assert 500000 in source_values
+    assert 1000000 in source_values
+    occurrences = extract_numeric_occurrences_from_text(source_text)
+    assert 500000 in occurrences
+    assert 1000000 in occurrences
+
+
 def test_rulespec_grounding_treats_household_size_match_keys_as_structural():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.411"
+version = "0.2.412"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Parses English cardinal phrases with hundred/thousand/million/billion scale words during numeric grounding.
- Keeps existing special handling for percentages/fractions and skips cardinal phrase matches that overlap normalized percentage spans.
- Bumps axiom-encode to `0.2.412`.

## Why
Colorado 39-22-104(3)(o) states AGI thresholds as “five hundred thousand dollars” and “one million dollars.” The validator incorrectly rejected generated `500000` and `1000000` literals as ungrounded.

## Verification
- `uv run --extra dev ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `uv run --extra dev python -m pytest tests/test_rulespec_validation.py -k "large_cardinal_word_amounts or cardinal_words_above_twelve or spelled_hundredths_percentage or spelled_fractional_percentage"`
- `uv run --extra dev python -m pytest tests/test_rulespec_validation.py`