### PR TITLE
Classify California SNAP utility allowance outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.481"
+version = "0.2.482"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.481"
+__version__ = "0.2.482"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -664,6 +664,32 @@ mappings:
     mapping_type: not_comparable
     rationale: Axiom composition helper summing California shelter costs and standard utility allowance; PE uses separate housing-cost and SNAP utility-allowance variables.
 
+  - legal_id: us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance_amount
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_standard_utility_allowance
+    candidate_priority: P4
+    rationale: California FFY 2026 source parameter for the heating/cooling standard utility allowance amount; PE exposes the resulting allowance after eligibility/type selection, not this state source parameter alone.
+
+  - legal_id: us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance_eligible
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: California source predicate for heating/cooling standard utility allowance eligibility; PE derives utility allowance type internally rather than exposing this predicate.
+
+  - legal_id: us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance
+    country: us
+    program: snap
+    mapping_type: direct_variable
+    policyengine_variable: snap_standard_utility_allowance
+    entity: spm_unit
+    period: month
+    unit: USD
+    comparison: money
+    rationale: California standard utility allowance, with state and utility eligibility inputs supplied by the ECPS SNAP adapter.
+
   - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_total_allowable_shelter_expenses
     country: us
     program: snap

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.481"
+version = "0.2.482"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify the new California SNAP utility allowance RuleSpec outputs in the PolicyEngine registry
- map the final standard utility allowance to PE's snap_standard_utility_allowance
- mark the source amount parameter and eligibility predicate as not directly comparable

## Validation
- uv run --extra dev axiom-encode oracle-coverage --root /Users/pavelmakarchuk --program snap --limit 10
- uv run --extra dev pytest tests/test_cli.py -k "oracle_coverage or classify or current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata"