### PR TITLE
Harden generated bundle repair and Colorado oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.412"
+version = "0.2.413"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.412"
+__version__ = "0.2.413"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10306,21 +10306,23 @@ def _append_oracle_parameter_tests_if_missing(
             continue
 
         index_name = _single_parameter_index_name(rule)
-        if index_name is None:
-            continue
-        sample = _first_scalar_parameter_value(rule)
+        sample = _first_scalar_parameter_value(rule, indexed=index_name is not None)
         if sample is None:
             continue
         key, value = sample
+        case_name_parts = ["oracle_parameter", _safe_test_name(rule_name)]
+        if index_name is not None:
+            case_name_parts.append(_safe_test_name(str(key)))
+        inputs = {f"{target_base}#input.{index_name}": key} if index_name else {}
         appended_cases.append(
             {
-                "name": f"oracle_parameter_{_safe_test_name(rule_name)}_{_safe_test_name(str(key))}",
+                "name": "_".join(case_name_parts),
                 "period": {
                     "period_kind": "tax_year",
                     "start": "2026-01-01",
                     "end": "2026-12-31",
                 },
-                "input": {f"{target_base}#input.{index_name}": key},
+                "input": inputs,
                 "output": {legal_id: value},
             }
         )
@@ -10367,20 +10369,39 @@ def _single_parameter_index_name(rule: dict) -> str | None:
     return None
 
 
-def _first_scalar_parameter_value(rule: dict) -> tuple[object, object] | None:
+def _first_scalar_parameter_value(
+    rule: dict, *, indexed: bool
+) -> tuple[object | None, object] | None:
     versions = rule.get("versions")
     if not isinstance(versions, list):
         return None
     for version in versions:
         if not isinstance(version, dict):
             continue
-        values = version.get("values")
-        if not isinstance(values, dict):
-            continue
-        for key, value in values.items():
-            if isinstance(value, (str, int, float, bool)) or value is None:
-                return key, value
+        if indexed:
+            values = version.get("values")
+            if not isinstance(values, dict):
+                continue
+            for key, value in values.items():
+                if isinstance(value, (str, int, float, bool)) or value is None:
+                    return key, value
+        else:
+            value = _scalar_formula_value(version.get("formula"))
+            if value is not None:
+                return None, value
     return None
+
+
+def _scalar_formula_value(formula: object) -> int | float | str | bool | None:
+    if isinstance(formula, (int, float, bool)):
+        return formula
+    if not isinstance(formula, str):
+        return None
+    stripped = formula.strip()
+    if not re.fullmatch(r"-?\d+(?:\.\d+)?", stripped):
+        return None
+    parsed = yaml.safe_load(stripped)
+    return parsed if isinstance(parsed, (int, float)) else None
 
 
 def _rulespec_companion_test_failures(

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -6884,7 +6884,64 @@ def _clean_generated_file_content(content: str) -> str:
         lambda match: match.group(1),
         stripped,
     )
+    stripped = _normalize_backslash_escaped_yaml_apostrophes(stripped)
     return stripped + ("\n" if stripped and not stripped.endswith("\n") else "")
+
+
+def _normalize_backslash_escaped_yaml_apostrophes(content: str) -> str:
+    """Repair LLM-emitted YAML quote escapes that PyYAML cannot parse."""
+    if "\\'" not in content:
+        return content
+
+    repaired_lines: list[str] = []
+    for line in content.splitlines(keepends=True):
+        if "\\'" not in line:
+            repaired_lines.append(line)
+            continue
+        repaired_lines.append(
+            _normalize_backslash_escaped_yaml_apostrophes_in_line(line)
+        )
+    return "".join(repaired_lines)
+
+
+def _normalize_backslash_escaped_yaml_apostrophes_in_line(line: str) -> str:
+    output: list[str] = []
+    quote: str | None = None
+    index = 0
+    while index < len(line):
+        char = line[index]
+        next_char = line[index + 1] if index + 1 < len(line) else ""
+        if quote is None:
+            if char in {"'", '"'}:
+                quote = char
+            output.append(char)
+            index += 1
+            continue
+
+        if quote == "'":
+            if char == "\\" and next_char == "'":
+                output.append("''")
+                index += 2
+                continue
+            if char == "'" and next_char == "'":
+                output.append("''")
+                index += 2
+                continue
+            if char == "'":
+                quote = None
+            output.append(char)
+            index += 1
+            continue
+
+        if char == "\\" and next_char == "'":
+            output.append("'")
+            index += 2
+            continue
+        if char == '"':
+            quote = None
+        output.append(char)
+        index += 1
+    return "".join(output)
 
 
 def _normalize_comma_numeric_literals(content: str) -> str:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -6867,7 +6867,17 @@ def _normalize_requested_source_to_corpus_path(requested_source: str) -> str:
     fails the input is returned unchanged so corpus-path inputs pass through.
     """
     candidate = requested_source.strip()
-    if not candidate or candidate.startswith(("us/", "us-")):
+    if not candidate:
+        return candidate
+    target_ref = _parse_rulespec_target(candidate)
+    if target_ref is not None:
+        target_parts = target_ref.relative_path.with_suffix("").parts
+        if len(target_parts) >= 3 and target_parts[0] == "statutes":
+            return "/".join((target_ref.prefix, "statute", *target_parts[1:]))
+        if len(target_parts) >= 4 and target_parts[0] == "regulations":
+            title = target_parts[1].removesuffix("-cfr")
+            return "/".join((target_ref.prefix, "regulation", title, *target_parts[2:]))
+    if candidate.startswith(("us/", "us-")):
         return candidate
     try:
         parts = parse_usc_citation(candidate)
@@ -6966,6 +6976,13 @@ def _source_subparagraph_citation_pattern(citation_path: str) -> re.Pattern[str]
             r"(?P<suffix>(?:\([A-Za-z0-9]+\))+)",
             flags=re.IGNORECASE,
         )
+    if len(parts) >= 4 and parts[0].startswith("us-") and parts[1] == "statute":
+        section = re.escape(parts[3])
+        return re.compile(
+            rf"(?<![\w.-])(?:{section}|C\.?\s*R\.?\s*S\.?\s*{section})"
+            r"(?P<suffix>(?:\([A-Za-z0-9]+\))+)",
+            flags=re.IGNORECASE,
+        )
     if len(parts) >= 5 and parts[:2] == ["us", "regulation"]:
         title = re.escape(parts[2])
         section = re.escape(f"{parts[3]}.{parts[4]}")
@@ -6979,7 +6996,11 @@ def _source_subparagraph_citation_pattern(citation_path: str) -> re.Pattern[str]
 
 def _rulespec_base_parts_for_corpus_path(citation_path: str) -> tuple[str, ...]:
     parts = citation_path.strip("/").split("/")
-    if len(parts) >= 4 and parts[:2] == ["us", "statute"]:
+    if (
+        len(parts) >= 4
+        and parts[1] == "statute"
+        and (parts[0] == "us" or parts[0].startswith("us-"))
+    ):
         return ("statutes", parts[2], parts[3])
     if len(parts) >= 5 and parts[:2] == ["us", "regulation"]:
         return ("regulations", f"{parts[2]}-cfr", parts[3], parts[4])
@@ -7005,6 +7026,8 @@ def _format_source_subparagraph_citation(citation_path: str, label: str) -> str:
     parts = citation_path.strip("/").split("/")
     if len(parts) >= 4 and parts[:2] == ["us", "statute"]:
         return f"{parts[2]} USC {parts[3]}({label})"
+    if len(parts) >= 4 and parts[0].startswith("us-") and parts[1] == "statute":
+        return f"{parts[3]}({label})"
     if len(parts) >= 5 and parts[:2] == ["us", "regulation"]:
         return f"{parts[2]} CFR {parts[3]}.{parts[4]}({label})"
     return f"{citation_path}({label})"

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -907,6 +907,62 @@ mappings:
     mapping_type: not_comparable
     rationale: This generated output is the statutory 4.55% base rate before applying later TABOR/form-rate reductions; PolicyEngine exposes the final Colorado form rate for each tax year.
 
+  - legal_id: us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_initial_phase
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.subtractions.military_retirement.max_amount
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado military-retirement subtraction cap for 2019, represented in PE as the date-varying max-amount parameter.
+
+  - legal_id: us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_second_phase
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.subtractions.military_retirement.max_amount
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado military-retirement subtraction cap for 2020, represented in PE as the date-varying max-amount parameter.
+
+  - legal_id: us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_third_phase
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.subtractions.military_retirement.max_amount
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado military-retirement subtraction cap for 2021, represented in PE as the date-varying max-amount parameter.
+
+  - legal_id: us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_final_phase
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.subtractions.military_retirement.max_amount
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado military-retirement subtraction cap for 2022 through 2028, represented in PE as the date-varying max-amount parameter.
+
+  - legal_id: us-co:statutes/39/39-22-104/4/y#qualified_individual_for_military_retirement_benefits_subtraction
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.co.tax.income.subtractions.military_retirement.age_threshold
+    candidate_priority: P4
+    rationale: This RuleSpec output is a person-level under-age-threshold predicate; PE stores the threshold parameter and uses it inside the tax-unit subtraction formula rather than exposing this predicate.
+
+  - legal_id: us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_subtraction
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_military_retirement_subtraction
+    candidate_priority: P4
+    rationale: This RuleSpec output is the person-level statutory subtraction amount; PE exposes a tax-unit aggregate limited to head and spouse military-retirement pay.
+
   - legal_id_prefix: us-ny:regulations/18-nycrr/387/14/a/1#
     country: us
     program: snap

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13303,6 +13303,87 @@ rules:
             "statutes/26/32.test.yaml",
         ]
 
+    def test_repair_oracle_parameter_tests_appends_scalar_parameter_case(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us-co"
+        target = policy_repo / "statutes/39/39-22-104/4/y.yaml"
+        test_file = policy_repo / "statutes/39/39-22-104/4/y.test.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+rules:
+  - name: military_retirement_benefits_cap_initial_phase
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2019-01-01'
+        formula: '4500'
+"""
+        )
+        test_file.write_text(
+            """- name: existing
+  output:
+    us-co:statutes/39/39-22-104/4/y#some_other_output: 1
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("statutes/39/39-22-104/4/y.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakeRegistry:
+            def mapping_for_legal_id(self, legal_id, *, country=None):
+                assert country == "us"
+                if (
+                    legal_id
+                    == "us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_initial_phase"
+                ):
+                    return SimpleNamespace(mapping_type="parameter_value")
+                return None
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli.load_policyengine_registry",
+                return_value=FakeRegistry(),
+            ),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures", return_value=[]
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_oracle_parameter_tests(args)
+
+        payload = yaml.safe_load(test_file.read_text())
+        added = payload[-1]
+        assert (
+            added["name"]
+            == "oracle_parameter_military_retirement_benefits_cap_initial_phase"
+        )
+        assert added["input"] == {}
+        assert added["output"] == {
+            "us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_initial_phase": 4500
+        }
+
     def test_repair_oracle_parameter_tests_does_not_mutate_without_signing_key(
         self, tmp_path
     ):

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3549,6 +3549,33 @@ class TestGeneratedBundleCleaning:
         assert "26.05 GBP" not in cleaned.split("formula:", 1)[1]
         assert "formula: 26.05" in cleaned
 
+    def test_clean_generated_file_content_repairs_yaml_apostrophe_escapes(self):
+        content = (
+            "format: rulespec/v1\n"
+            "module:\n"
+            '  summary: "Double quoted taxpayer\\\'s amount"\n'
+            "rules:\n"
+            "  - name: military_retirement_benefits_definition\n"
+            "    kind: derived\n"
+            "    metadata:\n"
+            "      proof:\n"
+            "        atoms:\n"
+            "          - source:\n"
+            "              excerpt: 'benefits received as a result of the individual\\'s service'\n"
+            "    versions:\n"
+            "      - effective_from: '2019-01-01'\n"
+            "        formula: benefit_amount\n"
+        )
+
+        cleaned = _clean_generated_file_content(content)
+        payload = yaml.safe_load(cleaned)
+
+        assert payload["module"]["summary"] == "Double quoted taxpayer's amount"
+        excerpt = payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"][
+            "excerpt"
+        ]
+        assert excerpt == "benefits received as a result of the individual's service"
+
     def test_materialize_eval_artifact_rejects_non_rulespec_bundle(self, tmp_path):
         output_file = tmp_path / "source" / "example.yaml"
         response = (

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -741,6 +741,93 @@ rules:
     assert {item["tested"] for item in report["items"]} == {True}
 
 
+def test_policyengine_coverage_classifies_colorado_military_retirement_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/4/y.yaml",
+        """format: rulespec/v1
+rules:
+  - name: military_retirement_benefits_cap_initial_phase
+    kind: parameter
+    versions:
+      - effective_from: '2019-01-01'
+        formula: '4500'
+  - name: military_retirement_benefits_cap_second_phase
+    kind: parameter
+    versions:
+      - effective_from: '2020-01-01'
+        formula: '7500'
+  - name: military_retirement_benefits_cap_third_phase
+    kind: parameter
+    versions:
+      - effective_from: '2021-01-01'
+        formula: '10000'
+  - name: military_retirement_benefits_cap_final_phase
+    kind: parameter
+    versions:
+      - effective_from: '2022-01-01'
+        formula: '15000'
+  - name: qualified_individual_for_military_retirement_benefits_subtraction
+    kind: derived
+    versions:
+      - effective_from: '2019-01-01'
+        formula: individual_under_fifty_five_at_close_of_taxable_year
+  - name: military_retirement_benefits_subtraction
+    kind: derived
+    versions:
+      - effective_from: '2019-01-01'
+        formula: military_retirement_benefits
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/4/y.test.yaml",
+        """- name: military retirement cap outputs
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  output:
+    us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_initial_phase: 4500
+    us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_second_phase: 7500
+    us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_third_phase: 10000
+    us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_final_phase: 15000
+    us-co:statutes/39/39-22-104/4/y#qualified_individual_for_military_retirement_benefits_subtraction: holds
+    us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_subtraction: 15000
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {
+        "comparable": 4,
+        "known_not_comparable": 2,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    initial_cap = items_by_id[
+        "us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_initial_phase"
+    ]
+    subtraction = items_by_id[
+        "us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_subtraction"
+    ]
+    age_predicate = items_by_id[
+        "us-co:statutes/39/39-22-104/4/y#qualified_individual_for_military_retirement_benefits_subtraction"
+    ]
+    assert (
+        initial_cap["policyengine_parameter"]
+        == "gov.states.co.tax.income.subtractions.military_retirement.max_amount"
+    )
+    assert initial_cap["tested"] is True
+    assert subtraction["status"] == "known_not_comparable"
+    assert subtraction["policyengine_variable"] == "co_military_retirement_subtraction"
+    assert age_predicate["status"] == "known_not_comparable"
+    assert (
+        age_predicate["policyengine_parameter"]
+        == "gov.states.co.tax.income.subtractions.military_retirement.age_threshold"
+    )
+
+
 def test_policyengine_coverage_classifies_3102a_collection_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3102/a.yaml",

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -12518,6 +12518,73 @@ rules:
     )
 
 
+def test_source_subparagraph_coverage_scopes_state_statute_file_path(tmp_path):
+    source_text = """Modifications to federal taxable income
+(4) Subtractions from federal taxable income.
+    (y) Military retirement benefits may be subtracted subject to stated dollar limits.
+(f) Pensions or annuities from federal adjusted gross income may be subtracted.
+"""
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-co/statute/39/39-22-104
+rules:
+  - name: military_retirement_benefits_subtraction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    source: 39-22-104(4)(y)(I)
+    versions:
+      - effective_from: '2019-01-01'
+        formula: military_retirement_benefits
+"""
+    rules_file = (
+        tmp_path / "rulespec-us-co" / "statutes" / "39" / "39-22-104" / "4" / "y.yaml"
+    )
+
+    assert (
+        find_source_subparagraph_coverage_issues(
+            content,
+            rules_file=rules_file,
+            source_texts={"us-co/statute/39/39-22-104": source_text},
+        )
+        == []
+    )
+
+
+def test_source_subparagraph_coverage_accepts_state_rulespec_target_requested_source():
+    source_text = """Modifications to federal taxable income
+(4) Subtractions from federal taxable income.
+    (y) Military retirement benefits may be subtracted subject to stated dollar limits.
+(f) Pensions or annuities from federal adjusted gross income may be subtracted.
+"""
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-co/statute/39/39-22-104
+rules:
+  - name: military_retirement_benefits_subtraction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    source: 39-22-104(4)(y)(I)
+    versions:
+      - effective_from: '2019-01-01'
+        formula: military_retirement_benefits
+"""
+
+    assert (
+        find_source_subparagraph_coverage_issues(
+            content,
+            source_texts={"us-co/statute/39/39-22-104": source_text},
+            requested_source="us-co:statutes/39/39-22-104/4/y",
+        )
+        == []
+    )
+
+
 def test_source_subparagraph_coverage_scopes_to_requested_source_under_parent_fallback(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.412"
+version = "0.2.413"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary\n- repair backslash-escaped apostrophes in generated YAML before parsing\n- let oracle parameter test repair add scalar parameter cases as well as indexed tables\n- add PolicyEngine mappings for Colorado military retirement caps and non-comparable outputs\n- scope source subparagraph validation for state statute paths and RuleSpec-target requested sources\n\n## Tests\n- uv run --extra dev ruff check src/axiom_encode/cli.py src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_evals.py tests/test_policyengine_coverage.py tests/test_rulespec_validation.py pyproject.toml src/axiom_encode/__init__.py\n- uv run --extra dev python -m pytest tests/test_cli.py tests/test_evals.py tests/test_policyengine_coverage.py tests/test_rulespec_validation.py -k 'repair_oracle_parameter_tests or clean_generated_file_content_repairs_yaml_apostrophe_escapes or colorado_military_retirement or colorado_income_tax_rate or colorado_1999_income_tax or colorado_base_rates or source_subparagraph_coverage_scopes_state_statute_file_path or source_subparagraph_coverage_accepts_state_rulespec_target_requested_source or source_subparagraph_coverage_scopes_nested_rulespec_file_path or source_subparagraph_coverage_uses_applied_manifest_requested_source'\n- uv run --extra dev axiom-encode validate /Users/maxghenis/_axiom-worktrees/colorado-military-retirement-20260529/rulespec-us-co/statutes/39/39-22-104/4/y.yaml --skip-reviewers