### PR TITLE
Classify section 3306(h) PolicyEngine oracle coverage

### DIFF
--- a/changelog.d/section-3306h-policyengine-coverage.changed.md
+++ b/changelog.d/section-3306h-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classified section 3306(h) unemployment compensation outputs in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.532"
+version = "0.2.533"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.532"
+__version__ = "0.2.533"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -14973,6 +14973,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(g) defines payment-level State-law unemployment fund contributions for chapter 23 credit calculations; PolicyEngine exposes final employer FUTA tax, not these State contribution amounts separately.
 
+  - legal_id_prefix: us:statutes/26/3306/h#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(h) defines payment-level unemployment compensation benefits for chapter 23 unemployment-fund administration; PolicyEngine exposes final FUTA taxable earnings, not these unemployment-benefit payment predicates separately.
+
   - legal_id_prefix: us:statutes/26/3307#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4613,6 +4613,38 @@ rules:
     assert item["policyengine_variable"] == "employer_federal_unemployment_tax"
 
 
+def test_policyengine_coverage_classifies_3306_h_compensation(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/h.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: compensation
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: payment_is_cash_benefit
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == "us:statutes/26/3306/h#compensation"
+    assert item["status"] == "known_not_comparable"
+    assert item["policyengine_variable"] == (
+        "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3307_deduction_payment_treatment(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.532"
+version = "0.2.533"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Classify generated 26 USC 3306(h) RuleSpec outputs as known-not-comparable for PolicyEngine tax oracle coverage.
- Add a focused coverage test for the 3306(h) compensation output so future generated rules do not regress to unmapped.

## Checks
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py
- uv run --extra dev ruff check tests/test_policyengine_coverage.py
- uv run --extra dev python - <<PY
from axiom_encode.oracles.policyengine.registry import load_policyengine_registry
load_policyengine_registry()
print("ok")
PY
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306h-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json
- git diff --check origin/main