### PR TITLE
Add UK PolicyEngine oracle mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.427"
+version = "0.2.435"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.427"
+__version__ = "0.2.435"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -213,7 +213,10 @@ def _iter_policyengine_coverage_items(
                     rulespec_file=rulespec_file,
                     rule_name=rule_name,
                 )
-                mapping = registry.mapping_for_legal_id(legal_id, country="us")
+                mapping = registry.mapping_for_legal_id(
+                    legal_id,
+                    country=_country_from_rulespec_prefix(prefix),
+                )
                 test_output_count = _mapping_test_output_count(
                     legal_id,
                     mapping=mapping,
@@ -475,6 +478,11 @@ def _canonical_rulespec_legal_id(
     return f"{prefix}:{relative.as_posix()}#{rule_name}"
 
 
+def _country_from_rulespec_prefix(prefix: str) -> str:
+    """Infer PolicyEngine country from a RuleSpec repository prefix."""
+    return prefix.split("-", 1)[0]
+
+
 def _coverage_item_from_mapping(
     *,
     legal_id: str,
@@ -519,6 +527,14 @@ def _coverage_item_from_mapping(
 
 def _infer_program_from_legal_id(legal_id: str) -> str:
     lowered = legal_id.lower()
+    if lowered.startswith("uk:statutes/ukpga/2007/3/35"):
+        return "tax"
+    if lowered.startswith("uk:regulations/uksi/2006/965/2"):
+        return "child_benefit"
+    if lowered.startswith("uk:regulations/uksi/2002/1792/6"):
+        return "pension_credit"
+    if lowered.startswith("uk:regulations/uksi/2013/376/36"):
+        return "universal_credit"
     if "snap" in lowered:
         return "snap"
     if (

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1,0 +1,301 @@
+mappings:
+  - legal_id: uk:statutes/ukpga/2007/3/35#personal_allowance_base_amount
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.income_tax.allowances.personal_allowance.amount
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK income tax personal allowance base amount.
+
+  - legal_id: uk:statutes/ukpga/2007/3/35#adjusted_net_income_reduction_threshold
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.income_tax.allowances.personal_allowance.maximum_ANI
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same adjusted net income threshold above which the UK personal allowance is reduced.
+
+  - legal_id: uk:statutes/ukpga/2007/3/35#excess_income_reduction_fraction
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.income_tax.allowances.personal_allowance.reduction_rate
+    period: year
+    comparison: rate
+    rationale: Same UK personal allowance taper rate.
+
+  - legal_id: uk:statutes/ukpga/2007/3/35#personal_allowance
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: personal_allowance
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK income tax personal allowance output.
+
+  - legal_id: uk:regulations/uksi/2006/965/2#child_benefit_enhanced_weekly_rate
+    country: uk
+    program: child_benefit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.child_benefit.amount.eldest
+    aliases:
+      - uk:regulations/uksi/2006/965/2#child_benefit_weekly_rate
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same eldest or enhanced child benefit weekly amount. Companion tests exercise it through the branch-selected weekly rate output.
+
+  - legal_id: uk:regulations/uksi/2006/965/2#child_benefit_other_weekly_rate
+    country: uk
+    program: child_benefit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.child_benefit.amount.additional
+    aliases:
+      - uk:regulations/uksi/2006/965/2#child_benefit_weekly_rate
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same additional or other-child child benefit weekly amount. Companion tests exercise it through the branch-selected weekly rate output.
+
+  - legal_id: uk:regulations/uksi/2006/965/2#child_benefit_weekly_rate
+    country: uk
+    program: child_benefit
+    mapping_type: direct_variable
+    policyengine_variable: child_benefit_respective_amount
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same branch-selected statutory child benefit weekly amount for a child or qualifying young person.
+
+  - legal_id: uk:regulations/uksi/2002/1792/6#standard_minimum_guarantee_with_partner
+    country: uk
+    program: pension_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.pension_credit.guarantee_credit.minimum_guarantee.COUPLE
+    aliases:
+      - uk:regulations/uksi/2002/1792/6#standard_minimum_guarantee
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Pension Credit guarantee credit minimum guarantee for a claimant with a partner. Companion tests exercise it through the branch-selected standard minimum guarantee output.
+
+  - legal_id: uk:regulations/uksi/2002/1792/6#standard_minimum_guarantee_no_partner
+    country: uk
+    program: pension_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.pension_credit.guarantee_credit.minimum_guarantee.SINGLE
+    aliases:
+      - uk:regulations/uksi/2002/1792/6#standard_minimum_guarantee
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Pension Credit guarantee credit minimum guarantee for a claimant without a partner. Companion tests exercise the same branch-selected standard minimum guarantee surface.
+
+  - legal_id: uk:regulations/uksi/2002/1792/6#standard_minimum_guarantee
+    country: uk
+    program: pension_credit
+    mapping_type: direct_variable
+    policyengine_variable: standard_minimum_guarantee
+    entity: benunit
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Pension Credit standard minimum guarantee output.
+
+  - legal_id: uk:regulations/uksi/2002/1792/6#severe_disability_additional_amount_single
+    country: uk
+    program: pension_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.pension_credit.guarantee_credit.severe_disability.addition
+    aliases:
+      - uk:regulations/uksi/2002/1792/6#severe_disability_additional_amount
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same per-person Pension Credit severe disability addition. Companion tests exercise severe-disability additions through the branch-selected additional amount output.
+
+  - legal_id: uk:regulations/uksi/2002/1792/6#severe_disability_additional_amount
+    country: uk
+    program: pension_credit
+    mapping_type: direct_variable
+    policyengine_variable: severe_disability_minimum_guarantee_addition
+    entity: benunit
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Pension Credit severe disability addition output after applying claimant circumstances.
+
+  - legal_id: uk:regulations/uksi/2002/1792/6#carer_additional_amount_per_partner
+    country: uk
+    program: pension_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.pension_credit.guarantee_credit.carer.addition
+    aliases:
+      - uk:regulations/uksi/2002/1792/6#carer_additional_amount
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Pension Credit carer addition amount. Companion tests exercise it through the branch-selected carer additional amount output.
+
+  - legal_id: uk:regulations/uksi/2002/1792/6#carer_additional_amount
+    country: uk
+    program: pension_credit
+    mapping_type: direct_variable
+    policyengine_variable: carer_minimum_guarantee_addition
+    entity: benunit
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Pension Credit carer addition output after applying claimant circumstances.
+
+  - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_single_under_25
+    country: uk
+    program: universal_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.universal_credit.standard_allowance.amount.SINGLE_YOUNG
+    period: month
+    unit: GBP
+    comparison: money
+    rationale: Same Universal Credit standard allowance for a single claimant aged under 25.
+
+  - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_single_25_or_over
+    country: uk
+    program: universal_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.universal_credit.standard_allowance.amount.SINGLE_OLD
+    period: month
+    unit: GBP
+    comparison: money
+    rationale: Same Universal Credit standard allowance for a single claimant aged 25 or over.
+
+  - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_joint_both_under_25
+    country: uk
+    program: universal_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.universal_credit.standard_allowance.amount.COUPLE_YOUNG
+    period: month
+    unit: GBP
+    comparison: money
+    rationale: Same Universal Credit standard allowance for joint claimants both aged under 25.
+
+  - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_joint_either_25_or_over
+    country: uk
+    program: universal_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.universal_credit.standard_allowance.amount.COUPLE_OLD
+    period: month
+    unit: GBP
+    comparison: money
+    rationale: Same Universal Credit standard allowance for joint claimants where either is aged 25 or over.
+
+  - legal_id: uk:regulations/uksi/2013/376/36#child_element_first_child_or_qualifying_young_person
+    country: uk
+    program: universal_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.universal_credit.elements.child.first.higher_amount
+    period: month
+    unit: GBP
+    comparison: money
+    rationale: Same Universal Credit first-child child element amount.
+
+  - legal_id: uk:regulations/uksi/2013/376/36#child_element_second_and_each_subsequent_child_or_qualifying_young_person
+    country: uk
+    program: universal_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.universal_credit.elements.child.amount
+    period: month
+    unit: GBP
+    comparison: money
+    rationale: Same Universal Credit second and subsequent child element amount.
+
+  - legal_id: uk:regulations/uksi/2013/376/36#disabled_child_additional_amount_lower_rate
+    country: uk
+    program: universal_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.universal_credit.elements.child.disabled.amount
+    period: month
+    unit: GBP
+    comparison: money
+    rationale: Same Universal Credit lower disabled-child addition amount.
+
+  - legal_id: uk:regulations/uksi/2013/376/36#disabled_child_additional_amount_higher_rate
+    country: uk
+    program: universal_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.universal_credit.elements.child.severely_disabled.amount
+    period: month
+    unit: GBP
+    comparison: money
+    rationale: Same Universal Credit higher disabled-child addition amount.
+
+  - legal_id: uk:regulations/uksi/2013/376/36#lcwra_element_standard_lcwra_claimant
+    country: uk
+    program: universal_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.universal_credit.elements.disabled.amount
+    period: month
+    unit: GBP
+    comparison: money
+    rationale: Same Universal Credit standard limited capability for work and work-related activity element amount.
+
+  - legal_id: uk:regulations/uksi/2013/376/36#carer_element
+    country: uk
+    program: universal_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.universal_credit.elements.carer.amount
+    period: month
+    unit: GBP
+    comparison: money
+    rationale: Same Universal Credit carer element amount.
+
+  - legal_id: uk:regulations/uksi/2013/376/36#childcare_costs_element_maximum_one_child
+    country: uk
+    program: universal_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.universal_credit.elements.childcare.cap.1
+    period: month
+    unit: GBP
+    comparison: money
+    rationale: Same Universal Credit maximum childcare costs element for one child.
+
+  - legal_id: uk:regulations/uksi/2013/376/36#childcare_costs_element_maximum_two_or_more_children
+    country: uk
+    program: universal_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.universal_credit.elements.childcare.cap.2
+    period: month
+    unit: GBP
+    comparison: money
+    rationale: Same Universal Credit maximum childcare costs element for two or more children.
+
+prefixes:
+  - legal_id_prefix: uk:statutes/ukpga/2007/3/35#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: UK personal allowance helper outputs not listed above are legal entitlement or rounding intermediates that PolicyEngine UK does not expose as one-to-one oracle variables or parameters.
+
+  - legal_id_prefix: uk:regulations/uksi/2006/965/2#
+    country: uk
+    program: child_benefit
+    mapping_type: not_comparable
+    rationale: Child Benefit helper outputs not listed above are payability, relationship-coordination, or specified-benefit predicates that PolicyEngine UK does not expose as one-to-one oracle variables or parameters.
+
+  - legal_id_prefix: uk:regulations/uksi/2002/1792/6#
+    country: uk
+    program: pension_credit
+    mapping_type: not_comparable
+    rationale: Pension Credit helper outputs not listed above are remand-prisoner, tax-credit cessation, nil substitution, or branch-control intermediates that PolicyEngine UK does not expose as one-to-one oracle variables or parameters.
+
+  - legal_id_prefix: uk:regulations/uksi/2013/376/36#
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    rationale: Universal Credit helper outputs not listed above are statutory amount variants that PolicyEngine UK does not expose as one-to-one oracle parameters in the current model, including the protected pre-2026 LCWRA amount.

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -146,6 +146,111 @@ rules:
     assert report["items"][0]["kind"] == "derived_relation"
 
 
+def test_policyengine_coverage_uses_uk_registry_mappings(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2007/3/35.yaml",
+        """format: rulespec/v1
+rules:
+  - name: personal_allowance
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 12570
+  - name: allowance_rounding_multiple
+    kind: parameter
+    dtype: Money
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 1
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2007/3/35.test.yaml",
+        """- name: personal allowance
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    uk:statutes/ukpga/2007/3/35#personal_allowance: 12570
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 1,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    personal_allowance = items_by_id["uk:statutes/ukpga/2007/3/35#personal_allowance"]
+    rounding_multiple = items_by_id[
+        "uk:statutes/ukpga/2007/3/35#allowance_rounding_multiple"
+    ]
+    assert personal_allowance["policyengine_variable"] == "personal_allowance"
+    assert personal_allowance["tested"] is True
+    assert rounding_multiple["status"] == "known_not_comparable"
+
+
+def test_policyengine_coverage_counts_uk_aliases_as_tested(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2006/965/2.yaml",
+        """format: rulespec/v1
+rules:
+  - name: child_benefit_enhanced_weekly_rate
+    kind: parameter
+    dtype: Money
+    period: Week
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 27.05
+  - name: child_benefit_weekly_rate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Week
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: child_benefit_enhanced_weekly_rate
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2006/965/2.test.yaml",
+        """- name: eldest child rate
+  period:
+    period_kind: custom
+    name: benefit_week
+    start: '2026-01-05'
+    end: '2026-01-11'
+  input: {}
+  output:
+    uk:regulations/uksi/2006/965/2#child_benefit_weekly_rate: 27.05
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="child_benefit")
+
+    assert report["status_counts"] == {"comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    enhanced_rate = items_by_id[
+        "uk:regulations/uksi/2006/965/2#child_benefit_enhanced_weekly_rate"
+    ]
+    assert (
+        enhanced_rate["policyengine_parameter"]
+        == "gov.hmrc.child_benefit.amount.eldest"
+    )
+    assert enhanced_rate["tested"] is True
+    assert enhanced_rate["test_output_count"] == 1
+
+
 def test_policyengine_coverage_classifies_arizona_snap_medical_and_child_support(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.427"
+version = "0.2.435"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add UK PolicyEngine oracle mapping registry entries for the initial UK tax and benefit seed sections
- make oracle coverage resolve registry country from the RuleSpec repo prefix instead of hard-coding US
- add regression coverage for UK mappings and alias-backed tested counts

## Tests
- uv run ruff check src/axiom_encode/oracles/policyengine/coverage.py tests/test_policyengine_coverage.py
- uv run --with pytest --with pytest-cov python -m pytest -q tests/test_policyengine_coverage.py
- uv run --with pytest --with pytest-cov python -m pytest -q tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed
- uv run --with pytest --with pytest-cov python -m pytest -q tests/test_cli.py::TestMain::test_oracle_coverage_command_dispatches tests/test_cli.py::TestCmdValidate::test_oracle_coverage_fail_on_unmapped_exits_nonzero tests/test_cli.py::TestCmdValidate::test_oracle_coverage_fail_on_untested_comparable_exits_nonzero
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/uk-pe-parity-20260529 --json