### PR TITLE
Classify interval bound helpers for oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.522"
+version = "0.2.523"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.522"
+__version__ = "0.2.523"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -19,6 +19,9 @@ _PROGRAM_TOKEN_RE = {
     for token in ("medicaid", "chip", "aca")
 }
 _HEALTH_PROGRAMS = frozenset({"medicaid", "chip", "aca_ptc"})
+_INTERVAL_BOUND_HELPER_RE = re.compile(
+    r"(^|_)(tier|band|bracket|interval|row)_(lower|upper)_bound$"
+)
 
 
 @dataclass(frozen=True)
@@ -236,6 +239,7 @@ def _iter_policyengine_coverage_items(
                         root=root,
                         rulespec_file=rulespec_file,
                         rule_name=rule_name,
+                        rule=rule,
                         kind=kind,
                         mapping=mapping,
                         test_output_count=test_output_count,
@@ -497,13 +501,34 @@ def _coverage_item_from_mapping(
     root: Path,
     rulespec_file: Path,
     rule_name: str,
+    rule: dict[str, Any],
     kind: str,
     mapping: PolicyEngineMapping | None,
     test_output_count: int,
 ) -> PolicyEngineCoverageItem:
     if mapping is None:
-        status = "unmapped"
         program = _infer_program_from_legal_id(legal_id, rule_name=rule_name)
+        if _is_interval_bound_helper_rule(rule_name, rule):
+            return PolicyEngineCoverageItem(
+                legal_id=legal_id,
+                repo=repo.name,
+                file=str(rulespec_file.resolve().relative_to(root)),
+                rule_name=rule_name,
+                kind=kind,
+                status="known_not_comparable",
+                program=program,
+                mapping_type="not_comparable",
+                rationale=(
+                    "Indexed interval-bound helper used to select or interpolate "
+                    "a source table row; PolicyEngine generally stores final "
+                    "parameter scales or computed outputs, not these generated "
+                    "RuleSpec row-bound helpers as one-to-one oracle targets."
+                ),
+                candidate_priority="P4",
+                tested=test_output_count > 0,
+                test_output_count=test_output_count,
+            )
+        status = "unmapped"
         mapping_type = None
     elif mapping.comparable:
         status = "comparable"
@@ -534,6 +559,15 @@ def _coverage_item_from_mapping(
         tested=test_output_count > 0,
         test_output_count=test_output_count,
     )
+
+
+def _is_interval_bound_helper_rule(rule_name: str, rule: dict[str, Any]) -> bool:
+    """Identify generated indexed table-bound helpers that are not PE outputs."""
+    if str(rule.get("kind") or "").strip() != "parameter":
+        return False
+    if not rule.get("indexed_by"):
+        return False
+    return bool(_INTERVAL_BOUND_HELPER_RE.search(rule_name))
 
 
 def _program_filter_values(program: str) -> frozenset[str]:

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -397,6 +397,20 @@ rules:
     versions:
       - effective_from: '1990-01-01'
         formula: 0
+  - name: applicable_percentage_tier_lower_bound
+    kind: parameter
+    indexed_by: applicable_percentage_income_tier
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          1: 1.33
+  - name: applicable_percentage_tier_upper_bound
+    kind: parameter
+    indexed_by: applicable_percentage_income_tier
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          0: 1.33
   - name: initial_premium_percentage_by_income_tier
     kind: parameter
     versions:
@@ -419,10 +433,10 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path, program="aca_ptc")
 
-    assert report["total_outputs"] == 10
+    assert report["total_outputs"] == 12
     assert report["status_counts"] == {
         "comparable": 1,
-        "known_not_comparable": 9,
+        "known_not_comparable": 11,
     }
     assert report["untested_comparable"] == 0
     items_by_id = {item["legal_id"]: item for item in report["items"]}
@@ -441,6 +455,17 @@ rules:
         statute_applicable["policyengine_variable"]
         == "aca_required_contribution_percentage"
     )
+    lower_bound = items_by_id[
+        "us:statutes/26/36B/b/3/A#applicable_percentage_tier_lower_bound"
+    ]
+    upper_bound = items_by_id[
+        "us:statutes/26/36B/b/3/A#applicable_percentage_tier_upper_bound"
+    ]
+    assert lower_bound["status"] == "known_not_comparable"
+    assert upper_bound["status"] == "known_not_comparable"
+    assert lower_bound["mapping_type"] == "not_comparable"
+    assert upper_bound["mapping_type"] == "not_comparable"
+    assert "Indexed interval-bound helper" in str(lower_bound["rationale"])
 
 
 def test_policyengine_coverage_classifies_alabama_snap_manual_prefix(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.522"
+version = "0.2.523"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated indexed interval-bound helper parameters as known-not-comparable in PolicyEngine oracle coverage
- keep explicit registry mappings taking precedence over the structural helper classifier
- bump axiom-encode to 0.2.523

This unblocks the generated rulespec-us 36B PR whose only failing CI check was oracle coverage for `applicable_percentage_tier_lower_bound` and `applicable_percentage_tier_upper_bound`.

## Verification
- `uv run --extra dev python -m pytest tests/ -q`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/reencode-36b-interval-bounds-20260601 --json`
- subagent cycle review: no actionable findings