### PR TITLE
Repair SNAP minimum benefit allotment repair

### DIFF
--- a/changelog.d/snap-minimum-benefit-allotment-repair.fixed.md
+++ b/changelog.d/snap-minimum-benefit-allotment-repair.fixed.md
@@ -1,0 +1,1 @@
+Repair the SNAP 273.10 deterministic allotment fix so minimum-benefit formulas use the encoded one-person COLA allotment producer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.502"
+version = "0.2.503"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.502"
+__version__ = "0.2.503"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5213,17 +5213,35 @@ def _repair_snap_273_10_allotment_rules(content: str) -> str:
         "us:policies/usda/snap/fy-2026-cola/maximum-allotments",
         before_import="us:regulations/7-cfr/273/9",
     )
-    return content.replace(
+    content = content.replace(
         "snap_maximum_allotment_for_household_size",
         "snap_maximum_allotment",
+    )
+    return content.replace(
+        "snap_maximum_allotment_for_one_person_household",
+        "snap_one_person_thrifty_food_plan_cost",
     )
 
 
 def _repair_snap_273_10_allotment_tests(content: str) -> str:
-    return content.replace(
-        "    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_household_size: 298\n",
-        "    us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1\n",
+    household_size_input = (
+        "    us:policies/usda/snap/fy-2026-cola/maximum-allotments"
+        "#input.household_size: 1\n"
     )
+    content = content.replace(
+        "    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_household_size: 298\n",
+        household_size_input,
+    )
+    content = content.replace(
+        "    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_one_person_household: 298\n",
+        household_size_input,
+    )
+    while household_size_input + household_size_input in content:
+        content = content.replace(
+            household_size_input + household_size_input,
+            household_size_input,
+        )
+    return content
 
 
 def cmd_repair_snap_273_10_allotment(args):

--- a/src/axiom_encode/concepts/data/snap.yaml
+++ b/src/axiom_encode/concepts/data/snap.yaml
@@ -222,13 +222,15 @@ concepts:
       - snap_maximum_allotment_for_household_size
 
   - id: snap.allotment.max_for_one_person
-    canonical_name: snap_maximum_allotment_for_one_person_household
-    producer_anchor: us:regulations/7-cfr/273/10
-    producer_missing: true
+    canonical_name: snap_one_person_thrifty_food_plan_cost
+    producer_anchor: us:policies/usda/snap/fy-2026-cola/maximum-allotments
     description: >-
       Maximum allotment for a one-person household, used to compute the
-      minimum benefit per 7 CFR 273.10(e)(2)(ii)(C). No producer encoded yet.
-    blocked_synonyms: []
+      minimum benefit per 7 CFR 273.10(e)(2)(ii)(C). The FY COLA
+      maximum-allotments file owns this as the one-person Thrifty Food Plan
+      cost.
+    blocked_synonyms:
+      - snap_maximum_allotment_for_one_person_household
 
   # ---------------------------------------------------------------------------
   # Utility allowances (regional)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12366,6 +12366,15 @@ rules:
       - effective_from: '2025-10-01'
         formula: |-
           if state_agency_rounds_thirty_percent_net_income_up: max(0, snap_maximum_allotment_for_household_size - ceil(snap_net_monthly_income * snap_allotment_net_income_reduction_rate)) else: max(0, floor(snap_maximum_allotment_for_household_size - (snap_net_monthly_income * snap_allotment_net_income_reduction_rate)))
+  - name: snap_minimum_benefit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          floor((snap_maximum_allotment_for_one_person_household * snap_minimum_benefit_rate) + 0.5)
 """
         )
         test_file = policy_repo / "regulations/7-cfr/273/10.test.yaml"
@@ -12374,6 +12383,7 @@ rules:
   period: 2026-01
   input:
     us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_household_size: 298
+    us:regulations/7-cfr/273/10#input.snap_maximum_allotment_for_one_person_household: 298
   output:
     us:regulations/7-cfr/273/10#snap_minimum_benefit: 24
 """
@@ -12408,12 +12418,18 @@ rules:
         content = target.read_text()
         assert "us:policies/usda/snap/fy-2026-cola/maximum-allotments" in content
         assert "snap_maximum_allotment_for_household_size" not in content
+        assert "snap_maximum_allotment_for_one_person_household" not in content
         assert "snap_maximum_allotment - ceil(" in content
+        assert (
+            "snap_one_person_thrifty_food_plan_cost * snap_minimum_benefit_rate"
+            in content
+        )
         test_content = test_file.read_text()
         assert (
             "us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size: 1"
             in test_content
         )
+        assert "snap_maximum_allotment_for_one_person_household" not in test_content
         manifest = (
             policy_repo / ".axiom/encoding-manifests/regulations/7-cfr/273/10.json"
         )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.502"
+version = "0.2.503"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- extend the signed 7 CFR 273.10 allotment repair to rewrite the one-person maximum allotment input used by snap_minimum_benefit
- map that one-person value to the existing FY COLA producer, snap_one_person_thrifty_food_plan_cost
- mark the old one-person maximum-allotment name as a blocked synonym in the SNAP concept registry

## Validation
- uv run pytest -q tests/test_cli.py -k 'repair_snap_273_10_allotment' tests/test_concepts_registry.py