### PR TITLE
Tighten deferred child and per-unit cap prompts

### DIFF
--- a/changelog.d/deferred-child-composite-prompts.fixed.md
+++ b/changelog.d/deferred-child-composite-prompts.fixed.md
@@ -1,0 +1,1 @@
+Strengthen encoder prompts for deferred child branches and per-unit caps.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.424"
+version = "0.2.425"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.424"
+__version__ = "0.2.425"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -13386,6 +13386,52 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_deferred_rules = []
+                seen_deferred_rules = set()
+                for _repair_attempt in range(5):
+                    repaired_batch = (
+                        _try_repair_generated_unsafe_formula_outputs_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            issues=apply_issues,
+                        )
+                    )
+                    if not repaired_batch:
+                        break
+                    new_repairs = [
+                        repair
+                        for repair in repaired_batch
+                        if repair not in seen_deferred_rules
+                    ]
+                    seen_deferred_rules.update(repaired_batch)
+                    repaired_deferred_rules.extend(new_repairs)
+                    prior_repairs = outcome.get("auto_deferred_unsafe_formula_outputs")
+                    if not isinstance(prior_repairs, list):
+                        prior_repairs = []
+                    outcome["auto_deferred_unsafe_formula_outputs"] = [
+                        *prior_repairs,
+                        *new_repairs,
+                    ]
+                    print(
+                        "  apply=auto_deferred_unsafe_formula_outputs:"
+                        + ",".join(repaired_batch)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+                    if can_apply:
+                        break
+            if not can_apply:
                 repaired_kinds = (
                     _try_repair_generated_invalid_proof_atom_kinds_for_apply(
                         result,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3830,6 +3830,12 @@ RuleSpec requirements:
   deduction, or benefit output is not itself a displacement predicate and is not
   a reason to defer the requested source's own formula. Include a companion case
   where the cross-reference boundary blocks the local output.
+- When that output also composes an imported child or sibling result, check
+  that the imported file does not defer another branch, period, or purpose that
+  can affect the same final amount. Do not treat a missing deferred child branch
+  as zero by importing only the available branch result. Either scope the
+  executable output to the branch where the deferred child branch is impossible,
+  or defer the composite output and list the child deferred dependency.
 - Importing a child rate or threshold is not enough when the child file already
   exports the executable tax, benefit, deduction, or eligibility result. For
   aggregate parent sections, import the child result output itself and sum,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -10688,6 +10688,109 @@ def find_deferred_purpose_specific_limitation_issues(content: str) -> list[str]:
     return issues
 
 
+def find_imported_deferred_branch_composition_issues(
+    content: str,
+    *,
+    rules_file: Path,
+    policy_repo_path: Path,
+) -> list[str]:
+    """Reject final outputs that compose one child branch while another is deferred."""
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+
+    deferred_by_imported_symbol: dict[str, list[tuple[str, set[str], set[str]]]] = {}
+    for import_item in _extract_import_items_from_content(content):
+        import_base, separator, imported_symbol = import_item.partition("#")
+        imported_symbol = imported_symbol.strip()
+        if not separator or not imported_symbol:
+            continue
+        import_file = _resolve_rulespec_import_file_static(
+            import_base,
+            rules_file=rules_file,
+            policy_repo_path=policy_repo_path,
+        )
+        if import_file is None:
+            continue
+        with contextlib.suppress(OSError, yaml.YAMLError, TypeError, ValueError):
+            imported_payload = yaml.safe_load(import_file.read_text()) or {}
+            module = (
+                imported_payload.get("module")
+                if isinstance(imported_payload, dict)
+                else None
+            )
+            deferred_outputs = (
+                module.get("deferred_outputs") if isinstance(module, dict) else None
+            )
+            if not isinstance(deferred_outputs, list):
+                continue
+            imported_tokens = _purpose_surface_tokens(imported_symbol)
+            if len(imported_tokens) < 2:
+                continue
+            for record in deferred_outputs:
+                output = (
+                    str(record.get("output") or "").strip()
+                    if isinstance(record, dict)
+                    else str(record or "").strip()
+                )
+                if not output or "#" not in output:
+                    continue
+                deferred_symbol = output.rsplit("#", 1)[1].strip()
+                if not deferred_symbol or deferred_symbol == imported_symbol:
+                    continue
+                deferred_tokens = _purpose_surface_tokens(deferred_symbol)
+                if len(imported_tokens & deferred_tokens) < 2:
+                    continue
+                if not deferred_tokens.intersection(_PURPOSE_AMOUNT_TOKENS):
+                    continue
+                deferred_by_imported_symbol.setdefault(imported_symbol, []).append(
+                    (deferred_symbol, deferred_tokens, imported_tokens)
+                )
+    if not deferred_by_imported_symbol:
+        return []
+
+    issues: list[str] = []
+    for name, kind, formula, _source, rule in _rulespec_rule_formula_rule_records(
+        payload
+    ):
+        if kind != "derived":
+            continue
+        dtype = str(rule.get("dtype") or "").strip().lower()
+        if dtype in {"judgment", "boolean", "bool"}:
+            continue
+        if _PURPOSE_SPECIFIC_NAME_MARKER_PATTERN.search(name):
+            continue
+        identifiers = _formula_local_identifiers(formula)
+        rule_tokens = _purpose_surface_tokens(name)
+        if len(rule_tokens) < 2:
+            continue
+        for imported_symbol in sorted(identifiers):
+            for (
+                deferred_symbol,
+                deferred_tokens,
+                imported_tokens,
+            ) in deferred_by_imported_symbol.get(imported_symbol, []):
+                if imported_tokens.issubset(rule_tokens):
+                    continue
+                overlap = rule_tokens & deferred_tokens
+                if len(overlap) < 3:
+                    continue
+                overlap_hint = ", ".join(f"`{token}`" for token in sorted(overlap)[:4])
+                issues.append(
+                    "Generic output with deferred purpose-specific limitation: "
+                    f"`{name}` composes imported child/sibling output "
+                    f"`{imported_symbol}` while overlapping deferred output "
+                    f"`{deferred_symbol}` remains unresolved on {overlap_hint}. "
+                    "Do not treat the deferred branch as zero; split the "
+                    "branch-specific output or defer the generic surface."
+                )
+                break
+            else:
+                continue
+            break
+    return issues
+
+
 def _purpose_specific_prefix(symbol: str) -> str:
     match = _PURPOSE_SPLIT_PATTERN.search(symbol)
     if match:
@@ -12117,6 +12220,8 @@ def find_child_fragment_reencoding_issues(
         if parent_inputs:
             shared_inputs = sorted(parent_inputs & child_inputs)
             if shared_inputs:
+                if _rulespec_has_same_section_displacement_boundary(payload):
+                    continue
                 terminal_child_names = _rulespec_terminal_executable_names_from_payload(
                     child_payload
                 )
@@ -12157,6 +12262,19 @@ def find_child_fragment_reencoding_issues(
             )
         )
     return issues
+
+
+def _rulespec_has_same_section_displacement_boundary(payload: dict[str, Any]) -> bool:
+    """Return whether formulas gate the parent rule on a child displacement fact."""
+    for _name, _kind, formula in _rulespec_rule_formulas(payload):
+        for identifier in _formula_local_identifiers(formula):
+            normalized = identifier.lower()
+            if (
+                "does_not_displace_this_subsection" in normalized
+                or "does_not_displace_this_section" in normalized
+            ):
+                return True
+    return False
 
 
 _FORMULA_ABSOLUTE_REFERENCE_PATTERN = re.compile(
@@ -16625,6 +16743,13 @@ class ValidatorPipeline:
         issues.extend(find_scoped_exception_category_gate_issues(content))
         issues.extend(find_current_purpose_placeholder_issues(content))
         issues.extend(find_deferred_purpose_specific_limitation_issues(content))
+        issues.extend(
+            find_imported_deferred_branch_composition_issues(
+                content,
+                rules_file=rules_file,
+                policy_repo_path=self.policy_repo_path,
+            )
+        )
         issues.extend(find_broad_application_passthrough_issues(content))
         issues.extend(find_formula_absolute_reference_issues(content))
         issues.extend(find_import_shape_issues(content))

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -16,6 +16,11 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   household, unit, filing-unit, tax-unit, or family output. Do not sum a broad
   relation and then cap the aggregate unless the source says the cap applies to
   that aggregate unit.
+- When the source states a cap per one unit and per another unit, such as
+  "per taxpayer per beneficiary", preserve both dimensions. Do not apply one
+  per-unit cap to a single aggregate amount. If the schema or available inputs
+  cannot represent the per-unit relation and aggregate the capped results,
+  defer that executable output instead of approximating it with one cap.
 - When a tax, credit, deduction, contribution, or other amount is computed as a
   rate or percentage of a legal base stated for each/every individual, person,
   member, employee, claimant, child, dependent, or spouse, compute that base and
@@ -555,6 +560,13 @@ Hard requirements:
   subtype, carve-out, or branch, defer only that branch or expose a
   source-named boundary input for that branch. Do not defer an unrelated
   source-stated cap/base computation that can be executed from the source text.
+- When an otherwise executable output composes an imported child or sibling
+  result, check that the imported file does not defer another branch, period,
+  or purpose that can also affect the same final amount. Do not treat a missing
+  deferred child branch as zero by importing only the available branch result.
+  Either scope the executable output to the branch where the deferred child
+  branch is impossible, or defer the composite output and list the child
+  deferred dependency.
 - Do not create parallel statutory-dollar executable parameters when a copied
   current-year authority already provides the applicable inflation-adjusted
   parameter. Import the current-year authority unless the task is to encode the

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -76,6 +76,11 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "min(source_amount, cap)" in ENCODER_PROMPT
     assert "compute the uncapped base amount separately" in ENCODER_PROMPT
     assert "min(uncapped_amount, max(cap_a," in ENCODER_PROMPT
+    assert '"per taxpayer per beneficiary"' in ENCODER_PROMPT
+    assert (
+        "Do not apply one\n  per-unit cap to a single aggregate amount"
+        in ENCODER_PROMPT
+    )
     assert "unless the source expressly says" in ENCODER_PROMPT
     assert (
         "Never use `post_YYYY`, `pre_YYYY`, `after_YYYY`, `before_YYYY`"
@@ -166,6 +171,7 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "Importing an adjacent upstream output only as proof" in prompt
     assert "does not satisfy the dependency" in prompt
     assert "is not an executable dependency" in prompt
+    assert "Do not treat a missing\n  deferred child branch as zero" in prompt
     assert "purpose-limited replacement rate" in prompt
     assert "computed at" in prompt
     assert "instead of the rate provided by" in prompt

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -588,6 +588,8 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "then cap the aggregate" in prompt
     assert "rate-applied result at the source-stated lower entity" in prompt
     assert "unit-level placeholder or aggregate base by the rate" in prompt
+    assert '"per taxpayer per beneficiary"' in prompt
+    assert "Do not apply one\n  per-unit cap to a single aggregate amount" in prompt
     assert (
         "Imported definitions do not override the current source's legal subject"
         in prompt
@@ -7055,6 +7057,7 @@ rules:
         assert "Never preserve, rename, or recreate a legacy local input" in prompt
         assert "source-stated formula executable" in prompt
         assert "defer only that branch" in prompt
+        assert "Do not treat a missing deferred child branch\n  as zero" in prompt
         assert 'excess of" a cap' in prompt
         assert "min(source_amount, cap)" in prompt
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -48,6 +48,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_formula_date_literal_issues,
     find_helper_only_definition_issues,
     find_import_shape_issues,
+    find_imported_deferred_branch_composition_issues,
     find_judgment_conditional_formula_issues,
     find_judgment_positive_companion_output_issues,
     find_missing_child_exception_import_issues,
@@ -6644,6 +6645,47 @@ rules:
               dependent_standard_deduction
           else:
               basic_standard_deduction_amount
+"""
+
+    assert (
+        find_child_fragment_reencoding_issues(
+            content,
+            rules_file=rules_file,
+            policy_repo_path=repo,
+        )
+        == []
+    )
+
+
+def test_child_fragment_reencoding_allows_displacement_boundary(tmp_path):
+    repo = tmp_path / "rulespec-us-co"
+    rules_file = repo / "statutes" / "39" / "39-22-104" / "3" / "p.yaml"
+    child = repo / "statutes" / "39" / "39-22-104" / "3" / "p" / "5.yaml"
+    child.parent.mkdir(parents=True)
+    child.write_text(
+        """format: rulespec/v1
+rules:
+  - name: initial_window_addition_to_federal_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    versions:
+      - effective_from: '2023-01-01'
+        formula: federal_adjusted_gross_income + itemized_deductions_deducted_from_gross_income
+"""
+    )
+    content = """format: rulespec/v1
+rules:
+  - name: taxpayer_subject_to_itemized_deduction_addition
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          subsection_p_5_does_not_displace_this_subsection
+          and federal_adjusted_gross_income >= 400000
+          and taxpayer_files_single_return
 """
 
     assert (
@@ -16880,3 +16922,89 @@ rules:
 """
 
     assert find_deferred_purpose_specific_limitation_issues(content) == []
+
+
+def test_imported_deferred_branch_composition_rejects_generic_output(tmp_path):
+    policy_repo = tmp_path / "rulespec-us-co"
+    child = policy_repo / "statutes" / "39" / "39-22-104" / "3" / "p" / "5.yaml"
+    child.parent.mkdir(parents=True)
+    child.write_text(
+        """format: rulespec/v1
+module:
+  deferred_outputs:
+    - output: us-co:statutes/39/39-22-104/3/p/5#post_initial_window_addition_to_federal_taxable_income
+      reason: Later-year threshold amounts are deferred.
+rules:
+  - name: initial_window_addition_to_federal_taxable_income
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2023-01-01'
+        formula: initial_window_addition
+"""
+    )
+    rules_file = policy_repo / "statutes" / "39" / "39-22-104" / "3" / "p.yaml"
+    content = """format: rulespec/v1
+imports:
+  - us-co:statutes/39/39-22-104/3/p/5#initial_window_addition_to_federal_taxable_income
+rules:
+  - name: itemized_deduction_addition_to_federal_taxable_income
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2022-01-01'
+        formula: itemized_deduction_addition_before_subsection_p_5 + initial_window_addition_to_federal_taxable_income
+"""
+
+    issues = find_imported_deferred_branch_composition_issues(
+        content,
+        rules_file=rules_file,
+        policy_repo_path=policy_repo,
+    )
+
+    assert len(issues) == 1
+    assert "Generic output with deferred purpose-specific limitation" in issues[0]
+    assert "itemized_deduction_addition_to_federal_taxable_income" in issues[0]
+    assert "post_initial_window_addition_to_federal_taxable_income" in issues[0]
+
+
+def test_imported_deferred_branch_composition_allows_branch_specific_output(tmp_path):
+    policy_repo = tmp_path / "rulespec-us-co"
+    child = policy_repo / "statutes" / "39" / "39-22-104" / "3" / "p" / "5.yaml"
+    child.parent.mkdir(parents=True)
+    child.write_text(
+        """format: rulespec/v1
+module:
+  deferred_outputs:
+    - output: us-co:statutes/39/39-22-104/3/p/5#post_initial_window_addition_to_federal_taxable_income
+      reason: Later-year threshold amounts are deferred.
+rules:
+  - name: initial_window_addition_to_federal_taxable_income
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2023-01-01'
+        formula: initial_window_addition
+"""
+    )
+    rules_file = policy_repo / "statutes" / "39" / "39-22-104" / "3" / "p.yaml"
+    content = """format: rulespec/v1
+imports:
+  - us-co:statutes/39/39-22-104/3/p/5#initial_window_addition_to_federal_taxable_income
+rules:
+  - name: initial_window_itemized_deduction_addition_to_federal_taxable_income
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2023-01-01'
+        formula: initial_window_addition_to_federal_taxable_income
+"""
+
+    assert (
+        find_imported_deferred_branch_composition_issues(
+            content,
+            rules_file=rules_file,
+            policy_repo_path=policy_repo,
+        )
+        == []
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.424"
+version = "0.2.425"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- tell the encoder not to treat deferred child/sibling branches as zero when composing a final amount
- tell the encoder to preserve multi-dimensional per-unit caps such as per taxpayer per beneficiary instead of capping one aggregate amount
- bump axiom-encode to 0.2.425

## Tests
- uv run --extra dev ruff format --check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_evals.py tests/test_encoder_backend.py
- uv run --extra dev ruff check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_evals.py tests/test_encoder_backend.py
- uv run --extra dev python -m pytest tests/test_evals.py::test_build_eval_prompt_targets_rulespec_yaml tests/test_evals.py::TestRepoAugmentedContext::test_build_eval_prompt_preserves_existing_executable_surface tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_statutory_base_naming_guidance tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q