### PR TITLE
Classify Alabama SNAP POE oracle coverage

### DIFF
--- a/changelog.d/al-snap-poe-oracle-coverage.fixed.md
+++ b/changelog.d/al-snap-poe-oracle-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify Alabama DHR POE SNAP manual outputs under a PolicyEngine oracle coverage prefix so bulk manual encodings do not fail repository validation as unmapped.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.503"
+version = "0.2.504"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.503"
+__version__ = "0.2.504"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -13902,6 +13902,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Tennessee DHS SNAP manual pages encode state administrative procedures, verification rules, disqualification predicates, eligibility subtests, and other generated policy intermediates. PolicyEngine does not expose one-to-one variables for this manual-page surface; exact direct mappings should be added later only for individually verified outputs.
 
+  - legal_id_prefix: us-al:policies/dhr/poe/
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Alabama DHR POE SNAP manual sections encode state administrative procedures, verification rules, disqualification predicates, eligibility subtests, and other generated policy intermediates. PolicyEngine does not expose one-to-one variables for this manual-page surface; exact direct mappings should be added later only for individually verified outputs.
+
   - legal_id_prefix: us-co:statutes/39/39-22-104/3/
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -135,6 +135,51 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_alabama_snap_manual_prefix(tmp_path):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-al"
+        / "policies/dhr/poe/chapter-07-work-requirements/710.yaml",
+        """format: rulespec/v1
+rules:
+  - name: person_subject_to_abawd_provision
+    kind: derived
+    versions:
+      - effective_from: '2025-10-01'
+        formula: person_age >= 18
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-al"
+        / "policies/dhr/poe/chapter-09-income-and-deductions/900.yaml",
+        """format: rulespec/v1
+rules:
+  - name: household_meets_snap_income_eligibility_standards
+    kind: derived
+    versions:
+      - effective_from: '2025-10-01'
+        formula: household_income <= income_limit
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="snap")
+
+    assert report["total_outputs"] == 2
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    manual_output = items_by_id[
+        "us-al:policies/dhr/poe/chapter-07-work-requirements/710#person_subject_to_abawd_provision"
+    ]
+    exact_output = items_by_id[
+        "us-al:policies/dhr/poe/chapter-09-income-and-deductions/900#household_meets_snap_income_eligibility_standards"
+    ]
+    assert manual_output["mapping_type"] == "not_comparable"
+    assert "Alabama DHR POE SNAP manual sections" in str(manual_output["rationale"])
+    assert exact_output["mapping_type"] == "not_comparable"
+    assert "state income bridge" in str(exact_output["rationale"])
+
+
 def test_policyengine_coverage_ignores_nested_axiom_dependency_checkout(tmp_path):
     content = """format: rulespec/v1
 rules:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.503"
+version = "0.2.504"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Alabama DHR POE SNAP manual outputs under a PolicyEngine oracle coverage prefix
- preserve exact mappings for individually verified Alabama outputs
- bump axiom-encode to 0.2.504 and add a regression test

## Validation
- AL changed coverage check: 278 changed outputs, 0 failures
- uv run pytest -q tests/test_policyengine_coverage.py
- uv run pytest -q tests/test_cli.py -k "version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump" tests/test_policyengine_coverage.py
- uv run ruff check src tests
- uv run ruff format --check src tests