### PR TITLE
Fix PolicyEngine oracle decimal literals

### DIFF
--- a/changelog.d/policyengine-oracle-decimal-literals.fixed.md
+++ b/changelog.d/policyengine-oracle-decimal-literals.fixed.md
@@ -1,0 +1,1 @@
+Format PolicyEngine oracle decimal request values without scientific notation so RuleSpec runtime comparisons can cover full EFRS samples.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.446"
+version = "0.2.447"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.446"
+__version__ = "0.2.447"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import tempfile
 from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any
@@ -2268,8 +2269,24 @@ def scalar_value(value: Any) -> dict[str, Any]:
     if isinstance(value, int):
         return {"kind": "integer", "value": value}
     if isinstance(value, float):
-        return {"kind": "decimal", "value": str(value)}
+        return {"kind": "decimal", "value": decimal_literal(value)}
     return {"kind": "text", "value": str(value)}
+
+
+def decimal_literal(value: float) -> str:
+    text = str(value)
+    if "e" not in text.lower():
+        return text
+    try:
+        decimal = Decimal(text)
+    except InvalidOperation:
+        return text
+    fixed = format(decimal, "f")
+    if "." in fixed:
+        fixed = fixed.rstrip("0").rstrip(".")
+    if fixed in {"", "-0"}:
+        return "0"
+    return fixed
 
 
 def output_number(output: Any) -> float:

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -91,6 +91,23 @@ def test_person_entity_id_is_stable_and_namespaced():
     assert person_entity_id(42) == "person_42"
 
 
+def test_scalar_value_formats_scientific_float_as_decimal_literal():
+    value = ecps_tax.scalar_value(1.105810581991662e-11)
+
+    assert value == {
+        "kind": "decimal",
+        "value": "0.00000000001105810581991662",
+    }
+    assert "e" not in value["value"].lower()
+
+
+def test_scalar_value_keeps_plain_float_literal_format():
+    assert ecps_tax.scalar_value(184500.0) == {
+        "kind": "decimal",
+        "value": "184500.0",
+    }
+
+
 def test_run_axiom_program_compiles_through_canonical_repo_alias(
     monkeypatch,
     tmp_path,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.446"
+version = "0.2.447"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Format PolicyEngine oracle decimal request values without scientific notation before sending them to the RuleSpec runtime.
- Add regression coverage for tiny scientific-notation floats while preserving existing plain float formatting.
- Bump axiom-encode to 0.2.447 with a Towncrier fragment.

## Root Cause
Full UK EFRS comparison projected a tiny residual adjusted-net-income value as `1.105810581991662e-11`. The RuleSpec runtime accepts fixed decimal literals but rejected that scientific notation as an invalid decimal literal.

## Validation
- `git diff --check`
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py`
- `uv run python -m compileall -q src/axiom_encode scripts`
- `uv run --with towncrier python -m towncrier build --draft --version 0.0.0`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_ecps_tax.py tests/test_policyengine_efrs_uk.py -q`
- `uv run --with 'policyengine[uk]==4.11.0' axiom-encode uk-efrs-compare --rulespec-root /Users/maxghenis/_axiom-worktrees/rulespec-uk-income-tax-ni-efrs-20260530 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine --sample-size 0 --fail-on-mismatch`

## Cycle
- Independent subagent review found no actionable findings.
