### PR TITLE
Fix PolicyEngine oracle runtime RuleSpec aliases

### DIFF
--- a/changelog.d/policyengine-oracle-runtime-aliases.fixed.md
+++ b/changelog.d/policyengine-oracle-runtime-aliases.fixed.md
@@ -1,0 +1,1 @@
+Translate canonical RuleSpec request names to compiled runtime IDs in PolicyEngine oracle runners and restore canonical output keys, so ECPS/EFRS comparisons work from temporary RuleSpec worktrees.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.445"
+version = "0.2.446"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.445"
+__version__ = "0.2.446"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -9,6 +9,7 @@ surface under test as Axiom inputs.
 from __future__ import annotations
 
 import argparse
+import copy
 import json
 import math
 import os
@@ -21,6 +22,13 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+
+from axiom_encode.concepts.jurisdiction import jurisdiction_prefix
+from axiom_encode.harness.validator_pipeline import (
+    _canonical_rulespec_compile_path,
+    _rulespec_public_item_keys,
+    _rulespec_repo_alias_parent,
+)
 
 try:
     import numpy as np
@@ -1920,7 +1928,22 @@ def run_axiom_program(
     if not binary.exists():
         raise SystemExit(f"axiom-rules-engine binary not found: {binary}")
     env = os.environ.copy()
-    env["AXIOM_RULESPEC_REPO_ROOTS"] = str(rulespec_root)
+    roots = [rulespec_root, rulespec_root.parent]
+    alias_parent = _rulespec_repo_alias_parent(rulespec_root)
+    if alias_parent is not None:
+        roots.insert(0, alias_parent)
+    existing_roots = env.get("AXIOM_RULESPEC_REPO_ROOTS", "")
+    if existing_roots:
+        roots.extend(Path(root) for root in existing_roots.split(os.pathsep) if root)
+    deduped_roots: list[str] = []
+    seen: set[str] = set()
+    for root in roots:
+        raw = str(root)
+        if raw and raw not in seen:
+            seen.add(raw)
+            deduped_roots.append(raw)
+    env["AXIOM_RULESPEC_REPO_ROOTS"] = os.pathsep.join(deduped_roots)
+    compile_program = _canonical_rulespec_compile_path(program, rulespec_root)
     with tempfile.TemporaryDirectory(prefix="axiom-tax-ecps-") as tmpdir:
         artifact = Path(tmpdir) / f"{program.stem}.json"
         compile_result = subprocess.run(
@@ -1928,7 +1951,7 @@ def run_axiom_program(
                 str(binary),
                 "compile",
                 "--program",
-                str(program),
+                str(compile_program),
                 "--output",
                 str(artifact),
             ],
@@ -1942,9 +1965,15 @@ def run_axiom_program(
             raise SystemExit(
                 compile_result.stderr.strip() or compile_result.stdout.strip()
             )
+        artifact_payload = json.loads(artifact.read_text())
+        runtime_request, public_output_by_runtime = _runtime_axiom_request(
+            request,
+            artifact_payload=artifact_payload,
+            rulespec_root=rulespec_root,
+        )
         run_result = subprocess.run(
             [str(binary), "run-compiled", "--artifact", str(artifact)],
-            input=json.dumps(request),
+            input=json.dumps(runtime_request),
             capture_output=True,
             text=True,
             cwd=str(axiom_rules_path),
@@ -1953,7 +1982,109 @@ def run_axiom_program(
         )
         if run_result.returncode != 0:
             raise SystemExit(run_result.stderr.strip() or run_result.stdout.strip())
-        return json.loads(run_result.stdout)["results"]
+        results = json.loads(run_result.stdout)["results"]
+        _restore_public_axiom_outputs(
+            results,
+            public_output_by_runtime=public_output_by_runtime,
+        )
+        return results
+
+
+def _runtime_axiom_request(
+    request: dict[str, Any],
+    *,
+    artifact_payload: dict[str, Any],
+    rulespec_root: Path,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    runtime_by_public_output = _runtime_output_ids_by_public_name(
+        artifact_payload,
+        rulespec_root=rulespec_root,
+    )
+    runtime_request = copy.deepcopy(request)
+    for item in (runtime_request.get("dataset") or {}).get("inputs") or []:
+        if isinstance(item, dict) and isinstance(item.get("name"), str):
+            item["name"] = _runtime_rulespec_name(
+                item["name"],
+                rulespec_root=rulespec_root,
+            )
+    for item in (runtime_request.get("dataset") or {}).get("relations") or []:
+        if isinstance(item, dict) and isinstance(item.get("name"), str):
+            item["name"] = _runtime_rulespec_name(
+                item["name"],
+                rulespec_root=rulespec_root,
+            )
+
+    public_output_by_runtime: dict[str, str] = {}
+    for query in runtime_request.get("queries") or []:
+        if not isinstance(query, dict):
+            continue
+        outputs = query.get("outputs")
+        if not isinstance(outputs, list):
+            continue
+        runtime_outputs: list[Any] = []
+        for output in outputs:
+            if not isinstance(output, str):
+                runtime_outputs.append(output)
+                continue
+            runtime_output = runtime_by_public_output.get(
+                output
+            ) or _runtime_rulespec_name(
+                output,
+                rulespec_root=rulespec_root,
+            )
+            runtime_outputs.append(runtime_output)
+            public_output_by_runtime[runtime_output] = output
+        query["outputs"] = runtime_outputs
+    return runtime_request, public_output_by_runtime
+
+
+def _runtime_output_ids_by_public_name(
+    artifact_payload: dict[str, Any],
+    *,
+    rulespec_root: Path,
+) -> dict[str, str]:
+    output_by_public: dict[str, str] = {}
+    program = artifact_payload.get("program") or {}
+    for section in ("parameters", "derived"):
+        for item in program.get(section) or []:
+            if not isinstance(item, dict):
+                continue
+            runtime_id = item.get("id")
+            if not isinstance(runtime_id, str) or not runtime_id:
+                continue
+            for public_key in _rulespec_public_item_keys(
+                item,
+                policy_repo_path=rulespec_root,
+            ):
+                output_by_public[public_key] = runtime_id
+    return output_by_public
+
+
+def _runtime_rulespec_name(name: str, *, rulespec_root: Path) -> str:
+    if ":" not in name:
+        return name
+    prefix, relative = name.split(":", 1)
+    canonical_prefix = jurisdiction_prefix(rulespec_root)
+    local_prefix = rulespec_root.name.removeprefix("rulespec-")
+    if prefix == canonical_prefix and local_prefix != canonical_prefix:
+        return f"{local_prefix}:{relative}"
+    return name
+
+
+def _restore_public_axiom_outputs(
+    results: list[Any],
+    *,
+    public_output_by_runtime: dict[str, str],
+) -> None:
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        outputs = result.get("outputs")
+        if not isinstance(outputs, dict):
+            continue
+        for runtime_output, public_output in public_output_by_runtime.items():
+            if runtime_output in outputs and public_output not in outputs:
+                outputs[public_output] = outputs[runtime_output]
 
 
 def compare_outputs(

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -91,6 +91,153 @@ def test_person_entity_id_is_stable_and_namespaced():
     assert person_entity_id(42) == "person_42"
 
 
+def test_run_axiom_program_compiles_through_canonical_repo_alias(
+    monkeypatch,
+    tmp_path,
+):
+    rulespec_root = tmp_path / "rulespec-uk-worktree"
+    program = rulespec_root / "statutes" / "ukpga" / "2007" / "3" / "35.yaml"
+    program.parent.mkdir(parents=True)
+    program.write_text("format: rulespec/v1\nrules: []\n")
+    axiom_rules_path = tmp_path / "axiom-rules-engine"
+    binary = axiom_rules_path / "target" / "release" / "axiom-rules-engine"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("")
+
+    compiled_programs = []
+    compile_env_roots = []
+    runtime_requests = []
+
+    def fake_run(cmd, **kwargs):
+        if len(cmd) >= 6 and cmd[:3] == ["git", "-C", str(rulespec_root)]:
+            return ecps_tax.subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout="https://github.com/TheAxiomFoundation/rulespec-uk.git\n",
+                stderr="",
+            )
+        if "compile" in cmd:
+            compiled_programs.append(cmd[cmd.index("--program") + 1])
+            compile_env_roots.extend(
+                kwargs["env"]["AXIOM_RULESPEC_REPO_ROOTS"].split(ecps_tax.os.pathsep)
+            )
+            output_path = cmd[cmd.index("--output") + 1]
+            with open(output_path, "w") as artifact:
+                artifact.write(
+                    ecps_tax.json.dumps(
+                        {
+                            "program": {
+                                "parameters": [],
+                                "derived": [
+                                    {
+                                        "id": "uk-worktree:statutes/ukpga/2007/3/35#personal_allowance",
+                                        "name": "personal_allowance",
+                                        "entity": "Person",
+                                    }
+                                ],
+                            }
+                        }
+                    )
+                )
+            return ecps_tax.subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if "run-compiled" in cmd:
+            runtime_requests.append(ecps_tax.json.loads(kwargs["input"]))
+            return ecps_tax.subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=ecps_tax.json.dumps(
+                    {
+                        "results": [
+                            {
+                                "outputs": {
+                                    "uk-worktree:statutes/ukpga/2007/3/35#personal_allowance": {
+                                        "kind": "scalar",
+                                        "value": {
+                                            "kind": "integer",
+                                            "value": 12570,
+                                        },
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(ecps_tax.subprocess, "run", fake_run)
+
+    results = ecps_tax.run_axiom_program(
+        program=program,
+        request={
+            "mode": "explain",
+            "dataset": {
+                "inputs": [
+                    {
+                        "name": "uk:statutes/ukpga/2007/3/35#input.adjusted_net_income",
+                        "entity": "Person",
+                        "entity_id": "person_1",
+                        "interval": {
+                            "start": "2026-01-01",
+                            "end": "2026-12-31",
+                        },
+                        "value": {
+                            "kind": "decimal",
+                            "value": "20000",
+                        },
+                    }
+                ],
+                "relations": [
+                    {
+                        "name": "uk:statutes/ukpga/2007/3/35#relation.members",
+                        "tuple": ["person_1", "household_1"],
+                        "interval": {
+                            "start": "2026-01-01",
+                            "end": "2026-12-31",
+                        },
+                    }
+                ],
+            },
+            "queries": [
+                {
+                    "entity_id": "person_1",
+                    "period": {
+                        "period_kind": "tax_year",
+                        "start": "2026-01-01",
+                        "end": "2026-12-31",
+                    },
+                    "outputs": ["uk:statutes/ukpga/2007/3/35#personal_allowance"],
+                }
+            ],
+        },
+        rulespec_root=rulespec_root,
+        axiom_rules_path=axiom_rules_path,
+    )
+
+    assert (
+        results[0]["outputs"]["uk:statutes/ukpga/2007/3/35#personal_allowance"][
+            "value"
+        ]["value"]
+        == 12570
+    )
+    assert compiled_programs
+    assert "rulespec-uk" in compiled_programs[0].split("/")
+    assert "rulespec-uk-worktree" not in compiled_programs[0].split("/")
+    assert runtime_requests[0]["dataset"]["inputs"][0]["name"] == (
+        "uk-worktree:statutes/ukpga/2007/3/35#input.adjusted_net_income"
+    )
+    assert runtime_requests[0]["dataset"]["relations"][0]["name"] == (
+        "uk-worktree:statutes/ukpga/2007/3/35#relation.members"
+    )
+    assert runtime_requests[0]["queries"][0]["outputs"] == [
+        "uk-worktree:statutes/ukpga/2007/3/35#personal_allowance"
+    ]
+    assert str(rulespec_root) in compile_env_roots
+    assert str(rulespec_root.parent) in compile_env_roots
+    assert compile_env_roots[0] != str(rulespec_root)
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.445"
+version = "0.2.446"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- translate canonical RuleSpec request input, relation, and output IDs to the compiled runtime IDs used by temporary RuleSpec worktrees
- restore canonical public output keys after `run-compiled`, so PE oracle comparators can continue comparing against stable `us:` / `uk:` output names
- bump axiom-encode to 0.2.446 and add a towncrier fragment

## Cycle review
- Independent subagent review found no actionable issues.
- Added the reviewer-suggested relation-name regression coverage before opening this PR.

## Validation
- `uv run ruff check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py`
- `uv run ruff format --check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_ecps_tax.py::test_run_axiom_program_compiles_through_canonical_repo_alias tests/test_policyengine_efrs_uk.py -q`
- `uv run --with towncrier python -m towncrier build --draft --version 0.0.0`
- `uv run --with 'policyengine[uk]==4.11.0' axiom-encode uk-efrs-compare --rulespec-root /Users/maxghenis/_axiom-worktrees/rulespec-uk-income-tax-ni-efrs-20260530 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine --sample-size 100 --json --fail-on-mismatch`\n\nEFRS result: 631 compared values, 0 unexplained mismatches, 343 known PE-UK oracle divergences.