### PR TITLE
Repair generated tests for deferred imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.524"
+version = "0.2.525"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.527"
+version = "0.2.528"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.525"
+version = "0.2.526"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.526"
+version = "0.2.527"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.524"
+__version__ = "0.2.525"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.526"
+__version__ = "0.2.527"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.527"
+__version__ = "0.2.528"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.525"
+__version__ = "0.2.526"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -14007,6 +14007,34 @@ def _producer_rule_names(rules_file: Path) -> set[str]:
     return names
 
 
+def _deferred_output_names(rules_file: Path) -> set[str]:
+    """Return output fragments declared under `module.deferred_outputs`."""
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, ValueError, yaml.YAMLError):
+        return set()
+    if not isinstance(payload, dict):
+        return set()
+    module = payload.get("module")
+    if not isinstance(module, dict):
+        return set()
+    deferred_outputs = module.get("deferred_outputs")
+    if not isinstance(deferred_outputs, list):
+        return set()
+
+    names: set[str] = set()
+    for record in deferred_outputs:
+        if not isinstance(record, dict):
+            continue
+        output = str(record.get("output") or "").strip()
+        if "#" not in output:
+            continue
+        fragment = output.rsplit("#", 1)[1].strip()
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", fragment):
+            names.add(fragment)
+    return names
+
+
 def _input_ref_is_import_output_placeholder(
     input_ref: str,
     *,
@@ -14202,6 +14230,7 @@ def _local_factual_input_names_from_rules_content(rules_content: str) -> set[str
     rules = payload.get("rules")
     if not isinstance(rules, list):
         return set()
+    factual_inputs: set[str] = set()
 
     defined_symbols = {
         str(rule.get("name") or "").strip()
@@ -14229,7 +14258,6 @@ def _local_factual_input_names_from_rules_content(rules_content: str) -> set[str
         "sum_where",
         "true",
     }
-    factual_inputs: set[str] = set()
     for rule in rules:
         if not isinstance(rule, dict):
             continue
@@ -24587,10 +24615,23 @@ def _collect_imported_input_refs_by_name(
     except (OSError, ValueError, yaml.YAMLError):
         return {}
     imports = payload.get("imports") if isinstance(payload, dict) else None
-    if not isinstance(imports, list):
-        return {}
-
     refs_by_name: dict[str, list[str]] = {}
+    current_base = _rulespec_base_for_file(rules_file, repo_path=repo_path)
+    if isinstance(payload, dict) and current_base:
+        for input_name in sorted(
+            _direct_imported_deferred_output_names(
+                payload,
+                repo_path=repo_path,
+            )
+        ):
+            _append_unique_input_ref(
+                refs_by_name,
+                input_name,
+                f"{current_base}#input.{input_name}",
+            )
+    if not isinstance(imports, list):
+        return refs_by_name
+
     for raw_import in imports:
         if not isinstance(raw_import, str):
             continue
@@ -24626,6 +24667,47 @@ def _collect_imported_input_refs_by_name(
                     input_ref,
                 )
     return refs_by_name
+
+
+def _rulespec_base_for_file(rules_file: Path, *, repo_path: Path) -> str:
+    try:
+        relative = rules_file.relative_to(repo_path)
+    except ValueError:
+        return ""
+    return (
+        f"{_repo_jurisdiction_prefix(repo_path)}:"
+        f"{_relative_rulespec_import_target(relative)}"
+    )
+
+
+def _direct_imported_deferred_output_names(
+    payload: dict[str, object],
+    *,
+    repo_path: Path,
+) -> set[str]:
+    imports = payload.get("imports")
+    if not isinstance(imports, list):
+        return set()
+
+    names: set[str] = set()
+    for raw_import in imports:
+        if not isinstance(raw_import, str) or "#" not in raw_import:
+            continue
+        fragment = raw_import.rsplit("#", 1)[1].strip()
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", fragment):
+            continue
+        resolved_import = _same_repo_import_base_and_file(
+            raw_import,
+            repo_path=repo_path,
+        )
+        if resolved_import is None:
+            continue
+        _, import_file = resolved_import
+        if import_file is None or not import_file.exists():
+            continue
+        if fragment in _deferred_output_names(import_file):
+            names.add(fragment)
+    return names
 
 
 def _same_repo_import_base_and_file(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -24845,6 +24845,7 @@ def _insert_input_default_in_test_cases(
 ) -> str:
     """Insert an input default into every concrete test input block that needs it."""
     lines = content.splitlines(keepends=True)
+    lines = _expand_empty_inline_yaml_input_blocks(lines)
     blocks = _find_yaml_input_blocks(lines)
     if not blocks:
         return content
@@ -24875,6 +24876,22 @@ def _insert_input_default_in_test_cases(
         lines.insert(start + 1, f"{indent}{input_ref}: {rendered}{newline}")
     lines = _insert_input_default_in_relation_rows(lines, input_ref, rendered)
     return "".join(lines)
+
+
+def _expand_empty_inline_yaml_input_blocks(lines: list[str]) -> list[str]:
+    expanded = list(lines)
+    for index, line in enumerate(expanded):
+        match = re.match(
+            r"^(?P<indent>\s*)input:(?P<anchor>\s*&\S+)?\s*\{\}\s*(?P<comment>#.*)?(?P<newline>\r?\n?)$",
+            line,
+        )
+        if not match:
+            continue
+        anchor = match.group("anchor") or ""
+        comment = f" {match.group('comment')}" if match.group("comment") else ""
+        newline = match.group("newline")
+        expanded[index] = f"{match.group('indent')}input:{anchor}{comment}{newline}"
+    return expanded
 
 
 def _insert_input_default_in_table_entity_rows(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -24691,10 +24691,7 @@ def _direct_imported_deferred_output_names(
 
     names: set[str] = set()
     for raw_import in imports:
-        if not isinstance(raw_import, str) or "#" not in raw_import:
-            continue
-        fragment = raw_import.rsplit("#", 1)[1].strip()
-        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", fragment):
+        if not isinstance(raw_import, str):
             continue
         resolved_import = _same_repo_import_base_and_file(
             raw_import,
@@ -24705,7 +24702,17 @@ def _direct_imported_deferred_output_names(
         _, import_file = resolved_import
         if import_file is None or not import_file.exists():
             continue
-        if fragment in _deferred_output_names(import_file):
+        deferred_names = _deferred_output_names(import_file)
+        if not deferred_names:
+            continue
+        if "#" not in raw_import:
+            names.update(deferred_names)
+            continue
+        fragment = raw_import.rsplit("#", 1)[1].strip()
+        if (
+            re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", fragment)
+            and fragment in deferred_names
+        ):
             names.add(fragment)
     return names
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -14844,23 +14844,53 @@ def _title_qualified_reference_for_section(
 def _section_reference_to_named_act_without_title(
     section: str,
     source_text: str,
+    *,
+    identifier: str | None = None,
 ) -> bool:
     """Return whether source cites `section X of the Some Act` without USC title."""
-    return bool(
-        re.search(
-            rf"\bsection\s+{re.escape(section)}(?:\([^)]+\))*\s+of\s+"
-            r"(?:the\s+)?(?!title\s+\d+\b)"
-            r"[A-Z][A-Za-z0-9'&.-]*(?:\s+[A-Z][A-Za-z0-9'&.-]*){0,8}\s+Act\b",
-            source_text,
-            flags=re.IGNORECASE,
+    named_acts = _named_act_references_for_section(section, source_text)
+    if not named_acts:
+        return False
+    if (
+        _title_qualified_reference_for_section(section, source_text)
+        and identifier is not None
+    ):
+        return any(
+            _identifier_mentions_named_act(identifier, named_act)
+            for named_act in named_acts
         )
-        or re.search(
-            r"\b[A-Z][A-Za-z0-9'&.-]*(?:\s+[A-Z][A-Za-z0-9'&.-]*){0,8}\s+"
-            rf"Act\s+section\s+{re.escape(section)}(?:\([^)]+\))*\b",
-            source_text,
-            flags=re.IGNORECASE,
-        )
-    )
+    if _title_qualified_reference_for_section(section, source_text):
+        return False
+    return True
+
+
+def _named_act_references_for_section(section: str, source_text: str) -> list[str]:
+    """Return named acts cited with `section X` without a USC title."""
+    names: list[str] = []
+    for match in re.finditer(
+        rf"\bsection\s+{re.escape(section)}(?:\([^)]+\))*\s+of\s+"
+        r"(?:the\s+)?(?!title\s+\d+\b)"
+        r"(?P<act>[A-Z][A-Za-z0-9'&.-]*(?:\s+[A-Z][A-Za-z0-9'&.-]*){0,8}\s+Act)\b",
+        source_text,
+    ):
+        names.append(match.group("act"))
+    for match in re.finditer(
+        r"\b(?P<act>[A-Z][A-Za-z0-9'&.-]*(?:\s+[A-Z][A-Za-z0-9'&.-]*){0,8}\s+Act)"
+        rf"\s+section\s+{re.escape(section)}(?:\([^)]+\))*\b",
+        source_text,
+    ):
+        names.append(match.group("act"))
+    return names
+
+
+def _identifier_mentions_named_act(identifier: str, named_act: str) -> bool:
+    identifier_tokens = set(re.findall(r"[a-z0-9]+", identifier.lower()))
+    act_tokens = [
+        token
+        for token in re.findall(r"[a-z0-9]+", named_act.lower())
+        if token not in {"a", "act", "an", "the", "of"}
+    ]
+    return bool(act_tokens) and all(token in identifier_tokens for token in act_tokens)
 
 
 def _is_exception_identifier(identifier: str) -> bool:
@@ -19141,7 +19171,9 @@ class ValidatorPipeline:
                     label = _normalize_identifier(match.group("label"))
                     section = match.group("section")
                     if _section_reference_to_named_act_without_title(
-                        section, source_text
+                        section,
+                        source_text,
+                        identifier=label,
                     ):
                         continue
                     target_title = (
@@ -19381,7 +19413,11 @@ class ValidatorPipeline:
                 continue
             break
         section = match.group("section")
-        if _section_reference_to_named_act_without_title(section, source_text):
+        if _section_reference_to_named_act_without_title(
+            section,
+            source_text,
+            identifier=identifier,
+        ):
             return None
         target_title = (
             _title_qualified_reference_for_section(section, source_text) or title
@@ -19445,7 +19481,11 @@ class ValidatorPipeline:
             and citation.lower() not in source_text.lower()
         ):
             return None
-        if _section_reference_to_named_act_without_title(section, source_text):
+        if _section_reference_to_named_act_without_title(
+            section,
+            source_text,
+            identifier=identifier,
+        ):
             return None
         target_title = (
             _title_qualified_reference_for_section(section, source_text) or title

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -14872,12 +14872,14 @@ def _named_act_references_for_section(section: str, source_text: str) -> list[st
         r"(?:the\s+)?(?!title\s+\d+\b)"
         r"(?P<act>[A-Z][A-Za-z0-9'&.-]*(?:\s+[A-Z][A-Za-z0-9'&.-]*){0,8}\s+Act)\b",
         source_text,
+        flags=re.IGNORECASE,
     ):
         names.append(match.group("act"))
     for match in re.finditer(
         r"\b(?P<act>[A-Z][A-Za-z0-9'&.-]*(?:\s+[A-Z][A-Za-z0-9'&.-]*){0,8}\s+Act)"
         rf"\s+section\s+{re.escape(section)}(?:\([^)]+\))*\b",
         source_text,
+        flags=re.IGNORECASE,
     ):
         names.append(match.group("act"))
     return names
@@ -14888,8 +14890,12 @@ def _identifier_mentions_named_act(identifier: str, named_act: str) -> bool:
     act_tokens = [
         token
         for token in re.findall(r"[a-z0-9]+", named_act.lower())
-        if token not in {"a", "act", "an", "the", "of"}
+        if token not in {"a", "act", "an", "by", "of", "the", "to"}
     ]
+    for start in range(len(act_tokens)):
+        suffix = act_tokens[start:]
+        if len(suffix) >= 2 and all(token in identifier_tokens for token in suffix):
+            return True
     return bool(act_tokens) and all(token in identifier_tokens for token in act_tokens)
 
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -14846,7 +14846,7 @@ def _section_reference_to_named_act_without_title(
     source_text: str,
 ) -> bool:
     """Return whether source cites `section X of the Some Act` without USC title."""
-    return (
+    return bool(
         re.search(
             rf"\bsection\s+{re.escape(section)}(?:\([^)]+\))*\s+of\s+"
             r"(?:the\s+)?(?!title\s+\d+\b)"
@@ -14854,7 +14854,12 @@ def _section_reference_to_named_act_without_title(
             source_text,
             flags=re.IGNORECASE,
         )
-        is not None
+        or re.search(
+            r"\b[A-Z][A-Za-z0-9'&.-]*(?:\s+[A-Z][A-Za-z0-9'&.-]*){0,8}\s+"
+            rf"Act\s+section\s+{re.escape(section)}(?:\([^)]+\))*\b",
+            source_text,
+            flags=re.IGNORECASE,
+        )
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11822,6 +11822,72 @@ rules: []
             updated.count("us:statutes/26/1/h#input.investment_income_amount: 0") == 2
         )
 
+    def test_complete_missing_imported_test_inputs_adds_deferred_import_defaults(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        imported = policy_repo / "statutes/26/1402/a.yaml"
+        dependent = policy_repo / "statutes/26/1402/b.yaml"
+        dependent_test = policy_repo / "statutes/26/1402/b.test.yaml"
+        imported.parent.mkdir(parents=True)
+        dependent.parent.mkdir(parents=True, exist_ok=True)
+        imported.write_text(
+            """format: rulespec/v1
+module:
+  status: deferred
+  deferred_outputs:
+    - output: us:statutes/26/1402/a#net_earnings_from_self_employment
+      reason: Requires unresolved upstream exclusions.
+rules: []
+"""
+        )
+        dependent.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/1402/a#net_earnings_from_self_employment
+rules:
+  - name: self_employment_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: net_earnings_from_self_employment
+"""
+        )
+        dependent_test.write_text(
+            """- name: case_one
+  input:
+    us:statutes/26/1402/b#input.individual_is_nonresident_alien: false
+  output:
+    us:statutes/26/1402/b#self_employment_income: 0
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    error=(
+                        "Test case `case_one` execution failed: "
+                        "missing input `net_earnings_from_self_employment`"
+                    )
+                )
+            }
+        )
+
+        changed = _complete_missing_imported_test_inputs(
+            rules_file=dependent,
+            test_file=dependent_test,
+            repo_path=policy_repo,
+            validation=validation,
+        )
+
+        assert changed is True
+        assert (
+            "us:statutes/26/1402/b#input.net_earnings_from_self_employment: 0"
+            in dependent_test.read_text()
+        )
+
     def test_complete_missing_imported_test_inputs_adds_transitive_import_defaults(
         self, tmp_path
     ):
@@ -11901,6 +11967,98 @@ rules: []
         assert (
             "us:statutes/26/1402/b#input.individual_is_nonresident_alien: false"
             in updated
+        )
+
+    def test_complete_missing_imported_test_inputs_adds_transitive_deferred_defaults(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        deferred = policy_repo / "statutes/26/1402/a.yaml"
+        middle = policy_repo / "statutes/26/1402/b.yaml"
+        imported = policy_repo / "statutes/26/1401/a.yaml"
+        dependent = policy_repo / "statutes/26/164/f.yaml"
+        dependent_test = policy_repo / "statutes/26/164/f.test.yaml"
+        deferred.parent.mkdir(parents=True)
+        middle.parent.mkdir(parents=True, exist_ok=True)
+        imported.parent.mkdir(parents=True, exist_ok=True)
+        dependent.parent.mkdir(parents=True, exist_ok=True)
+        deferred.write_text(
+            """format: rulespec/v1
+module:
+  status: deferred
+  deferred_outputs:
+    - output: us:statutes/26/1402/a#net_earnings_from_self_employment
+      reason: Requires unresolved upstream exclusions.
+rules: []
+"""
+        )
+        middle.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/1402/a#net_earnings_from_self_employment
+rules:
+  - name: self_employment_income_for_section_1401_a
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: net_earnings_from_self_employment
+"""
+        )
+        imported.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/1402/b#self_employment_income_for_section_1401_a
+rules:
+  - name: old_age_survivors_and_disability_insurance_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: self_employment_income_for_section_1401_a * 0.124
+"""
+        )
+        dependent.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/1401/a#old_age_survivors_and_disability_insurance_tax
+rules: []
+"""
+        )
+        dependent_test.write_text(
+            """- name: case_one
+  input:
+    us:statutes/26/164/f#input.taxpayer_is_individual: true
+  output:
+    us:statutes/26/164/f#self_employment_tax_deduction: 0
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    error=(
+                        "Test case `case_one` execution failed: "
+                        "missing input `net_earnings_from_self_employment`"
+                    )
+                )
+            }
+        )
+
+        changed = _complete_missing_imported_test_inputs(
+            rules_file=dependent,
+            test_file=dependent_test,
+            repo_path=policy_repo,
+            validation=validation,
+        )
+
+        assert changed is True
+        assert (
+            "us:statutes/26/1402/b#input.net_earnings_from_self_employment: 0"
+            in dependent_test.read_text()
         )
 
     def test_complete_missing_imported_test_inputs_adds_table_entity_defaults(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11888,6 +11888,71 @@ rules:
             in dependent_test.read_text()
         )
 
+    def test_complete_missing_imported_test_inputs_adds_whole_module_deferred_import_defaults(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        imported = policy_repo / "statutes/26/1402/a.yaml"
+        dependent = policy_repo / "statutes/26/1402/b.yaml"
+        dependent_test = policy_repo / "statutes/26/1402/b.test.yaml"
+        imported.parent.mkdir(parents=True)
+        dependent.parent.mkdir(parents=True, exist_ok=True)
+        imported.write_text(
+            """format: rulespec/v1
+module:
+  status: deferred
+  deferred_outputs:
+    - output: us:statutes/26/1402/a#net_earnings_from_self_employment
+      reason: Requires unresolved upstream exclusions.
+rules: []
+"""
+        )
+        dependent.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/1402/a
+rules:
+  - name: self_employment_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: net_earnings_from_self_employment
+"""
+        )
+        dependent_test.write_text(
+            """- name: case_one
+  input: {}
+  output:
+    us:statutes/26/1402/b#self_employment_income: 0
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    error=(
+                        "Test case `case_one` execution failed: "
+                        "missing input `net_earnings_from_self_employment`"
+                    )
+                )
+            }
+        )
+
+        changed = _complete_missing_imported_test_inputs(
+            rules_file=dependent,
+            test_file=dependent_test,
+            repo_path=policy_repo,
+            validation=validation,
+        )
+
+        assert changed is True
+        assert (
+            "us:statutes/26/1402/b#input.net_earnings_from_self_employment: 0"
+            in dependent_test.read_text()
+        )
+
     def test_complete_missing_imported_test_inputs_adds_transitive_import_defaults(
         self, tmp_path
     ):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6561,6 +6561,42 @@ rules:
     assert issues == []
 
 
+def test_cross_reference_placeholder_allows_named_act_before_section(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "1402" / "b.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    The term self-employment income excludes nonresident alien individuals
+    except as provided by a Social Security Act section 233 agreement.
+rules:
+  - name: self_employment_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if (
+            individual_is_nonresident_alien
+            and not social_security_agreement_under_section_233_applies_to_nonresident_alien
+          ): 0 else: net_earnings_from_self_employment
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_cross_reference_exception_placeholders(rules_file)
+
+    assert issues == []
+
+
 def test_cross_reference_placeholder_allows_current_section_helpers(tmp_path):
     repo = tmp_path / "rulespec-us"
     rules_file = repo / "statutes" / "26" / "22.yaml"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6597,6 +6597,82 @@ rules:
     assert issues == []
 
 
+def test_cross_reference_placeholder_mixed_named_act_keeps_title_qualified_import(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "1402" / "b.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    Except as provided under section 233 of title 26, the special rule applies.
+    A separate sentence refers to a Social Security Act section 233 agreement.
+rules:
+  - name: special_rule
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          baseline_condition
+          and not section_233_exception_applies
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_cross_reference_exception_placeholders(rules_file)
+
+    assert len(issues) == 1
+    assert "statutes/26/233" in issues[0]
+
+
+def test_cross_reference_placeholder_mixed_named_act_allows_act_identifier(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "1402" / "b.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    Except as provided under section 233 of title 26, one unrelated rule applies.
+    The term self-employment income also excludes nonresident alien individuals
+    except as provided by a Social Security Act section 233 agreement.
+rules:
+  - name: self_employment_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if (
+            individual_is_nonresident_alien
+            and not social_security_agreement_under_section_233_applies_to_nonresident_alien
+          ): 0 else: net_earnings_from_self_employment
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_cross_reference_exception_placeholders(rules_file)
+
+    assert issues == []
+
+
 def test_cross_reference_placeholder_allows_current_section_helpers(tmp_path):
     repo = tmp_path / "rulespec-us"
     rules_file = repo / "statutes" / "26" / "22.yaml"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6597,6 +6597,42 @@ rules:
     assert issues == []
 
 
+def test_cross_reference_placeholder_allows_lowercase_named_act_reference(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "1402" / "b.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    The term self-employment income excludes nonresident alien individuals
+    except as provided by section 233 of the social security act.
+rules:
+  - name: self_employment_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if (
+            individual_is_nonresident_alien
+            and not social_security_agreement_under_section_233_applies_to_nonresident_alien
+          ): 0 else: net_earnings_from_self_employment
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_cross_reference_exception_placeholders(rules_file)
+
+    assert issues == []
+
+
 def test_cross_reference_placeholder_mixed_named_act_keeps_title_qualified_import(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.524"
+version = "0.2.525"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.526"
+version = "0.2.527"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.527"
+version = "0.2.528"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.525"
+version = "0.2.526"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- Treat outputs imported from deferred producers as consumer-local test inputs when repairing missing imported test inputs.
- Recognize named-act citations written as `Social Security Act section 233`, not only `section 233 of the Social Security Act`, so the validator does not infer a bogus current-title import.
- Bump `axiom-encode` to `0.2.526` for rulespec toolchain pinning.

## Validation

- `uv run python -m pytest -q tests/test_cli.py -k 'local_factual_input_names or complete_missing_imported_test_inputs' tests/test_rulespec_validation.py -k 'named_act or cross_reference_placeholder'`
- `uv run ruff check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_rulespec_validation.py`
- `uv run ruff format --check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_rulespec_validation.py`
- `git diff --check`

## Notes

This unblocks generated RuleSpec tests like `26 USC 164(f)`, where a target imports `1401(a)`, which imports `1402(b)`, which imports deferred `1402(a)#net_earnings_from_self_employment`. The repair should add `1402(b)#input.net_earnings_from_self_employment`, not the invalid producer ref `1402(a)#input.net_earnings_from_self_employment`.
