### PR TITLE
Repair duplicate-only source relation apply overlays

### DIFF
--- a/changelog.d/source-relation-duplicate-apply.fixed.md
+++ b/changelog.d/source-relation-duplicate-apply.fixed.md
@@ -1,0 +1,1 @@
+Repair apply overlays that reduce duplicate-only generated modules to source_relation restatements instead of invalid empty modules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.537"
+version = "0.2.538"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.537"
+__version__ = "0.2.538"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -23368,6 +23368,55 @@ def _repair_upstream_placement_duplicate_imports(
     if not duplicate_targets_by_name:
         return []
 
+    target_base = (
+        f"{_repo_jurisdiction_prefix(repo_path)}:"
+        f"{_relative_rulespec_import_target(relative_output)}"
+    )
+    remaining_rules = [
+        rule for index, rule in enumerate(rules) if index not in duplicate_indexes
+    ]
+    if not any(_is_executable_rulespec_rule(rule) for rule in remaining_rules):
+        duplicate_sources_by_name = {
+            str(rule.get("name") or "").strip(): rule.get("source")
+            for index, rule in enumerate(rules)
+            if index in duplicate_indexes
+            and isinstance(rule, dict)
+            and str(rule.get("name") or "").strip()
+        }
+        existing_rule_names = {
+            str(rule.get("name") or "").strip()
+            for rule in remaining_rules
+            if isinstance(rule, dict) and str(rule.get("name") or "").strip()
+        }
+        restatement_rules: list[dict[str, Any]] = []
+        for name, target in sorted(duplicate_targets_by_name.items()):
+            relation_name = f"{name}_restatement"
+            suffix = 2
+            while relation_name in existing_rule_names:
+                relation_name = f"{name}_restatement_{suffix}"
+                suffix += 1
+            existing_rule_names.add(relation_name)
+            restatement_rule: dict[str, Any] = {
+                "name": relation_name,
+                "kind": "source_relation",
+                "source_relation": {
+                    "type": "restates",
+                    "target": target,
+                },
+            }
+            source = duplicate_sources_by_name.get(name)
+            if isinstance(source, str) and source.strip():
+                restatement_rule["source"] = source.strip()
+            restatement_rules.append(restatement_rule)
+        rules_document["rules"] = [*remaining_rules, *restatement_rules]
+        rules_document.pop("imports", None)
+        rules_file.write_text(
+            yaml.safe_dump(rules_document, sort_keys=False, allow_unicode=False)
+        )
+        if test_file.exists():
+            test_file.write_text("[]\n")
+        return sorted(duplicate_targets_by_name)
+
     imports = rules_document.get("imports")
     if not isinstance(imports, list):
         imports = []
@@ -23382,14 +23431,8 @@ def _repair_upstream_placement_duplicate_imports(
             imports.append(target)
             existing_imports.add(target)
 
-    rules_document["rules"] = [
-        rule for index, rule in enumerate(rules) if index not in duplicate_indexes
-    ]
+    rules_document["rules"] = remaining_rules
 
-    target_base = (
-        f"{_repo_jurisdiction_prefix(repo_path)}:"
-        f"{_relative_rulespec_import_target(relative_output)}"
-    )
     for rule in rules_document["rules"]:
         if not isinstance(rule, dict):
             continue

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -8024,6 +8024,9 @@ def find_source_subparagraph_coverage_issues(
 
     covered_children = _rule_source_covered_subparagraphs(payload, citation_path)
     covered_children.update(
+        _source_relation_covered_subparagraphs(payload, citation_path)
+    )
+    covered_children.update(
         _deferred_output_covered_subparagraphs(payload, citation_path)
     )
 
@@ -8170,6 +8173,37 @@ def _rule_source_subparagraph_paths(
     for _name, _kind, _formula, source, _rule in _rulespec_rule_formula_rule_records(
         payload
     ):
+        if isinstance(source, str):
+            paths.update(_source_citation_subparagraph_paths(source, citation_path))
+    return paths
+
+
+def _source_relation_covered_subparagraphs(
+    payload: dict[str, Any],
+    citation_path: str,
+) -> set[tuple[str, ...]]:
+    return {
+        _top_level_subparagraph_path(path)
+        for path in _source_relation_subparagraph_paths(payload, citation_path)
+        if path
+    }
+
+
+def _source_relation_subparagraph_paths(
+    payload: dict[str, Any],
+    citation_path: str,
+) -> set[tuple[str, ...]]:
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return set()
+
+    paths: set[tuple[str, ...]] = set()
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "source_relation":
+            continue
+        source = rule.get("source")
         if isinstance(source, str):
             paths.update(_source_citation_subparagraph_paths(source, citation_path))
     return paths

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10432,6 +10432,112 @@ rules:
         assert proof_import["hash"] == f"sha256:{_sha256_file(upstream_file)}"
         assert test_cases[0]["output"] == {"us:statutes/26/3306/d#pay_period": "holds"}
 
+    def test_upstream_placement_duplicate_repair_restates_duplicate_only_module(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        upstream_file = policy_repo / "statutes/26/3121/f.yaml"
+        rules_file = policy_repo / "statutes/26/3306/m.yaml"
+        test_file = policy_repo / "statutes/26/3306/m.test.yaml"
+        upstream_file.parent.mkdir(parents=True)
+        rules_file.parent.mkdir(parents=True)
+        upstream_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/3121/base#asset_rule_applies
+rules:
+  - name: american_vessel
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: asset_rule_applies and asset_is_vessel and vessel_documented_or_numbered_under_laws_of_united_states
+  - name: american_aircraft
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: asset_rule_applies and asset_is_aircraft and aircraft_registered_under_laws_of_united_states
+"""
+        )
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/3121/base#asset_rule_applies
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: american_vessel
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(m)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: asset_rule_applies and asset_is_vessel and vessel_documented_or_numbered_under_laws_of_united_states
+  - name: american_aircraft
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(m)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: asset_rule_applies and asset_is_aircraft and aircraft_registered_under_laws_of_united_states
+"""
+        )
+        test_file.write_text(
+            """- name: vessel_case
+  period: 2026
+  input:
+    us:statutes/26/3306/m#input.asset_is_vessel: true
+    us:statutes/26/3306/m#input.vessel_documented_or_numbered_under_laws_of_united_states: true
+    us:statutes/26/3306/m#input.asset_is_aircraft: false
+    us:statutes/26/3306/m#input.aircraft_registered_under_laws_of_united_states: false
+  output:
+    us:statutes/26/3306/m#american_vessel: holds
+    us:statutes/26/3306/m#american_aircraft: not_holds
+"""
+        )
+
+        repaired = _repair_upstream_placement_duplicate_imports(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=policy_repo,
+            relative_output=Path("statutes/26/3306/m.yaml"),
+        )
+
+        rules_payload = yaml.safe_load(rules_file.read_text())
+        assert repaired == ["american_aircraft", "american_vessel"]
+        assert "imports" not in rules_payload
+        assert rules_payload["rules"] == [
+            {
+                "name": "american_aircraft_restatement",
+                "kind": "source_relation",
+                "source": "26 USC 3306(m)",
+                "source_relation": {
+                    "type": "restates",
+                    "target": "us:statutes/26/3121/f#american_aircraft",
+                },
+            },
+            {
+                "name": "american_vessel_restatement",
+                "kind": "source_relation",
+                "source": "26 USC 3306(m)",
+                "source_relation": {
+                    "type": "restates",
+                    "target": "us:statutes/26/3121/f#american_vessel",
+                },
+            },
+        ]
+        assert yaml.safe_load(test_file.read_text()) == []
+
     def test_missing_deferred_output_repair_adds_definition_target(self, tmp_path):
         output_root = tmp_path / "out"
         rules_file = output_root / "codex-gpt-5.5" / "statutes/26/3306/e.yaml"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -14242,6 +14242,32 @@ rules:
     )
 
 
+def test_source_subparagraph_coverage_allows_source_relation_citing_child():
+    source_text = """Definitions
+(m) American vessel and aircraft For purposes of this chapter, the term American vessel means any vessel documented or numbered under the laws of the United States; and the term American aircraft means an aircraft registered under the laws of the United States.
+"""
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: american_vessel_restatement
+    kind: source_relation
+    source: 26 USC 3306(m)
+    source_relation:
+      type: restates
+      target: us:statutes/26/3121/f#american_vessel
+"""
+
+    assert (
+        find_source_subparagraph_coverage_issues(
+            content,
+            source_texts={"us/statute/26/3306": source_text},
+        )
+        == []
+    )
+
+
 def test_source_subparagraph_coverage_rejects_sibling_omission_for_top_level_rule():
     source_text = """Definitions
 (a) Benefit means the amount payable under this program.

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.537"
+version = "0.2.538"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- convert duplicate-only generated modules into non-executable source_relation restatements instead of invalid empty modules
- count source_relation source citations toward source-subparagraph coverage
- bump axiom-encode to 0.2.538 and add changelog fragment

## Verification
- uv run --all-extras python -m pytest tests/test_cli.py -k 'upstream_placement_duplicate_repair or package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump'\n- uv run --all-extras python -m pytest tests/test_rulespec_validation.py -k 'source_subparagraph_coverage_allows_source_relation_citing_child or upstream_placement_allows_pure_source_relation_restatement'\n- uv run ruff check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_rulespec_validation.py\n- git diff --check HEAD~1..HEAD\n- direct overlay reproduction for saved 26 USC 3306(m) artifact: can_apply=True, issues=[]\n\n## Review\n- subagent review pass 1 found stale import risk in duplicate-only modules; fixed by dropping imports in source_relation-only repair and adding coverage\n- subagent review pass 2 found no actionable findings\n