### PR TITLE
Tighten interval repair prompt guidance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.520"
+version = "0.2.521"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.520"
+__version__ = "0.2.521"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3744,7 +3744,6 @@ Test file rules:
 - Do not collapse a list of cited exceptions or cross-reference carve-outs into one aggregate fact such as `sections_..._do_not_preclude...`. Encode or import each cited exception separately, then combine them in a helper if useful.
 - If context files import this target file or reference this target file's outputs, use that as a signal to repair the dependency graph, not as a requirement to preserve old names. Keep an old output only when it remains the cleanest source-faithful RuleSpec surface.
 - Do not preserve existing factual input slots referenced by copied formulas or companion tests when a cleaner source-faithful encoding removes them. For names listed under invalid copied local inputs, do not preserve, rename, or recreate them.
-- For cross-reference boundary facts that remain local because the cited source is not present in context at all, keep the legal pointer in the identifier. If context for the cited source is present but unsupported, deferred, empty, or missing the exact displacement or exception export, encode a source-grounded local boundary predicate for whether that cited source displaces or blocks the requested source's formula; do not defer the requested formula merely because the copied cited file exports only its own separate amount.
 - When this source text itself names the operative factual disqualification,
   exception, or eligibility condition, encode that named condition as a local
   factual input even if the sentence cites another section for definitions or
@@ -3849,6 +3848,12 @@ RuleSpec requirements:
 - Do not invent schema keys like `namespace:`, `parameter`, `variable`, or `rule:`.
 - Rule kinds are `parameter`, `derived`, `derived_relation`, `data_relation`, or `source_relation`. Use `parameter` for named source scalars, `derived` for entity-scoped outputs, `derived_relation` when source text defines a filtered legal membership relation, `data_relation` for runtime predicates, and `source_relation` for non-executable legal/provenance edges.
 - Use `kind: parameter` with `indexed_by` and versioned `values` for source-stated numeric tables/scales keyed by household size, family size, income band, age band, or another row key. Do not encode those cells as `match` arms or numeric literals inside a derived formula. For source tables with interval/range row labels such as "at least / but less than" bands, do not create one scalar parameter per row, bound, or cell with names like `*_row_0_upper_*`, `*_row_3_rate`, or `*_lower_bound_band_9`. Define a source-backed band selector as a `derived` rule, store each substantive output column as a `kind: parameter` with `indexed_by: <band_selector>` and versioned `values`, and have the exported outputs look up the indexed table. Indexed table keys must be integer band ids such as `0`, `1`, and `2`; do not use decimal row thresholds like `1.33`, `2.5`, or strings such as `2_5_to_less_than_3_0` as lookup keys. Use structural row bounds inline only in the band selector and have it return integer band ids; do not promote those row labels to public scalar outputs. If interpolation or clamping needs the active row bounds before native interval-table support exists, store lower/upper bounds as private indexed parameter columns and reference those names in derived formulas; do not repeat bound literals outside the selector. Preserve source row identity: open lower or upper interval cells are real rows, not defaults and not dropped rows; omit only the open side of the predicate.
+- Do not treat the final interval row as open-ended unless the source row is actually open-ended. If the last source row has an upper bound, the selector must return an out-of-table sentinel above that bound and the principal output must handle that sentinel. Include a companion test above the final bounded row so the generated artifact cannot silently extend the table.
+- The out-of-table sentinel is not itself a source table row. Do not add sentinel entries to indexed parameter tables and do not clamp sentinel cases to the final table row's values. Handle the sentinel before table lookups, using the existing target's source-grounded out-of-range branch when repairing an existing artifact.
+- Do not hard-code the final real band id in non-selector formulas merely to make the final row constant. If the final row's initial and final table values are the same, let the indexed interpolation formula produce that constant value; branch only on the out-of-table sentinel and on genuinely distinct source-stated first-row behavior.
+- For percentage interval row labels, bounds, rates, and ratio inputs, encode percent values as decimal ratios. For example, source text `133%` should be represented as `1.33`, and `60%` as `0.60`, not as percent-point values like `133` or `60`. When repairing an existing artifact, update companion tests to the same ratio scale instead of preserving old percent-point test inputs.
+- For interval-table repair of an existing target, keep the executable surface narrow: add indexed bound columns and update the existing source-faithful principal formula, but do not add extra exported derived rules that merely project table columns such as `initial_*` or `final_*` unless the source text makes those projections legal outputs in their own right. Reference indexed table columns directly from the principal formula when they are only helpers for interpolation.
+- Structural interval bounds that are only used by the selector should stay inline inside the selector. Do not create one scalar parameter per selector bound, such as `tier_0_upper_bound`; use indexed bound columns only when a non-selector formula needs the active row bounds.
 - For source-stated rate or percentage tables whose column header names a legal
   application such as "applicable percentage for section 3201(b)" or
   "applicable percentage for sections 3211(b) and 3221(b)", name the exported
@@ -4142,18 +4147,27 @@ RuleSpec requirements:
   subtype, carve-out, or branch, defer only that branch or expose a
   source-named boundary input for that branch. Do not defer an unrelated
   source-stated cap/base computation that can be executed from the source text.
+- For cross-reference boundary facts that remain local because the cited source
+  is not present in context at all, keep the legal pointer in the identifier.
+  If context for the cited source is present but unsupported, deferred, empty,
+  or missing the needed export, do not preserve, rename, or recreate the local
+  cross-reference fact; import a real export, defer the affected executable
+  surface, or encode a source-grounded overriding branch that avoids it.
 - When the requested source states its own amount, cap, threshold, or formula
   but begins with an exception such as `except as otherwise provided in section
-  X` or `except as otherwise provided in subsection X`, do not defer the
-  requested formula merely because section X has unresolved effective versions,
-  ballot triggers, repeal facts, or program conditions. Encode the requested
-  source's own formula and represent the cross-reference boundary with a
-  source-named predicate such as
-  `subsection_x_does_not_displace_this_subsection` unless an import supplies the
-  exact displacement predicate. A cited provision's separate amount, addition,
-  deduction, or benefit output is not itself a displacement predicate and is not
-  a reason to defer the requested source's own formula. Include a companion case
-  where the cross-reference boundary blocks the local output.
+  X` or `except as otherwise provided in subsection X` and the cited external
+  or parent source is not present in copied context at all, do not defer the
+  requested formula merely because section X may have unresolved effective
+  versions, ballot triggers, repeal facts, or program conditions. Encode the
+  requested source's own formula and represent the absent cross-reference
+  boundary with a source-named predicate such as
+  `subsection_x_does_not_displace_this_subsection`. Include a companion case
+  where the cross-reference boundary blocks the local output. If copied context
+  for the cited source is present but lacks the exact displacement predicate,
+  follow the copied-context rule above instead. This applies to cited external
+  or parent sources, not to uncopied sibling clauses; for sibling clause
+  exception phrases, follow the sibling-clause rule below and do not invent
+  local `clause_*` booleans.
 - When that output also composes an imported child or sibling result, check
   that the imported file does not defer another branch, period, or purpose that
   can affect the same final amount. Do not treat a missing deferred child branch
@@ -4394,6 +4408,12 @@ RuleSpec requirements:
   those cited sources. Import the cited RuleSpec source when it exists; if the
   target source is needed but unavailable, stop with an explicit
   missing-upstream/dependency request instead of encoding an opaque placeholder.
+- For opening scope phrases such as `except as provided in clause (ii)` that
+  point to a sibling clause outside the requested target and no copied context
+  supplies that sibling's executable output, do not invent a local boolean like
+  `clause_ii_provides_otherwise`. Keep the current target scoped to the
+  source-stated positive calculation, or defer only the final affected surface
+  if the sibling exception is essential to the requested output.
 - A pure `notwithstanding subsection ...` override does not require importing
   the overridden subsection unless the formula actually needs that cited
   subsection's computed output.

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -180,6 +180,37 @@ Hard requirements:
   dimensions, keep the interval selector separate from the categorical key and
   use indexed parameter columns over the combined selectors instead of flattening
   legal categories into formula literals.
+- Do not treat the final interval row as open-ended unless the source row is
+  actually open-ended. If the last source row has an upper bound, the selector
+  must return an out-of-table sentinel above that bound and the principal output
+  must handle that sentinel. Include a companion test above the final bounded
+  row so the generated artifact cannot silently extend the table.
+- The out-of-table sentinel is not itself a source table row. Do not add
+  sentinel entries to indexed parameter tables and do not clamp sentinel cases
+  to the final table row's values. Handle the sentinel before table lookups,
+  using the existing target's source-grounded out-of-range branch when repairing
+  an existing artifact.
+- Do not hard-code the final real band id in non-selector formulas merely to
+  make the final row constant. If the final row's initial and final table values
+  are the same, let the indexed interpolation formula produce that constant
+  value; branch only on the out-of-table sentinel and on genuinely distinct
+  source-stated first-row behavior.
+- For percentage interval row labels, bounds, rates, and ratio inputs, encode
+  percent values as decimal ratios. For example, source text `133%` should be
+  represented as `1.33`, and `60%` as `0.60`, not as percent-point values like
+  `133` or `60`. When repairing an existing artifact, update companion tests to
+  the same ratio scale instead of preserving old percent-point test inputs.
+- For interval-table repair of an existing target, keep the executable surface
+  narrow: add indexed bound columns and update the existing source-faithful
+  principal formula, but do not add extra exported derived rules that merely
+  project table columns such as `initial_*` or `final_*` unless the source text
+  makes those projections legal outputs in their own right. Reference indexed
+  table columns directly from the principal formula when they are only helpers
+  for interpolation.
+- Structural interval bounds that are only used by the selector should stay
+  inline inside the selector. Do not create one scalar parameter per selector
+  bound, such as `tier_0_upper_bound`; use indexed bound columns only when a
+  non-selector formula needs the active row bounds.
 - For source-stated rate or percentage tables whose column header names a legal
   application such as "applicable percentage for section 3201(b)" or
   "applicable percentage for sections 3211(b) and 3221(b)", name the exported
@@ -775,6 +806,12 @@ Hard requirements:
   Import the cited RuleSpec source when it exists; if that upstream source is
   required but unavailable, stop with a missing-upstream/dependency request
   rather than encoding an opaque local fact.
+- For opening scope phrases such as `except as provided in clause (ii)` that
+  point to a sibling clause outside the requested target and no copied context
+  supplies that sibling's executable output, do not invent a local boolean like
+  `clause_ii_provides_otherwise`. Keep the current target scoped to the
+  source-stated positive calculation, or defer only the final affected surface
+  if the sibling exception is essential to the requested output.
 - A pure `notwithstanding subsection ...` override does not require importing
   the overridden subsection unless the formula actually needs that cited
   subsection's computed output.
@@ -804,6 +841,12 @@ Hard requirements:
   or missing the needed export, do not preserve, rename, or recreate the local
   cross-reference fact; import a real export, defer the affected executable
   surface, or encode a source-grounded overriding branch that avoids it.
+- When the requested source states its own amount, cap, threshold, or formula
+  but begins with a cross-reference exception such as `except as otherwise
+  provided in section X` or `except as otherwise provided in subsection X`,
+  this local-boundary escape hatch applies only to cited external or parent
+  sources. It does not apply to uncopied sibling clauses; for sibling clause
+  exception phrases, do not invent local `clause_*` booleans.
 - Do not emit Python code, markdown fences, prose, or file-write confirmations.
 - Do not invent values or ontology beyond the source text.
 - When source text uses amendment markup like `[old] new`, treat the bracketed

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -138,6 +138,27 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "Never drop the jurisdiction prefix" in ENCODER_PROMPT
     assert "listed under invalid copied local inputs" in ENCODER_PROMPT
     assert "do not preserve, rename, or recreate" in ENCODER_PROMPT
+    assert "For interval-table repair of an existing target" in ENCODER_PROMPT
+    assert "do not add extra exported derived rules" in ENCODER_PROMPT
+    assert "`clause_ii_provides_otherwise`" in ENCODER_PROMPT
+    assert "Do not treat the final interval row as open-ended" in ENCODER_PROMPT
+    assert "Include a companion test above the final bounded" in ENCODER_PROMPT
+    assert (
+        "The out-of-table sentinel is not itself a source table row" in ENCODER_PROMPT
+    )
+    assert "do not clamp sentinel cases\n  to the final table row" in ENCODER_PROMPT
+    assert "Do not hard-code the final real band id" in ENCODER_PROMPT
+    assert (
+        "let the indexed interpolation formula produce that constant" in ENCODER_PROMPT
+    )
+    assert "source text `133%` should be\n  represented as `1.33`" in ENCODER_PROMPT
+    assert "old percent-point test inputs" in ENCODER_PROMPT
+    assert (
+        "Structural interval bounds that are only used by the selector"
+        in ENCODER_PROMPT
+    )
+    assert "`tier_0_upper_bound`" in ENCODER_PROMPT
+    assert "for sibling clause\n  exception phrases" in ENCODER_PROMPT
     assert "kind: derived_relation" in ENCODER_PROMPT
     assert "derived_relation:" in ENCODER_PROMPT
     assert "arity: 2" in ENCODER_PROMPT
@@ -186,6 +207,20 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "Never drop the jurisdiction prefix" in prompt
     assert "listed under invalid copied local inputs" in prompt
     assert "do not preserve, rename, or recreate" in prompt
+    assert "For interval-table repair of an existing target" in prompt
+    assert "do not add extra exported derived rules" in prompt
+    assert "`clause_ii_provides_otherwise`" in prompt
+    assert "Do not treat the final interval row as open-ended" in prompt
+    assert "Include a companion test above the final bounded" in prompt
+    assert "The out-of-table sentinel is not itself a source table row" in prompt
+    assert "do not clamp sentinel cases\n  to the final table row" in prompt
+    assert "Do not hard-code the final real band id" in prompt
+    assert "let the indexed interpolation formula produce that constant" in prompt
+    assert "source text `133%` should be\n  represented as `1.33`" in prompt
+    assert "old percent-point test inputs" in prompt
+    assert "Structural interval bounds that are only used by the selector" in prompt
+    assert "`tier_0_upper_bound`" in prompt
+    assert "for sibling clause\n  exception phrases" in prompt
     assert "kind: derived_relation" in prompt
     assert "derived_relation:" in prompt
     assert "arity: 2" in prompt

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -919,6 +919,21 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "integer band ids such as `0`, `1`, and `2`" in prompt
     assert "do not use decimal row thresholds like `1.33`, `2.5`" in prompt
     assert "or strings such as `2_5_to_less_than_3_0`" in prompt
+    assert "For interval-table repair of an existing target" in prompt
+    assert "do not add extra exported derived rules" in prompt
+    assert "`clause_ii_provides_otherwise`" in prompt
+    assert "Do not treat the final interval row as open-ended" in prompt
+    assert "Include a companion test above the final bounded row" in prompt
+    assert "The out-of-table sentinel is not itself a source table row" in prompt
+    assert "do not clamp sentinel cases" in prompt
+    assert "Do not hard-code the final real band id" in prompt
+    assert "let the indexed interpolation formula produce that constant" in prompt
+    assert "source text `133%` should be represented as `1.33`" in prompt
+    assert "old percent-point test inputs" in prompt
+    assert "Structural interval bounds that are only used by the selector" in prompt
+    assert "`tier_0_upper_bound`" in prompt
+    assert "do not preserve, rename, or recreate the local" in prompt
+    assert "for sibling clause\n  exception phrases" in prompt
     assert "Before finalizing, do this self-check:" in prompt
     assert "Numeric inventory: every source-stated legal amount" in prompt
     assert "exact imported parameter from\n     context" in prompt
@@ -6284,8 +6299,58 @@ rules:
 
         assert "Target-specific schema limit" not in prompt
         assert "except as otherwise provided in section" in prompt
-        assert "cited provision's separate amount" in prompt
-        assert "subsection_x_does_not_displace_this_subsection" in prompt
+        assert "If copied context\n  for the cited source is present" in prompt
+        assert "do not preserve, rename, or recreate the local" in prompt
+        assert "follow the copied-context rule above instead" in prompt
+
+    def test_build_eval_prompt_no_tests_includes_copied_context_boundary_rule(
+        self, tmp_path
+    ):
+        policy_repo_root = tmp_path / "rulespec-us-co"
+        child_file = (
+            policy_repo_root / "statutes" / "39" / "39-22-104" / "3" / "p" / "5.yaml"
+        )
+        child_file.parent.mkdir(parents=True, exist_ok=True)
+        child_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: initial_window_addition_to_federal_taxable_income
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2023-01-01'
+        formula: federal_deduction_addition
+"""
+        )
+        workspace = prepare_eval_workspace(
+            citation="us-co/statute/39/39-22-104/3/p",
+            runner=parse_runner_spec("openai:gpt-5.5"),
+            output_root=tmp_path / "out",
+            source_text=(
+                "(p) Except as otherwise provided in subsection (3)(p.5), "
+                "for taxpayers who claim itemized deductions, the amount by "
+                "which itemized deductions exceed thirty thousand dollars."
+            ),
+            axiom_rules_path=policy_repo_root,
+            mode="repo-augmented",
+            extra_context_paths=[child_file],
+        )
+
+        prompt = _build_eval_prompt(
+            "us-co/statute/39/39-22-104/3/p",
+            "repo-augmented",
+            workspace,
+            workspace.context_files,
+            target_file_name="p.yaml",
+            target_ref_prefix="us-co:statutes/39/39-22-104/3/p",
+            runner_backend="openai",
+        )
+
+        assert "Test file rules:" not in prompt
+        assert "do not preserve, rename, or recreate the local" in prompt
+        assert "follow the copied-context rule above instead" in prompt
 
     def test_build_eval_prompt_scopes_partial_extent_to_numeric_target_paragraph(
         self, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.520"
+version = "0.2.521"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- tighten interval-table repair guidance so bounded final rows get an out-of-table sentinel instead of being silently extended
- require percent interval labels and tests to use decimal-ratio scale, e.g. 133% -> 1.33
- keep interval repair surfaces narrow by using indexed lower/upper bound columns and avoiding final real band-id branches in non-selector formulas
- clarify copied-context cross-reference and sibling-clause exception handling

## Validation
- uv run --extra dev python -m pytest tests/test_evals.py -k 'prompt or partial_extent or copied_context' -q
- uv run --extra dev python -m pytest tests/test_encoder_backend.py -q
- git diff --check
- dry run: uv run axiom-encode encode "26 USC 36B(b)(3)(A)" ... --apply-target-only => success=True, compile=yes, ci=yes, grounded=23, ungrounded=0

## Review
- /cycle read-only subagent review completed twice with no actionable findings
