### PR TITLE
Include full cited subsection context

### DIFF
--- a/changelog.d/full-cited-subsection-context.fixed.md
+++ b/changelog.d/full-cited-subsection-context.fixed.md
@@ -1,0 +1,1 @@
+Include every child RuleSpec file for explicitly cited same-section subsections instead of truncating cited child context, and let amount-adjustment parent lists compose child outputs even when child branches use "to the extent" language.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.497"
+version = "0.2.498"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.497"
+__version__ = "0.2.498"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2150,7 +2150,12 @@ def _select_same_section_subsection_context_files(
             )
             if candidate_rel == target_rel:
                 continue
-            candidates = _cited_context_candidates(policy_root, candidate_rel)
+            candidates = _cited_context_candidates(
+                policy_root,
+                candidate_rel,
+                max_child_candidates=None,
+                include_exporting_candidate_children=True,
+            )
             if not candidates:
                 continue
             for candidate in candidates:
@@ -2309,7 +2314,13 @@ def _citation_parts_from_match(match: re.Match[str]) -> CitationParts:
     return CitationParts("", section, fragments)
 
 
-def _cited_context_candidates(policy_root: Path, candidate_rel: Path) -> list[Path]:
+def _cited_context_candidates(
+    policy_root: Path,
+    candidate_rel: Path,
+    *,
+    max_child_candidates: int | None = 8,
+    include_exporting_candidate_children: bool = False,
+) -> list[Path]:
     """Return an exact cited RuleSpec file or child fragments when only a section exists."""
     candidate = policy_root / candidate_rel
     child_root = policy_root / candidate_rel.with_suffix("")
@@ -2323,9 +2334,12 @@ def _cited_context_candidates(policy_root: Path, candidate_rel: Path) -> list[Pa
         child_candidates.sort(
             key=lambda path: (len(path.relative_to(child_root).parts), str(path))
         )
-        child_candidates = child_candidates[:8]
+        if max_child_candidates is not None:
+            child_candidates = child_candidates[:max_child_candidates]
 
     if candidate.exists():
+        if include_exporting_candidate_children and child_candidates:
+            return [candidate, *child_candidates]
         if _context_file_exports(str(candidate)) or not child_candidates:
             return [candidate]
         return [candidate, *child_candidates]
@@ -4963,6 +4977,8 @@ def _format_partial_extent_child_schema_limit_guidance(
     scoped_source_text = _target_source_scope_for_heuristics(
         source_text, target_ref_prefix
     )
+    if _source_opens_amount_adjustment_list(scoped_source_text):
+        return ""
     if not _source_has_partial_extent_child_rewiring_limit(scoped_source_text):
         return ""
     child_prefix = f"{target_ref_prefix.rstrip('/')}/"
@@ -5143,6 +5159,20 @@ def _source_has_partial_extent_child_rewiring_limit(source_text: str) -> bool:
         ):
             return True
     return False
+
+
+def _source_opens_amount_adjustment_list(source_text: str) -> bool:
+    """Return true when the source opens an aggregate list of amount adjustments."""
+    normalized = " ".join(source_text.split())
+    return bool(
+        re.search(
+            r"\bthere\s+shall\s+be\s+"
+            r"(?:added|subtracted|deducted)\s+"
+            r"(?:to|from)\b",
+            normalized[:500],
+            re.IGNORECASE,
+        )
+    )
 
 
 def _format_child_exception_import_guidance(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -6058,6 +6058,56 @@ rules:
         assert "`rules: []`" in prompt
         assert "`*_before_exemption`" in prompt
 
+    def test_build_eval_prompt_does_not_defer_amount_adjustment_parent_list(
+        self, tmp_path
+    ):
+        policy_repo_root = tmp_path / "rulespec-us-co"
+        child_file = policy_repo_root / "statutes" / "39" / "39-22-104" / "4" / "i.yaml"
+        child_file.parent.mkdir(parents=True, exist_ok=True)
+        child_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: qualifying_income_subtraction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: income_included_in_federal_taxable_income
+"""
+        )
+        workspace = prepare_eval_workspace(
+            citation="us-co/statute/39/39-22-104/4",
+            runner=parse_runner_spec("openai:gpt-5.5"),
+            output_root=tmp_path / "out",
+            source_text=(
+                "(4) There shall be subtracted from federal taxable income:\n"
+                "(i) Qualifying income to the extent included in federal "
+                "taxable income and exempt from taxes imposed by this article."
+            ),
+            axiom_rules_path=policy_repo_root,
+            mode="repo-augmented",
+            extra_context_paths=[child_file],
+        )
+
+        prompt = _build_eval_prompt(
+            "us-co/statute/39/39-22-104/4",
+            "repo-augmented",
+            workspace,
+            workspace.context_files,
+            target_file_name="4.yaml",
+            target_ref_prefix="us-co:statutes/39/39-22-104/4",
+            include_tests=True,
+            runner_backend="openai",
+        )
+
+        assert "Target-specific schema limit" not in prompt
+        assert "Aggregate parent child outputs detected" in prompt
+        assert (
+            "`us-co:statutes/39/39-22-104/4/i#qualifying_income_subtraction`" in prompt
+        )
+
     def test_build_eval_prompt_does_not_defer_taxable_income_for_incidental_extent(
         self, tmp_path
     ):
@@ -7408,14 +7458,47 @@ rules:
         )
         additions_root.mkdir(parents=True)
         subtractions_root.mkdir(parents=True)
+        addition_parent = additions_root.with_suffix(".yaml")
+        subtraction_parent = subtractions_root.with_suffix(".yaml")
+        addition_parent.write_text(
+            "format: rulespec/v1\n"
+            "rules:\n"
+            "  - name: subsection_3_additions\n"
+            "    kind: derived\n"
+            "    entity: TaxUnit\n"
+            "    dtype: Money\n"
+            "    period: Year\n"
+            "    formula: 0\n"
+        )
+        subtraction_parent.write_text(
+            "format: rulespec/v1\n"
+            "rules:\n"
+            "  - name: subsection_4_subtractions\n"
+            "    kind: derived\n"
+            "    entity: TaxUnit\n"
+            "    dtype: Money\n"
+            "    period: Year\n"
+            "    formula: 0\n"
+        )
+        for label in "abcdefghij":
+            addition_file = additions_root / f"{label}.yaml"
+            addition_test = additions_root / f"{label}.test.yaml"
+            subtraction_file = subtractions_root / f"{label}.yaml"
+            subtraction_test = subtractions_root / f"{label}.test.yaml"
+            addition_file.write_text("format: rulespec/v1\nrules: []\n")
+            addition_test.write_text(f"- name: addition_{label}_case\n  period: 2026\n")
+            subtraction_file.write_text("format: rulespec/v1\nrules: []\n")
+            subtraction_test.write_text(
+                f"- name: subtraction_{label}_case\n  period: 2026\n"
+            )
         addition_file = additions_root / "d.yaml"
         addition_test = additions_root / "d.test.yaml"
+        late_addition_file = additions_root / "j.yaml"
+        late_addition_test = additions_root / "j.test.yaml"
         subtraction_file = subtractions_root / "a.yaml"
         subtraction_test = subtractions_root / "a.test.yaml"
-        addition_file.write_text("format: rulespec/v1\nrules: []\n")
-        addition_test.write_text("- name: addition_case\n  period: 2026\n")
-        subtraction_file.write_text("format: rulespec/v1\nrules: []\n")
-        subtraction_test.write_text("- name: subtraction_case\n  period: 2026\n")
+        late_subtraction_file = subtractions_root / "j.yaml"
+        late_subtraction_test = subtractions_root / "j.test.yaml"
 
         runner = parse_runner_spec("codex:gpt-5.4")
         with patch(
@@ -7441,6 +7524,9 @@ rules:
         }
         assert copied_sources[str(addition_file)]["kind"] == "implementation_precedent"
         assert (
+            copied_sources[str(addition_parent)]["kind"] == "implementation_precedent"
+        )
+        assert (
             copied_sources[str(addition_file)]["import_path"]
             == "us:statutes/39/39-22-104/3/d"
         )
@@ -7448,11 +7534,31 @@ rules:
             copied_sources[str(addition_test)]["kind"] == "implementation_test_context"
         )
         assert (
+            copied_sources[str(late_addition_file)]["kind"]
+            == "implementation_precedent"
+        )
+        assert (
+            copied_sources[str(late_addition_test)]["kind"]
+            == "implementation_test_context"
+        )
+        assert (
             copied_sources[str(subtraction_file)]["import_path"]
             == "us:statutes/39/39-22-104/4/a"
         )
         assert (
+            copied_sources[str(subtraction_parent)]["kind"]
+            == "implementation_precedent"
+        )
+        assert (
             copied_sources[str(subtraction_test)]["kind"]
+            == "implementation_test_context"
+        )
+        assert (
+            copied_sources[str(late_subtraction_file)]["kind"]
+            == "implementation_precedent"
+        )
+        assert (
+            copied_sources[str(late_subtraction_test)]["kind"]
             == "implementation_test_context"
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.497"
+version = "0.2.498"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- copy all child RuleSpec files for explicit same-section subsection citations instead of truncating after eight
- include child files even when the cited parent aggregate exports rules
- let amount-adjustment parent lists compose child outputs instead of deferring solely because child branches use "to the extent" language
- expand eval workspace coverage for exporting parent aggregates plus late child files/tests, and add a CO-like aggregate-list regression

## Verification
- uv run ruff check src/axiom_encode/harness/evals.py tests/test_evals.py
- git diff --check
- uv run pytest tests/test_evals.py -k "partial_extent or amount_adjustment_parent_list or same_section_subsection_context or same_section_under_subsection_context or nested_same_section_context"
- uv run pytest tests/test_evals.py -q
- uv run pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject -q
- uv run python -m compileall -q src
- uv run towncrier build --draft --version 0.2.498

Second subagent review found no actionable issues; follow-up review for the aggregate-list guard also found no actionable issues.