### PR TITLE
Repair generated scalar relation row apply loops

### DIFF
--- a/changelog.d/generated-relation-row-repair.fixed.md
+++ b/changelog.d/generated-relation-row-repair.fixed.md
@@ -1,0 +1,1 @@
+Repair scalar generated relation-row test inputs by inferring the row child fact from generated formulas when no companion-test exemplar exists.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.444"
+version = "0.2.445"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.444"
+__version__ = "0.2.445"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -2131,6 +2131,7 @@ def _execute_rulespec_test_file(
                     parameter_by_id=parameter_by_id,
                     derived_ids=derived_ids,
                     derived_by_id=derived_by_id,
+                    policy_repo_path=item_policy_repo_path,
                 )
             )
         except Exception as error:
@@ -2167,6 +2168,7 @@ def _execute_rulespec_test_case(
     parameter_by_id: dict[str, dict],
     derived_ids: set[str],
     derived_by_id: dict[str, dict],
+    policy_repo_path: Path,
 ) -> list[dict[str, str | None]]:
     failures: list[dict[str, str | None]] = []
     period = _rulespec_period_spec(case.get("period", "2026-01"))
@@ -2180,13 +2182,17 @@ def _execute_rulespec_test_case(
         key = str(key)
         flat_inputs[key] = value
         if isinstance(value, list) and "#relation." in key:
+            relation_name = _rulespec_test_relation_request_name(
+                key,
+                policy_repo_path=policy_repo_path,
+            )
             for row_index, row in enumerate(value):
                 related_id = f"related_{row_index}"
                 # The current relation slot convention is related entity first,
                 # enclosing entity second.
                 relations.append(
                     {
-                        "name": key,
+                        "name": relation_name,
                         "tuple": [related_id, root_entity_id],
                         "interval": interval,
                     }
@@ -2466,6 +2472,20 @@ def _execute_rulespec_test_case(
                 }
             )
     return failures
+
+
+def _rulespec_test_relation_request_name(
+    key: str,
+    *,
+    policy_repo_path: Path,
+) -> str:
+    if ":" in key:
+        prefix, relative = key.split(":", 1)
+        canonical_prefix = _repo_jurisdiction_prefix(policy_repo_path)
+        local_prefix = policy_repo_path.name.removeprefix("rulespec-")
+        if prefix == canonical_prefix and local_prefix != canonical_prefix:
+            return f"{local_prefix}:{relative}"
+    return key
 
 
 def _safe_artifact_stem(path: Path) -> str:
@@ -14011,6 +14031,62 @@ def cmd_encode(args):
                         repaired_input_cases
                     )
             if not can_apply:
+                repaired_scalar_rows = list(
+                    outcome.get("auto_repaired_scalar_relation_rows") or []
+                )
+                repaired_input_cases = list(
+                    outcome.get("auto_repaired_test_input_assignments") or []
+                )
+                while not can_apply:
+                    repaired_batch = (
+                        _try_repair_generated_scalar_relation_rows_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            issues=apply_issues,
+                        )
+                    )
+                    if not repaired_batch:
+                        repaired_test_cases = (
+                            _try_repair_generated_test_input_assignments_for_apply(
+                                result,
+                                output_root=args.output,
+                                policy_repo_path=policy_repo_path,
+                                issues=apply_issues,
+                            )
+                        )
+                        if not repaired_test_cases:
+                            break
+                        repaired_input_cases.extend(repaired_test_cases)
+                        outcome["auto_repaired_test_input_assignments"] = (
+                            repaired_input_cases
+                        )
+                        print(
+                            "  apply=auto_repaired_test_input_assignments:"
+                            + ",".join(repaired_test_cases)
+                        )
+                    else:
+                        repaired_scalar_rows.extend(repaired_batch)
+                        outcome["auto_repaired_scalar_relation_rows"] = (
+                            repaired_scalar_rows
+                        )
+                        print(
+                            "  apply=auto_repaired_scalar_relation_rows:"
+                            + ",".join(repaired_batch)
+                        )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_output_cases: list[str] = []
                 while not can_apply:
                     repaired_test_cases = (
@@ -14437,6 +14513,7 @@ def _try_repair_generated_scalar_relation_rows_for_apply(
     rules_file = Path(str(getattr(result, "output_file", "") or ""))
     test_file = _rulespec_test_path(rules_file)
     return _repair_scalar_relation_rows(
+        rules_file=rules_file,
         test_file=test_file,
         policy_repo_path=policy_repo_path,
         parsed_issues=parsed_issues,
@@ -14458,6 +14535,7 @@ def _parse_scalar_relation_row_issue(
 
 def _repair_scalar_relation_rows(
     *,
+    rules_file: Path | None = None,
     test_file: Path,
     policy_repo_path: Path,
     parsed_issues: list[tuple[str, str, int]],
@@ -14501,6 +14579,12 @@ def _repair_scalar_relation_rows(
                     policy_repo_path=policy_repo_path,
                 )
                 if replacement is None:
+                    replacement = _relation_row_replacement_from_generated_rules(
+                        relation_key,
+                        scalar_value,
+                        rules_file=rules_file,
+                    )
+                if replacement is None:
                     continue
                 rows[list_index] = replacement
                 repaired.append(f"{case_name}:{relation_key}[{row_index}]")
@@ -14536,6 +14620,78 @@ def _relation_row_replacement_from_companion_tests(
         if changed:
             return template
     return None
+
+
+def _relation_row_replacement_from_generated_rules(
+    relation_ref: str,
+    scalar_value: object,
+    *,
+    rules_file: Path | None,
+) -> dict[str, object] | None:
+    """Infer a relation row mapping when a generated formula uses one child fact.
+
+    Companion tests are preferred because they preserve established row shape.
+    New generated files can define a relation and immediately test it before any
+    companion exists; in that case a scalar row like `- 30000` is unambiguous
+    only when the formulas reference exactly one child fact through
+    `relation_name.child_fact`.
+    """
+    if rules_file is None or not rules_file.exists():
+        return None
+    relation_name = _relation_name_from_relation_ref(relation_ref)
+    if not relation_name:
+        return None
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, ValueError, yaml.YAMLError):
+        return None
+    child_names = _single_relation_child_fact_names(payload, relation_name)
+    if len(child_names) != 1:
+        return None
+    relation_base = relation_ref.split("#", 1)[0].strip()
+    child_ref = f"{relation_base}#input.{next(iter(child_names))}"
+    return {child_ref: copy.deepcopy(scalar_value)}
+
+
+def _relation_name_from_relation_ref(relation_ref: str) -> str:
+    fragment = relation_ref.split("#", 1)[1] if "#" in relation_ref else relation_ref
+    fragment = fragment.strip()
+    if fragment.startswith("relation."):
+        return fragment.removeprefix("relation.").strip()
+    return ""
+
+
+def _single_relation_child_fact_names(
+    payload: object,
+    relation_name: str,
+) -> set[str]:
+    if not isinstance(payload, dict) or not relation_name:
+        return set()
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return set()
+    escaped_relation = re.escape(relation_name)
+    child_pattern = re.compile(
+        rf"(?<![A-Za-z0-9_]){escaped_relation}\."
+        r"(?P<child>[A-Za-z_][A-Za-z0-9_]*)\b"
+    )
+    child_names: set[str] = set()
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            child_names.update(
+                match.group("child") for match in child_pattern.finditer(formula)
+            )
+    return child_names
 
 
 def _relation_row_matches_scalar_value(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2143,6 +2143,48 @@ rules:
         assert exc_info.value.code == 0
         assert json.loads(capsys.readouterr().out)["success"] is True
 
+    def test_executes_companion_tests_with_absolute_relation_inputs(
+        self, capsys, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us"
+        target = repo / "statutes/1/relation.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+rules:
+  - name: income_component_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: household_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum(income_component_of_household.amount)
+"""
+        )
+        target.with_name("relation.test.yaml").write_text(
+            """- name: sums_relation_rows
+  period: 2026-01
+  input:
+    us:statutes/1/relation#relation.income_component_of_household:
+      - us:statutes/1/relation#input.amount: 5
+      - us:statutes/1/relation#input.amount: 7
+  output:
+    us:statutes/1/relation#household_income: 12
+"""
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_test(self._args(repo, json_output=True))
+
+        assert exc_info.value.code == 0
+        assert json.loads(capsys.readouterr().out)["success"] is True
+
     def test_executes_companion_tests_failure_json(self, capsys, tmp_path):
         repo = self._write_rulespec_with_test(tmp_path, expected_benefit=16)
 
@@ -2456,6 +2498,120 @@ rules:
         assert len(compile_programs) == 1
         assert "rulespec-us" in compile_programs[0].parts
         assert "rulespec-us-clean.abcd" not in str(compile_programs[0])
+
+    def test_executes_relation_tests_from_canonical_alias_checkout(
+        self, capsys, monkeypatch, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us-clean.abcd"
+        rules_file = repo / "statutes/1/relation.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: members
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2024-01-01'
+        formula: sum(members.income)
+"""
+        )
+        rules_file.with_name("relation.test.yaml").write_text(
+            """- name: canonical_temp_checkout_relation_input
+  period: 2026-01
+  input:
+    us:statutes/1/relation#relation.members:
+      - us:statutes/1/relation#input.income: 5
+  output:
+    us:statutes/1/relation#benefit: 5
+"""
+        )
+
+        engine_root = tmp_path / "axiom-rules-engine"
+        binary = engine_root / "target/debug/axiom-rules-engine"
+        relation_names: list[str] = []
+
+        def fake_binary(self):
+            return binary
+
+        def fake_run(cmd, **kwargs):
+            if len(cmd) >= 6 and cmd[:3] == ["git", "-C", str(repo)]:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout="https://github.com/TheAxiomFoundation/rulespec-us.git\n",
+                    stderr="",
+                )
+            if "compile" in cmd:
+                output_path = Path(cmd[cmd.index("--output") + 1])
+                output_path.write_text(
+                    json.dumps(
+                        {
+                            "program": {
+                                "parameters": [],
+                                "derived": [
+                                    {
+                                        "id": "us-clean.abcd:statutes/1/relation#benefit",
+                                        "name": "benefit",
+                                        "entity": "Household",
+                                    }
+                                ],
+                            }
+                        }
+                    )
+                )
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if "run-compiled" in cmd:
+                request = json.loads(kwargs["input"])
+                relation_names.extend(
+                    relation["name"] for relation in request["dataset"]["relations"]
+                )
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout=json.dumps(
+                        {
+                            "results": [
+                                {
+                                    "outputs": {
+                                        "us-clean.abcd:statutes/1/relation#benefit": {
+                                            "kind": "scalar",
+                                            "value": {"kind": "integer", "value": 5},
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ),
+                    stderr="",
+                )
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        args = MagicMock()
+        args.root = repo
+        args.paths = []
+        args.json = True
+        args.axiom_rules_path = engine_root
+
+        monkeypatch.setattr(
+            "axiom_encode.harness.validator_pipeline.ValidatorPipeline._axiom_rules_binary",
+            fake_binary,
+        )
+        monkeypatch.setattr("axiom_encode.cli.subprocess.run", fake_run)
+
+        with pytest.raises(SystemExit) as exc_info:
+            cmd_test(args)
+
+        assert exc_info.value.code == 0
+        assert json.loads(capsys.readouterr().out)["success"] is True
+        assert relation_names == ["us-clean.abcd:statutes/1/relation#relation.members"]
 
     def test_discovery_skips_axiom_dependency_tree(self, tmp_path):
         root = tmp_path / "workspace"
@@ -6253,6 +6409,155 @@ rules:
         assert run.outcome["auto_repaired_scalar_relation_rows"] == [
             "first_generated_case:us:statutes/7/2012/j#relation.member_of_household[1]",
             "second_generated_case:us:statutes/7/2012/j#relation.member_of_household[1]",
+        ]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
+    def test_encode_apply_repairs_scalar_rows_after_test_input_repair(
+        self, capsys, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-uk"
+        policy_repo.mkdir()
+        args = self._make_args(
+            tmp_path,
+            backend="codex",
+            citation="uk/statute/ukpga/2007/3/23",
+            policy_repo_path=policy_repo,
+            sync=False,
+        )
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path
+            / "out"
+            / "codex-test-model"
+            / "statutes"
+            / "ukpga"
+            / "2007"
+            / "3"
+            / "23.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: income_components_charged_to_income_tax
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: total_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-04-06'
+        formula: sum(income_components_charged_to_income_tax.amount_charged_to_income_tax_for_tax_year)
+"""
+        )
+        test_file = output_file.with_name("23.test.yaml")
+        test_file.write_text(
+            """- name: ordinary_taxpayer_liability_steps
+  period: 2026
+  input:
+    uk:statutes/ukpga/2007/3/23#relation.income_components_charged_to_income_tax:
+      - 30000
+  output:
+    uk:statutes/ukpga/2007/3/23#total_income: 30000
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = policy_repo / "statutes/ukpga/2007/3/23.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "statutes/ukpga/2007/3/23.yaml: ci: "
+                            "Test case `ordinary_taxpayer_liability_steps` "
+                            "assigns computed RuleSpec output(s) as input"
+                        ],
+                        {},
+                    ),
+                    (
+                        False,
+                        [
+                            "statutes/ukpga/2007/3/23.yaml: ci: "
+                            "Test case `ordinary_taxpayer_liability_steps` input invalid: relation "
+                            "`uk:statutes/ukpga/2007/3/23#relation.income_components_charged_to_income_tax` "
+                            "item #1 must be a mapping"
+                        ],
+                        {},
+                    ),
+                    (
+                        False,
+                        [
+                            "statutes/ukpga/2007/3/23.yaml: ci: "
+                            "Test input assignment missing: "
+                            "`ordinary_taxpayer_liability_steps` does not assign "
+                            "#input.amount_charged_to_income_tax_for_tax_year."
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._try_repair_generated_test_input_assignments_for_apply",
+                side_effect=[
+                    ["ordinary_taxpayer_liability_steps"],
+                    [],
+                    ["ordinary_taxpayer_liability_steps_child_fact"],
+                ],
+            ) as mock_assignment_repair,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert (
+            "apply=auto_repaired_test_input_assignments:"
+            "ordinary_taxpayer_liability_steps"
+        ) in output
+        assert (
+            "apply=auto_repaired_scalar_relation_rows:"
+            "ordinary_taxpayer_liability_steps:"
+            "uk:statutes/ukpga/2007/3/23#relation.income_components_charged_to_income_tax[1]"
+        ) in output
+        assert (
+            "apply=auto_repaired_test_input_assignments:"
+            "ordinary_taxpayer_liability_steps_child_fact"
+        ) in output
+        assert mock_overlay.call_count == 4
+        assert mock_assignment_repair.call_count == 3
+        mock_apply.assert_called_once()
+        [case] = yaml.safe_load(test_file.read_text())
+        assert case["input"][
+            "uk:statutes/ukpga/2007/3/23#relation.income_components_charged_to_income_tax"
+        ] == [
+            {
+                "uk:statutes/ukpga/2007/3/23#input.amount_charged_to_income_tax_for_tax_year": 30000
+            }
+        ]
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_test_input_assignments"] == [
+            "ordinary_taxpayer_liability_steps",
+            "ordinary_taxpayer_liability_steps_child_fact",
+        ]
+        assert run.outcome["auto_repaired_scalar_relation_rows"] == [
+            "ordinary_taxpayer_liability_steps:"
+            "uk:statutes/ukpga/2007/3/23#relation.income_components_charged_to_income_tax[1]"
         ]
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
@@ -10243,6 +10548,81 @@ rules: []
         [case] = yaml.safe_load(test_file.read_text())
         assert case["input"]["us:statutes/7/2012/j#relation.member_of_household"] == [
             {"us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled": True}
+        ]
+
+    def test_repair_scalar_relation_rows_from_generated_formula(self, tmp_path):
+        policy_repo = tmp_path / "rulespec-uk"
+        policy_repo.mkdir()
+        rules_file = (
+            tmp_path / "generated" / "statutes" / "ukpga" / "2007" / "3" / "23.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: ITA 2007 section 23 calculates liability steps.
+rules:
+  - name: income_components_charged_to_income_tax
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: total_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-04-06'
+        formula: sum(income_components_charged_to_income_tax.amount_charged_to_income_tax_for_tax_year)
+"""
+        )
+        test_file = rules_file.with_name("23.test.yaml")
+        test_file.write_text(
+            """- name: charged_income_less_reliefs_and_allowances
+  period: 2026
+  input:
+    uk:statutes/ukpga/2007/3/23#relation.income_components_charged_to_income_tax:
+      - 30000
+      - 5000
+  output:
+    uk:statutes/ukpga/2007/3/23#total_income: 35000
+"""
+        )
+
+        repaired = _repair_scalar_relation_rows(
+            rules_file=rules_file,
+            test_file=test_file,
+            policy_repo_path=policy_repo,
+            parsed_issues=[
+                (
+                    "charged_income_less_reliefs_and_allowances",
+                    "uk:statutes/ukpga/2007/3/23#relation.income_components_charged_to_income_tax",
+                    1,
+                ),
+                (
+                    "charged_income_less_reliefs_and_allowances",
+                    "uk:statutes/ukpga/2007/3/23#relation.income_components_charged_to_income_tax",
+                    2,
+                ),
+            ],
+        )
+
+        assert repaired == [
+            "charged_income_less_reliefs_and_allowances:"
+            "uk:statutes/ukpga/2007/3/23#relation.income_components_charged_to_income_tax[1]",
+            "charged_income_less_reliefs_and_allowances:"
+            "uk:statutes/ukpga/2007/3/23#relation.income_components_charged_to_income_tax[2]",
+        ]
+        [case] = yaml.safe_load(test_file.read_text())
+        assert case["input"][
+            "uk:statutes/ukpga/2007/3/23#relation.income_components_charged_to_income_tax"
+        ] == [
+            {
+                "uk:statutes/ukpga/2007/3/23#input.amount_charged_to_income_tax_for_tax_year": 30000
+            },
+            {
+                "uk:statutes/ukpga/2007/3/23#input.amount_charged_to_income_tax_for_tax_year": 5000
+            },
         ]
 
     def test_apply_overlay_validation_rejects_dropped_source_relation(self, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.444"
+version = "0.2.445"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair generated scalar relation-row test inputs from generated formulas when no companion exemplar exists
- alternate apply-time scalar relation-row repair and missing test-input assignment repair until overlay validation clears
- preserve absolute relation input keys while rewriting canonical prefixes to temporary local checkout prefixes for companion-test execution
- bump axiom-encode to 0.2.445 and add a towncrier entry

## Cycle review
- Independent subagent review found no actionable issues in the encoder production changes.
- Added the reviewer-suggested regression coverage for canonical relation inputs in temporary local RuleSpec checkouts before opening this PR.

## Tests
- `uv run ruff check src/axiom_encode/cli.py tests/test_cli.py`
- `uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py`
- `uv run python -m pytest tests/test_cli.py::TestCmdTest::test_executes_relation_tests_from_canonical_alias_checkout tests/test_cli.py::TestCmdTest::test_executes_companion_tests_with_absolute_relation_inputs tests/test_cli.py::TestCmdTest::test_executes_companion_tests_from_canonical_alias_checkout tests/test_cli.py::TestCmdEncode::test_encode_apply_repairs_scalar_rows_after_test_input_repair tests/test_cli.py::TestApplyDependencyValidation::test_repair_scalar_relation_rows_from_generated_formula tests/test_cli.py::TestApplyDependencyValidation::test_repair_scalar_relation_rows_from_companion_tests -q`
- `uv run python -m towncrier build --draft --version 0.0.0`