### PR TITLE
Wire California SNAP ECPS comparison

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.451"
+version = "0.2.452"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.460"
+version = "0.2.461"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.458"
+version = "0.2.459"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.478"
+version = "0.2.479"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.461"
+version = "0.2.462"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.455"
+version = "0.2.456"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.448"
+version = "0.2.449"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.465"
+version = "0.2.466"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.468"
+version = "0.2.469"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.459"
+version = "0.2.460"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.479"
+version = "0.2.480"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.471"
+version = "0.2.472"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.472"
+version = "0.2.473"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.467"
+version = "0.2.468"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.473"
+version = "0.2.474"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.469"
+version = "0.2.470"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.466"
+version = "0.2.467"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.474"
+version = "0.2.475"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.477"
+version = "0.2.478"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.450"
+version = "0.2.451"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.476"
+version = "0.2.477"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.452"
+version = "0.2.454"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.447"
+version = "0.2.448"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.462"
+version = "0.2.463"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.463"
+version = "0.2.464"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.454"
+version = "0.2.455"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.456"
+version = "0.2.457"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.470"
+version = "0.2.471"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.449"
+version = "0.2.450"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.457"
+version = "0.2.458"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.464"
+version = "0.2.465"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.475"
+version = "0.2.476"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.480"
+version = "0.2.481"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.474"
+__version__ = "0.2.475"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.448"
+__version__ = "0.2.449"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.457"
+__version__ = "0.2.458"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.461"
+__version__ = "0.2.462"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.470"
+__version__ = "0.2.471"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.447"
+__version__ = "0.2.448"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.458"
+__version__ = "0.2.459"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.472"
+__version__ = "0.2.473"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.477"
+__version__ = "0.2.478"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.468"
+__version__ = "0.2.469"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.450"
+__version__ = "0.2.451"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.473"
+__version__ = "0.2.474"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.471"
+__version__ = "0.2.472"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.467"
+__version__ = "0.2.468"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.449"
+__version__ = "0.2.450"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.454"
+__version__ = "0.2.455"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.451"
+__version__ = "0.2.452"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.475"
+__version__ = "0.2.476"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.460"
+__version__ = "0.2.461"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.480"
+__version__ = "0.2.481"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.459"
+__version__ = "0.2.460"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.469"
+__version__ = "0.2.470"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.478"
+__version__ = "0.2.479"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.465"
+__version__ = "0.2.466"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.456"
+__version__ = "0.2.457"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.464"
+__version__ = "0.2.465"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.466"
+__version__ = "0.2.467"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.479"
+__version__ = "0.2.480"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.452"
+__version__ = "0.2.454"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.476"
+__version__ = "0.2.477"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.462"
+__version__ = "0.2.463"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.455"
+__version__ = "0.2.456"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.463"
+__version__ = "0.2.464"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5416,16 +5416,19 @@ NY_SNAP_CATEGORICAL_FINAL_TESTS = """
 
 
 def _repair_new_york_snap_categorical_eligibility_rules(content: str) -> str:
-    repaired = re.sub(
-        r"(?ms)^  deferred_outputs:\n"
-        r"(?:    - output: us-ny:regulations/18-nycrr/387/14/a/5#"
-        r"(?:ny_snap_categorically_eligible|"
-        r"snap_categorically_eligible_for_resource_exemption|"
-        r"snap_income_limit_exemption_for_categorically_eligible_household)\n"
-        r"(?:      .*\n|        .*\n)*)+",
-        "",
-        content,
-    )
+    repaired = content
+    deferred_start = repaired.find("  deferred_outputs:\n")
+    if deferred_start != -1 and all(
+        output in repaired[deferred_start:]
+        for output in (
+            "#ny_snap_categorically_eligible",
+            "#snap_categorically_eligible_for_resource_exemption",
+            "#snap_income_limit_exemption_for_categorically_eligible_household",
+        )
+    ):
+        deferred_end = repaired.find("\n  summary:", deferred_start)
+        if deferred_end != -1:
+            repaired = repaired[:deferred_start] + repaired[deferred_end + 1 :]
     if "  - name: ny_snap_categorically_eligible\n" not in repaired:
         repaired = repaired.rstrip() + NY_SNAP_CATEGORICAL_FINAL_RULES + "\n"
     return repaired

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3554,6 +3554,7 @@ def cmd_repair_california_snap_shelter_surface(args):
         sys.exit(1)
 
     manifest_groups = _california_snap_repair_manifest_groups(repo_path)
+    guard_manifest_groups = _california_snap_repair_guard_manifest_groups(repo_path)
     for relative_output, _files in manifest_groups:
         rules_file = repo_path / relative_output
         old_sua = repo_path / CALIFORNIA_SNAP_OLD_SUA_RELATIVE
@@ -3563,9 +3564,11 @@ def cmd_repair_california_snap_shelter_surface(args):
             print(f"RuleSpec file not found: {rules_file}")
             sys.exit(1)
     try:
+        _ensure_no_california_snap_sua_layout_collision(repo_path)
         _ensure_no_unmanifested_preexisting_rulespec_changes(
             repo_path,
-            manifest_groups,
+            guard_manifest_groups,
+            roots=tuple(sorted(RULESPEC_SOURCE_ROOTS | {"guidance"})),
         )
     except RuntimeError as exc:
         print(str(exc))
@@ -3584,7 +3587,7 @@ def cmd_repair_california_snap_shelter_surface(args):
     ]
     preexisting_changed_files = _changed_manifest_group_files(
         repo_path,
-        manifest_groups,
+        guard_manifest_groups,
     )
     originals = {
         path: path.read_text() if path.exists() else None
@@ -3642,6 +3645,36 @@ def _california_snap_repair_manifest_groups(
             files.append(test_file)
         groups.append((relative_output, files))
     return groups
+
+
+def _california_snap_repair_guard_manifest_groups(
+    repo_path: Path,
+) -> list[tuple[Path, list[Path]]]:
+    old_rules_file = repo_path / CALIFORNIA_SNAP_OLD_SUA_RELATIVE
+    old_test_file = _rulespec_test_path(old_rules_file)
+    return _california_snap_repair_manifest_groups(repo_path) + [
+        (CALIFORNIA_SNAP_OLD_SUA_RELATIVE, [old_rules_file, old_test_file])
+    ]
+
+
+def _ensure_no_california_snap_sua_layout_collision(repo_path: Path) -> None:
+    collisions = [
+        (
+            repo_path / CALIFORNIA_SNAP_OLD_SUA_RELATIVE,
+            repo_path / CALIFORNIA_SNAP_SUA_RELATIVE,
+        ),
+        (
+            _rulespec_test_path(repo_path / CALIFORNIA_SNAP_OLD_SUA_RELATIVE),
+            _rulespec_test_path(repo_path / CALIFORNIA_SNAP_SUA_RELATIVE),
+        ),
+    ]
+    for old_file, new_file in collisions:
+        if old_file.exists() and new_file.exists():
+            raise RuntimeError(
+                "Refusing to migrate California SNAP standard utility allowance "
+                "while both old and new RuleSpec paths exist: "
+                f"{old_file.relative_to(repo_path)} and {new_file.relative_to(repo_path)}"
+            )
 
 
 def _write_california_snap_repair_manifests(
@@ -5258,22 +5291,27 @@ def cmd_repair_snap_273_10_allotment(args):
         rules_file.write_text(repaired_content)
         test_file.write_text(repaired_test_content)
 
-        validation = ValidatorPipeline(
-            policy_repo_path=repo_path,
-            axiom_rules_path=axiom_rules_path,
-            enable_oracles=False,
-            require_policy_proofs=True,
-        ).validate(rules_file, skip_reviewers=True)
-        if not validation.all_passed:
-            rules_file.write_text(original_content)
-            test_file.write_text(original_test_content)
-            issues = [
-                result.error for result in validation.results.values() if result.error
-            ]
-            print("Repair failed validation; restored original files.")
-            for issue in issues:
-                print(f"- {issue}")
-            sys.exit(1)
+        try:
+            validation = ValidatorPipeline(
+                policy_repo_path=repo_path,
+                axiom_rules_path=axiom_rules_path,
+                enable_oracles=False,
+                require_policy_proofs=True,
+            ).validate(rules_file, skip_reviewers=True)
+            if not validation.all_passed:
+                issues = [
+                    result.error
+                    for result in validation.results.values()
+                    if result.error
+                ]
+                print("Repair failed validation; restored original files.")
+                for issue in issues:
+                    print(f"- {issue}")
+                sys.exit(1)
+        finally:
+            if "validation" not in locals() or not validation.all_passed:
+                rules_file.write_text(original_content)
+                test_file.write_text(original_test_content)
 
         result = argparse.Namespace(
             output_file=str(generated_output),
@@ -7305,6 +7343,8 @@ def cmd_repair_section_172_c_capacity(args):
 def _ensure_no_unmanifested_preexisting_rulespec_changes(
     repo_path: Path,
     manifest_groups: list[tuple[Path, list[Path]]],
+    *,
+    roots: tuple[str, ...] = tuple(sorted(RULESPEC_SOURCE_ROOTS)),
 ) -> None:
     """Refuse to sign over target files already dirty outside encoder manifests."""
     try:
@@ -7335,7 +7375,7 @@ def _ensure_no_unmanifested_preexisting_rulespec_changes(
     )
     issues = guard_generated_change_issues(
         repo_path,
-        roots=tuple(sorted(RULESPEC_SOURCE_ROOTS)),
+        roots=roots,
         changed_files=sorted(dirty_targets | relevant_manifest_paths),
     )
     if not issues:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5601,6 +5601,13 @@ def _repair_new_york_snap_benefit_tests(content: str) -> str:
         flags=re.MULTILINE,
     )
     repaired = re.sub(
+        r"^    us-ny:regulations/18-nycrr/387/14/a/5#input\."
+        r"household_all_members_receive_family_assistance_nonemergency_safety_net_or_ssi: .*\n",
+        "",
+        repaired,
+        flags=re.MULTILINE,
+    )
+    repaired = re.sub(
         r"^    us-ny:regulations/18-nycrr/387/14/a/1#"
         r"(snap_allotment|snap_initial_month_proration_applies|"
         r"snap_initial_month_prorated_allotment): .*\n",

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5612,6 +5612,22 @@ def _repair_new_york_snap_benefit_tests(content: str) -> str:
             "#snap_excess_shelter_deduction: 744\n",
             1,
         )
+    if (
+        "initial_month_prorated_allotment_below_minimum_gets_zero_issuance"
+        not in repaired
+    ):
+        repaired = (
+            repaired.rstrip()
+            + """
+
+- name: initial_month_prorated_allotment_below_minimum_gets_zero_issuance
+  period: 2026-01
+  input:
+    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.snap_initial_month_prorated_allotment: 5
+  output:
+    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_initial_month_allotment_after_minimum_issuance: 0
+"""
+        )
     return repaired
 
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5389,8 +5389,7 @@ NY_SNAP_CATEGORICAL_FINAL_TESTS = """
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2012/j#relation.member_of_household:
       - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
-    us-ny:regulations/18-nycrr/387/14/a/5#relation.member_of_household:
-      - us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: true
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: true
         us-ny:regulations/18-nycrr/387/14/a/5#input.member_authorized_to_receive_family_assistance_nonemergency_safety_net_or_ssi_benefits_but_not_yet_paid: false
         us-ny:regulations/18-nycrr/387/14/a/5#input.member_family_assistance_nonemergency_safety_net_or_ssi_benefits_suspended_or_being_recouped: false
         us-ny:regulations/18-nycrr/387/14/a/5#input.member_determined_eligible_for_family_assistance_or_nonemergency_safety_net_benefits: false
@@ -5416,8 +5415,7 @@ NY_SNAP_CATEGORICAL_FINAL_TESTS = """
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2012/j#relation.member_of_household:
       - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
-    us-ny:regulations/18-nycrr/387/14/a/5#relation.member_of_household:
-      - us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: true
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: true
         us-ny:regulations/18-nycrr/387/14/a/5#input.member_authorized_to_receive_family_assistance_nonemergency_safety_net_or_ssi_benefits_but_not_yet_paid: false
         us-ny:regulations/18-nycrr/387/14/a/5#input.member_family_assistance_nonemergency_safety_net_or_ssi_benefits_suspended_or_being_recouped: false
         us-ny:regulations/18-nycrr/387/14/a/5#input.member_determined_eligible_for_family_assistance_or_nonemergency_safety_net_benefits: false
@@ -5438,6 +5436,24 @@ NY_SNAP_CATEGORICAL_FINAL_TESTS = """
 
 def _repair_new_york_snap_categorical_eligibility_rules(content: str) -> str:
     repaired = content
+    repaired = repaired.replace(
+        "  - us:statutes/7/2012/j#snap_household_has_elderly_or_disabled_member\n",
+        "  - us:statutes/7/2012/j\n",
+        1,
+    )
+    repaired = re.sub(
+        r"\n  - name: member_of_household\n"
+        r"    kind: data_relation\n"
+        r"    data_relation:\n"
+        r"      predicate: member_of_household\n"
+        r"      arity: 2\n"
+        r"      arguments:\n"
+        r"        - Person\n"
+        r"        - Household\n",
+        "\n",
+        repaired,
+        count=1,
+    )
     deferred_start = repaired.find("  deferred_outputs:\n")
     if deferred_start != -1 and all(
         output in repaired[deferred_start:]
@@ -5456,12 +5472,26 @@ def _repair_new_york_snap_categorical_eligibility_rules(content: str) -> str:
 
 
 def _repair_new_york_snap_categorical_eligibility_tests(content: str) -> str:
+    repaired = re.sub(
+        r"(    us:statutes/7/2012/j#relation\.member_of_household:\n"
+        r"      - us:statutes/7/2012/j#input\.snap_member_is_elderly_or_disabled: .*\n)"
+        r"    us-ny:regulations/18-nycrr/387/14/a/5#relation\.member_of_household:\n"
+        r"      - (us-ny:regulations/18-nycrr/387/14/a/5#input\.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: .*\n)"
+        r"        (us-ny:regulations/18-nycrr/387/14/a/5#input\.member_authorized_to_receive_family_assistance_nonemergency_safety_net_or_ssi_benefits_but_not_yet_paid: .*\n)"
+        r"        (us-ny:regulations/18-nycrr/387/14/a/5#input\.member_family_assistance_nonemergency_safety_net_or_ssi_benefits_suspended_or_being_recouped: .*\n)"
+        r"        (us-ny:regulations/18-nycrr/387/14/a/5#input\.member_determined_eligible_for_family_assistance_or_nonemergency_safety_net_benefits: .*\n)"
+        r"        (us-ny:regulations/18-nycrr/387/14/a/5#input\.member_paid_family_assistance_or_nonemergency_safety_net_benefits: .*\n)"
+        r"        (us-ny:regulations/18-nycrr/387/14/a/5#input\.member_family_assistance_or_nonemergency_safety_net_grant_amount: .*\n)",
+        r"\1        \2        \3        \4        \5        \6        \7",
+        content,
+        flags=re.MULTILINE,
+    )
     if (
         "all_members_public_assistance_path_makes_household_categorically_eligible"
-        in content
+        in repaired
     ):
-        return content
-    return content.rstrip() + NY_SNAP_CATEGORICAL_FINAL_TESTS + "\n"
+        return repaired
+    return repaired.rstrip() + NY_SNAP_CATEGORICAL_FINAL_TESTS + "\n"
 
 
 def cmd_repair_new_york_snap_categorical_eligibility(args):

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5594,6 +5594,29 @@ def _repair_new_york_snap_benefit_tests(content: str) -> str:
             "household_member_ineligible_to_participate_in_snap: false\n",
             1,
         )
+    local_prorated_input = (
+        "us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+        "#input.snap_initial_month_prorated_allotment"
+    )
+    if local_prorated_input not in repaired:
+        repaired = repaired.replace(
+            "    us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+            "#input.household_shelter_costs_incurred: 500\n",
+            "    us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+            "#input.household_shelter_costs_incurred: 500\n"
+            f"    {local_prorated_input}: 0\n",
+            1,
+        )
+    if (
+        "us-ny:regulations/18-nycrr/387/14/a/1#input.application_date: '2026-01-16'\n"
+        f"    {local_prorated_input}: 153\n" not in repaired
+    ):
+        repaired = repaired.replace(
+            "    us-ny:regulations/18-nycrr/387/14/a/1#input.application_date: '2026-01-16'\n",
+            "    us-ny:regulations/18-nycrr/387/14/a/1#input.application_date: '2026-01-16'\n"
+            f"    {local_prorated_input}: 153\n",
+            1,
+        )
     output_ref = (
         "us-ny:policies/otda/snap/fy-2026-benefit-calculation"
         "#ny_snap_excess_shelter_cost"

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3687,8 +3687,7 @@ def _repair_california_snap_program_tests(path: Path) -> None:
     )
     if (
         base_shelter_input in content
-        and "standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage"
-        not in content
+        and base_sua_input not in content
     ):
         content = content.replace(
             base_shelter_input,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1082,6 +1082,25 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_ny_snap_categorical_parser = subparsers.add_parser(
+        "repair-new-york-snap-categorical-eligibility",
+        help="Apply signed deterministic repairs for New York SNAP categorical eligibility",
+    )
+    repair_ny_snap_categorical_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="rulespec-us-ny repository root used for manifest signing",
+    )
+    repair_ny_snap_categorical_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     # test command
     test_parser = subparsers.add_parser(
         "test", help="Execute RuleSpec companion .test.yaml cases"
@@ -1683,6 +1702,8 @@ def main():
         cmd_repair_california_snap_shelter_surface(args)
     elif args.command == "repair-snap-273-10-allotment":
         cmd_repair_snap_273_10_allotment(args)
+    elif args.command == "repair-new-york-snap-categorical-eligibility":
+        cmd_repair_new_york_snap_categorical_eligibility(args)
     elif args.command == "encode":
         cmd_encode(args)
     elif args.command == "eval":
@@ -5256,6 +5277,265 @@ def cmd_repair_snap_273_10_allotment(args):
         )
 
     print("Applied 7 CFR 273.10 maximum-allotment repair")
+    print(f"changed={relative_output}")
+    print(f"changed={_rulespec_test_path(relative_output)}")
+    print(f"manifest={manifest_path}")
+
+
+NY_SNAP_CATEGORICAL_RELATIVE = Path("regulations/18-nycrr/387/14/a/5.yaml")
+NY_SNAP_CATEGORICAL_FINAL_RULES = """
+
+  - name: ny_snap_categorically_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: us-ny/regulation/18-nycrr/387/14/a/5(i)-(iii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/regulation/18-nycrr/387/14/a/5
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us-ny/regulation/18-nycrr/387/14/a/5
+              excerpt: Under no circumstances can any household be considered categorically eligible for SNAP if any member of that household is disqualified
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          (
+            ny_snap_all_members_public_assistance_categorical_path_satisfied
+            or ny_snap_elderly_disabled_200_percent_categorical_path_satisfied
+            or ny_snap_dependent_care_200_percent_categorical_path_satisfied
+            or ny_snap_earned_income_150_percent_categorical_path_satisfied
+            or ny_snap_residual_130_percent_categorical_path_satisfied
+          )
+          and not household_member_disqualified_for_intentional_program_violation
+          and not household_member_disqualified_for_failure_to_comply_with_periodic_reporting_requirements
+          and not household_member_disqualified_for_failure_to_comply_with_work_requirements
+          and not household_member_ineligible_to_participate_in_snap
+
+  - name: snap_categorically_eligible_for_resource_exemption
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: us-ny/regulation/18-nycrr/387/14/a/5(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/regulation/18-nycrr/387/14/a/5
+              excerpt: Categorically eligible households are presumed, without further investigation or verification, to meet the resource limits
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          ny_snap_categorically_eligible
+
+  - name: snap_income_limit_exemption_for_categorically_eligible_household
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: us-ny/regulation/18-nycrr/387/14/a/5(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us-ny/regulation/18-nycrr/387/14/a/5
+              excerpt: Categorically eligible households are exempted from the gross and net income limits
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          ny_snap_categorically_eligible
+"""
+
+NY_SNAP_CATEGORICAL_FINAL_TESTS = """
+
+- name: all_members_public_assistance_path_makes_household_categorically_eligible
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 3000
+    us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
+    us:statutes/7/2012/j#relation.member_of_household:
+      - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
+    us-ny:regulations/18-nycrr/387/14/a/5#relation.member_of_household:
+      - us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: true
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_authorized_to_receive_family_assistance_nonemergency_safety_net_or_ssi_benefits_but_not_yet_paid: false
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_family_assistance_nonemergency_safety_net_or_ssi_benefits_suspended_or_being_recouped: false
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_determined_eligible_for_family_assistance_or_nonemergency_safety_net_benefits: false
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_paid_family_assistance_or_nonemergency_safety_net_benefits: false
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_family_assistance_or_nonemergency_safety_net_grant_amount: 0
+    us-ny:regulations/18-nycrr/387/14/a/5#input.household_has_out_of_pocket_dependent_care_expenses: false
+    us-ny:regulations/18-nycrr/387/14/a/5#input.household_has_earned_income_budgeted_for_snap: false
+    us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_disqualified_for_intentional_program_violation: false
+    us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_disqualified_for_failure_to_comply_with_periodic_reporting_requirements: false
+    us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_disqualified_for_failure_to_comply_with_work_requirements: false
+    us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_ineligible_to_participate_in_snap: false
+  output:
+    us-ny:regulations/18-nycrr/387/14/a/5#ny_snap_categorically_eligible: holds
+    us-ny:regulations/18-nycrr/387/14/a/5#snap_categorically_eligible_for_resource_exemption: holds
+    us-ny:regulations/18-nycrr/387/14/a/5#snap_income_limit_exemption_for_categorically_eligible_household: holds
+
+- name: intentional_program_violation_blocks_categorical_eligibility
+  period: 2026-01
+  input:
+    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1
+    us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 3000
+    us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0
+    us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
+    us:statutes/7/2012/j#relation.member_of_household:
+      - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
+    us-ny:regulations/18-nycrr/387/14/a/5#relation.member_of_household:
+      - us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: true
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_authorized_to_receive_family_assistance_nonemergency_safety_net_or_ssi_benefits_but_not_yet_paid: false
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_family_assistance_nonemergency_safety_net_or_ssi_benefits_suspended_or_being_recouped: false
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_determined_eligible_for_family_assistance_or_nonemergency_safety_net_benefits: false
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_paid_family_assistance_or_nonemergency_safety_net_benefits: false
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_family_assistance_or_nonemergency_safety_net_grant_amount: 0
+    us-ny:regulations/18-nycrr/387/14/a/5#input.household_has_out_of_pocket_dependent_care_expenses: false
+    us-ny:regulations/18-nycrr/387/14/a/5#input.household_has_earned_income_budgeted_for_snap: false
+    us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_disqualified_for_intentional_program_violation: true
+    us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_disqualified_for_failure_to_comply_with_periodic_reporting_requirements: false
+    us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_disqualified_for_failure_to_comply_with_work_requirements: false
+    us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_ineligible_to_participate_in_snap: false
+  output:
+    us-ny:regulations/18-nycrr/387/14/a/5#ny_snap_categorically_eligible: not_holds
+    us-ny:regulations/18-nycrr/387/14/a/5#snap_categorically_eligible_for_resource_exemption: not_holds
+    us-ny:regulations/18-nycrr/387/14/a/5#snap_income_limit_exemption_for_categorically_eligible_household: not_holds
+"""
+
+
+def _repair_new_york_snap_categorical_eligibility_rules(content: str) -> str:
+    repaired = re.sub(
+        r"(?ms)^  deferred_outputs:\n"
+        r"(?:    - output: us-ny:regulations/18-nycrr/387/14/a/5#"
+        r"(?:ny_snap_categorically_eligible|"
+        r"snap_categorically_eligible_for_resource_exemption|"
+        r"snap_income_limit_exemption_for_categorically_eligible_household)\n"
+        r"(?:      .*\n|        .*\n)*)+",
+        "",
+        content,
+    )
+    if "  - name: ny_snap_categorically_eligible\n" not in repaired:
+        repaired = repaired.rstrip() + NY_SNAP_CATEGORICAL_FINAL_RULES + "\n"
+    return repaired
+
+
+def _repair_new_york_snap_categorical_eligibility_tests(content: str) -> str:
+    if (
+        "all_members_public_assistance_path_makes_household_categorically_eligible"
+        in content
+    ):
+        return content
+    return content.rstrip() + NY_SNAP_CATEGORICAL_FINAL_TESTS + "\n"
+
+
+def cmd_repair_new_york_snap_categorical_eligibility(args):
+    """Apply a signed deterministic repair for NY SNAP categorical eligibility."""
+    repo_path = Path(args.repo).resolve()
+    if _repo_jurisdiction_prefix(repo_path) != "us-ny":
+        print(
+            "repair-new-york-snap-categorical-eligibility must run against "
+            f"rulespec-us-ny; got {repo_path}"
+        )
+        sys.exit(1)
+
+    relative_output = NY_SNAP_CATEGORICAL_RELATIVE
+    rules_file = repo_path / relative_output
+    test_file = _rulespec_test_path(rules_file)
+    if not rules_file.exists():
+        print(f"RuleSpec file not found: {rules_file}")
+        sys.exit(1)
+    if not test_file.exists():
+        print(f"RuleSpec companion test file not found: {test_file}")
+        sys.exit(1)
+
+    original_content = rules_file.read_text()
+    original_test_content = test_file.read_text()
+    repaired_content = _repair_new_york_snap_categorical_eligibility_rules(
+        original_content
+    )
+    repaired_test_content = _repair_new_york_snap_categorical_eligibility_tests(
+        original_test_content
+    )
+    if (
+        repaired_content == original_content
+        and repaired_test_content == original_test_content
+    ):
+        print("No New York SNAP categorical eligibility repairs found.")
+        return
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        generated_output = output_root / "deterministic-repair" / relative_output
+        generated_output.parent.mkdir(parents=True, exist_ok=True)
+        generated_output.write_text(repaired_content)
+        generated_test = _rulespec_test_path(generated_output)
+        generated_test.write_text(repaired_test_content)
+
+        rules_file.write_text(repaired_content)
+        test_file.write_text(repaired_test_content)
+        try:
+            validation = ValidatorPipeline(
+                policy_repo_path=repo_path,
+                axiom_rules_path=axiom_rules_path,
+                enable_oracles=False,
+                require_policy_proofs=True,
+            ).validate(rules_file, skip_reviewers=True)
+            if not validation.all_passed:
+                issues = [
+                    result.error
+                    for result in validation.results.values()
+                    if result.error
+                ]
+                print("Repair failed validation; restored original files.")
+                for issue in issues:
+                    print(f"- {issue}")
+                sys.exit(1)
+        finally:
+            if "validation" not in locals() or not validation.all_passed:
+                rules_file.write_text(original_content)
+                test_file.write_text(original_test_content)
+
+        result = argparse.Namespace(
+            output_file=str(generated_output),
+            runner="deterministic-repair",
+            backend="deterministic",
+            model="ny-snap-categorical-eligibility-v1",
+            tool="axiom-encode repair-new-york-snap-categorical-eligibility",
+            citation="us-ny:regulations/18-nycrr/387/14/a/5",
+            generation_prompt_sha256=None,
+            trace_file=None,
+            context_manifest_file=None,
+        )
+        manifest_path = _write_applied_encoding_manifest(
+            result,
+            output_root=output_root,
+            policy_repo_path=repo_path,
+            relative_output=relative_output,
+            applied_files=[rules_file, test_file],
+            run_id="deterministic-repair",
+            signing_key=signing_key,
+            axiom_encode_git=axiom_encode_git,
+        )
+
+    print("Applied New York SNAP categorical eligibility repair")
     print(f"changed={relative_output}")
     print(f"changed={_rulespec_test_path(relative_output)}")
     print(f"manifest={manifest_path}")

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5582,6 +5582,25 @@ def _repair_new_york_snap_benefit_tests(content: str) -> str:
         "household_member_disqualified_for_failure_to_comply_with_work_requirements",
     )
     repaired = re.sub(
+        r"^(\s*)us:regulations/7-cfr/273/10#input\.snap_countable_earned_income: (.*)\n",
+        (
+            r"\1us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+            r"#input.snap_countable_earned_income: \2\n"
+            r"\1us:statutes/7/2014/e/2#input.snap_countable_earned_income: \2\n"
+        ),
+        repaired,
+        flags=re.MULTILINE,
+    )
+    repaired = re.sub(
+        r"^(\s*)us:regulations/7-cfr/273/10#input\.snap_countable_unearned_income: (.*)\n",
+        (
+            r"\1us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+            r"#input.snap_countable_unearned_income: \2\n"
+        ),
+        repaired,
+        flags=re.MULTILINE,
+    )
+    repaired = re.sub(
         r"^    us-ny:regulations/18-nycrr/387/14/a/1#"
         r"(snap_allotment|snap_initial_month_proration_applies|"
         r"snap_initial_month_prorated_allotment): .*\n",

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3674,12 +3674,40 @@ def _california_snap_member_eligible_rule() -> dict[str, object]:
 
 def _repair_california_snap_program_tests(path: Path) -> None:
     content = path.read_text()
+    content = content.replace(
+        "us:statutes/7/2012/j#relation.member_of_household",
+        "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#relation.member_of_household",
+    )
     if "us:regulations/7-cfr/273/10#input.household_size:" not in content:
         content = content.replace(
             "    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1\n",
             "    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1\n"
             "    us:regulations/7-cfr/273/10#input.household_size: 1\n",
             1,
+        )
+    alien_status_defaults = (
+        "        us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false\n"
+        "        us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false\n"
+        "        us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false\n"
+        "        us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false\n"
+        "        us:regulations/7-cfr/273/4#input.member_is_refugee: false\n"
+        "        us:regulations/7-cfr/273/4#input.member_is_asylee: false\n"
+        "        us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false\n"
+        "        us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false\n"
+        "        us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false\n"
+        "        us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false\n"
+        "        us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false\n"
+        "        us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false\n"
+        "        us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false\n"
+        "        us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false\n"
+        "        us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false\n"
+        "        us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false\n"
+    )
+    if "member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member" not in content:
+        content = content.replace(
+            "        us:regulations/7-cfr/273/7#input.member_age: 60\n",
+            "        us:regulations/7-cfr/273/7#input.member_age: 60\n"
+            + alien_status_defaults,
         )
     if (
         "us:regulations/7-cfr/273/8#input.snap_categorically_eligible_for_resource_exemption:"

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5635,9 +5635,16 @@ def cmd_repair_new_york_snap_benefit_tests(args):
         print(f"RuleSpec companion test file not found: {test_file}")
         sys.exit(1)
 
+    original_content = rules_file.read_text()
     original_test_content = test_file.read_text()
+    repaired_content, repaired_rules = _repair_missing_source_proof_atoms(
+        original_content
+    )
     repaired_test_content = _repair_new_york_snap_benefit_tests(original_test_content)
-    if repaired_test_content == original_test_content:
+    if (
+        repaired_content == original_content
+        and repaired_test_content == original_test_content
+    ):
         print("No New York SNAP benefit test repairs found.")
         return
 
@@ -5651,10 +5658,11 @@ def cmd_repair_new_york_snap_benefit_tests(args):
         output_root = Path(tmpdir)
         generated_output = output_root / "deterministic-repair" / relative_output
         generated_output.parent.mkdir(parents=True, exist_ok=True)
-        generated_output.write_text(rules_file.read_text())
+        generated_output.write_text(repaired_content)
         generated_test = _rulespec_test_path(generated_output)
         generated_test.write_text(repaired_test_content)
 
+        rules_file.write_text(repaired_content)
         test_file.write_text(repaired_test_content)
         try:
             validation = ValidatorPipeline(
@@ -5675,6 +5683,7 @@ def cmd_repair_new_york_snap_benefit_tests(args):
                 sys.exit(1)
         finally:
             if "validation" not in locals() or not validation.all_passed:
+                rules_file.write_text(original_content)
                 test_file.write_text(original_test_content)
 
         result = argparse.Namespace(
@@ -5700,6 +5709,9 @@ def cmd_repair_new_york_snap_benefit_tests(args):
         )
 
     print("Applied New York SNAP benefit companion-test repair")
+    if repaired_rules:
+        print(f"proof_repairs={', '.join(repaired_rules)}")
+    print(f"changed={relative_output}")
     print(f"changed={_rulespec_test_path(relative_output)}")
     print(f"manifest={manifest_path}")
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5414,30 +5414,99 @@ NY_SNAP_CATEGORICAL_FINAL_TESTS = """
     us-ny:regulations/18-nycrr/387/14/a/5#snap_income_limit_exemption_for_categorically_eligible_household: not_holds
 """
 
+NY_SNAP_CATEGORICAL_REPAIRED_OUTPUTS = (
+    "us-ny:regulations/18-nycrr/387/14/a/5#ny_snap_categorically_eligible",
+    "us-ny:regulations/18-nycrr/387/14/a/5#snap_categorically_eligible_for_resource_exemption",
+    "us-ny:regulations/18-nycrr/387/14/a/5#snap_income_limit_exemption_for_categorically_eligible_household",
+)
+
+
+def _remove_new_york_snap_categorical_deferred_outputs(content: str) -> str:
+    lines = content.splitlines(keepends=True)
+    deferred_start = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if re.match(r"^  deferred_outputs:\s*(?:#.*)?$", line)
+        ),
+        None,
+    )
+    if deferred_start is None:
+        return content
+
+    deferred_end = len(lines)
+    for index in range(deferred_start + 1, len(lines)):
+        line = lines[index]
+        if re.match(r"^  [A-Za-z_][^:]*:\s*", line):
+            deferred_end = index
+            break
+        if line and not line.startswith((" ", "\n", "\r")):
+            deferred_end = index
+            break
+
+    entries: list[list[str]] = []
+    prefix_lines: list[str] = []
+    index = deferred_start + 1
+    while index < deferred_end:
+        if re.match(r"^    -\s+", lines[index]):
+            entry_start = index
+            index += 1
+            while index < deferred_end and not re.match(r"^    -\s+", lines[index]):
+                index += 1
+            entries.append(lines[entry_start:index])
+        else:
+            prefix_lines.append(lines[index])
+            index += 1
+
+    kept_entries: list[list[str]] = []
+    removed_any = False
+    for entry in entries:
+        entry_text = "".join(entry)
+        output_match = re.search(r"(?m)^\s*(?:-\s*)?output:\s*([^\s]+)", entry_text)
+        output = output_match.group(1) if output_match else ""
+        if output in NY_SNAP_CATEGORICAL_REPAIRED_OUTPUTS:
+            removed_any = True
+        else:
+            kept_entries.append(entry)
+
+    if not removed_any:
+        return content
+
+    replacement: list[str] = []
+    if kept_entries:
+        replacement.append(lines[deferred_start])
+        replacement.extend(prefix_lines)
+        for entry in kept_entries:
+            replacement.extend(entry)
+
+    return "".join(lines[:deferred_start] + replacement + lines[deferred_end:])
+
+
+def _new_york_snap_categorical_test_surface_available(rules_content: str) -> bool:
+    return all(
+        f"#{output.rsplit('#', 1)[1]}" in rules_content
+        or f"name: {output.rsplit('#', 1)[1]}" in rules_content
+        for output in NY_SNAP_CATEGORICAL_REPAIRED_OUTPUTS
+    )
+
 
 def _repair_new_york_snap_categorical_eligibility_rules(content: str) -> str:
-    repaired = content
-    deferred_start = repaired.find("  deferred_outputs:\n")
-    if deferred_start != -1 and all(
-        output in repaired[deferred_start:]
-        for output in (
-            "#ny_snap_categorically_eligible",
-            "#snap_categorically_eligible_for_resource_exemption",
-            "#snap_income_limit_exemption_for_categorically_eligible_household",
-        )
-    ):
-        deferred_end = repaired.find("\n  summary:", deferred_start)
-        if deferred_end != -1:
-            repaired = repaired[:deferred_start] + repaired[deferred_end + 1 :]
+    repaired = _remove_new_york_snap_categorical_deferred_outputs(content)
     if "  - name: ny_snap_categorically_eligible\n" not in repaired:
         repaired = repaired.rstrip() + NY_SNAP_CATEGORICAL_FINAL_RULES + "\n"
     return repaired
 
 
-def _repair_new_york_snap_categorical_eligibility_tests(content: str) -> str:
+def _repair_new_york_snap_categorical_eligibility_tests(
+    content: str, *, rules_content: str | None = None
+) -> str:
     if (
         "all_members_public_assistance_path_makes_household_categorically_eligible"
         in content
+    ):
+        return content
+    if rules_content is not None and not (
+        _new_york_snap_categorical_test_surface_available(rules_content)
     ):
         return content
     return content.rstrip() + NY_SNAP_CATEGORICAL_FINAL_TESTS + "\n"
@@ -5469,7 +5538,7 @@ def cmd_repair_new_york_snap_categorical_eligibility(args):
         original_content
     )
     repaired_test_content = _repair_new_york_snap_categorical_eligibility_tests(
-        original_test_content
+        original_test_content, rules_content=repaired_content
     )
     if (
         repaired_content == original_content

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3703,7 +3703,10 @@ def _repair_california_snap_program_tests(path: Path) -> None:
         "        us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false\n"
         "        us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false\n"
     )
-    if "member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member" not in content:
+    if (
+        "member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member"
+        not in content
+    ):
         content = content.replace(
             "        us:regulations/7-cfr/273/7#input.member_age: 60\n",
             "        us:regulations/7-cfr/273/7#input.member_age: 60\n"
@@ -3734,17 +3737,12 @@ def _repair_california_snap_program_tests(path: Path) -> None:
         "us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 0",
         "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0",
     )
-    base_shelter_input = (
-        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0\n"
-    )
+    base_shelter_input = "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0\n"
     base_sua_input = (
         "    ? us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage\n"
         "    : false\n"
     )
-    if (
-        base_shelter_input in content
-        and base_sua_input not in content
-    ):
+    if base_shelter_input in content and base_sua_input not in content:
         content = content.replace(
             base_shelter_input,
             base_shelter_input + base_sua_input,
@@ -3776,9 +3774,7 @@ def _repair_california_snap_program_tests(path: Path) -> None:
         "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_residency_citizenship_eligible: not_holds\n",
         "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_household_member_eligible: not_holds\n",
     )
-    shelter_case_input = (
-        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500\n"
-    )
+    shelter_case_input = "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500\n"
     shelter_sua_input = (
         "    ? us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage\n"
         "    : true\n"

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3633,9 +3633,6 @@ def _migrate_california_snap_sua_layout(repo_path: Path) -> None:
     """Move generated CA SUA RuleSpec out of the disallowed guidance/ root."""
     old_rules_file = repo_path / CALIFORNIA_SNAP_OLD_SUA_RELATIVE
     old_test_file = _rulespec_test_path(old_rules_file)
-    old_manifest_file = repo_path / _applied_encoding_manifest_path(
-        CALIFORNIA_SNAP_OLD_SUA_RELATIVE
-    )
     new_rules_file = repo_path / CALIFORNIA_SNAP_SUA_RELATIVE
     new_test_file = _rulespec_test_path(new_rules_file)
 
@@ -3657,9 +3654,6 @@ def _migrate_california_snap_sua_layout(repo_path: Path) -> None:
         new_file.write_text(content)
         if old_file.exists():
             old_file.unlink()
-
-    if old_manifest_file.exists():
-        old_manifest_file.unlink()
 
 
 def _repair_california_snap_policy_composition(path: Path) -> None:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5304,6 +5304,7 @@ def cmd_repair_snap_273_10_allotment(args):
 
 
 NY_SNAP_CATEGORICAL_RELATIVE = Path("regulations/18-nycrr/387/14/a/5.yaml")
+NY_SNAP_CATEGORICAL_MEMBER_RELATION = "ny_snap_categorical_member_of_household"
 NY_SNAP_CATEGORICAL_FINAL_RULES = """
 
   - name: ny_snap_categorically_eligible
@@ -5389,7 +5390,8 @@ NY_SNAP_CATEGORICAL_FINAL_TESTS = """
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2012/j#relation.member_of_household:
       - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
-        us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: true
+    us-ny:regulations/18-nycrr/387/14/a/5#relation.ny_snap_categorical_member_of_household:
+      - us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: true
         us-ny:regulations/18-nycrr/387/14/a/5#input.member_authorized_to_receive_family_assistance_nonemergency_safety_net_or_ssi_benefits_but_not_yet_paid: false
         us-ny:regulations/18-nycrr/387/14/a/5#input.member_family_assistance_nonemergency_safety_net_or_ssi_benefits_suspended_or_being_recouped: false
         us-ny:regulations/18-nycrr/387/14/a/5#input.member_determined_eligible_for_family_assistance_or_nonemergency_safety_net_benefits: false
@@ -5415,7 +5417,8 @@ NY_SNAP_CATEGORICAL_FINAL_TESTS = """
     us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0
     us:statutes/7/2012/j#relation.member_of_household:
       - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
-        us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: true
+    us-ny:regulations/18-nycrr/387/14/a/5#relation.ny_snap_categorical_member_of_household:
+      - us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: true
         us-ny:regulations/18-nycrr/387/14/a/5#input.member_authorized_to_receive_family_assistance_nonemergency_safety_net_or_ssi_benefits_but_not_yet_paid: false
         us-ny:regulations/18-nycrr/387/14/a/5#input.member_family_assistance_nonemergency_safety_net_or_ssi_benefits_suspended_or_being_recouped: false
         us-ny:regulations/18-nycrr/387/14/a/5#input.member_determined_eligible_for_family_assistance_or_nonemergency_safety_net_benefits: false
@@ -5516,18 +5519,44 @@ def _repair_new_york_snap_categorical_eligibility_rules(content: str) -> str:
         "  - us:statutes/7/2012/j\n",
         1,
     )
-    repaired = re.sub(
-        r"\n  - name: member_of_household\n"
-        r"    kind: data_relation\n"
-        r"    data_relation:\n"
-        r"      predicate: member_of_household\n"
-        r"      arity: 2\n"
-        r"      arguments:\n"
-        r"        - Person\n"
-        r"        - Household\n",
-        "\n",
-        repaired,
-        count=1,
+    repaired = repaired.replace(
+        "  - name: member_of_household\n"
+        "    kind: data_relation\n"
+        "    data_relation:\n"
+        "      predicate: member_of_household\n",
+        "  - name: ny_snap_categorical_member_of_household\n"
+        "    kind: data_relation\n"
+        "    data_relation:\n"
+        "      predicate: ny_snap_categorical_member_of_household\n",
+        1,
+    )
+    if (
+        "  - name: ny_snap_categorical_member_of_household\n" not in repaired
+        and "  - name: ny_snap_all_members_public_assistance_categorical_path_satisfied\n"
+        in repaired
+    ):
+        repaired = repaired.replace(
+            "  - name: ny_snap_all_members_public_assistance_categorical_path_satisfied\n",
+            "  - name: ny_snap_categorical_member_of_household\n"
+            "    kind: data_relation\n"
+            "    data_relation:\n"
+            "      predicate: ny_snap_categorical_member_of_household\n"
+            "      arity: 2\n"
+            "      arguments:\n"
+            "        - Person\n"
+            "        - Household\n\n"
+            "  - name: ny_snap_all_members_public_assistance_categorical_path_satisfied\n",
+            1,
+        )
+    repaired = repaired.replace(
+        "count_where(member_of_household, "
+        "member_has_family_assistance_nonemergency_safety_net_or_ssi_categorical_status)",
+        "count_where(ny_snap_categorical_member_of_household, "
+        "member_has_family_assistance_nonemergency_safety_net_or_ssi_categorical_status)",
+    )
+    repaired = repaired.replace(
+        "len(member_of_household)",
+        "len(ny_snap_categorical_member_of_household)",
     )
     repaired = _remove_new_york_snap_categorical_deferred_outputs(repaired)
     if "  - name: ny_snap_categorically_eligible\n" not in repaired:
@@ -5540,6 +5569,10 @@ def _repair_new_york_snap_categorical_eligibility_tests(
 ) -> str:
     us_relation = "us:statutes/7/2012/j#relation.member_of_household"
     ny_relation = "us-ny:regulations/18-nycrr/387/14/a/5#relation.member_of_household"
+    categorical_relation = (
+        "us-ny:regulations/18-nycrr/387/14/a/5#relation."
+        f"{NY_SNAP_CATEGORICAL_MEMBER_RELATION}"
+    )
     elderly_input = "us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled"
     try:
         payload = yaml.safe_load(content)
@@ -5551,22 +5584,26 @@ def _repair_new_york_snap_categorical_eligibility_tests(
             if not isinstance(case, dict):
                 continue
             inputs = case.get("input")
-            if not isinstance(inputs, dict) or ny_relation not in inputs:
+            if not isinstance(inputs, dict):
                 continue
-            ny_rows = inputs.pop(ny_relation)
+            ny_rows = inputs.pop(ny_relation, None)
+            if ny_rows is not None and categorical_relation not in inputs:
+                inputs[categorical_relation] = ny_rows
+            categorical_rows = inputs.get(categorical_relation)
             us_rows = inputs.get(us_relation)
-            if not isinstance(ny_rows, list):
+            if not isinstance(categorical_rows, list):
                 continue
             if not isinstance(us_rows, list):
-                us_rows = [{} for _ in ny_rows]
+                us_rows = [{} for _ in categorical_rows]
                 inputs[us_relation] = us_rows
-            while len(us_rows) < len(ny_rows):
+            while len(us_rows) < len(categorical_rows):
                 us_rows.append({})
-            for index, ny_row in enumerate(ny_rows):
-                if not isinstance(ny_row, dict) or not isinstance(us_rows[index], dict):
+            for index, categorical_row in enumerate(categorical_rows):
+                if not isinstance(categorical_row, dict) or not isinstance(
+                    us_rows[index], dict
+                ):
                     continue
                 us_rows[index].setdefault(elderly_input, False)
-                us_rows[index].update(ny_row)
             changed = True
         repaired = yaml.safe_dump(payload, sort_keys=False) if changed else content
     else:
@@ -5714,7 +5751,109 @@ def _repair_new_york_snap_benefit_rules(content: str) -> str:
         "        formula: count_where(member_of_household, snap_member_student_ineligible) == 0\n",
         1,
     )
+    if "  - name: member_of_household\n" not in repaired:
+        repaired = repaired.replace(
+            "  - name: shelter_costs\n",
+            "  - name: member_of_household\n"
+            "    kind: data_relation\n"
+            "    data_relation:\n"
+            "      predicate: member_of_household\n"
+            "      arity: 2\n"
+            "      arguments:\n"
+            "        - Person\n"
+            "        - Household\n\n"
+            "  - name: shelter_costs\n",
+            1,
+        )
     return repaired
+
+
+def _ny_snap_categorical_member_defaults(
+    elderly_or_disabled: object = False,
+) -> dict[str, object]:
+    return {
+        "us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled": (
+            elderly_or_disabled
+        ),
+        "us-ny:regulations/18-nycrr/387/14/a/5#input."
+        "member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits": False,
+        "us-ny:regulations/18-nycrr/387/14/a/5#input."
+        "member_authorized_to_receive_family_assistance_nonemergency_safety_net_or_ssi_benefits_but_not_yet_paid": False,
+        "us-ny:regulations/18-nycrr/387/14/a/5#input."
+        "member_family_assistance_nonemergency_safety_net_or_ssi_benefits_suspended_or_being_recouped": False,
+        "us-ny:regulations/18-nycrr/387/14/a/5#input."
+        "member_determined_eligible_for_family_assistance_or_nonemergency_safety_net_benefits": False,
+        "us-ny:regulations/18-nycrr/387/14/a/5#input."
+        "member_paid_family_assistance_or_nonemergency_safety_net_benefits": False,
+        "us-ny:regulations/18-nycrr/387/14/a/5#input."
+        "member_family_assistance_or_nonemergency_safety_net_grant_amount": 0,
+    }
+
+
+def _repair_new_york_snap_benefit_relation_tests(content: str) -> str:
+    try:
+        payload = yaml.safe_load(content)
+    except yaml.YAMLError:
+        return content
+    if not isinstance(payload, list):
+        return content
+
+    us_relation = "us:statutes/7/2012/j#relation.member_of_household"
+    policy_relation = (
+        "us-ny:policies/otda/snap/fy-2026-benefit-calculation#relation."
+        "member_of_household"
+    )
+    old_categorical_relation = (
+        "us-ny:regulations/18-nycrr/387/14/a/5#relation.member_of_household"
+    )
+    categorical_relation = (
+        "us-ny:regulations/18-nycrr/387/14/a/5#relation."
+        f"{NY_SNAP_CATEGORICAL_MEMBER_RELATION}"
+    )
+    elderly_input = "us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled"
+    prorated_input = (
+        "us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+        "#input.snap_initial_month_prorated_allotment"
+    )
+
+    changed = False
+    for case in payload:
+        if not isinstance(case, dict):
+            continue
+        inputs = case.get("input")
+        if not isinstance(inputs, dict):
+            continue
+        old_rows = inputs.pop(old_categorical_relation, None)
+        if old_rows is not None and categorical_relation not in inputs:
+            inputs[categorical_relation] = old_rows
+            changed = True
+        us_rows = inputs.get(us_relation)
+        if isinstance(us_rows, list):
+            if policy_relation not in inputs:
+                inputs[policy_relation] = us_rows
+                changed = True
+            if categorical_relation not in inputs:
+                categorical_rows = []
+                for row in us_rows:
+                    elderly = False
+                    if isinstance(row, dict):
+                        elderly = row.get(elderly_input, False)
+                    categorical_rows.append(
+                        _ny_snap_categorical_member_defaults(elderly)
+                    )
+                inputs[categorical_relation] = categorical_rows
+                changed = True
+        if (
+            case.get("name")
+            == "initial_month_proration_uses_new_york_certification_rule"
+            and inputs.get(prorated_input) != 153
+        ):
+            inputs[prorated_input] = 153
+            changed = True
+
+    if not changed:
+        return content
+    return yaml.safe_dump(payload, sort_keys=False)
 
 
 def _repair_new_york_snap_benefit_tests(content: str) -> str:
@@ -5862,7 +6001,7 @@ def _repair_new_york_snap_benefit_tests(content: str) -> str:
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_initial_month_allotment_after_minimum_issuance: 0
 """
         )
-    return repaired
+    return _repair_new_york_snap_benefit_relation_tests(repaired)
 
 
 def cmd_repair_new_york_snap_benefit_tests(args):

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3678,6 +3678,23 @@ def _repair_california_snap_program_tests(path: Path) -> None:
         "us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 0",
         "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0",
     )
+    base_shelter_input = (
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0\n"
+    )
+    base_sua_input = (
+        "    ? us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage\n"
+        "    : false\n"
+    )
+    if (
+        base_shelter_input in content
+        and "standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage"
+        not in content
+    ):
+        content = content.replace(
+            base_shelter_input,
+            base_shelter_input + base_sua_input,
+            1,
+        )
     content = content.replace(
         "us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 500",
         "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500",
@@ -3696,24 +3713,23 @@ def _repair_california_snap_program_tests(path: Path) -> None:
     shelter_case_input = (
         "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500\n"
     )
-    if (
-        shelter_case_input in content
-        and "standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage"
-        not in content
-    ):
+    shelter_sua_input = (
+        "    ? us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage\n"
+        "    : true\n"
+    )
+    if shelter_case_input in content and shelter_sua_input not in content:
         content = content.replace(
             shelter_case_input,
-            shelter_case_input
-            + "    ? us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage\n"
-            + "    : true\n",
+            shelter_case_input + shelter_sua_input,
             1,
         )
-    content = content.replace(
-        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 204.5\n",
-        "    us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#snap_standard_utility_allowance: 663\n"
-        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#shelter_costs: 1163\n"
-        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 744\n",
-    )
+    for old_shelter_output in ("204", "204.5"):
+        content = content.replace(
+            f"    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: {old_shelter_output}\n",
+            "    us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#snap_standard_utility_allowance: 663\n"
+            "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#shelter_costs: 1163\n"
+            "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 744\n",
+        )
     content = content.replace(
         "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_benefit: 182\n",
         "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_benefit: 298\n",

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3879,6 +3879,10 @@ def _repair_california_snap_program_tests(path: Path) -> None:
             1,
         )
     content = content.replace(
+        "    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_household_size: 298\n",
+        "",
+    )
+    content = content.replace(
         "us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 500",
         "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500",
     )

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5568,6 +5568,19 @@ def cmd_repair_new_york_snap_categorical_eligibility(args):
 NY_SNAP_BENEFIT_RELATIVE = Path("policies/otda/snap/fy-2026-benefit-calculation.yaml")
 
 
+def _repair_new_york_snap_benefit_rules(content: str) -> str:
+    return content.replace(
+        "          snap_income_eligible\n"
+        "          and (snap_resource_eligible or ny_snap_categorically_eligible)\n",
+        "          (\n"
+        "            snap_income_limit_exemption_for_categorically_eligible_household\n"
+        "            or snap_standard_income_eligible\n"
+        "          )\n"
+        "          and (snap_resource_eligible or ny_snap_categorically_eligible)\n",
+        1,
+    )
+
+
 def _repair_new_york_snap_benefit_tests(content: str) -> str:
     repaired = content.replace(
         "us-ny:regulations/18-nycrr/387/14/a/5#input."
@@ -5632,6 +5645,13 @@ def _repair_new_york_snap_benefit_tests(content: str) -> str:
     repaired = re.sub(
         r"^    us-ny:regulations/18-nycrr/387/12/f/3/v/[abc]#"
         r"snap_(standard|limited|individual)_utility_allowance: .*\n",
+        "",
+        repaired,
+        flags=re.MULTILINE,
+    )
+    repaired = re.sub(
+        r"^    us-ny:regulations/18-nycrr/387/14/a/5#"
+        r"snap_income_eligible: .*\n",
         "",
         repaired,
         flags=re.MULTILINE,
@@ -5731,8 +5751,9 @@ def cmd_repair_new_york_snap_benefit_tests(args):
 
     original_content = rules_file.read_text()
     original_test_content = test_file.read_text()
+    repaired_content = _repair_new_york_snap_benefit_rules(original_content)
     repaired_content, repaired_rules = _repair_missing_source_proof_atoms(
-        original_content
+        repaired_content
     )
     repaired_test_content = _repair_new_york_snap_benefit_tests(original_test_content)
     if (

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5587,6 +5587,7 @@ def _repair_new_york_snap_benefit_tests(content: str) -> str:
             r"\1us-ny:policies/otda/snap/fy-2026-benefit-calculation"
             r"#input.snap_countable_earned_income: \2\n"
             r"\1us:statutes/7/2014/e/2#input.snap_countable_earned_income: \2\n"
+            r"\1us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: \2\n"
         ),
         repaired,
         flags=re.MULTILINE,
@@ -5596,6 +5597,8 @@ def _repair_new_york_snap_benefit_tests(content: str) -> str:
         (
             r"\1us-ny:policies/otda/snap/fy-2026-benefit-calculation"
             r"#input.snap_countable_unearned_income: \2\n"
+            r"\1us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: \2\n"
+            r"\1us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0\n"
         ),
         repaired,
         flags=re.MULTILINE,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3748,6 +3748,28 @@ def _repair_california_snap_program_tests(path: Path) -> None:
         "us:statutes/7/2012/j#relation.member_of_household",
         "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#relation.member_of_household",
     )
+    base_output_anchor = (
+        "  output:\n"
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_gross_monthly_income: 0\n"
+    )
+    base_output_coverage = (
+        "  output:\n"
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_countable_earned_income: 0\n"
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_countable_unearned_income: 0\n"
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_gross_monthly_income: 0\n"
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_residency_eligible: holds\n"
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_member_eligible: holds\n"
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_household_member_eligible: holds\n"
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#shelter_costs: 0\n"
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_total_allowable_shelter_expenses: 0\n"
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 0\n"
+    )
+    if (
+        "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_countable_earned_income:"
+        not in content
+        and base_output_anchor in content
+    ):
+        content = content.replace(base_output_anchor, base_output_coverage, 1)
     if "us:regulations/7-cfr/273/10#input.household_size:" not in content:
         content = content.replace(
             "    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1\n",

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5581,6 +5581,14 @@ def _repair_new_york_snap_benefit_tests(content: str) -> str:
         "us-ny:regulations/18-nycrr/387/14/a/5#input."
         "household_member_disqualified_for_failure_to_comply_with_work_requirements",
     )
+    repaired = re.sub(
+        r"^    us-ny:regulations/18-nycrr/387/14/a/1#"
+        r"(snap_allotment|snap_initial_month_proration_applies|"
+        r"snap_initial_month_prorated_allotment): .*\n",
+        "",
+        repaired,
+        flags=re.MULTILINE,
+    )
     if (
         "us-ny:regulations/18-nycrr/387/14/a/5#input."
         "household_member_ineligible_to_participate_in_snap" not in repaired

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5584,6 +5584,17 @@ def _repair_new_york_snap_benefit_rules(content: str) -> str:
         "        formula: count_where(member_of_household, snap_member_ssn_requirement_ineligible) == 0\n",
         1,
     )
+    repaired = repaired.replace(
+        "          count_where(member_of_household, snap_member_work_requirement_eligible) > 0\n"
+        "          and count_where(member_of_household, snap_member_work_requirement_ineligible) == 0\n",
+        "          count_where(member_of_household, snap_member_work_requirement_ineligible) == 0\n",
+        1,
+    )
+    repaired = repaired.replace(
+        "        formula: count_where(member_of_household, snap_member_student_eligible) > 0\n",
+        "        formula: count_where(member_of_household, snap_member_student_ineligible) == 0\n",
+        1,
+    )
     return repaired
 
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3287,10 +3287,20 @@ CALIFORNIA_SNAP_SHELTER_SURFACE_REPAIR_MODEL = "california-snap-shelter-surface-
 CALIFORNIA_SNAP_PROGRAM_RELATIVE = Path(
     "policies/cdss/snap/fy-2026-benefit-calculation.yaml"
 )
-CALIFORNIA_SNAP_SUA_IMPORT = (
+CALIFORNIA_SNAP_SUA_RELATIVE = Path(
+    "policies/cdss/snap/standard-utility-allowance.yaml"
+)
+CALIFORNIA_SNAP_SUA_IMPORT = "us-ca:policies/cdss/snap/standard-utility-allowance"
+CALIFORNIA_SNAP_OLD_SUA_RELATIVE = Path(
+    "guidance/cdss/acin-2025-i-46-25/standard-utility-allowance.yaml"
+)
+CALIFORNIA_SNAP_OLD_SUA_IMPORT = (
     "us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance"
 )
-CALIFORNIA_SNAP_REPAIR_RELATIVE_OUTPUTS = (CALIFORNIA_SNAP_PROGRAM_RELATIVE,)
+CALIFORNIA_SNAP_REPAIR_RELATIVE_OUTPUTS = (
+    CALIFORNIA_SNAP_PROGRAM_RELATIVE,
+    CALIFORNIA_SNAP_SUA_RELATIVE,
+)
 
 
 def cmd_repair_colorado_snap_federal_refs(args):
@@ -3483,7 +3493,10 @@ def cmd_repair_california_snap_shelter_surface(args):
     manifest_groups = _california_snap_repair_manifest_groups(repo_path)
     for relative_output, _files in manifest_groups:
         rules_file = repo_path / relative_output
-        if not rules_file.exists():
+        old_sua = repo_path / CALIFORNIA_SNAP_OLD_SUA_RELATIVE
+        if not rules_file.exists() and not (
+            relative_output == CALIFORNIA_SNAP_SUA_RELATIVE and old_sua.exists()
+        ):
             print(f"RuleSpec file not found: {rules_file}")
             sys.exit(1)
     try:
@@ -3501,15 +3514,22 @@ def cmd_repair_california_snap_shelter_surface(args):
     tracked_files = _unique_paths(
         [path for _relative_output, files in manifest_groups for path in files]
     )
+    migration_files = [
+        repo_path / CALIFORNIA_SNAP_OLD_SUA_RELATIVE,
+        _rulespec_test_path(repo_path / CALIFORNIA_SNAP_OLD_SUA_RELATIVE),
+        repo_path / _applied_encoding_manifest_path(CALIFORNIA_SNAP_OLD_SUA_RELATIVE),
+    ]
     preexisting_changed_files = _changed_manifest_group_files(
         repo_path,
         manifest_groups,
     )
     originals = {
-        path: path.read_text() if path.exists() else None for path in tracked_files
+        path: path.read_text() if path.exists() else None
+        for path in _unique_paths(tracked_files + migration_files)
     }
 
     try:
+        _migrate_california_snap_sua_layout(repo_path)
         _repair_california_snap_policy_composition(
             repo_path / CALIFORNIA_SNAP_PROGRAM_RELATIVE
         )
@@ -3555,7 +3575,7 @@ def _california_snap_repair_manifest_groups(
         rules_file = repo_path / relative_output
         test_file = _rulespec_test_path(rules_file)
         files = [rules_file]
-        if test_file.exists():
+        if test_file.exists() or relative_output == CALIFORNIA_SNAP_SUA_RELATIVE:
             files.append(test_file)
         groups.append((relative_output, files))
     return groups
@@ -3609,8 +3629,45 @@ def _write_california_snap_repair_manifests(
     return manifest_paths
 
 
+def _migrate_california_snap_sua_layout(repo_path: Path) -> None:
+    """Move generated CA SUA RuleSpec out of the disallowed guidance/ root."""
+    old_rules_file = repo_path / CALIFORNIA_SNAP_OLD_SUA_RELATIVE
+    old_test_file = _rulespec_test_path(old_rules_file)
+    old_manifest_file = repo_path / _applied_encoding_manifest_path(
+        CALIFORNIA_SNAP_OLD_SUA_RELATIVE
+    )
+    new_rules_file = repo_path / CALIFORNIA_SNAP_SUA_RELATIVE
+    new_test_file = _rulespec_test_path(new_rules_file)
+
+    for old_file, new_file in (
+        (old_rules_file, new_rules_file),
+        (old_test_file, new_test_file),
+    ):
+        if not old_file.exists() and not new_file.exists():
+            continue
+        if old_file.exists():
+            content = old_file.read_text()
+        else:
+            content = new_file.read_text()
+        content = content.replace(
+            CALIFORNIA_SNAP_OLD_SUA_IMPORT,
+            CALIFORNIA_SNAP_SUA_IMPORT,
+        )
+        new_file.parent.mkdir(parents=True, exist_ok=True)
+        new_file.write_text(content)
+        if old_file.exists():
+            old_file.unlink()
+
+    if old_manifest_file.exists():
+        old_manifest_file.unlink()
+
+
 def _repair_california_snap_policy_composition(path: Path) -> None:
     content = path.read_text()
+    content = content.replace(
+        CALIFORNIA_SNAP_OLD_SUA_IMPORT,
+        CALIFORNIA_SNAP_SUA_IMPORT,
+    )
     content = _ensure_yaml_import_text(
         content,
         CALIFORNIA_SNAP_SUA_IMPORT,
@@ -3674,6 +3731,10 @@ def _california_snap_member_eligible_rule() -> dict[str, object]:
 
 def _repair_california_snap_program_tests(path: Path) -> None:
     content = path.read_text()
+    content = content.replace(
+        CALIFORNIA_SNAP_OLD_SUA_IMPORT,
+        CALIFORNIA_SNAP_SUA_IMPORT,
+    )
     content = content.replace(
         "us:statutes/7/2012/j#relation.member_of_household",
         "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#relation.member_of_household",
@@ -3739,9 +3800,11 @@ def _repair_california_snap_program_tests(path: Path) -> None:
     )
     base_shelter_input = "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0\n"
     base_sua_input = (
-        "    ? us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage\n"
+        "    ? us-ca:policies/cdss/snap/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage\n"
         "    : false\n"
     )
+    while base_sua_input + base_sua_input in content:
+        content = content.replace(base_sua_input + base_sua_input, base_sua_input)
     if base_shelter_input in content and base_sua_input not in content:
         content = content.replace(
             base_shelter_input,
@@ -3776,9 +3839,14 @@ def _repair_california_snap_program_tests(path: Path) -> None:
     )
     shelter_case_input = "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500\n"
     shelter_sua_input = (
-        "    ? us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage\n"
+        "    ? us-ca:policies/cdss/snap/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage\n"
         "    : true\n"
     )
+    while shelter_sua_input + shelter_sua_input in content:
+        content = content.replace(
+            shelter_sua_input + shelter_sua_input,
+            shelter_sua_input,
+        )
     if shelter_case_input in content and shelter_sua_input not in content:
         content = content.replace(
             shelter_case_input,
@@ -3788,7 +3856,7 @@ def _repair_california_snap_program_tests(path: Path) -> None:
     for old_shelter_output in ("204", "204.5"):
         content = content.replace(
             f"    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: {old_shelter_output}\n",
-            "    us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#snap_standard_utility_allowance: 663\n"
+            "    us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance: 663\n"
             "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#shelter_costs: 1163\n"
             "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 744\n",
         )

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3674,6 +3674,23 @@ def _california_snap_member_eligible_rule() -> dict[str, object]:
 
 def _repair_california_snap_program_tests(path: Path) -> None:
     content = path.read_text()
+    if "us:regulations/7-cfr/273/10#input.household_size:" not in content:
+        content = content.replace(
+            "    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1\n",
+            "    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1\n"
+            "    us:regulations/7-cfr/273/10#input.household_size: 1\n",
+            1,
+        )
+    if (
+        "us:regulations/7-cfr/273/8#input.snap_categorically_eligible_for_resource_exemption:"
+        not in content
+    ):
+        content = content.replace(
+            "    us:regulations/7-cfr/273/3#input.household_contains_individual_participating_in_more_than_one_household_or_project_area: false\n",
+            "    us:regulations/7-cfr/273/3#input.household_contains_individual_participating_in_more_than_one_household_or_project_area: false\n"
+            "    us:regulations/7-cfr/273/8#input.snap_categorically_eligible_for_resource_exemption: false\n",
+            1,
+        )
     content = content.replace(
         "us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 0",
         "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0",
@@ -3692,6 +3709,17 @@ def _repair_california_snap_program_tests(path: Path) -> None:
         content = content.replace(
             base_shelter_input,
             base_shelter_input + base_sua_input,
+            1,
+        )
+    if (
+        "us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_one_person_household:"
+        not in content
+    ):
+        content = content.replace(
+            base_shelter_input + base_sua_input,
+            base_shelter_input
+            + base_sua_input
+            + "    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_one_person_household: 298\n",
             1,
         )
     content = content.replace(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1044,6 +1044,25 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_ca_snap_refs_parser = subparsers.add_parser(
+        "repair-california-snap-shelter-surface",
+        help="Apply signed deterministic repairs for California SNAP shelter and member surface drift",
+    )
+    repair_ca_snap_refs_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="rulespec-us-ca repository root used for manifest signing",
+    )
+    repair_ca_snap_refs_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     # test command
     test_parser = subparsers.add_parser(
         "test", help="Execute RuleSpec companion .test.yaml cases"
@@ -1641,6 +1660,8 @@ def main():
         cmd_repair_missing_source_proofs(args)
     elif args.command == "repair-colorado-snap-federal-refs":
         cmd_repair_colorado_snap_federal_refs(args)
+    elif args.command == "repair-california-snap-shelter-surface":
+        cmd_repair_california_snap_shelter_surface(args)
     elif args.command == "encode":
         cmd_encode(args)
     elif args.command == "eval":
@@ -3262,6 +3283,15 @@ COLORADO_SNAP_REPAIR_RELATIVE_OUTPUTS = (
     COLORADO_SNAP_CCR_ROOT / "4.407.3.yaml",
 )
 
+CALIFORNIA_SNAP_SHELTER_SURFACE_REPAIR_MODEL = "california-snap-shelter-surface-v1"
+CALIFORNIA_SNAP_PROGRAM_RELATIVE = Path(
+    "policies/cdss/snap/fy-2026-benefit-calculation.yaml"
+)
+CALIFORNIA_SNAP_SUA_IMPORT = (
+    "us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance"
+)
+CALIFORNIA_SNAP_REPAIR_RELATIVE_OUTPUTS = (CALIFORNIA_SNAP_PROGRAM_RELATIVE,)
+
 
 def cmd_repair_colorado_snap_federal_refs(args):
     """Apply signed deterministic repairs for Colorado SNAP federal ref drift."""
@@ -3438,6 +3468,257 @@ def _write_colorado_snap_repair_manifests(
                 )
             )
     return manifest_paths
+
+
+def cmd_repair_california_snap_shelter_surface(args):
+    """Apply signed deterministic repairs for California SNAP composition drift."""
+    repo_path = Path(args.repo).resolve()
+    if _repo_jurisdiction_prefix(repo_path) != "us-ca":
+        print(
+            "repair-california-snap-shelter-surface must run against "
+            f"rulespec-us-ca; got {repo_path}"
+        )
+        sys.exit(1)
+
+    manifest_groups = _california_snap_repair_manifest_groups(repo_path)
+    for relative_output, _files in manifest_groups:
+        rules_file = repo_path / relative_output
+        if not rules_file.exists():
+            print(f"RuleSpec file not found: {rules_file}")
+            sys.exit(1)
+    try:
+        _ensure_no_unmanifested_preexisting_rulespec_changes(
+            repo_path,
+            manifest_groups,
+        )
+    except RuntimeError as exc:
+        print(str(exc))
+        sys.exit(1)
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+
+    tracked_files = _unique_paths(
+        [path for _relative_output, files in manifest_groups for path in files]
+    )
+    preexisting_changed_files = _changed_manifest_group_files(
+        repo_path,
+        manifest_groups,
+    )
+    originals = {
+        path: path.read_text() if path.exists() else None for path in tracked_files
+    }
+
+    try:
+        _repair_california_snap_policy_composition(
+            repo_path / CALIFORNIA_SNAP_PROGRAM_RELATIVE
+        )
+        _repair_california_snap_program_tests(
+            _rulespec_test_path(repo_path / CALIFORNIA_SNAP_PROGRAM_RELATIVE)
+        )
+
+        changed_by_command = _unique_paths(
+            [
+                path
+                for path in tracked_files
+                if _path_differs_from_original(path, originals.get(path))
+            ]
+        )
+        changed_files = _unique_paths(preexisting_changed_files + changed_by_command)
+        if not changed_files:
+            print("No California SNAP shelter surface repairs found.")
+            return
+    except Exception:
+        _restore_original_files(originals)
+        raise
+
+    manifest_paths = _write_california_snap_repair_manifests(
+        repo_path=repo_path,
+        signing_key=signing_key,
+        axiom_encode_git=axiom_encode_git,
+        manifest_groups=manifest_groups,
+        changed_files=changed_files,
+    )
+
+    print("Applied California SNAP shelter surface repair")
+    for path in changed_files:
+        print(f"changed={path.relative_to(repo_path)}")
+    for manifest_path in manifest_paths:
+        print(f"manifest={manifest_path}")
+
+
+def _california_snap_repair_manifest_groups(
+    repo_path: Path,
+) -> list[tuple[Path, list[Path]]]:
+    groups: list[tuple[Path, list[Path]]] = []
+    for relative_output in CALIFORNIA_SNAP_REPAIR_RELATIVE_OUTPUTS:
+        rules_file = repo_path / relative_output
+        test_file = _rulespec_test_path(rules_file)
+        files = [rules_file]
+        if test_file.exists():
+            files.append(test_file)
+        groups.append((relative_output, files))
+    return groups
+
+
+def _write_california_snap_repair_manifests(
+    *,
+    repo_path: Path,
+    signing_key: str,
+    axiom_encode_git: dict[str, object],
+    manifest_groups: list[tuple[Path, list[Path]]],
+    changed_files: list[Path],
+) -> list[Path]:
+    changed = {path.resolve() for path in changed_files}
+    manifest_paths: list[Path] = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        for relative_output, files in manifest_groups:
+            applied_files = [path for path in files if path.resolve() in changed]
+            if not applied_files:
+                continue
+            generated_output = output_root / "deterministic-repair" / relative_output
+            generated_output.parent.mkdir(parents=True, exist_ok=True)
+            generated_output.write_text((repo_path / relative_output).read_text())
+            result = argparse.Namespace(
+                output_file=str(generated_output),
+                runner="deterministic-repair",
+                backend="deterministic",
+                model=CALIFORNIA_SNAP_SHELTER_SURFACE_REPAIR_MODEL,
+                tool="axiom-encode repair-california-snap-shelter-surface",
+                citation=(
+                    f"{_repo_jurisdiction_prefix(repo_path)}:"
+                    f"{_relative_rulespec_import_target(relative_output)}"
+                ),
+                generation_prompt_sha256=None,
+                trace_file=None,
+                context_manifest_file=None,
+            )
+            manifest_paths.append(
+                _write_applied_encoding_manifest(
+                    result,
+                    output_root=output_root,
+                    policy_repo_path=repo_path,
+                    relative_output=relative_output,
+                    applied_files=applied_files,
+                    run_id="deterministic-repair",
+                    signing_key=signing_key,
+                    axiom_encode_git=axiom_encode_git,
+                )
+            )
+    return manifest_paths
+
+
+def _repair_california_snap_policy_composition(path: Path) -> None:
+    content = path.read_text()
+    content = _ensure_yaml_import_text(
+        content,
+        CALIFORNIA_SNAP_SUA_IMPORT,
+        before_import="us-ca:regulations/mpp/63-503/324",
+    )
+    content = _upsert_rules_text(
+        content,
+        [
+            _derived_money_bridge_rule(
+                "shelter_costs",
+                "household_shelter_costs_incurred + snap_standard_utility_allowance",
+                source="California CalFresh shelter utility allowance composition bridge",
+            ),
+            _derived_money_bridge_rule(
+                "snap_total_allowable_shelter_expenses",
+                "shelter_costs",
+                source="California CalFresh shelter utility allowance composition bridge",
+            ),
+            _california_snap_member_eligible_rule(),
+            _derived_judgment_bridge_rule(
+                "snap_residency_eligible",
+                "snap_household_residency_eligible",
+                source="California CalFresh SNAP eligibility composition bridge",
+            ),
+            _derived_judgment_bridge_rule(
+                "snap_household_member_eligible",
+                "count_where(member_of_household, snap_member_eligible) > 0",
+                source="California CalFresh SNAP eligibility composition bridge",
+            ),
+            _derived_judgment_bridge_rule(
+                "snap_eligible",
+                (
+                    "snap_residency_eligible\n"
+                    "and snap_household_member_eligible\n"
+                    "and snap_resource_eligible\n"
+                    "and snap_standard_income_eligible"
+                ),
+                source="California CalFresh SNAP eligibility composition bridge",
+            ),
+        ],
+    )
+    path.write_text(content)
+
+
+def _california_snap_member_eligible_rule() -> dict[str, object]:
+    return _bridge_rule(
+        name="snap_member_eligible",
+        kind="derived",
+        dtype="Judgment",
+        formula=(
+            "snap_member_citizenship_or_alien_status_eligible\n"
+            "and snap_member_ssn_requirement_eligible\n"
+            "and snap_member_work_requirement_eligible\n"
+            "and snap_member_student_eligible"
+        ),
+        source="California CalFresh SNAP eligibility member composition bridge",
+        entity="Person",
+        period="Month",
+    )
+
+
+def _repair_california_snap_program_tests(path: Path) -> None:
+    content = path.read_text()
+    content = content.replace(
+        "us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 0",
+        "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 0",
+    )
+    content = content.replace(
+        "us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 500",
+        "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500",
+    )
+    content = content.replace(
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_ssn_eligible: holds\n"
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_work_requirement_eligible: holds\n"
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_student_eligible: holds\n"
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_residency_citizenship_eligible: holds\n",
+        "",
+    )
+    content = content.replace(
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_residency_citizenship_eligible: not_holds\n",
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_household_member_eligible: not_holds\n",
+    )
+    shelter_case_input = (
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500\n"
+    )
+    if (
+        shelter_case_input in content
+        and "standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage"
+        not in content
+    ):
+        content = content.replace(
+            shelter_case_input,
+            shelter_case_input
+            + "    ? us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage\n"
+            + "    : true\n",
+            1,
+        )
+    content = content.replace(
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 204.5\n",
+        "    us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#snap_standard_utility_allowance: 663\n"
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#shelter_costs: 1163\n"
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 744\n",
+    )
+    content = content.replace(
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_benefit: 182\n",
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_benefit: 298\n",
+    )
+    path.write_text(content)
 
 
 def _repair_colorado_snap_policy_composition(path: Path) -> None:
@@ -3694,13 +3975,18 @@ def _derived_money_bridge_rule(
     )
 
 
-def _derived_judgment_bridge_rule(name: str, formula: str) -> dict[str, object]:
+def _derived_judgment_bridge_rule(
+    name: str,
+    formula: str,
+    *,
+    source: str = "Colorado SNAP federal surface bridge",
+) -> dict[str, object]:
     return _bridge_rule(
         name=name,
         kind="derived",
         dtype="Judgment",
         formula=formula,
-        source="Colorado SNAP federal surface bridge",
+        source=source,
         entity="Household",
         period="Month",
     )

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3664,6 +3664,15 @@ def _migrate_california_snap_sua_layout(repo_path: Path) -> None:
 
 def _repair_california_snap_policy_composition(path: Path) -> None:
     content = path.read_text()
+    if "  source_verification:" not in content:
+        content = content.replace(
+            "module:\n  kind: composition\n",
+            "module:\n"
+            "  kind: composition\n"
+            "  source_verification:\n"
+            "    corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1\n",
+            1,
+        )
     content = content.replace(
         CALIFORNIA_SNAP_OLD_SUA_IMPORT,
         CALIFORNIA_SNAP_SUA_IMPORT,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3677,6 +3677,7 @@ def _repair_california_snap_policy_composition(path: Path) -> None:
         CALIFORNIA_SNAP_OLD_SUA_IMPORT,
         CALIFORNIA_SNAP_SUA_IMPORT,
     )
+    content = _ensure_california_snap_member_relation_rule_text(content)
     content = _ensure_yaml_import_text(
         content,
         CALIFORNIA_SNAP_SUA_IMPORT,
@@ -3721,6 +3722,26 @@ def _repair_california_snap_policy_composition(path: Path) -> None:
     path.write_text(content)
 
 
+def _ensure_california_snap_member_relation_rule_text(content: str) -> str:
+    if "\n  - name: member_of_household\n" in f"\n{content}":
+        return content
+    relation_rule = """  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      predicate: member_of_household
+      arity: 2
+      arguments:
+        - Person
+        - Household
+"""
+    marker = "\n  - name: shelter_costs\n"
+    if marker in content:
+        return content.replace(marker, f"\n{relation_rule}{marker}", 1)
+    if not content.endswith("\n"):
+        content += "\n"
+    return f"{content}{relation_rule}"
+
+
 def _california_snap_member_eligible_rule() -> dict[str, object]:
     return _bridge_rule(
         name="snap_member_eligible",
@@ -3748,6 +3769,12 @@ def _repair_california_snap_program_tests(path: Path) -> None:
         "us:statutes/7/2012/j#relation.member_of_household",
         "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#relation.member_of_household",
     )
+    content = re.sub(
+        r"\n- name: member_eligibility_bridge_holds_for_basic_eligible_member\n.*?(?=\n- name: |\Z)",
+        "",
+        content,
+        flags=re.S,
+    )
     base_output_anchor = (
         "  output:\n"
         "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_gross_monthly_income: 0\n"
@@ -3758,7 +3785,6 @@ def _repair_california_snap_program_tests(path: Path) -> None:
         "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_countable_unearned_income: 0\n"
         "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_gross_monthly_income: 0\n"
         "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_residency_eligible: holds\n"
-        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_member_eligible: holds\n"
         "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_household_member_eligible: holds\n"
         "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#shelter_costs: 0\n"
         "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_total_allowable_shelter_expenses: 0\n"
@@ -3770,6 +3796,11 @@ def _repair_california_snap_program_tests(path: Path) -> None:
         and base_output_anchor in content
     ):
         content = content.replace(base_output_anchor, base_output_coverage, 1)
+    content = content.replace(
+        "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_member_eligible: holds\n",
+        "",
+    )
+    content = content.rstrip() + "\n\n" + _california_snap_member_test_case()
     if "us:regulations/7-cfr/273/10#input.household_size:" not in content:
         content = content.replace(
             "    us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#input.household_size: 1\n",
@@ -3896,6 +3927,42 @@ def _repair_california_snap_program_tests(path: Path) -> None:
         "    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_benefit: 298\n",
     )
     path.write_text(content)
+
+
+def _california_snap_member_test_case() -> str:
+    return """- name: member_eligibility_bridge_holds_for_basic_eligible_member
+  period: 2026-01
+  input:
+    us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
+    us:regulations/7-cfr/273/4#input.member_is_us_citizen: true
+    us:regulations/7-cfr/273/4#input.member_is_us_noncitizen_national: false
+    us:regulations/7-cfr/273/5#input.enrolled_at_least_half_time: false
+    us:regulations/7-cfr/273/6#input.member_refused_or_failed_to_provide_or_apply_for_ssn: false
+    us:regulations/7-cfr/273/6#input.member_has_documentary_or_collateral_evidence_of_ssn_application_or_every_effort: false
+    us:regulations/7-cfr/273/6#input.state_agency_fault_in_ssn_application_processing: false
+    us:regulations/7-cfr/273/6#input.member_unable_to_obtain_documents_required_for_ssn_application_with_caseworker_assistance_needed: false
+    us:regulations/7-cfr/273/6#input.member_ssn_application_filed_pending_state_agency_notification: false
+    us:regulations/7-cfr/273/6#input.member_later_provided_ssn_ending_disqualification: false
+    us:regulations/7-cfr/273/7#input.member_age: 60
+    us:regulations/7-cfr/273/4#input.member_is_american_indian_born_in_canada_or_recognized_indian_tribe_member: false
+    us:regulations/7-cfr/273/4#input.member_is_hmong_or_highland_laotian_qualifying_person_or_family_member: false
+    us:regulations/7-cfr/273/4#input.member_is_trafficking_victim_or_qualifying_family_member: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_with_forty_qualifying_quarters: false
+    us:regulations/7-cfr/273/4#input.member_is_refugee: false
+    us:regulations/7-cfr/273/4#input.member_is_asylee: false
+    us:regulations/7-cfr/273/4#input.member_has_deportation_or_removal_withheld: false
+    us:regulations/7-cfr/273/4#input.member_is_cuban_or_haitian_entrant: false
+    us:regulations/7-cfr/273/4#input.member_is_amerasian_immigrant: false
+    us:regulations/7-cfr/273/4#input.member_has_eligible_military_connection: false
+    us:regulations/7-cfr/273/4#input.member_receives_blindness_or_disability_benefits: false
+    us:regulations/7-cfr/273/4#input.member_was_lawfully_residing_on_1996_08_22_and_born_on_or_before_1931_08_22: false
+    us:regulations/7-cfr/273/4#input.member_is_under_age_eighteen: false
+    us:regulations/7-cfr/273/4#input.member_is_qualified_alien_subject_to_five_year_wait: false
+    us:regulations/7-cfr/273/4#input.qualified_alien_five_year_status_period_met: false
+    us:regulations/7-cfr/273/4#input.alien_status_documentation_missing_or_unwilling: false
+  output:
+    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_member_eligible: holds
+"""
 
 
 def _repair_colorado_snap_policy_composition(path: Path) -> None:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3716,7 +3716,18 @@ def _repair_california_snap_program_tests(path: Path) -> None:
         content = content.replace(
             "    us:regulations/7-cfr/273/3#input.household_contains_individual_participating_in_more_than_one_household_or_project_area: false\n",
             "    us:regulations/7-cfr/273/3#input.household_contains_individual_participating_in_more_than_one_household_or_project_area: false\n"
+            "    us:regulations/7-cfr/273/3#input.resident_of_battered_women_and_children_shelter_and_prior_abusive_household_member: false\n"
             "    us:regulations/7-cfr/273/8#input.snap_categorically_eligible_for_resource_exemption: false\n",
+            1,
+        )
+    elif (
+        "us:regulations/7-cfr/273/3#input.resident_of_battered_women_and_children_shelter_and_prior_abusive_household_member:"
+        not in content
+    ):
+        content = content.replace(
+            "    us:regulations/7-cfr/273/3#input.household_contains_individual_participating_in_more_than_one_household_or_project_area: false\n",
+            "    us:regulations/7-cfr/273/3#input.household_contains_individual_participating_in_more_than_one_household_or_project_area: false\n"
+            "    us:regulations/7-cfr/273/3#input.resident_of_battered_women_and_children_shelter_and_prior_abusive_household_member: false\n",
             1,
         )
     content = content.replace(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5616,6 +5616,17 @@ def _repair_new_york_snap_benefit_tests(content: str) -> str:
         flags=re.MULTILINE,
     )
     repaired = re.sub(
+        r"^    us-ny:regulations/18-nycrr/387/14/a/1#input\."
+        r"(initial_application_month|application_date|"
+        r"public_institution_joint_ssi_snap_application_before_release|"
+        r"public_institution_release_date|"
+        r"migrant_or_seasonal_farmworker_household_in_job_stream|"
+        r"break_in_participation_days): .*\n",
+        "",
+        repaired,
+        flags=re.MULTILINE,
+    )
+    repaired = re.sub(
         r"^    us-ny:regulations/18-nycrr/387/12/f/3/v/[abc]#"
         r"snap_(standard|limited|individual)_utility_allowance: .*\n",
         "",

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5569,7 +5569,7 @@ NY_SNAP_BENEFIT_RELATIVE = Path("policies/otda/snap/fy-2026-benefit-calculation.
 
 
 def _repair_new_york_snap_benefit_rules(content: str) -> str:
-    return content.replace(
+    repaired = content.replace(
         "          snap_income_eligible\n"
         "          and (snap_resource_eligible or ny_snap_categorically_eligible)\n",
         "          (\n"
@@ -5579,6 +5579,12 @@ def _repair_new_york_snap_benefit_rules(content: str) -> str:
         "          and (snap_resource_eligible or ny_snap_categorically_eligible)\n",
         1,
     )
+    repaired = repaired.replace(
+        "        formula: count_where(member_of_household, snap_member_ssn_requirement_eligible) > 0\n",
+        "        formula: count_where(member_of_household, snap_member_ssn_requirement_ineligible) == 0\n",
+        1,
+    )
+    return repaired
 
 
 def _repair_new_york_snap_benefit_tests(content: str) -> str:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1101,6 +1101,25 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_ny_snap_benefit_tests_parser = subparsers.add_parser(
+        "repair-new-york-snap-benefit-tests",
+        help="Apply signed deterministic repairs for New York SNAP benefit companion tests",
+    )
+    repair_ny_snap_benefit_tests_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="rulespec-us-ny repository root used for manifest signing",
+    )
+    repair_ny_snap_benefit_tests_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     # test command
     test_parser = subparsers.add_parser(
         "test", help="Execute RuleSpec companion .test.yaml cases"
@@ -1704,6 +1723,8 @@ def main():
         cmd_repair_snap_273_10_allotment(args)
     elif args.command == "repair-new-york-snap-categorical-eligibility":
         cmd_repair_new_york_snap_categorical_eligibility(args)
+    elif args.command == "repair-new-york-snap-benefit-tests":
+        cmd_repair_new_york_snap_benefit_tests(args)
     elif args.command == "encode":
         cmd_encode(args)
     elif args.command == "eval":
@@ -5540,6 +5561,145 @@ def cmd_repair_new_york_snap_categorical_eligibility(args):
 
     print("Applied New York SNAP categorical eligibility repair")
     print(f"changed={relative_output}")
+    print(f"changed={_rulespec_test_path(relative_output)}")
+    print(f"manifest={manifest_path}")
+
+
+NY_SNAP_BENEFIT_RELATIVE = Path("policies/otda/snap/fy-2026-benefit-calculation.yaml")
+
+
+def _repair_new_york_snap_benefit_tests(content: str) -> str:
+    repaired = content.replace(
+        "us-ny:regulations/18-nycrr/387/14/a/5#input."
+        "household_member_failed_periodic_reporting_requirement",
+        "us-ny:regulations/18-nycrr/387/14/a/5#input."
+        "household_member_disqualified_for_failure_to_comply_with_periodic_reporting_requirements",
+    )
+    repaired = repaired.replace(
+        "us-ny:regulations/18-nycrr/387/14/a/5#input."
+        "household_member_failed_snap_work_requirements",
+        "us-ny:regulations/18-nycrr/387/14/a/5#input."
+        "household_member_disqualified_for_failure_to_comply_with_work_requirements",
+    )
+    if (
+        "us-ny:regulations/18-nycrr/387/14/a/5#input."
+        "household_member_ineligible_to_participate_in_snap" not in repaired
+    ):
+        repaired = repaired.replace(
+            "    us-ny:regulations/18-nycrr/387/14/a/5#input."
+            "household_member_disqualified_for_failure_to_comply_with_work_requirements: false\n",
+            "    us-ny:regulations/18-nycrr/387/14/a/5#input."
+            "household_member_disqualified_for_failure_to_comply_with_work_requirements: false\n"
+            "    us-ny:regulations/18-nycrr/387/14/a/5#input."
+            "household_member_ineligible_to_participate_in_snap: false\n",
+            1,
+        )
+    output_ref = (
+        "us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+        "#ny_snap_excess_shelter_cost"
+    )
+    if output_ref not in repaired:
+        repaired = repaired.replace(
+            "    us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+            "#shelter_costs: 1562\n"
+            "    us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+            "#snap_excess_shelter_deduction: 744\n",
+            "    us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+            "#shelter_costs: 1562\n"
+            "    us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+            "#ny_snap_excess_shelter_cost: 1266.5\n"
+            "    us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+            "#snap_excess_shelter_deduction: 744\n",
+            1,
+        )
+    return repaired
+
+
+def cmd_repair_new_york_snap_benefit_tests(args):
+    """Apply a signed deterministic repair for NY SNAP benefit companion tests."""
+    repo_path = Path(args.repo).resolve()
+    if _repo_jurisdiction_prefix(repo_path) != "us-ny":
+        print(
+            "repair-new-york-snap-benefit-tests must run against "
+            f"rulespec-us-ny; got {repo_path}"
+        )
+        sys.exit(1)
+
+    relative_output = NY_SNAP_BENEFIT_RELATIVE
+    rules_file = repo_path / relative_output
+    test_file = _rulespec_test_path(rules_file)
+    if not rules_file.exists():
+        print(f"RuleSpec file not found: {rules_file}")
+        sys.exit(1)
+    if not test_file.exists():
+        print(f"RuleSpec companion test file not found: {test_file}")
+        sys.exit(1)
+
+    original_test_content = test_file.read_text()
+    repaired_test_content = _repair_new_york_snap_benefit_tests(original_test_content)
+    if repaired_test_content == original_test_content:
+        print("No New York SNAP benefit test repairs found.")
+        return
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        generated_output = output_root / "deterministic-repair" / relative_output
+        generated_output.parent.mkdir(parents=True, exist_ok=True)
+        generated_output.write_text(rules_file.read_text())
+        generated_test = _rulespec_test_path(generated_output)
+        generated_test.write_text(repaired_test_content)
+
+        test_file.write_text(repaired_test_content)
+        try:
+            validation = ValidatorPipeline(
+                policy_repo_path=repo_path,
+                axiom_rules_path=axiom_rules_path,
+                enable_oracles=False,
+                require_policy_proofs=True,
+            ).validate(rules_file, skip_reviewers=True)
+            if not validation.all_passed:
+                issues = [
+                    result.error
+                    for result in validation.results.values()
+                    if result.error
+                ]
+                print("Repair failed validation; restored original file.")
+                for issue in issues:
+                    print(f"- {issue}")
+                sys.exit(1)
+        finally:
+            if "validation" not in locals() or not validation.all_passed:
+                test_file.write_text(original_test_content)
+
+        result = argparse.Namespace(
+            output_file=str(generated_output),
+            runner="deterministic-repair",
+            backend="deterministic",
+            model="ny-snap-benefit-tests-v1",
+            tool="axiom-encode repair-new-york-snap-benefit-tests",
+            citation="us-ny:policies/otda/snap/fy-2026-benefit-calculation",
+            generation_prompt_sha256=None,
+            trace_file=None,
+            context_manifest_file=None,
+        )
+        manifest_path = _write_applied_encoding_manifest(
+            result,
+            output_root=output_root,
+            policy_repo_path=repo_path,
+            relative_output=relative_output,
+            applied_files=[rules_file, test_file],
+            run_id="deterministic-repair",
+            signing_key=signing_key,
+            axiom_encode_git=axiom_encode_git,
+        )
+
+    print("Applied New York SNAP benefit companion-test repair")
     print(f"changed={_rulespec_test_path(relative_output)}")
     print(f"manifest={manifest_path}")
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5472,20 +5472,39 @@ def _repair_new_york_snap_categorical_eligibility_rules(content: str) -> str:
 
 
 def _repair_new_york_snap_categorical_eligibility_tests(content: str) -> str:
-    repaired = re.sub(
-        r"(    us:statutes/7/2012/j#relation\.member_of_household:\n"
-        r"      - us:statutes/7/2012/j#input\.snap_member_is_elderly_or_disabled: .*\n)"
-        r"    us-ny:regulations/18-nycrr/387/14/a/5#relation\.member_of_household:\n"
-        r"      - (us-ny:regulations/18-nycrr/387/14/a/5#input\.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: .*\n)"
-        r"        (us-ny:regulations/18-nycrr/387/14/a/5#input\.member_authorized_to_receive_family_assistance_nonemergency_safety_net_or_ssi_benefits_but_not_yet_paid: .*\n)"
-        r"        (us-ny:regulations/18-nycrr/387/14/a/5#input\.member_family_assistance_nonemergency_safety_net_or_ssi_benefits_suspended_or_being_recouped: .*\n)"
-        r"        (us-ny:regulations/18-nycrr/387/14/a/5#input\.member_determined_eligible_for_family_assistance_or_nonemergency_safety_net_benefits: .*\n)"
-        r"        (us-ny:regulations/18-nycrr/387/14/a/5#input\.member_paid_family_assistance_or_nonemergency_safety_net_benefits: .*\n)"
-        r"        (us-ny:regulations/18-nycrr/387/14/a/5#input\.member_family_assistance_or_nonemergency_safety_net_grant_amount: .*\n)",
-        r"\1        \2        \3        \4        \5        \6        \7",
-        content,
-        flags=re.MULTILINE,
-    )
+    us_relation = "us:statutes/7/2012/j#relation.member_of_household"
+    ny_relation = "us-ny:regulations/18-nycrr/387/14/a/5#relation.member_of_household"
+    elderly_input = "us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled"
+    try:
+        payload = yaml.safe_load(content)
+    except yaml.YAMLError:
+        payload = None
+    if isinstance(payload, list):
+        changed = False
+        for case in payload:
+            if not isinstance(case, dict):
+                continue
+            inputs = case.get("input")
+            if not isinstance(inputs, dict) or ny_relation not in inputs:
+                continue
+            ny_rows = inputs.pop(ny_relation)
+            us_rows = inputs.get(us_relation)
+            if not isinstance(ny_rows, list):
+                continue
+            if not isinstance(us_rows, list):
+                us_rows = [{} for _ in ny_rows]
+                inputs[us_relation] = us_rows
+            while len(us_rows) < len(ny_rows):
+                us_rows.append({})
+            for index, ny_row in enumerate(ny_rows):
+                if not isinstance(ny_row, dict) or not isinstance(us_rows[index], dict):
+                    continue
+                us_rows[index].setdefault(elderly_input, False)
+                us_rows[index].update(ny_row)
+            changed = True
+        repaired = yaml.safe_dump(payload, sort_keys=False) if changed else content
+    else:
+        repaired = content
     if (
         "all_members_public_assistance_path_makes_household_categorically_eligible"
         in repaired

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1063,6 +1063,25 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_snap_273_10_parser = subparsers.add_parser(
+        "repair-snap-273-10-allotment",
+        help="Apply signed deterministic repairs for 7 CFR 273.10 maximum-allotment drift",
+    )
+    repair_snap_273_10_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="rulespec-us repository root used for manifest signing",
+    )
+    repair_snap_273_10_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     # test command
     test_parser = subparsers.add_parser(
         "test", help="Execute RuleSpec companion .test.yaml cases"
@@ -1662,6 +1681,8 @@ def main():
         cmd_repair_colorado_snap_federal_refs(args)
     elif args.command == "repair-california-snap-shelter-surface":
         cmd_repair_california_snap_shelter_surface(args)
+    elif args.command == "repair-snap-273-10-allotment":
+        cmd_repair_snap_273_10_allotment(args)
     elif args.command == "encode":
         cmd_encode(args)
     elif args.command == "eval":
@@ -5108,6 +5129,135 @@ def cmd_repair_nonnegative_floors(args):
         "Applied nonnegative floor repair to "
         f"{relative_output}: {', '.join(repaired_rules)}"
     )
+    print(f"manifest={manifest_path}")
+
+
+def _repair_snap_273_10_allotment_rules(content: str) -> str:
+    content = _ensure_yaml_import_text(
+        content,
+        "us:policies/usda/snap/fy-2026-cola/maximum-allotments",
+        before_import="us:regulations/7-cfr/273/9",
+    )
+    return content.replace(
+        "snap_maximum_allotment_for_household_size",
+        "snap_maximum_allotment",
+    )
+
+
+def _repair_snap_273_10_allotment_tests(content: str) -> str:
+    return content.replace(
+        "    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_household_size: 298\n",
+        "    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1\n",
+    )
+
+
+def cmd_repair_snap_273_10_allotment(args):
+    """Apply a signed deterministic repair for the 273.10 allotment input drift."""
+    repo_path = Path(args.repo).resolve()
+    if _repo_jurisdiction_prefix(repo_path) != "us":
+        print(
+            "repair-snap-273-10-allotment must run against rulespec-us; "
+            f"got {repo_path}"
+        )
+        sys.exit(1)
+
+    relative_output = Path("regulations/7-cfr/273/10.yaml")
+    rules_file = repo_path / relative_output
+    test_file = _rulespec_test_path(rules_file)
+    if not rules_file.exists():
+        print(f"RuleSpec file not found: {rules_file}")
+        sys.exit(1)
+    if not test_file.exists():
+        print(f"RuleSpec companion test file not found: {test_file}")
+        sys.exit(1)
+
+    original_content = rules_file.read_text()
+    original_test_content = test_file.read_text()
+    repaired_content = _repair_snap_273_10_allotment_rules(original_content)
+    repaired_test_content = _repair_snap_273_10_allotment_tests(original_test_content)
+
+    applied_files = [rules_file, test_file]
+    if (
+        repaired_content == original_content
+        and repaired_test_content == original_test_content
+    ):
+        manifest_path = repo_path / _applied_encoding_manifest_path(relative_output)
+        if manifest_path.exists():
+            current_hashes = {
+                rules_file.relative_to(repo_path).as_posix(): _sha256_file(rules_file),
+                test_file.relative_to(repo_path).as_posix(): _sha256_file(test_file),
+            }
+            payload = json.loads(manifest_path.read_text())
+            manifest_hashes = {
+                item.get("path"): item.get("sha256")
+                for item in payload.get("applied_files", [])
+                if isinstance(item, dict)
+            }
+            if all(
+                manifest_hashes.get(path) == sha for path, sha in current_hashes.items()
+            ):
+                print("No 7 CFR 273.10 maximum-allotment repairs found.")
+                return
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        generated_output = output_root / "deterministic-repair" / relative_output
+        generated_output.parent.mkdir(parents=True, exist_ok=True)
+        generated_output.write_text(repaired_content)
+        generated_test = _rulespec_test_path(generated_output)
+        generated_test.write_text(repaired_test_content)
+
+        rules_file.write_text(repaired_content)
+        test_file.write_text(repaired_test_content)
+
+        validation = ValidatorPipeline(
+            policy_repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+            enable_oracles=False,
+            require_policy_proofs=True,
+        ).validate(rules_file, skip_reviewers=True)
+        if not validation.all_passed:
+            rules_file.write_text(original_content)
+            test_file.write_text(original_test_content)
+            issues = [
+                result.error for result in validation.results.values() if result.error
+            ]
+            print("Repair failed validation; restored original files.")
+            for issue in issues:
+                print(f"- {issue}")
+            sys.exit(1)
+
+        result = argparse.Namespace(
+            output_file=str(generated_output),
+            runner="deterministic-repair",
+            backend="deterministic",
+            model="snap-273-10-allotment-v1",
+            tool="axiom-encode repair-snap-273-10-allotment",
+            citation="us:regulations/7-cfr/273/10",
+            generation_prompt_sha256=None,
+            trace_file=None,
+            context_manifest_file=None,
+        )
+        manifest_path = _write_applied_encoding_manifest(
+            result,
+            output_root=output_root,
+            policy_repo_path=repo_path,
+            relative_output=relative_output,
+            applied_files=applied_files,
+            run_id="deterministic-repair",
+            signing_key=signing_key,
+            axiom_encode_git=axiom_encode_git,
+        )
+
+    print("Applied 7 CFR 273.10 maximum-allotment repair")
+    print(f"changed={relative_output}")
+    print(f"changed={_rulespec_test_path(relative_output)}")
     print(f"manifest={manifest_path}")
 
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5589,6 +5589,13 @@ def _repair_new_york_snap_benefit_tests(content: str) -> str:
         repaired,
         flags=re.MULTILINE,
     )
+    repaired = re.sub(
+        r"^    us-ny:regulations/18-nycrr/387/12/f/3/v/[abc]#"
+        r"snap_(standard|limited|individual)_utility_allowance: .*\n",
+        "",
+        repaired,
+        flags=re.MULTILINE,
+    )
     if (
         "us-ny:regulations/18-nycrr/387/14/a/5#input."
         "household_member_ineligible_to_participate_in_snap" not in repaired

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -132,7 +132,7 @@ JURISDICTION_CONFIGS = {
                 "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction"
             ),
             "snap_standard_utility_allowance": (
-                "us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#snap_standard_utility_allowance"
+                "us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance"
             ),
         },
         utility_allowance_labels=("snap_standard_utility_allowance",),

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -68,6 +68,7 @@ class JurisdictionConfig:
     output_id_by_label: dict[str, str]
     utility_allowance_labels: tuple[str, ...]
     relation_id: str
+    member_entity_type: str
     temp_prefix: str
     display_name: str
 
@@ -109,6 +110,7 @@ JURISDICTION_CONFIGS = {
             "snap_individual_utility_allowance",
         ),
         relation_id=AXIOM_RELATION_ID_BY_LABEL["member_of_household"],
+        member_entity_type="Member",
         temp_prefix="co-snap-pe-ecps-",
         display_name="Colorado SNAP",
     ),
@@ -139,6 +141,7 @@ JURISDICTION_CONFIGS = {
         relation_id=(
             "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#relation.member_of_household"
         ),
+        member_entity_type="Person",
         temp_prefix="ca-snap-pe-ecps-",
         display_name="California SNAP",
     ),
@@ -170,6 +173,7 @@ JURISDICTION_CONFIGS = {
             "snap_individual_utility_allowance",
         ),
         relation_id=AXIOM_RELATION_ID_BY_LABEL["member_of_household"],
+        member_entity_type="Member",
         temp_prefix="ny-snap-pe-ecps-",
         display_name="New York SNAP",
     ),
@@ -1292,7 +1296,7 @@ def money(value: Any) -> float:
 
 
 def native(value: Any) -> Any:
-    if isinstance(value, np.generic):
+    if np is not None and isinstance(value, np.generic):
         value = value.item()
     if isinstance(value, float):
         return money(value)
@@ -1352,6 +1356,7 @@ def run_axiom_cases(
     period: Period,
     output_ids: list[str],
     relation_id: str,
+    member_entity_type: str,
     env: dict[str, str],
 ) -> list[dict[str, Any]]:
     interval = {
@@ -1392,7 +1397,7 @@ def run_axiom_cases(
                 inputs.append(
                     {
                         "name": name,
-                        "entity": "Member",
+                        "entity": member_entity_type,
                         "entity_id": member_entity_id,
                         "interval": interval,
                         "value": scalar_value(value),
@@ -1700,6 +1705,7 @@ def main(args: argparse.Namespace | None = None) -> int:
             period=period,
             output_ids=list(config.output_id_by_label.values()),
             relation_id=config.relation_id,
+            member_entity_type=config.member_entity_type,
             env=env,
         )
 

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -71,6 +71,7 @@ class JurisdictionConfig:
     member_entity_type: str
     temp_prefix: str
     display_name: str
+    additional_relation_ids: tuple[str, ...] = ()
 
 
 JURISDICTION_CONFIGS = {
@@ -172,10 +173,18 @@ JURISDICTION_CONFIGS = {
             "snap_limited_utility_allowance",
             "snap_individual_utility_allowance",
         ),
-        relation_id=AXIOM_RELATION_ID_BY_LABEL["member_of_household"],
-        member_entity_type="Member",
+        relation_id=(
+            "us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+            "#relation.member_of_household"
+        ),
+        member_entity_type="Person",
         temp_prefix="ny-snap-pe-ecps-",
         display_name="New York SNAP",
+        additional_relation_ids=(
+            AXIOM_RELATION_ID_BY_LABEL["member_of_household"],
+            "us-ny:regulations/18-nycrr/387/14/a/5#relation."
+            "ny_snap_categorical_member_of_household",
+        ),
     ),
 }
 AXIOM_MEMBER_INPUT_ID_BY_LABEL = {
@@ -1116,6 +1125,7 @@ def load_policyengine_cases(
                 bool(values["meets_snap_work_requirements"][idx])
             )
         )
+        member_inputs.update(project_jurisdiction_member_inputs(config))
         member_inputs["snap_member_is_elderly_or_disabled"] = bool(
             values["has_usda_elderly_disabled"][idx]
         )
@@ -1153,9 +1163,26 @@ def project_jurisdiction_household_inputs(
             "household_has_earned_income_budgeted_for_snap": (
                 money(values["snap_earned_income"][idx]) > 0
             ),
-            "household_member_failed_snap_work_requirements": not bool(
-                values["meets_snap_work_requirements"][idx]
+            "household_member_disqualified_for_failure_to_comply_with_work_requirements": (
+                not bool(values["meets_snap_work_requirements"][idx])
             ),
+            "household_member_disqualified_for_failure_to_comply_with_periodic_reporting_requirements": False,
+            "household_member_disqualified_for_intentional_program_violation": False,
+            "household_member_ineligible_to_participate_in_snap": False,
+        }
+    return {}
+
+
+def project_jurisdiction_member_inputs(config: JurisdictionConfig) -> dict[str, Any]:
+    if config.jurisdiction == "us-ny":
+        base = "us-ny:regulations/18-nycrr/387/14/a/5#input."
+        return {
+            f"{base}member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits": False,
+            f"{base}member_authorized_to_receive_family_assistance_nonemergency_safety_net_or_ssi_benefits_but_not_yet_paid": False,
+            f"{base}member_family_assistance_nonemergency_safety_net_or_ssi_benefits_suspended_or_being_recouped": False,
+            f"{base}member_determined_eligible_for_family_assistance_or_nonemergency_safety_net_benefits": False,
+            f"{base}member_paid_family_assistance_or_nonemergency_safety_net_benefits": False,
+            f"{base}member_family_assistance_or_nonemergency_safety_net_grant_amount": 0,
         }
     return {}
 
@@ -1356,6 +1383,7 @@ def run_axiom_cases(
     period: Period,
     output_ids: list[str],
     relation_id: str,
+    additional_relation_ids: tuple[str, ...],
     member_entity_type: str,
     env: dict[str, str],
 ) -> list[dict[str, Any]]:
@@ -1386,13 +1414,14 @@ def run_axiom_cases(
             )
         for member_index, member_inputs in enumerate(case.member_inputs, 1):
             member_entity_id = f"{entity_id}-member-{member_index}"
-            relations.append(
-                {
-                    "name": relation_id,
-                    "tuple": [member_entity_id, entity_id],
-                    "interval": interval,
-                }
-            )
+            for current_relation_id in (relation_id, *additional_relation_ids):
+                relations.append(
+                    {
+                        "name": current_relation_id,
+                        "tuple": [member_entity_id, entity_id],
+                        "interval": interval,
+                    }
+                )
             for name, value in member_inputs.items():
                 inputs.append(
                     {
@@ -1705,6 +1734,7 @@ def main(args: argparse.Namespace | None = None) -> int:
             period=period,
             output_ids=list(config.output_id_by_label.values()),
             relation_id=config.relation_id,
+            additional_relation_ids=config.additional_relation_ids,
             member_entity_type=config.member_entity_type,
             env=env,
         )

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -155,8 +155,14 @@ JURISDICTION_CONFIGS = {
         ),
         output_id_by_label={
             **COMMON_AXIOM_OUTPUT_ID_BY_LABEL,
+            "snap_gross_monthly_income": (
+                "us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_gross_monthly_income"
+            ),
             "snap_eligible": (
                 "us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_eligible"
+            ),
+            "snap_excess_shelter_deduction": (
+                "us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction"
             ),
             "snap_standard_utility_allowance": (
                 "us-ny:regulations/18-nycrr/387/12/f/3/v/a#snap_standard_utility_allowance"
@@ -1096,6 +1102,7 @@ def load_policyengine_cases(
             **project_income_resource_inputs(config, values, idx),
             "household_size": int(values["snap_unit_size"][idx]),
             "household_shelter_costs_incurred": money(values["housing_cost"][idx]),
+            "us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction": 0,
             "household_lives_in_application_state": True,
             "household_in_project_area_solely_for_vacation": False,
             "household_contains_individual_participating_in_more_than_one_household_or_project_area": False,

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -67,6 +67,7 @@ class JurisdictionConfig:
     program_relative_path: Path
     output_id_by_label: dict[str, str]
     utility_allowance_labels: tuple[str, ...]
+    relation_id: str
     temp_prefix: str
     display_name: str
 
@@ -107,8 +108,39 @@ JURISDICTION_CONFIGS = {
             "snap_one_utility_allowance",
             "snap_individual_utility_allowance",
         ),
+        relation_id=AXIOM_RELATION_ID_BY_LABEL["member_of_household"],
         temp_prefix="co-snap-pe-ecps-",
         display_name="Colorado SNAP",
+    ),
+    "us-ca": JurisdictionConfig(
+        jurisdiction="us-ca",
+        state_code="CA",
+        repo_name="rulespec-us-ca",
+        program_relative_path=Path(
+            "policies/cdss/snap/fy-2026-benefit-calculation.yaml"
+        ),
+        output_id_by_label={
+            **COMMON_AXIOM_OUTPUT_ID_BY_LABEL,
+            "snap_regular_month_allotment": (
+                "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_benefit"
+            ),
+            "snap_net_income": "us:regulations/7-cfr/273/10#snap_net_monthly_income",
+            "snap_eligible": (
+                "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_eligible"
+            ),
+            "snap_excess_shelter_deduction": (
+                "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction"
+            ),
+            "snap_standard_utility_allowance": (
+                "us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#snap_standard_utility_allowance"
+            ),
+        },
+        utility_allowance_labels=("snap_standard_utility_allowance",),
+        relation_id=(
+            "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#relation.member_of_household"
+        ),
+        temp_prefix="ca-snap-pe-ecps-",
+        display_name="California SNAP",
     ),
     "us-ny": JurisdictionConfig(
         jurisdiction="us-ny",
@@ -137,6 +169,7 @@ JURISDICTION_CONFIGS = {
             "snap_limited_utility_allowance",
             "snap_individual_utility_allowance",
         ),
+        relation_id=AXIOM_RELATION_ID_BY_LABEL["member_of_household"],
         temp_prefix="ny-snap-pe-ecps-",
         display_name="New York SNAP",
     ),
@@ -752,6 +785,15 @@ def project_income_resource_inputs(
             "snap_countable_unearned_income": unearned_income,
             "snap_countable_financial_resources": assets,
         }
+    if config.jurisdiction == "us-ca":
+        return {
+            "snap_gross_monthly_earned_income": earned_income,
+            "snap_total_monthly_unearned_income": unearned_income,
+            "snap_countable_financial_resources": assets,
+            "snap_categorically_eligible_for_resource_exemption": bool(
+                values["meets_snap_categorical_eligibility"][idx]
+            ),
+        }
     return {
         "employee_wages_received": earned_income,
         "other_gain_or_benefit_payments": unearned_income,
@@ -770,6 +812,19 @@ def project_deduction_inputs(
     child_support_deduction: float,
     medical_deduction: float,
 ) -> dict[str, Any]:
+    if config.jurisdiction == "us-ca":
+        return {
+            "dependent_care_deduction": dependent_care_deduction,
+            "child_support_deduction": child_support_deduction,
+            "medical_deduction": medical_deduction,
+            "snap_allowable_monthly_dependent_care_expenses": (
+                dependent_care_deduction
+            ),
+            "snap_allowable_monthly_child_support_payments": child_support_deduction,
+            "snap_total_medical_expenses": medical_expenses_for_deduction(
+                medical_deduction
+            ),
+        }
     if config.jurisdiction == "us-ny":
         return {
             "dependent_care_deduction": dependent_care_deduction,
@@ -1113,6 +1168,12 @@ def project_raw_utility_inputs(
     idx: int,
     utility_region: str,
 ) -> dict[str, bool]:
+    if config.jurisdiction == "us-ca":
+        return {
+            "household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage": bool(
+                values["heating_cooling_expense"][idx] > 0
+            )
+        }
     if config.jurisdiction == "us-ny":
         non_phone_utility = any(
             bool(values[name][idx] > 0)
@@ -1160,6 +1221,12 @@ def project_raw_utility_inputs(
 def project_utility_allowance_type(
     config: JurisdictionConfig, utility_type: str, utility_region: str
 ) -> dict[str, bool]:
+    if config.jurisdiction == "us-ca":
+        return {
+            "household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage": (
+                utility_type == "SUA"
+            )
+        }
     if config.jurisdiction == "us-ny":
         inputs = new_york_utility_region_inputs(utility_region)
         if utility_type == "SUA":
@@ -1284,6 +1351,7 @@ def run_axiom_cases(
     cases: list[ProjectedCase],
     period: Period,
     output_ids: list[str],
+    relation_id: str,
     env: dict[str, str],
 ) -> list[dict[str, Any]]:
     interval = {
@@ -1315,7 +1383,7 @@ def run_axiom_cases(
             member_entity_id = f"{entity_id}-member-{member_index}"
             relations.append(
                 {
-                    "name": AXIOM_RELATION_ID_BY_LABEL["member_of_household"],
+                    "name": relation_id,
                     "tuple": [member_entity_id, entity_id],
                     "interval": interval,
                 }
@@ -1631,6 +1699,7 @@ def main(args: argparse.Namespace | None = None) -> int:
             cases=cases,
             period=period,
             output_ids=list(config.output_id_by_label.values()),
+            relation_id=config.relation_id,
             env=env,
         )
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -626,6 +626,96 @@ mappings:
     mapping_type: not_comparable
     rationale: Axiom composition helper summing Colorado shelter costs and utility allowances; PE uses separate housing-cost and SNAP utility-allowance variables.
 
+  - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_countable_earned_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_earned_income
+    candidate_priority: P4
+    rationale: California CalFresh composition helper clamps federal earned income before state composition; PolicyEngine's SNAP earned-income variable is adjacent but computed from PE's own income source graph.
+
+  - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_countable_unearned_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_unearned_income
+    candidate_priority: P4
+    rationale: California CalFresh composition helper clamps federal unearned income before state composition; PolicyEngine's SNAP unearned-income variable is adjacent but computed from PE's own income source graph.
+
+  - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_gross_monthly_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_gross_income
+    candidate_priority: P4
+    rationale: California CalFresh composition alias combining Axiom countable earned and unearned income; PolicyEngine's SNAP gross income is adjacent but computed from PE's own income source graph.
+
+  - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_monthly_household_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_gross_income
+    candidate_priority: P4
+    rationale: California CalFresh composition alias for monthly household income; PolicyEngine's SNAP gross income is adjacent but not the same legal output boundary.
+
+  - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#shelter_costs
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Axiom composition helper summing California shelter costs and standard utility allowance; PE uses separate housing-cost and SNAP utility-allowance variables.
+
+  - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_total_allowable_shelter_expenses
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: California CalFresh composition helper feeding federal excess-shelter deduction; PE derives allowable shelter expense through its own housing and utility abstractions.
+
+  - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_excess_shelter_expense_deduction
+    candidate_priority: P4
+    rationale: California CalFresh composition passes California shelter and utility inputs into the federal deduction; PolicyEngine's shelter deduction is adjacent but uses PE-specific housing and utility inputs.
+
+  - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_member_eligible
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: is_snap_eligible
+    candidate_priority: P4
+    rationale: California CalFresh person-level bridge combines citizenship, SSN, work, and student predicates; PE eligibility is household/SPM-unit level and not this bridge output.
+
+  - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_residency_eligible
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: California CalFresh residency bridge is a state composition output; PolicyEngine does not expose a comparable standalone SNAP residency variable.
+
+  - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_household_member_eligible
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: is_snap_eligible
+    candidate_priority: P4
+    rationale: California CalFresh household bridge counts Axiom member eligibility over the household relation; PolicyEngine's SNAP eligibility is adjacent but includes PE's full eligibility graph.
+
+  - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_eligible
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: is_snap_eligible
+    candidate_priority: P4
+    rationale: California CalFresh eligibility composition combines state and federal Axiom outputs; PE eligibility is adjacent but computed from PE's own eligibility graph.
+
+  - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_benefit
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap
+    candidate_priority: P4
+    rationale: California CalFresh benefit composition gates the federal allotment through Axiom eligibility and state shelter surfaces; PE's SNAP amount is adjacent but depends on PE's own full graph.
+
   - legal_id: us-co:regulations/10-ccr-2506-1/4.407.3#excess_shelter_deduction
     country: us
     program: snap

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,7 @@ from axiom_encode.cli import (
     _repair_missing_source_proof_atoms,
     _repair_mixed_derived_entity_output_tests,
     _repair_mixed_scalar_output_tests,
+    _repair_new_york_snap_benefit_rules,
     _repair_new_york_snap_benefit_tests,
     _repair_new_york_snap_categorical_eligibility_rules,
     _repair_new_york_snap_categorical_eligibility_tests,
@@ -5209,6 +5210,25 @@ rules:
         )
 
     def test_repair_new_york_snap_benefit_tests_covers_excess_shelter_cost(self):
+        repaired_rules = _repair_new_york_snap_benefit_rules(
+            """rules:
+  - name: snap_eligible
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_income_eligible
+          and (snap_resource_eligible or ny_snap_categorically_eligible)
+          and snap_ssn_eligible
+"""
+        )
+
+        assert "snap_income_eligible" not in repaired_rules
+        assert (
+            "snap_income_limit_exemption_for_categorically_eligible_household"
+            in repaired_rules
+        )
+        assert "or snap_standard_income_eligible" in repaired_rules
+
         repaired = _repair_new_york_snap_benefit_tests(
             """- name: ongoing_month_derives_new_york_allotment_with_heating_cooling_allowance
   period: 2026-01
@@ -5223,6 +5243,7 @@ rules:
   output:
     us-ny:regulations/18-nycrr/387/14/a/1#snap_allotment: 298
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#snap_standard_utility_allowance: 1062
+    us-ny:regulations/18-nycrr/387/14/a/5#snap_income_eligible: holds
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#shelter_costs: 1562
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 744
 """
@@ -5291,6 +5312,9 @@ rules:
         assert (
             "us-ny:regulations/18-nycrr/387/12/f/3/v/a"
             "#snap_standard_utility_allowance" not in repaired
+        )
+        assert (
+            "us-ny:regulations/18-nycrr/387/14/a/5#snap_income_eligible" not in repaired
         )
 
     def test_repair_colorado_snap_program_tests_covers_bridge_outputs(self, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5279,7 +5279,8 @@ rules:
         repaired_payload = yaml.safe_load(repaired)
         repaired_inputs = repaired_payload[0]["input"]
         repaired_member = repaired_inputs[
-            "us:statutes/7/2012/j#relation.member_of_household"
+            "us-ny:regulations/18-nycrr/387/14/a/5#relation."
+            "ny_snap_categorical_member_of_household"
         ][0]
         assert (
             repaired_member[
@@ -5287,6 +5288,12 @@ rules:
                 "member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits"
             ]
             is True
+        )
+        assert (
+            repaired_inputs["us:statutes/7/2012/j#relation.member_of_household"][0][
+                "us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled"
+            ]
+            is False
         )
 
         appended = _repair_new_york_snap_categorical_eligibility_tests(
@@ -5348,6 +5355,10 @@ rules:
     versions:
       - effective_from: '2025-10-01'
         formula: count_where(member_of_household, snap_member_student_eligible) > 0
+  - name: shelter_costs
+    versions:
+      - effective_from: '2025-10-01'
+        formula: household_shelter_costs_incurred
 """
         )
 
@@ -5372,6 +5383,7 @@ rules:
             "count_where(member_of_household, snap_member_student_ineligible) == 0"
             in repaired_rules
         )
+        assert "  - name: member_of_household\n" in repaired_rules
 
         repaired = _repair_new_york_snap_benefit_tests(
             """- name: ongoing_month_derives_new_york_allotment_with_heating_cooling_allowance
@@ -5384,6 +5396,8 @@ rules:
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_all_members_receive_family_assistance_nonemergency_safety_net_or_ssi: false
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_periodic_reporting_requirement: false
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_snap_work_requirements: false
+    us:statutes/7/2012/j#relation.member_of_household:
+      - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
   output:
     us-ny:regulations/18-nycrr/387/14/a/1#snap_allotment: 298
     us-ny:regulations/18-nycrr/387/12/f/3/v/a#snap_standard_utility_allowance: 1062
@@ -5393,10 +5407,14 @@ rules:
 """
         )
 
+        repaired_case = yaml.safe_load(repaired)[0]
+        repaired_inputs = repaired_case["input"]
         assert (
-            "us-ny:regulations/18-nycrr/387/14/a/5#input."
-            "household_member_disqualified_for_failure_to_comply_with_periodic_reporting_requirements: false"
-            in repaired
+            repaired_inputs[
+                "us-ny:regulations/18-nycrr/387/14/a/5#input."
+                "household_member_disqualified_for_failure_to_comply_with_periodic_reporting_requirements"
+            ]
+            is False
         )
         assert (
             "us-ny:regulations/18-nycrr/387/14/a/5#input."
@@ -5414,6 +5432,14 @@ rules:
         assert (
             "us-ny:policies/otda/snap/fy-2026-benefit-calculation"
             "#input.snap_initial_month_prorated_allotment: 0" in repaired
+        )
+        assert (
+            "us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+            "#relation.member_of_household" in repaired_inputs
+        )
+        assert (
+            "us-ny:regulations/18-nycrr/387/14/a/5#relation."
+            "ny_snap_categorical_member_of_household" in repaired_inputs
         )
         assert (
             "us-ny:policies/otda/snap/fy-2026-benefit-calculation"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5213,6 +5213,7 @@ rules:
             """- name: ongoing_month_derives_new_york_allotment_with_heating_cooling_allowance
   period: 2026-01
   input:
+    us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_periodic_reporting_requirement: false
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_snap_work_requirements: false
   output:
@@ -5238,6 +5239,10 @@ rules:
         assert (
             "us-ny:policies/otda/snap/fy-2026-benefit-calculation"
             "#ny_snap_excess_shelter_cost: 1266.5" in repaired
+        )
+        assert (
+            "us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+            "#input.snap_initial_month_prorated_allotment: 0" in repaired
         )
         assert (
             "initial_month_prorated_allotment_below_minimum_gets_zero_issuance"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5215,6 +5215,7 @@ rules:
   input:
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
     us:regulations/7-cfr/273/10#input.snap_countable_earned_income: 1000
+    us-ny:regulations/18-nycrr/387/14/a/5#input.household_all_members_receive_family_assistance_nonemergency_safety_net_or_ssi: false
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_periodic_reporting_requirement: false
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_snap_work_requirements: false
   output:
@@ -5257,6 +5258,10 @@ rules:
         )
         assert (
             "us:regulations/7-cfr/273/10#input.snap_countable_earned_income"
+            not in repaired
+        )
+        assert (
+            "household_all_members_receive_family_assistance_nonemergency_safety_net_or_ssi"
             not in repaired
         )
         assert (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,6 +110,7 @@ from axiom_encode.cli import (
     cmd_repair_section_63_f_stale_test_inputs,
     cmd_repair_section_172_c_capacity,
     cmd_repair_section_911_a_1_exclusion,
+    cmd_repair_snap_273_10_allotment,
     cmd_repair_tax_filing_status_branches,
     cmd_repair_tax_status_components,
     cmd_repair_unreferenced_proof_imports,
@@ -11018,6 +11019,84 @@ rules:
             "regulations/7-cfr/273/10.yaml",
         ]
         assert payload["tool"] == "axiom-encode repair-nonnegative-floors"
+
+    def test_repair_snap_273_10_allotment_writes_signed_manifest(self, tmp_path):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "regulations/7-cfr/273/10.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+imports:
+  - us:policies/usda/snap/fy-2026-cola/deductions
+  - us:regulations/7-cfr/273/9
+rules:
+  - name: snap_calculated_monthly_allotment_before_minimums
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if state_agency_rounds_thirty_percent_net_income_up: max(0, snap_maximum_allotment_for_household_size - ceil(snap_net_monthly_income * snap_allotment_net_income_reduction_rate)) else: max(0, floor(snap_maximum_allotment_for_household_size - (snap_net_monthly_income * snap_allotment_net_income_reduction_rate)))
+"""
+        )
+        test_file = policy_repo / "regulations/7-cfr/273/10.test.yaml"
+        test_file.write_text(
+            """- name: one_person_household_receives_minimum_benefit
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_household_size: 298
+  output:
+    us:regulations/7-cfr/273/10#snap_minimum_benefit: 24
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_snap_273_10_allotment(args)
+
+        content = target.read_text()
+        assert "us:policies/usda/snap/fy-2026-cola/maximum-allotments" in content
+        assert "snap_maximum_allotment_for_household_size" not in content
+        assert "snap_maximum_allotment - ceil(" in content
+        test_content = test_file.read_text()
+        assert (
+            "us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1"
+            in test_content
+        )
+        manifest = (
+            policy_repo / ".axiom/encoding-manifests/regulations/7-cfr/273/10.json"
+        )
+        payload = json.loads(manifest.read_text())
+        assert payload["schema_version"] == APPLIED_ENCODING_MANIFEST_SCHEMA
+        assert [applied_file["path"] for applied_file in payload["applied_files"]] == [
+            "regulations/7-cfr/273/10.yaml",
+            "regulations/7-cfr/273/10.test.yaml",
+        ]
+        assert payload["tool"] == "axiom-encode repair-snap-273-10-allotment"
 
     def test_repair_current_year_final_amounts_writes_signed_manifest(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5225,10 +5225,17 @@ rules:
             "us-ny:regulations/18-nycrr/387/14/a/5#relation.member_of_household"
             not in repaired
         )
+        repaired_payload = yaml.safe_load(repaired)
+        repaired_inputs = repaired_payload[0]["input"]
+        repaired_member = repaired_inputs[
+            "us:statutes/7/2012/j#relation.member_of_household"
+        ][0]
         assert (
-            "        us-ny:regulations/18-nycrr/387/14/a/5#input."
-            "member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: true"
-            in repaired
+            repaired_member[
+                "us-ny:regulations/18-nycrr/387/14/a/5#input."
+                "member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits"
+            ]
+            is True
         )
 
         appended = _repair_new_york_snap_categorical_eligibility_tests(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5223,6 +5223,16 @@ rules:
     versions:
       - effective_from: '2025-10-01'
         formula: count_where(member_of_household, snap_member_ssn_requirement_eligible) > 0
+  - name: snap_work_requirement_eligible
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          count_where(member_of_household, snap_member_work_requirement_eligible) > 0
+          and count_where(member_of_household, snap_member_work_requirement_ineligible) == 0
+  - name: snap_student_eligible
+    versions:
+      - effective_from: '2025-10-01'
+        formula: count_where(member_of_household, snap_member_student_eligible) > 0
 """
         )
 
@@ -5235,6 +5245,16 @@ rules:
         assert "snap_member_ssn_requirement_eligible" not in repaired_rules
         assert (
             "count_where(member_of_household, snap_member_ssn_requirement_ineligible) == 0"
+            in repaired_rules
+        )
+        assert "snap_member_work_requirement_eligible" not in repaired_rules
+        assert (
+            "count_where(member_of_household, snap_member_work_requirement_ineligible) == 0"
+            in repaired_rules
+        )
+        assert "snap_member_student_eligible" not in repaired_rules
+        assert (
+            "count_where(member_of_household, snap_member_student_ineligible) == 0"
             in repaired_rules
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5160,7 +5160,17 @@ module:
     - output: us-ny:regulations/18-nycrr/387/14/a/5#snap_income_limit_exemption_for_categorically_eligible_household
       reason: Missing final categorical eligibility.
   summary: New York SNAP categorical eligibility.
+imports:
+  - us:statutes/7/2012/j#snap_household_has_elderly_or_disabled_member
 rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      predicate: member_of_household
+      arity: 2
+      arguments:
+        - Person
+        - Household
   - name: ny_snap_residual_130_percent_categorical_path_satisfied
     kind: derived
     entity: Household
@@ -5174,6 +5184,8 @@ rules:
         repaired = _repair_new_york_snap_categorical_eligibility_rules(rules)
 
         assert "deferred_outputs:" not in repaired
+        assert "  - us:statutes/7/2012/j\n" in repaired
+        assert "name: member_of_household" not in repaired
         assert "  - name: ny_snap_categorically_eligible\n" in repaired
         assert (
             "not household_member_disqualified_for_intentional_program_violation"
@@ -5190,7 +5202,19 @@ rules:
 
     def test_repair_new_york_snap_categorical_eligibility_tests_cover_blockers(self):
         repaired = _repair_new_york_snap_categorical_eligibility_tests(
-            "- name: existing\n  output: {}\n"
+            """- name: all_members_public_assistance_path_makes_household_categorically_eligible
+  input:
+    us:statutes/7/2012/j#relation.member_of_household:
+      - us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled: false
+    us-ny:regulations/18-nycrr/387/14/a/5#relation.member_of_household:
+      - us-ny:regulations/18-nycrr/387/14/a/5#input.member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: true
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_authorized_to_receive_family_assistance_nonemergency_safety_net_or_ssi_benefits_but_not_yet_paid: false
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_family_assistance_nonemergency_safety_net_or_ssi_benefits_suspended_or_being_recouped: false
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_determined_eligible_for_family_assistance_or_nonemergency_safety_net_benefits: false
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_paid_family_assistance_or_nonemergency_safety_net_benefits: false
+        us-ny:regulations/18-nycrr/387/14/a/5#input.member_family_assistance_or_nonemergency_safety_net_grant_amount: 0
+  output: {}
+"""
         )
 
         assert (
@@ -5198,15 +5222,28 @@ rules:
             in repaired
         )
         assert (
-            "intentional_program_violation_blocks_categorical_eligibility" in repaired
+            "us-ny:regulations/18-nycrr/387/14/a/5#relation.member_of_household"
+            not in repaired
+        )
+        assert (
+            "        us-ny:regulations/18-nycrr/387/14/a/5#input."
+            "member_receives_family_assistance_nonemergency_safety_net_or_ssi_benefits: true"
+            in repaired
+        )
+
+        appended = _repair_new_york_snap_categorical_eligibility_tests(
+            "- name: existing\n  output: {}\n"
+        )
+        assert (
+            "intentional_program_violation_blocks_categorical_eligibility" in appended
         )
         assert (
             "us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_disqualified_for_intentional_program_violation: true"
-            in repaired
+            in appended
         )
         assert (
             "us-ny:regulations/18-nycrr/387/14/a/5#snap_categorically_eligible_for_resource_exemption: not_holds"
-            in repaired
+            in appended
         )
 
     def test_repair_new_york_snap_benefit_tests_covers_excess_shelter_cost(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5186,6 +5186,57 @@ rules:
             in repaired
         )
 
+    def test_repair_new_york_snap_categorical_eligibility_keeps_unrelated_deferred_outputs(
+        self,
+    ):
+        rules = """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ny/regulation/18-nycrr/387/14/a/5
+  deferred_outputs:
+    - output: us-ny:regulations/18-nycrr/387/14/a/5#ny_snap_categorically_eligible
+      reason: Missing work requirement dependency.
+    - output: us-ny:regulations/18-nycrr/387/14/a/5#still_deferred_output
+      reason: Still requires encoder follow-up.
+    - output: us-ny:regulations/18-nycrr/387/14/a/5#snap_categorically_eligible_for_resource_exemption
+      reason: Missing final categorical eligibility.
+    - output: us-ny:regulations/18-nycrr/387/14/a/5#snap_income_limit_exemption_for_categorically_eligible_household
+      reason: Missing final categorical eligibility.
+  summary: New York SNAP categorical eligibility.
+rules:
+  - name: ny_snap_residual_130_percent_categorical_path_satisfied
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: existing_path
+"""
+
+        repaired = _repair_new_york_snap_categorical_eligibility_rules(rules)
+
+        assert "  deferred_outputs:\n" in repaired
+        assert (
+            "output: us-ny:regulations/18-nycrr/387/14/a/5#still_deferred_output"
+            in repaired
+        )
+        assert "reason: Still requires encoder follow-up." in repaired
+        assert (
+            "output: us-ny:regulations/18-nycrr/387/14/a/5#ny_snap_categorically_eligible"
+            not in repaired
+        )
+        assert (
+            "output: us-ny:regulations/18-nycrr/387/14/a/5#snap_categorically_eligible_for_resource_exemption"
+            not in repaired
+        )
+        assert (
+            "output: us-ny:regulations/18-nycrr/387/14/a/5#snap_income_limit_exemption_for_categorically_eligible_household"
+            not in repaired
+        )
+
     def test_repair_new_york_snap_categorical_eligibility_tests_cover_blockers(self):
         repaired = _repair_new_york_snap_categorical_eligibility_tests(
             "- name: existing\n  output: {}\n"
@@ -5206,6 +5257,26 @@ rules:
             "us-ny:regulations/18-nycrr/387/14/a/5#snap_categorically_eligible_for_resource_exemption: not_holds"
             in repaired
         )
+
+    def test_repair_new_york_snap_categorical_eligibility_tests_noop_for_current_surface(
+        self,
+    ):
+        current_rules = """format: rulespec/v1
+rules:
+  - name: ny_snap_categorically_eligible
+    kind: derived
+  - name: snap_categorically_eligible_for_resource_exemption
+    kind: derived
+  - name: snap_income_eligible
+    kind: derived
+"""
+        original_tests = "- name: existing\n  output: {}\n"
+
+        repaired = _repair_new_york_snap_categorical_eligibility_tests(
+            original_tests, rules_content=current_rules
+        )
+
+        assert repaired == original_tests
 
     def test_repair_colorado_snap_program_tests_covers_bridge_outputs(self, tmp_path):
         test_file = tmp_path / "fy-2026-benefit-calculation.test.yaml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,8 @@ from axiom_encode.cli import (
     _remove_invalid_dependent_test_inputs,
     _remove_unknown_test_output_refs,
     _repair_anaphoric_scope_identifiers,
+    _repair_california_snap_policy_composition,
+    _repair_california_snap_program_tests,
     _repair_colorado_snap_401,
     _repair_colorado_snap_401_tests,
     _repair_colorado_snap_2072,
@@ -5040,6 +5042,97 @@ rules:
         assert test_payload[-1]["output"] == {
             "us:statutes/26/1401/b/1#self_employment_income_tax": 61.59745
         }
+
+    def test_repair_california_snap_policy_composition_adds_sua_shelter_bridge(
+        self, tmp_path
+    ):
+        rules_file = tmp_path / "fy-2026-benefit-calculation.yaml"
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  kind: composition
+imports:
+  - us:regulations/7-cfr/273/10
+  - us-ca:regulations/mpp/63-503/324
+rules:
+  - name: snap_excess_shelter_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: California CalFresh FY 2026 benefit calculation composition
+    versions:
+      - effective_from: '2025-10-01'
+        formula: snap_excess_shelter_deduction_for_net_income
+  - name: snap_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: California CalFresh FY 2026 benefit calculation composition
+    versions:
+      - effective_from: '2025-10-01'
+        formula: snap_standard_income_eligible
+"""
+        )
+
+        _repair_california_snap_policy_composition(rules_file)
+
+        repaired = rules_file.read_text()
+        assert (
+            "  - us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance\n"
+            in repaired
+        )
+        assert "  - name: shelter_costs\n" in repaired
+        assert "household_shelter_costs_incurred + snap_standard_utility_allowance" in repaired
+        assert "  - name: snap_total_allowable_shelter_expenses\n" in repaired
+        assert "  - name: snap_member_eligible\n" in repaired
+        assert "  - name: snap_household_member_eligible\n" in repaired
+        assert "and snap_household_member_eligible" in repaired
+
+    def test_repair_california_snap_program_tests_uses_sua_shelter_input(
+        self, tmp_path
+    ):
+        test_file = tmp_path / "fy-2026-benefit-calculation.test.yaml"
+        test_file.write_text(
+            """- name: shelter_costs_raise_benefit_when_income_is_positive
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 500
+  output:
+    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 204.5
+    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_benefit: 182
+- name: ineligible_member_receives_zero
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses: 0
+  output:
+    us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_residency_citizenship_eligible: not_holds
+"""
+        )
+
+        _repair_california_snap_program_tests(test_file)
+
+        repaired = test_file.read_text()
+        assert "us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses" not in repaired
+        assert (
+            "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500"
+            in repaired
+        )
+        assert "standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage" in repaired
+        assert (
+            "us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#snap_standard_utility_allowance: 663"
+            in repaired
+        )
+        assert (
+            "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 744"
+            in repaired
+        )
+        assert (
+            "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_household_member_eligible: not_holds"
+            in repaired
+        )
 
     def test_repair_colorado_snap_program_tests_covers_bridge_outputs(self, tmp_path):
         test_file = tmp_path / "fy-2026-benefit-calculation.test.yaml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5215,6 +5215,7 @@ rules:
   input:
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
     us:regulations/7-cfr/273/10#input.snap_countable_earned_income: 1000
+    us-ny:regulations/18-nycrr/387/14/a/1#input.initial_application_month: false
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_all_members_receive_family_assistance_nonemergency_safety_net_or_ssi: false
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_periodic_reporting_requirement: false
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_snap_work_requirements: false
@@ -5262,6 +5263,10 @@ rules:
         )
         assert (
             "household_all_members_receive_family_assistance_nonemergency_safety_net_or_ssi"
+            not in repaired
+        )
+        assert (
+            "us-ny:regulations/18-nycrr/387/14/a/1#input.initial_application_month"
             not in repaired
         )
         assert (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5218,6 +5218,7 @@ rules:
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_snap_work_requirements: false
   output:
     us-ny:regulations/18-nycrr/387/14/a/1#snap_allotment: 298
+    us-ny:regulations/18-nycrr/387/12/f/3/v/a#snap_standard_utility_allowance: 1062
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#shelter_costs: 1562
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 744
 """
@@ -5254,6 +5255,10 @@ rules:
             "#snap_initial_month_allotment_after_minimum_issuance: 0" in repaired
         )
         assert "us-ny:regulations/18-nycrr/387/14/a/1#snap_allotment" not in repaired
+        assert (
+            "us-ny:regulations/18-nycrr/387/12/f/3/v/a"
+            "#snap_standard_utility_allowance" not in repaired
+        )
 
     def test_repair_colorado_snap_program_tests_covers_bridge_outputs(self, tmp_path):
         test_file = tmp_path / "fy-2026-benefit-calculation.test.yaml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,12 +25,15 @@ from axiom_encode.cli import (
     _append_generated_derived_output_tests_if_missing,
     _append_generated_judgment_positive_tests_if_missing,
     _apply_generated_encoding_result,
+    _california_snap_repair_guard_manifest_groups,
     _complete_missing_dependent_test_inputs,
     _complete_missing_imported_test_inputs,
     _default_generated_test_input_value,
     _discover_rulespec_test_files,
     _effective_runner_specs,
     _ensure_generated_dependency_files_safe,
+    _ensure_no_california_snap_sua_layout_collision,
+    _ensure_no_unmanifested_preexisting_rulespec_changes,
     _find_rulespec_dependents,
     _has_zero_output_test,
     _hoist_nested_test_tables,
@@ -5143,6 +5146,67 @@ rules:
         assert (
             "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_household_member_eligible: not_holds"
             in repaired
+        )
+
+    def test_california_snap_sua_migration_rejects_old_and_new_paths(self, tmp_path):
+        repo = tmp_path / "rulespec-us-ca"
+        old_path = (
+            repo / "guidance/cdss/acin-2025-i-46-25/standard-utility-allowance.yaml"
+        )
+        new_path = repo / "policies/cdss/snap/standard-utility-allowance.yaml"
+        old_path.parent.mkdir(parents=True)
+        new_path.parent.mkdir(parents=True)
+        old_path.write_text("format: rulespec/v1\n")
+        new_path.write_text("format: rulespec/v1\n")
+
+        with pytest.raises(RuntimeError, match="both old and new RuleSpec paths"):
+            _ensure_no_california_snap_sua_layout_collision(repo)
+
+    def test_california_snap_guard_covers_dirty_old_sua_path(self, tmp_path):
+        repo = tmp_path / "rulespec-us-ca"
+        old_path = (
+            repo / "guidance/cdss/acin-2025-i-46-25/standard-utility-allowance.yaml"
+        )
+        old_path.parent.mkdir(parents=True)
+        old_path.write_text("format: rulespec/v1\n")
+        subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(["git", "add", "."], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "initial"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+        old_path.write_text("format: rulespec/v1\nmodule:\n  summary: dirty\n")
+
+        with (
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+            pytest.raises(RuntimeError) as exc,
+        ):
+            _ensure_no_unmanifested_preexisting_rulespec_changes(
+                repo,
+                _california_snap_repair_guard_manifest_groups(repo),
+                roots=("guidance", "policies", "regulations", "statutes"),
+            )
+
+        assert (
+            ".axiom/encoding-manifests/guidance/cdss/acin-2025-i-46-25/standard-utility-allowance.json"
+            in str(exc.value)
         )
 
     def test_repair_new_york_snap_categorical_eligibility_adds_final_outputs(self):
@@ -11443,6 +11507,71 @@ rules:
             "regulations/7-cfr/273/10.test.yaml",
         ]
         assert payload["tool"] == "axiom-encode repair-snap-273-10-allotment"
+
+    def test_repair_snap_273_10_allotment_restores_files_when_validation_raises(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "regulations/7-cfr/273/10.yaml"
+        target.parent.mkdir(parents=True)
+        original_rules = """format: rulespec/v1
+imports:
+  - us:policies/usda/snap/fy-2026-cola/deductions
+  - us:regulations/7-cfr/273/9
+rules:
+  - name: snap_calculated_monthly_allotment_before_minimums
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if state_agency_rounds_thirty_percent_net_income_up: max(0, snap_maximum_allotment_for_household_size - ceil(snap_net_monthly_income * snap_allotment_net_income_reduction_rate)) else: max(0, floor(snap_maximum_allotment_for_household_size - (snap_net_monthly_income * snap_allotment_net_income_reduction_rate)))
+"""
+        target.write_text(original_rules)
+        test_file = policy_repo / "regulations/7-cfr/273/10.test.yaml"
+        original_tests = """- name: one_person_household_receives_minimum_benefit
+  period: 2026-01
+  input:
+    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_household_size: 298
+  output:
+    us:regulations/7-cfr/273/10#snap_minimum_benefit: 24
+"""
+        test_file.write_text(original_tests)
+        args = SimpleNamespace(
+            repo=policy_repo,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FailingPipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                raise RuntimeError("validator crashed")
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FailingPipeline),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+            pytest.raises(RuntimeError, match="validator crashed"),
+        ):
+            cmd_repair_snap_273_10_allotment(args)
+
+        assert target.read_text() == original_rules
+        assert test_file.read_text() == original_tests
+        assert not (
+            policy_repo / ".axiom/encoding-manifests/regulations/7-cfr/273/10.json"
+        ).exists()
 
     def test_repair_current_year_final_amounts_writes_signed_manifest(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5215,6 +5215,7 @@ rules:
   input:
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
     us:regulations/7-cfr/273/10#input.snap_countable_earned_income: 1000
+    us:regulations/7-cfr/273/10#input.snap_countable_unearned_income: 0
     us-ny:regulations/18-nycrr/387/14/a/1#input.initial_application_month: false
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_all_members_receive_family_assistance_nonemergency_safety_net_or_ssi: false
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_periodic_reporting_requirement: false
@@ -5257,6 +5258,15 @@ rules:
             "us:statutes/7/2014/e/2#input.snap_countable_earned_income: 1000"
             in repaired
         )
+        assert (
+            "us:regulations/7-cfr/273/10#input.snap_gross_monthly_earned_income: 1000"
+            in repaired
+        )
+        assert (
+            "us:regulations/7-cfr/273/10#input.snap_total_monthly_unearned_income: 0"
+            in repaired
+        )
+        assert "us:regulations/7-cfr/273/10#input.snap_income_exclusions: 0" in repaired
         assert (
             "us:regulations/7-cfr/273/10#input.snap_countable_earned_income"
             not in repaired

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5085,7 +5085,10 @@ rules:
             in repaired
         )
         assert "  - name: shelter_costs\n" in repaired
-        assert "household_shelter_costs_incurred + snap_standard_utility_allowance" in repaired
+        assert (
+            "household_shelter_costs_incurred + snap_standard_utility_allowance"
+            in repaired
+        )
         assert "  - name: snap_total_allowable_shelter_expenses\n" in repaired
         assert "  - name: snap_member_eligible\n" in repaired
         assert "  - name: snap_household_member_eligible\n" in repaired
@@ -5115,12 +5118,18 @@ rules:
         _repair_california_snap_program_tests(test_file)
 
         repaired = test_file.read_text()
-        assert "us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses" not in repaired
+        assert (
+            "us:regulations/7-cfr/273/10#input.snap_total_allowable_shelter_expenses"
+            not in repaired
+        )
         assert (
             "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500"
             in repaired
         )
-        assert "standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage" in repaired
+        assert (
+            "standard-utility-allowance#input.household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage"
+            in repaired
+        )
         assert (
             "us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#snap_standard_utility_allowance: 663"
             in repaired

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,7 @@ from axiom_encode.cli import (
     _repair_missing_source_proof_atoms,
     _repair_mixed_derived_entity_output_tests,
     _repair_mixed_scalar_output_tests,
+    _repair_new_york_snap_benefit_tests,
     _repair_new_york_snap_categorical_eligibility_rules,
     _repair_new_york_snap_categorical_eligibility_tests,
     _repair_person_scoped_definition_entities,
@@ -5205,6 +5206,38 @@ rules:
         assert (
             "us-ny:regulations/18-nycrr/387/14/a/5#snap_categorically_eligible_for_resource_exemption: not_holds"
             in repaired
+        )
+
+    def test_repair_new_york_snap_benefit_tests_covers_excess_shelter_cost(self):
+        repaired = _repair_new_york_snap_benefit_tests(
+            """- name: ongoing_month_derives_new_york_allotment_with_heating_cooling_allowance
+  period: 2026-01
+  input:
+    us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_periodic_reporting_requirement: false
+    us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_snap_work_requirements: false
+  output:
+    us-ny:policies/otda/snap/fy-2026-benefit-calculation#shelter_costs: 1562
+    us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 744
+"""
+        )
+
+        assert (
+            "us-ny:regulations/18-nycrr/387/14/a/5#input."
+            "household_member_disqualified_for_failure_to_comply_with_periodic_reporting_requirements: false"
+            in repaired
+        )
+        assert (
+            "us-ny:regulations/18-nycrr/387/14/a/5#input."
+            "household_member_disqualified_for_failure_to_comply_with_work_requirements: false"
+            in repaired
+        )
+        assert (
+            "us-ny:regulations/18-nycrr/387/14/a/5#input."
+            "household_member_ineligible_to_participate_in_snap: false" in repaired
+        )
+        assert (
+            "us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+            "#ny_snap_excess_shelter_cost: 1266.5" in repaired
         )
 
     def test_repair_colorado_snap_program_tests_covers_bridge_outputs(self, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,6 +61,8 @@ from axiom_encode.cli import (
     _repair_missing_source_proof_atoms,
     _repair_mixed_derived_entity_output_tests,
     _repair_mixed_scalar_output_tests,
+    _repair_new_york_snap_categorical_eligibility_rules,
+    _repair_new_york_snap_categorical_eligibility_tests,
     _repair_person_scoped_definition_entities,
     _repair_scalar_relation_rows,
     _repair_section_151_imports,
@@ -5138,6 +5140,70 @@ rules:
         )
         assert (
             "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_household_member_eligible: not_holds"
+            in repaired
+        )
+
+    def test_repair_new_york_snap_categorical_eligibility_adds_final_outputs(self):
+        rules = """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us-ny/regulation/18-nycrr/387/14/a/5
+  deferred_outputs:
+    - output: us-ny:regulations/18-nycrr/387/14/a/5#ny_snap_categorically_eligible
+      reason: Missing work requirement dependency.
+    - output: us-ny:regulations/18-nycrr/387/14/a/5#snap_categorically_eligible_for_resource_exemption
+      reason: Missing final categorical eligibility.
+    - output: us-ny:regulations/18-nycrr/387/14/a/5#snap_income_limit_exemption_for_categorically_eligible_household
+      reason: Missing final categorical eligibility.
+  summary: New York SNAP categorical eligibility.
+rules:
+  - name: ny_snap_residual_130_percent_categorical_path_satisfied
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: existing_path
+"""
+
+        repaired = _repair_new_york_snap_categorical_eligibility_rules(rules)
+
+        assert "deferred_outputs:" not in repaired
+        assert "  - name: ny_snap_categorically_eligible\n" in repaired
+        assert (
+            "not household_member_disqualified_for_intentional_program_violation"
+            in repaired
+        )
+        assert "count_where(member_of_household, member_disqualified" not in repaired
+        assert (
+            "  - name: snap_categorically_eligible_for_resource_exemption\n" in repaired
+        )
+        assert (
+            "  - name: snap_income_limit_exemption_for_categorically_eligible_household\n"
+            in repaired
+        )
+
+    def test_repair_new_york_snap_categorical_eligibility_tests_cover_blockers(self):
+        repaired = _repair_new_york_snap_categorical_eligibility_tests(
+            "- name: existing\n  output: {}\n"
+        )
+
+        assert (
+            "all_members_public_assistance_path_makes_household_categorically_eligible"
+            in repaired
+        )
+        assert (
+            "intentional_program_violation_blocks_categorical_eligibility" in repaired
+        )
+        assert (
+            "us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_disqualified_for_intentional_program_violation: true"
+            in repaired
+        )
+        assert (
+            "us-ny:regulations/18-nycrr/387/14/a/5#snap_categorically_eligible_for_resource_exemption: not_holds"
             in repaired
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5217,6 +5217,7 @@ rules:
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_periodic_reporting_requirement: false
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_snap_work_requirements: false
   output:
+    us-ny:regulations/18-nycrr/387/14/a/1#snap_allotment: 298
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#shelter_costs: 1562
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 744
 """
@@ -5252,6 +5253,7 @@ rules:
             "us-ny:policies/otda/snap/fy-2026-benefit-calculation"
             "#snap_initial_month_allotment_after_minimum_issuance: 0" in repaired
         )
+        assert "us-ny:regulations/18-nycrr/387/14/a/1#snap_allotment" not in repaired
 
     def test_repair_colorado_snap_program_tests_covers_bridge_outputs(self, tmp_path):
         test_file = tmp_path / "fy-2026-benefit-calculation.test.yaml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5214,6 +5214,7 @@ rules:
   period: 2026-01
   input:
     us-ny:policies/otda/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
+    us:regulations/7-cfr/273/10#input.snap_countable_earned_income: 1000
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_periodic_reporting_requirement: false
     us-ny:regulations/18-nycrr/387/14/a/5#input.household_member_failed_snap_work_requirements: false
   output:
@@ -5245,6 +5246,18 @@ rules:
         assert (
             "us-ny:policies/otda/snap/fy-2026-benefit-calculation"
             "#input.snap_initial_month_prorated_allotment: 0" in repaired
+        )
+        assert (
+            "us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+            "#input.snap_countable_earned_income: 1000" in repaired
+        )
+        assert (
+            "us:statutes/7/2014/e/2#input.snap_countable_earned_income: 1000"
+            in repaired
+        )
+        assert (
+            "us:regulations/7-cfr/273/10#input.snap_countable_earned_income"
+            not in repaired
         )
         assert (
             "initial_month_prorated_allotment_below_minimum_gets_zero_issuance"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5219,6 +5219,10 @@ rules:
           snap_income_eligible
           and (snap_resource_eligible or ny_snap_categorically_eligible)
           and snap_ssn_eligible
+  - name: snap_ssn_eligible
+    versions:
+      - effective_from: '2025-10-01'
+        formula: count_where(member_of_household, snap_member_ssn_requirement_eligible) > 0
 """
         )
 
@@ -5228,6 +5232,11 @@ rules:
             in repaired_rules
         )
         assert "or snap_standard_income_eligible" in repaired_rules
+        assert "snap_member_ssn_requirement_eligible" not in repaired_rules
+        assert (
+            "count_where(member_of_household, snap_member_ssn_requirement_ineligible) == 0"
+            in repaired_rules
+        )
 
         repaired = _repair_new_york_snap_benefit_tests(
             """- name: ongoing_month_derives_new_york_allotment_with_heating_cooling_allowance

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5080,10 +5080,7 @@ rules:
         _repair_california_snap_policy_composition(rules_file)
 
         repaired = rules_file.read_text()
-        assert (
-            "  - us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance\n"
-            in repaired
-        )
+        assert "  - us-ca:policies/cdss/snap/standard-utility-allowance\n" in repaired
         assert "  - name: shelter_costs\n" in repaired
         assert (
             "household_shelter_costs_incurred + snap_standard_utility_allowance"
@@ -5131,7 +5128,7 @@ rules:
             in repaired
         )
         assert (
-            "us-ca:guidance/cdss/acin-2025-i-46-25/standard-utility-allowance#snap_standard_utility_allowance: 663"
+            "us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance: 663"
             in repaired
         )
         assert (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5239,6 +5239,14 @@ rules:
             "us-ny:policies/otda/snap/fy-2026-benefit-calculation"
             "#ny_snap_excess_shelter_cost: 1266.5" in repaired
         )
+        assert (
+            "initial_month_prorated_allotment_below_minimum_gets_zero_issuance"
+            in repaired
+        )
+        assert (
+            "us-ny:policies/otda/snap/fy-2026-benefit-calculation"
+            "#snap_initial_month_allotment_after_minimum_issuance: 0" in repaired
+        )
 
     def test_repair_colorado_snap_program_tests_covers_bridge_outputs(self, tmp_path):
         test_file = tmp_path / "fy-2026-benefit-calculation.test.yaml"

--- a/tests/test_policyengine_ecps_snap.py
+++ b/tests/test_policyengine_ecps_snap.py
@@ -1,15 +1,22 @@
 import shutil
+from datetime import date
 from types import SimpleNamespace
 
 import pytest
 
+from axiom_encode.oracles.policyengine import ecps_snap
 from axiom_encode.oracles.policyengine.ecps_snap import (
     COMMON_AXIOM_OUTPUT_ID_BY_LABEL,
     JURISDICTION_CONFIGS,
+    Period,
+    ProjectedCase,
     add_snapscreener_results,
+    project_deduction_inputs,
     project_income_resource_inputs,
+    project_raw_utility_inputs,
     project_utility_allowance_type,
     projected_child_support_payment,
+    run_axiom_cases,
     set_input_value,
 )
 from axiom_encode.oracles.snapscreener import (
@@ -45,6 +52,106 @@ def test_new_york_projector_uses_federal_income_and_resource_inputs():
         "snap_countable_unearned_income": 67.89,
         "snap_countable_financial_resources": 999,
     }
+
+
+def test_california_projectors_use_california_snap_input_surface():
+    config = JURISDICTION_CONFIGS["us-ca"]
+    values = {
+        "snap_earned_income": [123.45],
+        "snap_unearned_income": [67.89],
+        "snap_assets": [999],
+        "meets_snap_categorical_eligibility": [True],
+        "heating_cooling_expense": [10],
+    }
+
+    assert project_income_resource_inputs(config, values, 0) == {
+        "snap_gross_monthly_earned_income": 123.45,
+        "snap_total_monthly_unearned_income": 67.89,
+        "snap_countable_financial_resources": 999,
+        "snap_categorically_eligible_for_resource_exemption": True,
+    }
+    assert project_deduction_inputs(
+        config,
+        dependent_care_deduction=12,
+        child_support_deduction=34,
+        medical_deduction=200,
+    ) == {
+        "dependent_care_deduction": 12,
+        "child_support_deduction": 34,
+        "medical_deduction": 200,
+        "snap_allowable_monthly_dependent_care_expenses": 12,
+        "snap_allowable_monthly_child_support_payments": 34,
+        "snap_total_medical_expenses": 235,
+    }
+    assert project_raw_utility_inputs(config, values, 0, "") == {
+        "household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage": True
+    }
+    assert project_utility_allowance_type(config, "SUA", "") == {
+        "household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage": True
+    }
+    assert project_utility_allowance_type(config, "LUA", "") == {
+        "household_has_heating_and_cooling_costs_separate_from_rent_or_mortgage": False
+    }
+
+
+def test_run_axiom_cases_uses_configured_california_member_entity(
+    monkeypatch, tmp_path
+):
+    runtime_requests = []
+
+    def fake_run(cmd, **kwargs):
+        assert "run-compiled" in cmd
+        runtime_requests.append(ecps_snap.json.loads(kwargs["input"]))
+        return ecps_snap.subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=ecps_snap.json.dumps({"results": [{"outputs": {}}]}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(ecps_snap.subprocess, "run", fake_run)
+    period = Period(
+        label="2026-01",
+        year=2026,
+        month=1,
+        start=date(2026, 1, 1),
+        end=date(2026, 1, 31),
+    )
+    config = JURISDICTION_CONFIGS["us-ca"]
+
+    run_axiom_cases(
+        binary=tmp_path / "axiom-rules-engine",
+        artifact=tmp_path / "program.json",
+        cases=[
+            ProjectedCase(
+                spm_unit_id=42,
+                household_id=420,
+                inputs={"household-input": 1},
+                member_inputs=[{"member-input": True}],
+                pe_outputs={},
+            )
+        ],
+        period=period,
+        output_ids=["output-id"],
+        relation_id=config.relation_id,
+        member_entity_type=config.member_entity_type,
+        env={},
+    )
+
+    assert config.member_entity_type == "Person"
+    request = runtime_requests[0]
+    assert request["dataset"]["relations"] == [
+        {
+            "name": config.relation_id,
+            "tuple": ["spm-42-member-1", "spm-42"],
+            "interval": {"start": "2026-01-01", "end": "2026-01-31"},
+        }
+    ]
+    inputs_by_name = {
+        input_item["name"]: input_item for input_item in request["dataset"]["inputs"]
+    }
+    assert inputs_by_name["household-input"]["entity"] == "Household"
+    assert inputs_by_name["member-input"]["entity"] == "Person"
 
 
 def test_common_snap_outputs_track_current_federal_rulespec_surface():

--- a/tests/test_policyengine_ecps_snap.py
+++ b/tests/test_policyengine_ecps_snap.py
@@ -134,6 +134,7 @@ def test_run_axiom_cases_uses_configured_california_member_entity(
         period=period,
         output_ids=["output-id"],
         relation_id=config.relation_id,
+        additional_relation_ids=config.additional_relation_ids,
         member_entity_type=config.member_entity_type,
         env={},
     )

--- a/tests/test_policyengine_ecps_snap.py
+++ b/tests/test_policyengine_ecps_snap.py
@@ -13,6 +13,7 @@ from axiom_encode.oracles.policyengine.ecps_snap import (
     add_snapscreener_results,
     project_deduction_inputs,
     project_income_resource_inputs,
+    project_jurisdiction_household_inputs,
     project_raw_utility_inputs,
     project_utility_allowance_type,
     projected_child_support_payment,
@@ -52,6 +53,26 @@ def test_new_york_projector_uses_federal_income_and_resource_inputs():
         "snap_countable_unearned_income": 67.89,
         "snap_countable_financial_resources": 999,
     }
+
+
+def test_new_york_projector_uses_repaired_work_disqualification_input():
+    values = {
+        "snap_dependent_care_deduction": [0],
+        "snap_earned_income": [0],
+        "meets_snap_work_requirements": [False],
+    }
+
+    projected = project_jurisdiction_household_inputs(
+        JURISDICTION_CONFIGS["us-ny"], values, 0
+    )
+
+    assert "household_member_failed_snap_work_requirements" not in projected
+    assert (
+        projected[
+            "household_member_disqualified_for_failure_to_comply_with_work_requirements"
+        ]
+        is True
+    )
 
 
 def test_california_projectors_use_california_snap_input_surface():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2083,6 +2083,18 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
     assert section_2014c_poverty_line_mapping.mapping_type == "not_comparable"
     assert section_2014c_poverty_line_mapping.policyengine_variable == "snap_fpg"
+    ca_snap_benefit_mapping = registry.mapping_for_legal_id(
+        "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_benefit",
+        country="us",
+    )
+    assert ca_snap_benefit_mapping.mapping_type == "not_comparable"
+    assert ca_snap_benefit_mapping.policyengine_variable == "snap"
+    ca_snap_monthly_income_mapping = registry.mapping_for_legal_id(
+        "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_monthly_household_income",
+        country="us",
+    )
+    assert ca_snap_monthly_income_mapping.mapping_type == "not_comparable"
+    assert ca_snap_monthly_income_mapping.policyengine_variable == "snap_gross_income"
     shelter_cap_mapping = registry.mapping_for_legal_id(
         "us:policies/usda/snap/fy-2026-cola/deductions#snap_maximum_excess_shelter_deduction_alaska",
         country="us",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.466"
+version = "0.2.467"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.456"
+version = "0.2.457"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.458"
+version = "0.2.459"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.461"
+version = "0.2.462"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.454"
+version = "0.2.455"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.474"
+version = "0.2.475"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.450"
+version = "0.2.451"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.479"
+version = "0.2.480"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.478"
+version = "0.2.479"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.452"
+version = "0.2.454"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.460"
+version = "0.2.461"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.469"
+version = "0.2.470"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.465"
+version = "0.2.466"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.464"
+version = "0.2.465"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.448"
+version = "0.2.449"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.457"
+version = "0.2.458"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.480"
+version = "0.2.481"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.463"
+version = "0.2.464"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.459"
+version = "0.2.460"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.477"
+version = "0.2.478"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.462"
+version = "0.2.463"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.475"
+version = "0.2.476"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.471"
+version = "0.2.472"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.447"
+version = "0.2.448"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.468"
+version = "0.2.469"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.476"
+version = "0.2.477"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.473"
+version = "0.2.474"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.455"
+version = "0.2.456"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.470"
+version = "0.2.471"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.451"
+version = "0.2.452"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.472"
+version = "0.2.473"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.449"
+version = "0.2.450"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.467"
+version = "0.2.468"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- Fix California SNAP ECPS oracle projection to emit person-level household members for California while keeping Colorado/New York member projections intact.
- Add California SNAP oracle mappings and focused request-shape tests.
- Preserve and extend Pavel's New York SNAP deterministic repair work, including categorical, benefit, income, SSN, household eligibility, relation repair paths, and final gross-income/excess-shelter diagnostics.
- Project New York SNAP ECPS relation/member inputs for the repaired categorical and benefit surfaces.
- Address review findings: emit the repaired New York work-disqualification input, guard the California old SUA guidance path and old/new layout collisions, and restore 7 CFR 273.10 files if validation fails or raises.
- Bump encoder metadata to 0.2.481.

## Verification

- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run ruff format --check src/axiom_encode tests`
- `uv run python -m compileall -q src/axiom_encode scripts`
- `uv run --python 3.13 --with pytest --with pytest-cov --with pytest-asyncio python -m pytest tests/test_policyengine_ecps_snap.py -q`
- `uv run --python 3.13 --with pytest --with pytest-cov --with pytest-asyncio python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
- `uv run --python 3.13 --with pytest --with pytest-cov --with pytest-asyncio python -m pytest tests/test_policyengine_ecps_snap.py tests/test_cli.py -k 'california_snap or new_york_snap or 273_10_allotment' -q`

Read-only subagent review was clean on `90342d7`; final read-only review was also clean on pushed head `64c5bbe`.


