### PR TITLE
Classify Colorado CTC oracle coverage

### DIFF
--- a/changelog.d/co-ctc-policyengine-coverage.changed.md
+++ b/changelog.d/co-ctc-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated Colorado child tax credit current-law outputs in the PolicyEngine oracle registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.492"
+version = "0.2.493"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.492"
+__version__ = "0.2.493"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1328,6 +1328,183 @@ mappings:
     candidate_priority: P2
     rationale: This RuleSpec output is the person-level statutory AMT amount before the regular-tax offset and before nonresident apportionment; PolicyEngine exposes a tax-unit tentative minimum tax derived from its Colorado AMTI aggregate.
 
+  - legal_id: us-co:statutes/39/39-22-129/4.5#single_return_low_income_upper_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.ctc.amount.single
+    parameter_key_path:
+      - thresholds
+      - 1
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado CTC single-filer threshold where the per-child amount falls from $1,200 to $600.
+
+  - legal_id: us-co:statutes/39/39-22-129/4.5#single_return_middle_income_lower_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.ctc.amount.single
+    parameter_key_path:
+      - thresholds
+      - 1
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado CTC single-filer threshold where the $600 per-child amount begins.
+
+  - legal_id: us-co:statutes/39/39-22-129/4.5#single_return_middle_income_upper_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.ctc.amount.single
+    parameter_key_path:
+      - thresholds
+      - 2
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado CTC single-filer threshold where the per-child amount falls from $600 to $200.
+
+  - legal_id: us-co:statutes/39/39-22-129/4.5#single_return_high_income_lower_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.ctc.amount.single
+    parameter_key_path:
+      - thresholds
+      - 2
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado CTC single-filer threshold where the $200 per-child amount begins.
+
+  - legal_id: us-co:statutes/39/39-22-129/4.5#single_return_high_income_upper_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.ctc.amount.single
+    parameter_key_path:
+      - thresholds
+      - 3
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado CTC single-filer threshold where the per-child amount falls to zero.
+
+  - legal_id: us-co:statutes/39/39-22-129/4.5#joint_return_low_income_upper_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.ctc.amount.joint
+    parameter_key_path:
+      - thresholds
+      - 1
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado CTC joint-filer threshold where the per-child amount falls from $1,200 to $600.
+
+  - legal_id: us-co:statutes/39/39-22-129/4.5#joint_return_middle_income_lower_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.ctc.amount.joint
+    parameter_key_path:
+      - thresholds
+      - 1
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado CTC joint-filer threshold where the $600 per-child amount begins.
+
+  - legal_id: us-co:statutes/39/39-22-129/4.5#joint_return_middle_income_upper_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.ctc.amount.joint
+    parameter_key_path:
+      - thresholds
+      - 2
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado CTC joint-filer threshold where the per-child amount falls from $600 to $200.
+
+  - legal_id: us-co:statutes/39/39-22-129/4.5#joint_return_high_income_lower_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.ctc.amount.joint
+    parameter_key_path:
+      - thresholds
+      - 2
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado CTC joint-filer threshold where the $200 per-child amount begins.
+
+  - legal_id: us-co:statutes/39/39-22-129/4.5#joint_return_high_income_upper_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.ctc.amount.joint
+    parameter_key_path:
+      - thresholds
+      - 3
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado CTC joint-filer threshold where the per-child amount falls to zero.
+
+  - legal_id: us-co:statutes/39/39-22-129/4.5#low_income_child_credit_amount
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.ctc.amount.single
+    parameter_key_path:
+      - amounts
+      - 0
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado CTC low-income per-child amount; PE stores the same amount in both single and joint bracket scales.
+
+  - legal_id: us-co:statutes/39/39-22-129/4.5#middle_income_child_credit_amount
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.ctc.amount.single
+    parameter_key_path:
+      - amounts
+      - 1
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado CTC middle-income per-child amount; PE stores the same amount in both single and joint bracket scales.
+
+  - legal_id: us-co:statutes/39/39-22-129/4.5#high_income_child_credit_amount
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.ctc.amount.single
+    parameter_key_path:
+      - amounts
+      - 2
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado CTC high-income per-child amount; PE stores the same amount in both single and joint bracket scales.
+
+  - legal_id: us-co:statutes/39/39-22-129/4.5#child_tax_credit_per_eligible_child
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_ctc
+    candidate_priority: P2
+    rationale: This RuleSpec output is a statutory per-child amount selected from resident single/joint AGI bands; PolicyEngine exposes final tax-unit co_ctc after eligible-child counting, filing-status mapping, and inflation-adjusted bracket-scale lookup.
+
   - legal_id: us-co:statutes/39/39-22-123.5#credit_percentage_after_revenue_adjustment
     country: us
     program: tax
@@ -13554,6 +13731,14 @@ prefixes:
     program: tax
     mapping_type: not_comparable
     rationale: Colorado AMT section 105 generated outputs include statutory minimum-tax-credit and nonresident-apportionment pieces, plus deferred final AMT assembly; PolicyEngine exposes only the AMT rate parameter and tax-unit AMT variables unless an exact mapping above records a narrower adjacent target.
+
+  - legal_id_prefix: us-co:statutes/39/39-22-129/4.5#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_ctc
+    candidate_priority: P2
+    rationale: Remaining Colorado CTC subsection 4.5 outputs are adjacent current-law statutory helpers; exact mappings above compare the threshold and amount parameters, while PolicyEngine exposes final tax-unit co_ctc after eligible-child counting, filing-status mapping, and inflation adjustments.
 
   - legal_id_prefix: us-co:statutes/39/39-22-123.5#
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1537,6 +1537,87 @@ rules:
     assert credit["policyengine_variable"] is None
 
 
+def test_policyengine_coverage_classifies_colorado_ctc_45_outputs(tmp_path):
+    output_names = (
+        "single_return_low_income_upper_threshold",
+        "single_return_middle_income_lower_threshold",
+        "single_return_middle_income_upper_threshold",
+        "single_return_high_income_lower_threshold",
+        "single_return_high_income_upper_threshold",
+        "joint_return_low_income_upper_threshold",
+        "joint_return_middle_income_lower_threshold",
+        "joint_return_middle_income_upper_threshold",
+        "joint_return_high_income_lower_threshold",
+        "joint_return_high_income_upper_threshold",
+        "low_income_child_credit_amount",
+        "middle_income_child_credit_amount",
+        "high_income_child_credit_amount",
+        "child_tax_credit_per_eligible_child",
+    )
+    rules = "\n".join(
+        f"""  - name: {name}
+    kind: derived
+    versions:
+      - effective_from: '2024-01-01'
+        formula: '1'"""
+        for name in output_names
+    )
+    outputs = "\n".join(
+        f"    us-co:statutes/39/39-22-129/4.5#{name}: 1" for name in output_names
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-129/4.5.yaml",
+        f"""format: rulespec/v1
+rules:
+{rules}
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-129/4.5.test.yaml",
+        f"""- name: colorado ctc current-law outputs
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {{}}
+  output:
+{outputs}
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["total_outputs"] == len(output_names)
+    assert report["status_counts"] == {
+        "comparable": len(output_names) - 1,
+        "known_not_comparable": 1,
+    }
+    assert report["untested_comparable"] == 0
+    assert {item["tested"] for item in report["items"]} == {True}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    per_child = items_by_id[
+        "us-co:statutes/39/39-22-129/4.5#child_tax_credit_per_eligible_child"
+    ]
+    threshold = items_by_id[
+        "us-co:statutes/39/39-22-129/4.5#single_return_low_income_upper_threshold"
+    ]
+    amount = items_by_id[
+        "us-co:statutes/39/39-22-129/4.5#low_income_child_credit_amount"
+    ]
+    assert per_child["status"] == "known_not_comparable"
+    assert per_child["policyengine_variable"] == "co_ctc"
+    assert threshold["status"] == "comparable"
+    assert (
+        threshold["policyengine_parameter"]
+        == "gov.states.co.tax.income.credits.ctc.amount.single"
+    )
+    assert amount["status"] == "comparable"
+    assert (
+        amount["policyengine_parameter"]
+        == "gov.states.co.tax.income.credits.ctc.amount.single"
+    )
+
+
 def test_policyengine_coverage_classifies_colorado_eitc_outputs(tmp_path):
     output_names = (
         "base_credit_percentage",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.492"
+version = "0.2.493"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated Colorado CTC current-law outputs as known adjacent to PolicyEngine co_ctc
- cover the 39-22-129(4.5) thresholds, per-child statutory amounts, and per-child amount formula through the oracle registry
- add a focused coverage test and bump axiom-encode to 0.2.493

## Verification
- uv run ruff format --check src/ tests/
- uv run ruff check src/ tests/
- uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_colorado_ctc_45_outputs
- uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/co-income-tax-next-20260531 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run python -m compileall -q src/axiom_encode scripts
- git diff --check