### PR TITLE
Add federal tax before credits ECPS surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.524"
+version = "0.2.525"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.524"
+__version__ = "0.2.525"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -114,6 +114,7 @@ JURISDICTION_CONFIGS = {
         member_entity_type="Person",
         temp_prefix="co-snap-pe-ecps-",
         display_name="Colorado SNAP",
+        additional_relation_ids=("member_of_household",),
     ),
     "us-ca": JurisdictionConfig(
         jurisdiction="us-ca",

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -76,6 +76,8 @@ FICA_PRE_TAX_CONTRIBUTION_COLUMNS = (
 )
 CAPITAL_GAINS_PROGRAM_PATH = Path("statutes/26/1/h.yaml")
 CAPITAL_GAINS_BASE = "us:statutes/26/1/h"
+TAX_BEFORE_CREDITS_PROGRAM_PATH = Path("statutes/26/1/j.yaml")
+TAX_BEFORE_CREDITS_BASE = "us:statutes/26/1/j"
 EITC_PROGRAM_PATH = Path("statutes/26/32.yaml")
 EITC_BASE = "us:statutes/26/32"
 SECTION_112_BASE = "us:statutes/26/112"
@@ -228,6 +230,12 @@ CAPITAL_GAINS_DEFINITION_OUTPUTS = {
         "pe": "adjusted_net_capital_gain",
     },
 }
+TAX_BEFORE_CREDITS_OUTPUTS = {
+    "income_tax_main_rates": {
+        "axiom": f"{TAX_BEFORE_CREDITS_BASE}#income_tax_main_rates",
+        "pe": "income_tax_main_rates",
+    },
+}
 EITC_OUTPUTS = {
     "eitc_earned_income": {
         "axiom": f"{SECTION_32_C_2_BASE}#earned_income",
@@ -278,6 +286,7 @@ SURFACE_OUTPUTS = {
     "ctc": CTC_OUTPUTS,
     "standard-deduction": STANDARD_DEDUCTION_OUTPUTS,
     "capital-gain-definitions": CAPITAL_GAINS_DEFINITION_OUTPUTS,
+    "tax-before-credits": TAX_BEFORE_CREDITS_OUTPUTS,
     "eitc": EITC_OUTPUTS,
     **{surface: config["outputs"] for surface, config in PAYROLL_SURFACES.items()},
 }
@@ -285,6 +294,7 @@ SURFACE_PROGRAM_PATHS = {
     "ctc": CTC_PROGRAM_PATH,
     "standard-deduction": STANDARD_DEDUCTION_PROGRAM_PATH,
     "capital-gain-definitions": CAPITAL_GAINS_PROGRAM_PATH,
+    "tax-before-credits": TAX_BEFORE_CREDITS_PROGRAM_PATH,
     "eitc": EITC_PROGRAM_PATH,
     **{surface: config["program"] for surface, config in PAYROLL_SURFACES.items()},
 }
@@ -313,7 +323,9 @@ PE_TAX_UNIT_VARIABLES = tuple(
             "eitc_reduction",
             "filing_status",
             "net_capital_gain",
+            "income_tax_main_rates",
             "standard_deduction",
+            "taxable_income",
         }
     )
 )
@@ -849,6 +861,8 @@ def build_axiom_request(
         return build_standard_deduction_request(pe_data=pe_data, year=year)
     if surface == "capital-gain-definitions":
         return build_capital_gain_definitions_request(pe_data=pe_data, year=year)
+    if surface == "tax-before-credits":
+        return build_tax_before_credits_request(pe_data=pe_data, year=year)
     if surface == "eitc":
         if contribution_base is None:
             raise ValueError("EITC comparison requires a contribution-and-benefit base")
@@ -1016,6 +1030,67 @@ def build_capital_gain_definitions_request(
                 "period": interval,
                 "outputs": [
                     spec["axiom"] for spec in CAPITAL_GAINS_DEFINITION_OUTPUTS.values()
+                ],
+            }
+            for tax_unit_id in pe_data["tax_unit_ids"]
+        ],
+    }
+
+
+def build_tax_before_credits_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = {
+        "period_kind": "tax_year",
+        "start": f"{year:04d}-01-01",
+        "end": f"{year:04d}-12-31",
+    }
+    inputs: list[dict[str, Any]] = []
+    persons_by_tax_unit = group_person_rows_by_tax_unit(pe_data["persons"])
+    for _idx, row in pe_data["tax_units"].iterrows():
+        tax_unit_id = int(row["tax_unit_id"])
+        entity_id = tax_entity_id(tax_unit_id)
+        tax_inputs = project_tax_before_credits_inputs(row=row)
+        for name, value in tax_inputs.items():
+            inputs.append(
+                input_record(
+                    f"{TAX_BEFORE_CREDITS_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+            inputs.append(
+                input_record(
+                    f"{CAPITAL_GAINS_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        tax_unit_persons = persons_by_tax_unit.get(tax_unit_id, [])
+        for name, value in project_capital_gain_definition_inputs(
+            row=row,
+            persons=tax_unit_persons,
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{CAPITAL_GAINS_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": [
+            {
+                "entity_id": tax_entity_id(tax_unit_id),
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in TAX_BEFORE_CREDITS_OUTPUTS.values()
                 ],
             }
             for tax_unit_id in pe_data["tax_unit_ids"]
@@ -1521,6 +1596,13 @@ def project_capital_gain_definition_inputs(
             row.get("unrecaptured_section_1250_gain", 0)
         ),
         "capital_gains_28_percent_rate_gain": capital_gains_28_percent_rate_gain,
+    }
+
+
+def project_tax_before_credits_inputs(*, row: Any) -> dict[str, Any]:
+    return {
+        "filing_status": filing_status_code(str(row["filing_status"])),
+        "taxable_income": money(row["taxable_income"]),
     }
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ import pytest
 import yaml
 
 from axiom_encode import __version__ as AXIOM_ENCODE_TEST_VERSION
+from axiom_encode.oracles.policyengine.ecps_snap import JURISDICTION_CONFIGS
 from axiom_encode.cli import (
     APPLIED_ENCODING_MANIFEST_SCHEMA,
     APPLIED_ENCODING_SIGNING_KEY_ENV,
@@ -189,6 +190,13 @@ def test_current_encoder_affecting_changes_are_behind_version_bump():
     provenance = _require_axiom_encode_version_provenance(repo)
 
     assert provenance["version"] == AXIOM_ENCODE_TEST_VERSION
+
+
+def test_colorado_snap_ecps_projects_bare_member_relation_alias():
+    config = JURISDICTION_CONFIGS["us-co"]
+
+    assert config.relation_id == "us:statutes/7/2012/j#relation.member_of_household"
+    assert "member_of_household" in config.additional_relation_ids
 
 
 def _signed_manifest_payload(payload: dict) -> dict:

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -26,6 +26,8 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     SECTION_1402_A_BASE,
     SECTION_1402_B_BASE,
     SECTION_7703_BASE,
+    TAX_BEFORE_CREDITS_BASE,
+    TAX_BEFORE_CREDITS_OUTPUTS,
     additional_standard_deduction_entitlement_count,
     build_capital_gain_definitions_request,
     build_contribution_and_benefit_base_request,
@@ -33,6 +35,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     build_eitc_request,
     build_oasdi_wage_base_request,
     build_payroll_request,
+    build_tax_before_credits_request,
     compare_tax_ecps,
     contribution_and_benefit_base_from_results,
     contribution_and_benefit_base_from_rulespec_test,
@@ -1161,6 +1164,56 @@ def test_build_capital_gain_definitions_request_uses_raw_person_capital_gains():
     )
 
 
+def test_build_tax_before_credits_request_projects_section_1j_and_1h_inputs():
+    pd = pytest.importorskip("pandas")
+    pe_data = {
+        "tax_units": pd.DataFrame(
+            [
+                {
+                    "tax_unit_id": 3,
+                    "filing_status": "JOINT",
+                    "taxable_income": 125_000,
+                    "long_term_capital_gains": 2_500,
+                    "short_term_capital_gains": 750,
+                    "qualified_dividend_income": 400,
+                    "unrecaptured_section_1250_gain": 125,
+                    "capital_gains_28_percent_rate_gain": 300,
+                }
+            ]
+        ),
+        "persons": pd.DataFrame(
+            [
+                {"person_id": 10, "tax_unit_id": 3},
+                {
+                    "person_id": 11,
+                    "tax_unit_id": 3,
+                    "long_term_capital_gains": 2_000,
+                    "short_term_capital_gains": 250,
+                },
+            ]
+        ),
+        "tax_unit_ids": [3],
+    }
+
+    request = build_tax_before_credits_request(pe_data=pe_data, year=2026)
+
+    input_values = {
+        item["name"]: item["value"]["value"] for item in request["dataset"]["inputs"]
+    }
+    assert input_values[f"{TAX_BEFORE_CREDITS_BASE}#input.filing_status"] == 1
+    assert input_values[f"{TAX_BEFORE_CREDITS_BASE}#input.taxable_income"] == (
+        "125000.0"
+    )
+    assert input_values[f"{CAPITAL_GAINS_BASE}#input.filing_status"] == 1
+    assert input_values[f"{CAPITAL_GAINS_BASE}#input.taxable_income"] == "125000.0"
+    assert input_values[f"{CAPITAL_GAINS_BASE}#input.long_term_capital_gains"] == (
+        "2000.0"
+    )
+    assert request["queries"][0]["outputs"] == [
+        spec["axiom"] for spec in TAX_BEFORE_CREDITS_OUTPUTS.values()
+    ]
+
+
 def test_within_tolerance_keeps_cent_level_strictness_for_ordinary_outputs():
     assert within_tolerance(
         1000.005,
@@ -1642,6 +1695,16 @@ def test_policyengine_variables_for_non_payroll_surfaces_use_legacy_sets():
         ecps_tax.PE_TAX_UNIT_VARIABLES,
         ecps_tax.PE_PERSON_VARIABLES,
     )
+
+
+def test_policyengine_variables_for_tax_before_credits_include_main_rates_inputs():
+    tax_unit_variables, person_variables = ecps_tax.policyengine_variables_for_surfaces(
+        ["tax-before-credits"]
+    )
+
+    assert "income_tax_main_rates" in tax_unit_variables
+    assert "taxable_income" in tax_unit_variables
+    assert person_variables == ecps_tax.PE_PERSON_VARIABLES
 
 
 def test_taxable_oasdi_wages_come_from_axiom_3121_results():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.524"
+version = "0.2.525"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Adds the tax-before-credits FIIT ECPS surface backed by Section 1(j), projects taxable income and filing status plus imported Section 1(h) capital-gain inputs, and pins tests for the new request shape.\n\nValidation:\n- uv run pytest tests/test_policyengine_ecps_tax.py -q\n- tax-before-credits sample: 25 compared, 0 mismatches\n- full fiit-ecps in axiom-oracles: 208,486 compared, 172 EITC-only mismatches