### PR TITLE
Classify Colorado AMT oracle coverage

### DIFF
--- a/changelog.d/co-amt-policyengine-coverage.changed.md
+++ b/changelog.d/co-amt-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated Colorado AMT outputs in the PolicyEngine oracle registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.491"
+version = "0.2.492"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.491"
+__version__ = "0.2.492"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -544,6 +544,7 @@ def _infer_program_from_legal_id(legal_id: str) -> str:
         return "snap"
     if (
         lowered.startswith("us:statutes/26/")
+        or lowered.startswith("us-co:statutes/39/")
         or lowered.startswith("us:policies/irs/")
         or lowered.startswith("us:policies/ssa/")
     ):

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1311,6 +1311,23 @@ mappings:
     candidate_priority: P4
     rationale: This RuleSpec output is the person-level statutory subtraction amount; PE exposes a tax-unit aggregate limited to head and spouse military-retirement pay.
 
+  - legal_id: us-co:statutes/39/39-22-105#alternative_minimum_tax_rate
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.amt.rate
+    period: year
+    comparison: rate
+    rationale: Same Colorado alternative minimum tax rate, stored in PE as the Colorado AMT rate parameter.
+
+  - legal_id: us-co:statutes/39/39-22-105#individual_alternative_minimum_tax_amount_before_regular_tax_offset
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_tentative_minimum_tax
+    candidate_priority: P2
+    rationale: This RuleSpec output is the person-level statutory AMT amount before the regular-tax offset and before nonresident apportionment; PolicyEngine exposes a tax-unit tentative minimum tax derived from its Colorado AMTI aggregate.
+
   - legal_id: us-co:statutes/39/39-22-123.5#credit_percentage_after_revenue_adjustment
     country: us
     program: tax
@@ -13532,6 +13549,12 @@ mappings:
     rationale: "Source-specific intermediate output (rule `timely_application_for_recertification`, grounded against `Ala. Admin. Code 660-4-7-.08`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
 prefixes:
+  - legal_id_prefix: us-co:statutes/39/39-22-105#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Colorado AMT section 105 generated outputs include statutory minimum-tax-credit and nonresident-apportionment pieces, plus deferred final AMT assembly; PolicyEngine exposes only the AMT rate parameter and tax-unit AMT variables unless an exact mapping above records a narrower adjacent target.
+
   - legal_id_prefix: us-co:statutes/39/39-22-123.5#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1450,6 +1450,93 @@ rules:
     assert subtraction["policyengine_variable"] == "co_pension_subtraction"
 
 
+def test_policyengine_coverage_infers_unmapped_colorado_title_39_as_tax(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-999.yaml",
+        """format: rulespec/v1
+rules:
+  - name: unmapped_colorado_tax_output
+    kind: derived
+    versions:
+      - effective_from: '2024-01-01'
+        formula: '1'
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["total_outputs"] == 1
+    assert report["status_counts"] == {"unmapped": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == (
+        "us-co:statutes/39/39-22-999#unmapped_colorado_tax_output"
+    )
+    assert item["program"] == "tax"
+
+
+def test_policyengine_coverage_classifies_colorado_amt_outputs(tmp_path):
+    output_names = (
+        "alternative_minimum_tax_rate",
+        "minimum_tax_credit_percentage",
+        "individual_alternative_minimum_tax_amount_before_regular_tax_offset",
+        "individual_minimum_tax_credit_before_nonresident_apportionment",
+        "nonresident_apportionment_ratio",
+        "individual_minimum_tax_credit",
+    )
+    rules = "\n".join(
+        f"""  - name: {name}
+    kind: derived
+    versions:
+      - effective_from: '2024-01-01'
+        formula: '1'"""
+        for name in output_names
+    )
+    outputs = "\n".join(
+        f"    us-co:statutes/39/39-22-105#{name}: 1" for name in output_names
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-105.yaml",
+        f"""format: rulespec/v1
+rules:
+{rules}
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-105.test.yaml",
+        f"""- name: colorado amt outputs
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {{}}
+  output:
+{outputs}
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["total_outputs"] == len(output_names)
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 5,
+    }
+    assert report["untested_comparable"] == 0
+    assert {item["tested"] for item in report["items"]} == {True}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    rate = items_by_id["us-co:statutes/39/39-22-105#alternative_minimum_tax_rate"]
+    tentative_tax = items_by_id[
+        "us-co:statutes/39/39-22-105#individual_alternative_minimum_tax_amount_before_regular_tax_offset"
+    ]
+    credit = items_by_id["us-co:statutes/39/39-22-105#individual_minimum_tax_credit"]
+    assert rate["policyengine_parameter"] == "gov.states.co.tax.income.amt.rate"
+    assert rate["status"] == "comparable"
+    assert tentative_tax["policyengine_variable"] == "co_tentative_minimum_tax"
+    assert tentative_tax["status"] == "known_not_comparable"
+    assert credit["status"] == "known_not_comparable"
+    assert credit["policyengine_variable"] is None
+
+
 def test_policyengine_coverage_classifies_colorado_eitc_outputs(tmp_path):
     output_names = (
         "base_credit_percentage",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.491"
+version = "0.2.492"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- infer unmapped Colorado Title 39 statute outputs as tax-program surfaces in PolicyEngine oracle coverage
- classify generated Colorado AMT outputs, including the AMT rate parameter and adjacent non-comparable statutory intermediates
- add coverage tests for the Colorado Title 39 program filter and AMT output classification

## Verification
- uv run ruff format --check src/ tests/
- uv run ruff check src/ tests/
- uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/co-income-tax-next-20260531 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run python -m compileall -q src/axiom_encode scripts
- git diff --check