### PR TITLE
Fix encoder references for repo-relative state encodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.432"
+version = "0.2.433"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.435"
+version = "0.2.436"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.431"
+version = "0.2.432"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.429"
+version = "0.2.430"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.427"
+version = "0.2.428"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.436"
+version = "0.2.437"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.433"
+version = "0.2.434"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.434"
+version = "0.2.435"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.437"
+version = "0.2.438"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.430"
+version = "0.2.431"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.428"
+version = "0.2.429"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.431"
+__version__ = "0.2.432"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.429"
+__version__ = "0.2.430"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.435"
+__version__ = "0.2.436"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.432"
+__version__ = "0.2.433"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.437"
+__version__ = "0.2.438"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.436"
+__version__ = "0.2.437"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.433"
+__version__ = "0.2.434"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.430"
+__version__ = "0.2.431"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.434"
+__version__ = "0.2.435"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.428"
+__version__ = "0.2.429"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.427"
+__version__ = "0.2.428"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -12912,21 +12912,25 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
-                repaired_scalar_relation_rows = (
-                    _try_repair_generated_scalar_relation_rows_for_apply(
-                        result,
-                        output_root=args.output,
-                        policy_repo_path=policy_repo_path,
-                        issues=apply_issues,
+                repaired_scalar_rows: list[str] = []
+                while not can_apply:
+                    repaired_batch = (
+                        _try_repair_generated_scalar_relation_rows_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            issues=apply_issues,
+                        )
                     )
-                )
-                if repaired_scalar_relation_rows:
+                    if not repaired_batch:
+                        break
+                    repaired_scalar_rows.extend(repaired_batch)
                     outcome["auto_repaired_scalar_relation_rows"] = (
-                        repaired_scalar_relation_rows
+                        repaired_scalar_rows
                     )
                     print(
                         "  apply=auto_repaired_scalar_relation_rows:"
-                        + ",".join(repaired_scalar_relation_rows)
+                        + ",".join(repaired_batch)
                     )
                     can_apply, apply_issues, supplemental_files = (
                         _validate_generated_encoding_in_policy_overlay(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -893,6 +893,28 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_companion_test_refs_parser = subparsers.add_parser(
+        "repair-companion-test-references",
+        help="Apply signed deterministic repairs for stale companion-test references",
+    )
+    repair_companion_test_refs_parser.add_argument(
+        "file", type=Path, help="RuleSpec YAML file"
+    )
+    repair_companion_test_refs_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="Rules repository root used for manifest signing",
+    )
+    repair_companion_test_refs_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_oracle_parameter_tests_parser = subparsers.add_parser(
         "repair-oracle-parameter-tests",
         help="Apply signed deterministic repairs for missing oracle parameter tests",
@@ -1579,6 +1601,8 @@ def main():
         cmd_repair_section_63_f_stale_test_inputs(args)
     elif args.command == "repair-imported-test-inputs":
         cmd_repair_imported_test_inputs(args)
+    elif args.command == "repair-companion-test-references":
+        cmd_repair_companion_test_references(args)
     elif args.command == "repair-oracle-parameter-tests":
         cmd_repair_oracle_parameter_tests(args)
     elif args.command == "repair-tax-filing-status-branches":
@@ -5489,6 +5513,135 @@ def cmd_repair_imported_test_inputs(args):
 
     print(f"Applied imported test input repair to {relative_output}")
     print(f"manifest={manifest_path}")
+
+
+def cmd_repair_companion_test_references(args):
+    """Apply signed deterministic repairs for stale companion test references."""
+    repo_path = Path(args.repo).resolve()
+    rules_file = Path(args.file)
+    if not rules_file.is_absolute():
+        rules_file = repo_path / rules_file
+    rules_file = rules_file.resolve()
+    if not rules_file.exists():
+        print(f"RuleSpec file not found: {rules_file}")
+        sys.exit(1)
+    try:
+        relative_output = rules_file.relative_to(repo_path)
+    except ValueError:
+        print(f"RuleSpec file {rules_file} is not under repo {repo_path}")
+        sys.exit(1)
+
+    test_file = _rulespec_test_path(rules_file)
+    if not test_file.exists():
+        print(f"Companion test file not found: {test_file}")
+        sys.exit(1)
+
+    original_test_content = test_file.read_text()
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+
+    repaired_refs: list[str] = []
+    for _ in range(20):
+        failures = _rulespec_companion_test_failures(
+            test_file=test_file,
+            repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+        )
+        if not failures:
+            break
+        issues = [str(failure.get("message") or "") for failure in failures]
+        removed_inputs = _remove_invalid_test_input_refs(
+            test_file=test_file,
+            issues=issues,
+        )
+        removed_outputs = _remove_unknown_test_output_refs(
+            test_file=test_file,
+            issues=issues,
+        )
+        if not removed_inputs and not removed_outputs:
+            break
+        repaired_refs.extend([f"input:{ref}" for ref in removed_inputs])
+        repaired_refs.extend([f"output:{ref}" for ref in removed_outputs])
+
+    if not repaired_refs:
+        print("No companion test reference repairs found.")
+        return
+
+    failures = _rulespec_companion_test_failures(
+        test_file=test_file,
+        repo_path=repo_path,
+        axiom_rules_path=axiom_rules_path,
+    )
+    if failures:
+        test_file.write_text(original_test_content)
+        print("Repair failed validation; restored original test file.")
+        for failure in failures[:50]:
+            print(f"- {failure.get('case')}: {failure.get('message')}")
+        sys.exit(1)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        generated_output = output_root / "deterministic-repair" / relative_output
+        generated_output.parent.mkdir(parents=True, exist_ok=True)
+        generated_output.write_text(rules_file.read_text())
+        result = argparse.Namespace(
+            output_file=str(generated_output),
+            runner="deterministic-repair",
+            backend="deterministic",
+            model="companion-test-references-v1",
+            tool="axiom-encode repair-companion-test-references",
+            citation=(
+                f"{_repo_jurisdiction_prefix(repo_path)}:"
+                f"{_relative_rulespec_import_target(relative_output)}"
+            ),
+            generation_prompt_sha256=None,
+            trace_file=None,
+            context_manifest_file=None,
+        )
+        manifest_path = _write_applied_encoding_manifest(
+            result,
+            output_root=output_root,
+            policy_repo_path=repo_path,
+            relative_output=relative_output,
+            applied_files=[rules_file, test_file],
+            run_id="deterministic-repair",
+            signing_key=signing_key,
+            axiom_encode_git=axiom_encode_git,
+        )
+
+    print(f"Applied companion test reference repair to {relative_output}")
+    print(f"repaired={', '.join(sorted(set(repaired_refs)))}")
+    print(f"manifest={manifest_path}")
+
+
+def _rulespec_companion_test_failures(
+    *,
+    test_file: Path,
+    repo_path: Path,
+    axiom_rules_path: Path,
+) -> list[dict[str, str | None]]:
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo_path,
+        axiom_rules_path=axiom_rules_path,
+        enable_oracles=False,
+    )
+    binary = pipeline._axiom_rules_binary()
+    rulespec_env = pipeline._rulespec_compile_env()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = _execute_rulespec_test_file(
+            test_file,
+            binary=binary,
+            axiom_rules_path=Path(axiom_rules_path),
+            env=rulespec_env,
+            tmp_path=Path(tmpdir),
+            compiled_cache={},
+            policy_repo_path=repo_path,
+        )
+    failures = result.get("failures")
+    return failures if isinstance(failures, list) else []
 
 
 _SECTION_172_C_IMPORT = (
@@ -11481,6 +11634,44 @@ def _remove_invalid_test_input_refs(
     return sorted(removable_refs)
 
 
+def _remove_unknown_test_output_refs(
+    *,
+    test_file: Path,
+    issues: list[str],
+) -> list[str]:
+    if not test_file.exists():
+        return []
+    unknown_refs = _unknown_output_refs_from_issues(issues)
+    if not unknown_refs:
+        return []
+
+    try:
+        test_payload = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    if not isinstance(test_payload, list):
+        return []
+
+    removable_refs = _expand_refs_with_matching_test_output_keys(
+        test_payload,
+        unknown_refs,
+    )
+
+    changed = False
+    for test_case in test_payload:
+        if not isinstance(test_case, dict):
+            continue
+        outputs = test_case.get("output")
+        if _remove_mapping_keys_recursive(outputs, removable_refs):
+            changed = True
+    if not changed:
+        return []
+    test_file.write_text(
+        yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
+    )
+    return sorted(removable_refs)
+
+
 def _rewrite_import_output_test_input_refs(
     *,
     test_file: Path,
@@ -11945,6 +12136,15 @@ def _invalid_input_refs_from_issues(issues: list[str]) -> set[str]:
     return refs
 
 
+def _unknown_output_refs_from_issues(issues: list[str]) -> set[str]:
+    refs: set[str] = set()
+    pattern = r"unknown executable output (?P<output>\S+)"
+    for issue in issues:
+        for match in re.finditer(pattern, str(issue)):
+            refs.add(match.group("output").strip())
+    return refs
+
+
 def _expand_refs_with_matching_test_input_keys(
     value: object,
     refs: set[str],
@@ -11959,6 +12159,27 @@ def _expand_refs_with_matching_test_input_keys(
             continue
         if _rulespec_ref_without_jurisdiction(key_text) in tails:
             expanded.add(key_text)
+    return expanded
+
+
+def _expand_refs_with_matching_test_output_keys(
+    value: object,
+    refs: set[str],
+) -> set[str]:
+    if not refs:
+        return set()
+    tails = {_rulespec_ref_without_jurisdiction(ref) for ref in refs}
+    expanded = set(refs)
+    for test_case in value if isinstance(value, list) else []:
+        if not isinstance(test_case, dict):
+            continue
+        outputs = test_case.get("output")
+        if not isinstance(outputs, dict):
+            continue
+        for key in outputs:
+            key_text = str(key)
+            if _rulespec_ref_without_jurisdiction(key_text) in tails:
+                expanded.add(key_text)
     return expanded
 
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -12925,9 +12925,7 @@ def cmd_encode(args):
                     if not repaired_batch:
                         break
                     repaired_scalar_rows.extend(repaired_batch)
-                    outcome["auto_repaired_scalar_relation_rows"] = (
-                        repaired_scalar_rows
-                    )
+                    outcome["auto_repaired_scalar_relation_rows"] = repaired_scalar_rows
                     print(
                         "  apply=auto_repaired_scalar_relation_rows:"
                         + ",".join(repaired_batch)

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -12912,6 +12912,35 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_scalar_relation_rows = (
+                    _try_repair_generated_scalar_relation_rows_for_apply(
+                        result,
+                        output_root=args.output,
+                        policy_repo_path=policy_repo_path,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_scalar_relation_rows:
+                    outcome["auto_repaired_scalar_relation_rows"] = (
+                        repaired_scalar_relation_rows
+                    )
+                    print(
+                        "  apply=auto_repaired_scalar_relation_rows:"
+                        + ",".join(repaired_scalar_relation_rows)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_module_layout = _try_repair_generated_module_layout_for_apply(
                     result,
                     output_root=args.output,
@@ -14109,6 +14138,210 @@ def _try_repair_generated_table_relation_tests_for_apply(
     rules_file = Path(str(getattr(result, "output_file", "") or ""))
     test_file = _rulespec_test_path(rules_file)
     return _split_table_row_relation_test_cases(test_file)
+
+
+_SCALAR_RELATION_ROW_ISSUE_PATTERN = re.compile(
+    r"Test case `(?P<case>[^`]+)` input invalid: relation "
+    r"`(?P<relation>[^`]+)` item #(?P<index>\d+) must be a mapping"
+)
+
+
+def _try_repair_generated_scalar_relation_rows_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+    issues: list[str],
+) -> list[str]:
+    """Replace scalar relation rows with companion-test row mappings.
+
+    Generated tests occasionally write relation inputs as `- true`. The engine
+    needs each relation row to be a mapping of child facts. This repair is only
+    applied when validation has identified the exact bad row, and it derives the
+    replacement row from an existing companion test for the same relation target.
+    """
+    parsed_issues = [
+        parsed
+        for issue in issues
+        if (parsed := _parse_scalar_relation_row_issue(str(issue))) is not None
+    ]
+    if not parsed_issues:
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    test_file = _rulespec_test_path(rules_file)
+    return _repair_scalar_relation_rows(
+        test_file=test_file,
+        policy_repo_path=policy_repo_path,
+        parsed_issues=parsed_issues,
+    )
+
+
+def _parse_scalar_relation_row_issue(
+    issue: str,
+) -> tuple[str, str, int] | None:
+    match = _SCALAR_RELATION_ROW_ISSUE_PATTERN.search(issue)
+    if match is None:
+        return None
+    return (
+        match.group("case"),
+        match.group("relation"),
+        int(match.group("index")),
+    )
+
+
+def _repair_scalar_relation_rows(
+    *,
+    test_file: Path,
+    policy_repo_path: Path,
+    parsed_issues: list[tuple[str, str, int]],
+) -> list[str]:
+    if not test_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    if not isinstance(payload, list):
+        return []
+
+    repairs_by_case_relation: dict[tuple[str, str], set[int]] = defaultdict(set)
+    for case_name, relation_ref, row_index in parsed_issues:
+        repairs_by_case_relation[(case_name, relation_ref)].add(row_index)
+
+    repaired: list[str] = []
+    for case in payload:
+        if not isinstance(case, dict):
+            continue
+        case_name = str(case.get("name") or "")
+        inputs = case.get("input")
+        if not isinstance(inputs, dict):
+            continue
+        for relation_ref, rows in list(inputs.items()):
+            relation_key = str(relation_ref)
+            repair_rows = repairs_by_case_relation.get((case_name, relation_key))
+            if not repair_rows or not isinstance(rows, list):
+                continue
+            for row_index in sorted(repair_rows):
+                list_index = row_index - 1
+                if list_index < 0 or list_index >= len(rows):
+                    continue
+                scalar_value = rows[list_index]
+                if isinstance(scalar_value, dict):
+                    continue
+                replacement = _relation_row_replacement_from_companion_tests(
+                    relation_key,
+                    scalar_value,
+                    policy_repo_path=policy_repo_path,
+                )
+                if replacement is None:
+                    continue
+                rows[list_index] = replacement
+                repaired.append(f"{case_name}:{relation_key}[{row_index}]")
+
+    if not repaired:
+        return []
+    test_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repaired
+
+
+def _relation_row_replacement_from_companion_tests(
+    relation_ref: str,
+    scalar_value: object,
+    *,
+    policy_repo_path: Path,
+) -> dict[str, object] | None:
+    exemplar_rows = _relation_rows_from_companion_tests(
+        relation_ref,
+        policy_repo_path=policy_repo_path,
+    )
+    if not exemplar_rows:
+        return None
+    for row in exemplar_rows:
+        if _relation_row_matches_scalar_value(row, scalar_value):
+            return copy.deepcopy(row)
+    if isinstance(scalar_value, bool):
+        template = copy.deepcopy(exemplar_rows[0])
+        changed = False
+        for key, value in list(template.items()):
+            if isinstance(value, bool):
+                template[key] = scalar_value
+                changed = True
+        if changed:
+            return template
+    return None
+
+
+def _relation_row_matches_scalar_value(
+    row: dict[str, object],
+    scalar_value: object,
+) -> bool:
+    if isinstance(scalar_value, bool):
+        return any(value is scalar_value for value in row.values())
+    return False
+
+
+def _relation_rows_from_companion_tests(
+    relation_ref: str,
+    *,
+    policy_repo_path: Path,
+) -> list[dict[str, object]]:
+    relation_test_file = _companion_test_file_for_relation_ref(
+        relation_ref,
+        policy_repo_path=policy_repo_path,
+    )
+    if relation_test_file is None or not relation_test_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(relation_test_file.read_text()) or []
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    if not isinstance(payload, list):
+        return []
+    rows: list[dict[str, object]] = []
+    for case in payload:
+        if not isinstance(case, dict):
+            continue
+        inputs = case.get("input")
+        if not isinstance(inputs, dict):
+            continue
+        relation_rows = inputs.get(relation_ref)
+        if not isinstance(relation_rows, list):
+            continue
+        for row in relation_rows:
+            if isinstance(row, dict):
+                rows.append(copy.deepcopy(row))
+    return rows
+
+
+def _companion_test_file_for_relation_ref(
+    relation_ref: str,
+    *,
+    policy_repo_path: Path,
+) -> Path | None:
+    relation_base = relation_ref.split("#", 1)[0].strip().strip("/")
+    if ":" not in relation_base:
+        return None
+    prefix, relative = relation_base.split(":", 1)
+    if not prefix or not relative:
+        return None
+    relative_path = Path(relative)
+    if relative_path.suffix not in {".yaml", ".yml"}:
+        relative_path = relative_path.with_suffix(".yaml")
+    repo_roots = []
+    current_prefix = _repo_jurisdiction_prefix(policy_repo_path)
+    if prefix == current_prefix:
+        repo_roots.append(policy_repo_path)
+    repo_roots.append(policy_repo_path.parent / f"rulespec-{prefix}")
+    for repo_root in repo_roots:
+        test_file = _rulespec_test_path(repo_root / relative_path)
+        if test_file.exists():
+            return test_file
+    return None
 
 
 def _split_table_row_relation_test_cases(test_file: Path) -> list[str]:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5546,8 +5546,8 @@ def cmd_repair_companion_test_references(args):
     repaired_refs: list[str] = []
     for _ in range(20):
         failures = _rulespec_companion_test_failures(
-            test_file=test_file,
-            repo_path=repo_path,
+            test_file,
+            root=repo_path,
             axiom_rules_path=axiom_rules_path,
         )
         if not failures:
@@ -5571,8 +5571,8 @@ def cmd_repair_companion_test_references(args):
         return
 
     failures = _rulespec_companion_test_failures(
-        test_file=test_file,
-        repo_path=repo_path,
+        test_file,
+        root=repo_path,
         axiom_rules_path=axiom_rules_path,
     )
     if failures:
@@ -5615,33 +5615,6 @@ def cmd_repair_companion_test_references(args):
     print(f"Applied companion test reference repair to {relative_output}")
     print(f"repaired={', '.join(sorted(set(repaired_refs)))}")
     print(f"manifest={manifest_path}")
-
-
-def _rulespec_companion_test_failures(
-    *,
-    test_file: Path,
-    repo_path: Path,
-    axiom_rules_path: Path,
-) -> list[dict[str, str | None]]:
-    pipeline = ValidatorPipeline(
-        policy_repo_path=repo_path,
-        axiom_rules_path=axiom_rules_path,
-        enable_oracles=False,
-    )
-    binary = pipeline._axiom_rules_binary()
-    rulespec_env = pipeline._rulespec_compile_env()
-    with tempfile.TemporaryDirectory() as tmpdir:
-        result = _execute_rulespec_test_file(
-            test_file,
-            binary=binary,
-            axiom_rules_path=Path(axiom_rules_path),
-            env=rulespec_env,
-            tmp_path=Path(tmpdir),
-            compiled_cache={},
-            policy_repo_path=repo_path,
-        )
-    failures = result.get("failures")
-    return failures if isinstance(failures, list) else []
 
 
 _SECTION_172_C_IMPORT = (

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -13824,6 +13824,44 @@ def cmd_encode(args):
                         repaired_output_cases
                     )
             if not can_apply:
+                repaired_positive_cases = []
+                while not can_apply:
+                    repaired_test_cases = (
+                        _try_repair_generated_judgment_positive_tests_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            issues=apply_issues,
+                        )
+                    )
+                    if not repaired_test_cases:
+                        break
+                    repaired_positive_cases.extend(repaired_test_cases)
+                    prior_repairs = outcome.get("auto_repaired_judgment_positive_tests")
+                    if not isinstance(prior_repairs, list):
+                        prior_repairs = []
+                    outcome["auto_repaired_judgment_positive_tests"] = [
+                        *prior_repairs,
+                        *repaired_test_cases,
+                    ]
+                    print(
+                        "  apply=auto_repaired_judgment_positive_tests:"
+                        + ",".join(repaired_test_cases)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_output_cases = []
                 while not can_apply:
                     repaired_test_cases = (

--- a/src/axiom_encode/concepts/auto_repair.py
+++ b/src/axiom_encode/concepts/auto_repair.py
@@ -70,6 +70,8 @@ def _rewrite_anchored_refs(text: str, registry: ConceptRegistry) -> str:
         is_input_ref = bool(input_prefix)
         blocked = registry.lookup_synonym(name)
         if blocked is not None:
+            if is_input_ref and blocked.producer_anchor == anchor:
+                return match.group(0)
             new_anchor = anchor if is_input_ref else (blocked.producer_anchor or anchor)
             return f"{new_anchor}#{input_prefix}{blocked.canonical_name}"
         canonical = registry.lookup_canonical(name)

--- a/src/axiom_encode/concepts/validator.py
+++ b/src/axiom_encode/concepts/validator.py
@@ -18,7 +18,7 @@ from .registry import ConceptRegistry
 
 IDENT_RE = re.compile(r"\b([a-z][a-z0-9_]*)\b")
 ANCHORED_REF_RE = re.compile(
-    r"([a-z][a-z0-9-]*:[A-Za-z0-9_\-/\.]+)#(?:input\.)?([a-z][a-z0-9_]*)"
+    r"([a-z][a-z0-9-]*:[A-Za-z0-9_\-/\.]+)#(input\.)?([a-z][a-z0-9_]*)"
 )
 
 
@@ -69,9 +69,12 @@ def validate_generated_against_registry(
         # 1. Anchored-ref scan: catch any `us:file#name` whose name is a blocked synonym,
         #    or whose name is a registered canonical but referenced under the wrong anchor.
         for m in ANCHORED_REF_RE.finditer(text):
-            anchor, name = m.group(1), m.group(2)
+            anchor, input_prefix, name = m.group(1), m.group(2) or "", m.group(3)
+            is_input_ref = bool(input_prefix)
             blocked = registry.lookup_synonym(name)
             if blocked is not None:
+                if is_input_ref and blocked.producer_anchor == anchor:
+                    continue
                 violations.append(
                     CanonicalNameViolation(
                         kind="blocked_synonym",
@@ -87,6 +90,7 @@ def validate_generated_against_registry(
                 canonical is not None
                 and canonical.has_producer
                 and canonical.producer_anchor != anchor
+                and not is_input_ref
             ):
                 violations.append(
                     CanonicalNameViolation(

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -23,6 +23,7 @@ import requests
 import yaml
 
 from axiom_encode.codex_cli import resolve_codex_cli
+from axiom_encode.concepts.jurisdiction import jurisdiction_prefix
 from axiom_encode.concepts.registry import (
     Concept,
     ConceptRegistry,
@@ -118,6 +119,17 @@ _CONDITIONAL_AMOUNT_SLICE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _LOCAL_IMPORT_ROOT_TOKENS = {"legislation", "statutes", "regulation"}
+_RULESPEC_SOURCE_ROOT_TOKENS = {
+    "guidance",
+    "manual",
+    "manuals",
+    "policies",
+    "policy",
+    "regulation",
+    "regulations",
+    "statute",
+    "statutes",
+}
 _CODEX_DEFAULT_TIMEOUT_SECONDS = 600
 _CODEX_DEFAULT_IDLE_TIMEOUT_SECONDS = 300
 _CODEX_LONG_SOURCE_CHAR_THRESHOLD = 40_000
@@ -2780,7 +2792,9 @@ def _run_single_eval(
         workspace.context_files,
         target_file_name=relative_output.name,
         target_ref_prefix=_canonical_target_ref_prefix(
-            target_ref_source, relative_output
+            target_ref_source,
+            relative_output,
+            policy_repo_path=policy_path,
         ),
         include_tests=include_tests,
         runner_backend=runner.backend,
@@ -2907,7 +2921,11 @@ def _run_single_source_eval(
         workspace,
         workspace.context_files,
         target_file_name=relative_output.name,
-        target_ref_prefix=_canonical_target_ref_prefix(source_id, relative_output),
+        target_ref_prefix=_canonical_target_ref_prefix(
+            source_id,
+            relative_output,
+            policy_repo_path=policy_path,
+        ),
         include_tests=True,
         runner_backend=runner.backend,
         policyengine_rule_hint=policyengine_rule_hint,
@@ -3102,14 +3120,37 @@ def _canonical_us_regulation_tail(tail: list[str]) -> list[str]:
     return tail
 
 
-def _canonical_target_ref_prefix(source_id: str, relative_path: Path) -> str | None:
+def _canonical_target_ref_prefix(
+    source_id: str,
+    relative_path: Path,
+    *,
+    policy_repo_path: Path | None = None,
+) -> str | None:
     parts = [part for part in source_id.strip().strip("/").split("/") if part]
     if len(parts) < 3:
         return None
     if relative_path.parts and relative_path.parts[0] == "source":
         return None
-    jurisdiction = parts[0].split(":", 1)[0]
+    jurisdiction = _canonical_target_ref_jurisdiction(
+        parts, policy_repo_path=policy_repo_path
+    )
+    if not jurisdiction:
+        return None
     return f"{jurisdiction}:{_relative_rulespec_path_to_import_target(relative_path)}"
+
+
+def _canonical_target_ref_jurisdiction(
+    source_id_parts: list[str],
+    *,
+    policy_repo_path: Path | None = None,
+) -> str | None:
+    """Return the jurisdiction prefix for generated test references."""
+    first = source_id_parts[0].split(":", 1)[0]
+    if ":" in source_id_parts[0]:
+        return first
+    if first in _RULESPEC_SOURCE_ROOT_TOKENS:
+        return jurisdiction_prefix(policy_repo_path) if policy_repo_path else None
+    return first
 
 
 def _rulespec_test_path(path: Path) -> Path:

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1847,13 +1847,17 @@ def _candidate_corpus_citation_paths(identifier: str) -> tuple[str, ...]:
 
 
 def _looks_like_corpus_citation_path(identifier: str) -> bool:
-    parts = identifier.split("/")
+    parts = [part for part in identifier.strip().strip("/").split("/") if part]
+    if len(parts) >= 2 and parts[0] in _RULESPEC_SOURCE_ROOT_TOKENS:
+        return True
     return len(parts) >= 3 and parts[1] in {
         "guidance",
         "manual",
         "manuals",
+        "policies",
         "policy",
         "regulation",
+        "regulations",
         "statute",
         "statutes",
     }
@@ -3049,6 +3053,10 @@ def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
     time (issue #71).
     """
     parts = [part for part in source_id.strip().strip("/").split("/") if part]
+    if len(parts) >= 2 and parts[0] in _RULESPEC_SOURCE_ROOT_TOKENS:
+        tail = parts[1:]
+        if tail:
+            return Path(parts[0]) / _dotted_leaf_to_nested_yaml_path(tail)
     if len(parts) >= 3:
         document_roots = {
             "guidance": "guidance",

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2925,6 +2925,9 @@ def _run_single_source_eval(
     relative_output = _resolve_eval_output_path(
         source_id, requested_source=requested_source
     )
+    target_ref_source = _resolve_eval_reference_source_id(
+        source_id, requested_source=requested_source
+    )
     prompt = _build_eval_prompt(
         source_id,
         mode,
@@ -2932,7 +2935,7 @@ def _run_single_source_eval(
         workspace.context_files,
         target_file_name=relative_output.name,
         target_ref_prefix=_canonical_target_ref_prefix(
-            source_id,
+            target_ref_source,
             relative_output,
             policy_repo_path=policy_path,
         ),
@@ -3033,13 +3036,28 @@ def _resolve_eval_output_path(
          sites that always rendered free-text source_ids to
          ``source/<slug>.yaml``.
     """
-    if _looks_like_corpus_citation_path(citation):
-        return _source_identifier_to_relative_rulespec_path(citation)
-    if requested_source and _looks_like_corpus_citation_path(requested_source):
-        return _source_identifier_to_relative_rulespec_path(requested_source)
+    source_identifier = _resolve_eval_reference_source_id(
+        citation,
+        requested_source=requested_source,
+    )
+    if source_identifier != citation or _looks_like_corpus_citation_path(citation):
+        return _source_identifier_to_relative_rulespec_path(source_identifier)
     if fallback is not None:
         return fallback(citation)
     return _source_identifier_to_relative_rulespec_path(citation)
+
+
+def _resolve_eval_reference_source_id(
+    citation: str,
+    *,
+    requested_source: str | None = None,
+) -> str:
+    """Return the source identifier that should anchor output and test refs."""
+    if _looks_like_corpus_citation_path(citation):
+        return citation
+    if requested_source and _looks_like_corpus_citation_path(requested_source):
+        return requested_source
+    return citation
 
 
 def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3482,6 +3482,12 @@ Test file rules:
 - If context files import this target file or reference this target file's outputs, use that as a signal to repair the dependency graph, not as a requirement to preserve old names. Keep an old output only when it remains the cleanest source-faithful RuleSpec surface.
 - Do not preserve existing factual input slots referenced by copied formulas or companion tests when a cleaner source-faithful encoding removes them. For names listed under invalid copied local inputs, do not preserve, rename, or recreate them.
 - For cross-reference boundary facts that remain local because the cited source is not present in context at all, keep the legal pointer in the identifier. If context for the cited source is present but unsupported, deferred, empty, or missing the exact displacement or exception export, encode a source-grounded local boundary predicate for whether that cited source displaces or blocks the requested source's formula; do not defer the requested formula merely because the copied cited file exports only its own separate amount.
+- When this source text itself names the operative factual disqualification,
+  exception, or eligibility condition, encode that named condition as a local
+  factual input even if the sentence cites another section for definitions or
+  compliance procedures. Do not defer the target output solely because the
+  cited section is absent when the source gives enough facts to evaluate the
+  branch as true or false.
 - For repo-backed artifacts, every `input:` and `output:` key must be a canonical
   legal RuleSpec reference that resolves to an actual file and fragment; do not
   use bare friendly keys or absolute-looking placeholders.

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -4354,6 +4354,15 @@ source-subparagraph-coverage validator. There is no implicit "covered by
 the umbrella rule" path — composite rules cite the parent section, not
 the children.
 
+The citation strings below are exact validator keys, not examples. To satisfy
+coverage with an executable rule, copy the relevant string exactly into that
+rule's `source:` field, such as `source: us-ny/regulation/.../5(a)`. A
+human-readable source like `18 NYCRR 387.14(a)(5)(i)(a)` may be useful in prose
+but does not satisfy this checklist. If a top-level checklist item has nested
+legal clauses, at least one rule for that top-level item must cite the exact
+top-level checklist string, or the item must be listed under
+`module.deferred_outputs`.
+
 Subparagraphs requiring action:
 {rows_text}
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2616,7 +2616,13 @@ def _relative_rulespec_source_path(path: Path) -> Path | None:
 _MINIMAL_SCOPE_HINT = """Source-scope protocol (minimal):
 - Match each executable rule's `entity:` to the legal subject stated by the supplied source text.
 - If the source uses the word "household" or "household's", use `entity: Household`. Prefer `Household` over `SnapUnit` for plain household-level SNAP rules.
-- If the source uses "individual", "person", "member", "claimant", "child", "dependent", "spouse", or "employee", use `entity: Person` (or `Employer` for employer amounts).
+- If the source says "households in which all members", "households with a member",
+  or another household-level condition expressed through member facts, encode the
+  executable eligibility/result on `Household`. Use person/member facts only as
+  inputs or relation children needed to evaluate that household rule.
+- If the source's legal subject is an "individual", "person", "member", "claimant",
+  "child", "dependent", "spouse", or "employee" rather than a household/unit
+  described through those people, use `entity: Person` (or `Employer` for employer amounts).
 - Any rule that uses `entity: SnapUnit` (or another filtered entity) requires the same file to also declare that entity via a `kind: derived_relation` rule. The declaration shape is:
 
 ```yaml

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -6965,10 +6965,14 @@ def _source_citation_subparagraph_paths(
 
 def _source_subparagraph_citation_pattern(citation_path: str) -> re.Pattern[str] | None:
     parts = citation_path.strip("/").split("/")
+    exact_corpus_path = re.escape(citation_path.strip("/"))
     if len(parts) >= 4 and parts[:2] == ["us", "statute"]:
         title = re.escape(parts[2])
         section = re.escape(parts[3])
-        citation_prefixes = [rf"{title}\s+(?:U\.?\s*S\.?\s*C\.?|USC)\s+{section}"]
+        citation_prefixes = [
+            exact_corpus_path,
+            rf"{title}\s+(?:U\.?\s*S\.?\s*C\.?|USC)\s+{section}",
+        ]
         if parts[2] == "26":
             citation_prefixes.append(rf"I\.?\s*R\.?\s*C\.?\s+section\s+{section}")
             citation_prefixes.append(rf"IRC\s+section\s+{section}")
@@ -6980,7 +6984,7 @@ def _source_subparagraph_citation_pattern(citation_path: str) -> re.Pattern[str]
     if len(parts) >= 4 and parts[0].startswith("us-") and parts[1] == "statute":
         section = re.escape(parts[3])
         return re.compile(
-            rf"(?<![\w.-])(?:{section}|C\.?\s*R\.?\s*S\.?\s*{section})"
+            rf"(?<![\w.-])(?:{exact_corpus_path}|{section}|C\.?\s*R\.?\s*S\.?\s*{section})"
             r"(?P<suffix>(?:\([A-Za-z0-9]+\))+)",
             flags=re.IGNORECASE,
         )
@@ -6988,7 +6992,13 @@ def _source_subparagraph_citation_pattern(citation_path: str) -> re.Pattern[str]
         title = re.escape(parts[2])
         section = re.escape(f"{parts[3]}.{parts[4]}")
         return re.compile(
-            rf"\b{title}\s+(?:C\.?\s*F\.?\s*R\.?|CFR)\s+{section}"
+            rf"(?:\b{title}\s+(?:C\.?\s*F\.?\s*R\.?|CFR)\s+{section}|{exact_corpus_path})"
+            r"(?P<suffix>(?:\([A-Za-z0-9]+\))+)",
+            flags=re.IGNORECASE,
+        )
+    if len(parts) >= 3 and parts[0].startswith("us-") and parts[1] == "regulation":
+        return re.compile(
+            rf"(?<![\w.-]){exact_corpus_path}"
             r"(?P<suffix>(?:\([A-Za-z0-9]+\))+)",
             flags=re.IGNORECASE,
         )
@@ -7005,6 +7015,8 @@ def _rulespec_base_parts_for_corpus_path(citation_path: str) -> tuple[str, ...]:
         return ("statutes", parts[2], parts[3])
     if len(parts) >= 5 and parts[:2] == ["us", "regulation"]:
         return ("regulations", f"{parts[2]}-cfr", parts[3], parts[4])
+    if len(parts) >= 3 and parts[0].startswith("us-") and parts[1] == "regulation":
+        return ("regulations", *parts[2:])
     return ()
 
 

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -37,9 +37,14 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   other unit boundary. Only add a unit-level roll-up when this source text
   itself states that aggregate.
 - Treat legal subject nouns as stronger evidence than nearby repository
-  context. In particular, "individual", "person", "employee", "member",
-  "claimant", "child", "dependent", and "spouse" usually require
-  `entity: Person` for the current source's own amount, tax, credit,
+  context. When the source says "households in which all members",
+  "households with a member", or another household/unit-level condition stated
+  through member facts, the current eligibility/result belongs on the household
+  or unit; encode member facts as inputs or relation children only as needed to
+  evaluate that unit rule. In contrast, when the source's legal subject is an
+  "individual", "person", "employee", "member", "claimant", "child",
+  "dependent", or "spouse" rather than a unit described through those people,
+  use `entity: Person` for the current source's own amount, tax, credit,
   deduction, contribution, limit, or eligibility result. Do not choose
   `entity: TaxUnit`, `Household`, `Family`, or another aggregate entity merely
   because an imported base amount or companion test is currently declared at

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,7 @@ from axiom_encode.cli import (
     _qualify_deferred_output_subsection_paths,
     _remove_cross_module_dependent_test_outputs,
     _remove_invalid_dependent_test_inputs,
+    _remove_unknown_test_output_refs,
     _repair_anaphoric_scope_identifiers,
     _repair_colorado_snap_401,
     _repair_colorado_snap_401_tests,
@@ -4209,6 +4210,31 @@ rules:
             "us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income"
             in repaired
         )
+
+    def test_remove_unknown_test_output_refs_drops_stale_outputs(self, tmp_path):
+        test_file = tmp_path / "policy.test.yaml"
+        test_file.write_text(
+            """- name: stale_output
+  input: {}
+  output:
+    us-ny:regulations/18-nycrr/387/14/a/1#snap_allotment: 298
+    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_eligible: holds
+"""
+        )
+
+        removed = _remove_unknown_test_output_refs(
+            test_file=test_file,
+            issues=[
+                "stale_output: unknown executable output "
+                "us-ny:regulations/18-nycrr/387/14/a/1#snap_allotment"
+            ],
+        )
+
+        assert removed == ["us-ny:regulations/18-nycrr/387/14/a/1#snap_allotment"]
+        repaired = yaml.safe_load(test_file.read_text())
+        assert repaired[0]["output"] == {
+            "us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_eligible": "holds"
+        }
 
     def test_rewrite_import_output_test_input_refs_drops_input_prefix(self, tmp_path):
         """When a test case writes <producer>#input.X to override an imported

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6075,6 +6075,148 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_repeats_scalar_relation_row_repair(
+        self, capsys, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us-ny"
+        policy_repo.mkdir()
+        args = self._make_args(
+            tmp_path,
+            backend="codex",
+            citation="us-ny/regulation/18-nycrr/387/14/a/5",
+            policy_repo_path=policy_repo,
+            sync=False,
+        )
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path
+            / "out"
+            / "codex-test-model"
+            / "regulations"
+            / "18-nycrr"
+            / "387"
+            / "14"
+            / "a"
+            / "5.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: categorical_condition
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: len(member_of_household) > 0
+"""
+        )
+        test_file = output_file.with_name("5.test.yaml")
+        test_file.write_text(
+            """- name: first_generated_case
+  period: 2026-01
+  input:
+    us:statutes/7/2012/j#relation.member_of_household:
+      - true
+  output:
+    us-ny:regulations/18-nycrr/387/14/a/5#categorical_condition: holds
+- name: second_generated_case
+  period: 2026-01
+  input:
+    us:statutes/7/2012/j#relation.member_of_household:
+      - true
+  output:
+    us-ny:regulations/18-nycrr/387/14/a/5#categorical_condition: holds
+"""
+        )
+        companion_test = (
+            tmp_path / "rulespec-us" / "statutes" / "7" / "2012" / "j.test.yaml"
+        )
+        companion_test.parent.mkdir(parents=True)
+        companion_test.write_text(
+            """- name: household_has_elderly_or_disabled_member
+  period: 2026-01
+  input:
+    us:statutes/7/2012/j#relation.member_of_household:
+      - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: true
+  output:
+    us:statutes/7/2012/j#snap_household_has_elderly_or_disabled_member: holds
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "regulations/18-nycrr/387/14/a/5.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "regulations/18-nycrr/387/14/a/5.yaml: ci: "
+                            "Test case `first_generated_case` input invalid: relation "
+                            "`us:statutes/7/2012/j#relation.member_of_household` "
+                            "item #1 must be a mapping"
+                        ],
+                        {},
+                    ),
+                    (
+                        False,
+                        [
+                            "regulations/18-nycrr/387/14/a/5.yaml: ci: "
+                            "Test case `second_generated_case` input invalid: relation "
+                            "`us:statutes/7/2012/j#relation.member_of_household` "
+                            "item #1 must be a mapping"
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert (
+            "apply=auto_repaired_scalar_relation_rows:"
+            "first_generated_case:us:statutes/7/2012/j#relation.member_of_household[1]"
+        ) in output
+        assert (
+            "apply=auto_repaired_scalar_relation_rows:"
+            "second_generated_case:us:statutes/7/2012/j#relation.member_of_household[1]"
+        ) in output
+        assert mock_overlay.call_count == 3
+        mock_apply.assert_called_once()
+        test_payload = yaml.safe_load(test_file.read_text())
+        for case in test_payload:
+            assert case["input"][
+                "us:statutes/7/2012/j#relation.member_of_household"
+            ] == [
+                {"us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled": True}
+            ]
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_scalar_relation_rows"] == [
+            "first_generated_case:us:statutes/7/2012/j#relation.member_of_household[1]",
+            "second_generated_case:us:statutes/7/2012/j#relation.member_of_household[1]",
+        ]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_auto_repairs_missing_derived_output_coverage(
         self, capsys, tmp_path
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,6 +63,7 @@ from axiom_encode.cli import (
     _repair_section_151_temporal_fact_names,
     _repair_shared_statutory_rate_names,
     _repair_snap_2014c_income_standard_test_inputs,
+    _repair_scalar_relation_rows,
     _repair_tax_filing_status_branches,
     _repair_upstream_placement_duplicate_imports,
     _require_axiom_encode_version_provenance,
@@ -9880,6 +9881,56 @@ rules: []
             ]
             == 1200
         )
+
+    def test_repair_scalar_relation_rows_from_companion_tests(self, tmp_path):
+        policy_repo = tmp_path / "rulespec-us-ny"
+        companion_test = (
+            tmp_path / "rulespec-us" / "statutes" / "7" / "2012" / "j.test.yaml"
+        )
+        companion_test.parent.mkdir(parents=True)
+        companion_test.write_text(
+            """- name: household_has_elderly_or_disabled_member
+  period: 2026-01
+  input:
+    us:statutes/7/2012/j#relation.member_of_household:
+      - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: true
+  output:
+    us:statutes/7/2012/j#snap_household_has_elderly_or_disabled_member: holds
+"""
+        )
+        test_file = tmp_path / "a" / "5.test.yaml"
+        test_file.parent.mkdir()
+        test_file.write_text(
+            """- name: elderly_or_disabled_member_household
+  period: 2026-01
+  input:
+    us:statutes/7/2012/j#relation.member_of_household:
+      - true
+  output:
+    us-ny:regulations/18-nycrr/387/14/a/5#elderly_or_disabled_categorical_eligibility_group: holds
+"""
+        )
+
+        repaired = _repair_scalar_relation_rows(
+            test_file=test_file,
+            policy_repo_path=policy_repo,
+            parsed_issues=[
+                (
+                    "elderly_or_disabled_member_household",
+                    "us:statutes/7/2012/j#relation.member_of_household",
+                    1,
+                )
+            ],
+        )
+
+        assert repaired == [
+            "elderly_or_disabled_member_household:"
+            "us:statutes/7/2012/j#relation.member_of_household[1]"
+        ]
+        [case] = yaml.safe_load(test_file.read_text())
+        assert case["input"]["us:statutes/7/2012/j#relation.member_of_household"] == [
+            {"us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled": True}
+        ]
 
     def test_apply_overlay_validation_rejects_dropped_source_relation(self, tmp_path):
         output_root = tmp_path / "out"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5944,6 +5944,137 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_repairs_positive_coverage_after_imported_output_repair(
+        self, capsys, tmp_path
+    ):
+        args = self._make_args(
+            tmp_path, backend="codex", citation="26 USC 1402(b)", sync=False
+        )
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path
+            / "out"
+            / "codex-test-model"
+            / "statutes"
+            / "26"
+            / "1402"
+            / "b.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+imports:
+  - from: us:statutes/26/1402/a#net_earnings_from_self_employment
+rules:
+  - name: trade_or_business_income_condition
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: has_trade_or_business_income
+"""
+        )
+        test_file = output_file.with_name("b.test.yaml")
+        test_file.write_text(
+            """- name: imported_inputs_make_generated_positive_fail
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/1402/a#input.self_employment_trade_or_business_gross_income: 0
+    us:statutes/26/1402/b#input.has_trade_or_business_income: false
+  output:
+    us:statutes/26/1402/b#trade_or_business_income_condition: holds
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/26/1402/b.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "statutes/26/1402/b.yaml: ci: "
+                            "Test case "
+                            "imported_inputs_make_generated_positive_fail "
+                            "output "
+                            "us:statutes/26/1402/b#trade_or_business_income_condition "
+                            "expected holds, got not_holds."
+                        ],
+                        {},
+                    ),
+                    (
+                        False,
+                        [
+                            "statutes/26/1402/b.yaml: ci: "
+                            "Judgment rule missing positive companion output coverage: "
+                            "`us:statutes/26/1402/b#trade_or_business_income_condition` "
+                            "is not asserted as `holds` by the companion `.test.yaml` file."
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert (
+            "apply=auto_repaired_imported_output_tests:"
+            "imported_inputs_make_generated_positive_fail"
+        ) in output
+        assert (
+            "apply=auto_repaired_judgment_positive_tests:"
+            "auto_positive_trade_or_business_income_condition"
+        ) in output
+        assert mock_overlay.call_count == 3
+        mock_apply.assert_called_once()
+        test_payload = yaml.safe_load(test_file.read_text())
+        assert (
+            test_payload[0]["output"][
+                "us:statutes/26/1402/b#trade_or_business_income_condition"
+            ]
+            == "not_holds"
+        )
+        assert test_payload[1]["name"] == (
+            "auto_positive_trade_or_business_income_condition"
+        )
+        assert test_payload[1]["input"][
+            "us:statutes/26/1402/b#input.has_trade_or_business_income"
+        ] is True
+        assert test_payload[1]["output"][
+            "us:statutes/26/1402/b#trade_or_business_income_condition"
+        ] == "holds"
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_imported_output_tests"] == [
+            "imported_inputs_make_generated_positive_fail"
+        ]
+        assert run.outcome["auto_repaired_judgment_positive_tests"] == [
+            "auto_positive_trade_or_business_income_condition"
+        ]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_auto_repairs_missing_derived_output_coverage(
         self, capsys, tmp_path
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,11 +59,11 @@ from axiom_encode.cli import (
     _repair_mixed_derived_entity_output_tests,
     _repair_mixed_scalar_output_tests,
     _repair_person_scoped_definition_entities,
+    _repair_scalar_relation_rows,
     _repair_section_151_imports,
     _repair_section_151_temporal_fact_names,
     _repair_shared_statutory_rate_names,
     _repair_snap_2014c_income_standard_test_inputs,
-    _repair_scalar_relation_rows,
     _repair_tax_filing_status_branches,
     _repair_upstream_placement_duplicate_imports,
     _require_axiom_encode_version_provenance,
@@ -6059,12 +6059,18 @@ rules:
         assert test_payload[1]["name"] == (
             "auto_positive_trade_or_business_income_condition"
         )
-        assert test_payload[1]["input"][
-            "us:statutes/26/1402/b#input.has_trade_or_business_income"
-        ] is True
-        assert test_payload[1]["output"][
-            "us:statutes/26/1402/b#trade_or_business_income_condition"
-        ] == "holds"
+        assert (
+            test_payload[1]["input"][
+                "us:statutes/26/1402/b#input.has_trade_or_business_income"
+            ]
+            is True
+        )
+        assert (
+            test_payload[1]["output"][
+                "us:statutes/26/1402/b#trade_or_business_income_condition"
+            ]
+            == "holds"
+        )
         run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
         assert run.outcome["auto_repaired_imported_output_tests"] == [
             "imported_inputs_make_generated_positive_fail"
@@ -6075,9 +6081,7 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
-    def test_encode_apply_repeats_scalar_relation_row_repair(
-        self, capsys, tmp_path
-    ):
+    def test_encode_apply_repeats_scalar_relation_row_repair(self, capsys, tmp_path):
         policy_repo = tmp_path / "rulespec-us-ny"
         policy_repo.mkdir()
         args = self._make_args(

--- a/tests/test_concepts_auto_repair.py
+++ b/tests/test_concepts_auto_repair.py
@@ -115,6 +115,33 @@ def test_repair_preserves_consumer_anchor_on_input_refs(tmp_path: Path):
     assert "us:regulations/7-cfr/273/10#input." not in text
 
 
+def test_repair_preserves_producer_relation_child_input_refs(tmp_path: Path):
+    """A producer may use a child/member input to derive a household-level
+    canonical output. That input must not be rewritten to the output concept.
+    """
+    registry = load_concept_registry()
+    drift = _write(
+        tmp_path,
+        "drift.test.yaml",
+        """
+        - name: household_has_elderly_or_disabled_member
+          period: 2026-01
+          input:
+            us:statutes/7/2012/j#relation.member_of_household:
+              - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: true
+          output:
+            us:statutes/7/2012/j#snap_household_has_elderly_or_disabled_member: holds
+        """,
+    )
+    changed = auto_repair_test_yaml_canonical_violations([drift], registry)
+    assert changed == []
+    text = drift.read_text()
+    assert "us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled" in text
+    assert "#input.snap_household_has_elderly_or_disabled_member" not in text
+    violations = validate_generated_against_registry([drift], registry)
+    assert violations == []
+
+
 def test_repair_skips_non_test_files(tmp_path: Path):
     """Producer/source YAML must fail loudly — never silently rewritten."""
     registry = load_concept_registry()

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -231,6 +231,16 @@ def test_resolve_eval_output_path_uses_path_like_citation_directly():
     )
 
 
+def test_resolve_eval_output_path_uses_repo_relative_source_root_directly():
+    """Repo-relative logical targets are valid --source-id output paths."""
+    from axiom_encode.harness.evals import _resolve_eval_output_path
+
+    assert _resolve_eval_output_path(
+        "policies/otda/snap/fy-2026-benefit-calculation",
+        requested_source="us/guidance/usda/fns/snap-fy2026-cola/page-1",
+    ) == Path("policies/otda/snap/fy-2026-benefit-calculation.yaml")
+
+
 def test_resolve_eval_output_path_uses_requested_source_when_citation_is_free_text():
     """Free-text source_id falls through to requested_source for path derivation.
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -30,6 +30,7 @@ from axiom_encode.harness.evals import (
     _command_looks_out_of_bounds,
     _context_file_executable_surfaces,
     _eval_result_from_payload,
+    _format_subparagraph_coverage_checklist,
     _hydrate_eval_root,
     _is_single_amount_table_slice,
     _materialize_eval_artifact,
@@ -157,6 +158,17 @@ def test_canonical_target_ref_prefix_omits_repo_relative_source_without_repo():
         )
         is None
     )
+
+
+def test_subparagraph_coverage_checklist_requires_exact_corpus_source_keys():
+    checklist = _format_subparagraph_coverage_checklist(
+        "(a) First category is eligible.\n(b) Second category is ineligible.",
+        "us-ny/regulation/18-nycrr/387/14/a/5",
+    )
+
+    assert "copy the relevant string exactly" in checklist
+    assert "human-readable source like `18 NYCRR 387.14(a)(5)(i)(a)`" in checklist
+    assert "us-ny/regulation/18-nycrr/387/14/a/5(a)" in checklist
 
 
 @pytest.mark.parametrize(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -133,6 +133,32 @@ def test_canonical_target_ref_prefix_handles_canonical_source_id():
     )
 
 
+def test_canonical_target_ref_prefix_uses_policy_repo_for_repo_relative_source_id(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us-ny"
+    repo.mkdir()
+
+    assert (
+        _canonical_target_ref_prefix(
+            "regulations/18-nycrr/387/14/a/1",
+            Path("regulations/18-nycrr/387/14/a/1.yaml"),
+            policy_repo_path=repo,
+        )
+        == "us-ny:regulations/18-nycrr/387/14/a/1"
+    )
+
+
+def test_canonical_target_ref_prefix_omits_repo_relative_source_without_repo():
+    assert (
+        _canonical_target_ref_prefix(
+            "regulations/18-nycrr/387/14/a/1",
+            Path("regulations/18-nycrr/387/14/a/1.yaml"),
+        )
+        is None
+    )
+
+
 @pytest.mark.parametrize(
     "citation,expected",
     [

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -644,7 +644,7 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     )
     assert "rate-applied result at that lower entity" in prompt
     assert "Treat legal subject nouns as stronger evidence" in prompt
-    assert "usually require\n  `entity: Person`" in prompt
+    assert "use `entity: Person` for the current source's own amount" in prompt
     assert "thresholded, capped, base-limited" in prompt
     assert (
         "do not flatten the cited mechanics into `current_base * imported_rate`"

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -37,6 +37,8 @@ from axiom_encode.harness.evals import (
     _normalize_nonannual_test_period_value,
     _normalize_test_periods_to_effective_dates,
     _post_openai_eval_request,
+    _resolve_eval_output_path,
+    _resolve_eval_reference_source_id,
     _rulespec_validation_target,
     _run_codex_prompt_eval,
     _select_cross_section_context_files,
@@ -254,20 +256,43 @@ def test_resolve_eval_output_path_uses_requested_source_when_citation_is_free_te
     `source/<slug>.yaml` — outside any rulespec source-root directory,
     so downstream compile validators couldn't find it.
     """
-    from axiom_encode.harness.evals import _resolve_eval_output_path
-
     assert _resolve_eval_output_path(
         "SNAP earned income deduction under 7 USC 2014(e)(2)(B)",
         requested_source="us/statute/7/2014/e/2/B",
     ) == Path("statutes/7/2014/e/2/B.yaml")
 
 
+def test_eval_reference_source_id_uses_requested_source_with_free_text_citation(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us-ny"
+    repo.mkdir()
+
+    target_ref_source = _resolve_eval_reference_source_id(
+        "New York SNAP utility allowance",
+        requested_source="regulations/18-nycrr/387/14/a/1",
+    )
+    relative_output = _resolve_eval_output_path(
+        "New York SNAP utility allowance",
+        requested_source="regulations/18-nycrr/387/14/a/1",
+    )
+
+    assert target_ref_source == "regulations/18-nycrr/387/14/a/1"
+    assert relative_output == Path("regulations/18-nycrr/387/14/a/1.yaml")
+    assert (
+        _canonical_target_ref_prefix(
+            target_ref_source,
+            relative_output,
+            policy_repo_path=repo,
+        )
+        == "us-ny:regulations/18-nycrr/387/14/a/1"
+    )
+
+
 def test_resolve_eval_output_path_ignores_requested_source_when_also_free_text():
     """If both inputs are free-text, fall back to the existing USC parser
     (which may itself error out — that's a separate bug, not this fix's job).
     """
-    from axiom_encode.harness.evals import _resolve_eval_output_path
-
     # citation is path-like USC; requested_source is also path-like but
     # different — citation wins because it's path-like.
     assert _resolve_eval_output_path(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -12412,6 +12412,60 @@ rules: []
     ]
 
 
+def test_source_subparagraph_coverage_accepts_state_regulation_corpus_source():
+    source_text = """Categorical eligibility
+(a) Households in which all members are recipients of assistance are eligible.
+"""
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ny/regulation/18-nycrr/387/14/a/5
+  summary: New York categorical eligibility.
+rules:
+  - name: all_member_assistance_categorical_eligibility
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: us-ny/regulation/18-nycrr/387/14/a/5(a)
+    versions:
+      - effective_from: '2025-10-01'
+        formula: household_all_members_receive_assistance
+"""
+
+    assert (
+        find_source_subparagraph_coverage_issues(
+            content,
+            source_texts={"us-ny/regulation/18-nycrr/387/14/a/5": source_text},
+        )
+        == []
+    )
+
+
+def test_source_subparagraph_coverage_accepts_state_regulation_deferred_output():
+    source_text = """Categorical eligibility
+(a) Households in which all members are recipients of assistance are eligible.
+"""
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ny/regulation/18-nycrr/387/14/a/5
+  summary: New York categorical eligibility.
+  deferred_outputs:
+    - output: us-ny:regulations/18-nycrr/387/14/a/5/a#all_member_assistance_categorical_eligibility
+      reason: Depends on TANF assistance-unit eligibility not yet encoded.
+rules: []
+"""
+
+    assert (
+        find_source_subparagraph_coverage_issues(
+            content,
+            source_texts={"us-ny/regulation/18-nycrr/387/14/a/5": source_text},
+        )
+        == []
+    )
+
+
 def test_source_subparagraph_coverage_allows_repealed_empty_slice(tmp_path):
     source_text = """Wages
 (a) Wages means all remuneration for employment.

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.427"
+version = "0.2.428"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.432"
+version = "0.2.433"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.434"
+version = "0.2.435"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.428"
+version = "0.2.429"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.436"
+version = "0.2.437"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.437"
+version = "0.2.438"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.433"
+version = "0.2.434"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.431"
+version = "0.2.432"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.435"
+version = "0.2.436"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.430"
+version = "0.2.431"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.429"
+version = "0.2.430"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- derive generated test reference prefixes from the policy repo when --source-id is repo-relative
- require exact corpus-path source keys in subparagraph coverage prompts
- recognize state regulation corpus-path citations/deferred outputs in source coverage validation
- clarify household/member scope guidance for household-level SNAP rules

## Tests
- python -m pytest tests/test_evals.py -q
- python -m pytest tests/test_rulespec_validation.py::test_source_subparagraph_coverage_accepts_state_regulation_corpus_source tests/test_rulespec_validation.py::test_source_subparagraph_coverage_accepts_state_regulation_deferred_output tests/test_evals.py::test_subparagraph_coverage_checklist_requires_exact_corpus_source_keys -q