### PR TITLE
Fix CO SNAP oracle relation and ACA coverage mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.516"
+version = "0.2.517"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.517"
+version = "0.2.518"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.516"
+__version__ = "0.2.517"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.517"
+__version__ = "0.2.518"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -110,11 +110,10 @@ JURISDICTION_CONFIGS = {
             "snap_one_utility_allowance",
             "snap_individual_utility_allowance",
         ),
-        relation_id="member_of_household",
+        relation_id=AXIOM_RELATION_ID_BY_LABEL["member_of_household"],
         member_entity_type="Person",
         temp_prefix="co-snap-pe-ecps-",
         display_name="Colorado SNAP",
-        additional_relation_ids=(AXIOM_RELATION_ID_BY_LABEL["member_of_household"],),
     ),
     "us-ca": JurisdictionConfig(
         jurisdiction="us-ca",

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -913,8 +913,7 @@ def project_deduction_inputs(
                 "household_entitled_to_excess_medical_deduction"
             ): medical_deduction > 0,
             (
-                "us:regulations/7-cfr/273/10#input."
-                "snap_total_medical_expenses"
+                "us:regulations/7-cfr/273/10#input.snap_total_medical_expenses"
             ): medical_expenses_for_deduction(medical_deduction),
             (
                 "us:regulations/7-cfr/273/10#input."

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2046,6 +2046,89 @@ mappings:
     comparison: money
     rationale: Same statutory other-case additional Medicare wage threshold, stored in PE as parameter data.
 
+  - legal_id: us:statutes/26/36B/b/3/A#applicable_percentage_income_tier
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.required_contribution_percentage.threshold
+    candidate_priority: P4
+    rationale: Section 36B(b)(3)(A) income-tier selection is a statutory helper for the original applicable-percentage table. PolicyEngine stores current-law ACA threshold parameters and the interpolated required contribution percentage, not this source-level tier index as a one-to-one output.
+
+  - legal_id: us:statutes/26/36B/b/3/A#initial_premium_percentage_by_income_tier
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.required_contribution_percentage.initial
+    candidate_priority: P4
+    rationale: Section 36B(b)(3)(A) initial premium percentages are source-level statutory table entries that are indexed and updated for current law before PolicyEngine uses them. PolicyEngine exposes current-law ACA initial-rate parameters, not this original statutory indexed table as a scalar oracle output.
+
+  - legal_id: us:statutes/26/36B/b/3/A#final_premium_percentage_by_income_tier
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.required_contribution_percentage.final
+    candidate_priority: P4
+    rationale: Section 36B(b)(3)(A) final premium percentages are source-level statutory table entries that are indexed and updated for current law before PolicyEngine uses them. PolicyEngine exposes current-law ACA final-rate parameters, not this original statutory indexed table as a scalar oracle output.
+
+  - legal_id: us:statutes/26/36B/b/3/A#applicable_percentage
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_variable: aca_required_contribution_percentage
+    candidate_priority: P4
+    rationale: PolicyEngine's aca_required_contribution_percentage computes the current-law indexed ACA applicable figure for a tax unit. This RuleSpec output is the unindexed section 36B(b)(3)(A) statutory formula, so 2026 oracle cases differ from PolicyEngine after Revenue Procedure indexing.
+
+  - legal_id: us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_percentage_band
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.required_contribution_percentage.threshold
+    candidate_priority: P4
+    rationale: Revenue Procedure 2025-25 band selection is an Axiom helper for choosing a row from the 2026 ACA percentage table. PolicyEngine stores the corresponding thresholds and final interpolated percentage, but not this integer band as a one-to-one output.
+
+  - legal_id: us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_initial_percentage_table
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.required_contribution_percentage.initial
+    candidate_priority: P4
+    rationale: PolicyEngine stores the same 2026 ACA initial percentages as a current-law list parameter, while this RuleSpec output is a generated indexed table object. The current oracle compares scalar outputs, not whole indexed tables.
+
+  - legal_id: us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_final_percentage_table
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.required_contribution_percentage.final
+    candidate_priority: P4
+    rationale: PolicyEngine stores the same 2026 ACA final percentages as a current-law list parameter, while this RuleSpec output is a generated indexed table object. The current oracle compares scalar outputs, not whole indexed tables.
+
+  - legal_id: us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_initial_percentage
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.required_contribution_percentage.initial
+    candidate_priority: P4
+    rationale: Revenue Procedure 2025-25 applicable_initial_percentage selects the lower endpoint of the household-income band. PolicyEngine exposes the table parameter and the final interpolated required contribution percentage, not the selected endpoint as a separate variable.
+
+  - legal_id: us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_final_percentage
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.required_contribution_percentage.final
+    candidate_priority: P4
+    rationale: Revenue Procedure 2025-25 applicable_final_percentage selects the upper endpoint of the household-income band. PolicyEngine exposes the table parameter and the final interpolated required contribution percentage, not the selected endpoint as a separate variable.
+
+  - legal_id: us:policies/irs/rev-proc-2025-25/aca-ptc#required_contribution_percentage
+    country: us
+    program: aca_ptc
+    mapping_type: parameter_value
+    policyengine_parameter: gov.aca.required_contribution_percentage.final
+    parameter_key_path:
+      - 5
+    period: year
+    comparison: rate
+    rationale: Same 2026 ACA required contribution percentage, represented in PolicyEngine as the top final percentage in the current-law ACA required-contribution percentage table.
+
   - legal_id: us:statutes/26/3201#tier_2_employee_tax
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -248,6 +248,107 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_aca_ptc_percentage_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "policies/irs/rev-proc-2025-25/aca-ptc.yaml",
+        """format: rulespec/v1
+rules:
+  - name: applicable_percentage_band
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+  - name: applicable_initial_percentage_table
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          0: 0.021
+  - name: applicable_final_percentage_table
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          0: 0.021
+  - name: applicable_initial_percentage
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: applicable_initial_percentage_table[applicable_percentage_band]
+  - name: applicable_final_percentage
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: applicable_final_percentage_table[applicable_percentage_band]
+  - name: required_contribution_percentage
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.0996
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "policies/irs/rev-proc-2025-25/aca-ptc.test.yaml",
+        """- name: required_contribution_percentage_for_2026_plan_year
+  output:
+    us:policies/irs/rev-proc-2025-25/aca-ptc#required_contribution_percentage: 0.0996
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/36B/b/3/A.yaml",
+        """format: rulespec/v1
+rules:
+  - name: applicable_percentage_income_tier
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0
+  - name: initial_premium_percentage_by_income_tier
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          0: 0.02
+  - name: final_premium_percentage_by_income_tier
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          0: 0.02
+  - name: applicable_percentage
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.02
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="aca_ptc")
+
+    assert report["total_outputs"] == 10
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 9,
+    }
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    required = items_by_id[
+        "us:policies/irs/rev-proc-2025-25/aca-ptc#required_contribution_percentage"
+    ]
+    assert required["status"] == "comparable"
+    assert (
+        required["policyengine_parameter"]
+        == "gov.aca.required_contribution_percentage.final"
+    )
+    assert required["tested"] is True
+    statute_applicable = items_by_id["us:statutes/26/36B/b/3/A#applicable_percentage"]
+    assert statute_applicable["status"] == "known_not_comparable"
+    assert (
+        statute_applicable["policyengine_variable"]
+        == "aca_required_contribution_percentage"
+    )
+
+
 def test_policyengine_coverage_classifies_alabama_snap_manual_prefix(tmp_path):
     _write_rulespec_file(
         tmp_path

--- a/tests/test_policyengine_ecps_snap.py
+++ b/tests/test_policyengine_ecps_snap.py
@@ -205,7 +205,8 @@ def test_common_snap_outputs_track_current_federal_rulespec_surface():
 
 
 def test_colorado_snap_outputs_use_composed_allotment_and_cfr_net_income():
-    outputs = JURISDICTION_CONFIGS["us-co"].output_id_by_label
+    config = JURISDICTION_CONFIGS["us-co"]
+    outputs = config.output_id_by_label
 
     assert outputs["snap_regular_month_allotment"] == (
         "us-co:regulations/10-ccr-2506-1/4.207.2#snap_allotment"
@@ -213,6 +214,8 @@ def test_colorado_snap_outputs_use_composed_allotment_and_cfr_net_income():
     assert outputs["snap_net_income"] == (
         "us:regulations/7-cfr/273/10#snap_net_monthly_income"
     )
+    assert config.relation_id == "us:statutes/7/2012/j#relation.member_of_household"
+    assert config.additional_relation_ids == ()
 
 
 def test_projected_child_support_includes_gross_income_deduction():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.517"
+version = "0.2.518"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.516"
+version = "0.2.517"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Fixes two encoder-side oracle issues needed by the CO health and ACA generated RuleSpec PRs:

- CO SNAP ECPS PolicyEngine oracle now emits the absolute federal RuleSpec relation id for household members instead of the obsolete bare member_of_household dataset relation.
- PolicyEngine coverage registry now explicitly classifies generated ACA PTC percentage outputs from 26 USC 36B(b)(3)(A) and Rev. Proc. 2025-25, including a comparable mapping for the 2026 required contribution percentage.

Validation:
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py tests/test_policyengine_ecps_snap.py -q
- uv run --extra dev ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/registry.py src/axiom_encode/oracles/policyengine/ecps_snap.py tests/test_policyengine_ecps_snap.py
- uv run --extra dev ruff format --check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine/ecps_snap.py tests/test_policyengine_ecps_snap.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/co-health-20260601 --program aca_ptc --fail-on-unmapped --fail-on-untested-comparable
- AXIOM_CORPUS_LOCAL_ROOT=/Users/maxghenis/_axiom-worktrees/co-health-20260601/axiom-corpus uv run axiom-encode validate rulespec-us ACA PTC files --skip-reviewers
- AXIOM_CORPUS_LOCAL_ROOT=/Users/maxghenis/_axiom-worktrees/co-health-20260601/axiom-corpus uv run axiom-encode validate rulespec-us-co Colorado Medicaid/CHIP file --skip-reviewers
- local CO SNAP ECPS smoke: 20/20 matches within  tolerance, max diff 
- subagent review: no actionable findings