### PR TITLE
Classify active SNAP PolicyEngine coverage gaps

### DIFF
--- a/changelog.d/snap-pe-coverage-classification.changed.md
+++ b/changelog.d/snap-pe-coverage-classification.changed.md
@@ -1,0 +1,1 @@
+Classify remaining AL/CA/MA/NY SNAP PolicyEngine coverage gaps for active dashboard suites.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.501"
+version = "0.2.502"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.501"
+__version__ = "0.2.502"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -336,6 +336,12 @@ PE_US_VAR_ADAPTERS = (
         spm=True,
     ),
     PolicyEngineUSVarAdapter(
+        rule_names=("meets_snap_categorical_eligibility",),
+        pe_var="meets_snap_categorical_eligibility",
+        monthly=True,
+        spm=True,
+    ),
+    PolicyEngineUSVarAdapter(
         rule_names=("is_snap_eligible",),
         pe_var="is_snap_eligible",
         monthly=True,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -37,6 +37,35 @@ mappings:
     candidate_priority: P4
     rationale: PolicyEngine exposes final SNAP eligibility including categorical, resource, and other conditions; this output is limited to the 7 USC 2014(c) income-standard ineligibility predicate.
 
+  - legal_id: us-al:policies/dhr/poe/chapter-09-income-and-deductions/900#household_meets_snap_income_eligibility_standards
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: meets_snap_gross_income_test
+    candidate_priority: P4
+    rationale: Alabama's manual output combines categorical eligibility, elderly-or-disabled net-only treatment, and gross/net income standards into a state income bridge. PolicyEngine exposes separate gross, net, categorical, and final eligibility variables, but not this exact combined state bridge.
+
+  - legal_id: us-ma:policies/dta/snap/fy-2026-cola/heating-cooling-standard-utility-allowance#heating_cooling_standard_utility_allowance
+    country: us
+    program: snap
+    mapping_type: direct_variable
+    policyengine_variable: snap_standard_utility_allowance
+    entity: spm_unit
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Massachusetts heating/cooling SUA is the state standard utility allowance amount when the PolicyEngine SNAP utility allowance type is SUA.
+
+  - legal_id: us-ma:regulations/106-cmr/365/180/A#snap_household_is_categorically_eligible
+    country: us
+    program: snap
+    mapping_type: direct_variable
+    policyengine_variable: meets_snap_categorical_eligibility
+    entity: spm_unit
+    period: month
+    comparison: boolean
+    rationale: Same Massachusetts SNAP categorical eligibility decision at the household/SPM-unit boundary.
+
   - legal_id: us:statutes/7/2014/e/2#snap_earned_income_deduction
     country: us
     program: snap
@@ -13855,6 +13884,18 @@ mappings:
     rationale: "Source-specific intermediate output (rule `timely_application_for_recertification`, grounded against `Ala. Admin. Code 660-4-7-.08`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
 prefixes:
+  - legal_id_prefix: us:_compose/ca-snap#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Legacy generated CA SNAP compose outputs are Axiom assembly points across federal and state rules. The dashboard compares the maintained axiom-programs composition instead of these stale compose artifacts.
+
+  - legal_id_prefix: us:_compose/ny-snap#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Legacy generated NY SNAP compose outputs are Axiom assembly points across federal and state rules. The dashboard compares the maintained axiom-programs composition instead of these stale compose artifacts.
+
   - legal_id_prefix: us-tn:policies/dhs/snap/
     country: us
     program: snap

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.501"
+version = "0.2.502"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify legacy CA/NY compose outputs as non-comparable assembly artifacts
- classify Alabama's income-standard bridge as adjacent/non-comparable
- add PolicyEngine mappings for Massachusetts HCSUA and categorical eligibility surfaces

## Verification
- uv run --python 3.13 axiom-encode oracle-coverage --root /Users/pavelmakarchuk --program snap --json
- uv run --python 3.13 pytest -q tests/test_policyengine_classifier.py tests/test_rulespec_validation.py