### PR TITLE
Allow 3241(b) table header source references

### DIFF
--- a/changelog.d/3241b-source-table-scope.fixed.md
+++ b/changelog.d/3241b-source-table-scope.fixed.md
@@ -1,0 +1,1 @@
+Allow requested-source RuleSpec validation for 26 USC 3241(b) table headers that name downstream payroll sections as labels, not source citations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.538"
+version = "0.2.539"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.538"
+__version__ = "0.2.539"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1181,12 +1181,28 @@ def _source_citation_to_normalized_targets(
 
     targets: list[tuple[str, ...]] = []
     seen: set[tuple[str, ...]] = set()
+    previous_fragment_had_target = False
+    previous_raw_fragment: str | None = None
     for raw_fragment in _SOURCE_CITATION_SEPARATOR_RE.split(source):
         fragment_targets = _source_citation_fragment_to_normalized_targets(
             raw_fragment,
             default_title=current_title,
             default_section=current_section,
         )
+        if (
+            fragment_targets
+            and not previous_fragment_had_target
+            and targets
+            and _source_citation_fragment_is_bare_relative_table_label_tail(
+                raw_fragment,
+                previous_raw_fragment,
+            )
+        ):
+            previous_fragment_had_target = False
+            previous_raw_fragment = raw_fragment
+            continue
+        previous_fragment_had_target = bool(fragment_targets)
+        previous_raw_fragment = raw_fragment
         for target in fragment_targets:
             if len(target) >= 3:
                 current_title = target[1]
@@ -1196,6 +1212,32 @@ def _source_citation_to_normalized_targets(
             seen.add(target)
             targets.append(target)
     return tuple(targets)
+
+
+def _source_citation_fragment_is_bare_relative_table_label_tail(
+    fragment: str,
+    previous_fragment: str | None,
+) -> bool:
+    cleaned = _clean_source_citation_fragment(fragment)
+    if not cleaned:
+        return False
+    if _irc_source_fragment_to_usc_citation(cleaned) is not None:
+        return False
+    if re.match(r"^(?:§|section|subsection)\s+", cleaned, flags=re.IGNORECASE):
+        return False
+    if _looks_like_absolute_usc_source_fragment(cleaned):
+        return False
+    if previous_fragment is None:
+        return False
+    previous_cleaned = _clean_source_citation_fragment(previous_fragment)
+    return bool(
+        re.search(
+            r"^applicable\s+percentage\s+for\s+sections?\s+"
+            r"[0-9A-Za-z.-]+(?:\([^)]+\))*$",
+            previous_cleaned,
+            flags=re.IGNORECASE,
+        )
+    )
 
 
 def _source_citation_fragment_to_normalized_targets(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -13825,6 +13825,32 @@ rules:
     ]
 
 
+def test_out_of_scope_rule_source_rejects_bare_sibling_requested_source():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3306
+rules:
+  - name: american_vessel_for_chapter
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 3306(m)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: vessel_documented
+"""
+
+    issues = find_out_of_scope_rule_source_issues(
+        content,
+        requested_source="26 USC 3306(k)",
+    )
+
+    assert len(issues) == 1
+    assert "`american_vessel_for_chapter` source `3306(m)`" in issues[0]
+
+
 def test_out_of_scope_rule_source_rejects_sibling_in_multicitation_source():
     content = """format: rulespec/v1
 rules:
@@ -13930,6 +13956,30 @@ rules:
 
     assert len(issues) == 1
     assert "`ctc_threshold` source `26 USC 24(b)(2), 24(h)(3)`" in issues[0]
+
+
+def test_out_of_scope_rule_source_rejects_bare_sibling_after_non_table_label():
+    content = """format: rulespec/v1
+rules:
+  - name: mixed_scope_rule
+    kind: parameter
+    dtype: Money
+    source: 26 USC 24(b), formula applies for section 3306(k) and 3306(m)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 400000
+"""
+
+    issues = find_out_of_scope_rule_source_issues(
+        content,
+        requested_source="26 USC 24(b)",
+    )
+
+    assert len(issues) == 1
+    assert (
+        "`mixed_scope_rule` source "
+        "`26 USC 24(b), formula applies for section 3306(k) and 3306(m)`"
+    ) in issues[0]
 
 
 def test_out_of_scope_rule_source_allows_parent_requested_multicitation_source():
@@ -14102,6 +14152,43 @@ rules:
         find_out_of_scope_rule_source_issues(
             content,
             requested_source="26 USC 3306(k)",
+        )
+        == []
+    )
+
+
+def test_out_of_scope_rule_source_allows_requested_table_header_references():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3241
+rules:
+  - name: applicable_percentage_for_sections_3211_b_and_3221_b_by_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_band
+    source: 26 USC 3241(b), tax rate schedule, Applicable percentage for sections 3211(b) and 3221(b)
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          1: 0.221
+          2: 0.181
+  - name: applicable_percentage_for_section_3201_b_by_ratio_band
+    kind: parameter
+    dtype: Rate
+    indexed_by: average_account_benefits_ratio_band
+    source: 26 USC 3241(b), tax rate schedule, Applicable percentage for section 3201(b)
+    versions:
+      - effective_from: '1990-01-01'
+        values:
+          1: 0.049
+          2: 0.049
+"""
+
+    assert (
+        find_out_of_scope_rule_source_issues(
+            content,
+            requested_source="26 USC 3241(b)",
         )
         == []
     )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.538"
+version = "0.2.539"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- allow requested-source validation to treat `Applicable percentage for sections ... and ...` table labels as labels, not source citations
- keep sibling-source rejection for explicit and bare sibling citations, including a regression for non-table prose
- bump axiom-encode to 0.2.539 with changelog fragment

## Validation
- `uv run --all-extras python -m pytest tests/test_cli.py -k "package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump"`
- `uv run --all-extras python -m pytest tests/test_rulespec_validation.py -k "out_of_scope_rule_source"`
- `uv run --all-extras python -m pytest tests/test_rulespec_validation.py`
- `uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/3241b-20260602/rulespec-us/statutes/26/3241/b.yaml --skip-reviewers`
- `uv run axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/3241b-20260602/rulespec-us/statutes/26/3241/b.yaml`
- `uv run axiom-encode test /Users/maxghenis/_axiom-worktrees/3241b-20260602/rulespec-us/statutes/26/3241/b.test.yaml --axiom-rules-engine-path /Users/maxghenis/_axiom-worktrees/rulespec-numeric-concepts-20260601/axiom-rules-engine`

## Review
- Subagent /cycle review clean on second pass.