### PR TITLE
Classify section 3306(j) oracle coverage

### DIFF
--- a/changelog.d/section-3306j-policyengine-coverage.changed.md
+++ b/changelog.d/section-3306j-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classified section 3306(j) jurisdiction and American-employer definition outputs in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.534"
+version = "0.2.535"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.534"
+__version__ = "0.2.535"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -14989,6 +14989,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(i) defines the FUTA employee predicate by reference to section 3121(d) with specific paragraph exclusions; PolicyEngine exposes final FUTA taxable earnings, not this employee-definition predicate separately.
 
+  - legal_id_prefix: us:statutes/26/3306/j#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(j) defines chapter 23 jurisdiction, American-employer, and Puerto Rico or Virgin Islands citizenship predicates; PolicyEngine exposes final FUTA taxable earnings, not these definitional predicates separately.
+
   - legal_id_prefix: us:statutes/26/3307#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4677,6 +4677,44 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_3306_j_definitions(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/j.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: local_american_employer
+    kind: derived
+    entity: Employer
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: individual_employer_is_resident_of_united_states
+  - name: puerto_rico_or_virgin_islands_citizen_considered_united_states_citizen_for_section
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: individual_is_citizen_of_puerto_rico_or_virgin_islands
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {
+        "taxable_earnings_for_federal_unemployment_tax"
+    }
+
+
 def test_policyengine_coverage_classifies_3307_deduction_payment_treatment(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.534"
+version = "0.2.535"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 26 USC 3306(j) jurisdiction and American-employer definition outputs as known-not-comparable in PolicyEngine tax oracle coverage
- add a focused coverage regression test
- bump axiom-encode to 0.2.535 with changelog fragment

## Verification
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k "3306_j or 3306_i or 3307"
- uv run --python 3.13 --extra dev python -m pytest tests/test_policyengine_coverage.py -k "3306_j or 3306_i or 3307"
- uv run --python 3.13 --extra dev python -m pytest tests/test_policyengine_coverage.py
- uv run --extra dev ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine
- git diff --check
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/payroll-3306j-20260602 --oracle policyengine --program tax --fail-on-untested-comparable --json

## Review
- /cycle read-only subagent review found no actionable findings.