### PR TITLE
Fix bracketed subsection source scoping

### DIFF
--- a/changelog.d/subsection-bracketed-sibling-scope.fixed.md
+++ b/changelog.d/subsection-bracketed-sibling-scope.fixed.md
@@ -1,0 +1,1 @@
+Fixed source slicing and validation so subsection encodes stop before bracketed repealed sibling markers and reject executable rules sourced to sibling provisions of the requested citation; also classified section 3306(k) agricultural-labor outputs as known-not-comparable PolicyEngine oracle surfaces.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.536"
+version = "0.2.537"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.536"
+__version__ = "0.2.537"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -1789,7 +1789,7 @@ def _slice_legal_text_by_parenthetical_fragment(
 ) -> str | None:
     escaped = re.escape(fragment)
     if top_level:
-        marker_pattern = re.compile(rf"(?:^|\n\s*)(\({escaped}\)\s+)")
+        marker_pattern = re.compile(rf"(?:^|\n\s*)(\[?\({escaped}\)\s+)")
     else:
         marker_pattern = re.compile(rf"(?<![A-Za-z0-9])(\({escaped}\)\s+)")
     marker_match = next(
@@ -1878,7 +1878,7 @@ def _sibling_parenthetical_marker_pattern(
     else:
         marker = r"\([A-Za-z0-9]+\)"
     if top_level:
-        return re.compile(rf"\n\s*({marker}\s+)")
+        return re.compile(rf"\n\s*(\[?{marker}\s+)")
     return re.compile(rf"(?<![A-Za-z0-9])({marker}\s+)")
 
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1134,6 +1134,233 @@ def _citation_to_normalized_target(citation: str) -> tuple[str, ...] | None:
     return tuple(p.lower() for p in pieces if p)
 
 
+_SOURCE_CITATION_SEPARATOR_RE = re.compile(
+    r"\s*(?:,|;|\b(?:and|or)\b)\s*",
+    flags=re.IGNORECASE,
+)
+_USC_ABBREVIATION_RE = re.compile(
+    r"(?<![A-Za-z])U\.?\s*S\.?\s*C\.?(?![A-Za-z])",
+    flags=re.IGNORECASE,
+)
+_IRC_ABBREVIATION_RE = re.compile(
+    r"(?<![A-Za-z])I\.?\s*R\.?\s*C\.?(?![A-Za-z])",
+    flags=re.IGNORECASE,
+)
+_SOURCE_CITATION_RANGE_SUFFIX_RE = re.compile(
+    r"(?<=\))\s*(?:-|through)\s*(?P<endpoint>(?:\([^)]+\))+)\s*$",
+    flags=re.IGNORECASE,
+)
+
+
+def _source_citation_to_normalized_targets(
+    source: str,
+    *,
+    context_source: str | None = None,
+) -> tuple[tuple[str, ...], ...]:
+    """Parse one RuleSpec source field into normalized citation targets.
+
+    Rule sources commonly cite multiple provisions in one string and omit the
+    USC title after the first citation, e.g. ``26 USC 24(b)(2), 24(h)(3)``.
+    """
+    context_targets = (
+        _source_citation_fragment_to_normalized_targets(
+            context_source,
+            default_title=None,
+            default_section=None,
+        )
+        if context_source
+        else ()
+    )
+    context_target = context_targets[0] if context_targets else None
+    current_title = (
+        context_target[1] if context_target and len(context_target) >= 3 else None
+    )
+    current_section = (
+        context_target[2] if context_target and len(context_target) >= 3 else None
+    )
+
+    targets: list[tuple[str, ...]] = []
+    seen: set[tuple[str, ...]] = set()
+    for raw_fragment in _SOURCE_CITATION_SEPARATOR_RE.split(source):
+        fragment_targets = _source_citation_fragment_to_normalized_targets(
+            raw_fragment,
+            default_title=current_title,
+            default_section=current_section,
+        )
+        for target in fragment_targets:
+            if len(target) >= 3:
+                current_title = target[1]
+                current_section = target[2]
+            if target in seen:
+                continue
+            seen.add(target)
+            targets.append(target)
+    return tuple(targets)
+
+
+def _source_citation_fragment_to_normalized_targets(
+    fragment: str,
+    *,
+    default_title: str | None,
+    default_section: str | None,
+) -> tuple[tuple[str, ...], ...]:
+    cleaned = _clean_source_citation_fragment(fragment)
+    if not cleaned:
+        return ()
+
+    range_match = _SOURCE_CITATION_RANGE_SUFFIX_RE.search(cleaned)
+    if not range_match:
+        target = _single_source_citation_fragment_to_normalized_target(
+            cleaned,
+            default_title=default_title,
+            default_section=default_section,
+        )
+        return (target,) if target is not None else ()
+
+    start_fragment = _SOURCE_CITATION_RANGE_SUFFIX_RE.sub("", cleaned).strip()
+    start_target = _single_source_citation_fragment_to_normalized_target(
+        start_fragment,
+        default_title=default_title,
+        default_section=default_section,
+    )
+    if start_target is None:
+        return ()
+    endpoint_target = _range_endpoint_normalized_target(
+        start_target,
+        range_match.group("endpoint"),
+    )
+    if endpoint_target is None or endpoint_target == start_target:
+        return (start_target,)
+    return (start_target, endpoint_target)
+
+
+def _single_source_citation_fragment_to_normalized_target(
+    fragment: str,
+    *,
+    default_title: str | None,
+    default_section: str | None,
+) -> tuple[str, ...] | None:
+    irc_citation = _irc_source_fragment_to_usc_citation(fragment)
+    if irc_citation is not None:
+        return _citation_to_normalized_target(irc_citation)
+
+    if _looks_like_absolute_usc_source_fragment(fragment):
+        target = _citation_to_normalized_target(fragment)
+        if target is not None:
+            return target
+
+    relative_citation = _relative_source_fragment_to_usc_citation(
+        fragment,
+        default_title=default_title,
+        default_section=default_section,
+    )
+    if relative_citation is not None:
+        return _citation_to_normalized_target(relative_citation)
+    return None
+
+
+def _looks_like_absolute_usc_source_fragment(fragment: str) -> bool:
+    return bool(
+        re.match(
+            r"^(?:us:statutes?/|us/statutes?/|statutes?/|\d+\s+USC\b)",
+            fragment,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _range_endpoint_normalized_target(
+    start_target: tuple[str, ...],
+    endpoint: str,
+) -> tuple[str, ...] | None:
+    endpoint_fragments = tuple(
+        fragment.lower() for fragment in re.findall(r"\(([^)]+)\)", endpoint)
+    )
+    if not endpoint_fragments or len(start_target) <= 3:
+        return None
+    prefix_length = len(start_target) - len(endpoint_fragments)
+    if prefix_length < 3:
+        return None
+    return start_target[:prefix_length] + endpoint_fragments
+
+
+def _clean_source_citation_fragment(fragment: str) -> str:
+    cleaned = fragment.strip()
+    cleaned = re.sub(r"^(?:and|or)\s+", "", cleaned, flags=re.IGNORECASE)
+    cleaned = cleaned.rstrip(".")
+    cleaned = _USC_ABBREVIATION_RE.sub("USC", cleaned)
+    cleaned = _IRC_ABBREVIATION_RE.sub("IRC", cleaned)
+    return cleaned.strip()
+
+
+def _irc_source_fragment_to_usc_citation(fragment: str) -> str | None:
+    match = re.match(
+        r"^IRC\s*(?:section|sec\.?|§)?\s*"
+        r"(?P<section>[0-9A-Za-z.-]+)(?P<tail>(?:\([^)]+\))*)$",
+        fragment,
+        flags=re.IGNORECASE,
+    )
+    if match:
+        return f"26 USC {match.group('section')}{match.group('tail')}"
+
+    match = re.match(
+        r"^(?:the\s+)?Internal\s+Revenue\s+Code\s+"
+        r"(?:section|sec\.?|§)\s*"
+        r"(?P<section>[0-9A-Za-z.-]+)(?P<tail>(?:\([^)]+\))*)$",
+        fragment,
+        flags=re.IGNORECASE,
+    )
+    if match:
+        return f"26 USC {match.group('section')}{match.group('tail')}"
+
+    match = re.match(
+        r"^section\s+(?P<section>[0-9A-Za-z.-]+)"
+        r"(?P<tail>(?:\([^)]+\))*)\s+of\s+(?:the\s+)?"
+        r"(?:Internal\s+Revenue\s+Code|IRC)$",
+        fragment,
+        flags=re.IGNORECASE,
+    )
+    if match:
+        return f"26 USC {match.group('section')}{match.group('tail')}"
+    return None
+
+
+def _relative_source_fragment_to_usc_citation(
+    fragment: str,
+    *,
+    default_title: str | None,
+    default_section: str | None,
+) -> str | None:
+    if not default_title:
+        return None
+    fragment = re.sub(
+        r"^(?:§|section)\s+",
+        "",
+        fragment,
+        flags=re.IGNORECASE,
+    ).strip()
+    fragment = re.sub(
+        r"^subsection\s+",
+        "",
+        fragment,
+        flags=re.IGNORECASE,
+    ).strip()
+
+    match = re.match(
+        r"^(?P<section>[0-9A-Za-z.-]+)(?P<tail>(?:\([^)]+\))*)$",
+        fragment,
+    )
+    if match:
+        return f"{default_title} USC {match.group('section')}{match.group('tail')}"
+
+    if not default_section:
+        return None
+    match = re.match(r"^(?P<tail>(?:\([^)]+\))+)$", fragment)
+    if match:
+        return f"{default_title} USC {default_section}{match.group('tail')}"
+    return None
+
+
 def _source_metadata_sets_target_symbol(
     source_metadata: dict[str, object] | None, symbol_name: str
 ) -> bool:
@@ -7813,6 +8040,62 @@ def find_source_subparagraph_coverage_issues(
             f"`source: {citation}` or add a deferred_outputs entry naming the blocker."
         )
     return issues
+
+
+def find_out_of_scope_rule_source_issues(
+    content: str,
+    *,
+    requested_source: str | None,
+) -> list[str]:
+    """Flag executable rules sourced to sibling provisions of the encode target."""
+    if not requested_source:
+        return []
+    requested_targets = _source_citation_to_normalized_targets(requested_source)
+    requested_target = requested_targets[0] if requested_targets else None
+    if requested_target is None or len(requested_target) < 3:
+        return []
+
+    payload = _rulespec_payload(content)
+    if payload is None or payload.get("format") != "rulespec/v1":
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    issues: list[str] = []
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            continue
+        if not _is_executable_rulespec_rule(rule):
+            continue
+        source = rule.get("source")
+        if not isinstance(source, str) or not source.strip():
+            continue
+        source_targets = _source_citation_to_normalized_targets(
+            source,
+            context_source=requested_source,
+        )
+        if not source_targets:
+            continue
+        if all(
+            _normalized_target_within(source_target, requested_target)
+            for source_target in source_targets
+        ):
+            continue
+        name = str(rule.get("name") or f"rules[{index}]")
+        issues.append(
+            f"`{name}` source `{source.strip()}` is outside requested source "
+            f"`{requested_source}`. Encode only the requested citation subtree; "
+            "defer or separately encode sibling provisions."
+        )
+    return issues
+
+
+def _normalized_target_within(
+    candidate: tuple[str, ...],
+    anchor: tuple[str, ...],
+) -> bool:
+    return candidate == anchor or candidate[: len(anchor)] == anchor
 
 
 def _empty_deferred_editorial_source_slice(
@@ -18082,6 +18365,12 @@ class ValidatorPipeline:
                     self.policy_repo_path,
                 )
             )
+        issues.extend(
+            find_out_of_scope_rule_source_issues(
+                content,
+                requested_source=requested_source,
+            )
+        )
         issues.extend(
             find_source_subparagraph_coverage_issues(
                 content,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -14997,6 +14997,14 @@ prefixes:
     candidate_priority: P4
     rationale: Section 3306(j) defines chapter 23 jurisdiction, American-employer, and Puerto Rico or Virgin Islands citizenship predicates; PolicyEngine exposes final FUTA taxable earnings, not these definitional predicates separately.
 
+  - legal_id_prefix: us:statutes/26/3306/k#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: taxable_earnings_for_federal_unemployment_tax
+    candidate_priority: P4
+    rationale: Section 3306(k) incorporates and modifies the section 3121(g) agricultural-labor definition for chapter 23; PolicyEngine exposes final FUTA taxable earnings, not this chapter-specific agricultural-labor service classification separately.
+
   - legal_id_prefix: us:statutes/26/3307#
     country: us
     program: tax

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -147,6 +147,46 @@ def test_resolve_corpus_source_unit_accepts_form_citation_path(tmp_path):
     assert source_unit.body == "CMS Medicaid, CHIP, and BHP eligibility levels table"
 
 
+def test_resolve_corpus_source_unit_slices_before_bracketed_sibling(tmp_path):
+    corpus_path = _write_test_corpus_provision(
+        tmp_path,
+        citation_path="us/statute/26/3306",
+        body=(
+            "(k) Agricultural labor For purposes of this chapter, the term "
+            "agricultural labor has the meaning assigned by section 3121(g).\n\n"
+            "[(l) Repealed. Sept. 1, 1954.]\n\n"
+            "(m) American vessel and aircraft For purposes of this chapter, "
+            "the term American vessel means a documented vessel."
+        ),
+    )
+
+    source_unit = resolve_corpus_source_unit("26 USC 3306(k)", corpus_path)
+
+    assert source_unit.citation_path == "us/statute/26/3306"
+    assert source_unit.body.startswith("(k) Agricultural labor")
+    assert "[(l) Repealed" not in source_unit.body
+    assert "(m) American vessel" not in source_unit.body
+
+
+def test_resolve_corpus_source_unit_slices_bracketed_repealed_subsection(tmp_path):
+    corpus_path = _write_test_corpus_provision(
+        tmp_path,
+        citation_path="us/statute/26/3306",
+        body=(
+            "(k) Agricultural labor For purposes of this chapter, the term "
+            "agricultural labor has the meaning assigned by section 3121(g).\n\n"
+            "[(l) Repealed. Sept. 1, 1954.]\n\n"
+            "(m) American vessel and aircraft For purposes of this chapter, "
+            "the term American vessel means a documented vessel."
+        ),
+    )
+
+    source_unit = resolve_corpus_source_unit("26 USC 3306(l)", corpus_path)
+
+    assert source_unit.citation_path == "us/statute/26/3306"
+    assert source_unit.body == "[(l) Repealed. Sept. 1, 1954.]"
+
+
 def test_resolve_corpus_source_unit_uses_form_child_blocks(tmp_path):
     citation = "us/form/cms/medicaid-chip-bhp-eligibility-levels"
     corpus_path = tmp_path / "axiom-corpus"

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4715,6 +4715,44 @@ rules:
     }
 
 
+def test_policyengine_coverage_classifies_3306_k_agricultural_labor(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3306/k.yaml",
+        """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: chapter_group_operator_unmanufactured_commodity_handling_service
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: service_for_group_of_farm_operators and group_produced_more_than_half
+  - name: local_agricultural_labor
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: section_3121_g_agricultural_labor or chapter_group_operator_unmanufactured_commodity_handling_service
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {
+        "taxable_earnings_for_federal_unemployment_tax"
+    }
+
+
 def test_policyengine_coverage_classifies_3307_deduction_payment_treatment(
     tmp_path,
 ):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -57,6 +57,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_missing_derived_companion_output_issues,
     find_missing_same_section_subsection_import_issues,
     find_nonnegative_amount_reduction_issues,
+    find_out_of_scope_rule_source_issues,
     find_partial_extent_zeroing_issues,
     find_person_scoped_definition_unit_issues,
     find_person_scoped_rate_base_unit_issues,
@@ -2338,6 +2339,16 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
     assert research_payroll_credit_mapping.mapping_type == "not_comparable"
     assert research_payroll_credit_mapping.match_type == "prefix"
+    section_3306_k_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/3306/k#local_agricultural_labor",
+        country="us",
+    )
+    assert section_3306_k_mapping.mapping_type == "not_comparable"
+    assert section_3306_k_mapping.match_type == "prefix"
+    assert (
+        section_3306_k_mapping.policyengine_variable
+        == "taxable_earnings_for_federal_unemployment_tax"
+    )
     assert (
         registry.mapping_for_legal_id(
             "us:policies/irs/rev-proc-2025-32/standard-deduction#basic_standard_deduction_amount",
@@ -13783,6 +13794,317 @@ rules: []
         "`us:statutes/us-ca/17000#general_assistance_eligibility` embeds a "
         "jurisdiction in the path; use the target jurisdiction prefix instead."
     ]
+
+
+def test_out_of_scope_rule_source_rejects_sibling_requested_source():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: american_vessel_for_chapter
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(m)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: vessel_documented
+"""
+
+    issues = find_out_of_scope_rule_source_issues(
+        content,
+        requested_source="26 USC 3306(k)",
+    )
+
+    assert issues == [
+        "`american_vessel_for_chapter` source `26 USC 3306(m)` is outside "
+        "requested source `26 USC 3306(k)`. Encode only the requested citation "
+        "subtree; defer or separately encode sibling provisions."
+    ]
+
+
+def test_out_of_scope_rule_source_rejects_sibling_in_multicitation_source():
+    content = """format: rulespec/v1
+rules:
+  - name: mixed_agricultural_and_vessel_rule
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(k), 26 USC 3306(m)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: farm_service or vessel_documented
+"""
+
+    issues = find_out_of_scope_rule_source_issues(
+        content,
+        requested_source="26 USC 3306(k)",
+    )
+
+    assert issues == [
+        "`mixed_agricultural_and_vessel_rule` source "
+        "`26 USC 3306(k), 26 USC 3306(m)` is outside requested source "
+        "`26 USC 3306(k)`. Encode only the requested citation subtree; "
+        "defer or separately encode sibling provisions."
+    ]
+
+
+def test_out_of_scope_rule_source_rejects_and_joined_sibling_source():
+    content = """format: rulespec/v1
+rules:
+  - name: mixed_agricultural_and_vessel_rule
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(k) and 26 USC 3306(m)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: farm_service or vessel_documented
+"""
+
+    issues = find_out_of_scope_rule_source_issues(
+        content,
+        requested_source="26 USC 3306(k)",
+    )
+
+    assert len(issues) == 1
+    assert (
+        "`mixed_agricultural_and_vessel_rule` source "
+        "`26 USC 3306(k) and 26 USC 3306(m)`"
+    ) in issues[0]
+
+
+@pytest.mark.parametrize(
+    "relative_fragment",
+    [
+        "§ 3306(m)",
+        "section 3306(m)",
+        "subsection (m)",
+    ],
+)
+def test_out_of_scope_rule_source_rejects_labeled_relative_sibling_source(
+    relative_fragment: str,
+):
+    content = f"""format: rulespec/v1
+rules:
+  - name: mixed_agricultural_and_vessel_rule
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 26 USC § 3306(k), {relative_fragment}
+    versions:
+      - effective_from: '2026-01-01'
+        formula: farm_service or vessel_documented
+"""
+
+    issues = find_out_of_scope_rule_source_issues(
+        content,
+        requested_source="26 USC 3306(k)",
+    )
+
+    assert len(issues) == 1
+    assert "`mixed_agricultural_and_vessel_rule` source" in issues[0]
+
+
+def test_out_of_scope_rule_source_rejects_relative_multicitation_sibling():
+    content = """format: rulespec/v1
+rules:
+  - name: ctc_threshold
+    kind: parameter
+    dtype: Money
+    source: 26 USC 24(b)(2), 24(h)(3)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 400000
+"""
+
+    issues = find_out_of_scope_rule_source_issues(
+        content,
+        requested_source="26 USC 24(b)",
+    )
+
+    assert len(issues) == 1
+    assert "`ctc_threshold` source `26 USC 24(b)(2), 24(h)(3)`" in issues[0]
+
+
+def test_out_of_scope_rule_source_allows_parent_requested_multicitation_source():
+    content = """format: rulespec/v1
+rules:
+  - name: ctc_threshold
+    kind: parameter
+    dtype: Money
+    source: 26 USC 24(b)(2), 24(h)(3)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 400000
+"""
+
+    assert (
+        find_out_of_scope_rule_source_issues(
+            content,
+            requested_source="26 USC 24",
+        )
+        == []
+    )
+
+
+def test_out_of_scope_rule_source_allows_range_under_requested_source():
+    content = """format: rulespec/v1
+rules:
+  - name: additional_medicare_tax_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3101(b)(2)(A)-(C)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.009
+"""
+
+    assert (
+        find_out_of_scope_rule_source_issues(
+            content,
+            requested_source="26 USC 3101(b)(2)",
+        )
+        == []
+    )
+
+
+def test_out_of_scope_rule_source_rejects_range_crossing_requested_source():
+    content = """format: rulespec/v1
+rules:
+  - name: agricultural_labor_range_rule
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(k)-(m)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: farm_service
+"""
+
+    issues = find_out_of_scope_rule_source_issues(
+        content,
+        requested_source="26 USC 3306(k)",
+    )
+
+    assert len(issues) == 1
+    assert "`agricultural_labor_range_rule` source `26 USC 3306(k)-(m)`" in issues[0]
+
+
+def test_out_of_scope_rule_source_rejects_irc_alias_sibling():
+    content = """format: rulespec/v1
+rules:
+  - name: gross_income_rule
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    source: IRC section 61
+    versions:
+      - effective_from: '2026-01-01'
+        formula: income
+"""
+
+    issues = find_out_of_scope_rule_source_issues(
+        content,
+        requested_source="26 USC 63",
+    )
+
+    assert len(issues) == 1
+    assert "`gross_income_rule` source `IRC section 61`" in issues[0]
+
+
+def test_out_of_scope_rule_source_allows_irc_alias_requested_source():
+    content = """format: rulespec/v1
+rules:
+  - name: aged_additional_amount
+    kind: parameter
+    dtype: Money
+    source: IRC section 63(f)(3)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 1950
+"""
+
+    assert (
+        find_out_of_scope_rule_source_issues(
+            content,
+            requested_source="IRC section 63(f)(3)",
+        )
+        == []
+    )
+
+
+def test_out_of_scope_rule_source_allows_internal_revenue_code_alias():
+    content = """format: rulespec/v1
+rules:
+  - name: aged_additional_amount
+    kind: parameter
+    dtype: Money
+    source: Internal Revenue Code section 63(f)(3)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 1950
+"""
+
+    assert (
+        find_out_of_scope_rule_source_issues(
+            content,
+            requested_source="26 USC 63(f)",
+        )
+        == []
+    )
+
+
+def test_out_of_scope_rule_source_ignores_non_executable_source_relation():
+    content = """format: rulespec/v1
+rules:
+  - name: vessel_source_relation
+    kind: source_relation
+    source: 26 USC 3306(m)
+    relation: defines
+    target: us:statutes/26/3306/m#american_vessel
+"""
+
+    assert (
+        find_out_of_scope_rule_source_issues(
+            content,
+            requested_source="26 USC 3306(k)",
+        )
+        == []
+    )
+
+
+def test_out_of_scope_rule_source_allows_requested_descendant():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: agricultural_labor_branch
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(k)(1)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: farm_service
+"""
+
+    assert (
+        find_out_of_scope_rule_source_issues(
+            content,
+            requested_source="26 USC 3306(k)",
+        )
+        == []
+    )
 
 
 def test_source_subparagraph_coverage_rejects_high_signal_omission():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.536"
+version = "0.2.537"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- fix subsection source slicing so bracketed sibling markers like `[(l) Repealed...]` stop a targeted subsection encode before sibling provisions
- add a RuleSpec validator backstop that rejects executable rules sourced outside the requested citation subtree
- harden source parsing for multi-citation fields, ranges, relative fragments, USC/IRC aliases, and non-executable rule records
- classify generated `26 USC 3306(k)` agricultural-labor outputs as known-not-comparable against the PolicyEngine FUTA surface

## Validation
- `/cycle` subagent review completed clean after fixes
- `uv run python -m pytest tests/test_evals.py tests/test_rulespec_validation.py tests/test_policyengine_coverage.py` (1015 passed)
- `uv run python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3306_k_agricultural_labor tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed`
- `uv run ruff check src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py tests/test_rulespec_validation.py tests/test_policyengine_coverage.py`
- `uv run python -m pytest tests/test_cli.py -k 'package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump'`\n- generated `26 USC 3306(k)` checks: `axiom-encode validate`, `axiom-encode test`, `axiom-encode proof-validate`, `axiom-encode guard-generated`, and PolicyEngine coverage classification\n