### PR TITLE
Classify Colorado deduction addback oracle coverage

### DIFF
--- a/changelog.d/colorado-income-tax-oracle-coverage.changed.md
+++ b/changelog.d/colorado-income-tax-oracle-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify Colorado income-tax deduction addback and charitable subtraction outputs in the PolicyEngine oracle coverage registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.425"
+version = "0.2.426"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.425"
+__version__ = "0.2.426"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -907,6 +907,150 @@ mappings:
     mapping_type: not_comparable
     rationale: This generated output is the statutory 4.55% base rate before applying later TABOR/form-rate reductions; PolicyEngine exposes the final Colorado form rate for each tax year.
 
+  - legal_id: us-co:statutes/39/39-22-104/3/o#single_return_adjusted_gross_income_threshold_for_section_199a_addition
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.additions.qualified_business_income_deduction.agi_threshold
+    parameter_key: SINGLE
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado qualified business income deduction addback AGI threshold for single filers.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/o#joint_return_adjusted_gross_income_threshold_for_section_199a_addition
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.additions.qualified_business_income_deduction.agi_threshold
+    parameter_key: JOINT
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado qualified business income deduction addback AGI threshold for joint filers.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/o#taxpayer_subject_to_section_199a_deduction_addition
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_qualified_business_income_deduction_addback_required
+    candidate_priority: P2
+    rationale: This RuleSpec predicate includes the statutory Schedule F exception for section 199A addbacks; PolicyEngine's required predicate only applies the AGI threshold by filing status.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/o#section_199a_deduction_addition_to_federal_taxable_income
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_qualified_business_income_deduction_addback
+    candidate_priority: P2
+    rationale: This RuleSpec output applies the statutory Schedule F exception before adding back the section 199A deduction; PolicyEngine's addback amount does not model that exception.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/p#federal_adjusted_gross_income_threshold_for_itemized_deduction_addition
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.additions.federal_deductions.agi_threshold
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado federal deduction addback AGI threshold for the 2022 itemized-deduction rule.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/p#single_return_itemized_deduction_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.additions.federal_deductions.exemption
+    parameter_key: SINGLE
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado federal deduction addback exemption for single filers under the 2022 itemized-deduction rule.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/p#joint_return_itemized_deduction_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.additions.federal_deductions.exemption
+    parameter_key: JOINT
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado federal deduction addback exemption for joint filers under the 2022 itemized-deduction rule.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/p#taxpayer_subject_to_itemized_deduction_addition
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_federal_deduction_addback_required
+    candidate_priority: P3
+    rationale: This RuleSpec predicate is limited to the subsection (3)(p) itemized-deduction rule and is displaced by subsection (3)(p.5); PolicyEngine exposes a unified federal-deduction addback predicate across both statutory windows.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/p/5#federal_adjusted_gross_income_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.additions.federal_deductions.agi_threshold
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado federal deduction addback AGI threshold for the subsection (3)(p.5) rule.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/p/5#single_return_deduction_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.additions.federal_deductions.exemption
+    parameter_key: SINGLE
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado federal deduction addback exemption for single filers under subsection (3)(p.5).
+
+  - legal_id: us-co:statutes/39/39-22-104/3/p/5#joint_return_deduction_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.additions.federal_deductions.exemption
+    parameter_key: JOINT
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado federal deduction addback exemption for joint filers under subsection (3)(p.5).
+
+  - legal_id: us-co:statutes/39/39-22-104/3/p/5#itemized_or_standard_deduction_addition_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_federal_deduction_addback_required
+    candidate_priority: P3
+    rationale: This RuleSpec predicate includes the statutory healthy-school-meals repeal exception and source-window boundary; PolicyEngine exposes a unified federal-deduction addback predicate without that repeal condition.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/p/5#initial_window_addition_to_federal_taxable_income
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_federal_deduction_addback
+    candidate_priority: P3
+    rationale: This RuleSpec output is the subsection (3)(p.5) initial-window amount and includes the healthy-school-meals repeal exception; PolicyEngine exposes a unified federal-deduction addback amount without that repeal condition.
+
+  - legal_id: us-co:statutes/39/39-22-104/4/m#charitable_contribution_subtraction_floor
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.subtractions.charitable_contribution.adjustment
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado charitable contribution subtraction floor.
+
+  - legal_id: us-co:statutes/39/39-22-104/4/m#standard_deduction_charitable_contribution_subtraction
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_charitable_contribution_subtraction
+    candidate_priority: P3
+    rationale: This RuleSpec output is person-level and includes the 2015-2019 hunger-relief food-contribution credit disallowance; PolicyEngine exposes a tax-unit aggregate charitable contribution subtraction without that credit exception.
+
   - legal_id: us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction_cap_for_age_fifty_five_to_sixty_four
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -741,6 +741,221 @@ rules:
     assert {item["tested"] for item in report["items"]} == {True}
 
 
+def test_policyengine_coverage_classifies_colorado_deduction_addbacks(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/3/o.yaml",
+        """format: rulespec/v1
+rules:
+  - name: single_return_adjusted_gross_income_threshold_for_section_199a_addition
+    kind: parameter
+    versions:
+      - effective_from: '2021-01-01'
+        formula: '500000'
+  - name: joint_return_adjusted_gross_income_threshold_for_section_199a_addition
+    kind: parameter
+    versions:
+      - effective_from: '2021-01-01'
+        formula: '1000000'
+  - name: taxpayer_subject_to_section_199a_deduction_addition
+    kind: derived
+    versions:
+      - effective_from: '2021-01-01'
+        formula: agi_above_threshold and not schedule_f_exception
+  - name: section_199a_deduction_addition_to_federal_taxable_income
+    kind: derived
+    versions:
+      - effective_from: '2021-01-01'
+        formula: 'if taxpayer_subject_to_section_199a_deduction_addition: section_199a_deduction else: 0'
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/3/o.test.yaml",
+        """- name: qbi addback outputs
+  period:
+    period_kind: tax_year
+    start: '2021-01-01'
+    end: '2021-12-31'
+  input: {}
+  output:
+    us-co:statutes/39/39-22-104/3/o#single_return_adjusted_gross_income_threshold_for_section_199a_addition: 500000
+    us-co:statutes/39/39-22-104/3/o#joint_return_adjusted_gross_income_threshold_for_section_199a_addition: 1000000
+    us-co:statutes/39/39-22-104/3/o#taxpayer_subject_to_section_199a_deduction_addition: holds
+    us-co:statutes/39/39-22-104/3/o#section_199a_deduction_addition_to_federal_taxable_income: 1000
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/3/p.yaml",
+        """format: rulespec/v1
+rules:
+  - name: federal_adjusted_gross_income_threshold_for_itemized_deduction_addition
+    kind: parameter
+    versions:
+      - effective_from: '2022-01-01'
+        formula: '400000'
+  - name: single_return_itemized_deduction_threshold
+    kind: parameter
+    versions:
+      - effective_from: '2022-01-01'
+        formula: '30000'
+  - name: joint_return_itemized_deduction_threshold
+    kind: parameter
+    versions:
+      - effective_from: '2022-01-01'
+        formula: '60000'
+  - name: taxpayer_subject_to_itemized_deduction_addition
+    kind: derived
+    versions:
+      - effective_from: '2022-01-01'
+        formula: itemizes and agi_above_threshold and not subsection_p_5_displaced
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/3/p.test.yaml",
+        """- name: itemized deduction addback outputs
+  period:
+    period_kind: tax_year
+    start: '2022-01-01'
+    end: '2022-12-31'
+  input: {}
+  output:
+    us-co:statutes/39/39-22-104/3/p#federal_adjusted_gross_income_threshold_for_itemized_deduction_addition: 400000
+    us-co:statutes/39/39-22-104/3/p#single_return_itemized_deduction_threshold: 30000
+    us-co:statutes/39/39-22-104/3/p#joint_return_itemized_deduction_threshold: 60000
+    us-co:statutes/39/39-22-104/3/p#taxpayer_subject_to_itemized_deduction_addition: holds
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/3/p/5.yaml",
+        """format: rulespec/v1
+rules:
+  - name: federal_adjusted_gross_income_threshold
+    kind: parameter
+    versions:
+      - effective_from: '2023-01-01'
+        formula: '300000'
+  - name: single_return_deduction_threshold
+    kind: parameter
+    versions:
+      - effective_from: '2023-01-01'
+        formula: '12000'
+  - name: joint_return_deduction_threshold
+    kind: parameter
+    versions:
+      - effective_from: '2023-01-01'
+        formula: '16000'
+  - name: itemized_or_standard_deduction_addition_applies
+    kind: derived
+    versions:
+      - effective_from: '2023-01-01'
+        formula: claims_deduction and agi_above_threshold and not healthy_school_meals_repealed
+  - name: initial_window_addition_to_federal_taxable_income
+    kind: derived
+    versions:
+      - effective_from: '2023-01-01'
+        formula: 'if itemized_or_standard_deduction_addition_applies: deduction_excess else: 0'
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/3/p/5.test.yaml",
+        """- name: subsection p5 deduction addback outputs
+  period:
+    period_kind: tax_year
+    start: '2023-01-01'
+    end: '2023-12-31'
+  input: {}
+  output:
+    us-co:statutes/39/39-22-104/3/p/5#federal_adjusted_gross_income_threshold: 300000
+    us-co:statutes/39/39-22-104/3/p/5#single_return_deduction_threshold: 12000
+    us-co:statutes/39/39-22-104/3/p/5#joint_return_deduction_threshold: 16000
+    us-co:statutes/39/39-22-104/3/p/5#itemized_or_standard_deduction_addition_applies: holds
+    us-co:statutes/39/39-22-104/3/p/5#initial_window_addition_to_federal_taxable_income: 8000
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/4/m.yaml",
+        """format: rulespec/v1
+rules:
+  - name: charitable_contribution_subtraction_floor
+    kind: parameter
+    versions:
+      - effective_from: '2001-01-01'
+        formula: '500'
+  - name: standard_deduction_charitable_contribution_subtraction
+    kind: derived
+    entity: Person
+    versions:
+      - effective_from: '2001-01-01'
+        formula: charitable_deduction_if_itemized - charitable_contribution_subtraction_floor
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/4/m.test.yaml",
+        """- name: charitable contribution subtraction outputs
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  output:
+    us-co:statutes/39/39-22-104/4/m#charitable_contribution_subtraction_floor: 500
+    us-co:statutes/39/39-22-104/4/m#standard_deduction_charitable_contribution_subtraction: 1000
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["total_outputs"] == 15
+    assert report["status_counts"] == {
+        "comparable": 9,
+        "known_not_comparable": 6,
+    }
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    qbi_threshold = items_by_id[
+        "us-co:statutes/39/39-22-104/3/o#single_return_adjusted_gross_income_threshold_for_section_199a_addition"
+    ]
+    qbi_addback = items_by_id[
+        "us-co:statutes/39/39-22-104/3/o#section_199a_deduction_addition_to_federal_taxable_income"
+    ]
+    p5_threshold = items_by_id[
+        "us-co:statutes/39/39-22-104/3/p/5#joint_return_deduction_threshold"
+    ]
+    p5_addback = items_by_id[
+        "us-co:statutes/39/39-22-104/3/p/5#initial_window_addition_to_federal_taxable_income"
+    ]
+    charitable_floor = items_by_id[
+        "us-co:statutes/39/39-22-104/4/m#charitable_contribution_subtraction_floor"
+    ]
+    charitable_subtraction = items_by_id[
+        "us-co:statutes/39/39-22-104/4/m#standard_deduction_charitable_contribution_subtraction"
+    ]
+    assert (
+        qbi_threshold["policyengine_parameter"]
+        == "gov.states.co.tax.income.additions.qualified_business_income_deduction.agi_threshold"
+    )
+    assert qbi_threshold["tested"] is True
+    assert qbi_addback["status"] == "known_not_comparable"
+    assert (
+        qbi_addback["policyengine_variable"]
+        == "co_qualified_business_income_deduction_addback"
+    )
+    assert (
+        p5_threshold["policyengine_parameter"]
+        == "gov.states.co.tax.income.additions.federal_deductions.exemption"
+    )
+    assert p5_addback["status"] == "known_not_comparable"
+    assert p5_addback["policyengine_variable"] == "co_federal_deduction_addback"
+    assert (
+        charitable_floor["policyengine_parameter"]
+        == "gov.states.co.tax.income.subtractions.charitable_contribution.adjustment"
+    )
+    assert charitable_subtraction["status"] == "known_not_comparable"
+    assert (
+        charitable_subtraction["policyengine_variable"]
+        == "co_charitable_contribution_subtraction"
+    )
+
+
 def test_policyengine_coverage_classifies_colorado_military_retirement_outputs(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.425"
+version = "0.2.426"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Colorado QBI, federal deduction addback, and charitable subtraction outputs in the PolicyEngine oracle coverage registry
- map exact threshold/floor parameters to PE parameter paths and mark adjacent PE variables known-not-comparable where PE lacks statutory exceptions or exposes a different aggregate boundary
- add coverage-registry tests and bump axiom-encode to 0.2.426

## Validation
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run python -m towncrier build --draft --version 0.0.0
- uv run pytest tests/test_policyengine_coverage.py -q --no-cov
- local CO coverage gate reproduction: changed 5 outputs 15 failures 0