### PR TITLE
Allow exception outputs to compose helpers

### DIFF
--- a/changelog.d/exception-aggregate-components.fixed.md
+++ b/changelog.d/exception-aggregate-components.fixed.md
@@ -1,0 +1,1 @@
+Allow generated exception outputs to compose other exception outputs without triggering unconsumed-exception validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.531"
+version = "0.2.532"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.531"
+__version__ = "0.2.532"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -14509,9 +14509,15 @@ def find_unconsumed_local_exception_output_issues(content: str) -> list[str]:
             )
             if not imports_exception and not name_matches_exception_target:
                 continue
-            if any(
-                _formula_negates_identifier(formula, exception_name)
-                for formula in formulas
+            target_is_judgment_exception_output = dtypes_by_name.get(
+                rule_name
+            ) == "judgment" and _is_exception_identifier(rule_name)
+            if (
+                any(
+                    _formula_negates_identifier(formula, exception_name)
+                    for formula in formulas
+                )
+                and not target_is_judgment_exception_output
             ):
                 continue
             if _is_positive_excluded_amount_output(
@@ -14519,6 +14525,14 @@ def find_unconsumed_local_exception_output_issues(content: str) -> list[str]:
                 dtype=dtypes_by_name.get(rule_name),
             ) and any(
                 _formula_uses_identifier_as_positive_exclusion_amount(
+                    formula,
+                    exception_name,
+                )
+                for formula in formulas
+            ):
+                continue
+            if target_is_judgment_exception_output and any(
+                _formula_uses_identifier_as_positive_exception_component(
                     formula,
                     exception_name,
                 )
@@ -14663,6 +14677,52 @@ def _formula_uses_identifier_as_positive_exclusion_amount(
         return False
     condition = _strip_wrapping_parentheses(match.group("condition").strip())
     return condition == identifier
+
+
+def _formula_uses_identifier_as_positive_exception_component(
+    formula: str,
+    identifier: str,
+) -> bool:
+    normalized = _strip_wrapping_parentheses(" ".join(formula.split()))
+    or_terms = _split_top_level_or_terms(normalized)
+    if len(or_terms) < 2:
+        return False
+    return any(_strip_wrapping_parentheses(term) == identifier for term in or_terms)
+
+
+def _split_top_level_or_terms(expression: str) -> list[str]:
+    terms: list[str] = []
+    start = 0
+    depth = 0
+    quote: str | None = None
+    i = 0
+    while i < len(expression):
+        character = expression[i]
+        if quote is not None:
+            if character == quote:
+                quote = None
+            i += 1
+            continue
+        if character in {"'", '"'}:
+            quote = character
+            i += 1
+            continue
+        if character == "(":
+            depth += 1
+            i += 1
+            continue
+        if character == ")":
+            depth = max(0, depth - 1)
+            i += 1
+            continue
+        if depth == 0 and expression[i : i + 4].lower() == " or ":
+            terms.append(expression[start:i].strip())
+            i += 4
+            start = i
+            continue
+        i += 1
+    terms.append(expression[start:].strip())
+    return terms
 
 
 def _strip_wrapping_parentheses(text: str) -> str:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6038,6 +6038,192 @@ rules:
 @pytest.mark.parametrize(
     "formula",
     [
+        (
+            "specified_exempt_payee_payment_exception_applies "
+            "or otherwise_required_withholding_exception_applies"
+        ),
+        (
+            "(specified_exempt_payee_payment_exception_applies "
+            "or otherwise_required_withholding_exception_applies)"
+        ),
+    ],
+)
+def test_unconsumed_local_exception_output_allows_exception_aggregate(formula):
+    content = f"""format: rulespec/v1
+rules:
+  - name: specified_exempt_payee_payment_exception_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: Subsection (a) shall not apply to a payment to an exempt payee.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: payment_made_to_exempt_payee
+  - name: otherwise_required_withholding_exception_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: Subsection (a) shall not apply to an amount otherwise withheld.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: withholding_otherwise_required
+  - name: subsection_a_payment_exception_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/g#specified_exempt_payee_payment_exception_applies
+              output: specified_exempt_payee_payment_exception_applies
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/g#otherwise_required_withholding_exception_applies
+              output: otherwise_required_withholding_exception_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          {formula}
+"""
+
+    assert find_unconsumed_local_exception_output_issues(content) == []
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "specified_exempt_payee_payment_exception_applies == False",
+        "specified_exempt_payee_payment_exception_applies != True",
+        "specified_exempt_payee_payment_exception_applies and other_condition",
+        "not specified_exempt_payee_payment_exception_applies or other_exception",
+    ],
+)
+def test_unconsumed_local_exception_output_rejects_unsafe_exception_aggregate(
+    formula,
+):
+    content = f"""format: rulespec/v1
+rules:
+  - name: specified_exempt_payee_payment_exception_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3406
+              excerpt: Subsection (a) shall not apply to a payment to an exempt payee.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: payment_made_to_exempt_payee
+  - name: subsection_a_payment_exception_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3406/g#specified_exempt_payee_payment_exception_applies
+              output: specified_exempt_payee_payment_exception_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          {formula}
+"""
+
+    assert find_unconsumed_local_exception_output_issues(content) == [
+        "Unconsumed local exception output: "
+        "`specified_exempt_payee_payment_exception_applies` appears to carve out "
+        "`subsection_a_payment_exception_applies`, but "
+        "`subsection_a_payment_exception_applies` does not negate it. "
+        "Compose the exception into the affected exported rule instead of "
+        "exposing both outputs independently."
+    ]
+
+
+def test_unconsumed_local_exception_output_rejects_numeric_exclusion_aggregate():
+    content = """format: rulespec/v1
+rules:
+  - name: employer_plan_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: exception
+            source:
+              corpus_citation_path: us/statute/26/3231
+              excerpt: Clause (i) shall not apply to this payment.
+    versions:
+      - effective_from: '2026-01-01'
+        formula: employer_plan_covers_payment
+  - name: payment_exclusion_amount
+    kind: derived
+    entity: Payment
+    dtype: Money
+    period: Year
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/3231/e#employer_plan_exclusion_applies
+              output: employer_plan_exclusion_applies
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          employer_plan_exclusion_applies or other_exception_applies
+"""
+
+    assert find_unconsumed_local_exception_output_issues(content) == [
+        "Unconsumed local exception output: "
+        "`employer_plan_exclusion_applies` appears to carve out "
+        "`payment_exclusion_amount`, but "
+        "`payment_exclusion_amount` does not negate it. "
+        "Compose the exception into the affected exported rule instead of "
+        "exposing both outputs independently."
+    ]
+
+
+@pytest.mark.parametrize(
+    "formula",
+    [
         "if employer_plan_exclusion_applies == False: payment_amount else: 0",
         "if employer_plan_exclusion_applies or other_condition: payment_amount else: 0",
         "if employer_plan_exclusion_applies: payment_amount else: 1",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.531"
+version = "0.2.532"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- allow Judgment exception outputs to compose local exception helpers as bare top-level OR terms
- keep ordinary apply-rule negation behavior and numeric exclusion outputs guarded
- bump axiom-encode to 0.2.532 with a changelog fragment

## Verification
- /cycle read-only subagent review: no actionable findings after fixes
- uv run pytest tests/test_rulespec_validation.py -k unconsumed_local_exception_output -q
- uv run pytest tests/test_rulespec_validation.py -q
- uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- uv run axiom-encode validate --skip-reviewers /tmp/axiom-encode-encodings/openai-gpt-5.5/statutes/26/3406/g.yaml