### PR TITLE
Map UK income tax section 23 oracle coverage

### DIFF
--- a/changelog.d/uk-s23-oracle-coverage.fixed.md
+++ b/changelog.d/uk-s23-oracle-coverage.fixed.md
@@ -1,0 +1,1 @@
+Map UK Income Tax Act section 23 outputs in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.447"
+version = "0.2.448"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.447"
+__version__ = "0.2.448"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -527,7 +527,12 @@ def _coverage_item_from_mapping(
 
 def _infer_program_from_legal_id(legal_id: str) -> str:
     lowered = legal_id.lower()
-    if lowered.startswith("uk:statutes/ukpga/2007/3/35"):
+    if lowered.startswith(
+        (
+            "uk:statutes/ukpga/2007/3/23",
+            "uk:statutes/ukpga/2007/3/35",
+        )
+    ):
         return "tax"
     if lowered.startswith("uk:regulations/uksi/2006/965/2"):
         return "child_benefit"

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1,4 +1,55 @@
 mappings:
+  - legal_id: uk:statutes/ukpga/2007/3/23#total_income
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: total_income
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK income tax total-income component sum before personal allowances.
+
+  - legal_id: uk:statutes/ukpga/2007/3/23#net_income
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: adjusted_net_income
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK income tax adjusted net income after reliefs and before allowances.
+
+  - legal_id: uk:statutes/ukpga/2007/3/23#income_tax_liability
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: income_tax
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final UK income tax liability after reductions and listed tax additions.
+
+  - legal_id: uk:statutes/ukpga/2007/3/23#income_remaining_after_allowances
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: UK income tax step-control value with no one-to-one PolicyEngine UK oracle variable.
+
+  - legal_id: uk:statutes/ukpga/2007/3/23#tax_left_after_reductions
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: UK income tax intermediate value before listed additions with no one-to-one PolicyEngine UK oracle variable.
+
+  - legal_id: uk:statutes/ukpga/2007/3/23#net_income_zero_amount
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Generated statutory zero constant rather than a PolicyEngine UK variable or parameter.
+
   - legal_id: uk:statutes/ukpga/2007/3/35#personal_allowance_base_amount
     country: uk
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -198,6 +198,119 @@ rules:
     assert rounding_multiple["status"] == "known_not_comparable"
 
 
+def test_policyengine_coverage_classifies_uk_income_tax_section_23_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2007/3/23.yaml",
+        """format: rulespec/v1
+rules:
+  - name: total_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: income
+  - name: net_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(0, total_income - reliefs)
+  - name: income_tax_liability
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: income_tax
+  - name: income_remaining_after_allowances
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: taxable_income
+  - name: tax_left_after_reductions
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: tax_after_reductions
+  - name: net_income_zero_amount
+    kind: parameter
+    dtype: Money
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+  - name: future_section_23_output
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2007/3/23.test.yaml",
+        """- name: income tax steps
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    uk:statutes/ukpga/2007/3/23#total_income: 40000
+    uk:statutes/ukpga/2007/3/23#net_income: 38500
+    uk:statutes/ukpga/2007/3/23#income_tax_liability: 4300
+    uk:statutes/ukpga/2007/3/23#income_remaining_after_allowances: 25430
+    uk:statutes/ukpga/2007/3/23#tax_left_after_reductions: 4200
+    uk:statutes/ukpga/2007/3/23#net_income_zero_amount: 0
+    uk:statutes/ukpga/2007/3/23#future_section_23_output: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {
+        "comparable": 3,
+        "known_not_comparable": 3,
+        "unmapped": 1,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    total_income = items_by_id["uk:statutes/ukpga/2007/3/23#total_income"]
+    net_income = items_by_id["uk:statutes/ukpga/2007/3/23#net_income"]
+    liability = items_by_id["uk:statutes/ukpga/2007/3/23#income_tax_liability"]
+    remaining = items_by_id[
+        "uk:statutes/ukpga/2007/3/23#income_remaining_after_allowances"
+    ]
+    future_output = items_by_id["uk:statutes/ukpga/2007/3/23#future_section_23_output"]
+
+    assert total_income["policyengine_variable"] == "total_income"
+    assert total_income["tested"] is True
+    assert net_income["policyengine_variable"] == "adjusted_net_income"
+    assert net_income["tested"] is True
+    assert liability["policyengine_variable"] == "income_tax"
+    assert liability["tested"] is True
+    assert remaining["status"] == "known_not_comparable"
+    assert future_output["status"] == "unmapped"
+
+
 def test_policyengine_coverage_counts_uk_aliases_as_tested(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-uk" / "regulations/uksi/2006/965/2.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.447"
+version = "0.2.448"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map UK Income Tax Act 2007 section 23 outputs to PolicyEngine UK oracle targets where exact
- classify section 23 intermediate outputs with exact not-comparable rationales instead of a broad prefix
- infer section 23 legal IDs as tax so future unmapped section 23 outputs stay visible in tax coverage reports
- bump axiom-encode to 0.2.448

## Validation
- git diff --check
- uv run ruff check pyproject.toml src/axiom_encode scripts tests
- uv run ruff format --check src/axiom_encode/oracles/policyengine tests/test_policyengine_coverage.py
- uv run python -m compileall -q src/axiom_encode scripts
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- copied rulespec-uk PR #2 locally and verified section 23 oracle coverage has no unmapped or untested comparable outputs

## Cycle
- independent review pass 1: no actionable findings; noted broad-prefix masking risk
- tightened implementation to exact not-comparable entries and added a future-output unmapped guard
- independent review pass 2: no actionable findings

Unblocks TheAxiomFoundation/rulespec-uk#2 oracle coverage.