### PR TITLE
Teach encoder to reuse scalar numeric concepts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.528"
+version = "0.2.529"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.528"
+__version__ = "0.2.529"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -4390,6 +4390,12 @@ RuleSpec requirements:
 - Do not invent `dtype: String` variables just to restate the effective date.
 - Do not decompose legal dates into numeric `year`, `month`, or `day` scalar variables.
 - Do not create public outputs for structural table row labels, household-size row indexes, or branch numbers. When those labels are source-stated numeric bounds or grid cells, keep them as private named numeric concepts or indexed table/grid values; consuming formulas should reference names rather than embedding the policy literal.
+- If a source-stated scalar is needed to compute another local scalar, reference
+  the named scalar concept instead of repeating its literal value in a formula.
+  For example, if the source states a five-year period and a one-fifth fraction,
+  encode the period as `benefit_cost_rate_compensation_lookback_years = 5` and
+  the fraction as `1 / benefit_cost_rate_compensation_lookback_years`, not
+  `1 / 5`.
 - In a state-specific RuleSpec repository, if the source is a multi-state or
   multi-jurisdiction table, encode only the row(s) for the target repository's
   jurisdiction. Do not invent a fake `State` entity, row-index input, or

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -149,6 +149,12 @@ Hard requirements:
   it fits the local schema, but the invariant is the named concept: consuming
   formulas reference that name, so the concept can later change from a direct
   scalar to a computed formula without rewriting every consumer.
+- If a source-stated scalar is needed to compute another local scalar, reference
+  the named scalar concept instead of repeating its literal value in a formula.
+  For example, if the source states a five-year period and a one-fifth fraction,
+  encode the period as `benefit_cost_rate_compensation_lookback_years = 5` and
+  the fraction as `1 / benefit_cost_rate_compensation_lookback_years`, not
+  `1 / 5`.
 - Use `kind: parameter` with `indexed_by` and versioned `values` for source-stated
   numeric tables/scales keyed by household size, family size, income band,
   age band, or another row key. Do not encode those cells as `match` arms or

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -908,6 +908,8 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "do not assume one upstream raw input equals that imported output" in prompt
     assert "For IRC section 151 repairs" not in prompt
     assert "named numeric concept" in prompt
+    assert "1 / benefit_cost_rate_compensation_lookback_years" in prompt
+    assert "`1 / 5`" in prompt
     assert "if the source is a multi-state or\n  multi-jurisdiction table" in prompt
     assert "Do not invent a fake `State` entity" in prompt
     assert "do not create one scalar parameter per row, bound, or cell" in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.528"
+version = "0.2.529"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Add encoder guidance to reuse named source-stated scalar concepts in local scalar formulas instead of repeating numeric literals.
- Mirror the guidance in the eval prompt surface used by `axiom-encode encode`.
- Bump axiom-encode to 0.2.529 and add prompt regression coverage for the `1 / 5` case.

## Verification
- `uv run pytest -q tests/test_evals.py::test_build_eval_prompt_targets_rulespec_yaml tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::test_package_version_metadata_matches_pyproject`
- `uv run pytest -q tests/test_evals.py -k 'targets_rulespec_yaml or requires_named_scalars_for_repeated_and_threshold_numbers'`\n- `uv run ruff check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py src/axiom_encode/__init__.py tests/test_evals.py`\n- `uv run ruff format --check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py src/axiom_encode/__init__.py tests/test_evals.py`\n- `git diff --check`\n\nSubagent review: no blocking findings.