### PR TITLE
Select plural subsection context

### DIFF
--- a/changelog.d/plural-subsection-context.fixed.md
+++ b/changelog.d/plural-subsection-context.fixed.md
@@ -1,0 +1,1 @@
+Select repo-augmented context for plural same-section subsection references such as `subsections (3) and (4)`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.496"
+version = "0.2.497"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.496"
+__version__ = "0.2.497"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2130,25 +2130,14 @@ def _select_same_section_subsection_context_files(
     policy_root: Path,
 ) -> list[Path]:
     """Select existing RuleSpecs for same-section subsections cited by source text."""
-    try:
-        parts = parse_usc_citation(citation)
-    except Exception:
+    parts = _citation_parts_for_eval_identifier(citation)
+    if parts is None:
         return []
 
     target_rel = citation_to_relative_rulespec_path(parts)
     selected: list[Path] = []
     seen: set[Path] = set()
-    for match in re.finditer(
-        r"\bsubsection\s+\((?P<subsection>[A-Za-z0-9]+)\)"
-        r"(?P<tail>(?:\([A-Za-z0-9]+\))*)"
-        r"(?:\s+of\s+this\s+section)?(?=\W|$)",
-        source_text,
-        flags=re.IGNORECASE,
-    ):
-        referenced_fragments = (
-            match.group("subsection"),
-            *re.findall(r"\(([A-Za-z0-9]+)\)", match.group("tail") or ""),
-        )
+    for referenced_fragments in _iter_same_section_subsection_references(source_text):
         if referenced_fragments[0] in parts.fragments:
             continue
         for length in range(len(referenced_fragments), 0, -1):
@@ -2171,6 +2160,65 @@ def _select_same_section_subsection_context_files(
                     seen.add(resolved)
             break
     return selected
+
+
+def _citation_parts_for_eval_identifier(citation: str) -> CitationParts | None:
+    """Return citation parts for either USC text or corpus-backed eval identifiers."""
+    target_rel = _target_rel_for_eval_identifier(citation)
+    if target_rel is None:
+        return None
+    path_parts = list(target_rel.parts)
+    if len(path_parts) < 3 or path_parts[0] != "statutes":
+        return None
+    if len(path_parts) == 3:
+        return CitationParts(
+            title=path_parts[1],
+            section=Path(path_parts[2]).stem,
+            fragments=(),
+        )
+    return CitationParts(
+        title=path_parts[1],
+        section=path_parts[2],
+        fragments=tuple((*path_parts[3:-1], Path(path_parts[-1]).stem)),
+    )
+
+
+_SUBSECTION_REFERENCE_START_RE = re.compile(r"\bsubsections?\s+", re.IGNORECASE)
+_PARENTHETICAL_FRAGMENT_RE = re.compile(r"\s*\((?P<fragment>[A-Za-z0-9.]+)\)")
+_SUBSECTION_REFERENCE_SEPARATOR_RE = re.compile(
+    r"\s*(?:,\s*(?:(?:and|or)\b)?|\band\b|\bor\b)\s*",
+    re.IGNORECASE,
+)
+
+
+def _iter_same_section_subsection_references(
+    source_text: str,
+) -> Iterator[tuple[str, ...]]:
+    """Yield subsection fragment paths cited after `subsection(s)` in source text."""
+    for match in _SUBSECTION_REFERENCE_START_RE.finditer(source_text):
+        position = match.end()
+        while True:
+            fragments: list[str] = []
+            while fragment_match := _PARENTHETICAL_FRAGMENT_RE.match(
+                source_text, position
+            ):
+                fragment = fragment_match.group("fragment").strip()
+                if not fragment:
+                    break
+                fragments.append(fragment)
+                position = fragment_match.end()
+
+            if not fragments:
+                break
+            yield tuple(fragments)
+
+            separator = _SUBSECTION_REFERENCE_SEPARATOR_RE.match(source_text, position)
+            if separator is None:
+                break
+            next_position = separator.end()
+            if _PARENTHETICAL_FRAGMENT_RE.match(source_text, next_position) is None:
+                break
+            position = next_position
 
 
 def _select_cross_section_context_files(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -7394,6 +7394,68 @@ rules:
             copied_sources[str(context_test)]["kind"] == "implementation_test_context"
         )
 
+    def test_prepare_eval_workspace_adds_plural_same_section_subsection_context(
+        self, tmp_path
+    ):
+        repo_root = tmp_path / "repos"
+        policy_repo_root = repo_root / "axiom-rules-engine"
+        policy_repo_root.mkdir(parents=True)
+        additions_root = (
+            repo_root / "rulespec-us" / "statutes" / "39" / "39-22-104" / "3"
+        )
+        subtractions_root = (
+            repo_root / "rulespec-us" / "statutes" / "39" / "39-22-104" / "4"
+        )
+        additions_root.mkdir(parents=True)
+        subtractions_root.mkdir(parents=True)
+        addition_file = additions_root / "d.yaml"
+        addition_test = additions_root / "d.test.yaml"
+        subtraction_file = subtractions_root / "a.yaml"
+        subtraction_test = subtractions_root / "a.test.yaml"
+        addition_file.write_text("format: rulespec/v1\nrules: []\n")
+        addition_test.write_text("- name: addition_case\n  period: 2026\n")
+        subtraction_file.write_text("format: rulespec/v1\nrules: []\n")
+        subtraction_test.write_text("- name: subtraction_case\n  period: 2026\n")
+
+        runner = parse_runner_spec("codex:gpt-5.4")
+        with patch(
+            "axiom_encode.harness.evals.select_context_files",
+            return_value=[],
+        ):
+            workspace = prepare_eval_workspace(
+                citation="us-co/statute/39/39-22-104/2",
+                runner=runner,
+                output_root=tmp_path / "out",
+                source_text=(
+                    "Federal taxable income shall be modified as provided in "
+                    "subsections (3) and (4) of this section."
+                ),
+                axiom_rules_path=policy_repo_root,
+                mode="repo-augmented",
+                extra_context_paths=[],
+            )
+
+        manifest = json.loads(workspace.manifest_file.read_text())
+        copied_sources = {
+            item["source_path"]: item for item in manifest["context_files"]
+        }
+        assert copied_sources[str(addition_file)]["kind"] == "implementation_precedent"
+        assert (
+            copied_sources[str(addition_file)]["import_path"]
+            == "us:statutes/39/39-22-104/3/d"
+        )
+        assert (
+            copied_sources[str(addition_test)]["kind"] == "implementation_test_context"
+        )
+        assert (
+            copied_sources[str(subtraction_file)]["import_path"]
+            == "us:statutes/39/39-22-104/4/a"
+        )
+        assert (
+            copied_sources[str(subtraction_test)]["kind"]
+            == "implementation_test_context"
+        )
+
     def test_prepare_eval_workspace_adds_same_section_under_subsection_context(
         self, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.496"
+version = "0.2.497"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- parse same-section plural subsection lists like `subsections (3) and (4)` for repo-augmented context selection
- support corpus/source identifiers such as `us-co/statute/39/39-22-104/2` when deriving same-section context targets
- add regression coverage for the Colorado 39-22-104(2) pattern and bump encoder provenance metadata

## Validation
- `uv run ruff format --check src/axiom_encode/harness/evals.py tests/test_evals.py`
- `uv run ruff check src/axiom_encode/harness/evals.py tests/test_evals.py`
- `uv run python -m pytest -q tests/test_evals.py -k "same_section_subsection_context or same_section_under_subsection_context or nested_same_section_context"`
- `uv run python -m pytest -q tests/test_cli.py::test_package_version_metadata_matches_pyproject`
- `uv run python -m compileall -q src`
- `uv run towncrier build --draft --version 0.2.497`
- `git diff --check`

Subagent review completed clean after the actual `us-co/statute/39/39-22-104/2` citation-form blocker was fixed.