### PR TITLE
Classify Colorado Works TANF oracle coverage

### DIFF
--- a/changelog.d/co-tanf-oracle-coverage.fixed.md
+++ b/changelog.d/co-tanf-oracle-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classified Colorado Works TANF RuleSpec outputs in the PolicyEngine oracle coverage registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.501"
+version = "0.2.502"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.501"
+__version__ = "0.2.502"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -14067,6 +14067,13 @@ prefixes:
     mapping_type: not_comparable
     rationale: Colorado manual outputs are source-specific legal computations unless an exact PolicyEngine mapping overrides this prefix.
 
+  - legal_id_prefix: us-co:regulations/9-ccr-2503-6/3.606.1/
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Colorado Works basic-cash-assistance outputs decompose certification periods, assistance-unit table selection, current need and grant standards, pregnancy allowance, earned-income reporting, and grant authorization. PolicyEngine-US exposes adjacent Colorado TANF variables built from its own annual parameter table, but does not expose these month-level legal helper boundaries one-to-one; its current grant-standard table also needs a 2025 update before direct oracle comparison.
+
   - legal_id_prefix: us-co:policies/cdhs/snap/
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -91,6 +91,50 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_colorado_tanf_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "regulations/9-ccr-2503-6/3.606.1/F.yaml",
+        """format: rulespec/v1
+rules:
+  - name: basic_cash_assistance_grant_standard
+    kind: derived
+    versions:
+      - effective_from: '2025-07-01'
+        formula: grant_table_amount
+  - name: basic_cash_assistance_need_standard
+    kind: derived
+    versions:
+      - effective_from: '2025-07-01'
+        formula: need_table_amount
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co" / "regulations/9-ccr-2503-6/3.606.1/K.yaml",
+        """format: rulespec/v1
+rules:
+  - name: basic_cash_assistance_authorized_grant_for_eligible_assistance_unit
+    kind: derived
+    versions:
+      - effective_from: '2025-07-01'
+        formula: grant_standard - net_countable_income
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tanf")
+
+    assert report["total_outputs"] == 3
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert report["untested_comparable"] == 0
+    assert {item["program"] for item in report["items"]} == {"tanf"}
+    assert {item["mapping_type"] for item in report["items"]} == {"not_comparable"}
+    assert {item["candidate_priority"] for item in report["items"]} == {"P4"}
+    assert all(
+        "PolicyEngine-US exposes adjacent Colorado TANF variables"
+        in str(item["rationale"])
+        for item in report["items"]
+    )
+
+
 def test_policyengine_coverage_ignores_nested_axiom_dependency_checkout(tmp_path):
     content = """format: rulespec/v1
 rules:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.501"
+version = "0.2.502"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Classifies Colorado Works / TANF 9 CCR 2503-6 § 3.606.1 generated outputs as PolicyEngine-known non-comparable.
- Adds a focused coverage test for the TANF prefix mapping.
- Adds a Towncrier changelog fragment.

This unblocks rulespec-us-co#16's changed PolicyEngine oracle coverage gate. PE-US has adjacent Colorado TANF variables, but the current grant-standard table is stale versus Colorado's 2025-07-01 rule; I filed PolicyEngine/policyengine-us#8545 for that update.

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_colorado_tanf_outputs tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed -q`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev python -m towncrier build --draft --version 0.0.0`
- `uv run --extra dev python -m ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/registry.py`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/co-tanf-20260531 --program tanf`
  - `Executable outputs: 31`
  - `Status: known_not_comparable=31`
