### PR TITLE
Fix multiline nonnegative floor validation

### DIFF
--- a/changelog.d/colorado-income-tax-federal-return-bases.fixed.md
+++ b/changelog.d/colorado-income-tax-federal-return-bases.fixed.md
@@ -1,0 +1,1 @@
+Fixed nonnegative-floor validation for multiline conditional formulas and clarified encoder guidance for downstream tax rules that consume completed federal return amounts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.415"
+version = "0.2.416"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.415"
+__version__ = "0.2.416"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3622,6 +3622,20 @@ RuleSpec requirements:
   `additional_standard_deduction_entitlement_count_under_subsection_f`, rather
   than inventing the cross-referenced age, blindness, household, or membership
   tests locally.
+- When a state, local, or downstream tax source consumes a completed federal
+  return amount, such as a deduction, credit, federal adjusted gross income,
+  federal taxable income, or itemized deductions already claimed on the federal
+  return, keep the current source executable from a neutral federal-return
+  amount input if no same-period imported RuleSpec output directly exports that
+  completed return line. Name that input for the completed return amount, not
+  for the legal citation pointer: for example use a name like
+  `federal_return_deduction_amount` or
+  `itemized_deductions_claimed_on_federal_return`, not
+  `section_<section>_*`, `*_under_section_<section>`, or
+  `*_allowed_under_section_<section>`. This rule applies only when the current
+  source merely adds, subtracts, caps, gates, or otherwise consumes the
+  completed upstream return amount; do not use it to restate upstream mechanics
+  that the current source does not provide.
 - When an unencoded cross-reference must be represented as a semantic local
   input, name it after the legal status with an `_under_section_<section>` or
   `_under_subsection_<subsection>` suffix. Do not start a local input with

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -8335,9 +8335,98 @@ def _formula_result_expressions(formula: str) -> list[str]:
         if branch is not None:
             expression = _branch_result_expression(branch.group(1).strip())
             expressions.extend(_split_inline_conditional_result_expressions(expression))
+    if not expressions:
+        expressions.extend(_indented_conditional_result_expressions(formula))
     if not expressions and formula.strip():
         expressions.append(formula.strip())
     return expressions
+
+
+_INDENTED_CONDITIONAL_CONTROL_LINE_PATTERN = re.compile(
+    r"^\s*(?:if\b.+|elif\b.+|else)\s*:\s*$",
+    flags=re.IGNORECASE,
+)
+_EXPRESSION_CONTINUATION_PREFIX_PATTERN = re.compile(
+    r"^(?:and|or|[+*/%<>=!&|])\b|^[-+*/%)]"
+)
+_EXPRESSION_CONTINUATION_SUFFIX_PATTERN = re.compile(
+    r"(?:[+\-*/%<>=!&|]|\b(?:and|or)\b|[,([{])$",
+    flags=re.IGNORECASE,
+)
+
+
+def _indented_conditional_result_expressions(formula: str) -> list[str]:
+    """Return leaf expressions from an indented Rulespec conditional block."""
+    lines = formula.splitlines()
+    if not any(
+        _INDENTED_CONDITIONAL_CONTROL_LINE_PATTERN.match(line) for line in lines
+    ):
+        return []
+
+    expressions: list[str] = []
+    index = 0
+    while index < len(lines):
+        raw_line = lines[index]
+        line = raw_line.strip()
+        if not line or _INDENTED_CONDITIONAL_CONTROL_LINE_PATTERN.match(raw_line):
+            index += 1
+            continue
+
+        expression_lines = [line]
+        depth = _formula_bracket_depth_delta(line)
+        index += 1
+        while index < len(lines):
+            next_raw = lines[index]
+            next_line = next_raw.strip()
+            if not next_line:
+                index += 1
+                continue
+            if depth <= 0 and _INDENTED_CONDITIONAL_CONTROL_LINE_PATTERN.match(
+                next_raw
+            ):
+                break
+            if depth <= 0 and not _formula_line_continues_expression(
+                expression_lines[-1],
+                next_line,
+            ):
+                break
+            expression_lines.append(next_line)
+            depth += _formula_bracket_depth_delta(next_line)
+            index += 1
+
+        expression = "\n".join(expression_lines).strip()
+        expressions.extend(_split_inline_conditional_result_expressions(expression))
+
+    return expressions
+
+
+def _formula_line_continues_expression(previous_line: str, next_line: str) -> bool:
+    return bool(
+        _EXPRESSION_CONTINUATION_SUFFIX_PATTERN.search(previous_line.strip())
+        or _EXPRESSION_CONTINUATION_PREFIX_PATTERN.search(next_line.strip())
+    )
+
+
+def _formula_bracket_depth_delta(expression: str) -> int:
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for char in expression:
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            continue
+        if char in {"'", '"'}:
+            quote = char
+        elif char in "([{":
+            depth += 1
+        elif char in ")]}" and depth:
+            depth -= 1
+    return depth
 
 
 _INLINE_CONDITIONAL_RESULT_PATTERN = re.compile(

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -341,6 +341,20 @@ Hard requirements:
   `additional_standard_deduction_entitlement_count_under_subsection_f`, rather
   than inventing the cross-referenced age, blindness, household, or membership
   tests locally.
+- When a state, local, or downstream tax source consumes a completed federal
+  return amount, such as a deduction, credit, federal adjusted gross income,
+  federal taxable income, or itemized deductions already claimed on the federal
+  return, keep the current source executable from a neutral federal-return
+  amount input if no same-period imported RuleSpec output directly exports that
+  completed return line. Name that input for the completed return amount, not
+  for the legal citation pointer: for example use a name like
+  `federal_return_deduction_amount` or
+  `itemized_deductions_claimed_on_federal_return`, not
+  `section_<section>_*`, `*_under_section_<section>`, or
+  `*_allowed_under_section_<section>`. This rule applies only when the current
+  source merely adds, subtracts, caps, gates, or otherwise consumes the
+  completed upstream return amount; do not use it to restate upstream mechanics
+  that the current source does not provide.
 - When an unencoded cross-reference must be represented as a semantic local
   input, name it after the legal status with an `_under_section_<section>` or
   `_under_subsection_<subsection>` suffix. Do not start a local input with

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -118,6 +118,8 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "`organization described in section X`" in ENCODER_PROMPT
     assert "organization_described_in_section_509_a_3" in ENCODER_PROMPT
     assert "testing\n  membership in the described category" in ENCODER_PROMPT
+    assert "completed federal\n  return amount" in ENCODER_PROMPT
+    assert "itemized_deductions_claimed_on_federal_return" in ENCODER_PROMPT
     assert "unrelated-trade-or-business" in ENCODER_PROMPT
     assert "within-meaning/described-in definitions" in ENCODER_PROMPT
     assert "positive/nonzero" in ENCODER_PROMPT

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -4005,6 +4005,8 @@ class TestEvalPrompt:
         )
         assert "Do not start a local input with" in prompt
         assert "_under_section_<section>" in prompt
+        assert "completed federal\n  return amount" in prompt
+        assert "itemized_deductions_claimed_on_federal_return" in prompt
         assert "For IRC section 22" not in prompt
         assert "dependent_of_tax_unit" in prompt
         assert "only the exception input changes" in prompt

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -13505,6 +13505,32 @@ rules:
     assert find_nonnegative_amount_reduction_issues(repaired) == []
 
 
+def test_nonnegative_taxable_income_allows_multiline_floored_branches():
+    content = """format: rulespec/v1
+rules:
+  - name: itemized_deduction_addition_to_federal_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          if taxpayer_subject_to_itemized_deduction_addition:
+            if taxpayer_files_single_return:
+              max(0, itemized_deductions - single_return_floor)
+            else:
+              if taxpayers_file_joint_return:
+                max(0, itemized_deductions - joint_return_floor)
+              else:
+                0
+          else:
+            0
+"""
+
+    assert find_nonnegative_amount_reduction_issues(content) == []
+
+
 def test_repair_nonnegative_amount_reductions_does_not_replace_identifier_substrings():
     content = """format: rulespec/v1
 rules:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.415"
+version = "0.2.416"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary\n- accept zero-floored leaf branches inside multiline conditional formulas\n- clarify encoder guidance for state/downstream tax rules that consume completed federal return-line amounts\n- bump axiom-encode to 0.2.416\n\n## Tests\n- uv run pytest tests/test_rulespec_validation.py::test_nonnegative_taxable_income_allows_multiline_floored_branches tests/test_rulespec_validation.py::test_nonnegative_amount_reduction_rejects_unfloored_taxable_income_branch tests/test_rulespec_validation.py::test_repair_nonnegative_amount_reductions_floors_taxable_income_branches -q\n- uv run pytest tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_statutory_base_naming_guidance tests/test_evals.py::TestEvalPrompt::test_build_eval_prompt_includes_rulespec_schema_guardrails -q\n- uv run ruff check src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/harness/evals.py src/axiom_encode/prompts/encoder.py tests/test_rulespec_validation.py tests/test_encoder_backend.py tests/test_evals.py\n- uv run pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q