### PR TITLE
Classify historical TN SNAP table outputs as not comparable

### DIFF
--- a/changelog.d/tn-snap-oracle-coverage.fixed.md
+++ b/changelog.d/tn-snap-oracle-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify historical Tennessee SNAP table outputs as outside PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.499"
+version = "0.2.500"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.499"
+__version__ = "0.2.500"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -13353,13 +13353,8 @@ mappings:
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_standard_deduction
     country: us
     program: snap
-    mapping_type: direct_variable
-    policyengine_variable: snap_standard_deduction
-    entity: spm_unit
-    period: month
-    unit: USD
-    comparison: money
-    rationale: "State SNAP output `snap_standard_deduction` matches the PolicyEngine variable `snap_standard_deduction` via the ECPS adapter catalog (rule_names includes `snap_standard_deduction`)."
+    mapping_type: not_comparable
+    rationale: "Historical Tennessee regulation table value from 1240-01-04-.27 block 1. It shares the generic rule name `snap_standard_deduction`, but the encoded table is not the current FY PolicyEngine SNAP standard deduction parameter and should not be treated as a direct oracle comparable."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_max_shelter_deduction_non_elderly_disabled
     country: us
@@ -13370,13 +13365,8 @@ mappings:
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_standard_utility_allowance
     country: us
     program: snap
-    mapping_type: direct_variable
-    policyengine_variable: snap_standard_utility_allowance
-    entity: spm_unit
-    period: month
-    unit: USD
-    comparison: money
-    rationale: "State SNAP output `snap_standard_utility_allowance` matches the PolicyEngine variable `snap_standard_utility_allowance` via the ECPS adapter catalog (rule_names includes `snap_standard_utility_allowance`)."
+    mapping_type: not_comparable
+    rationale: "Historical Tennessee regulation table value from 1240-01-04-.27 block 1. It shares the generic rule name `snap_standard_utility_allowance`, but the encoded table is not the current FY PolicyEngine SNAP utility allowance parameter and should not be treated as a direct oracle comparable."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_basic_utility_allowance
     country: us

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.499"
+version = "0.2.500"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark the historical Tennessee 1240-01-04-.27 block-1 standard deduction and utility allowance outputs as not comparable to current PolicyEngine SNAP variables
- add a changelog entry

## Validation
- uv run --python 3.13 axiom-encode oracle-coverage --root /Users/pavelmakarchuk --program snap --limit 5
- uv run --python 3.13 pytest tests/test_policyengine_coverage.py tests/test_policyengine_classifier.py