### PR TITLE
Repair Judgment numeric comparisons

### DIFF
--- a/changelog.d/judgment-numeric-comparison.fixed.md
+++ b/changelog.d/judgment-numeric-comparison.fixed.md
@@ -1,0 +1,1 @@
+Repair generated formulas that compare Judgment predicates to numeric truth values.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.494"
+version = "0.2.495"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.494"
+__version__ = "0.2.495"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -15538,6 +15538,34 @@ def cmd_encode(args):
                 if repaired_zero_cases:
                     outcome["auto_repaired_zero_branch_tests"] = repaired_zero_cases
             if not can_apply:
+                repaired_judgment_comparisons = (
+                    _try_repair_generated_judgment_numeric_comparisons_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_judgment_comparisons:
+                    outcome["auto_repaired_judgment_numeric_comparisons"] = (
+                        repaired_judgment_comparisons
+                    )
+                    print(
+                        "  apply=auto_repaired_judgment_numeric_comparisons:"
+                        + ",".join(repaired_judgment_comparisons)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_test_cases = _try_repair_generated_exception_tests_for_apply(
                     result,
                     output_root=args.output,
@@ -16092,6 +16120,29 @@ def _try_repair_generated_boolean_comparison_predicates_for_apply(
     )
 
 
+def _try_repair_generated_judgment_numeric_comparisons_for_apply(
+    result,
+    *,
+    output_root: Path,
+    issues: list[str],
+) -> list[str]:
+    """Rewrite generated Judgment numeric comparisons into predicates."""
+    if not any(_issue_mentions_judgment_scalar_request(issue) for issue in issues):
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    rule_names = _judgment_scalar_rule_names_from_issues(issues)
+    if not rule_names:
+        rule_names = _local_judgment_rule_names(rules_file)
+    if not rule_names:
+        return []
+    return _rewrite_judgment_numeric_comparisons(rules_file, names=rule_names)
+
+
 def _try_repair_generated_boolean_parameter_inputs_for_apply(
     result,
     *,
@@ -16137,6 +16188,10 @@ def _issue_mentions_boolean_comparison_in_scalar_position(issue: str) -> bool:
     return "binary op" in text and "in scalar position" in text
 
 
+def _issue_mentions_judgment_scalar_request(issue: str) -> bool:
+    return "is judgment, but a scalar was requested" in str(issue).lower()
+
+
 def _boolean_comparison_rule_names_from_issues(issues: list[str]) -> set[str]:
     names: set[str] = set()
     for issue in issues:
@@ -16150,6 +16205,22 @@ def _boolean_comparison_rule_names_from_issues(issues: list[str]) -> set[str]:
             r"variable `([A-Za-z_][A-Za-z0-9_]*)`",
         ):
             names.update(re.findall(pattern, text))
+    return names
+
+
+def _judgment_scalar_rule_names_from_issues(issues: list[str]) -> set[str]:
+    names: set[str] = set()
+    for issue in issues:
+        text = str(issue)
+        if not _issue_mentions_judgment_scalar_request(text):
+            continue
+        for match in re.finditer(
+            r"(?:derived|parameter|rule|variable)\s+[`']"
+            r"([A-Za-z_][A-Za-z0-9_]*)[`']\s+is judgment",
+            text,
+            flags=re.IGNORECASE,
+        ):
+            names.add(match.group(1))
     return names
 
 
@@ -16176,6 +16247,27 @@ def _single_boolean_comparison_candidate_rule_name(rules_file: Path) -> set[str]
         and _rule_has_top_level_comparison_formula(rule)
     }
     return candidates if len(candidates) == 1 else set()
+
+
+def _local_judgment_rule_names(rules_file: Path) -> set[str]:
+    if not rules_file.exists():
+        return set()
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return set()
+    if not isinstance(payload, dict):
+        return set()
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return set()
+    return {
+        str(rule.get("name") or "").strip()
+        for rule in rules
+        if isinstance(rule, dict)
+        and str(rule.get("name") or "").strip()
+        and str(rule.get("dtype") or "").strip().lower() == "judgment"
+    }
 
 
 def _convert_versioned_boolean_parameters_to_indicators(
@@ -16754,6 +16846,88 @@ def _promote_boolean_comparison_predicates_to_judgment(
     if test_file is not None:
         _rewrite_boolean_test_values_as_judgments(test_file, set(repaired))
     return repaired
+
+
+def _rewrite_judgment_numeric_comparisons(
+    rules_file: Path,
+    *,
+    names: set[str],
+) -> list[str]:
+    if not rules_file.exists() or not names:
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    repaired: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        rule_changed = False
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            rewritten = _rewrite_judgment_numeric_comparison_formula(
+                formula,
+                names=names,
+            )
+            if rewritten != formula:
+                version["formula"] = rewritten
+                rule_changed = True
+        if rule_changed:
+            repaired.append(str(rule.get("name") or "formula_rule"))
+
+    if not repaired:
+        return []
+
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repaired
+
+
+def _rewrite_judgment_numeric_comparison_formula(
+    formula: str,
+    *,
+    names: set[str],
+) -> str:
+    rewritten = str(formula)
+    for name in sorted(names, key=len, reverse=True):
+        escaped = re.escape(name)
+        name_token = rf"(?<![A-Za-z0-9_]){escaped}(?![A-Za-z0-9_])"
+        zero = r"(?<![A-Za-z0-9_.])0(?:\.0+)?(?![A-Za-z0-9_.])"
+        one = r"(?<![A-Za-z0-9_.])1(?:\.0+)?(?![A-Za-z0-9_.])"
+        replacements = (
+            (rf"{name_token}\s*==\s*{zero}", f"not {name}"),
+            (rf"\b{zero}\s*==\s*{name_token}", f"not {name}"),
+            (rf"{name_token}\s*!=\s*{zero}", name),
+            (rf"\b{zero}\s*!=\s*{name_token}", name),
+            (rf"{name_token}\s*==\s*{one}", name),
+            (rf"\b{one}\s*==\s*{name_token}", name),
+            (rf"{name_token}\s*!=\s*{one}", f"not {name}"),
+            (rf"\b{one}\s*!=\s*{name_token}", f"not {name}"),
+            (rf"{name_token}\s*==\s*false\b", f"not {name}"),
+            (rf"\bfalse\s*==\s*{name_token}", f"not {name}"),
+            (rf"{name_token}\s*!=\s*false\b", name),
+            (rf"\bfalse\s*!=\s*{name_token}", name),
+            (rf"{name_token}\s*==\s*true\b", name),
+            (rf"\btrue\s*==\s*{name_token}", name),
+            (rf"{name_token}\s*!=\s*true\b", f"not {name}"),
+            (rf"\btrue\s*!=\s*{name_token}", f"not {name}"),
+        )
+        for pattern, replacement in replacements:
+            rewritten = re.sub(pattern, replacement, rewritten, flags=re.IGNORECASE)
+    return rewritten
 
 
 def _rule_has_comparison_formula(rule: dict[str, object]) -> bool:

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -213,6 +213,8 @@ Hard requirements:
   export's `dtype:`. An imported `dtype: Judgment` is a predicate, not a scalar
   amount, rate, or base. Never multiply, add, subtract, divide, `min`, or `max`
   a Judgment import as if it were Money, Rate, Count, or another numeric value.
+  Do not compare a Judgment import to `0`, `1`, `true`, or `false`; use the
+  predicate directly (`judgment_name`) or its negation (`not judgment_name`).
   If the current source states a numeric base such as wages, remuneration,
   payments, or amounts attributable to a category and the copied import only
   identifies whether an item is attributable to that category, encode the source-stated numeric base as a local amount fact, or as a relation-filtered

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -84,6 +84,7 @@ from axiom_encode.cli import (
     _require_axiom_encode_version_provenance,
     _rewrite_gpt_runner_backend,
     _rewrite_import_output_test_input_refs,
+    _rewrite_judgment_numeric_comparisons,
     _sha256_file,
     _sha256_text,
     _sign_applied_encoding_manifest,
@@ -91,6 +92,7 @@ from axiom_encode.cli import (
     _split_table_row_relation_test_cases,
     _suppress_rulespec_ancestor_targets_for_subsection_overlay,
     _try_repair_generated_boolean_comparison_predicates_for_apply,
+    _try_repair_generated_judgment_numeric_comparisons_for_apply,
     _try_repair_generated_missing_deferred_outputs_for_apply,
     _try_repair_generated_missing_same_section_subsection_imports_for_apply,
     _try_repair_generated_nonoperative_source_coverage_for_apply,
@@ -4345,6 +4347,175 @@ rules:
 
         assert repaired == []
         assert rules_file.read_text() == original
+
+    def test_rewrite_judgment_numeric_comparisons_updates_formula(self, tmp_path):
+        rules_file = tmp_path / "credit.yaml"
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: eligibility
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  versions:
+  - effective_from: '2026-01-01'
+    formula: |-
+      resident
+      and imported_credit_allowed == 0
+      and 1 == local_judgment
+- name: amount
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  versions:
+  - effective_from: '2026-01-01'
+    formula: |-
+      if imported_credit_allowed != 0: 0 else: amount_before_credit
+"""
+        )
+
+        repaired = _rewrite_judgment_numeric_comparisons(
+            rules_file,
+            names={"imported_credit_allowed", "local_judgment"},
+        )
+
+        assert repaired == ["eligibility", "amount"]
+        payload = yaml.safe_load(rules_file.read_text())
+        eligibility_formula = payload["rules"][0]["versions"][0]["formula"]
+        amount_formula = payload["rules"][1]["versions"][0]["formula"]
+        assert "and not imported_credit_allowed" in eligibility_formula
+        assert "and local_judgment" in eligibility_formula
+        assert amount_formula == (
+            "if imported_credit_allowed: 0 else: amount_before_credit"
+        )
+
+    def test_judgment_numeric_comparison_repair_uses_issue_name(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "credit.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+- us-co:statutes/39/39-22-119#child_and_dependent_care_expenses_credit_allowed
+rules:
+- name: low_income_child_care_credit_eligibility
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  versions:
+  - effective_from: '2026-01-01'
+    formula: |-
+      resident_individual
+      and child_and_dependent_care_expenses_credit_allowed == 0
+- name: unrelated_amount
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  versions:
+  - effective_from: '2026-01-01'
+    formula: |-
+      if other_status == 0: 0 else: 100
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_judgment_numeric_comparisons_for_apply(
+            result,
+            output_root=output_root,
+            issues=[
+                "Test case `single dependent credit below cap` execution failed: "
+                "derived 'child_and_dependent_care_expenses_credit_allowed' "
+                "is judgment, but a scalar was requested"
+            ],
+        )
+
+        assert repaired == ["low_income_child_care_credit_eligibility"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["rules"][0]["versions"][0]["formula"] == (
+            "resident_individual\n"
+            "and not child_and_dependent_care_expenses_credit_allowed"
+        )
+        assert payload["rules"][1]["versions"][0]["formula"] == (
+            "if other_status == 0: 0 else: 100"
+        )
+
+    def test_judgment_numeric_comparison_repair_skips_non_truth_decimals(
+        self, tmp_path
+    ):
+        rules_file = tmp_path / "credit.yaml"
+        original = """format: rulespec/v1
+rules:
+- name: amount
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  versions:
+  - effective_from: '2026-01-01'
+    formula: |-
+      if imported_credit_allowed == 0.5: 1 else: 0
+- name: other_amount
+  kind: derived
+  entity: TaxUnit
+  dtype: Money
+  period: Year
+  versions:
+  - effective_from: '2026-01-01'
+    formula: |-
+      if imported_credit_allowed != 1.5: 1 else: 0
+"""
+        rules_file.write_text(original)
+
+        repaired = _rewrite_judgment_numeric_comparisons(
+            rules_file,
+            names={"imported_credit_allowed"},
+        )
+
+        assert repaired == []
+        assert rules_file.read_text() == original
+
+    def test_judgment_numeric_comparison_repair_falls_back_to_local_judgments(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "credit.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: source_judgment
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  versions:
+  - effective_from: '2026-01-01'
+    formula: resident
+- name: eligibility
+  kind: derived
+  entity: TaxUnit
+  dtype: Judgment
+  period: Year
+  versions:
+  - effective_from: '2026-01-01'
+    formula: source_judgment != 1
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_judgment_numeric_comparisons_for_apply(
+            result,
+            output_root=output_root,
+            issues=["execution failed: rule is judgment, but a scalar was requested"],
+        )
+
+        assert repaired == ["eligibility"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["rules"][1]["versions"][0]["formula"] == "not source_judgment"
 
     def test_convert_versioned_boolean_parameters_to_indicators(self, tmp_path):
         rules_file = tmp_path / "credit.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.494"
+version = "0.2.495"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair generated formulas that compare Judgment predicates to numeric truth values during apply validation
- reinforce encoder prompt guidance to use Judgment predicates directly instead of comparing to 0/1/true/false
- add CLI regression coverage for imported and local Judgment comparisons

## Verification
- uv run ruff format --check src/axiom_encode/cli.py src/axiom_encode/prompts/encoder.py tests/test_cli.py
- uv run ruff check src/axiom_encode/cli.py src/axiom_encode/prompts/encoder.py tests/test_cli.py
- uv run --extra dev python -m pytest -q tests/test_cli.py::TestCmdEncode::test_rewrite_judgment_numeric_comparisons_updates_formula tests/test_cli.py::TestCmdEncode::test_judgment_numeric_comparison_repair_uses_issue_name tests/test_cli.py::TestCmdEncode::test_judgment_numeric_comparison_repair_falls_back_to_local_judgments tests/test_cli.py::TestCmdEncode::test_promote_boolean_comparison_predicates_to_judgment_updates_tests tests/test_cli.py::TestCmdEncode::test_boolean_comparison_repair_falls_back_to_single_candidate
- uv run towncrier build --draft --version 0.2.495
- uv run python -m compileall src
- git diff --check