### PR TITLE
Normalize UK weekly test periods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.426"
+version = "0.2.427"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.426"
+__version__ = "0.2.427"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -12704,6 +12704,8 @@ def cmd_encode(args):
         print(f"Policy repo not found: {policy_repo_path}")
         sys.exit(1)
 
+    os.environ.setdefault("AXIOM_CORPUS_REPO", str(corpus_path))
+
     source_id = getattr(args, "source_id", None)
     source_unit = None
     if source_id:

--- a/src/axiom_encode/harness/eval_prompt_surface.py
+++ b/src/axiom_encode/harness/eval_prompt_surface.py
@@ -130,6 +130,7 @@ def render_uk_legislation_guidance() -> str:
 - When a boolean output ultimately depends on a final fact-shaped input and the source text makes a meaningful false case possible, include a `.test.yaml` case where the applicability conditions hold but that final fact input is false.
 - In `.test.yaml`, choose periods on or after the explicit effective date in `./source.txt`.
 - Do not add speculative future-period tests that would rely on uprating, later amendments, or rates not stated in `./source.txt`.
+- In `.test.yaml`, do not use ISO week shorthands like `2025-W01`; for weekly UK rules use an explicit mapping such as `period_kind: benefit_week`, `start: YYYY-MM-DD`, and `end: YYYY-MM-DD`.
 - Reference RuleSpec rule names by bare name inside formulas. Do not write function-style calls like `some_variable(person, period)`.
 """
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -7254,6 +7254,24 @@ def _default_test_period_for_granularity(
     return effective_date.isoformat()
 
 
+def _normalize_week_test_period_value(period: object) -> object:
+    """Convert ISO week shorthands into explicit benefit-week periods."""
+    if not isinstance(period, str) or not _ISO_WEEK_PERIOD_PATTERN.fullmatch(period):
+        return period
+    year = int(period[:4])
+    week = int(period[-2:])
+    try:
+        start = date.fromisocalendar(year, week, 1)
+    except ValueError:
+        return period
+    end = date.fromordinal(start.toordinal() + 6)
+    return {
+        "period_kind": "benefit_week",
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+    }
+
+
 def _normalize_nonannual_test_period_value(
     period: object,
     effective_date: date,
@@ -7296,6 +7314,11 @@ def _normalize_nonannual_test_period_value(
                 except ValueError:
                     return period
                 return parsed.strftime("%Y-%m")
+
+    if granularity == "Week":
+        normalized_week = _normalize_week_test_period_value(period)
+        if normalized_week != period:
+            return normalized_week
 
     if period is None:
         return effective_date.isoformat()
@@ -7560,6 +7583,10 @@ def _normalize_test_periods_to_effective_dates(
                 _normalize_placeholder_monthly_test_period_value(
                     normalized_case.get("period")
                 )
+            )
+        elif granularity == "Week":
+            normalized_case["period"] = _normalize_week_test_period_value(
+                normalized_case.get("period")
             )
 
         for key in ("input", "inputs", "output"):

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3803,6 +3803,38 @@ rules:
         }
         assert "end" not in cases[0]
 
+    def test_normalize_test_periods_rewrites_iso_week_shorthand(self):
+        rulespec_text = """format: rulespec/v1
+module:
+  summary: Weekly child benefit rate.
+rules:
+  - name: child_benefit_weekly_rate
+    kind: parameter
+    dtype: Money
+    period: Week
+    unit: GBP
+    versions:
+      - effective_from: '0001-01-01'
+        formula: 27.05
+"""
+        test_text = _normalize_test_periods_to_effective_dates(
+            """- name: weekly_case
+  period: 2025-W01
+  input: {}
+  output:
+    child_benefit_weekly_rate: 27.05
+""",
+            rulespec_content=rulespec_text,
+        )
+
+        cases = yaml.safe_load(test_text)
+
+        assert cases[0]["period"] == {
+            "period_kind": "benefit_week",
+            "start": "2024-12-30",
+            "end": "2025-01-05",
+        }
+
     def test_materialize_eval_artifact_normalizes_mapping_style_tests_to_list(
         self, tmp_path
     ):
@@ -4172,6 +4204,7 @@ class TestEvalPrompt:
             "`Employer`, `Asset`."
         ) in prompt
         assert "Allowed `period:` values are `Year`, `Month`, `Week`, `Day`." in prompt
+        assert "do not use ISO week shorthands like `2025-W01`" in prompt
         assert (
             "Allowed `dtype:` values are `Money`, `Rate`, `Boolean`, `Integer`, "
             "`Count`, `String`, `Decimal`, `Float`, or `Enum[Name]`."

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.426"
+version = "0.2.427"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- pass the selected corpus checkout into encode-time validation via AXIOM_CORPUS_REPO
- tell UK prompt runners not to emit ISO week shorthand periods
- normalize generated ISO week test periods like 2025-W01 to explicit benefit_week mappings

## Checks
- uv run ruff check src/axiom_encode/cli.py src/axiom_encode/harness/evals.py src/axiom_encode/harness/eval_prompt_surface.py tests/test_evals.py
- uv run ruff format --check src/axiom_encode/cli.py src/axiom_encode/harness/evals.py src/axiom_encode/harness/eval_prompt_surface.py tests/test_evals.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_evals.py -q