### PR TITLE
Classify section 3306(i) oracle coverage

### DIFF
--- a/changelog.d/section-3306i-policyengine-coverage.changed.md
+++ b/changelog.d/section-3306i-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classified section 3306(i) employee-definition outputs in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.533"
+version = "0.2.534"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.533"
+__version__ = "0.2.534"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -14981,6 +14981,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(h) defines payment-level unemployment compensation benefits for chapter 23 unemployment-fund administration; PolicyEngine exposes final FUTA taxable earnings, not these unemployment-benefit payment predicates separately.
 
+  - legal_id_prefix: us:statutes/26/3306/i#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(i) defines the FUTA employee predicate by reference to section 3121(d) with specific paragraph exclusions; PolicyEngine exposes final FUTA taxable earnings, not this employee-definition predicate separately.
+
   - legal_id_prefix: us:statutes/26/3307#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4645,6 +4645,38 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_i_employee_definition(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/i.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: employee
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: officer_of_corporation or common_law_employee_status
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == "us:statutes/26/3306/i#employee"
+    assert item["status"] == "known_not_comparable"
+    assert item["policyengine_variable"] == (
+        "taxable_earnings_for_federal_unemployment_tax"
+    )
+
+
 def test_policyengine_coverage_classifies_3307_deduction_payment_treatment(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.533"
+version = "0.2.534"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 26 USC 3306(i) employee-definition outputs as known-not-comparable in PolicyEngine tax oracle coverage
- add a focused coverage regression test
- bump axiom-encode to 0.2.534 with changelog fragment

## Verification
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k "3306_i or 3306_h or 3307"
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py
- uv run --python 3.13 --extra dev python -m pytest tests/test_policyengine_coverage.py -k "3306_i or 3306_h or 3307"
- uv run --extra dev ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine
- git diff --check
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306i-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json

## Review
- /cycle read-only subagent review found no remaining actionable findings after staging the changelog fragment.