### PR TITLE
Allow positive excluded amount exception helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.529"
+version = "0.2.530"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.529"
+__version__ = "0.2.530"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -889,6 +889,28 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_judgment_positive_tests_parser = subparsers.add_parser(
+        "repair-judgment-positive-tests",
+        help="Apply signed deterministic repairs for missing positive Judgment tests",
+    )
+    repair_judgment_positive_tests_parser.add_argument(
+        "file", type=Path, help="RuleSpec YAML file"
+    )
+    repair_judgment_positive_tests_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="Rules repository root used for manifest signing",
+    )
+    repair_judgment_positive_tests_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_unused_imports_parser = subparsers.add_parser(
         "repair-unused-imports",
         help="Apply signed deterministic repairs for unused RuleSpec imports",
@@ -1808,6 +1830,8 @@ def main():
         cmd_repair_current_year_final_amounts(args)
     elif args.command == "repair-zero-branch-tests":
         cmd_repair_zero_branch_tests(args)
+    elif args.command == "repair-judgment-positive-tests":
+        cmd_repair_judgment_positive_tests(args)
     elif args.command == "repair-unused-imports":
         cmd_repair_unused_imports(args)
     elif args.command == "repair-proof-import-hashes":
@@ -6724,6 +6748,134 @@ def cmd_repair_zero_branch_tests(args):
 
     print(
         "Applied zero-branch test repair to "
+        f"{relative_output}: {', '.join(repaired_test_cases)}"
+    )
+    print(f"manifest={manifest_path}")
+
+
+def cmd_repair_judgment_positive_tests(args):
+    """Apply signed deterministic positive Judgment companion test repairs."""
+    repo_path = Path(args.repo).resolve()
+    rules_file = Path(args.file)
+    if not rules_file.is_absolute():
+        rules_file = repo_path / rules_file
+    rules_file = rules_file.resolve()
+    if not rules_file.exists():
+        print(f"RuleSpec file not found: {rules_file}")
+        sys.exit(1)
+    try:
+        relative_output = rules_file.relative_to(repo_path)
+    except ValueError:
+        print(f"RuleSpec file {rules_file} is not under repo {repo_path}")
+        sys.exit(1)
+
+    test_file = _rulespec_test_path(rules_file)
+    if not test_file.exists():
+        print(f"Companion test file not found: {test_file}")
+        sys.exit(1)
+
+    original_test_content = test_file.read_text()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+
+    repaired_test_cases: list[str] = []
+    signing_key: str | None = None
+    axiom_encode_git: dict[str, object] | None = None
+    for _ in range(50):
+        validation = ValidatorPipeline(
+            policy_repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+            enable_oracles=False,
+            require_policy_proofs=True,
+        ).validate(rules_file, skip_reviewers=True)
+        if validation.all_passed:
+            break
+        issues = [
+            result.error for result in validation.results.values() if result.error
+        ]
+        if not _only_pending_judgment_positive_output_coverage_issues(issues):
+            if not repaired_test_cases:
+                test_file.write_text(original_test_content)
+                print("No positive Judgment test repairs found.")
+                return
+            test_file.write_text(original_test_content)
+            print("Repair failed validation; restored original test file.")
+            for issue in issues:
+                print(f"- {issue}")
+            sys.exit(1)
+        if signing_key is None:
+            signing_key = _require_applied_encoding_manifest_signing_key()
+            axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+        try:
+            repaired_now = _append_generated_judgment_positive_tests_if_missing(
+                rules_file=rules_file,
+                test_file=test_file,
+                repo_path=repo_path,
+                axiom_rules_path=axiom_rules_path,
+                relative_output=relative_output,
+                issues=issues,
+                test_failure_checker=_rulespec_companion_test_failures,
+            )
+        except Exception:
+            test_file.write_text(original_test_content)
+            raise
+        if not repaired_now:
+            test_file.write_text(original_test_content)
+            if not repaired_test_cases:
+                print("No positive Judgment test repairs found.")
+                return
+            print("Repair failed validation; restored original test file.")
+            for issue in issues:
+                print(f"- {issue}")
+            sys.exit(1)
+        repaired_test_cases.extend(repaired_now)
+    else:
+        test_file.write_text(original_test_content)
+        print("Repair failed validation; restored original test file.")
+        print("- Exceeded positive Judgment test repair iteration limit.")
+        sys.exit(1)
+
+    if not repaired_test_cases:
+        test_file.write_text(original_test_content)
+        print("No positive Judgment test repairs found.")
+        return
+    if signing_key is None or axiom_encode_git is None:
+        signing_key = _require_applied_encoding_manifest_signing_key()
+        axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        generated_output = output_root / "deterministic-repair" / relative_output
+        generated_output.parent.mkdir(parents=True, exist_ok=True)
+        generated_output.write_text(rules_file.read_text())
+        result = argparse.Namespace(
+            output_file=str(generated_output),
+            runner="deterministic-repair",
+            backend="deterministic",
+            model="judgment-positive-test-v1",
+            tool="axiom-encode repair-judgment-positive-tests",
+            citation=(
+                f"{_repo_jurisdiction_prefix(repo_path)}:"
+                f"{_relative_rulespec_import_target(relative_output)}"
+            ),
+            generation_prompt_sha256=None,
+            trace_file=None,
+            context_manifest_file=None,
+        )
+        manifest_path = _write_applied_encoding_manifest(
+            result,
+            output_root=output_root,
+            policy_repo_path=repo_path,
+            relative_output=relative_output,
+            applied_files=[rules_file, test_file],
+            run_id="deterministic-repair",
+            signing_key=signing_key,
+            axiom_encode_git=axiom_encode_git,
+        )
+
+    print(
+        "Applied positive Judgment test repair to "
         f"{relative_output}: {', '.join(repaired_test_cases)}"
     )
     print(f"manifest={manifest_path}")

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -14466,6 +14466,7 @@ def find_unconsumed_local_exception_output_issues(content: str) -> list[str]:
 
     formulas_by_name: dict[str, list[str]] = {}
     imported_outputs_by_name: dict[str, set[str]] = {}
+    dtypes_by_name: dict[str, str] = {}
     exception_names: list[str] = []
     for rule in rules:
         if not isinstance(rule, dict):
@@ -14473,6 +14474,9 @@ def find_unconsumed_local_exception_output_issues(content: str) -> list[str]:
         name = str(rule.get("name") or "").strip()
         if not name:
             continue
+        dtype = str(rule.get("dtype") or "").strip().lower()
+        if dtype:
+            dtypes_by_name[name] = dtype
         formulas = _rule_formula_texts(rule)
         if formulas:
             formulas_by_name[name] = formulas
@@ -14507,6 +14511,17 @@ def find_unconsumed_local_exception_output_issues(content: str) -> list[str]:
                 continue
             if any(
                 _formula_negates_identifier(formula, exception_name)
+                for formula in formulas
+            ):
+                continue
+            if _is_positive_excluded_amount_output(
+                rule_name,
+                dtype=dtypes_by_name.get(rule_name),
+            ) and any(
+                _formula_uses_identifier_as_positive_exclusion_amount(
+                    formula,
+                    exception_name,
+                )
                 for formula in formulas
             ):
                 continue
@@ -14623,6 +14638,52 @@ def _formula_negates_identifier(formula: str, identifier: str) -> bool:
             formula,
         )
     )
+
+
+def _is_positive_excluded_amount_output(
+    rule_name: str,
+    *,
+    dtype: str | None,
+) -> bool:
+    return dtype in {"decimal", "integer", "money", "number"} and (
+        "_excluded_from_" in rule_name or "_disregarded_for_" in rule_name
+    )
+
+
+def _formula_uses_identifier_as_positive_exclusion_amount(
+    formula: str,
+    identifier: str,
+) -> bool:
+    normalized = " ".join(formula.split())
+    match = re.fullmatch(
+        r"if\s+(?P<condition>.+?)\s*:\s*(?P<positive>.+?)\s+else\s*:\s*0(?:\.0+)?",
+        normalized,
+    )
+    if match is None:
+        return False
+    condition = _strip_wrapping_parentheses(match.group("condition").strip())
+    return condition == identifier
+
+
+def _strip_wrapping_parentheses(text: str) -> str:
+    while text.startswith("(") and text.endswith(")"):
+        inner = text[1:-1].strip()
+        if not inner or not _parentheses_balanced(inner):
+            break
+        text = inner
+    return text
+
+
+def _parentheses_balanced(text: str) -> bool:
+    depth = 0
+    for character in text:
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+            if depth < 0:
+                return False
+    return depth == 0
 
 
 def find_missing_child_exception_import_issues(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,6 +123,7 @@ from axiom_encode.cli import (
     cmd_oracle_coverage,
     cmd_repair_current_year_final_amounts,
     cmd_repair_imported_test_inputs,
+    cmd_repair_judgment_positive_tests,
     cmd_repair_missing_source_proofs,
     cmd_repair_nonnegative_floors,
     cmd_repair_oracle_parameter_tests,
@@ -8733,6 +8734,172 @@ rules:
             "us:statutes/26/3303#input.account_maintained_for_employer"
             not in synthesized["input"]
         )
+
+    def test_repair_judgment_positive_tests_repeats_until_validation_passes(
+        self, tmp_path
+    ):
+        repo_path = tmp_path / "rulespec-us"
+        rules_file = repo_path / "statutes" / "26" / "3231" / "e.yaml"
+        test_file = repo_path / "statutes" / "26" / "3231" / "e.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: first_positive_judgment
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-01-01'
+        formula: first_condition
+  - name: second_positive_judgment
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-01-01'
+        formula: second_condition
+"""
+        )
+        test_file.write_text("[]\n")
+        args = SimpleNamespace(
+            repo=repo_path,
+            file=Path("statutes/26/3231/e.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        def has_holds_output(rule_name):
+            test_payload = yaml.safe_load(test_file.read_text()) or []
+            return any(
+                isinstance(test_case, dict)
+                and test_case.get("output")
+                == {f"us:statutes/26/3231/e#{rule_name}": "holds"}
+                for test_case in test_payload
+            )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == rules_file.resolve()
+                assert skip_reviewers is True
+                for rule_name in (
+                    "first_positive_judgment",
+                    "second_positive_judgment",
+                ):
+                    if not has_holds_output(rule_name):
+                        return SimpleNamespace(
+                            all_passed=False,
+                            results={
+                                "ci": SimpleNamespace(
+                                    error=(
+                                        "Judgment rule missing positive companion "
+                                        "output coverage: "
+                                        f"`us:statutes/26/3231/e#{rule_name}` "
+                                        "is not asserted as `holds` by the companion "
+                                        "`.test.yaml` file."
+                                    )
+                                )
+                            },
+                        )
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures", return_value=[]
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_judgment_positive_tests(args)
+
+        test_payload = yaml.safe_load(test_file.read_text())
+        assert [test_case["name"] for test_case in test_payload] == [
+            "auto_positive_first_positive_judgment",
+            "auto_positive_second_positive_judgment",
+        ]
+        manifest = repo_path / ".axiom/encoding-manifests/statutes/26/3231/e.json"
+        payload = json.loads(manifest.read_text())
+        assert payload["tool"] == "axiom-encode repair-judgment-positive-tests"
+        assert [item["path"] for item in payload["applied_files"]] == [
+            "statutes/26/3231/e.yaml",
+            "statutes/26/3231/e.test.yaml",
+        ]
+
+    def test_repair_judgment_positive_tests_restores_when_no_candidate_passes(
+        self, tmp_path
+    ):
+        repo_path = tmp_path / "rulespec-us"
+        rules_file = repo_path / "statutes" / "26" / "3231" / "e.yaml"
+        test_file = repo_path / "statutes" / "26" / "3231" / "e.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: first_positive_judgment
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-01-01'
+        formula: first_condition
+"""
+        )
+        original_test_content = "# preserve this comment\n[]\n"
+        test_file.write_text(original_test_content)
+        args = SimpleNamespace(
+            repo=repo_path,
+            file=Path("statutes/26/3231/e.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == rules_file.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(
+                    all_passed=False,
+                    results={
+                        "ci": SimpleNamespace(
+                            error=(
+                                "Judgment rule missing positive companion output "
+                                "coverage: "
+                                "`us:statutes/26/3231/e#first_positive_judgment` "
+                                "is not asserted as `holds` by the companion "
+                                "`.test.yaml` file."
+                            )
+                        )
+                    },
+                )
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures",
+                return_value=["candidate still fails"],
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_judgment_positive_tests(args)
+
+        assert test_file.read_text() == original_test_content
+        manifest = repo_path / ".axiom/encoding-manifests/statutes/26/3231/e.json"
+        assert not manifest.exists()
 
     def test_encode_apply_auto_repairs_auto_output_test_mismatches(
         self, capsys, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5993,6 +5993,156 @@ rules:
     assert find_unconsumed_local_exception_output_issues(content) == []
 
 
+def test_unconsumed_local_exception_output_allows_positive_excluded_amount_helper():
+    content = """format: rulespec/v1
+rules:
+  - name: employer_plan_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: Clause (i) shall not apply to this payment.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: employer_plan_covers_payment
+  - name: employer_plan_excluded_from_compensation
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3231/e#employer_plan_exclusion_applies
+              output: employer_plan_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if employer_plan_exclusion_applies: payment_amount else: 0
+"""
+
+    assert find_unconsumed_local_exception_output_issues(content) == []
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "if employer_plan_exclusion_applies == False: payment_amount else: 0",
+        "if employer_plan_exclusion_applies or other_condition: payment_amount else: 0",
+        "if employer_plan_exclusion_applies: payment_amount else: 1",
+    ],
+)
+def test_unconsumed_local_exception_output_rejects_unsafe_positive_excluded_amount_helper(
+    formula,
+):
+    content = f"""format: rulespec/v1
+rules:
+  - name: employer_plan_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: Clause (i) shall not apply to this payment.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: employer_plan_covers_payment
+  - name: employer_plan_excluded_from_compensation
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3231/e#employer_plan_exclusion_applies
+              output: employer_plan_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          {formula}
+"""
+
+    assert find_unconsumed_local_exception_output_issues(content) == [
+        "Unconsumed local exception output: "
+        "`employer_plan_exclusion_applies` appears to carve out "
+        "`employer_plan_excluded_from_compensation`, but "
+        "`employer_plan_excluded_from_compensation` does not negate it. "
+        "Compose the exception into the affected exported rule instead of "
+        "exposing both outputs independently."
+    ]
+
+
+def test_unconsumed_local_exception_output_rejects_non_amount_excluded_helper():
+    content = """format: rulespec/v1
+rules:
+  - name: employer_plan_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: Clause (i) shall not apply to this payment.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: employer_plan_covers_payment
+  - name: employer_plan_excluded_from_compensation
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3231/e#employer_plan_exclusion_applies
+              output: employer_plan_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if employer_plan_exclusion_applies: payment_amount else: 0
+"""
+
+    assert find_unconsumed_local_exception_output_issues(content) == [
+        "Unconsumed local exception output: "
+        "`employer_plan_exclusion_applies` appears to carve out "
+        "`employer_plan_excluded_from_compensation`, but "
+        "`employer_plan_excluded_from_compensation` does not negate it. "
+        "Compose the exception into the affected exported rule instead of "
+        "exposing both outputs independently."
+    ]
+
+
 def test_anaphoric_scope_omission_rejects_broad_condition_predicate():
     source_text = (
         "Subparagraph (B) of paragraph (2) shall not apply with respect to a "

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.529"
+version = "0.2.530"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- allow positive excluded/disregarded amount helper formulas to consume local exception outputs when the condition is the bare exception predicate and the else branch is zero
- add a signed deterministic `repair-judgment-positive-tests` command for existing generated RuleSpecs that need positive Judgment companion coverage
- make the repair command iterative and restore companion tests on no-repair/failure paths

## Validation
- `uv run ruff check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py tests/test_cli.py src/axiom_encode/__init__.py`
- `uv run ruff format --check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py tests/test_cli.py src/axiom_encode/__init__.py`
- `uv run pytest -q tests/test_rulespec_validation.py -k 'unconsumed_local_exception_output' tests/test_cli.py -k 'judgment_positive_test_repair or repair_judgment_positive_tests_repeats or repair_judgment_positive_tests_restores or current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject'`\n\n## Notes\n- This supports generated RuleSpec repair for `26 USC 3231(e)` without hand-editing generated files.\n- First subagent review found two issues; both are fixed in this branch. A second review pass is still pending before merge.