### PR TITLE
Classify Colorado EITC oracle coverage

### DIFF
--- a/changelog.d/co-eitc-policyengine-coverage.changed.md
+++ b/changelog.d/co-eitc-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated Colorado EITC RuleSpec outputs in the PolicyEngine oracle registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.490"
+version = "0.2.491"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.490"
+__version__ = "0.2.491"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1311,6 +1311,30 @@ mappings:
     candidate_priority: P4
     rationale: This RuleSpec output is the person-level statutory subtraction amount; PE exposes a tax-unit aggregate limited to head and spouse military-retirement pay.
 
+  - legal_id: us-co:statutes/39/39-22-123.5#credit_percentage_after_revenue_adjustment
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.co.tax.income.credits.eitc.match
+    candidate_priority: P2
+    rationale: This RuleSpec output computes Colorado's EITC percentage from the statutory base rate plus temporary and revenue-growth adjustments using the estimated adjustment factor; PolicyEngine stores a final date-varying match parameter and does not expose the adjustment-factor calculation boundary.
+
+  - legal_id: us-co:statutes/39/39-22-123.5#regular_federal_return_eitc_branch_before_part_year_apportionment
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_eitc
+    candidate_priority: P2
+    rationale: This RuleSpec output is the person-level regular federal-return branch before part-year apportionment; PolicyEngine exposes a final tax-unit Colorado EITC amount computed from federal eitc and a date-varying match parameter, not this branch-specific statutory boundary.
+
+  - legal_id: us-co:statutes/39/39-22-123.5#missing_valid_ssn_eitc_branch_before_part_year_apportionment
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_eitc
+    candidate_priority: P2
+    rationale: This RuleSpec output is the Colorado branch for credits that would have been allowed but for missing valid employment Social Security numbers; PolicyEngine's co_eitc uses federal eitc and does not expose this alternate state statutory branch.
+
   - legal_id_prefix: us-ny:regulations/18-nycrr/387/14/a/1#
     country: us
     program: snap
@@ -13508,6 +13532,12 @@ mappings:
     rationale: "Source-specific intermediate output (rule `timely_application_for_recertification`, grounded against `Ala. Admin. Code 660-4-7-.08`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
 prefixes:
+  - legal_id_prefix: us-co:statutes/39/39-22-123.5#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Colorado EITC generated outputs decompose statutory rates, revenue-growth adjustments, person-level branches, refundable-excess amounts, and public-benefit exclusions; PolicyEngine exposes only a final tax-unit co_eitc amount and date-varying match parameter unless an exact mapping above records a narrower adjacent target.
+
   - legal_id_prefix: us-az:policies/des/faa5/na-child-support-expense/allowable-deductions#
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1450,6 +1450,92 @@ rules:
     assert subtraction["policyengine_variable"] == "co_pension_subtraction"
 
 
+def test_policyengine_coverage_classifies_colorado_eitc_outputs(tmp_path):
+    output_names = (
+        "base_credit_percentage",
+        "temporary_credit_percentage_increase",
+        "revenue_adjustment_regime",
+        "adjustment_factor_threshold_for_single_year_increase",
+        "single_year_revenue_growth_percentage_point_increase",
+        "adjustment_factor_lower_bound_for_small_increase",
+        "small_revenue_growth_percentage_point_increase",
+        "adjustment_factor_lower_bound_for_moderate_increase",
+        "moderate_revenue_growth_percentage_point_increase",
+        "adjustment_factor_lower_bound_for_large_increase",
+        "large_revenue_growth_percentage_point_increase",
+        "adjustment_factor_lower_bound_for_larger_increase",
+        "larger_revenue_growth_percentage_point_increase",
+        "adjustment_factor_lower_bound_for_maximum_increase",
+        "maximum_revenue_growth_percentage_point_increase",
+        "revenue_growth_adjustment_percentage_points",
+        "credit_percentage_after_revenue_adjustment",
+        "regular_federal_return_eitc_branch_before_part_year_apportionment",
+        "missing_valid_ssn_eitc_branch_before_part_year_apportionment",
+        "regular_federal_return_eitc_branch_refundable_excess",
+        "missing_valid_ssn_eitc_branch_refundable_excess",
+        "regular_federal_return_eitc_branch_excluded_from_public_benefit_income_or_resources",
+        "missing_valid_ssn_eitc_branch_excluded_from_public_benefit_income_or_resources",
+    )
+    rules = "\n".join(
+        f"""  - name: {name}
+    kind: derived
+    versions:
+      - effective_from: '2024-01-01'
+        formula: '1'"""
+        for name in output_names
+    )
+    outputs = "\n".join(
+        f"    us-co:statutes/39/39-22-123.5#{name}: 1" for name in output_names
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-123.5.yaml",
+        f"""format: rulespec/v1
+rules:
+{rules}
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-123.5.test.yaml",
+        f"""- name: colorado eitc outputs
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {{}}
+  output:
+{outputs}
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["total_outputs"] == len(output_names)
+    assert report["status_counts"] == {"known_not_comparable": len(output_names)}
+    assert report["untested_comparable"] == 0
+    assert {item["program"] for item in report["items"]} == {"tax"}
+    assert {item["tested"] for item in report["items"]} == {True}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    rate = items_by_id[
+        "us-co:statutes/39/39-22-123.5#credit_percentage_after_revenue_adjustment"
+    ]
+    regular_branch = items_by_id[
+        "us-co:statutes/39/39-22-123.5#regular_federal_return_eitc_branch_before_part_year_apportionment"
+    ]
+    missing_ssn_branch = items_by_id[
+        "us-co:statutes/39/39-22-123.5#missing_valid_ssn_eitc_branch_before_part_year_apportionment"
+    ]
+    refundable_excess = items_by_id[
+        "us-co:statutes/39/39-22-123.5#regular_federal_return_eitc_branch_refundable_excess"
+    ]
+    assert (
+        rate["policyengine_parameter"] == "gov.states.co.tax.income.credits.eitc.match"
+    )
+    assert rate["candidate_priority"] == "P2"
+    assert regular_branch["policyengine_variable"] == "co_eitc"
+    assert missing_ssn_branch["policyengine_variable"] == "co_eitc"
+    assert refundable_excess["policyengine_variable"] is None
+
+
 def test_policyengine_coverage_classifies_3102a_collection_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3102/a.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.490"
+version = "0.2.491"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated Colorado EITC outputs in the PolicyEngine oracle registry
- record adjacent PE targets for the final EITC match parameter and `co_eitc`, while keeping branch/rate-boundary outputs known-not-comparable
- add regression coverage for the full generated 39-22-123.5 output surface
- bump axiom-encode to 0.2.491

## Verification
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_colorado_eitc_outputs`
- `uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py`
- `uv run --extra dev python -m towncrier build --draft --version 0.0.0`
- `uv run python -m compileall -q src/axiom_encode scripts`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/co-income-tax-next-20260531 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 10`

## Review
- Subagent read-only review: no actionable findings; focused CO EITC coverage test passed.