### PR TITLE
Map Colorado health thresholds in PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.518"
+version = "0.2.519"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.518"
+__version__ = "0.2.519"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2129,6 +2129,85 @@ mappings:
     comparison: rate
     rationale: Same 2026 ACA required contribution percentage, represented in PolicyEngine as the top final percentage in the current-law ACA required-contribution percentage table.
 
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#magi_fpl_disregard_rate
+    country: us
+    program: health
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table's separate 5% MAGI FPL disregard. PolicyEngine-US bakes that disregard into Medicaid and CHIP income-limit parameters rather than exposing it as a separate parameter.
+
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: CO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Colorado CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: CO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Colorado CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: CO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Colorado CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: CO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Colorado CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: CO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Colorado CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_pregnant_women_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: CO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Colorado CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person CHIP income limit including that disregard.
+
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: CO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Colorado CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective parent and caretaker Medicaid income limit including that disregard.
+
+  - legal_id: us-co:policies/cms/colorado-medicaid-chip-bhp-eligibility-levels#colorado_adult_medicaid_expansion_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: CO
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Colorado CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
+
   - legal_id: us:statutes/26/3201#tier_2_employee_tax
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -248,6 +248,100 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_colorado_medicaid_chip_thresholds(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-co"
+        / "policies/cms/colorado-medicaid-chip-bhp-eligibility-levels.yaml",
+        """format: rulespec/v1
+rules:
+  - name: magi_fpl_disregard_rate
+    kind: parameter
+    versions:
+      - effective_from: '2023-12-01'
+        formula: 0.05
+  - name: colorado_children_medicaid_ages_0_to_1_fpl_limit
+    kind: parameter
+    versions:
+      - effective_from: '2023-12-01'
+        formula: 1.42
+  - name: colorado_children_medicaid_ages_1_to_5_fpl_limit
+    kind: parameter
+    versions:
+      - effective_from: '2023-12-01'
+        formula: 1.42
+  - name: colorado_children_medicaid_ages_6_to_18_fpl_limit
+    kind: parameter
+    versions:
+      - effective_from: '2023-12-01'
+        formula: 1.42
+  - name: colorado_children_separate_chip_fpl_limit
+    kind: parameter
+    versions:
+      - effective_from: '2023-12-01'
+        formula: 2.60
+  - name: colorado_pregnant_women_medicaid_fpl_limit
+    kind: parameter
+    versions:
+      - effective_from: '2023-12-01'
+        formula: 1.95
+  - name: colorado_pregnant_women_chip_fpl_limit
+    kind: parameter
+    versions:
+      - effective_from: '2023-12-01'
+        formula: 2.60
+  - name: colorado_parent_caretaker_adults_medicaid_fpl_limit
+    kind: parameter
+    versions:
+      - effective_from: '2023-12-01'
+        formula: 0.68
+  - name: colorado_adult_medicaid_expansion_fpl_limit
+    kind: parameter
+    versions:
+      - effective_from: '2023-12-01'
+        formula: 1.33
+""",
+    )
+
+    medicaid = build_policyengine_coverage_report(tmp_path, program="medicaid")
+    chip = build_policyengine_coverage_report(tmp_path, program="chip")
+    health = build_policyengine_coverage_report(tmp_path, program="health")
+
+    assert medicaid["total_outputs"] == 6
+    assert chip["total_outputs"] == 2
+    assert health["total_outputs"] == 9
+    assert health["status_counts"] == {"known_not_comparable": 9}
+    assert health["untested_comparable"] == 0
+    assert {item["mapping_type"] for item in health["items"]} == {"not_comparable"}
+    assert {item["candidate_priority"] for item in health["items"]} == {"P4"}
+
+    items_by_name = {item["rule_name"]: item for item in health["items"]}
+    assert items_by_name["magi_fpl_disregard_rate"]["program"] == "health"
+    assert (
+        items_by_name["colorado_adult_medicaid_expansion_fpl_limit"][
+            "policyengine_parameter"
+        ]
+        == "gov.hhs.medicaid.eligibility.categories.adult.income_limit"
+    )
+    assert (
+        items_by_name["colorado_children_medicaid_ages_0_to_1_fpl_limit"][
+            "policyengine_parameter"
+        ]
+        == "gov.hhs.medicaid.eligibility.categories.infant.income_limit"
+    )
+    assert (
+        items_by_name["colorado_children_separate_chip_fpl_limit"][
+            "policyengine_parameter"
+        ]
+        == "gov.hhs.chip.child.income_limit"
+    )
+    assert all(
+        "5% MAGI FPL disregard" in str(item["rationale"]) for item in health["items"]
+    )
+
+
 def test_policyengine_coverage_classifies_aca_ptc_percentage_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "policies/irs/rev-proc-2025-25/aca-ptc.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.518"
+version = "0.2.519"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated Colorado Medicaid and CHIP CMS table outputs in the PolicyEngine coverage registry
- record that Axiom exposes raw CMS table thresholds plus a separate 5% MAGI disregard, while PolicyEngine stores effective thresholds with the disregard included
- add a focused coverage regression test and bump axiom-encode to 0.2.519

## Tests
- uv run --python 3.13 --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_colorado_medicaid_chip_thresholds tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- uv run --python 3.13 --extra dev ruff check src/ tests/
- uv run --python 3.13 --extra dev ruff format --check src/ tests/
- uv run --python 3.13 axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/co-health-20260601 --program health --fail-on-unmapped --fail-on-untested-comparable --limit 20