### PR TITLE
Slice state statute children for Colorado income tax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.484"
+version = "0.2.485"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.483"
+version = "0.2.484"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.487"
+version = "0.2.488"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.486"
+version = "0.2.487"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.482"
+version = "0.2.483"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.485"
+version = "0.2.486"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.486"
+__version__ = "0.2.487"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.483"
+__version__ = "0.2.484"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.485"
+__version__ = "0.2.486"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.484"
+__version__ = "0.2.485"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.487"
+__version__ = "0.2.488"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.482"
+__version__ = "0.2.483"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1707,7 +1707,24 @@ def _slice_legal_text_by_parenthetical_fragments(
     fragments: tuple[str, ...],
 ) -> str | None:
     current = text
-    for depth, fragment in enumerate(fragments):
+    depth = 0
+    while depth < len(fragments):
+        fragment = fragments[depth]
+        if depth + 1 < len(fragments):
+            combined = _combined_dotted_parenthetical_fragment(
+                fragment, fragments[depth + 1]
+            )
+            if combined is not None:
+                combined_slice = _slice_legal_text_by_parenthetical_fragment(
+                    current,
+                    combined,
+                    top_level=depth == 0,
+                )
+                if combined_slice is not None:
+                    current = combined_slice
+                    depth += 2
+                    continue
+
         current = _slice_legal_text_by_parenthetical_fragment(
             current,
             fragment,
@@ -1715,7 +1732,18 @@ def _slice_legal_text_by_parenthetical_fragments(
         )
         if current is None:
             return None
+        depth += 1
     return current.strip()
+
+
+def _combined_dotted_parenthetical_fragment(
+    fragment: str, next_fragment: str
+) -> str | None:
+    if not next_fragment.isdigit():
+        return None
+    if re.fullmatch(r"(?:[A-Za-z]|\d+)(?:\.\d+)*", fragment):
+        return f"{fragment}.{next_fragment}"
+    return None
 
 
 def _slice_legal_text_by_parenthetical_fragment(
@@ -1769,7 +1797,10 @@ _NONSTRUCTURAL_PARENTHETICAL_REFERENCE_PREFIX = re.compile(
 def _parenthetical_marker_context_is_structural(text: str, marker_start: int) -> bool:
     prefix = text[max(0, marker_start - 60) : marker_start]
     previous = prefix.rstrip()[-1:] if prefix.rstrip() else ""
-    if previous == ")":
+    if previous == ")" and not re.search(
+        r"(?:^|\n)\s*\([A-Za-z0-9]+(?:\.[0-9]+)*\)\s+$",
+        prefix,
+    ):
         return False
     if _NONSTRUCTURAL_PARENTHETICAL_REFERENCE_PREFIX.search(prefix):
         return False
@@ -1793,10 +1824,12 @@ def _sibling_parenthetical_marker_pattern(
     fragment: str,
     top_level: bool,
 ) -> re.Pattern[str]:
-    if fragment.isdigit():
-        marker = rf"\({int(fragment) + 1}\)"
-    elif top_level and re.fullmatch(r"\d+(?:\.\d+)+", fragment):
-        marker = r"\([0-9]+(?:\.[0-9]+)*\)"
+    if re.fullmatch(r"\d+(?:\.\d+)*", fragment):
+        marker = _numeric_sibling_parenthetical_marker(fragment)
+    elif re.fullmatch(r"[A-Z](?:\.\d+)*", fragment):
+        marker = _alpha_sibling_parenthetical_marker(fragment)
+    elif re.fullmatch(r"[a-z](?:\.\d+)*", fragment):
+        marker = _alpha_sibling_parenthetical_marker(fragment)
     elif len(fragment) == 1 and fragment.isalpha() and fragment.isupper():
         marker = (
             _next_alpha_parenthetical_marker(fragment) if top_level else r"\([A-Z]\)"
@@ -1812,6 +1845,34 @@ def _sibling_parenthetical_marker_pattern(
     if top_level:
         return re.compile(rf"\n\s*({marker}\s+)")
     return re.compile(rf"(?<![A-Za-z0-9])({marker}\s+)")
+
+
+def _numeric_sibling_parenthetical_marker(fragment: str) -> str:
+    stem = fragment.split(".", 1)[0]
+    same_stem = _same_stem_dotted_sibling_marker(stem, fragment)
+    next_stem = str(int(stem) + 1)
+    return rf"\((?:{same_stem}|{next_stem}(?:\.[0-9]+)*)\)"
+
+
+def _alpha_sibling_parenthetical_marker(fragment: str) -> str:
+    stem = fragment[0]
+    same_stem = _same_stem_dotted_sibling_marker(stem, fragment)
+    next_codepoint = ord(stem) + 1
+    if stem.islower() and next_codepoint <= ord("z"):
+        next_stem = chr(next_codepoint)
+    elif stem.isupper() and next_codepoint <= ord("Z"):
+        next_stem = chr(next_codepoint)
+    else:
+        next_stem = r"\b\B"
+    return rf"\((?:{same_stem}|{next_stem}(?:\.[0-9]+)*)\)"
+
+
+def _same_stem_dotted_sibling_marker(stem: str, fragment: str) -> str:
+    escaped_stem = re.escape(stem)
+    if "." not in fragment:
+        return rf"{escaped_stem}(?:\.[0-9]+)+"
+    suffix = re.escape(fragment.split(".", 1)[1])
+    return rf"{escaped_stem}\.(?!{suffix}(?:\.|\)))[0-9]+(?:\.[0-9]+)*"
 
 
 def _next_alpha_parenthetical_marker(fragment: str) -> str:
@@ -4955,12 +5016,10 @@ def _legal_fragments_from_rulespec_ref(target_ref_prefix: str) -> list[str]:
 
 def _sibling_marker_pattern(fragment: str) -> str | None:
     """Return a parenthetical marker pattern for the next same-level sibling."""
-    if re.fullmatch(r"\d+(?:\.\d+)?", fragment):
-        return r"\(\d+(?:\.\d+)?\)"
-    if re.fullmatch(r"[a-z](?:\.\d+)?", fragment, flags=re.IGNORECASE):
-        if fragment.isupper():
-            return r"\([A-Z](?:\.\d+)?\)"
-        return r"\([a-z](?:\.\d+)?\)"
+    if re.fullmatch(r"\d+(?:\.\d+)*", fragment):
+        return _numeric_sibling_parenthetical_marker(fragment)
+    if re.fullmatch(r"[a-z](?:\.\d+)*", fragment, flags=re.IGNORECASE):
+        return _alpha_sibling_parenthetical_marker(fragment)
     return None
 
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1690,12 +1690,16 @@ def _slice_parent_corpus_text_for_requested_path(
     if (
         len(requested_parts) <= len(resolved_parts)
         or requested_parts[: len(resolved_parts)] != resolved_parts
-        or resolved_parts[:2] not in (["us", "statute"], ["us", "regulation"])
+        or not _citation_path_supports_parenthetical_slicing(resolved_parts)
     ):
         return text
     missing_fragments = tuple(requested_parts[len(resolved_parts) :])
     sliced = _slice_legal_text_by_parenthetical_fragments(text, missing_fragments)
     return sliced if sliced is not None else text
+
+
+def _citation_path_supports_parenthetical_slicing(parts: list[str]) -> bool:
+    return len(parts) >= 2 and parts[1] in {"statute", "regulation"}
 
 
 def _slice_legal_text_by_parenthetical_fragments(
@@ -1722,7 +1726,7 @@ def _slice_legal_text_by_parenthetical_fragment(
 ) -> str | None:
     escaped = re.escape(fragment)
     if top_level:
-        marker_pattern = re.compile(rf"(?:^|\n\s*\n)(\({escaped}\)\s+)")
+        marker_pattern = re.compile(rf"(?:^|\n\s*)(\({escaped}\)\s+)")
     else:
         marker_pattern = re.compile(rf"(?<![A-Za-z0-9])(\({escaped}\)\s+)")
     marker_match = next(
@@ -1791,6 +1795,8 @@ def _sibling_parenthetical_marker_pattern(
 ) -> re.Pattern[str]:
     if fragment.isdigit():
         marker = rf"\({int(fragment) + 1}\)"
+    elif top_level and re.fullmatch(r"\d+(?:\.\d+)+", fragment):
+        marker = r"\([0-9]+(?:\.[0-9]+)*\)"
     elif len(fragment) == 1 and fragment.isalpha() and fragment.isupper():
         marker = (
             _next_alpha_parenthetical_marker(fragment) if top_level else r"\([A-Z]\)"
@@ -1804,7 +1810,7 @@ def _sibling_parenthetical_marker_pattern(
     else:
         marker = r"\([A-Za-z0-9]+\)"
     if top_level:
-        return re.compile(rf"\n\s*\n({marker}\s+)")
+        return re.compile(rf"\n\s*({marker}\s+)")
     return re.compile(rf"(?<![A-Za-z0-9])({marker}\s+)")
 
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1706,34 +1706,54 @@ def _slice_legal_text_by_parenthetical_fragments(
     text: str,
     fragments: tuple[str, ...],
 ) -> str | None:
-    current = text
-    depth = 0
-    while depth < len(fragments):
-        fragment = fragments[depth]
-        if depth + 1 < len(fragments):
-            combined = _combined_dotted_parenthetical_fragment(
-                fragment, fragments[depth + 1]
-            )
-            if combined is not None:
-                combined_slice = _slice_legal_text_by_parenthetical_fragment(
-                    current,
-                    combined,
-                    top_level=depth == 0,
-                )
-                if combined_slice is not None:
-                    current = combined_slice
-                    depth += 2
-                    continue
+    sliced = _slice_legal_text_by_parenthetical_fragments_from(
+        text,
+        fragments,
+        depth=0,
+    )
+    return sliced.strip() if sliced is not None else None
 
-        current = _slice_legal_text_by_parenthetical_fragment(
-            current,
-            fragment,
-            top_level=depth == 0,
+
+def _slice_legal_text_by_parenthetical_fragments_from(
+    text: str,
+    fragments: tuple[str, ...],
+    *,
+    depth: int,
+) -> str | None:
+    if not fragments:
+        return text
+
+    fragment = fragments[0]
+    simple_slice = _slice_legal_text_by_parenthetical_fragment(
+        text,
+        fragment,
+        top_level=depth == 0,
+    )
+    if simple_slice is not None:
+        simple_result = _slice_legal_text_by_parenthetical_fragments_from(
+            simple_slice,
+            fragments[1:],
+            depth=depth + 1,
         )
-        if current is None:
-            return None
-        depth += 1
-    return current.strip()
+        if simple_result is not None:
+            return simple_result
+
+    if len(fragments) >= 2:
+        combined = _combined_dotted_parenthetical_fragment(fragment, fragments[1])
+        if combined is not None:
+            combined_slice = _slice_legal_text_by_parenthetical_fragment(
+                text,
+                combined,
+                top_level=depth == 0,
+            )
+            if combined_slice is not None:
+                return _slice_legal_text_by_parenthetical_fragments_from(
+                    combined_slice,
+                    fragments[2:],
+                    depth=depth + 2,
+                )
+
+    return None
 
 
 def _combined_dotted_parenthetical_fragment(
@@ -1827,9 +1847,9 @@ def _sibling_parenthetical_marker_pattern(
     if re.fullmatch(r"\d+(?:\.\d+)*", fragment):
         marker = _numeric_sibling_parenthetical_marker(fragment)
     elif re.fullmatch(r"[A-Z](?:\.\d+)*", fragment):
-        marker = _alpha_sibling_parenthetical_marker(fragment)
+        marker = _alpha_sibling_parenthetical_marker(fragment, top_level=top_level)
     elif re.fullmatch(r"[a-z](?:\.\d+)*", fragment):
-        marker = _alpha_sibling_parenthetical_marker(fragment)
+        marker = _alpha_sibling_parenthetical_marker(fragment, top_level=top_level)
     elif len(fragment) == 1 and fragment.isalpha() and fragment.isupper():
         marker = (
             _next_alpha_parenthetical_marker(fragment) if top_level else r"\([A-Z]\)"
@@ -1854,17 +1874,33 @@ def _numeric_sibling_parenthetical_marker(fragment: str) -> str:
     return rf"\((?:{same_stem}|{next_stem}(?:\.[0-9]+)*)\)"
 
 
-def _alpha_sibling_parenthetical_marker(fragment: str) -> str:
+def _alpha_sibling_parenthetical_marker(fragment: str, *, top_level: bool) -> str:
     stem = fragment[0]
     same_stem = _same_stem_dotted_sibling_marker(stem, fragment)
+    following_stem = (
+        _next_alpha_parenthetical_stem_marker(stem)
+        if top_level
+        else _following_alpha_parenthetical_stem_marker(stem)
+    )
+    return rf"\((?:{same_stem}|{following_stem}(?:\.[0-9]+)*)\)"
+
+
+def _next_alpha_parenthetical_stem_marker(stem: str) -> str:
     next_codepoint = ord(stem) + 1
     if stem.islower() and next_codepoint <= ord("z"):
-        next_stem = chr(next_codepoint)
-    elif stem.isupper() and next_codepoint <= ord("Z"):
-        next_stem = chr(next_codepoint)
-    else:
-        next_stem = r"\b\B"
-    return rf"\((?:{same_stem}|{next_stem}(?:\.[0-9]+)*)\)"
+        return chr(next_codepoint)
+    if stem.isupper() and next_codepoint <= ord("Z"):
+        return chr(next_codepoint)
+    return r"\b\B"
+
+
+def _following_alpha_parenthetical_stem_marker(stem: str) -> str:
+    next_codepoint = ord(stem) + 1
+    if stem.islower() and next_codepoint <= ord("z"):
+        return f"[{chr(next_codepoint)}-z]"
+    if stem.isupper() and next_codepoint <= ord("Z"):
+        return f"[{chr(next_codepoint)}-Z]"
+    return r"\b\B"
 
 
 def _same_stem_dotted_sibling_marker(stem: str, fragment: str) -> str:
@@ -5019,7 +5055,7 @@ def _sibling_marker_pattern(fragment: str) -> str | None:
     if re.fullmatch(r"\d+(?:\.\d+)*", fragment):
         return _numeric_sibling_parenthetical_marker(fragment)
     if re.fullmatch(r"[a-z](?:\.\d+)*", fragment, flags=re.IGNORECASE):
-        return _alpha_sibling_parenthetical_marker(fragment)
+        return _alpha_sibling_parenthetical_marker(fragment, top_level=False)
     return None
 
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1870,8 +1870,25 @@ def _sibling_parenthetical_marker_pattern(
 def _numeric_sibling_parenthetical_marker(fragment: str) -> str:
     stem = fragment.split(".", 1)[0]
     same_stem = _same_stem_dotted_sibling_marker(stem, fragment)
-    next_stem = str(int(stem) + 1)
-    return rf"\((?:{same_stem}|{next_stem}(?:\.[0-9]+)*)\)"
+    following_stem = _following_numeric_parenthetical_stem_marker(stem)
+    return rf"\((?:{same_stem}|{following_stem}(?:\.[0-9]+)*)\)"
+
+
+def _following_numeric_parenthetical_stem_marker(stem: str) -> str:
+    digits = str(int(stem))
+    same_width_patterns: list[str] = []
+    for idx, digit in enumerate(digits):
+        lower = int(digit) + 1
+        if idx == 0:
+            lower = max(lower, 1)
+        if lower > 9:
+            continue
+        prefix = re.escape(digits[:idx])
+        suffix_len = len(digits) - idx - 1
+        suffix = rf"[0-9]{{{suffix_len}}}" if suffix_len else ""
+        same_width_patterns.append(rf"{prefix}[{lower}-9]{suffix}")
+    longer_width = rf"[1-9][0-9]{{{len(digits)},}}"
+    return "(?:" + "|".join([*same_width_patterns, longer_width]) + ")"
 
 
 def _alpha_sibling_parenthetical_marker(fragment: str, *, top_level: bool) -> str:

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -1102,7 +1102,6 @@ def load_policyengine_cases(
             **project_income_resource_inputs(config, values, idx),
             "household_size": int(values["snap_unit_size"][idx]),
             "household_shelter_costs_incurred": money(values["housing_cost"][idx]),
-            "us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction": 0,
             "household_lives_in_application_state": True,
             "household_in_project_area_solely_for_vacation": False,
             "household_contains_individual_participating_in_more_than_one_household_or_project_area": False,
@@ -1118,6 +1117,12 @@ def load_policyengine_cases(
         }
         for input_name, value in projected_inputs.items():
             set_input_value(inputs, input_name, value)
+        set_input_value(
+            inputs,
+            "snap_claimed_homeless_shelter_deduction",
+            0,
+            required=False,
+        )
         member_inputs = project_student_member_inputs(
             bool(student_ok_by_spm.get(spm_id, False))
         )

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1023,6 +1023,25 @@ mappings:
     mapping_type: not_comparable
     rationale: This generated output is the statutory 4.55% base rate before applying later TABOR/form-rate reductions; PolicyEngine exposes the final Colorado form rate for each tax year.
 
+  - legal_id: us-co:statutes/39/39-22-104/3/d#state_income_tax_deduction_addition_limit
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_state_addback
+    candidate_priority: P4
+    rationale: This RuleSpec output is the statutory cap used inside the Colorado state-income-tax deduction addback; PolicyEngine computes the same cap inside co_state_addback rather than exposing it as a separate variable.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/d#state_income_tax_deduction_addition_to_federal_taxable_income
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: co_state_addback
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado state income tax addback amount. PolicyEngine implements the filing-guide worksheet to derive the state-income-tax deduction claimed and statutory itemized-minus-standard-deduction limit from federal tax inputs.
+
   - legal_id: us-co:statutes/39/39-22-104/3/o#single_return_adjusted_gross_income_threshold_for_section_199a_addition
     country: us
     program: tax
@@ -1148,6 +1167,17 @@ mappings:
     policyengine_variable: co_federal_deduction_addback
     candidate_priority: P3
     rationale: This RuleSpec output is the subsection (3)(p.5) initial-window amount and includes the healthy-school-meals repeal exception; PolicyEngine exposes a unified federal-deduction addback amount without that repeal condition.
+
+  - legal_id: us-co:statutes/39/39-22-104/4/a#united_states_possessions_obligations_interest_income_subtraction
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: us_govt_interest
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado subtraction for interest income on obligations of the United States and its possessions to the extent included in federal taxable income; PolicyEngine supplies that amount as us_govt_interest and includes it in Colorado subtractions.
 
   - legal_id: us-co:statutes/39/39-22-104/4/m#charitable_contribution_subtraction_floor
     country: us

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -439,6 +439,24 @@ class TestCorpusSourceResolution:
         assert source.body == "(a) First rate period."
         assert "(c) Third rate period" not in source.body
 
+    def test_resolves_numeric_child_path_stops_at_later_omitted_sibling(self, tmp_path):
+        corpus_path = _write_test_corpus_provision(
+            tmp_path,
+            citation_path="us-co/statute/39/39-22-104",
+            body=(
+                "(1) First addition rule.\n"
+                "(3) Third addition rule after omitted subsection."
+            ),
+        )
+
+        source = resolve_corpus_source_unit(
+            "us-co/statute/39/39-22-104/1",
+            corpus_path,
+        )
+
+        assert source.body == "(1) First addition rule."
+        assert "(3) Third addition rule" not in source.body
+
     def test_resolves_usc_child_citation_to_sliced_section_provision(self, tmp_path):
         corpus_path = tmp_path / "axiom-corpus"
         provisions_dir = (
@@ -6151,6 +6169,53 @@ rules:
         assert "except as otherwise provided in section" in prompt
         assert "cited provision's separate amount" in prompt
         assert "subsection_x_does_not_displace_this_subsection" in prompt
+
+    def test_build_eval_prompt_scopes_partial_extent_to_numeric_target_paragraph(
+        self, tmp_path
+    ):
+        policy_repo_root = tmp_path / "rulespec-us"
+        child_file = policy_repo_root / "statutes" / "26" / "999" / "1" / "a.yaml"
+        child_file.parent.mkdir(parents=True, exist_ok=True)
+        child_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: child_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: taxable_amount * rate
+"""
+        )
+        workspace = prepare_eval_workspace(
+            citation="26 USC 999(1)",
+            runner=parse_runner_spec("openai:gpt-5.5"),
+            output_root=tmp_path / "out",
+            source_text=(
+                "(1) First rule imposes a tax.\n"
+                "(3) Wages are exempt from taxes imposed by this section "
+                "to the extent such wages are subject exclusively to another "
+                "country's social security laws."
+            ),
+            axiom_rules_path=policy_repo_root,
+            mode="repo-augmented",
+            extra_context_paths=[child_file],
+        )
+
+        prompt = _build_eval_prompt(
+            "26 USC 999(1)",
+            "repo-augmented",
+            workspace,
+            workspace.context_files,
+            target_file_name="1.yaml",
+            target_ref_prefix="us:statutes/26/999/1",
+            include_tests=True,
+            runner_backend="openai",
+        )
+
+        assert "Target-specific schema limit" not in prompt
 
     def test_build_eval_prompt_recommends_final_deduction_imports(self, tmp_path):
         policy_repo_root = tmp_path / "rulespec-us"

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -382,8 +382,7 @@ class TestCorpusSourceResolution:
         )
 
         assert us_interest.body == (
-            "(a) United States obligation interest included in federal "
-            "taxable income."
+            "(a) United States obligation interest included in federal taxable income."
         )
         assert "(a.5) Repealed" not in us_interest.body
         assert itemized_addback.body == "(p) Itemized deduction addback."
@@ -392,14 +391,53 @@ class TestCorpusSourceResolution:
             "(p.5) Healthy school meals deduction addback."
         )
         assert (
-            "(p.5) Alternate healthy school meals"
-            in healthy_school_meals_addback.body
+            "(p.5) Alternate healthy school meals" in healthy_school_meals_addback.body
         )
         assert (
             "(p.7) Additional healthy school meals"
             not in healthy_school_meals_addback.body
         )
         assert "(q) Food and beverage" not in healthy_school_meals_addback.body
+
+    def test_resolves_nested_child_before_dotted_sibling_fallback(self, tmp_path):
+        corpus_path = _write_test_corpus_provision(
+            tmp_path,
+            citation_path="us-co/statute/39/39-22-104",
+            body=(
+                "(4) There shall be subtracted from federal taxable income:\n"
+                "(a) United States obligation interest.\n"
+                "(1) Nested qualifying amount.\n"
+                "(a.1) Dotted sibling subtraction.\n"
+                "(b) Basis adjustment subtraction."
+            ),
+        )
+
+        source = resolve_corpus_source_unit(
+            "us-co/statute/39/39-22-104/4/a/1",
+            corpus_path,
+        )
+
+        assert source.body == "(1) Nested qualifying amount."
+        assert "(a.1) Dotted sibling" not in source.body
+
+    def test_resolves_alpha_child_path_stops_at_later_omitted_sibling(self, tmp_path):
+        corpus_path = _write_test_corpus_provision(
+            tmp_path,
+            citation_path="us-co/statute/39/39-22-104",
+            body=(
+                "(1) Tax is imposed as follows:\n"
+                "(a) First rate period.\n"
+                "(c) Third rate period after omitted subsection."
+            ),
+        )
+
+        source = resolve_corpus_source_unit(
+            "us-co/statute/39/39-22-104/1/a",
+            corpus_path,
+        )
+
+        assert source.body == "(a) First rate period."
+        assert "(c) Third rate period" not in source.body
 
     def test_resolves_usc_child_citation_to_sliced_section_provision(self, tmp_path):
         corpus_path = tmp_path / "axiom-corpus"

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -320,6 +320,33 @@ class TestCorpusSourceResolution:
         assert source.body == "manual child support text"
         assert source.source == "local"
 
+    def test_resolves_state_statute_child_path_to_sliced_section_provision(
+        self, tmp_path
+    ):
+        corpus_path = _write_test_corpus_provision(
+            tmp_path,
+            citation_path="us-co/statute/39/39-22-104",
+            body=(
+                "(1.7) (a) A prior rate applies.\n"
+                "(b) A second prior rate applies.\n"
+                "(c) Except as otherwise provided, a tax of four and "
+                "forty one-hundredths percent is imposed.\n"
+                "(2) Federal taxable income shall be modified before the rate."
+            ),
+        )
+
+        source = resolve_corpus_source_unit(
+            "us-co/statute/39/39-22-104/1.7/c",
+            corpus_path,
+        )
+
+        assert source.citation_path == "us-co/statute/39/39-22-104"
+        assert source.body == (
+            "(c) Except as otherwise provided, a tax of four and "
+            "forty one-hundredths percent is imposed."
+        )
+        assert "(2) Federal taxable income" not in source.body
+
     def test_resolves_usc_child_citation_to_sliced_section_provision(self, tmp_path):
         corpus_path = tmp_path / "axiom-corpus"
         provisions_dir = (

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -347,6 +347,60 @@ class TestCorpusSourceResolution:
         )
         assert "(2) Federal taxable income" not in source.body
 
+    def test_resolves_state_statute_child_path_stops_at_dotted_alpha_sibling(
+        self, tmp_path
+    ):
+        corpus_path = _write_test_corpus_provision(
+            tmp_path,
+            citation_path="us-co/statute/39/39-22-104",
+            body=(
+                "(4) There shall be subtracted from federal taxable income:\n"
+                "(a) United States obligation interest included in federal "
+                "taxable income.\n"
+                "(a.5) Repealed.\n"
+                "(b) Basis adjustment subtraction.\n"
+                "(3) There shall be added to federal taxable income:\n"
+                "(p) Itemized deduction addback.\n"
+                "(p.5) Healthy school meals deduction addback.\n"
+                "(p.5) Alternate healthy school meals deduction addback.\n"
+                "(p.7) Additional healthy school meals deduction addback.\n"
+                "(q) Food and beverage expense addback."
+            ),
+        )
+
+        us_interest = resolve_corpus_source_unit(
+            "us-co/statute/39/39-22-104/4/a",
+            corpus_path,
+        )
+        itemized_addback = resolve_corpus_source_unit(
+            "us-co/statute/39/39-22-104/3/p",
+            corpus_path,
+        )
+        healthy_school_meals_addback = resolve_corpus_source_unit(
+            "us-co/statute/39/39-22-104/3/p/5",
+            corpus_path,
+        )
+
+        assert us_interest.body == (
+            "(a) United States obligation interest included in federal "
+            "taxable income."
+        )
+        assert "(a.5) Repealed" not in us_interest.body
+        assert itemized_addback.body == "(p) Itemized deduction addback."
+        assert "(p.5) Healthy school meals" not in itemized_addback.body
+        assert healthy_school_meals_addback.body.startswith(
+            "(p.5) Healthy school meals deduction addback."
+        )
+        assert (
+            "(p.5) Alternate healthy school meals"
+            in healthy_school_meals_addback.body
+        )
+        assert (
+            "(p.7) Additional healthy school meals"
+            not in healthy_school_meals_addback.body
+        )
+        assert "(q) Food and beverage" not in healthy_school_meals_addback.body
+
     def test_resolves_usc_child_citation_to_sliced_section_provision(self, tmp_path):
         corpus_path = tmp_path / "axiom-corpus"
         provisions_dir = (

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -959,6 +959,101 @@ rules:
     assert {item["tested"] for item in report["items"]} == {True}
 
 
+def test_policyengine_coverage_maps_colorado_state_tax_and_us_interest_adjustments(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/3/d.yaml",
+        """format: rulespec/v1
+rules:
+  - name: state_income_tax_deduction_addition_limit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1992-01-01'
+        formula: itemized_deductions - standard_deduction
+  - name: state_income_tax_deduction_addition_to_federal_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1992-01-01'
+        formula: min(state_income_tax_deduction, state_income_tax_deduction_addition_limit)
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/3/d.test.yaml",
+        """- name: state income tax deduction addback outputs
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  output:
+    us-co:statutes/39/39-22-104/3/d#state_income_tax_deduction_addition_limit: 4000
+    us-co:statutes/39/39-22-104/3/d#state_income_tax_deduction_addition_to_federal_taxable_income: 500
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/4/a.yaml",
+        """format: rulespec/v1
+rules:
+  - name: united_states_possessions_obligations_interest_income_subtraction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1989-01-01'
+        formula: max(0, us_obligation_interest_included_in_federal_taxable_income)
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/4/a.test.yaml",
+        """- name: us obligations interest subtraction output
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {}
+  output:
+    us-co:statutes/39/39-22-104/4/a#united_states_possessions_obligations_interest_income_subtraction: 1200
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["total_outputs"] == 3
+    assert report["status_counts"] == {
+        "comparable": 2,
+        "known_not_comparable": 1,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    state_addback = items_by_id[
+        "us-co:statutes/39/39-22-104/3/d#state_income_tax_deduction_addition_to_federal_taxable_income"
+    ]
+    state_addback_limit = items_by_id[
+        "us-co:statutes/39/39-22-104/3/d#state_income_tax_deduction_addition_limit"
+    ]
+    us_interest = items_by_id[
+        "us-co:statutes/39/39-22-104/4/a#united_states_possessions_obligations_interest_income_subtraction"
+    ]
+    assert state_addback["policyengine_variable"] == "co_state_addback"
+    assert state_addback["status"] == "comparable"
+    assert state_addback["tested"] is True
+    assert state_addback_limit["status"] == "known_not_comparable"
+    assert state_addback_limit["policyengine_variable"] == "co_state_addback"
+    assert us_interest["policyengine_variable"] == "us_govt_interest"
+    assert us_interest["status"] == "comparable"
+    assert us_interest["tested"] is True
+
+
 def test_policyengine_coverage_classifies_colorado_deduction_addbacks(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/3/o.yaml",

--- a/tests/test_policyengine_ecps_snap.py
+++ b/tests/test_policyengine_ecps_snap.py
@@ -39,6 +39,25 @@ def test_set_input_value_updates_every_matching_legal_input():
     assert set(inputs.values()) == {4}
 
 
+def test_set_input_value_can_skip_optional_unknown_inputs():
+    inputs = {
+        "us-co:regulations/10-ccr-2506-1/4.407.3#input.verified_higher_homeless_shelter_costs": False,
+    }
+
+    set_input_value(
+        inputs,
+        "snap_claimed_homeless_shelter_deduction",
+        0,
+        required=False,
+    )
+
+    assert "snap_claimed_homeless_shelter_deduction" not in inputs
+    assert (
+        "us:regulations/7-cfr/273/10#input.snap_claimed_homeless_shelter_deduction"
+        not in inputs
+    )
+
+
 def test_new_york_projector_uses_federal_income_and_resource_inputs():
     values = {
         "snap_earned_income": [123.45],

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.485"
+version = "0.2.486"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.482"
+version = "0.2.483"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.486"
+version = "0.2.487"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.483"
+version = "0.2.484"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.487"
+version = "0.2.488"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.484"
+version = "0.2.485"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- slice state statute child citations from section-level corpus text, including dotted sibling paths like 39-22-104(3)(p.5)
- prefer ordinary nested parenthetical paths before dotted fallback, with omitted-sibling regression coverage
- map Colorado state income tax addback and U.S. obligations interest subtraction outputs to PolicyEngine coverage
- bump axiom-encode to 0.2.487

## Verification
- uv run --extra dev python -m pytest
- uv run --extra dev python -m pytest tests/test_evals.py -k 'state_statute_child or nested_child_before_dotted or omitted_sibling or nested_usc_child or nested_cfr_child or parenthetical_cross_reference'
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k 'colorado_state_tax_and_us_interest_adjustments or colorado_deduction_addbacks or colorado_income_tax_rate_parameter'
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/co-income-tax-20260531 --program tax --json