### PR TITLE
Pattern-based SNAP oracle classifier (replaces bulk state prefixes)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.413"
+version = "0.2.414"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.414"
+version = "0.2.415"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.414"
+__version__ = "0.2.415"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.413"
+__version__ = "0.2.414"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -12629,3 +12629,207 @@ prefixes:
     program: snap
     mapping_type: not_comparable
     rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
+  - legal_id_prefix: us-nc:regulations/10a-ncac/71u/0210/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: North Carolina DSS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-nc:regulations/10a-ncac/71u/0212/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: North Carolina DSS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-nc:regulations/10a-ncac/71u/0215/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: North Carolina DSS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-nc:regulations/10a-ncac/71u/0302/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: North Carolina DSS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/03/05/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/03/10/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/03/13/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/03/15/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/03/44/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/03/46/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/04/01/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/04/03/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/04/05/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/04/07/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/04/09/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/04/15/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/04/16/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/04/17/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/04/18/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/04/24/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/04/27/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/08/01/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/12/06/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/14/04/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/14/09/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/14/11/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-tn:regulations/1240-01/14/14/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-fl:regulations/fac/65a-1/205/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Florida DCF SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-fl:regulations/fac/65a-1/400/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Florida DCF SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-fl:regulations/fac/65a-1/703/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Florida DCF SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-fl:regulations/fac/65a-1/711/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Florida DCF SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-fl:regulations/fac/65a-1/7141/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Florida DCF SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-fl:regulations/fac/65a-1/803/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Florida DCF SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+
+  - legal_id_prefix: us-fl:regulations/fac/65a-1/900/block-1#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Florida DCF SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
+

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -5759,7 +5759,6 @@ mappings:
     comparison: money
     rationale: Same final Net Investment Income Tax for PE-supported individual cases.
 
-
   # === California CalFresh MPP §63 bulk encoding (auto-generated) ===
   - legal_id: us-ca:regulations/mpp/63-300/1#application_process_completed
     country: us
@@ -10084,6 +10083,2719 @@ mappings:
     comparison: rate
     rationale: Same statutory percentage of adjusted gross income that floors deductible medical-care expenses.
 
+  - legal_id: us-ma:regulations/106-cmr/360/030/block-1#max_days_temporary_accommodation_in_other_residence
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `max_days_temporary_accommodation_in_other_residence`); grounded against 106 CMR 360.030 (Homeless Individual)(3). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/360/030/block-1#individual_is_homeless
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `individual_is_homeless`); grounded against 106 CMR 360.030 (Homeless Individual). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/360/030/block-1#event_is_household_disaster
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `event_is_household_disaster`); grounded against 106 CMR 360.030 (Household Disaster). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/360/030/block-1#event_is_household_misfortune
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `event_is_household_misfortune`); grounded against 106 CMR 360.030 (Household Misfortune). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/360/030/block-1#program_is_means_tested
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `program_is_means_tested`); grounded against 106 CMR 360.030 (Means-tested Program). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/360/100/block-1#cooking_facilities_required_for_snap
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `cooking_facilities_required_for_snap`); grounded against 106 CMR 360.100. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/360/250/block-1#condition_qualifies_as_disability
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `condition_qualifies_as_disability`); grounded against 106 CMR 360.250 (block 1) - Disability exclusion. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/360/250/block-1#is_qualified_individual
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `is_qualified_individual`); grounded against 106 CMR 360.250 (block 1) - Qualified individual exclusions. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/360/600/block-1#household_ineligible_for_snap_due_to_quality_control_noncooperation
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_ineligible_for_snap_due_to_quality_control_noncooperation`); grounded against 106 CMR 360.600. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/360/950/block-1#voter_registration_transmittal_deadline_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `voter_registration_transmittal_deadline_days`); grounded against 106 CMR 360.950. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/360/950/block-1#voter_registration_minimum_age
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `voter_registration_minimum_age`); grounded against 106 CMR 360.950. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/360/950/block-1#voter_registration_form_available_to_person
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `voter_registration_form_available_to_person`); grounded against 106 CMR 360.950. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/080/block-1#snap_application_processing_standard_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_application_processing_standard_days`); grounded against 106 CMR 361.080. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/080/block-1#snap_opportunity_to_participate_timely
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_opportunity_to_participate_timely`); grounded against 106 CMR 361.080. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/080/block-1#snap_benefits_retroactive_to_application_date
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_benefits_retroactive_to_application_date`); grounded against 106 CMR 361.080. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/100/block-1#snap_application_is_identifiable
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_application_is_identifiable`); grounded against 106 CMR 361.100 (block-1). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/120/block-1#ssi_only_household_applying_at_ssa_office
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ssi_only_household_applying_at_ssa_office`); grounded against 106 CMR 361.120 (first paragraph). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/120/block-1#application_date_is_ssa_receipt_date
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `application_date_is_ssa_receipt_date`); grounded against 106 CMR 361.120 (first paragraph). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/120/block-1#application_date_advances_to_next_business_day
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `application_date_advances_to_next_business_day`); grounded against 106 CMR 361.120 (second paragraph). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/120/block-1#application_date_is_department_receipt_date
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `application_date_is_department_receipt_date`); grounded against 106 CMR 361.120 (second paragraph). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/160/block-1#simultaneous_snap_application_allowed
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `simultaneous_snap_application_allowed`); grounded against 106 CMR 361.160. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/160/block-1#snap_eligibility_based_solely_on_snap_criteria
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_eligibility_based_solely_on_snap_criteria`); grounded against 106 CMR 361.160. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/160/block-1#snap_certified_under_snap_processing_standards
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_certified_under_snap_processing_standards`); grounded against 106 CMR 361.160. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/190/block-1#ssi_household_categorically_eligible_for_snap
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ssi_household_categorically_eligible_for_snap`); grounded against 106 CMR 361.190. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/190/block-1#ssi_household_not_subject_to_additional_interview_at_department
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ssi_household_not_subject_to_additional_interview_at_department`); grounded against 106 CMR 361.190. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/200/block-1#parental_control_age_limit
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `parental_control_age_limit`); grounded against 106 CMR 361.200 - Parental control definition. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/200/block-1#child_age_limit_for_same_household
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `child_age_limit_for_same_household`); grounded against 106 CMR 361.200 - same household rule for elderly/disabled. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/200/block-1#parental_control_child_age_limit
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `parental_control_child_age_limit`); grounded against 106 CMR 361.200 - children under parental control. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/200/block-1#is_spouse
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `is_spouse`); grounded against 106 CMR 361.200 - Spouse definition. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/200/block-1#has_parental_control_over_individual
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `has_parental_control_over_individual`); grounded against 106 CMR 361.200 - Parental control definition. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/200/block-1#disability_verification_required
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `disability_verification_required`); grounded against 106 CMR 361.200 - Disability verification requirement. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/200/block-1#disability_verification_is_sufficient
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `disability_verification_is_sufficient`); grounded against 106 CMR 361.200 - Physician statement requirement. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/200/block-1#person_is_unable_to_purchase_food_and_prepare_meals
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_is_unable_to_purchase_food_and_prepare_meals`); grounded against 106 CMR 361.200 - Disabled individuals meeting definition deemed unable. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/200/block-1#elderly_and_disabled_individual_must_be_in_same_household
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `elderly_and_disabled_individual_must_be_in_same_household`); grounded against 106 CMR 361.200(A) - Same household requirement for elderly/disabled. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/210/block-1#special_treatment_maximum_asset_limit
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `special_treatment_maximum_asset_limit`); grounded against 106 CMR 361.210. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/210/block-1#special_treatment_entitled
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `special_treatment_entitled`); grounded against 106 CMR 361.210. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/220/block-1#person_eligible_as_head_of_household
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_eligible_as_head_of_household`); grounded against 106 CMR 361.220 - \"head of household may be any adult member of the household, except that if there is a minor child, the head of household must be an adult who has parental control of the child\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/220/block-1#head_of_household_change_allowed_during_certification_period
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `head_of_household_change_allowed_during_certification_period`); grounded against 106 CMR 361.220 - \"It may not change the designation during a certification period unless there is a change in the household composition, including a change due to death or institutionalization of a household member.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/220/block-1#household_may_select_head_of_household
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_may_select_head_of_household`); grounded against 106 CMR 361.220 - \"The household may select its head of household at initial certification and at each subsequent recertification.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/240/block-1#individual_paying_less_than_reasonable_compensation_not_boarder_and_household_member
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `individual_paying_less_than_reasonable_compensation_not_boarder_and_household_member`); grounded against 106 CMR 361.240, less-than-reasonable-compensation individuals. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/240/block-1#boarder_separate_participation_ineligible
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `boarder_separate_participation_ineligible`); grounded against 106 CMR 361.240, boarder separate participation. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/240/block-1#boarder_member_participation_allowed_at_providing_household_request
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `boarder_member_participation_allowed_at_providing_household_request`); grounded against 106 CMR 361.240, boarder participation as household member. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/240/block-1#unrequested_boarder_income_and_resources_unavailable_to_providing_household
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `unrequested_boarder_income_and_resources_unavailable_to_providing_household`); grounded against 106 CMR 361.240, unrequested boarder income and resources. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/240/block-1#unrequested_boarder_payment_treatment_under_365_200_applies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `unrequested_boarder_payment_treatment_under_365_200_applies`); grounded against 106 CMR 361.240, boarder payment cross-reference. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/240/block-1#foster_care_person_included_in_snap_household_by_household_option
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `foster_care_person_included_in_snap_household_by_household_option`); grounded against 106 CMR 361.240, foster care household option. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/240/block-1#included_foster_care_payments_counted_as_unearned_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `included_foster_care_payments_counted_as_unearned_income`); grounded against 106 CMR 361.240, foster care payments as unearned income. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/310/block-1#non_household_member_adult_may_be_authorized_representative_for_minors
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `non_household_member_adult_may_be_authorized_representative_for_minors`); grounded against 106 CMR 361.310 (block 1, exception). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/330/block-1#authorized_representative_may_purchase_food
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `authorized_representative_may_purchase_food`); grounded against 106 CMR 361.330 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/350/block-1#designated_employee_may_act_as_authorized_representative
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `designated_employee_may_act_as_authorized_representative`); grounded against 106 CMR 361.350. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/400/block-1#household_refuses_to_cooperate
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_refuses_to_cooperate`); grounded against 106 CMR 361.400 - refusal determination. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/400/block-1#application_denied_for_refusal_to_cooperate
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `application_denied_for_refusal_to_cooperate`); grounded against 106 CMR 361.400 - denial at time of refusal. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/400/block-1#household_ineligible_for_refusal_in_subsequent_review
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_ineligible_for_refusal_in_subsequent_review`); grounded against 106 CMR 361.400 - subsequent review refusal. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/400/block-1#reapplication_ineligible_until_cooperates
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `reapplication_ineligible_until_cooperates`); grounded against 106 CMR 361.400 - reapplication after denial or termination for refusal. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/500/block-1#interview_required
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `interview_required`); grounded against 106 CMR 361.500. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/500/block-1#face_to_face_interview_required
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `face_to_face_interview_required`); grounded against 106 CMR 361.500. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/520/block-1#household_subject_to_verification_requirements_despite_office_interview_waiver
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_subject_to_verification_requirements_despite_office_interview_waiver`); grounded against 106 CMR 361.520 (block 1). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/520/block-1#collateral_contact_may_be_substituted_for_documentary_evidence
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `collateral_contact_may_be_substituted_for_documentary_evidence`); grounded against 106 CMR 361.520 (block 1). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/540/block-1#snap_application_processing_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_application_processing_days`); grounded against 106 CMR 361.540. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/540/block-1#household_may_reschedule_missed_first_interview_without_good_cause
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_may_reschedule_missed_first_interview_without_good_cause`); grounded against 106 CMR 361.540. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/610/block-1#member_disqualified_for_ssn_noncompliance
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `member_disqualified_for_ssn_noncompliance`); grounded against 106 CMR 361.610. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/610/block-1#document_accepted_as_actual_child_support_payment_verification
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `document_accepted_as_actual_child_support_payment_verification`); grounded against 106 CMR 361.610. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/620/block-1#information_is_questionable
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `information_is_questionable`); grounded against 106 CMR 361.620 block 1 (definition of questionable information). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/620/block-1#more_intensive_verification_requirement_based_on_protected_characteristics_permitted
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `more_intensive_verification_requirement_based_on_protected_characteristics_permitted`); grounded against 106 CMR 361.620 block 1 (anti-discrimination in verification). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/630/block-1#household_must_be_given_opportunity_to_resolve_discrepancy
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_must_be_given_opportunity_to_resolve_discrepancy`); grounded against 106 CMR 361.630. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/700/block-1#compliance_lower_day_threshold
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `compliance_lower_day_threshold`); grounded against 106 CMR 361.700. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/700/block-1#compliance_upper_day_threshold
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `compliance_upper_day_threshold`); grounded against 106 CMR 361.700. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/700/block-1#benefits_paid_back_to_application_date
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `benefits_paid_back_to_application_date`); grounded against 106 CMR 361.700. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/900/block-1#processing_period_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `processing_period_days`); grounded against 106 CMR 361.900. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/900/block-1#worker_must_determine_cause_of_delay
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `worker_must_determine_cause_of_delay`); grounded against 106 CMR 361.900. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/910/block-1#delay_is_fault_of_household
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `delay_is_fault_of_household`); grounded against 106 CMR 361.910. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/930/block-1#eligibility_determination_period_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `eligibility_determination_period_days`); grounded against 106 CMR 361.930 - \"within 30 calendar days\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/930/block-1#pending_status_application_deadline_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `pending_status_application_deadline_days`); grounded against 106 CMR 361.930 - \"within 60 calendar days following the date the application was filed\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/930/block-1#notice_of_pending_status_required
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `notice_of_pending_status_required`); grounded against 106 CMR 361.930 - \"he or she shall send the household a Notice of Pending Status on the 30th day\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/930/block-1#worker_must_take_immediate_corrective_action
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `worker_must_take_immediate_corrective_action`); grounded against 106 CMR 361.930 - \"If some action by the worker is needed ... he or she shall take immediate corrective action\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/930/block-1#notice_must_explain_household_action_and_denial
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `notice_must_explain_household_action_and_denial`); grounded against 106 CMR 361.930 - \"the notice shall also explain what action the household must take and that its application will be denied if the required action is not taken within 60 calendar days\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/930/block-1#notice_must_advise_of_missing_verifications
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `notice_must_advise_of_missing_verifications`); grounded against 106 CMR 361.930 - \"If the pending status is the result of lack of verifications ... the written notice must also contain a statement advising the household of the missing verification(s) and the option to contact the worker for assistance\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/930/block-1#no_further_worker_action_required
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `no_further_worker_action_required`); grounded against 106 CMR 361.930 - \"No further action is required by the worker after the Notice of Pending Status is sent if the household fails to take the required action within 60 calendar days\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/940/block-1#snap_benefits_retroactive_to_application_date
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_benefits_retroactive_to_application_date`); grounded against 106 CMR 361.940. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/940/block-1#snap_benefits_begin_month_application_completed
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_benefits_begin_month_application_completed`); grounded against 106 CMR 361.940. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/950/block-1#notice_of_denial_required
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `notice_of_denial_required`); grounded against 106 CMR 361.950 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/950/block-1#notice_must_inform_of_right_to_reapply
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `notice_must_inform_of_right_to_reapply`); grounded against 106 CMR 361.950 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/950/block-1#notice_must_state_missing_verifications_and_department_help_option
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `notice_must_state_missing_verifications_and_department_help_option`); grounded against 106 CMR 361.950 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/960/block-1#application_processing_deadline_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `application_processing_deadline_days`); grounded against 106 CMR 361.960 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/361/960/block-1#worker_must_ensure_application_process_completed
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `worker_must_ensure_application_process_completed`); grounded against 106 CMR 361.960 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/100/block-1#household_meets_residency_requirement
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_meets_residency_requirement`); grounded against 106 CMR 362.100. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/100/block-1#individual_meets_dual_participation_restriction
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `individual_meets_dual_participation_restriction`); grounded against 106 CMR 362.100. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/120/block-1#household_is_unusual_case_for_residency_verification
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_is_unusual_case_for_residency_verification`); grounded against 106 CMR 362.120 (unusual cases clause). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/120/block-1#residency_verification_required_before_initial_certification
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `residency_verification_required_before_initial_certification`); grounded against 106 CMR 362.120 (residency verification rule). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/210/block-1#snap_citizenship_verified_by_tafdc_or_eaedc
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_citizenship_verified_by_tafdc_or_eaedc`); grounded against 106 CMR 362.210 block 1 (TAFDC/EAEDC proof acceptable). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/210/block-1#snap_citizenship_signed_statement_accepted
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_citizenship_signed_statement_accepted`); grounded against 106 CMR 362.210 block 1 (signed statement fallback). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/210/block-1#snap_citizenship_verification_accepted
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_citizenship_verification_accepted`); grounded against 106 CMR 362.210 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/220/block-1#temporary_certification_max_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `temporary_certification_max_months`); grounded against 106 CMR 362.220 block 1 \u2014 \"certify the individual for up to six months from the date of the original request for verification\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/220/block-1#noncitizen_member_ineligible_due_to_verification
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `noncitizen_member_ineligible_due_to_verification`); grounded against 106 CMR 362.220 block 1 \u2014 inability or unwillingness to provide verification of eligible noncitizen status, or to provide or apply for an SSN due to immigration status. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/220/block-1#noncitizen_eligible_for_temporary_certification
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `noncitizen_eligible_for_temporary_certification`); grounded against 106 CMR 362.220 block 1 \u2014 lost or missing documentation paired with verified formal federal verification request. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/220/block-1#noncitizen_temporary_certification_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `noncitizen_temporary_certification_months`); grounded against 106 CMR 362.220 block 1 \u2014 up to six months certification from the date of the original verification request. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/220/block-1#quarter_not_claimable
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `quarter_not_claimable`); grounded against 106 CMR 362.220 block 1 \u2014 no quarter claimable after December 31, 1996 if federal means-tested program benefits were received during that same quarter. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/220/block-1#commissioner_must_report_to_uscis
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `commissioner_must_report_to_uscis`); grounded against 106 CMR 362.220 block 1 \u2014 Commissioner or designee required to report noncitizens \"known to be in the U.S. unlawfully\" to USCIS. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/270/block-1#indigency_determination_period_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `indigency_determination_period_months`); grounded against 106 CMR 362.270 (\"Each indigence determination is effective for 12 months and may be renewed for additional 12-month periods.\"). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/270/block-1#sponsor_deeming_applies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `sponsor_deeming_applies`); grounded against 106 CMR 362.270 (deeming rules application and categorical eligibility exemption). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/270/block-1#sponsored_noncitizen_ineligible
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `sponsored_noncitizen_ineligible`); grounded against 106 CMR 362.270 (\"The sponsored noncitizen shall be ineligible.\"). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/270/block-1#indigency_determination_active
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `indigency_determination_active`); grounded against 106 CMR 362.270 (12-month indigence determination effectiveness). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/270/block-1#battery_or_cruelty_exception_renewable
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `battery_or_cruelty_exception_renewable`); grounded against 106 CMR 362.270 (battery or cruelty exception review after 12-month period). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/270/block-1#quarter_excluded_from_count
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `quarter_excluded_from_count`); grounded against 106 CMR 362.270 (quarter exclusion when means-tested benefits received). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/300/block-1#mandatory_work_minimum_age
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `mandatory_work_minimum_age`); grounded against 106 CMR 362.300. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/300/block-1#mandatory_work_maximum_age
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `mandatory_work_maximum_age`); grounded against 106 CMR 362.300. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/300/block-1#abawd_minimum_age
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `abawd_minimum_age`); grounded against 106 CMR 362.300. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/300/block-1#abawd_maximum_age
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `abawd_maximum_age`); grounded against 106 CMR 362.300. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/300/block-1#abawd_noncompliance_month_limit
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `abawd_noncompliance_month_limit`); grounded against 106 CMR 362.300. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/300/block-1#person_subject_to_mandatory_snap_work_requirements
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_subject_to_mandatory_snap_work_requirements`); grounded against 106 CMR 362.300. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/300/block-1#person_disqualified_for_mandatory_snap_work_noncompliance
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_disqualified_for_mandatory_snap_work_noncompliance`); grounded against 106 CMR 362.300; 106 CMR 367.800. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/300/block-1#person_subject_to_abawd_work_requirements
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_subject_to_abawd_work_requirements`); grounded against 106 CMR 362.300. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/300/block-1#person_ineligible_for_abawd_noncompliance
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_ineligible_for_abawd_noncompliance`); grounded against 106 CMR 362.300; 106 CMR 362.320. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/310/block-1#voluntary_et_participant_disqualified_for_noncompliance
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `voluntary_et_participant_disqualified_for_noncompliance`); grounded against 106 CMR 362.310 - voluntary E&T participants not disqualified. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/310/block-1#temporarily_unfit_person_must_meet_work_requirements
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `temporarily_unfit_person_must_meet_work_requirements`); grounded against 106 CMR 362.310 - temporary unfitness exemption ends when fit. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/310/block-1#caregiver_must_fulfill_work_requirements_at_next_recertification_due_to_child_age_six
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `caregiver_must_fulfill_work_requirements_at_next_recertification_due_to_child_age_six`); grounded against 106 CMR 362.310 - child sixth birthday within certification period. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/310/block-1#teen_must_fulfill_work_registration_at_next_recertification_due_to_age_eighteen
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `teen_must_fulfill_work_registration_at_next_recertification_due_to_age_eighteen`); grounded against 106 CMR 362.310 - exempt teen turning 18 within certification period. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/310/block-1#person_must_register_for_work_after_loss_of_exemption
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_must_register_for_work_after_loss_of_exemption`); grounded against 106 CMR 362.310 - loss of exemption due to change in circumstances. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/310/block-1#student_qualifies_for_student_exemption
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `student_qualifies_for_student_exemption`); grounded against 106 CMR 362.310 - student exemption disqualifying conditions. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/330/block-1#crisis_or_emergency_situation_applies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `crisis_or_emergency_situation_applies`); grounded against 106 CMR 362.330(B) - crisis or emergency situations (death, health emergency, domestic violence, child's school problem). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/330/block-1#childcare_breakdown_good_cause_applies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `childcare_breakdown_good_cause_applies`); grounded against 106 CMR 362.330(B) - breakdown of suitable, state-standard childcare with appropriate verification. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/330/block-1#special_needs_childcare_unavailable_good_cause_applies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `special_needs_childcare_unavailable_good_cause_applies`); grounded against 106 CMR 362.330(B) - unavailability of suitable childcare for children with identified special needs, verified. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/330/block-1#snap_work_requirement_good_cause_applies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_work_requirement_good_cause_applies`); grounded against 106 CMR 362.330(B) - good cause criteria applies to SNAP work requirements only; not to ABA WD work program requirements. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/340/block-1#same_application_remaining_disqualification_days_threshold
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `same_application_remaining_disqualification_days_threshold`); grounded against 106 CMR 362.340. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/340/block-1#sanction_carries_to_new_household
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `sanction_carries_to_new_household`); grounded against 106 CMR 362.340. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/340/block-1#strike_dismissal_treated_as_voluntary_quit_without_good_cause
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `strike_dismissal_treated_as_voluntary_quit_without_good_cause`); grounded against 106 CMR 362.340 Exception. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/340/block-1#same_application_used_for_remaining_disqualification_and_subsequent_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `same_application_used_for_remaining_disqualification_and_subsequent_months`); grounded against 106 CMR 362.340. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/400/block-1#person_attends_institution_of_post_secondary_education
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_attends_institution_of_post_secondary_education`); grounded against 106 CMR 362.400 (definition of institution of post-secondary education). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/420/block-1#student_enrollment_status_continues
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `student_enrollment_status_continues`); grounded against 106 CMR 362.420 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/362/500/block-1#good_cause_monthly_verification_required
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `good_cause_monthly_verification_required`); grounded against 106 CMR 362.500 - \"Good cause must be verified monthly until the SSN is provided and verified by computer match with SSA\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/100/block-1#nonliquid_asset_countable_equity_value
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `nonliquid_asset_countable_equity_value`); grounded against 106 CMR 363.100 - \"The countable value of a nonliquid asset shall be its equity value which is determined by fair market value less any encumbrances.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/100/block-1#asset_is_counted_in_eligibility
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `asset_is_counted_in_eligibility`); grounded against 106 CMR 363.100 - \"All of the household's assets shall be counted in determining eligibility unless specifically exempted by 106 CMR 363.140.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/110/block-1#household_subject_to_asset_limits
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_subject_to_asset_limits`); grounded against 106 CMR 363.110. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/130/block-1#recertification_low_balance_verification_threshold
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `recertification_low_balance_verification_threshold`); grounded against 106 CMR 363.130 - \"If at recertification the household member declares a balance of $25 or less in an account, other than a checking account, verification shall not be required\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/130/block-1#bank_account_funds_are_available_asset
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `bank_account_funds_are_available_asset`); grounded against 106 CMR 363.130 - \"Funds in a bank account are considered available when a member of the household has both ownership of, and access to, the balance of funds in the account.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/130/block-1#crowdfunding_account_is_liquid_resource
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `crowdfunding_account_is_liquid_resource`); grounded against 106 CMR 363.130 - \"Crowdfunding accounts (e.g., GoFundMe and Kickstarter) shall also be considered liquid resources if funds are accessible to the household.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/130/block-1#recertification_account_balance_verification_waived
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `recertification_account_balance_verification_waived`); grounded against 106 CMR 363.130 - \"If at recertification the household member declares a balance of $25 or less in an account, other than a checking account, verification shall not be required if the balance was $25 or less at the last eligibility determination and the account balance, in combination with other countable assets, is not over the asset limit.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/140/block-1#asset_is_noncountable
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `asset_is_noncountable`); grounded against 106 CMR 363.140. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/200/block-1#household_must_meet_income_eligibility_standards
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_must_meet_income_eligibility_standards`); grounded against 106 CMR 363.200. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/210/block-1#loan_income_verification_sufficient
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `loan_income_verification_sufficient`); grounded against 106 CMR 363.210. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/210/block-1#self_employment_income_verification_sufficient
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `self_employment_income_verification_sufficient`); grounded against 106 CMR 363.210. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/220/block-1#tafdc_related_support_alimony_unearned_income_cap
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `tafdc_related_support_alimony_unearned_income_cap`); grounded against 106 CMR 363.220. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/220/block-1#tafdc_related_support_alimony_unearned_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `tafdc_related_support_alimony_unearned_income`); grounded against 106 CMR 363.220. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/230/block-1#cash_contribution_from_non_legally_responsible_person_is_excluded
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `cash_contribution_from_non_legally_responsible_person_is_excluded`); grounded against 106 CMR 363.230 (cash contributions from non-legally responsible persons). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/230/block-1#vendor_payment_is_excluded
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `vendor_payment_is_excluded`); grounded against 106 CMR 363.230 (vendor payments). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/230/block-1#employer_provided_housing_is_excluded_vendor_payment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `employer_provided_housing_is_excluded_vendor_payment`); grounded against 106 CMR 363.230 (employer-provided housing as vendor payment). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/230/block-1#pass_funds_are_excluded_from_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `pass_funds_are_excluded_from_income`); grounded against 106 CMR 363.230 (PASS funds exclusion). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/230/block-1#pass_funds_exclusion_is_verified
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `pass_funds_exclusion_is_verified`); grounded against 106 CMR 363.230 (PASS verification). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/363/230/block-1#ssi_benefits_are_countable_income_for_snap
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ssi_benefits_are_countable_income_for_snap`); grounded against 106 CMR 363.230 (SSI treatment for SNAP). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/120/block-1#minimum_verification_response_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `minimum_verification_response_days`); grounded against 106 CMR 364.120. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/120/block-1#first_month_of_new_certification_period_is_initial_month
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `first_month_of_new_certification_period_is_initial_month`); grounded against 106 CMR 364.120. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/120/block-1#notice_of_expiration_proration_exception_applies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `notice_of_expiration_proration_exception_applies`); grounded against 106 CMR 364.120. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/120/block-1#verification_request_proration_exception_applies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `verification_request_proration_exception_applies`); grounded against 106 CMR 364.120. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/120/block-1#first_month_subject_to_proration
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `first_month_subject_to_proration`); grounded against 106 CMR 364.120. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/200/block-1#assets_used_for_eligibility
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `assets_used_for_eligibility`); grounded against 106 CMR 364.200. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/310/block-1#anticipated_income_is_reasonably_certain
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `anticipated_income_is_reasonably_certain`); grounded against 106 CMR 364.310 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/310/block-1#countable_anticipated_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `countable_anticipated_income`); grounded against 106 CMR 364.310 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/310/block-1#household_may_elect_income_averaging
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_may_elect_income_averaging`); grounded against 106 CMR 364.310 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/320/block-1#default_anticipated_income_lookback_weeks
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `default_anticipated_income_lookback_weeks`); grounded against 106 CMR 364.320. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/320/block-1#anticipated_income_lookback_weeks
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `anticipated_income_lookback_weeks`); grounded against 106 CMR 364.320. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/320/block-1#past_income_used_as_anticipated_income_indicator
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `past_income_used_as_anticipated_income_indicator`); grounded against 106 CMR 364.320. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/330/block-1#payment_counted_as_income_in_month
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `payment_counted_as_income_in_month`); grounded against 106 CMR 364.330. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/330/block-1#nonrecurring_lump_sum_counted_as_asset_in_month
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `nonrecurring_lump_sum_counted_as_asset_in_month`); grounded against 106 CMR 364.330. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/340/block-1#weekly_to_monthly_conversion_factor
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `weekly_to_monthly_conversion_factor`); grounded against 106 CMR 364.340 (weekly amounts multiplied by 4.333). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/340/block-1#biweekly_to_monthly_conversion_factor
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `biweekly_to_monthly_conversion_factor`); grounded against 106 CMR 364.340 (biweekly amounts multiplied by 2.167). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/340/block-1#converted_monthly_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `converted_monthly_income`); grounded against 106 CMR 364.340 (conversion of weekly/biweekly income to monthly). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/360/block-1#maximum_tafdc_related_child_support_payment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `maximum_tafdc_related_child_support_payment`); grounded against 106 CMR 364.360. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/360/block-1#countable_tafdc_related_child_support_payment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `countable_tafdc_related_child_support_payment`); grounded against 106 CMR 364.360. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/370/block-1#countable_gross_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `countable_gross_income`); grounded against 106 CMR 364.370 (\"gross income minus the exclusions listed in 106 CMR 363.230\"). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/370/block-1#applicable_gross_income_standard
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `applicable_gross_income_standard`); grounded against 106 CMR 364.370 (chooses between 364.976 and 364.950 standards). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/370/block-1#exempt_from_gross_income_test
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `exempt_from_gross_income_test`); grounded against 106 CMR 364.370 (exception for elderly/disabled meeting 361.210 or public assistance categorically eligible per 365.180; not extended to SNAP-only TANF Services categorically eligible households). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/370/block-1#meets_gross_income_standard
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `meets_gross_income_standard`); grounded against 106 CMR 364.370 (countable gross income equal to or less than the applicable standard). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/370/block-1#net_income_sole_basis_of_eligibility
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `net_income_sole_basis_of_eligibility`); grounded against 106 CMR 364.370 (net income at 364.550 is the sole basis for elderly/disabled households not categorically eligible per 365.180). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/370/block-1#household_meets_income_eligibility
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_meets_income_eligibility`); grounded against 106 CMR 364.370 (gross income test, except when exempt; net income test always determined when not ineligible on gross). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/400/block-1#medical_expense_lower_threshold
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `medical_expense_lower_threshold`); grounded against 106 CMR 364.400 medical expense table, \"$35/month or under $0\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/400/block-1#medical_expense_standard_upper_threshold
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `medical_expense_standard_upper_threshold`); grounded against 106 CMR 364.400 medical expense table, \"Over $35.00 to $190/month $155\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/400/block-1#medical_expense_standard_deduction_amount
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `medical_expense_standard_deduction_amount`); grounded against 106 CMR 364.400 medical expense table, \"Over $35.00 to $190/month $155\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/400/block-1#medical_expense_deduction
+    country: us
+    program: snap
+    mapping_type: direct_variable
+    policyengine_variable: snap_excess_medical_expense_deduction
+    entity: spm_unit
+    period: month
+    unit: USD
+    comparison: money
+    rationale: "State SNAP excess medical expense deduction is the same household-level deduction PolicyEngine exposes as snap_excess_medical_expense_deduction."
+
+  - legal_id: us-ma:regulations/106-cmr/364/400/block-1#earned_income_deduction_allowed_for_overissuance
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `earned_income_deduction_allowed_for_overissuance`); grounded against 106 CMR 364.400, \"This deduction shall not be allowed in determining an overissuance if the household fails to report earned income in a timely manner and the failure to report the income is the basis for the claim.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/400/block-1#vacated_home_shelter_deduction_allowed
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `vacated_home_shelter_deduction_allowed`); grounded against 106 CMR 364.400, vacated home shelter deduction conditions. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/400/block-1#child_support_deduction_includes_third_party_payment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `child_support_deduction_includes_third_party_payment`); grounded against 106 CMR 364.400, child support deduction inclusion of third-party payments. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/400/block-1#child_support_deduction_includes_children_health_insurance
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `child_support_deduction_includes_children_health_insurance`); grounded against 106 CMR 364.400, \"Payments that are made by the household to obtain health insurance for their children shall also be included as part of the child support deduction.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/400/block-1#arrearage_payments_allowed_in_child_support_deduction
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `arrearage_payments_allowed_in_child_support_deduction`); grounded against 106 CMR 364.400, \"The Department shall allow a deduction for amounts paid toward arrearages, even for households without a payment history.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/400/block-1#alimony_excluded_from_child_support_deduction
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `alimony_excluded_from_child_support_deduction`); grounded against 106 CMR 364.400, \"Alimony payments made to or for a non-household member shall not be included in the child support deduction.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/400/block-1#public_housing_central_meter_sua_allowed
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `public_housing_central_meter_sua_allowed`); grounded against 106 CMR 364.400(G), public housing central meter SUA. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/400/block-1#electric_blower_sua_not_allowed
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `electric_blower_sua_not_allowed`); grounded against 106 CMR 364.400(G), electric blower exclusion. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/400/block-1#liheaa_recipient_entitled_to_heating_cooling_sua
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `liheaa_recipient_entitled_to_heating_cooling_sua`); grounded against 106 CMR 364.400(G), LIHEAA recipients. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/400/block-1#non_liheaa_household_eligible_for_heating_sua
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `non_liheaa_household_eligible_for_heating_sua`); grounded against 106 CMR 364.400(G), non-LIHEAA indirect energy assistance with continuing out-of-pocket heating expenses. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/410/block-1#child_support_history_minimum_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `child_support_history_minimum_months`); grounded against 106 CMR 364.410. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/410/block-1#child_support_deduction
+    country: us
+    program: snap
+    mapping_type: direct_variable
+    policyengine_variable: snap_child_support_gross_income_deduction
+    entity: spm_unit
+    period: month
+    unit: USD
+    comparison: money
+    rationale: "State SNAP child-support gross-income deduction matches the household-level deduction PolicyEngine exposes as snap_child_support_gross_income_deduction."
+
+  - legal_id: us-ma:regulations/106-cmr/364/420/block-1#verification_required_before_acting_on_reported_medical_expense_change
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `verification_required_before_acting_on_reported_medical_expense_change`); grounded against 106 CMR 364.420. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/420/block-1#department_acts_on_reported_medical_expense_change_without_verification
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `department_acts_on_reported_medical_expense_change_without_verification`); grounded against 106 CMR 364.420. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/420/block-1#household_required_to_report_medical_expenses_during_certification_period
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_required_to_report_medical_expenses_during_certification_period`); grounded against 106 CMR 364.420. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/430/block-1#expense_is_deductible_this_month
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `expense_is_deductible_this_month`); grounded against 106 CMR 364.430 (block 1). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/450/block-1#application_processing_standard_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `application_processing_standard_days`); grounded against 106 CMR 364.450. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/450/block-1#minimum_verification_request_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `minimum_verification_request_days`); grounded against 106 CMR 364.450. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/450/block-1#notice_of_pending_denial_day
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `notice_of_pending_denial_day`); grounded against 106 CMR 364.450. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/450/block-1#household_may_elect_certification_without_deduction
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_may_elect_certification_without_deduction`); grounded against 106 CMR 364.450. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/450/block-1#later_verification_treated_as_reported_change
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `later_verification_treated_as_reported_change`); grounded against 106 CMR 364.450. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/450/block-1#household_entitled_to_lost_benefits
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_entitled_to_lost_benefits`); grounded against 106 CMR 364.450. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/450/block-1#notice_of_pending_denial_required
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `notice_of_pending_denial_required`); grounded against 106 CMR 364.450. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/500/block-1#cost_threshold
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `cost_threshold`); grounded against 106 CMR 364.500 block-1 (\"If these costs exceed $35 per month\"). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/500/block-1#costs_exceed_threshold
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `costs_exceed_threshold`); grounded against 106 CMR 364.500 block-1 (\"If these costs exceed $35 per month, go to the next step.\"). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/500/block-1#route_to_section_g
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `route_to_section_g`); grounded against 106 CMR 364.500 block-1 (\"If these costs are $35 or less, go to 106 CMR 364.500 (G).\"). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/550/block-1#household_meets_net_income_standard
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_meets_net_income_standard`); grounded against 106 CMR 364.550. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/600/block-1#minimum_household_size_for_categorical_suspension
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `minimum_household_size_for_categorical_suspension`); grounded against 106 CMR 364.600. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/600/block-1#calculated_allotment_is_zero_or_less
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `calculated_allotment_is_zero_or_less`); grounded against 106 CMR 364.600. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/600/block-1#household_must_be_suspended
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_must_be_suspended`); grounded against 106 CMR 364.600. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/600/block-1#household_ineligible_due_to_zero_allotment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_ineligible_due_to_zero_allotment`); grounded against 106 CMR 364.600. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/600/block-1#monthly_allotment
+    country: us
+    program: snap
+    mapping_type: direct_variable
+    policyengine_variable: snap_normal_allotment
+    entity: spm_unit
+    period: month
+    unit: USD
+    comparison: money
+    rationale: "State SNAP normal monthly allotment matches the household-level allotment PolicyEngine exposes as snap_normal_allotment."
+
+  - legal_id: us-ma:regulations/106-cmr/364/650/block-1#monthly_allotment_proration_threshold
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `monthly_allotment_proration_threshold`); grounded against 106 CMR 364.650. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/650/block-1#proration_denominator
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `proration_denominator`); grounded against 106 CMR 364.650. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/650/block-1#mid_month_application_day_threshold
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `mid_month_application_day_threshold`); grounded against 106 CMR 364.650. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/650/block-1#initial_month_prorated_allotment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `initial_month_prorated_allotment`); grounded against 106 CMR 364.650. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/650/block-1#combined_allotment_applies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `combined_allotment_applies`); grounded against 106 CMR 364.650. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/650/block-1#combined_allotment_amount
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `combined_allotment_amount`); grounded against 106 CMR 364.650. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/700/block-1#benefits_terminated_without_pretermination_hearing
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `benefits_terminated_without_pretermination_hearing`); grounded against 106 CMR 364.700 block-1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/870/block-1#minimum_claim_amount
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `minimum_claim_amount`); grounded against 106 CMR 364.870. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/870/block-1#applicable_claim_threshold
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `applicable_claim_threshold`); grounded against 106 CMR 364.870. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/870/block-1#unintentional_program_violation_claim_demand_letter_required
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `unintentional_program_violation_claim_demand_letter_required`); grounded against 106 CMR 364.870. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/900/block-1#statement_deadline_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `statement_deadline_days`); grounded against 106 CMR 364.900 (statement received within ten days of the date of the report). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/900/block-1#expungement_notice_minimum_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `expungement_notice_minimum_days`); grounded against 106 CMR 364.900 (notice must be mailed no later than 30 days before the date of expungement). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/900/block-1#statement_timely_received
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `statement_timely_received`); grounded against 106 CMR 364.900 (statement timely if within ten days, or weekend/holiday extension). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/900/block-1#expungement_notice_timely_mailed
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `expungement_notice_timely_mailed`); grounded against 106 CMR 364.900 (notice mailed no later than 30 days before expungement). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/980/block-1#snap_allotment_percentage
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_allotment_percentage`); grounded against 106 CMR 364.980. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/364/980/block-1#snap_benefit_allotment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_benefit_allotment`); grounded against 106 CMR 364.980. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/110/block-1#is_pa_household
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `is_pa_household`); grounded against 106 CMR 365.110 (PA household definition). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/120/block-1#snap_initial_processing_period_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_initial_processing_period_days`); grounded against 106 CMR 365.120 (initial 30-day period). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/120/block-1#snap_maximum_processing_period_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_maximum_processing_period_days`); grounded against 106 CMR 365.120 (more than 60 days reapplication threshold). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/120/block-1#snap_benefits_start_from_application_date
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_benefits_start_from_application_date`); grounded against 106 CMR 365.120 (benefits from date of application if verification within initial 30 days). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/120/block-1#snap_benefits_start_from_completion_date
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_benefits_start_from_completion_date`); grounded against 106 CMR 365.120 (benefits from completion/verification date if completed in second 30 days). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/120/block-1#snap_reapplication_required
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_reapplication_required`); grounded against 106 CMR 365.120 (reapplication required after 60 days). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/130/block-1#person_exempt_from_snap_work_requirements
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_exempt_from_snap_work_requirements`); grounded against 106 CMR 365.130. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/130/block-1#snap_benefit_increase_blocked_for_pa_household
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_benefit_increase_blocked_for_pa_household`); grounded against 106 CMR 365.130. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/140/block-1#pa_household_certification_period_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `pa_household_certification_period_months`); grounded against 106 CMR 365.140. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/140/block-1#pa_household_certification_period_end_month
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `pa_household_certification_period_end_month`); grounded against 106 CMR 365.140. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/150/block-1#months_without_pa_review_triggering_snap_termination_notice
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `months_without_pa_review_triggering_snap_termination_notice`); grounded against 106 CMR 365.150. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/150/block-1#snap_termination_notice_required
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_termination_notice_required`); grounded against 106 CMR 365.150. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/170/block-1#uninterrupted_benefits_reapplication_deadline_day_of_month
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `uninterrupted_benefits_reapplication_deadline_day_of_month`); grounded against 106 CMR 365.170 - \"files an application by the 15th day of the last month of its certification period\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/170/block-1#household_entitled_to_uninterrupted_snap_benefits
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_entitled_to_uninterrupted_snap_benefits`); grounded against 106 CMR 365.170 - \"shall be entitled to uninterrupted benefits if it files an application by the 15 th day of the last month of its certification period and completes its recertification responsibilities\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/170/block-1#snap_benefits_continue_at_previous_level_pending_appeal
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_benefits_continue_at_previous_level_pending_appeal`); grounded against 106 CMR 365.170 - \"If the household decides to appeal and its PA benefits are continued, the household's SNAP benefits shall continue at the previous level.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/170/block-1#snap_termination_notice_required_for_pa_change
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_termination_notice_required_for_pa_change`); grounded against 106 CMR 365.170 - \"If there is insufficient information to determine the effect on the household's SNAP eligibility and benefit level, a Notice of SNAP Termination shall be sent.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/180/block-1#categorical_eligibility_minimum_monthly_benefit
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `categorical_eligibility_minimum_monthly_benefit`); grounded against 106 CMR 365.180. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/180/block-1#small_household_categorical_minimum_snap_benefit
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `small_household_categorical_minimum_snap_benefit`); grounded against 106 CMR 365.180. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/180/block-1#large_household_snap_benefits_must_be_suspended_for_excess_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `large_household_snap_benefits_must_be_suspended_for_excess_income`); grounded against 106 CMR 365.180. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/190/block-1#tba_snap_benefit_period_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `tba_snap_benefit_period_months`); grounded against 106 CMR 365.190 - TBA five-month period. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/190/block-1#tss_income_excluded_in_tba_snap_calculation
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `tss_income_excluded_in_tba_snap_calculation`); grounded against 106 CMR 365.190 - TSS income exclusion for TBA NPA SNAP. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/190/block-1#snap_benefits_recalculated_at_tafdc_closing
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_benefits_recalculated_at_tafdc_closing`); grounded against 106 CMR 365.190 - recalculation on reported change at TAFDC closing. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/190/block-1#tba_case_closes_for_over_income_during_tba_period
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `tba_case_closes_for_over_income_during_tba_period`); grounded against 106 CMR 365.190 - TBA closure for over income on recalculation. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/200/block-1#boarder_payment_is_self_employment_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `boarder_payment_is_self_employment_income`); grounded against 106 CMR 365.200. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/200/block-1#non_member_boarder_income_and_resources_excluded
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `non_member_boarder_income_and_resources_excluded`); grounded against 106 CMR 365.200. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/200/block-1#boarder_cost_of_doing_business_allowed
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `boarder_cost_of_doing_business_allowed`); grounded against 106 CMR 365.200. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/200/block-1#boarder_shelter_costs_paid_to_third_party_excluded
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `boarder_shelter_costs_paid_to_third_party_excluded`); grounded against 106 CMR 365.200. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/430/block-1#person_receives_compensation_for_entire_year
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_receives_compensation_for_entire_year`); grounded against 106 CMR 365.430 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/510/block-1#nondisqualified_nonhousehold_member_may_be_separate_snap_household
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `nondisqualified_nonhousehold_member_may_be_separate_snap_household`); grounded against 106 CMR 365.510 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/600/block-1#drug_or_alcohol_treatment_center_resident_may_participate
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `drug_or_alcohol_treatment_center_resident_may_participate`); grounded against 106 CMR 365.600. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/605/block-1#group_living_arrangement_resident_snap_eligibility_not_precluded
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `group_living_arrangement_resident_snap_eligibility_not_precluded`); grounded against 106 CMR 365.605. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/610/block-1#qualifying_drug_or_alcohol_treatment_program
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `qualifying_drug_or_alcohol_treatment_program`); grounded against 106 CMR 365.610 block 1, sentence 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/610/block-1#resident_applies_for_snap_on_own_behalf
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `resident_applies_for_snap_on_own_behalf`); grounded against 106 CMR 365.610 block 1, sentence 3. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/610/block-1#resident_authorized_allotment_transfer_to_center
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `resident_authorized_allotment_transfer_to_center`); grounded against 106 CMR 365.610 block 1, sentence 4. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/620/block-1#maximum_residents_for_group_living_arrangement
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `maximum_residents_for_group_living_arrangement`); grounded against 106 CMR 365.620. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/620/block-1#facility_is_certified_group_living_arrangement
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `facility_is_certified_group_living_arrangement`); grounded against 106 CMR 365.620. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/620/block-1#resident_eligible_for_snap_in_group_living_arrangement
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `resident_eligible_for_snap_in_group_living_arrangement`); grounded against 106 CMR 365.620. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/620/block-1#worker_verified_group_living_arrangement_before_certification
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `worker_verified_group_living_arrangement_before_certification`); grounded against 106 CMR 365.620. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/670/block-1#authorized_representative_status_suspended
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `authorized_representative_status_suspended`); grounded against 106 CMR 365.670 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/700/block-1#person_is_enrolled_in_qualifying_institution
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_is_enrolled_in_qualifying_institution`); grounded against 106 CMR 365.700 (definition of student, first sentence). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/700/block-1#person_enrolled_at_least_half_time
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_enrolled_at_least_half_time`); grounded against 106 CMR 365.700 (definition of student, first sentence). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/700/block-1#person_status_preserved_during_temporary_break
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_status_preserved_during_temporary_break`); grounded against 106 CMR 365.700 (definition of student, second sentence). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/700/block-1#student
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `student`); grounded against 106 CMR 365.700 (definition of student). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/730/block-1#student_household_asset_exclusion_for_income_averaged_monies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `student_household_asset_exclusion_for_income_averaged_monies`); grounded against 106 CMR 365.730. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/810/block-1#member_income_source_unchanged_after_job_change
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `member_income_source_unchanged_after_job_change`); grounded against 106 CMR 365.810 (continuity of income source for same-employer job change). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/810/block-1#member_income_source_terminated_by_grower_change
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `member_income_source_terminated_by_grower_change`); grounded against 106 CMR 365.810 (grower-not-crew-chief attribution; new grower terminates prior source). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/810/block-1#travel_advance_disregarded_for_expedited_service
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `travel_advance_disregarded_for_expedited_service`); grounded against 106 CMR 365.810 (travel advances disregarded for expedited service). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/830/block-1#household_identity_verified
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_identity_verified`); grounded against 106 CMR 365.830 - \"The household's identity is the only eligibility factor that must be verified before expedited service is provided.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/830/block-1#all_required_members_registered_for_work
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `all_required_members_registered_for_work`); grounded against 106 CMR 365.830 - \"Every household member required to meet SNAP Work Requirements must register for work before expedited service is provided\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/830/block-1#expedited_service_pre_certification_requirements_met
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `expedited_service_pre_certification_requirements_met`); grounded against 106 CMR 365.830 - identity must always be verified and required members must register for work before expedited service is provided. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/830/block-1#ssn_requirements_required_before_expedited_service
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ssn_requirements_required_before_expedited_service`); grounded against 106 CMR 365.830 - \"The Social Security number requirements of 106 CMR 362.500 ... do not have to be met before expedited service is provided.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/840/block-1#anticipated_income_in_month_of_application_disregarded
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `anticipated_income_in_month_of_application_disregarded`); grounded against 106 CMR 365.840. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/840/block-1#travel_advance_disregarded_as_reimbursement
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `travel_advance_disregarded_as_reimbursement`); grounded against 106 CMR 365.840. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/840/block-1#travel_advance_counted_as_income_under_written_contract
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `travel_advance_counted_as_income_under_written_contract`); grounded against 106 CMR 365.840. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/840/block-1#proration_of_initial_month_benefits_applies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `proration_of_initial_month_benefits_applies`); grounded against 106 CMR 365.840. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/850/block-1#third_month_benefits_processing_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `third_month_benefits_processing_days`); grounded against 106 CMR 365.850. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/850/block-1#destitute_migrant_household_third_month_verification_required
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `destitute_migrant_household_third_month_verification_required`); grounded against 106 CMR 365.850 (destitute migrant verification requirement). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/850/block-1#destitute_migrant_household_third_month_benefits_issuable
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `destitute_migrant_household_third_month_benefits_issuable`); grounded against 106 CMR 365.850 (third month issuance condition). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/910/block-1#commercial_boarding_house_income_is_self_employment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `commercial_boarding_house_income_is_self_employment`); grounded against 106 CMR 365.910 block 1 (roomers, rental property, and boarders of a commercial boarding house). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/910/block-1#non_commercial_boarder_income_is_self_employment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `non_commercial_boarder_income_is_self_employment`); grounded against 106 CMR 365.910 block 1 (boarder income other than commercial boarding house). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/920/block-1#self_employed_household_member_must_comply_with_work_requirements
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `self_employed_household_member_must_comply_with_work_requirements`); grounded against 106 CMR 365.920. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/940/block-1#allowable_self_employment_cost
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `allowable_self_employment_cost`); grounded against 106 CMR 365.940. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/970/block-1#farm_self_employment_minimum_annual_gross_proceeds
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `farm_self_employment_minimum_annual_gross_proceeds`); grounded against 106 CMR 365.970. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/365/970/block-1#farm_self_employment_loss_offsets_other_countable_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `farm_self_employment_loss_offsets_other_countable_income`); grounded against 106 CMR 365.970. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/110/block-1#edsap_elderly_age_threshold
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `edsap_elderly_age_threshold`); grounded against 106 CMR 366.110(A) - \"elderly (age 60 or more)\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/110/block-1#edsap_child_age_threshold
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `edsap_child_age_threshold`); grounded against 106 CMR 366.110(A) - \"Children (less than 18 years old)\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/110/block-1#edsap_certification_period_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `edsap_certification_period_months`); grounded against 106 CMR 366.110(A) - \"EDSAP households are certified for 36 months\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/110/block-1#person_qualifies_for_edsap_household
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_qualifies_for_edsap_household`); grounded against 106 CMR 366.110(A) - EDSAP households include elderly or disabled members; children may also be included. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/110/block-1#household_is_edsap
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_is_edsap`); grounded against 106 CMR 366.110(A) - EDSAP households include elderly or disabled members. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/110/block-1#edsap_household_must_report_change
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `edsap_household_must_report_change`); grounded against 106 CMR 366.110(A) - During the certification period, EDSAP households must report changes in household composition and whenever any household member begins to receive earned income.. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/110/block-1#edsap_household_required_to_complete_interim_report
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `edsap_household_required_to_complete_interim_report`); grounded against 106 CMR 366.110(A) - \"EDSAP households are not required to complete an Interim Report.\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/110/block-1#information_is_verified_upon_receipt
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `information_is_verified_upon_receipt`); grounded against 106 CMR 366.110(A) - The Department considers information to be verified upon receipt when the information is not questionable and the provider is the primary source of the information.. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/130/block-1#mass_change_advance_notice_days_threshold
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `mass_change_advance_notice_days_threshold`); grounded against 106 CMR 366.130 (block 1). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/130/block-1#snap_mass_change_effective_same_month_as_pa_change
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_mass_change_effective_same_month_as_pa_change`); grounded against 106 CMR 366.130 (block 1). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/130/block-1#snap_mass_change_effective_month_following_pa_change
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_mass_change_effective_month_following_pa_change`); grounded against 106 CMR 366.130 (block 1). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/140/block-1#pa_household_change_reported_for_snap
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `pa_household_change_reported_for_snap`); grounded against 106 CMR 366.140. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/200/block-1#minimum_advance_notice_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `minimum_advance_notice_days`); grounded against 106 CMR 366.200 (\"at least ten days before the effective date of the proposed action\"). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/200/block-1#notice_of_adverse_action_is_timely
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `notice_of_adverse_action_is_timely`); grounded against 106 CMR 366.200 (\"The notice of adverse action shall be considered timely if it is mailed to the household at least ten days before the effective date of the proposed action, except as specified in 106 CMR 366.215.\"). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/200/block-1#advance_notice_of_adverse_action_required
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `advance_notice_of_adverse_action_required`); grounded against 106 CMR 366.200 (\"Before taking action to reduce or terminate a household's benefits during the certification period, the worker shall, except as specified in 106 CMR 366.210, provide the household with advance notice of adverse action.\"). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/215/block-1#notice_of_reduction_or_termination_is_timely
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `notice_of_reduction_or_termination_is_timely`); grounded against 106 CMR 366.215 (block 1). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/220/block-1#benefits_continued_at_prior_level
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `benefits_continued_at_prior_level`); grounded against 106 CMR 366.220. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/220/block-1#benefits_reinstated_to_prior_level
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `benefits_reinstated_to_prior_level`); grounded against 106 CMR 366.220. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/220/block-1#benefits_reduced_or_terminated_as_proposed
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `benefits_reduced_or_terminated_as_proposed`); grounded against 106 CMR 366.220. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/300/block-1#household_entitled_to_uninterrupted_benefits
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_entitled_to_uninterrupted_benefits`); grounded against 106 CMR 366.300. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/300/block-1#household_snap_benefits_continue
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_snap_benefits_continue`); grounded against 106 CMR 366.300. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/300/block-1#household_recertification_complete
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_recertification_complete`); grounded against 106 CMR 366.300. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/320/block-1#timely_reapplication_day_of_month
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `timely_reapplication_day_of_month`); grounded against 106 CMR 366.320 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/320/block-1#household_timely_reapplied
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_timely_reapplied`); grounded against 106 CMR 366.320 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/320/block-1#pure_ssi_household_timely_recertification_at_ssa
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `pure_ssi_household_timely_recertification_at_ssa`); grounded against 106 CMR 366.320 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/320/block-1#pure_ssi_household_exempt_from_second_interview
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `pure_ssi_household_exempt_from_second_interview`); grounded against 106 CMR 366.320 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/320/block-1#verification_response_timeframe_is_valid
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `verification_response_timeframe_is_valid`); grounded against 106 CMR 366.320 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/320/block-1#noncountable_income_must_be_verified
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `noncountable_income_must_be_verified`); grounded against 106 CMR 366.320 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/330/block-1#department_must_issue_recertification_determination_by_end_of_current_certification_period
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `department_must_issue_recertification_determination_by_end_of_current_certification_period`); grounded against 106 CMR 366.330. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/340/block-1#post_termination_notice_filing_window_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `post_termination_notice_filing_window_days`); grounded against 106 CMR 366.340. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/340/block-1#untimely_recertification_treated_as_initial_application
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `untimely_recertification_treated_as_initial_application`); grounded against 106 CMR 366.340. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/340/block-1#household_loses_right_to_uninterrupted_benefits
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_loses_right_to_uninterrupted_benefits`); grounded against 106 CMR 366.340. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/340/block-1#recertification_benefits_not_prorated_for_first_month
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `recertification_benefits_not_prorated_for_first_month`); grounded against 106 CMR 366.340. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/340/block-1#recertification_application_denied_for_refusal_to_complete_process
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `recertification_application_denied_for_refusal_to_complete_process`); grounded against 106 CMR 366.340. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/550/block-1#restoration_offset_applies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `restoration_offset_applies`); grounded against 106 CMR 366.550. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/550/block-1#restoration_amount_offset_against_claim
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `restoration_amount_offset_against_claim`); grounded against 106 CMR 366.550. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/550/block-1#restoration_balance_to_household
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `restoration_balance_to_household`); grounded against 106 CMR 366.550. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/560/block-1#ipv_disqualification_reversed
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ipv_disqualification_reversed`); grounded against 106 CMR 366.560. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/560/block-1#ipv_restoration_entitlement
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ipv_restoration_entitlement`); grounded against 106 CMR 366.560. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/560/block-1#ipv_restoration_amount
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ipv_restoration_amount`); grounded against 106 CMR 366.560. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/570/block-1#restored_lost_benefits_allotment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `restored_lost_benefits_allotment`); grounded against 106 CMR 366.570. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/580/block-1#household_receives_restored_lost_benefits
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_receives_restored_lost_benefits`); grounded against 106 CMR 366.580. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/366/610/block-1#disaster_snap_benefit
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `disaster_snap_benefit`); grounded against 106 CMR 366.610. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/025/block-1#snap_fair_hearing_available
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_fair_hearing_available`); grounded against 106 CMR 367.025. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/100/block-1#prior_loss_hearing_request_window_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `prior_loss_hearing_request_window_days`); grounded against 106 CMR 367.100, block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/100/block-1#restoration_denial_prior_loss_lower_bound_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `restoration_denial_prior_loss_lower_bound_days`); grounded against 106 CMR 367.100, block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/100/block-1#restoration_denial_prior_loss_upper_bound_years
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `restoration_denial_prior_loss_upper_bound_years`); grounded against 106 CMR 367.100, block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/100/block-1#restoration_denial_included_as_department_action
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `restoration_denial_included_as_department_action`); grounded against 106 CMR 367.100, block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/100/block-1#department_action_for_hearing_request
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `department_action_for_hearing_request`); grounded against 106 CMR 367.100, block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/100/block-1#household_allowed_to_request_fair_hearing
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_allowed_to_request_fair_hearing`); grounded against 106 CMR 367.100, block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/125/block-1#request_for_hearing
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `request_for_hearing`); grounded against 106 CMR 367.125. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/200/block-1#maximum_hearing_postponement_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `maximum_hearing_postponement_days`); grounded against 106 CMR 367.200. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/200/block-1#hearing_decision_time_limit_extension_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `hearing_decision_time_limit_extension_days`); grounded against 106 CMR 367.200. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/275/block-1#continuation_of_benefits_pending_appeal_applies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `continuation_of_benefits_pending_appeal_applies`); grounded against 106 CMR 367.275. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/275/block-1#benefits_reinstated_to_prior_level_for_untimely_request
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `benefits_reinstated_to_prior_level_for_untimely_request`); grounded against 106 CMR 367.275. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/275/block-1#mass_change_prior_level_reinstatement_applies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `mass_change_prior_level_reinstatement_applies`); grounded against 106 CMR 367.275. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/325/block-1#minimum_hearing_notice_weeks
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `minimum_hearing_notice_weeks`); grounded against 106 CMR 367.325. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/325/block-1#hearing_notice_satisfies_advance_notice_requirement
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `hearing_notice_satisfies_advance_notice_requirement`); grounded against 106 CMR 367.325. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/325/block-1#hearing_arrangement_is_accessible_to_household
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `hearing_arrangement_is_accessible_to_household`); grounded against 106 CMR 367.325. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/490/block-1#claim_for_overissuance_must_be_established
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `claim_for_overissuance_must_be_established`); grounded against 106 CMR 367.490. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/490/block-1#adult_members_jointly_and_severally_liable_for_overissuance
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `adult_members_jointly_and_severally_liable_for_overissuance`); grounded against 106 CMR 367.490. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/495/block-1#unintentional_claim_max_lookback_years
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `unintentional_claim_max_lookback_years`); grounded against 106 CMR 367.495. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/495/block-1#agency_error_max_effective_lookback_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `agency_error_max_effective_lookback_months`); grounded against 106 CMR 367.495. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/495/block-1#repayment_agreement_response_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `repayment_agreement_response_days`); grounded against 106 CMR 367.495. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/495/block-1#unintentional_claim_within_lookback
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `unintentional_claim_within_lookback`); grounded against 106 CMR 367.495. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/495/block-1#agency_error_effective_month_within_cap
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `agency_error_effective_month_within_cap`); grounded against 106 CMR 367.495. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/495/block-1#automatic_benefit_reduction_triggered
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `automatic_benefit_reduction_triggered`); grounded against 106 CMR 367.495. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/500/block-1#overissuance_claim_pursued_as_ipv
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `overissuance_claim_pursued_as_ipv`); grounded against 106 CMR 367.500. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/500/block-1#first_month_of_overissuance_for_unreported_change
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `first_month_of_overissuance_for_unreported_change`); grounded against 106 CMR 367.500. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/510/block-1#unintentional_violation_benefit_reduction_rate
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `unintentional_violation_benefit_reduction_rate`); grounded against 106 CMR 367.510 (unintentional program violation - 10%). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/510/block-1#unintentional_violation_benefit_reduction_minimum
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `unintentional_violation_benefit_reduction_minimum`); grounded against 106 CMR 367.510 (unintentional program violation - $10 minimum). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/510/block-1#intentional_violation_benefit_reduction_rate
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `intentional_violation_benefit_reduction_rate`); grounded against 106 CMR 367.510 (intentional program violation - 20%). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/510/block-1#intentional_violation_benefit_reduction_minimum
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `intentional_violation_benefit_reduction_minimum`); grounded against 106 CMR 367.510 (intentional program violation - $20 minimum). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/510/block-1#claim_adjustment_payoff_period_years
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `claim_adjustment_payoff_period_years`); grounded against 106 CMR 367.510 (three-year claim adjustment period). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/510/block-1#repayment_start_days_from_agreement
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `repayment_start_days_from_agreement`); grounded against 106 CMR 367.510 (repayment begins no later than 30 days from mailing). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/510/block-1#minimum_installment_or_wage_assignment_payment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `minimum_installment_or_wage_assignment_payment`); grounded against 106 CMR 367.510 (installment/wage assignment floor equals automatic benefit reduction). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/510/block-1#claim_compromise_floor
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `claim_compromise_floor`); grounded against 106 CMR 367.510 (compromise floor). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/510/block-1#benefit_reduction_is_collection_method
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `benefit_reduction_is_collection_method`); grounded against 106 CMR 367.510 (benefit reduction when no agreement). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/510/block-1#wage_assignment_is_collection_method
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `wage_assignment_is_collection_method`); grounded against 106 CMR 367.510 (wage assignment for employed delinquent former clients). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_advance_notice_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_advance_notice_days`); grounded against 106 CMR 367.625 - advance notice of hearing. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_maximum_postponement_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_maximum_postponement_days`); grounded against 106 CMR 367.625 - postponement of up to 30 days. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_postponement_request_advance_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_postponement_request_advance_days`); grounded against 106 CMR 367.625 - postponement request advance days. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_decision_time_limit_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_decision_time_limit_days`); grounded against 106 CMR 367.625 - 90-day hearing/decision time limit. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_advance_notice_satisfied
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_advance_notice_satisfied`); grounded against 106 CMR 367.625 - written notice at least 30 days in advance. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_postponement_request_timely
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_postponement_request_timely`); grounded against 106 CMR 367.625 - postponement request timeliness. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_postponement_entitlement
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_postponement_entitlement`); grounded against 106 CMR 367.625 - entitlement to one postponement of up to 30 days. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_decision_deadline_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_decision_deadline_days`); grounded against 106 CMR 367.625 - 90-day limit extended by postponement days. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_decision_timely
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_decision_timely`); grounded against 106 CMR 367.625 - hearing held and decision rendered within deadline. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/675/block-1#adh_advance_notice_may_be_sent
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `adh_advance_notice_may_be_sent`); grounded against 106 CMR 367.675. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/700/block-1#good_cause_presentation_period_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `good_cause_presentation_period_days`); grounded against 106 CMR 367.700. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/700/block-1#adh_conducted_without_household_member
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `adh_conducted_without_household_member`); grounded against 106 CMR 367.700. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/700/block-1#ipv_determined_by_clear_and_convincing_evidence
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ipv_determined_by_clear_and_convincing_evidence`); grounded against 106 CMR 367.700. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/700/block-1#previous_ipv_decision_invalidated
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `previous_ipv_decision_invalidated`); grounded against 106 CMR 367.700. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/700/block-1#new_hearing_required
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `new_hearing_required`); grounded against 106 CMR 367.700. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/700/block-1#good_cause_presentation_timely
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `good_cause_presentation_timely`); grounded against 106 CMR 367.700. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/750/block-1#ipv_determination_supported
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ipv_determination_supported`); grounded against 106 CMR 367.750. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/800/block-1#voluntary_quit_first_finding_disqualification_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `voluntary_quit_first_finding_disqualification_months`); grounded against 106 CMR 367.800. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/800/block-1#voluntary_quit_second_finding_disqualification_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `voluntary_quit_second_finding_disqualification_months`); grounded against 106 CMR 367.800. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/800/block-1#voluntary_quit_third_finding_disqualification_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `voluntary_quit_third_finding_disqualification_months`); grounded against 106 CMR 367.800. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/800/block-1#head_of_household_quit_disqualification_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `head_of_household_quit_disqualification_months`); grounded against 106 CMR 367.800. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/800/block-1#person_ineligible_as_fleeing_felon
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_ineligible_as_fleeing_felon`); grounded against 106 CMR 367.800. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/800/block-1#person_voluntary_quit_disqualification_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_voluntary_quit_disqualification_months`); grounded against 106 CMR 367.800. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/800/block-1#person_ineligible_due_to_voluntary_quit
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_ineligible_due_to_voluntary_quit`); grounded against 106 CMR 367.800. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/800/block-1#household_ineligible_due_to_head_voluntary_quit
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_ineligible_due_to_head_voluntary_quit`); grounded against 106 CMR 367.800. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/800/block-1#household_categorically_eligible_blocked_by_disqualified_member
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_categorically_eligible_blocked_by_disqualified_member`); grounded against 106 CMR 367.800. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/800/block-1#household_benefit_level_increase_from_ipv_disqualification_prohibited
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_benefit_level_increase_from_ipv_disqualification_prohibited`); grounded against 106 CMR 367.800. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/800/block-1#law_enforcement_actively_seeking_established
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `law_enforcement_actively_seeking_established`); grounded against 106 CMR 367.800. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/900/block-1#person_disqualified_for_court_ipv
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_disqualified_for_court_ipv`); grounded against 106 CMR 367.900. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/925/block-1#disqualification_start_max_days_after_court_order
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `disqualification_start_max_days_after_court_order`); grounded against 106 CMR 367.925. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/925/block-1#ipv_disqualification_start_compliant
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ipv_disqualification_start_compliant`); grounded against 106 CMR 367.925. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/950/block-1#individual_reinstated_in_program
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `individual_reinstated_in_program`); grounded against 106 CMR 367.950. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-ma:regulations/106-cmr/367/950/block-1#benefits_lost_due_to_disqualification_restored
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `benefits_lost_due_to_disqualification_restored`); grounded against 106 CMR 367.950. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-nc:regulations/10a-ncac/71u/0210/block-1#educational_assistance_is_excepted_scholarship
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `educational_assistance_is_excepted_scholarship`); grounded against 10A NCAC 71U .0210 (additional exclusions clause). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-nc:regulations/10a-ncac/71u/0210/block-1#additional_excluded_earned_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `additional_excluded_earned_income`); grounded against 10A NCAC 71U .0210 (additional exclusions clause). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-nc:regulations/10a-ncac/71u/0212/block-1#transitional_fns_benefit_period_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `transitional_fns_benefit_period_months`); grounded against 10A NCAC 71U .0212 (transitional FNS benefits for a period of five months). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-nc:regulations/10a-ncac/71u/0212/block-1#household_eligible_for_transitional_fns_benefits
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_eligible_for_transitional_fns_benefits`); grounded against 10A NCAC 71U .0212 (transitional FNS benefits when households lose Work First benefits; not eligible if loss is for enumerated disqualifying reason). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-nc:regulations/10a-ncac/71u/0212/block-1#transitional_fns_benefit_amount
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `transitional_fns_benefit_amount`); grounded against 10A NCAC 71U .0212 (FNS benefits shall be no less than the amount received prior to termination of Work First; only adjustment is deletion of Work First benefits; other income not recalculated). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-nc:regulations/10a-ncac/71u/0302/block-1#applicant_may_participate_in_food_and_nutrition_services
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `applicant_may_participate_in_food_and_nutrition_services`); grounded against 10A NCAC 71U .0302 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/03/10/block-1#citizenship_verification_accepted
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `citizenship_verification_accepted`); grounded against Tenn. Comp. R. & Regs. 1240-01-03-.10. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/03/13/block-1#food_stamp_program_ineligibility_period_years
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `food_stamp_program_ineligibility_period_years`); grounded against 1240-1-3-.13. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/03/13/block-1#alien_eligible_for_food_stamp_and_cash_assistance
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `alien_eligible_for_food_stamp_and_cash_assistance`); grounded against 1240-1-3-.13. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/03/13/block-1#alien_eligible_for_food_stamp_program
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `alien_eligible_for_food_stamp_program`); grounded against 1240-1-3-.13. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/03/13/block-1#alien_included_in_assistance_group
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `alien_included_in_assistance_group`); grounded against 1240-1-3-.13. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/03/15/block-1#person_meets_ssn_enumeration_requirement
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_meets_ssn_enumeration_requirement`); grounded against Tenn. Comp. R. & Regs. 1240-01-03-.15. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/03/15/block-1#food_stamp_member_must_apply_at_dhs_county_office
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `food_stamp_member_must_apply_at_dhs_county_office`); grounded against Tenn. Comp. R. & Regs. 1240-01-03-.15 (Food Stamps Only). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/03/46/block-1#voluntary_quit_minimum_hours_per_week
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `voluntary_quit_minimum_hours_per_week`); grounded against Tenn. Comp. R. & Regs. 1240-01-03-.46. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/03/46/block-1#voluntary_reduction_hours_per_week_threshold
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `voluntary_reduction_hours_per_week_threshold`); grounded against Tenn. Comp. R. & Regs. 1240-01-03-.46. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/03/46/block-1#member_subject_to_food_stamp_disqualification_for_voluntary_quit_or_reduction
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `member_subject_to_food_stamp_disqualification_for_voluntary_quit_or_reduction`); grounded against Tenn. Comp. R. & Regs. 1240-01-03-.46. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/07/block-1#total_countable_resources
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `total_countable_resources`); grounded against Tenn. Comp. R. & Regs. 1240-01-04-.07. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/09/block-1#jointly_owned_resource_totally_inaccessible
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `jointly_owned_resource_totally_inaccessible`); grounded against Tenn. Comp. R. & Regs. 1240-01-04-.09. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/09/block-1#ineligible_alien_or_disqualified_individual_is_food_stamp_household_member
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `ineligible_alien_or_disqualified_individual_is_food_stamp_household_member`); grounded against Tenn. Comp. R. & Regs. 1240-01-04-.09. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/16/block-1#payment_treated_as_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `payment_treated_as_income`); grounded against TN Reg. 1240-01-04-.16 block 1. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#household_size
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_size`); grounded against Tables I-VII row key. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_gross_income_standard
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_gross_income_standard`); grounded against Table I. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_gross_income_standard_additional_member
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_gross_income_standard_additional_member`); grounded against Table I \"For each additional member add $406\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_max_net_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_max_net_income`); grounded against Table II. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_max_net_income_additional_member
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_max_net_income_additional_member`); grounded against Table II \"For each additional member add $312\". PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_max_coupon_allotment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_max_coupon_allotment`); grounded against Table III. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_standard_deduction
+    country: us
+    program: snap
+    mapping_type: direct_variable
+    policyengine_variable: snap_standard_deduction
+    entity: spm_unit
+    period: month
+    unit: USD
+    comparison: money
+    rationale: "State SNAP standard deduction is the same household-level standard deduction PolicyEngine exposes as snap_standard_deduction."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_max_shelter_deduction_non_elderly_disabled
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_max_shelter_deduction_non_elderly_disabled`); grounded against Table IV-B. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_standard_utility_allowance
+    country: us
+    program: snap
+    mapping_type: direct_variable
+    policyengine_variable: snap_standard_utility_allowance
+    entity: spm_unit
+    period: month
+    unit: USD
+    comparison: money
+    rationale: "State SNAP standard utility allowance is the same household-level allowance PolicyEngine exposes as snap_standard_utility_allowance."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_basic_utility_allowance
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_basic_utility_allowance`); grounded against Table V-B. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_telephone_standard
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_telephone_standard`); grounded against Food Stamp Standard Telephone Allowance. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_homeless_shelter_standard
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `snap_homeless_shelter_standard`); grounded against Table VII Homeless Household Shelter Allowance. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#assistance_unit_size
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `assistance_unit_size`); grounded against Table VIII row key. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#afdc_gross_income_standard
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `afdc_gross_income_standard`); grounded against Table VIII Gross Income Standard. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#afdc_consolidated_need_standard
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `afdc_consolidated_need_standard`); grounded against Table VIII Consolidated Need Standard. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#afdc_standard_payment_amount
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `afdc_standard_payment_amount`); grounded against Table VIII Standard Payment Amount. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/04/27/block-1#minimum_afdc_payment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `minimum_afdc_payment`); grounded against Table VIII Minimum AFDC Payment. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/12/06/block-1#coupon_allotment_excluded_from_income_and_resources
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `coupon_allotment_excluded_from_income_and_resources`); grounded against TN Reg 1240-01-12-.06. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/14/09/block-1#gross_income_limit_rate
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `gross_income_limit_rate`); grounded against 1240-01-14-.09 (gross income limit of 130 percent). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/14/09/block-1#gross_income_test_applies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `gross_income_test_applies`); grounded against 1240-01-14-.09 (households without elderly or disabled member subject to gross income limit). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/14/09/block-1#household_passes_gross_income_test
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_passes_gross_income_test`); grounded against 1240-01-14-.09 (if monthly income exceeds Table I, household is ineligible). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/14/09/block-1#household_passes_net_income_test
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_passes_net_income_test`); grounded against 1240-01-14-.09 (all households subject to net monthly income standards in Table II). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/14/09/block-1#household_financially_eligible
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `household_financially_eligible`); grounded against 1240-01-14-.09 (financial eligibility determination). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/14/11/block-1#eligibility_notice_deadline_days
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `eligibility_notice_deadline_days`); grounded against Tenn. Comp. R. & Regs. 1240-01-14-.11. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-tn:regulations/1240-01/14/11/block-1#eligibility_notice_timely
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `eligibility_notice_timely`); grounded against Tenn. Comp. R. & Regs. 1240-01-14-.11. PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-fl:regulations/fac/65a-1/711/block-1#person_considered_florida_resident_for_medicaid
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_considered_florida_resident_for_medicaid`); grounded against Fla. Admin. Code r. 65A-1.711 (Florida temporary residents may be considered residents on a case-by-case basis if intent and verification are shown). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
+  - legal_id: us-fl:regulations/fac/65a-1/711/block-1#person_may_qualify_for_breast_and_cervical_cancer_treatment_medicaid
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: "Source-specific intermediate output (rule `person_may_qualify_for_breast_and_cervical_cancer_treatment_medicaid`); grounded against Fla. Admin. Code r. 65A-1.711 (exception that individuals who are neither aged nor disabled may qualify for breast and cervical cancer treatment). PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+
 prefixes:
   - legal_id_prefix: us-az:policies/des/faa5/na-child-support-expense/allowable-deductions#
     country: us
@@ -11352,1484 +14064,3 @@ prefixes:
     program: snap
     mapping_type: not_comparable
     rationale: Section 2014(g) resource-test intermediates (vehicle countable amount, fair-market-value threshold, indexed base-amount components, rounding increments) are internal pieces of PolicyEngine's asset-limit aggregation; PE exposes the final snap_assets and snap_asset_limit but not these per-vehicle and base-amount computation steps.
-  - legal_id_prefix: us-ma:regulations/106-cmr/360/010/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP general-provisions outputs cover source-specific definitions, scope, and administrative predicates; PolicyEngine does not expose these as one-to-one comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/360/020/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP general-provisions outputs cover source-specific definitions, scope, and administrative predicates; PolicyEngine does not expose these as one-to-one comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/360/030/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP general-provisions outputs cover source-specific definitions, scope, and administrative predicates; PolicyEngine does not expose these as one-to-one comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/360/100/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP general-provisions outputs cover source-specific definitions, scope, and administrative predicates; PolicyEngine does not expose these as one-to-one comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/360/120/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP general-provisions outputs cover source-specific definitions, scope, and administrative predicates; PolicyEngine does not expose these as one-to-one comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/360/200/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP general-provisions outputs cover source-specific definitions, scope, and administrative predicates; PolicyEngine does not expose these as one-to-one comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/360/210/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP general-provisions outputs cover source-specific definitions, scope, and administrative predicates; PolicyEngine does not expose these as one-to-one comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/360/240/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP general-provisions outputs cover source-specific definitions, scope, and administrative predicates; PolicyEngine does not expose these as one-to-one comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/360/250/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP general-provisions outputs cover source-specific definitions, scope, and administrative predicates; PolicyEngine does not expose these as one-to-one comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/360/300/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP general-provisions outputs cover source-specific definitions, scope, and administrative predicates; PolicyEngine does not expose these as one-to-one comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/360/500/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP general-provisions outputs cover source-specific definitions, scope, and administrative predicates; PolicyEngine does not expose these as one-to-one comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/360/510/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP general-provisions outputs cover source-specific definitions, scope, and administrative predicates; PolicyEngine does not expose these as one-to-one comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/360/600/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP general-provisions outputs cover source-specific definitions, scope, and administrative predicates; PolicyEngine does not expose these as one-to-one comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/360/800/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP general-provisions outputs cover source-specific definitions, scope, and administrative predicates; PolicyEngine does not expose these as one-to-one comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/360/950/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP general-provisions outputs cover source-specific definitions, scope, and administrative predicates; PolicyEngine does not expose these as one-to-one comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/080/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/100/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/110/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/120/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/130/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/140/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/150/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/160/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/180/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/190/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/200/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/210/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/220/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/230/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/240/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/310/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/320/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/330/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/350/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/370/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/400/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/500/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/510/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/520/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/540/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/550/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/600/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/610/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/620/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/630/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/640/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/650/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/660/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/700/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/800/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/900/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/910/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/920/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/930/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/940/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/950/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/361/960/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP application-process outputs cover source-specific filing, interview, and verification mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/362/050/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP non-financial-eligibility outputs cover source-specific residency, work, and household-composition predicates; PolicyEngine exposes aggregate eligibility rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/362/100/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP non-financial-eligibility outputs cover source-specific residency, work, and household-composition predicates; PolicyEngine exposes aggregate eligibility rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/362/110/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP non-financial-eligibility outputs cover source-specific residency, work, and household-composition predicates; PolicyEngine exposes aggregate eligibility rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/362/120/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP non-financial-eligibility outputs cover source-specific residency, work, and household-composition predicates; PolicyEngine exposes aggregate eligibility rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/362/200/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP non-financial-eligibility outputs cover source-specific residency, work, and household-composition predicates; PolicyEngine exposes aggregate eligibility rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/362/210/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP non-financial-eligibility outputs cover source-specific residency, work, and household-composition predicates; PolicyEngine exposes aggregate eligibility rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/362/220/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP non-financial-eligibility outputs cover source-specific residency, work, and household-composition predicates; PolicyEngine exposes aggregate eligibility rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/362/270/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP non-financial-eligibility outputs cover source-specific residency, work, and household-composition predicates; PolicyEngine exposes aggregate eligibility rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/362/300/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP non-financial-eligibility outputs cover source-specific residency, work, and household-composition predicates; PolicyEngine exposes aggregate eligibility rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/362/310/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP non-financial-eligibility outputs cover source-specific residency, work, and household-composition predicates; PolicyEngine exposes aggregate eligibility rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/362/330/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP non-financial-eligibility outputs cover source-specific residency, work, and household-composition predicates; PolicyEngine exposes aggregate eligibility rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/362/340/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP non-financial-eligibility outputs cover source-specific residency, work, and household-composition predicates; PolicyEngine exposes aggregate eligibility rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/362/400/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP non-financial-eligibility outputs cover source-specific residency, work, and household-composition predicates; PolicyEngine exposes aggregate eligibility rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/362/420/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP non-financial-eligibility outputs cover source-specific residency, work, and household-composition predicates; PolicyEngine exposes aggregate eligibility rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/362/500/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP non-financial-eligibility outputs cover source-specific residency, work, and household-composition predicates; PolicyEngine exposes aggregate eligibility rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/363/100/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP financial-eligibility outputs cover source-specific income and asset gating predicates; PolicyEngine exposes aggregate gross- and net-income tests rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/363/110/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP financial-eligibility outputs cover source-specific income and asset gating predicates; PolicyEngine exposes aggregate gross- and net-income tests rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/363/130/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP financial-eligibility outputs cover source-specific income and asset gating predicates; PolicyEngine exposes aggregate gross- and net-income tests rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/363/140/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP financial-eligibility outputs cover source-specific income and asset gating predicates; PolicyEngine exposes aggregate gross- and net-income tests rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/363/200/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP financial-eligibility outputs cover source-specific income and asset gating predicates; PolicyEngine exposes aggregate gross- and net-income tests rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/363/210/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP financial-eligibility outputs cover source-specific income and asset gating predicates; PolicyEngine exposes aggregate gross- and net-income tests rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/363/220/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP financial-eligibility outputs cover source-specific income and asset gating predicates; PolicyEngine exposes aggregate gross- and net-income tests rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/363/230/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP financial-eligibility outputs cover source-specific income and asset gating predicates; PolicyEngine exposes aggregate gross- and net-income tests rather than these per-condition branches.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/050/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/120/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/200/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/300/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/310/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/320/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/330/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/340/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/350/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/360/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/370/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/400/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/410/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/420/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/430/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/450/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/500/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/550/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/600/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/650/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/700/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/820/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/830/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/840/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/850/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/860/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/870/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/880/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/895/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/900/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/910/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/946/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/950/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/970/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/975/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/976/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/980/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/364/990/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP household-eligibility-and-benefit-level outputs cover source-specific deduction-helper and benefit-calculation steps; PolicyEngine exposes aggregate snap_normal_allotment rather than these intermediate outputs.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/030/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/110/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/120/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/130/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/140/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/150/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/160/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/170/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/180/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/190/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/200/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/410/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/430/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/500/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/510/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/550/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/600/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/605/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/610/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/620/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/660/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/670/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/700/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/730/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/800/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/810/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/830/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/840/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/850/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/900/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/910/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/920/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/940/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/365/970/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP special-situation-household outputs cover source-specific categorical, transitional, and migrant predicates; PolicyEngine does not expose these per-condition branches as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/050/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/100/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/110/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/115/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/120/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/130/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/140/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/150/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/200/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/210/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/215/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/220/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/300/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/310/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/320/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/330/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/340/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/510/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/530/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/550/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/560/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/570/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/580/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/600/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/610/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/620/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/900/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/910/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/366/920/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP additional-certification outputs cover source-specific recertification, reporting, and case-action mechanics; PolicyEngine does not expose these procedural predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/025/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/050/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/075/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/100/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/125/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/200/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/250/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/275/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/325/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/350/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/400/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/485/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/490/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/495/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/500/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/510/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/515/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/520/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/525/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/550/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/600/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/625/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/650/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/660/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/675/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/700/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/725/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/750/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/800/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/900/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/925/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-
-  - legal_id_prefix: us-ma:regulations/106-cmr/367/950/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Massachusetts DTA SNAP violations/hearings/claims outputs cover source-specific enforcement and overissuance mechanics; PolicyEngine does not expose these enforcement-side predicates as comparable variables.
-  - legal_id_prefix: us-nc:regulations/10a-ncac/71u/0210/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: North Carolina DSS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-nc:regulations/10a-ncac/71u/0212/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: North Carolina DSS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-nc:regulations/10a-ncac/71u/0215/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: North Carolina DSS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-nc:regulations/10a-ncac/71u/0302/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: North Carolina DSS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/03/05/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/03/10/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/03/13/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/03/15/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/03/44/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/03/46/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/04/01/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/04/03/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/04/05/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/04/07/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/04/09/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/04/15/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/04/16/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/04/17/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/04/18/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/04/24/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/04/27/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/08/01/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/12/06/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/14/04/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/14/09/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/14/11/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-tn:regulations/1240-01/14/14/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Tennessee DHS SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-fl:regulations/fac/65a-1/205/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Florida DCF SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-fl:regulations/fac/65a-1/400/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Florida DCF SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-fl:regulations/fac/65a-1/703/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Florida DCF SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-fl:regulations/fac/65a-1/711/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Florida DCF SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-fl:regulations/fac/65a-1/7141/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Florida DCF SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-fl:regulations/fac/65a-1/803/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Florida DCF SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-
-  - legal_id_prefix: us-fl:regulations/fac/65a-1/900/block-1#
-    country: us
-    program: snap
-    mapping_type: not_comparable
-    rationale: Florida DCF SNAP outputs at this regulation section are source-specific intermediate predicates (definitions, eligibility branches, deduction helpers, or procedural conditions); PolicyEngine exposes only the aggregate SNAP eligibility and allotment variables, not these per-section intermediates.
-

--- a/src/axiom_encode/oracles/policyengine/pattern_classifier.py
+++ b/src/axiom_encode/oracles/policyengine/pattern_classifier.py
@@ -1,0 +1,381 @@
+"""Pattern-based oracle coverage classifier for state SNAP RuleSpec encodings.
+
+The classifier walks a rulespec-us-<state> repository, looks at each output's
+name + source text, and proposes a PolicyEngine oracle coverage entry. The
+result is a YAML block suitable for appending to
+`src/axiom_encode/oracles/policyengine/mappings/us.yaml`.
+
+The pattern list captures the high-confidence federal-aligned SNAP outputs
+(standard deduction, shelter deduction, etc.). Anything that does not match a
+pattern is classified as `not_comparable` with a per-rule rationale pulled from
+the rule's `source:` field — i.e., the rationale is the actual source text the
+encoder grounded against, not a chapter-level fig leaf.
+
+This lets future state encodings get the comparable mappings for free, and
+makes the residual `not_comparable` entries informative enough that a later
+Codex/agent pass can promote them to direct_variable / parameter_value based on
+the rule-specific rationale, without having to re-read the source corpus.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import yaml
+
+
+@dataclass(frozen=True)
+class Pattern:
+    """One rule-name pattern → PolicyEngine mapping."""
+
+    rule_pattern: re.Pattern[str]
+    mapping_type: str  # direct_variable | parameter_value
+    policyengine_variable: str | None = None
+    policyengine_parameter: str | None = None
+    entity: str = "spm_unit"
+    period: str = "month"
+    unit: str | None = None
+    comparison: str | None = None
+    rationale: str = ""
+
+
+# High-confidence SNAP patterns.
+#
+# Patterns are intentionally strict: the rule name must BE the canonical name,
+# not contain it as a fragment. A loose match would falsely classify predicates
+# like `arrearage_payments_allowed_in_child_support_deduction` as if they were
+# the deduction itself.
+#
+# A pattern also requires the rule's `dtype` to align with the PolicyEngine
+# variable's natural type (Money for $ amounts, Judgment for booleans), since
+# state encodings frequently use the same word in both a predicate name and an
+# amount name. The `dtype` check is performed by `classify_output`, not the
+# regex.
+#
+# Order matters — the first match wins. More specific patterns precede more
+# general ones.
+SNAP_PATTERNS: tuple[Pattern, ...] = (
+    Pattern(
+        rule_pattern=re.compile(r"^snap_standard_deduction$|^standard_deduction$|^standard_deduction_amount$"),
+        mapping_type="direct_variable",
+        policyengine_variable="snap_standard_deduction",
+        unit="USD",
+        comparison="money",
+        rationale="State SNAP standard deduction is the same household-level standard deduction PolicyEngine exposes as snap_standard_deduction.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^snap_earned_income_deduction$|^earned_income_deduction$|^earned_income_deduction_amount$"),
+        mapping_type="direct_variable",
+        policyengine_variable="snap_earned_income_deduction",
+        unit="USD",
+        comparison="money",
+        rationale="State SNAP earned-income deduction is the same household-level deduction PolicyEngine exposes as snap_earned_income_deduction.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^snap_excess_medical_expense_deduction$|^excess_medical_expense_deduction$|^medical_expense_deduction$"),
+        mapping_type="direct_variable",
+        policyengine_variable="snap_excess_medical_expense_deduction",
+        unit="USD",
+        comparison="money",
+        rationale="State SNAP excess medical expense deduction is the same household-level deduction PolicyEngine exposes as snap_excess_medical_expense_deduction.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^snap_excess_shelter_expense_deduction$|^excess_shelter_expense_deduction$|^excess_shelter_deduction$|^shelter_deduction$"),
+        mapping_type="direct_variable",
+        policyengine_variable="snap_excess_shelter_expense_deduction",
+        unit="USD",
+        comparison="money",
+        rationale="State SNAP excess shelter expense deduction is the same household-level deduction PolicyEngine exposes as snap_excess_shelter_expense_deduction.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^snap_dependent_care_deduction$|^dependent_care_deduction$"),
+        mapping_type="direct_variable",
+        policyengine_variable="snap_dependent_care_deduction",
+        unit="USD",
+        comparison="money",
+        rationale="State SNAP dependent care deduction matches the household-level deduction PolicyEngine exposes as snap_dependent_care_deduction.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^snap_child_support_gross_income_deduction$|^child_support_deduction$|^child_support_gross_income_deduction$"),
+        mapping_type="direct_variable",
+        policyengine_variable="snap_child_support_gross_income_deduction",
+        unit="USD",
+        comparison="money",
+        rationale="State SNAP child-support gross-income deduction matches the household-level deduction PolicyEngine exposes as snap_child_support_gross_income_deduction.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^snap_standard_utility_allowance$|^standard_utility_allowance$|^sua$"),
+        mapping_type="direct_variable",
+        policyengine_variable="snap_standard_utility_allowance",
+        unit="USD",
+        comparison="money",
+        rationale="State SNAP standard utility allowance is the same household-level allowance PolicyEngine exposes as snap_standard_utility_allowance.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^snap_limited_utility_allowance$|^limited_utility_allowance$|^lua$"),
+        mapping_type="direct_variable",
+        policyengine_variable="snap_limited_utility_allowance",
+        unit="USD",
+        comparison="money",
+        rationale="State SNAP limited utility allowance is the same household-level allowance PolicyEngine exposes as snap_limited_utility_allowance.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^snap_individual_utility_allowance$|^individual_utility_allowance$"),
+        mapping_type="direct_variable",
+        policyengine_variable="snap_individual_utility_allowance",
+        unit="USD",
+        comparison="money",
+        rationale="State SNAP individual utility allowance is the same household-level allowance PolicyEngine exposes as snap_individual_utility_allowance.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^meets_snap_gross_income_test$|^meets_gross_income_test$"),
+        mapping_type="direct_variable",
+        policyengine_variable="meets_snap_gross_income_test",
+        unit=None,
+        comparison="decision",
+        rationale="State SNAP gross-income eligibility test matches the household-level test PolicyEngine exposes as meets_snap_gross_income_test.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^meets_snap_net_income_test$|^meets_net_income_test$"),
+        mapping_type="direct_variable",
+        policyengine_variable="meets_snap_net_income_test",
+        unit=None,
+        comparison="decision",
+        rationale="State SNAP net-income eligibility test matches the household-level test PolicyEngine exposes as meets_snap_net_income_test.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^meets_snap_asset_test$|^meets_asset_test$"),
+        mapping_type="direct_variable",
+        policyengine_variable="meets_snap_asset_test",
+        unit=None,
+        comparison="decision",
+        rationale="State SNAP asset eligibility test matches the household-level test PolicyEngine exposes as meets_snap_asset_test.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^snap_normal_allotment$|^normal_allotment$|^monthly_allotment$|^monthly_snap_allotment$"),
+        mapping_type="direct_variable",
+        policyengine_variable="snap_normal_allotment",
+        unit="USD",
+        comparison="money",
+        rationale="State SNAP normal monthly allotment matches the household-level allotment PolicyEngine exposes as snap_normal_allotment.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^snap_max_allotment$|^maximum_allotment$|^max_allotment$"),
+        mapping_type="direct_variable",
+        policyengine_variable="snap_max_allotment",
+        unit="USD",
+        comparison="money",
+        rationale="State SNAP maximum allotment matches the household-level cap PolicyEngine exposes as snap_max_allotment.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^snap_min_allotment$|^minimum_allotment$|^min_allotment$"),
+        mapping_type="direct_variable",
+        policyengine_variable="snap_min_allotment",
+        unit="USD",
+        comparison="money",
+        rationale="State SNAP minimum allotment matches the household-level floor PolicyEngine exposes as snap_min_allotment.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^is_snap_eligible$|^snap_eligible$|^household_snap_eligible$"),
+        mapping_type="direct_variable",
+        policyengine_variable="is_snap_eligible",
+        unit=None,
+        comparison="decision",
+        rationale="State SNAP eligibility decision matches the household-level decision PolicyEngine exposes as is_snap_eligible.",
+    ),
+    Pattern(
+        rule_pattern=re.compile(r"^snap_expected_contribution$|^expected_contribution$"),
+        mapping_type="direct_variable",
+        policyengine_variable="snap_expected_contribution",
+        unit="USD",
+        comparison="money",
+        rationale="State SNAP expected contribution matches the household-level expected contribution PolicyEngine exposes as snap_expected_contribution.",
+    ),
+)
+
+
+# When a pattern would map to a Money/USD comparison, the rule's dtype must
+# align (Money or Integer). Boolean predicates with names like
+# `arrearage_payments_allowed_in_child_support_deduction` should not be matched
+# to the dollar-amount variable.
+_MONEY_DTYPES = {"Money", "USD", "Integer", "Decimal", "Number"}
+_DECISION_DTYPES = {"Judgment", "Bool", "Boolean", "Decision"}
+
+
+@dataclass(frozen=True)
+class Classification:
+    """One classification entry for us.yaml emission."""
+
+    legal_id: str
+    mapping_type: str
+    policyengine_variable: str | None
+    policyengine_parameter: str | None
+    entity: str | None
+    period: str | None
+    unit: str | None
+    comparison: str | None
+    rationale: str
+    matched_pattern: str | None
+
+
+def classify_output(
+    *,
+    rule_name: str,
+    legal_id: str,
+    source_text: str | None,
+    dtype: str | None = None,
+    patterns: Iterable[Pattern] = SNAP_PATTERNS,
+) -> Classification:
+    """Classify one output: return Classification with patterns applied.
+
+    `dtype` is the rule's RuleSpec dtype (e.g., "Money", "Judgment"). When a
+    pattern's `comparison` is "money", the rule's dtype must be a money-like
+    type; when "decision", the rule's dtype must be a boolean-like type. This
+    prevents predicates and amounts from matching the same pattern.
+    """
+    for pattern in patterns:
+        if not pattern.rule_pattern.match(rule_name):
+            continue
+        # dtype guard: reject pattern match when the rule's dtype clearly
+        # disagrees with the pattern's natural comparison kind.
+        if dtype:
+            if pattern.comparison == "money" and dtype not in _MONEY_DTYPES:
+                continue
+            if pattern.comparison == "decision" and dtype not in _DECISION_DTYPES:
+                continue
+        return Classification(
+            legal_id=legal_id,
+            mapping_type=pattern.mapping_type,
+            policyengine_variable=pattern.policyengine_variable,
+            policyengine_parameter=pattern.policyengine_parameter,
+            entity=pattern.entity,
+            period=pattern.period,
+            unit=pattern.unit,
+            comparison=pattern.comparison,
+            rationale=pattern.rationale,
+            matched_pattern=pattern.rule_pattern.pattern,
+        )
+    # Fallback: not_comparable with per-rule rationale.
+    rationale = (
+        f"Source-specific intermediate output (rule `{rule_name}`); "
+        + (
+            f"grounded against {source_text}. "
+            if source_text
+            else ""
+        )
+        + "PolicyEngine does not expose an aligned variable; promote to direct_variable / parameter_value if a one-to-one PE target is identified."
+    )
+    return Classification(
+        legal_id=legal_id,
+        mapping_type="not_comparable",
+        policyengine_variable=None,
+        policyengine_parameter=None,
+        entity=None,
+        period=None,
+        unit=None,
+        comparison=None,
+        rationale=rationale,
+        matched_pattern=None,
+    )
+
+
+def classification_to_yaml_block(c: Classification, *, program: str = "snap") -> str:
+    """Render a Classification as a us.yaml entry."""
+    lines = [f"  - legal_id: {c.legal_id}"]
+    lines.append(f"    country: us")
+    lines.append(f"    program: {program}")
+    lines.append(f"    mapping_type: {c.mapping_type}")
+    if c.policyengine_variable is not None:
+        lines.append(f"    policyengine_variable: {c.policyengine_variable}")
+    if c.policyengine_parameter is not None:
+        lines.append(f"    policyengine_parameter: {c.policyengine_parameter}")
+    if c.entity is not None:
+        lines.append(f"    entity: {c.entity}")
+    if c.period is not None:
+        lines.append(f"    period: {c.period}")
+    if c.unit is not None:
+        lines.append(f"    unit: {c.unit}")
+    if c.comparison is not None:
+        lines.append(f"    comparison: {c.comparison}")
+    if c.rationale:
+        # YAML scalar safety: always emit as a quoted scalar via yaml.safe_dump
+        # to escape colons, hashes, brackets, and other reserved characters.
+        rationale_one_line = c.rationale.replace("\n", " ").strip()
+        # `yaml.safe_dump` emits "value\n"; strip the trailing newline.
+        rendered = yaml.safe_dump(
+            rationale_one_line, default_style='"', width=10_000
+        ).strip()
+        lines.append(f"    rationale: {rendered}")
+    return "\n".join(lines)
+
+
+def iter_rules_in_rulespec_file(path: Path) -> Iterable[tuple[str, str | None, str | None]]:
+    """Yield (rule_name, source_text, dtype) for every executable rule in a RuleSpec file."""
+    payload = yaml.safe_load(path.read_text())
+    if not isinstance(payload, dict):
+        return
+    for rule in payload.get("rules", []) or []:
+        if not isinstance(rule, dict):
+            continue
+        name = rule.get("name")
+        if not name:
+            continue
+        kind = rule.get("kind")
+        # Executable outputs: derived, parameter.
+        if kind not in {"derived", "parameter"}:
+            continue
+        source = rule.get("source")
+        if isinstance(source, dict):
+            source_text = source.get("text") or source.get("excerpt")
+        else:
+            source_text = source if isinstance(source, str) else None
+        dtype = rule.get("dtype")
+        yield (name, source_text, dtype)
+
+
+def classify_rulespec_repo(
+    *,
+    repo_root: Path,
+    jurisdiction: str,
+    program: str = "snap",
+) -> list[Classification]:
+    """Walk a rulespec-us-<state> repository and classify every output."""
+    classifications: list[Classification] = []
+    for path in sorted(repo_root.rglob("*.yaml")):
+        if path.name.endswith(".test.yaml"):
+            continue
+        # Build legal-id prefix from path relative to repo root.
+        rel = path.relative_to(repo_root)
+        # rel: regulations/106-cmr/364/400/block-1.yaml
+        rel_no_ext = str(rel).removesuffix(".yaml")
+        file_legal_prefix = f"{jurisdiction}:{rel_no_ext}"
+        for rule_name, source_text, dtype in iter_rules_in_rulespec_file(path):
+            legal_id = f"{file_legal_prefix}#{rule_name}"
+            classifications.append(
+                classify_output(
+                    rule_name=rule_name,
+                    legal_id=legal_id,
+                    source_text=source_text,
+                    dtype=dtype,
+                )
+            )
+    return classifications
+
+
+def emit_us_yaml_block(classifications: Iterable[Classification], *, program: str = "snap") -> str:
+    """Emit a YAML fragment ready to splice into us.yaml under mappings:."""
+    return "\n\n".join(classification_to_yaml_block(c, program=program) for c in classifications)
+
+
+__all__ = [
+    "Classification",
+    "Pattern",
+    "SNAP_PATTERNS",
+    "classify_output",
+    "classify_rulespec_repo",
+    "classification_to_yaml_block",
+    "emit_us_yaml_block",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.414"
+version = "0.2.415"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.413"
+version = "0.2.414"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What this does

Replaces 247 chapter-level `legal_id_prefix: us-{ma,nc,tn,fl}` not_comparable bulk-marks with 448 per-rule mapping entries produced by a new `pattern_classifier.py` module.

## Why

The previous approach (PRs #437 and #444) bulk-marked every output in every state SNAP file as `not_comparable` via chapter-level prefixes. That unblocked CI but obscured real comparable mappings and left no per-rule rationale for follow-up promotion. This was unsustainable: every new state would repeat the pattern.

## How

A new module `src/axiom_encode/oracles/policyengine/pattern_classifier.py` walks a rulespec-us-<state> repo, matches each output's name against `SNAP_PATTERNS` (strict, dtype-guarded patterns for federal-aligned SNAP outputs), and emits a per-output classification:

- 5 high-confidence outputs promoted to `direct_variable` against real PolicyEngine variables (`medical_expense_deduction`, `child_support_deduction`, `monthly_allotment`, `standard_deduction`, `standard_utility_allowance`).
- The remaining 443 outputs are `not_comparable` with a per-rule rationale rather than a chapter-level one.

Strict patterns prevent false positives. A `Judgment`-typed predicate named `arrearage_payments_allowed_in_child_support_deduction` will not match the `Money`-typed `snap_child_support_gross_income_deduction` variable because of the dtype guard.

## Sustainability

`SNAP_PATTERNS` is shared across all states. Every new state encoding automatically gets the comparable matches as new patterns are added, and a Codex follow-up agent can promote individual per-rule `not_comparable` entries to `direct_variable` using the rule-specific rationale.

## Verification

```bash
axiom-encode oracle-coverage --root /path --program snap
# us-ma: comparable=3, not_comparable=398, unmapped=0
# us-nc: comparable=0, not_comparable=6, unmapped=0
# us-tn: comparable=2, not_comparable=37, unmapped=0
# us-fl: comparable=0, not_comparable=2, unmapped=0
```

System-wide SNAP comparable count: 56 → 61. Zero new unmapped outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)