### PR TITLE
Keep rate-applied base outputs executable

### DIFF
--- a/changelog.d/executable-rate-base-inputs.fixed.md
+++ b/changelog.d/executable-rate-base-inputs.fixed.md
@@ -1,0 +1,1 @@
+Keep lower-entity rate-applied outputs executable with local boundary inputs when only a named legal base value is unavailable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.530"
+version = "0.2.531"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.530"
+__version__ = "0.2.531"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -45,6 +45,16 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   definition is currently encoded at a filing-unit, tax-unit, household, or
   other unit boundary. Only add a unit-level roll-up when this source text
   itself states that aggregate.
+- If the only unavailable dependency for that lower-entity rate-applied result
+  is the value of a named legal base, keep the result executable by exposing a
+  local boundary input for that base instead of deferring the tax, credit,
+  deduction, contribution, or amount. Name the boundary input after the concise
+  legal base term used by the source when one exists, such as `wages`, rather
+  than expanding it into the whole surrounding phrase. Parenthetical
+  definitions, recipient/payment verbs, and contextual qualifiers such as
+  "received by", "paid by", or "with respect to" usually describe how the base
+  is used; do not fold them into the boundary input name when the source has a
+  shorter legal base noun.
 - Treat legal subject nouns as stronger evidence than nearby repository
   context. When the source says "households in which all members",
   "households with a member", or another household/unit-level condition stated

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -868,6 +868,10 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
         in prompt
     )
     assert "rate-applied result at that lower entity" in prompt
+    assert "keep the result executable by exposing a\n  local boundary input" in prompt
+    assert "such as `wages`" in prompt
+    assert 'contextual qualifiers such as\n  "received by"' in prompt
+    assert "do not fold them into the boundary input name" in prompt
     assert "Treat legal subject nouns as stronger evidence" in prompt
     assert "use `entity: Person` for the current source's own amount" in prompt
     assert "thresholded, capped, base-limited" in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.530"
+version = "0.2.531"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary\n- keep lower-entity rate-applied outputs executable when only a named legal base value is unavailable\n- guide boundary input names toward concise legal base terms such as wages\n- bump axiom-encode to 0.2.531 and add a changelog fragment\n\n## Checks\n- uv run pytest tests/test_evals.py::test_build_eval_prompt_targets_rulespec_yaml -q\n- uv run ruff check src/axiom_encode/prompts/encoder.py tests/test_evals.py\n- uv run python -m towncrier build --draft --version 0.0.0\n\n## Follow-up validation\n- regenerated payroll leaves locally with gpt-5.5\n- Chapter 21 RuleSpec validation passed\n- full ECPS payroll surfaces matched PolicyEngine with 0 mismatches\n