### PR TITLE
Repair generated test periods and map CO pension outputs

### DIFF
--- a/changelog.d/scalar-parameter-test-periods.fixed.md
+++ b/changelog.d/scalar-parameter-test-periods.fixed.md
@@ -1,0 +1,1 @@
+Repair apply-time generated companion tests that assert scalar parameters or outputs before the RuleSpec output has a live version, and classify Colorado pension-subtraction outputs for PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.414"
+version = "0.2.415"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.414"
+__version__ = "0.2.415"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -27,6 +27,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from calendar import monthrange
 from collections import Counter, defaultdict
 from dataclasses import asdict, is_dataclass
 from datetime import date, datetime, timezone
@@ -17978,6 +17979,24 @@ def _validate_generated_encoding_in_policy_overlay(
                     dependents=dependents,
                 )
                 continue
+            future_effective_repairs = _repair_future_effective_output_tests(
+                rules_file=overlay_target,
+                test_file=_rulespec_test_path(overlay_target),
+                repo_path=overlay_repo,
+                relative_output=relative_output,
+            )
+            if future_effective_repairs:
+                test_path = _rulespec_test_path(overlay_target)
+                supplemental_files[test_path.relative_to(overlay_repo)] = (
+                    test_path.read_text()
+                )
+                validations = _validate_overlay_files(
+                    pipeline,
+                    dependent_pipeline=dependent_pipeline,
+                    overlay_target=overlay_target,
+                    dependents=dependents,
+                )
+                continue
             mixed_derived_entity_repairs = _repair_mixed_derived_entity_output_tests(
                 rules_file=overlay_target,
                 test_file=_rulespec_test_path(overlay_target),
@@ -18950,12 +18969,25 @@ def _repair_mixed_scalar_output_tests(
             if str(key) in scalar_outputs
         }
         if not scalar_items or len(scalar_items) == len(output):
+            repaired_case = case
+            if scalar_items:
+                repaired_case = _repair_scalar_parameter_case_period(
+                    case=case,
+                    scalar_output_keys={str(key) for key in scalar_items},
+                    scalar_parameter_rules=scalar_parameter_rules,
+                )
             if dropped_fractional_parameter_outputs:
-                repaired_case = dict(case)
+                repaired_case = dict(repaired_case)
                 repaired_case["output"] = output
+                repaired_cases.append(repaired_case)
+            elif repaired_case is not case:
                 repaired_cases.append(repaired_case)
             else:
                 repaired_cases.append(case)
+            if repaired_case is not case:
+                case_name = str(case.get("name") or "case").strip() or "case"
+                if case_name not in repaired_names:
+                    repaired_names.append(case_name)
             continue
 
         entity_items = {
@@ -18979,6 +19011,11 @@ def _repair_mixed_scalar_output_tests(
             "input": copy.deepcopy(case.get("input", {})),
             "output": scalar_items,
         }
+        scalar_case = _repair_scalar_parameter_case_period(
+            case=scalar_case,
+            scalar_output_keys={str(key) for key in scalar_items},
+            scalar_parameter_rules=scalar_parameter_rules,
+        )
         repaired_cases.append(scalar_case)
         if case_name not in repaired_names:
             repaired_names.append(case_name)
@@ -18987,6 +19024,221 @@ def _repair_mixed_scalar_output_tests(
         return []
     test_file.write_text(yaml.safe_dump(repaired_cases, sort_keys=False))
     return repaired_names
+
+
+def _repair_scalar_parameter_case_period(
+    *,
+    case: dict[str, Any],
+    scalar_output_keys: set[str],
+    scalar_parameter_rules: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    effective_date = _latest_earliest_parameter_effective_date(
+        scalar_output_keys=scalar_output_keys,
+        scalar_parameter_rules=scalar_parameter_rules,
+    )
+    if effective_date is None:
+        return case
+    period = case.get("period")
+    period_start = _test_period_start_date(period)
+    if period_start is not None and period_start >= effective_date:
+        return case
+    repaired_case = dict(case)
+    repaired_case["period"] = _test_period_on_or_after(period, effective_date)
+    return repaired_case
+
+
+def _repair_future_effective_output_tests(
+    *,
+    rules_file: Path,
+    test_file: Path,
+    repo_path: Path,
+    relative_output: Path,
+) -> list[str]:
+    """Move output assertions out of periods before the output is effective."""
+    if not test_file.exists():
+        return []
+    try:
+        rules_document = yaml.safe_load(rules_file.read_text()) or {}
+        test_cases = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(rules_document, dict) or not isinstance(test_cases, list):
+        return []
+
+    target_base = (
+        f"{_repo_jurisdiction_prefix(repo_path)}:"
+        f"{_relative_rulespec_import_target(relative_output)}"
+    )
+    output_rules: dict[str, dict[str, Any]] = {}
+    for rule in rules_document.get("rules") or []:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() not in {
+            "parameter",
+            "derived",
+        }:
+            continue
+        for key in _local_rulespec_output_keys(
+            rule,
+            target_base=target_base,
+            repo_path=repo_path,
+        ):
+            output_rules[key] = rule
+    if not output_rules:
+        return []
+
+    repaired_cases: list[object] = []
+    repaired_names: list[str] = []
+    existing_names = {
+        str(case.get("name") or "") for case in test_cases if isinstance(case, dict)
+    }
+    for case in test_cases:
+        if not isinstance(case, dict):
+            repaired_cases.append(case)
+            continue
+        output = case.get("output")
+        if not isinstance(output, dict) or not output:
+            repaired_cases.append(case)
+            continue
+        period_start = _test_period_start_date(case.get("period"))
+        current_items: dict[Any, Any] = {}
+        future_items: dict[Any, Any] = {}
+        future_dates: list[date] = []
+        for key, value in output.items():
+            effective_date = _earliest_rule_effective_date(output_rules.get(str(key)))
+            if effective_date is not None and (
+                period_start is None or period_start < effective_date
+            ):
+                future_items[key] = value
+                future_dates.append(effective_date)
+            else:
+                current_items[key] = value
+        if not future_items or not future_dates:
+            repaired_cases.append(case)
+            continue
+
+        case_name = str(case.get("name") or "case").strip() or "case"
+        effective_period = _test_period_on_or_after(
+            case.get("period"),
+            max(future_dates),
+        )
+        if current_items:
+            current_case = dict(case)
+            current_case["output"] = current_items
+            repaired_cases.append(current_case)
+
+            future_case_name = _unique_test_case_name(
+                f"{case_name}_effective_outputs",
+                existing_names,
+            )
+            existing_names.add(future_case_name)
+            future_case = dict(case)
+            future_case["name"] = future_case_name
+            future_case["period"] = effective_period
+            future_case["input"] = copy.deepcopy(case.get("input", {}))
+            future_case["output"] = future_items
+            repaired_cases.append(future_case)
+        else:
+            repaired_case = dict(case)
+            repaired_case["period"] = effective_period
+            repaired_cases.append(repaired_case)
+        if case_name not in repaired_names:
+            repaired_names.append(case_name)
+
+    if not repaired_names:
+        return []
+    test_file.write_text(yaml.safe_dump(repaired_cases, sort_keys=False))
+    return repaired_names
+
+
+def _latest_earliest_parameter_effective_date(
+    *,
+    scalar_output_keys: set[str],
+    scalar_parameter_rules: dict[str, dict[str, Any]],
+) -> date | None:
+    effective_dates: list[date] = []
+    for output_key in scalar_output_keys:
+        rule = scalar_parameter_rules.get(output_key)
+        if not isinstance(rule, dict):
+            continue
+        rule_dates: list[date] = []
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            parsed = _parse_iso_date(version.get("effective_from"))
+            if parsed is not None:
+                rule_dates.append(parsed)
+        if rule_dates:
+            effective_dates.append(min(rule_dates))
+    return max(effective_dates) if effective_dates else None
+
+
+def _earliest_rule_effective_date(rule: dict[str, Any] | None) -> date | None:
+    if not isinstance(rule, dict):
+        return None
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return None
+    dates = [
+        parsed
+        for version in versions
+        if isinstance(version, dict)
+        for parsed in [_parse_iso_date(version.get("effective_from"))]
+        if parsed is not None
+    ]
+    return min(dates) if dates else None
+
+
+def _parse_iso_date(value: Any) -> date | None:
+    try:
+        return date.fromisoformat(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _test_period_start_date(period: Any) -> date | None:
+    if isinstance(period, dict):
+        return _parse_iso_date(period.get("start"))
+    if isinstance(period, int):
+        return date(period, 1, 1)
+    if isinstance(period, str):
+        stripped = period.strip()
+        if re.fullmatch(r"\d{4}", stripped):
+            return date(int(stripped), 1, 1)
+        if re.fullmatch(r"\d{4}-\d{2}", stripped):
+            return date(int(stripped[:4]), int(stripped[5:]), 1)
+        return _parse_iso_date(stripped)
+    if isinstance(period, date):
+        return period
+    return None
+
+
+def _test_period_on_or_after(period: Any, effective_date: date) -> Any:
+    if isinstance(period, dict):
+        repaired = copy.deepcopy(period)
+        period_kind = str(repaired.get("period_kind") or "").lower()
+        if period_kind == "month":
+            start = date(effective_date.year, effective_date.month, 1)
+            end = date(
+                effective_date.year,
+                effective_date.month,
+                monthrange(effective_date.year, effective_date.month)[1],
+            )
+        elif period_kind == "tax_year":
+            start = effective_date
+            end = date(effective_date.year, 12, 31)
+        else:
+            start = effective_date
+            end = effective_date
+        repaired["start"] = start.isoformat()
+        repaired["end"] = end.isoformat()
+        return repaired
+    if isinstance(period, str) and re.fullmatch(r"\d{4}-\d{2}", period.strip()):
+        return effective_date.strftime("%Y-%m")
+    return effective_date.isoformat()
 
 
 def _repair_missing_entity_table_rows_for_row_ordered_outputs(

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -907,6 +907,64 @@ mappings:
     mapping_type: not_comparable
     rationale: This generated output is the statutory 4.55% base rate before applying later TABOR/form-rate reductions; PolicyEngine exposes the final Colorado form rate for each tax year.
 
+  - legal_id: us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction_cap_for_age_fifty_five_to_sixty_four
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.subtractions.pension.cap.younger
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same base $20,000 Colorado pension and annuity subtraction cap for individuals age 55 to 64, stored in PE as the younger pension cap.
+
+  - legal_id: us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction_cap_for_age_sixty_five_or_older
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.subtractions.pension.cap.older
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same $24,000 Colorado pension and annuity subtraction cap for individuals age 65 or older, stored in PE as the older pension cap.
+
+  - legal_id: us-co:statutes/39/39-22-104/4/f#individual_filing_agi_limit_for_age_fifty_five_to_sixty_four_social_security_cap_increase
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P2
+    rationale: PolicyEngine-US does not currently expose or implement the 2025 individual-filer AGI threshold for the age 55-64 Social Security cap increase; tracked in PolicyEngine/policyengine-us#8541.
+
+  - legal_id: us-co:statutes/39/39-22-104/4/f#joint_filing_agi_limit_for_age_fifty_five_to_sixty_four_social_security_cap_increase
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    candidate_priority: P2
+    rationale: PolicyEngine-US does not currently expose or implement the 2025 joint-filer AGI threshold for the age 55-64 Social Security cap increase; tracked in PolicyEngine/policyengine-us#8541.
+
+  - legal_id: us-co:statutes/39/39-22-104/4/f#individual_qualifies_for_pension_annuity_subtraction
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_pension_subtraction_indv_eligible
+    candidate_priority: P2
+    rationale: This RuleSpec predicate captures the statutory age-or-death-benefit qualification; PE's similarly named eligibility variable only limits the claim to the tax-unit head or spouse and leaves age and survivor logic inside amount formulas.
+
+  - legal_id: us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction_applicable_cap
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_pension_subtraction_indv
+    candidate_priority: P2
+    rationale: This RuleSpec output is the person-level statutory cap after Social Security cap-increase rules; PE computes separate Social Security and pension components and does not expose this combined cap boundary.
+
+  - legal_id: us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_pension_subtraction
+    candidate_priority: P2
+    rationale: This RuleSpec output is the person-level subsection (4)(f) subtraction including pension and Social Security benefit treatment; PE exposes a tax-unit aggregate split across pension and Social Security component variables and is missing the 2025 age 55-64 AGI-limited Social Security cap increase tracked in PolicyEngine/policyengine-us#8541.
+
   - legal_id: us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_initial_phase
     country: us
     program: tax
@@ -12832,4 +12890,3 @@ prefixes:
     program: snap
     mapping_type: not_comparable
     rationale: Florida DCF SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,6 +49,7 @@ from axiom_encode.cli import (
     _repair_colorado_snap_2072_tests,
     _repair_colorado_snap_program_tests,
     _repair_employer_scoped_entities,
+    _repair_future_effective_output_tests,
     _repair_generated_import_symbol_near_misses,
     _repair_generated_unused_imports_for_apply,
     _repair_imported_rule_name_collisions,
@@ -7384,6 +7385,141 @@ rules:
         )
         assert cases[1]["output"] == {
             "us:statutes/26/3121/a/7#cash_nontrade_service_annual_threshold": 100
+        }
+
+    def test_mixed_scalar_output_test_repair_moves_scalar_case_to_effective_period(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us-co"
+        rules_file = policy_repo / "statutes/39/39-22-104/4/f.yaml"
+        test_file = policy_repo / "statutes/39/39-22-104/4/f.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: social_security_cap_increase_individual_agi_threshold
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2025-01-01'
+        formula: '75000'
+  - name: pension_annuity_subtraction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1989-01-01'
+        formula: min(pension, social_security_cap_increase_individual_agi_threshold)
+"""
+        )
+        test_file.write_text(
+            """- name: age_fifty_five_to_sixty_four_pension_subtraction_is_capped
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-co:statutes/39/39-22-104/4/f#input.pension: 30000
+  output:
+    us-co:statutes/39/39-22-104/4/f#social_security_cap_increase_individual_agi_threshold: 75000
+    us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction: 30000
+"""
+        )
+
+        repaired = _repair_mixed_scalar_output_tests(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=policy_repo,
+            relative_output=Path("statutes/39/39-22-104/4/f.yaml"),
+        )
+
+        cases = yaml.safe_load(test_file.read_text())
+        assert repaired == [
+            "age_fifty_five_to_sixty_four_pension_subtraction_is_capped"
+        ]
+        assert cases[0]["period"]["start"] == "2024-01-01"
+        assert cases[0]["output"] == {
+            "us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction": 30000
+        }
+        assert cases[1]["name"] == (
+            "age_fifty_five_to_sixty_four_pension_subtraction_is_capped_scalar_outputs"
+        )
+        assert cases[1]["period"] == {
+            "period_kind": "tax_year",
+            "start": "2025-01-01",
+            "end": "2025-12-31",
+        }
+        assert cases[1]["output"] == {
+            "us-co:statutes/39/39-22-104/4/f#social_security_cap_increase_individual_agi_threshold": 75000
+        }
+
+    def test_future_effective_output_test_repair_splits_mixed_period_outputs(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us-co"
+        rules_file = policy_repo / "statutes/39/39-22-104/4/f.yaml"
+        test_file = policy_repo / "statutes/39/39-22-104/4/f.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: adjusted_gross_income_within_social_security_cap_limit
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2025-01-01'
+        formula: adjusted_gross_income <= 75000
+  - name: pension_annuity_subtraction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1989-01-01'
+        formula: min(pension, 20000)
+"""
+        )
+        test_file.write_text(
+            """- name: basic_cap_limits_subtraction
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input:
+    us-co:statutes/39/39-22-104/4/f#input.adjusted_gross_income: 70000
+    us-co:statutes/39/39-22-104/4/f#input.pension: 30000
+  output:
+    us-co:statutes/39/39-22-104/4/f#adjusted_gross_income_within_social_security_cap_limit: holds
+    us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction: 20000
+"""
+        )
+
+        repaired = _repair_future_effective_output_tests(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=policy_repo,
+            relative_output=Path("statutes/39/39-22-104/4/f.yaml"),
+        )
+
+        cases = yaml.safe_load(test_file.read_text())
+        assert repaired == ["basic_cap_limits_subtraction"]
+        assert cases[0]["name"] == "basic_cap_limits_subtraction"
+        assert cases[0]["period"]["start"] == "2024-01-01"
+        assert cases[0]["output"] == {
+            "us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction": 20000
+        }
+        assert cases[1]["name"] == "basic_cap_limits_subtraction_effective_outputs"
+        assert cases[1]["period"] == {
+            "period_kind": "tax_year",
+            "start": "2025-01-01",
+            "end": "2025-12-31",
+        }
+        assert cases[1]["output"] == {
+            "us-co:statutes/39/39-22-104/4/f#adjusted_gross_income_within_social_security_cap_limit": "holds"
         }
 
     def test_mixed_scalar_output_test_repair_drops_nonterminating_fraction_parameter(

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -828,6 +828,100 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_colorado_pension_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/4/f.yaml",
+        """format: rulespec/v1
+rules:
+  - name: pension_annuity_subtraction_cap_for_age_fifty_five_to_sixty_four
+    kind: parameter
+    versions:
+      - effective_from: '1989-01-01'
+        formula: '20000'
+  - name: pension_annuity_subtraction_cap_for_age_sixty_five_or_older
+    kind: parameter
+    versions:
+      - effective_from: '1989-01-01'
+        formula: '24000'
+  - name: individual_filing_agi_limit_for_age_fifty_five_to_sixty_four_social_security_cap_increase
+    kind: parameter
+    versions:
+      - effective_from: '2025-01-01'
+        formula: '75000'
+  - name: joint_filing_agi_limit_for_age_fifty_five_to_sixty_four_social_security_cap_increase
+    kind: parameter
+    versions:
+      - effective_from: '2025-01-01'
+        formula: '95000'
+  - name: individual_qualifies_for_pension_annuity_subtraction
+    kind: derived
+    versions:
+      - effective_from: '1989-01-01'
+        formula: individual_is_fifty_five_or_older
+  - name: pension_annuity_subtraction_applicable_cap
+    kind: derived
+    versions:
+      - effective_from: '1989-01-01'
+        formula: pension_annuity_subtraction_cap_for_age_fifty_five_to_sixty_four
+  - name: pension_annuity_subtraction
+    kind: derived
+    versions:
+      - effective_from: '1989-01-01'
+        formula: pension_annuity_subtraction_applicable_cap
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/4/f.test.yaml",
+        """- name: pension outputs
+  period:
+    period_kind: tax_year
+    start: '2025-01-01'
+    end: '2025-12-31'
+  input: {}
+  output:
+    us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction_cap_for_age_fifty_five_to_sixty_four: 20000
+    us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction_cap_for_age_sixty_five_or_older: 24000
+    us-co:statutes/39/39-22-104/4/f#individual_filing_agi_limit_for_age_fifty_five_to_sixty_four_social_security_cap_increase: 75000
+    us-co:statutes/39/39-22-104/4/f#joint_filing_agi_limit_for_age_fifty_five_to_sixty_four_social_security_cap_increase: 95000
+    us-co:statutes/39/39-22-104/4/f#individual_qualifies_for_pension_annuity_subtraction: holds
+    us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction_applicable_cap: 20000
+    us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction: 20000
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {
+        "comparable": 2,
+        "known_not_comparable": 5,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    younger_cap = items_by_id[
+        "us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction_cap_for_age_fifty_five_to_sixty_four"
+    ]
+    older_cap = items_by_id[
+        "us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction_cap_for_age_sixty_five_or_older"
+    ]
+    individual_agi_limit = items_by_id[
+        "us-co:statutes/39/39-22-104/4/f#individual_filing_agi_limit_for_age_fifty_five_to_sixty_four_social_security_cap_increase"
+    ]
+    subtraction = items_by_id[
+        "us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction"
+    ]
+    assert (
+        younger_cap["policyengine_parameter"]
+        == "gov.states.co.tax.income.subtractions.pension.cap.younger"
+    )
+    assert (
+        older_cap["policyengine_parameter"]
+        == "gov.states.co.tax.income.subtractions.pension.cap.older"
+    )
+    assert individual_agi_limit["status"] == "known_not_comparable"
+    assert individual_agi_limit["program"] == "tax"
+    assert subtraction["status"] == "known_not_comparable"
+    assert subtraction["policyengine_variable"] == "co_pension_subtraction"
+
+
 def test_policyengine_coverage_classifies_3102a_collection_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3102/a.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.414"
+version = "0.2.415"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Summary:
- move generated scalar-parameter companion assertions to periods where the parameter has a live version
- split generated test cases when future-effective outputs are asserted alongside currently effective outputs
- classify Colorado pension-subtraction outputs against the PolicyEngine oracle, including PE gap #8541 for the 2025 age 55-64 Social Security cap increase
- bump axiom-encode provenance to 0.2.415

Tests:
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run pytest tests/test_cli.py -k 'version or mixed_scalar_output_test_repair or future_effective_output_test_repair'\n- uv run pytest tests/test_policyengine_coverage.py -k 'colorado_pension_outputs or colorado_military_retirement_outputs'\n- uv run towncrier build --draft --version 0.0.0