### PR TITLE
Fix generated RuleSpec validation and deferral prompts

### DIFF
--- a/changelog.d/cross-reference-exception-boundary.fixed.md
+++ b/changelog.d/cross-reference-exception-boundary.fixed.md
@@ -1,0 +1,1 @@
+Scoped partial child-rewiring prompt guidance to the requested legal fragment and clarified that cross-reference exceptions should not cause whole-formula deferral when the target source states an executable formula.

--- a/changelog.d/inline-conditional-zero-floor.fixed.md
+++ b/changelog.d/inline-conditional-zero-floor.fixed.md
@@ -1,0 +1,1 @@
+Fix nonnegative floor validation for zero-floored formulas that contain nested inline conditionals.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.423"
+version = "0.2.424"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.423"
+__version__ = "0.2.424"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3425,8 +3425,8 @@ Test file rules:
   without this paired positive/negative companion.
 - Do not collapse a list of cited exceptions or cross-reference carve-outs into one aggregate fact such as `sections_..._do_not_preclude...`. Encode or import each cited exception separately, then combine them in a helper if useful.
 - If context files import this target file or reference this target file's outputs, use that as a signal to repair the dependency graph, not as a requirement to preserve old names. Keep an old output only when it remains the cleanest source-faithful RuleSpec surface.
-- Do not preserve existing factual input slots referenced by copied formulas or companion tests when a cleaner source-faithful encoding removes them. This is especially important for names listed under invalid copied local inputs.
-- For cross-reference boundary facts that remain local because the cited source is not present in context at all, keep the legal pointer in the identifier. If context for the cited source is present but unsupported, deferred, empty, or missing the needed export, do not preserve, rename, or recreate the local cross-reference fact; import a real export, defer the affected executable surface, or encode a source-grounded overriding branch that avoids it.
+- Do not preserve existing factual input slots referenced by copied formulas or companion tests when a cleaner source-faithful encoding removes them. For names listed under invalid copied local inputs, do not preserve, rename, or recreate them.
+- For cross-reference boundary facts that remain local because the cited source is not present in context at all, keep the legal pointer in the identifier. If context for the cited source is present but unsupported, deferred, empty, or missing the exact displacement or exception export, encode a source-grounded local boundary predicate for whether that cited source displaces or blocks the requested source's formula; do not defer the requested formula merely because the copied cited file exports only its own separate amount.
 - For repo-backed artifacts, every `input:` and `output:` key must be a canonical
   legal RuleSpec reference that resolves to an actual file and fragment; do not
   use bare friendly keys or absolute-looking placeholders.
@@ -3818,6 +3818,18 @@ RuleSpec requirements:
   subtype, carve-out, or branch, defer only that branch or expose a
   source-named boundary input for that branch. Do not defer an unrelated
   source-stated cap/base computation that can be executed from the source text.
+- When the requested source states its own amount, cap, threshold, or formula
+  but begins with an exception such as `except as otherwise provided in section
+  X` or `except as otherwise provided in subsection X`, do not defer the
+  requested formula merely because section X has unresolved effective versions,
+  ballot triggers, repeal facts, or program conditions. Encode the requested
+  source's own formula and represent the cross-reference boundary with a
+  source-named predicate such as
+  `subsection_x_does_not_displace_this_subsection` unless an import supplies the
+  exact displacement predicate. A cited provision's separate amount, addition,
+  deduction, or benefit output is not itself a displacement predicate and is not
+  a reason to defer the requested source's own formula. Include a companion case
+  where the cross-reference boundary blocks the local output.
 - Importing a child rate or threshold is not enough when the child file already
   exports the executable tax, benefit, deduction, or eligibility result. For
   aggregate parent sections, import the child result output itself and sum,
@@ -4680,7 +4692,10 @@ def _format_partial_extent_child_schema_limit_guidance(
     """Return target-specific guidance for unsupported partial child rewiring."""
     if not target_ref_prefix:
         return ""
-    if not _source_has_partial_extent_child_rewiring_limit(source_text):
+    scoped_source_text = _target_source_scope_for_heuristics(
+        source_text, target_ref_prefix
+    )
+    if not _source_has_partial_extent_child_rewiring_limit(scoped_source_text):
         return ""
     child_prefix = f"{target_ref_prefix.rstrip('/')}/"
     child_terminal_refs: list[str] = []
@@ -4783,6 +4798,70 @@ Aggregate parent child outputs detected:
   terminal numeric outputs for sibling child branches instead of recomputing
   them locally.{input_guidance}
 """
+
+
+def _target_source_scope_for_heuristics(
+    source_text: str, target_ref_prefix: str
+) -> str:
+    """Return the apparent target paragraph slice for prompt heuristics.
+
+    Some corpus pages contain a whole section even when the requested target is
+    a child paragraph. Prompt heuristics should not let unrelated sibling text
+    trigger target-specific instructions.
+    """
+    fragments = _legal_fragments_from_rulespec_ref(target_ref_prefix)
+    if not fragments:
+        return source_text
+
+    start = 0
+    for fragment in fragments:
+        match = re.search(
+            rf"\({re.escape(fragment)}\)",
+            source_text[start:],
+            flags=re.IGNORECASE,
+        )
+        if not match:
+            return source_text
+        start += match.start()
+        search_from = start + len(match.group(0))
+
+    sibling_pattern = _sibling_marker_pattern(fragments[-1])
+    end = len(source_text)
+    if sibling_pattern:
+        sibling = re.search(
+            sibling_pattern,
+            source_text[search_from:],
+            flags=re.IGNORECASE,
+        )
+        if sibling:
+            end = search_from + sibling.start()
+    return source_text[start:end]
+
+
+def _legal_fragments_from_rulespec_ref(target_ref_prefix: str) -> list[str]:
+    """Return legal child fragments after the title/section prefix."""
+    path = target_ref_prefix.split(":", 1)[-1]
+    parts = [part for part in path.split("/") if part]
+    if "statutes" in parts:
+        idx = parts.index("statutes")
+        if len(parts) > idx + 3:
+            return parts[idx + 3 :]
+    if "regulations" in parts:
+        idx = parts.index("regulations")
+        if len(parts) > idx + 3:
+            return parts[idx + 3 :]
+    return []
+
+
+def _sibling_marker_pattern(fragment: str) -> str | None:
+    """Return a parenthetical marker pattern for the next same-level sibling."""
+    if re.fullmatch(r"\d+(?:\.\d+)?", fragment):
+        return r"\(\d+(?:\.\d+)?\)"
+    if re.fullmatch(r"[a-z](?:\.\d+)?", fragment, flags=re.IGNORECASE):
+        if fragment.isupper():
+            return r"\([A-Z](?:\.\d+)?\)"
+        return r"\([a-z](?:\.\d+)?\)"
+    return None
 
 
 def _source_has_partial_extent_child_rewiring_limit(source_text: str) -> bool:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -7629,11 +7629,14 @@ def repair_nonnegative_amount_reductions(content: str) -> tuple[str, list[str]]:
             )
             if repaired_formula == formula:
                 continue
-            repaired_content = _replace_formula_text_once(
+            updated_content = _replace_formula_text_once(
                 repaired_content,
                 formula,
                 repaired_formula,
             )
+            if updated_content == repaired_content:
+                continue
+            repaired_content = updated_content
             repaired_rules.append(name or "<unknown>")
     return repaired_content, repaired_rules
 
@@ -8067,6 +8070,9 @@ def _replace_formula_text_once(content: str, old: str, new: str) -> str:
     replaced_block = _replace_indented_block_text_once(content, old, new)
     if replaced_block != content:
         return replaced_block
+    replaced_folded_scalar = _replace_folded_formula_scalar_text_once(content, old, new)
+    if replaced_folded_scalar != content:
+        return replaced_folded_scalar
     updated = content
     for old_line, new_line in zip(old.splitlines(), new.splitlines(), strict=False):
         if old_line == new_line:
@@ -8085,6 +8091,31 @@ def _replace_formula_text_once(content: str, old: str, new: str) -> str:
             updated = "".join(lines)
             break
     return updated
+
+
+def _replace_folded_formula_scalar_text_once(content: str, old: str, new: str) -> str:
+    old_normalized = _normalize_yaml_folded_scalar_text(old)
+    if not old_normalized:
+        return content
+    formula_scalar_pattern = re.compile(
+        r"formula:\s*(?P<quote>['\"])(?P<body>.*?)(?P=quote)",
+        flags=re.DOTALL,
+    )
+    for match in formula_scalar_pattern.finditer(content):
+        body = match.group("body")
+        if _normalize_yaml_folded_scalar_text(body) != old_normalized:
+            continue
+        line_start = content.rfind("\n", 0, match.start()) + 1
+        indent_match = re.match(r"[ \t]*", content[line_start : match.start()])
+        indent = indent_match.group(0) if indent_match is not None else ""
+        replacement_lines = [f"{indent}  {line}" for line in new.splitlines()]
+        replacement = "formula: |-\n" + "\n".join(replacement_lines)
+        return content[: match.start()] + replacement + content[match.end() :]
+    return content
+
+
+def _normalize_yaml_folded_scalar_text(value: str) -> str:
+    return " ".join(value.split())
 
 
 def _replace_indented_block_text_once(content: str, old: str, new: str) -> str:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -8322,8 +8322,7 @@ def _formula_result_expressions(formula: str) -> list[str]:
         line = raw_line.strip()
         if not line:
             continue
-        inline_conditional = _INLINE_CONDITIONAL_RESULT_PATTERN.match(line)
-        if inline_conditional is not None:
+        if _inline_conditional_result_parts(line) is not None:
             expressions.extend(_split_inline_conditional_result_expressions(line))
             continue
         match_arm = re.match(r"^(?:\d+|default|otherwise|_)\s*=>\s*(.+)$", line)
@@ -8430,34 +8429,92 @@ def _formula_bracket_depth_delta(expression: str) -> int:
     return depth
 
 
-_INLINE_CONDITIONAL_RESULT_PATTERN = re.compile(
-    r"^(?:if\b.+?|elif\b.+?)\s*:\s*(.+?)\s+else\s*:\s*(.+)$",
-    flags=re.IGNORECASE,
-)
+_INLINE_CONDITIONAL_START_PATTERN = re.compile(r"^(?:if|elif)\b", flags=re.IGNORECASE)
 
 
 def _branch_result_expression(branch_tail: str) -> str:
-    if _INLINE_CONDITIONAL_RESULT_PATTERN.match(branch_tail):
+    if _inline_conditional_result_parts(branch_tail) is not None:
         return branch_tail
-    return re.split(
-        r"\s+else\s*:",
-        branch_tail,
-        maxsplit=1,
-        flags=re.IGNORECASE,
-    )[0].strip()
+    top_level_else = _top_level_else_bounds(branch_tail)
+    if top_level_else is None:
+        return branch_tail.strip()
+    else_start, _else_end = top_level_else
+    return branch_tail[:else_start].strip()
 
 
 def _split_inline_conditional_result_expressions(expression: str) -> list[str]:
     expression = expression.strip()
     if not expression:
         return []
-    inline_conditional = _INLINE_CONDITIONAL_RESULT_PATTERN.match(expression)
+    inline_conditional = _inline_conditional_result_parts(expression)
     if inline_conditional is None:
         return [expression]
+    then_expression, else_expression = inline_conditional
     return [
-        *(_split_inline_conditional_result_expressions(inline_conditional.group(1))),
-        *(_split_inline_conditional_result_expressions(inline_conditional.group(2))),
+        *(_split_inline_conditional_result_expressions(then_expression)),
+        *(_split_inline_conditional_result_expressions(else_expression)),
     ]
+
+
+def _inline_conditional_result_parts(expression: str) -> tuple[str, str] | None:
+    expression = expression.strip()
+    if _INLINE_CONDITIONAL_START_PATTERN.match(expression) is None:
+        return None
+
+    colon_index = _top_level_conditional_colon_index(expression)
+    if colon_index is None:
+        return None
+    top_level_else = _top_level_else_bounds(expression[colon_index + 1 :])
+    if top_level_else is None:
+        return None
+
+    else_start, else_end = top_level_else
+    then_expression = expression[colon_index + 1 : colon_index + 1 + else_start]
+    else_expression = expression[colon_index + 1 + else_end :]
+    return then_expression.strip(), else_expression.strip()
+
+
+def _top_level_conditional_colon_index(expression: str) -> int | None:
+    for index, char, depth in _formula_scan_chars(expression):
+        if char == ":" and depth == 0:
+            return index
+    return None
+
+
+def _top_level_else_bounds(expression: str) -> tuple[int, int] | None:
+    for index, char, depth in _formula_scan_chars(expression):
+        if depth != 0 or char.lower() != "e":
+            continue
+        prefix_ok = index == 0 or expression[index - 1].isspace()
+        if not prefix_ok:
+            continue
+        match = re.match(r"else\s*:", expression[index:], flags=re.IGNORECASE)
+        if match is not None:
+            return index, index + match.end()
+    return None
+
+
+def _formula_scan_chars(expression: str) -> Iterable[tuple[int, str, int]]:
+    depth = 0
+    quote: str | None = None
+    escaped = False
+    for index, char in enumerate(expression):
+        if quote is not None:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == quote:
+                quote = None
+            yield index, char, depth
+            continue
+        if char in {"'", '"'}:
+            quote = char
+        elif char in "([{":
+            depth += 1
+        elif char in ")]}" and depth:
+            depth -= 1
+        yield index, char, depth
 
 
 def _final_expression_has_zero_floor(expression: str) -> bool:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -5863,6 +5863,68 @@ rules:
         assert "Taxpayer elections such as electing to itemize deductions" in prompt
         assert "Outputs named `taxable_income`" in prompt
 
+    def test_build_eval_prompt_scopes_partial_extent_to_target_paragraph(
+        self, tmp_path
+    ):
+        policy_repo_root = tmp_path / "rulespec-us-co"
+        child_file = (
+            policy_repo_root / "statutes" / "39" / "39-22-104" / "3" / "p" / "5.yaml"
+        )
+        child_file.parent.mkdir(parents=True, exist_ok=True)
+        child_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: initial_window_addition_to_federal_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2023-01-01'
+        formula: federal_deduction_addition
+"""
+        )
+        workspace = prepare_eval_workspace(
+            citation="us-co/statute/39/39-22-104/3/p",
+            runner=parse_runner_spec("openai:gpt-5.5"),
+            output_root=tmp_path / "out",
+            source_text=(
+                "(3) There shall be added to federal taxable income:\n"
+                "(p) Except as otherwise provided in subsection (3)(p.5), "
+                "for income tax years commencing on or after January 1, 2022, "
+                "for taxpayers who claim itemized deductions and have federal "
+                "adjusted gross income equal to or exceeding four hundred "
+                "thousand dollars: (I) For a taxpayer who files a single "
+                "return, the amount by which itemized deductions exceed thirty "
+                "thousand dollars; and (II) For taxpayers who file a joint "
+                "return, the amount by which itemized deductions exceed sixty "
+                "thousand dollars.\n"
+                "(p.5) For income tax years commencing on or after January 1, "
+                "2023, a different addition applies.\n"
+                "(4)(i) A subtraction is allowed to the extent included in "
+                "federal taxable income."
+            ),
+            axiom_rules_path=policy_repo_root,
+            mode="repo-augmented",
+            extra_context_paths=[child_file],
+        )
+
+        prompt = _build_eval_prompt(
+            "us-co/statute/39/39-22-104/3/p",
+            "repo-augmented",
+            workspace,
+            workspace.context_files,
+            target_file_name="p.yaml",
+            target_ref_prefix="us-co:statutes/39/39-22-104/3/p",
+            include_tests=True,
+            runner_backend="openai",
+        )
+
+        assert "Target-specific schema limit" not in prompt
+        assert "except as otherwise provided in section" in prompt
+        assert "cited provision's separate amount" in prompt
+        assert "subsection_x_does_not_displace_this_subsection" in prompt
+
     def test_build_eval_prompt_recommends_final_deduction_imports(self, tmp_path):
         policy_repo_root = tmp_path / "rulespec-us"
         cited_file = policy_repo_root / "statutes" / "26" / "170" / "p.yaml"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -13461,6 +13461,23 @@ rules:
     assert find_nonnegative_amount_reduction_issues(content) == []
 
 
+def test_nonnegative_amount_reduction_allows_zero_floor_with_nested_inline_condition():
+    content = """format: rulespec/v1
+rules:
+  - name: charitable_contribution_standard_deduction_subtraction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2001-01-01'
+        formula: |-
+          if eligible: max(0, charitable_contribution_amount - (if credit_claimed: food_contribution_amount else: 0) - charitable_contribution_floor) else: 0
+"""
+
+    assert find_nonnegative_amount_reduction_issues(content) == []
+
+
 def test_nonnegative_amount_reduction_rejects_unfloored_taxable_income_branch():
     content = """format: rulespec/v1
 rules:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -13522,6 +13522,32 @@ rules:
     assert find_nonnegative_amount_reduction_issues(repaired) == []
 
 
+def test_repair_nonnegative_amount_reductions_floors_folded_taxable_income_formula():
+    content = """format: rulespec/v1
+rules:
+  - name: itemized_deduction_addition_to_federal_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2022-01-01'
+        formula: 'if subsection_p5_does_not_displace_this_subsection: itemized_deduction_addition_under_subsection_p
+          else: initial_window_addition_to_federal_taxable_income'
+"""
+
+    repaired, rules = repair_nonnegative_amount_reductions(content)
+
+    assert rules == ["itemized_deduction_addition_to_federal_taxable_income"]
+    assert "formula: |-" in repaired
+    assert (
+        "if subsection_p5_does_not_displace_this_subsection: "
+        "max(0, itemized_deduction_addition_under_subsection_p) "
+        "else: max(0, initial_window_addition_to_federal_taxable_income)" in repaired
+    )
+    assert find_nonnegative_amount_reduction_issues(repaired) == []
+
+
 def test_nonnegative_taxable_income_allows_multiline_floored_branches():
     content = """format: rulespec/v1
 rules:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.423"
+version = "0.2.424"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- parse inline conditional result expressions with depth-aware top-level branch detection
- avoid treating nested inline conditionals inside zero-floored formulas as outer else branches
- repair nonnegative taxable-income formulas even when generated YAML folds a quoted formula scalar
- scope partial child-rewiring prompt guidance to the requested legal fragment
- clarify that cross-reference exceptions should not cause whole-formula deferral when the target source states an executable formula
- bump axiom-encode to 0.2.424

## Tests
- uv run pytest tests/test_rulespec_validation.py::test_repair_nonnegative_amount_reductions_floors_folded_taxable_income_formula tests/test_rulespec_validation.py::test_repair_nonnegative_amount_reductions_floors_taxable_income_branches tests/test_rulespec_validation.py::test_nonnegative_amount_reduction_rejects_unfloored_taxable_income_branch tests/test_rulespec_validation.py::test_nonnegative_amount_reduction_allows_zero_floor_with_nested_inline_condition tests/test_rulespec_validation.py::test_nonnegative_amount_reduction_allows_nested_inline_zero_branch_with_floored_inner_else tests/test_evals.py::TestEvalPrompt::test_build_eval_prompt_includes_rulespec_schema_guardrails tests/test_evals.py::TestEvalPrompt::test_build_eval_prompt_scopes_partial_extent_to_target_paragraph tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- uv run pytest tests/ -q
- uv run ruff check src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py tests/test_rulespec_validation.py
- uv run ruff format --check src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py tests/test_rulespec_validation.py
- smoke: reran us-co/statute/39/39-22-104/3/p to /tmp and verified deterministic nonnegative-floor repair clears its generated CI issue