### PR TITLE
Classify Colorado CDCC oracle coverage

### DIFF
--- a/changelog.d/colorado-cdcc-policyengine-coverage.fixed.md
+++ b/changelog.d/colorado-cdcc-policyengine-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify Colorado child and dependent care credit RuleSpec outputs against PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.495"
+version = "0.2.496"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.495"
+__version__ = "0.2.496"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1328,6 +1328,84 @@ mappings:
     candidate_priority: P2
     rationale: This RuleSpec output is the person-level statutory AMT amount before the regular-tax offset and before nonresident apportionment; PolicyEngine exposes a tax-unit tentative minimum tax derived from its Colorado AMTI aggregate.
 
+  - legal_id: us-co:statutes/39/39-22-119.5#low_income_adjusted_gross_income_limit
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.cdcc.low_income.federal_agi_threshold
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado low-income child care expenses credit adjusted-gross-income threshold.
+
+  - legal_id: us-co:statutes/39/39-22-119.5#dependent_age_exclusive_limit
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.cdcc.low_income.child_age_threshold
+    period: year
+    comparison: count
+    rationale: Same Colorado low-income child care expenses credit child age threshold.
+
+  - legal_id: us-co:statutes/39/39-22-119.5#single_dependent_credit_cap_dependent_count
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.cdcc.low_income.max_amount
+    parameter_key_path:
+      - thresholds
+      - 1
+    period: year
+    comparison: count
+    rationale: Same Colorado low-income child care expenses credit dependent-count threshold for the single-dependent cap.
+
+  - legal_id: us-co:statutes/39/39-22-119.5#multiple_dependents_credit_cap_minimum_dependents
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.cdcc.low_income.max_amount
+    parameter_key_path:
+      - thresholds
+      - 2
+    period: year
+    comparison: count
+    rationale: Same Colorado low-income child care expenses credit dependent-count threshold for the multiple-dependent cap.
+
+  - legal_id: us-co:statutes/39/39-22-119.5#low_income_child_care_expenses_credit_percentage
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.cdcc.low_income.rate
+    period: year
+    comparison: rate
+    rationale: Same Colorado low-income child care expenses credit percentage.
+
+  - legal_id: us-co:statutes/39/39-22-119.5#single_dependent_credit_cap
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.cdcc.low_income.max_amount
+    parameter_key_path:
+      - amounts
+      - 1
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado low-income child care expenses credit cap for one dependent.
+
+  - legal_id: us-co:statutes/39/39-22-119.5#multiple_dependents_credit_cap
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.credits.cdcc.low_income.max_amount
+    parameter_key_path:
+      - amounts
+      - 2
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado low-income child care expenses credit cap for two or more dependents.
+
   - legal_id: us-co:statutes/39/39-22-129/4.5#single_return_low_income_upper_threshold
     country: us
     program: tax
@@ -13731,6 +13809,22 @@ prefixes:
     program: tax
     mapping_type: not_comparable
     rationale: Colorado AMT section 105 generated outputs include statutory minimum-tax-credit and nonresident-apportionment pieces, plus deferred final AMT assembly; PolicyEngine exposes only the AMT rate parameter and tax-unit AMT variables unless an exact mapping above records a narrower adjacent target.
+
+  - legal_id_prefix: us-co:statutes/39/39-22-119#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_cdcc
+    candidate_priority: P2
+    rationale: Colorado section 119 generated outputs decompose the regular child and dependent care expenses credit into source-specific eligibility, federal-credit-base, child-care-assistance, inflation-adjusted limit, and refundable-excess pieces; PolicyEngine exposes a final tax-unit co_cdcc amount from capped federal CDCC and match parameters, not these statutory boundaries.
+
+  - legal_id_prefix: us-co:statutes/39/39-22-119.5#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_low_income_cdcc
+    candidate_priority: P2
+    rationale: Colorado section 119.5 generated outputs decompose the low-income child care expenses credit into statutory-window, provider-identification, dependent-age, earned-income-limit, cap, eligibility, amount, and refundable-excess pieces; exact parameter mappings above compare shared PE parameters, while PolicyEngine exposes final tax-unit co_low_income_cdcc and a simplified eligibility predicate.
 
   - legal_id_prefix: us-co:statutes/39/39-22-129/4.5#
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1618,6 +1618,159 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_colorado_cdcc_outputs(tmp_path):
+    section_119_names = (
+        "annual_federal_adjusted_gross_income_limit_after_inflation_adjustment",
+        "applicable_federal_adjusted_gross_income_limit",
+        "child_and_dependent_care_credit_percentage",
+        "child_and_dependent_care_expenses_credit_allowed",
+        "child_and_dependent_care_expenses_credit_before_part_year_apportionment",
+        "child_and_dependent_care_expenses_credit_refundable_excess_before_part_year_apportionment",
+        "federal_child_and_dependent_care_credit_base_after_child_care_assistance_limitation",
+        "federal_child_and_dependent_care_credit_base_before_assistance_limitation",
+        "federal_credit_base_uses_allowed_before_federal_tax_liability_limitation_indicator",
+        "income_limit_adjustment_minimum_increase",
+        "income_limit_inflation_adjustment_applies_indicator",
+        "income_limit_rounding_increment",
+        "rounded_federal_adjusted_gross_income_limit_after_cumulative_inflation",
+        "statutory_federal_adjusted_gross_income_limit",
+    )
+    section_1195_comparable_parameters = (
+        "dependent_age_exclusive_limit",
+        "low_income_adjusted_gross_income_limit",
+        "low_income_child_care_expenses_credit_percentage",
+        "multiple_dependents_credit_cap",
+        "multiple_dependents_credit_cap_minimum_dependents",
+        "single_dependent_credit_cap",
+        "single_dependent_credit_cap_dependent_count",
+    )
+    section_1195_remaining_names = (
+        "care_provider_information_requirement_satisfied",
+        "child_care_expense_basis_after_earned_income_limit",
+        "earned_income_limit_for_child_care_expense_basis",
+        "low_income_child_care_credit_tax_year_indicator",
+        "low_income_child_care_expenses_credit_allowed",
+        "low_income_child_care_expenses_credit_before_part_year_apportionment",
+        "low_income_child_care_expenses_credit_dependent_cap",
+        "low_income_child_care_expenses_credit_refundable_excess_before_part_year_apportionment",
+        "person_is_under_dependent_age_limit_for_credit",
+    )
+
+    section_119_rules = "\n".join(
+        f"""  - name: {name}
+    kind: derived
+    versions:
+      - effective_from: '2024-01-01'
+        formula: '1'"""
+        for name in section_119_names
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-119.yaml",
+        f"""format: rulespec/v1
+rules:
+{section_119_rules}
+""",
+    )
+    section_119_outputs = "\n".join(
+        f"    us-co:statutes/39/39-22-119#{name}: 1" for name in section_119_names
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-119.test.yaml",
+        f"""- name: colorado cdcc outputs
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {{}}
+  output:
+{section_119_outputs}
+""",
+    )
+
+    section_1195_parameter_rules = "\n".join(
+        f"""  - name: {name}
+    kind: parameter
+    versions:
+      - effective_from: '2024-01-01'
+        formula: '1'"""
+        for name in section_1195_comparable_parameters
+    )
+    section_1195_remaining_rules = "\n".join(
+        f"""  - name: {name}
+    kind: derived
+    versions:
+      - effective_from: '2024-01-01'
+        formula: '1'"""
+        for name in section_1195_remaining_names
+    )
+    section_1195_outputs = "\n".join(
+        f"    us-co:statutes/39/39-22-119.5#{name}: 1"
+        for name in (section_1195_comparable_parameters + section_1195_remaining_names)
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-119.5.yaml",
+        f"""format: rulespec/v1
+rules:
+{section_1195_parameter_rules}
+{section_1195_remaining_rules}
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-119.5.test.yaml",
+        f"""- name: colorado low-income cdcc outputs
+  period:
+    period_kind: tax_year
+    start: '2024-01-01'
+    end: '2024-12-31'
+  input: {{}}
+  output:
+{section_1195_outputs}
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["total_outputs"] == (
+        len(section_119_names)
+        + len(section_1195_comparable_parameters)
+        + len(section_1195_remaining_names)
+    )
+    assert report["status_counts"] == {
+        "comparable": len(section_1195_comparable_parameters),
+        "known_not_comparable": len(section_119_names)
+        + len(section_1195_remaining_names),
+    }
+    assert report["untested_comparable"] == 0
+    assert {item["tested"] for item in report["items"]} == {True}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    regular_credit = items_by_id[
+        "us-co:statutes/39/39-22-119#child_and_dependent_care_expenses_credit_before_part_year_apportionment"
+    ]
+    low_income_rate = items_by_id[
+        "us-co:statutes/39/39-22-119.5#low_income_child_care_expenses_credit_percentage"
+    ]
+    single_cap = items_by_id[
+        "us-co:statutes/39/39-22-119.5#single_dependent_credit_cap"
+    ]
+    low_income_credit = items_by_id[
+        "us-co:statutes/39/39-22-119.5#low_income_child_care_expenses_credit_before_part_year_apportionment"
+    ]
+    assert regular_credit["status"] == "known_not_comparable"
+    assert regular_credit["policyengine_variable"] == "co_cdcc"
+    assert low_income_rate["status"] == "comparable"
+    assert (
+        low_income_rate["policyengine_parameter"]
+        == "gov.states.co.tax.income.credits.cdcc.low_income.rate"
+    )
+    assert single_cap["status"] == "comparable"
+    assert (
+        single_cap["policyengine_parameter"]
+        == "gov.states.co.tax.income.credits.cdcc.low_income.max_amount"
+    )
+    assert low_income_credit["status"] == "known_not_comparable"
+    assert low_income_credit["policyengine_variable"] == "co_low_income_cdcc"
+
+
 def test_policyengine_coverage_classifies_colorado_eitc_outputs(tmp_path):
     output_names = (
         "base_credit_percentage",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.495"
+version = "0.2.496"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- classify generated Colorado CDCC RuleSpec outputs against PolicyEngine oracle coverage
- map shared low-income CDCC scalar parameters exactly to PolicyEngine parameter paths
- mark decomposed regular/low-income CDCC statutory intermediates as known non-comparable to PE final tax-unit variables
- bump axiom-encode to 0.2.496 and add a changelog fragment

## Validation

- `uv run ruff format --check tests/test_policyengine_coverage.py && uv run ruff check tests/test_policyengine_coverage.py`
- `uv run python -c "from axiom_encode.oracles.policyengine.registry import load_policyengine_registry; load_policyengine_registry(); print('registry ok')"`
- `uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_colorado_cdcc_outputs tests/test_cli.py::test_package_version_metadata_matches_pyproject`
- `uv run towncrier build --draft --version 0.2.496`
- `uv run python -m compileall src`
- `git diff --check`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/co-income-tax-next-20260531 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 50 --json`
- `uv run --extra dev python -m pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`

## Review

- `/cycle` subagent review: no actionable findings.
