### PR TITLE
Repair scaled income-base nonnegative floors

### DIFF
--- a/changelog.d/nonnegative-scaled-income-base.fixed.md
+++ b/changelog.d/nonnegative-scaled-income-base.fixed.md
@@ -1,0 +1,1 @@
+Repair scaled income-base `min(...)` formulas during generated RuleSpec apply.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.493"
+version = "0.2.494"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.493"
+__version__ = "0.2.494"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -864,6 +864,10 @@ _NONNEGATIVE_INCOME_BASE_FORMULA_PATTERN = re.compile(
     r"\bmin\s*\([^)]*\b[A-Za-z_][A-Za-z0-9_]*(?:income|earnings|wages)[A-Za-z0-9_]*\b[^)]*\)",
     flags=re.IGNORECASE,
 )
+_INCOME_BASE_IDENTIFIER_PATTERN = re.compile(
+    r"\b[A-Za-z_][A-Za-z0-9_]*(?:income|earnings|wages)[A-Za-z0-9_]*\b",
+    flags=re.IGNORECASE,
+)
 _ZERO_FLOORED_INCOME_BASE_PATTERN = re.compile(
     r"\bmax\s*\(\s*0\s*,[^)]*\b[A-Za-z_][A-Za-z0-9_]*(?:income|earnings|wages)[A-Za-z0-9_]*\b",
     flags=re.IGNORECASE,
@@ -7742,15 +7746,40 @@ def _repair_nonnegative_amount_reduction_expression(expression: str) -> str:
 
 
 def _repair_nonnegative_income_base_expression(expression: str) -> str:
-    return re.sub(
-        r"\bmin\s*\(\s*"
-        r"(?P<income>[A-Za-z_][A-Za-z0-9_]*(?:income|earnings|wages)[A-Za-z0-9_]*)"
-        r"\s*,",
-        r"min(max(0, \g<income>),",
-        expression,
-        count=1,
-        flags=re.IGNORECASE,
-    )
+    for start, end, arguments in _min_call_spans(expression):
+        repaired_arguments = [argument.strip() for argument in arguments]
+        for index, argument in enumerate(arguments):
+            stripped_argument = argument.strip()
+            if not _INCOME_BASE_IDENTIFIER_PATTERN.search(stripped_argument):
+                continue
+            if _ZERO_FLOORED_INCOME_BASE_PATTERN.search(stripped_argument):
+                continue
+            repaired_arguments[index] = f"max(0, {stripped_argument})"
+            return (
+                f"{expression[:start]}min({', '.join(repaired_arguments)})"
+                f"{expression[end:]}"
+            )
+    return expression
+
+
+def _min_call_spans(expression: str) -> list[tuple[int, int, list[str]]]:
+    spans: list[tuple[int, int, list[str]]] = []
+    for match in _MIN_FUNCTION_CALL_PATTERN.finditer(expression):
+        open_index = match.end() - 1
+        depth = 0
+        for index in range(open_index, len(expression)):
+            char = expression[index]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    arguments = _split_top_level_call_arguments(
+                        expression[open_index + 1 : index]
+                    )
+                    spans.append((match.start(), index + 1, arguments))
+                    break
+    return spans
 
 
 @dataclass(frozen=True)

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -14101,6 +14101,79 @@ rules:
     assert find_nonnegative_amount_reduction_issues(repaired) == []
 
 
+def test_repair_nonnegative_amount_reductions_floors_scaled_income_base_in_credit():
+    content = """format: rulespec/v1
+rules:
+  - name: child_care_expenses_tax_credit_before_part_year_apportionment
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2019-01-01'
+        formula: |-
+          if child_care_expenses_tax_credit_allowed: min(child_care_expenses_credit_percentage * applicable_child_care_expenses_after_earned_income_limit, maximum_credit_for_dependent_count) else: 0
+"""
+
+    repaired, rules = repair_nonnegative_amount_reductions(content)
+
+    assert rules == ["child_care_expenses_tax_credit_before_part_year_apportionment"]
+    assert (
+        "min(max(0, child_care_expenses_credit_percentage * "
+        "applicable_child_care_expenses_after_earned_income_limit), "
+        "maximum_credit_for_dependent_count)" in repaired
+    )
+    assert find_nonnegative_amount_reduction_issues(repaired) == []
+
+
+def test_repair_nonnegative_amount_reductions_floors_parenthesized_scaled_income_base():
+    content = """format: rulespec/v1
+rules:
+  - name: child_care_expenses_tax_credit_before_part_year_apportionment
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2019-01-01'
+        formula: |-
+          min((child_care_expenses_credit_percentage * earned_income), maximum_credit_for_dependent_count)
+"""
+
+    repaired, rules = repair_nonnegative_amount_reductions(content)
+
+    assert rules == ["child_care_expenses_tax_credit_before_part_year_apportionment"]
+    assert (
+        "min(max(0, (child_care_expenses_credit_percentage * earned_income)), "
+        "maximum_credit_for_dependent_count)" in repaired
+    )
+    assert find_nonnegative_amount_reduction_issues(repaired) == []
+
+
+def test_repair_nonnegative_amount_reductions_floors_wrapped_scaled_income_base():
+    content = """format: rulespec/v1
+rules:
+  - name: child_care_expenses_tax_credit_before_part_year_apportionment
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2019-01-01'
+        formula: |-
+          min(ceil(child_care_expenses_credit_percentage * earned_income), maximum_credit_for_dependent_count)
+"""
+
+    repaired, rules = repair_nonnegative_amount_reductions(content)
+
+    assert rules == ["child_care_expenses_tax_credit_before_part_year_apportionment"]
+    assert (
+        "min(max(0, ceil(child_care_expenses_credit_percentage * earned_income)), "
+        "maximum_credit_for_dependent_count)" in repaired
+    )
+    assert find_nonnegative_amount_reduction_issues(repaired) == []
+
+
 def test_current_year_final_amount_table_rejects_recomputed_maximum(tmp_path):
     repo = tmp_path / "rulespec-us"
     imported = repo / "policies/irs/rev-proc-2025-32/earned-income-credit.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.493"
+version = "0.2.494"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair deterministic nonnegative-floor handling for `min(...)` formulas whose income-like base is scaled before the cap
- add a regression test for the Colorado low-income CDCC-shaped formula
- bump encoder provenance to `0.2.494`

This is a general encoder repair; it avoids hand-editing generated RuleSpec when a generated credit formula needs `max(0, rate * income_base)` before a cap.

## Checks
- `uv run ruff format --check src/ tests/`
- `uv run ruff check src/ tests/`
- `uv run python -m pytest -q tests/test_rulespec_validation.py::test_repair_nonnegative_amount_reductions_floors_scaled_income_base_in_credit tests/test_rulespec_validation.py::test_repair_nonnegative_amount_reductions_floors_income_base_in_credit tests/test_rulespec_validation.py::test_repair_nonnegative_amount_reductions_floors_multiline_income_base_in_credit tests/test_cli.py::TestCmdEncode::test_encode_apply_auto_repairs_nonnegative_taxable_income_floor`
- `uv run towncrier build --draft --version 0.2.494`
- `uv run python -m compileall src`
- `git diff --check`