### PR TITLE
Classify Colorado income tax oracle coverage

### DIFF
--- a/changelog.d/co-income-tax-oracle-coverage.changed.md
+++ b/changelog.d/co-income-tax-oracle-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify newly encoded Colorado income tax adjustment outputs in the PolicyEngine oracle coverage registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.498"
+version = "0.2.499"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.498"
+__version__ = "0.2.499"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1011,6 +1011,17 @@ mappings:
     comparison: money
     rationale: Same pre-credit Colorado income tax on the subsection (2)-modified tax base; PE computes co_taxable_income times the Colorado income-tax rate before nonrefundable credits.
 
+  - legal_id: us-co:statutes/39/39-22-104/2#federal_taxable_income_after_subsection_2_modifications
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: co_taxable_income
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado taxable income base before applying the state rate; PE computes federal taxable income plus Colorado additions minus Colorado subtractions, floored at zero.
+
   - legal_id: us-co:statutes/39/39-22-104/1.7/a#individual_estate_trust_income_tax_rate_before_2020
     country: us
     program: tax
@@ -1167,6 +1178,56 @@ mappings:
     policyengine_variable: co_federal_deduction_addback
     candidate_priority: P3
     rationale: This RuleSpec output is the subsection (3)(p.5) initial-window amount and includes the healthy-school-meals repeal exception; PolicyEngine exposes a unified federal-deduction addback amount without that repeal condition.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/p/7#ongoing_federal_adjusted_gross_income_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.tax.income.additions.federal_deductions.agi_threshold
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado federal deduction addback AGI threshold for the ongoing subsection (3)(p.7) rule.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/p/7#ongoing_single_return_deduction_threshold
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.co.tax.income.additions.federal_deductions.exemption
+    candidate_priority: P2
+    rationale: This RuleSpec parameter is the 2026 ongoing subsection (3)(p.7) single-return exemption amount; PolicyEngine's federal-deduction exemption table currently retains the prior $12,000 single-filer schedule, so this is an adjacent PE target but not a valid parameter comparison.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/p/7#ongoing_joint_return_deduction_threshold
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.co.tax.income.additions.federal_deductions.exemption
+    candidate_priority: P2
+    rationale: This RuleSpec parameter is the 2026 ongoing subsection (3)(p.7) joint-return exemption amount; PolicyEngine's federal-deduction exemption table currently retains the prior $16,000 joint-filer schedule, so this is an adjacent PE target but not a valid parameter comparison.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/p/7#ongoing_return_deduction_threshold
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.co.tax.income.additions.federal_deductions.exemption
+    candidate_priority: P4
+    rationale: This RuleSpec output selects the subsection (3)(p.7) single or joint exemption and returns zero outside those filing statuses; PolicyEngine stores the filing-status keyed exemption table rather than exposing this statutory selector as a variable.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/p/7#ongoing_itemized_or_standard_deduction_addition_applies
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_federal_deduction_addback_required
+    candidate_priority: P3
+    rationale: This RuleSpec predicate includes the subsection (3)(p.7) ongoing source-window boundary and healthy-school-meals repeal exception; PolicyEngine exposes a unified federal-deduction addback predicate without that repeal condition.
+
+  - legal_id: us-co:statutes/39/39-22-104/3/p/7#ongoing_itemized_or_standard_deduction_addition_to_federal_taxable_income
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_federal_deduction_addback
+    candidate_priority: P3
+    rationale: This RuleSpec output is the subsection (3)(p.7) ongoing amount and includes the healthy-school-meals repeal exception; PolicyEngine exposes a unified federal-deduction addback amount without that repeal condition.
 
   - legal_id: us-co:statutes/39/39-22-104/4/a#united_states_possessions_obligations_interest_income_subtraction
     country: us
@@ -13804,6 +13865,22 @@ mappings:
     rationale: "Source-specific intermediate output (rule `timely_application_for_recertification`, grounded against `Ala. Admin. Code 660-4-7-.08`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
 prefixes:
+  - legal_id_prefix: us-co:statutes/39/39-22-104/3/
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_additions
+    candidate_priority: P3
+    rationale: Remaining Colorado subsection 3 generated outputs decompose source-specific federal-taxable-income additions, predicates, timing windows, and caps; exact mappings above compare PE-exposed parameters or one-to-one variables, while PolicyEngine otherwise exposes only aggregate co_additions and selected addback variables. Keep this prefix visible in candidate triage because future generated outputs may deserve exact mappings.
+
+  - legal_id_prefix: us-co:statutes/39/39-22-104/4/
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: co_subtractions
+    candidate_priority: P3
+    rationale: Remaining Colorado subsection 4 generated outputs decompose source-specific federal-taxable-income subtractions, predicates, timing windows, and caps; exact mappings above compare PE-exposed parameters or one-to-one variables, while PolicyEngine otherwise exposes only aggregate co_subtractions and selected subtraction variables. Keep this prefix visible in candidate triage because future generated outputs may deserve exact mappings.
+
   - legal_id_prefix: us-co:statutes/39/39-22-105#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -898,6 +898,98 @@ rules:
     assert tax["test_output_count"] == 1
 
 
+def test_policyengine_coverage_maps_colorado_taxable_income_base(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/2.yaml",
+        """format: rulespec/v1
+rules:
+  - name: federal_taxable_income_after_subsection_2_modifications
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1987-01-01'
+        formula: 'max(0, federal_taxable_income + additions - subtractions)'
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/2.test.yaml",
+        """- name: taxable income base is tested
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us-co:statutes/39/39-22-104/2#federal_taxable_income_after_subsection_2_modifications: 90000
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us-co:statutes/39/39-22-104/2#federal_taxable_income_after_subsection_2_modifications"
+    )
+    assert item["policyengine_variable"] == "co_taxable_income"
+    assert item["tested"] is True
+    assert item["test_output_count"] == 1
+
+
+def test_policyengine_coverage_classifies_remaining_colorado_104_adjustments(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/3/a.yaml",
+        """format: rulespec/v1
+rules:
+  - name: federal_net_operating_loss_carryover_addition_to_federal_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '1987-01-01'
+        formula: federal_net_operating_loss_carryover
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/4/z.yaml",
+        """format: rulespec/v1
+rules:
+  - name: retroactive_cares_act_subtraction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2021-01-01'
+        formula: retroactive_cares_act_subtraction_calculated_before_limitation
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    addition = items_by_id[
+        "us-co:statutes/39/39-22-104/3/a#federal_net_operating_loss_carryover_addition_to_federal_taxable_income"
+    ]
+    subtraction = items_by_id[
+        "us-co:statutes/39/39-22-104/4/z#retroactive_cares_act_subtraction"
+    ]
+    assert addition["policyengine_variable"] == "co_additions"
+    assert addition["candidate_priority"] == "P3"
+    assert subtraction["policyengine_variable"] == "co_subtractions"
+    assert subtraction["candidate_priority"] == "P3"
+
+
 def test_policyengine_coverage_classifies_colorado_base_rates_not_comparable(
     tmp_path,
 ):
@@ -1185,6 +1277,59 @@ rules:
 """,
     )
     _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/3/p/7.yaml",
+        """format: rulespec/v1
+rules:
+  - name: ongoing_federal_adjusted_gross_income_threshold
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '300000'
+  - name: ongoing_single_return_deduction_threshold
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '1000'
+  - name: ongoing_joint_return_deduction_threshold
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '2000'
+  - name: ongoing_return_deduction_threshold
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 'if single: ongoing_single_return_deduction_threshold else: ongoing_joint_return_deduction_threshold'
+  - name: ongoing_itemized_or_standard_deduction_addition_applies
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: claims_deduction and not healthy_school_meals_repealed
+  - name: ongoing_itemized_or_standard_deduction_addition_to_federal_taxable_income
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 'if ongoing_itemized_or_standard_deduction_addition_applies: deduction_excess else: 0'
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/3/p/7.test.yaml",
+        """- name: subsection p7 deduction addback outputs
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    us-co:statutes/39/39-22-104/3/p/7#ongoing_federal_adjusted_gross_income_threshold: 300000
+    us-co:statutes/39/39-22-104/3/p/7#ongoing_single_return_deduction_threshold: 1000
+    us-co:statutes/39/39-22-104/3/p/7#ongoing_joint_return_deduction_threshold: 2000
+    us-co:statutes/39/39-22-104/3/p/7#ongoing_return_deduction_threshold: 1000
+    us-co:statutes/39/39-22-104/3/p/7#ongoing_itemized_or_standard_deduction_addition_applies: holds
+    us-co:statutes/39/39-22-104/3/p/7#ongoing_itemized_or_standard_deduction_addition_to_federal_taxable_income: 8000
+""",
+    )
+    _write_rulespec_file(
         tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/4/m.yaml",
         """format: rulespec/v1
 rules:
@@ -1217,10 +1362,10 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path, program="tax")
 
-    assert report["total_outputs"] == 15
+    assert report["total_outputs"] == 21
     assert report["status_counts"] == {
-        "comparable": 9,
-        "known_not_comparable": 6,
+        "comparable": 10,
+        "known_not_comparable": 11,
     }
     assert report["untested_comparable"] == 0
     items_by_id = {item["legal_id"]: item for item in report["items"]}
@@ -1235,6 +1380,15 @@ rules:
     ]
     p5_addback = items_by_id[
         "us-co:statutes/39/39-22-104/3/p/5#initial_window_addition_to_federal_taxable_income"
+    ]
+    p7_agi_threshold = items_by_id[
+        "us-co:statutes/39/39-22-104/3/p/7#ongoing_federal_adjusted_gross_income_threshold"
+    ]
+    p7_single_threshold = items_by_id[
+        "us-co:statutes/39/39-22-104/3/p/7#ongoing_single_return_deduction_threshold"
+    ]
+    p7_addback = items_by_id[
+        "us-co:statutes/39/39-22-104/3/p/7#ongoing_itemized_or_standard_deduction_addition_to_federal_taxable_income"
     ]
     charitable_floor = items_by_id[
         "us-co:statutes/39/39-22-104/4/m#charitable_contribution_subtraction_floor"
@@ -1258,6 +1412,19 @@ rules:
     )
     assert p5_addback["status"] == "known_not_comparable"
     assert p5_addback["policyengine_variable"] == "co_federal_deduction_addback"
+    assert (
+        p7_agi_threshold["policyengine_parameter"]
+        == "gov.states.co.tax.income.additions.federal_deductions.agi_threshold"
+    )
+    assert (
+        p7_single_threshold["policyengine_parameter"]
+        == "gov.states.co.tax.income.additions.federal_deductions.exemption"
+    )
+    assert p7_single_threshold["status"] == "known_not_comparable"
+    assert p7_single_threshold["candidate_priority"] == "P2"
+    assert p7_single_threshold["tested"] is True
+    assert p7_addback["status"] == "known_not_comparable"
+    assert p7_addback["policyengine_variable"] == "co_federal_deduction_addback"
     assert (
         charitable_floor["policyengine_parameter"]
         == "gov.states.co.tax.income.subtractions.charitable_contribution.adjustment"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.498"
+version = "0.2.499"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map Colorado 39-22-104(2) modified taxable income to PolicyEngine co_taxable_income
- map the subsection (3)(p.7) AGI threshold to the matching PE parameter while keeping the stale PE single/joint exemption schedule as adjacent-not-comparable
- classify remaining generated 39-22-104(3)/(4) adjustment helpers as known not comparable against PE aggregate additions/subtractions, with candidate priority left visible for future review

## Validation
- uv run pytest -q tests/test_policyengine_coverage.py -k "colorado"
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/co-income-tax-next-20260531 --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 120
- uv run ruff check tests/test_policyengine_coverage.py && git diff --check
- uv run pytest -q