### PR TITLE
Add AOTC ECPS tax surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.540"
+version = "0.2.541"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.540"
+__version__ = "0.2.541"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -82,6 +82,8 @@ EITC_PROGRAM_PATH = Path("statutes/26/32.yaml")
 EITC_BASE = "us:statutes/26/32"
 CDCC_PROGRAM_PATH = Path("statutes/26/21.yaml")
 CDCC_BASE = "us:statutes/26/21"
+AOTC_PROGRAM_PATH = Path("statutes/26/25A.yaml")
+AOTC_BASE = "us:statutes/26/25A"
 SECTION_112_BASE = "us:statutes/26/112"
 SECTION_32_C_2_BASE = "us:statutes/26/32/c/2"
 SECTION_152_C_BASE = "us:statutes/26/152/c"
@@ -310,6 +312,24 @@ CDCC_OUTPUTS = {
         "pe": "cdcc",
     },
 }
+AOTC_OUTPUTS = {
+    "american_opportunity_credit": {
+        "axiom": f"{AOTC_BASE}#american_opportunity_credit",
+        "pe": "american_opportunity_credit",
+    },
+    "refundable_american_opportunity_credit": {
+        "axiom": f"{AOTC_BASE}#refundable_american_opportunity_credit",
+        "pe": "refundable_american_opportunity_credit",
+    },
+    "non_refundable_american_opportunity_credit": {
+        "axiom": f"{AOTC_BASE}#non_refundable_american_opportunity_credit",
+        "pe": "non_refundable_american_opportunity_credit",
+    },
+    "education_tax_credits": {
+        "axiom": f"{AOTC_BASE}#education_tax_credits",
+        "pe": "education_tax_credits",
+    },
+}
 SURFACE_OUTPUTS = {
     "ctc": CTC_OUTPUTS,
     "standard-deduction": STANDARD_DEDUCTION_OUTPUTS,
@@ -317,6 +337,7 @@ SURFACE_OUTPUTS = {
     "tax-before-credits": TAX_BEFORE_CREDITS_OUTPUTS,
     "eitc": EITC_OUTPUTS,
     "cdcc": CDCC_OUTPUTS,
+    "aotc": AOTC_OUTPUTS,
     **{surface: config["outputs"] for surface, config in PAYROLL_SURFACES.items()},
 }
 SURFACE_PROGRAM_PATHS = {
@@ -326,6 +347,7 @@ SURFACE_PROGRAM_PATHS = {
     "tax-before-credits": TAX_BEFORE_CREDITS_PROGRAM_PATH,
     "eitc": EITC_PROGRAM_PATH,
     "cdcc": CDCC_PROGRAM_PATH,
+    "aotc": AOTC_PROGRAM_PATH,
     **{surface: config["program"] for surface, config in PAYROLL_SURFACES.items()},
 }
 PE_TAX_UNIT_VARIABLES = tuple(
@@ -334,6 +356,7 @@ PE_TAX_UNIT_VARIABLES = tuple(
             "additional_standard_deduction",
             "adjusted_gross_income",
             "adjusted_net_capital_gain",
+            "american_opportunity_credit",
             "basic_standard_deduction",
             "cdcc",
             "cdcc_credit_limit",
@@ -358,10 +381,14 @@ PE_TAX_UNIT_VARIABLES = tuple(
             "eitc_phase_out_start",
             "eitc_phased_in",
             "eitc_reduction",
+            "education_tax_credits",
             "filing_status",
+            "foreign_tax_credit",
             "income_tax_before_credits",
             "min_head_spouse_earned",
             "net_capital_gain",
+            "non_refundable_american_opportunity_credit",
+            "refundable_american_opportunity_credit",
             "income_tax_main_rates",
             "standard_deduction",
             "tax_unit_childcare_expenses",
@@ -376,12 +403,21 @@ PE_PERSON_VARIABLES = tuple(
             "employee_social_security_tax",
             "employer_medicare_tax",
             "employer_social_security_tax",
+            "attends_eligible_educational_institution_for_american_opportunity_credit",
+            "american_opportunity_credit_claimed_prior_years",
+            "educational_assistance",
             "irs_employment_income",
+            "has_american_opportunity_credit_1098_t_or_exception",
+            "has_american_opportunity_credit_institution_ein",
+            "has_completed_first_four_years_of_postsecondary_education",
             "is_incapable_of_self_care",
+            "is_enrolled_at_least_half_time_for_american_opportunity_credit",
+            "is_pursuing_credential_for_american_opportunity_credit",
             "is_tax_unit_head",
             "is_tax_unit_head_or_spouse",
             "is_tax_unit_spouse",
             "payroll_tax_gross_wages",
+            "qualified_tuition_expenses",
         }
     )
 )
@@ -753,6 +789,11 @@ def load_policyengine_tax_data(
         tax_unit_ids=tax_unit_ids,
     )
     selected = raw_tax_units.iloc[indices].copy()
+    tax_unit_outputs = remove_output_columns_already_in_raw(
+        raw=selected,
+        outputs=tax_unit_outputs,
+        key="tax_unit_id",
+    )
     selected = selected.merge(
         tax_unit_outputs,
         on="tax_unit_id",
@@ -763,6 +804,11 @@ def load_policyengine_tax_data(
     selected_persons = raw_persons[
         raw_persons["person_tax_unit_id"].astype(int).isin(selected_ids)
     ].copy()
+    person_outputs = remove_output_columns_already_in_raw(
+        raw=selected_persons,
+        outputs=person_outputs,
+        key="person_id",
+    )
     selected_persons = selected_persons.merge(
         person_outputs,
         on="person_id",
@@ -775,6 +821,20 @@ def load_policyengine_tax_data(
         "tax_unit_ids": [int(value) for value in selected["tax_unit_id"]],
         "person_ids": [int(value) for value in selected_persons["person_id"]],
     }
+
+
+def remove_output_columns_already_in_raw(*, raw: Any, outputs: Any, key: str) -> Any:
+    """Avoid pandas suffixing when dataset inputs already contain a PE variable.
+
+    Newer ECPS data releases can store source variables that the harness also
+    requests through `extra_variables`. Those columns are already present in the
+    raw table, so keep the raw copy and merge only genuinely new outputs.
+    """
+
+    duplicate_columns = set(raw.columns).intersection(outputs.columns) - {key}
+    if not duplicate_columns:
+        return outputs
+    return outputs.drop(columns=sorted(duplicate_columns))
 
 
 def policyengine_variables_for_surfaces(
@@ -914,6 +974,8 @@ def build_axiom_request(
         )
     if surface == "cdcc":
         return build_cdcc_request(pe_data=pe_data, year=year)
+    if surface == "aotc":
+        return build_aotc_request(pe_data=pe_data, year=year)
     if surface in PAYROLL_SURFACES:
         return build_payroll_request(
             pe_data=pe_data,
@@ -1043,6 +1105,58 @@ def build_cdcc_request(*, pe_data: dict[str, Any], year: int) -> dict[str, Any]:
                 "entity_id": tax_entity_id(tax_unit_id),
                 "period": interval,
                 "outputs": [spec["axiom"] for spec in CDCC_OUTPUTS.values()],
+            }
+            for tax_unit_id in pe_data["tax_unit_ids"]
+        ],
+    }
+
+
+def build_aotc_request(*, pe_data: dict[str, Any], year: int) -> dict[str, Any]:
+    interval = {
+        "period_kind": "tax_year",
+        "start": f"{year:04d}-01-01",
+        "end": f"{year:04d}-12-31",
+    }
+    inputs: list[dict[str, Any]] = []
+    relations: list[dict[str, Any]] = []
+    persons_by_tax_unit = group_person_rows_by_tax_unit(pe_data["persons"])
+
+    for _idx, row in pe_data["tax_units"].iterrows():
+        tax_unit_id = int(row["tax_unit_id"])
+        entity_id = tax_entity_id(tax_unit_id)
+        tax_unit_persons = persons_by_tax_unit.get(tax_unit_id, [])
+        contexts = project_tax_unit_person_contexts(tax_unit_persons)
+        for name, value in project_aotc_tax_unit_inputs(row=row).items():
+            inputs.append(
+                input_record(f"{AOTC_BASE}#input.{name}", entity_id, interval, value)
+            )
+
+        for person_index, (person, context) in enumerate(
+            zip(tax_unit_persons, contexts, strict=True)
+        ):
+            person_id = f"{entity_id}_person_{person_index}"
+            relations.append(
+                {
+                    "name": f"{AOTC_BASE}#relation.education_credit_member_of_tax_unit",
+                    "tuple": [person_id, entity_id],
+                    "interval": interval,
+                }
+            )
+            for name, value in project_aotc_person_inputs(person, context).items():
+                inputs.append(
+                    input_record(
+                        f"{AOTC_BASE}#input.{name}", person_id, interval, value
+                    )
+                )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": relations},
+        "queries": [
+            {
+                "entity_id": tax_entity_id(tax_unit_id),
+                "period": interval,
+                "outputs": [spec["axiom"] for spec in AOTC_OUTPUTS.values()],
             }
             for tax_unit_id in pe_data["tax_unit_ids"]
         ],
@@ -1755,6 +1869,74 @@ def project_cdcc_person_inputs(
     }
 
 
+def project_aotc_tax_unit_inputs(*, row: Any) -> dict[str, Any]:
+    return {
+        "filing_status": filing_status_code(str(row["filing_status"])),
+        "modified_adjusted_gross_income": money(row["adjusted_gross_income"]),
+        "is_nonresident_alien": False,
+        "section_6013_resident_alien_election": False,
+        "taxpayer_is_section_1_g_child": False,
+        "income_tax_before_credits": money(row["income_tax_before_credits"]),
+        "foreign_tax_credit": money(row.get("foreign_tax_credit", 0)),
+        "cdcc": money(row.get("cdcc", 0)),
+    }
+
+
+def project_aotc_person_inputs(
+    person: Any,
+    context: PersonProjectionContext,
+) -> dict[str, Any]:
+    return {
+        "qualified_tuition_and_related_expenses": money(
+            person.get("qualified_tuition_expenses", 0)
+        ),
+        "excludable_educational_assistance": money(
+            person.get("educational_assistance", 0)
+        ),
+        "is_taxpayer": context.is_head,
+        "is_spouse": context.is_spouse,
+        "is_tax_unit_dependent": context.is_tax_unit_dependent,
+        "meets_higher_education_act_student_requirements": (
+            bool_value(
+                person.get(
+                    "is_pursuing_credential_for_american_opportunity_credit",
+                    False,
+                )
+            )
+            and bool_value(
+                person.get(
+                    "attends_eligible_educational_institution_for_american_opportunity_credit",
+                    False,
+                )
+            )
+        ),
+        "at_least_half_time_student": bool_value(
+            person.get(
+                "is_enrolled_at_least_half_time_for_american_opportunity_credit", False
+            )
+        ),
+        "aotc_prior_year_election_count": int(
+            money(person.get("american_opportunity_credit_claimed_prior_years", 0))
+        ),
+        "completed_first_four_years_postsecondary_before_year": bool_value(
+            person.get(
+                "has_completed_first_four_years_of_postsecondary_education", False
+            )
+        ),
+        "has_felony_drug_conviction": False,
+        "aotc_election_in_effect": True,
+        "education_credit_identification_requirements_met": context.has_valid_child_ssn,
+        "institution_employer_identification_number_included": bool_value(
+            person.get("has_american_opportunity_credit_institution_ein", False)
+        ),
+        "payee_statement_received": bool_value(
+            person.get("has_american_opportunity_credit_1098_t_or_exception", False)
+        ),
+        "aotc_disallowance_period_applies": False,
+        "education_credit_election_in_effect": False,
+    }
+
+
 def project_eitc_tax_unit_inputs(row: Any, persons: list[Any]) -> dict[str, Any]:
     filing_status = str(row["filing_status"])
     filing_status_numeric = filing_status_code(filing_status)
@@ -2437,6 +2619,12 @@ def compare_outputs(
             "Childcare expenses, the minimum head/spouse earned-income cap, and "
             "the available nonrefundable-credit limit remain explicit upstream "
             "boundary inputs until those federal tax chains are encoded "
+            "end-to-end.",
+            "AOTC projections run encoded 26 USC 25A math from ECPS tuition, "
+            "educational-assistance, enrollment, credential, institution, "
+            "prior-claim, and SSN-card facts. Income tax before credits, CDCC, "
+            "and foreign tax credit remain explicit upstream boundary inputs "
+            "until the full federal credit-ordering chain is encoded "
             "end-to-end.",
         ],
     )

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -4,6 +4,8 @@ import pytest
 
 import axiom_encode.oracles.policyengine.ecps_tax as ecps_tax
 from axiom_encode.oracles.policyengine.ecps_tax import (
+    AOTC_BASE,
+    AOTC_OUTPUTS,
     CAPITAL_GAINS_BASE,
     CAPITAL_GAINS_DEFINITION_OUTPUTS,
     CDCC_BASE,
@@ -31,6 +33,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     TAX_BEFORE_CREDITS_BASE,
     TAX_BEFORE_CREDITS_OUTPUTS,
     additional_standard_deduction_entitlement_count,
+    build_aotc_request,
     build_capital_gain_definitions_request,
     build_cdcc_request,
     build_contribution_and_benefit_base_request,
@@ -51,6 +54,8 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     output_number,
     person_entity_id,
     policyengine_data_certification_override_required,
+    project_aotc_person_inputs,
+    project_aotc_tax_unit_inputs,
     project_capital_gain_definition_inputs,
     project_cdcc_person_inputs,
     project_cdcc_tax_unit_inputs,
@@ -72,6 +77,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     project_standard_deduction_inputs,
     project_tax_unit_inputs,
     project_tax_unit_person_contexts,
+    remove_output_columns_already_in_raw,
     require_policyengine_versions,
     select_tax_unit_indices,
     taxable_oasdi_wages_by_person_id,
@@ -114,6 +120,40 @@ def test_scalar_value_keeps_plain_float_literal_format():
         "kind": "decimal",
         "value": "184500.0",
     }
+
+
+def test_remove_output_columns_already_in_raw_prevents_suffixing():
+    pd = pytest.importorskip("pandas")
+    raw = pd.DataFrame(
+        [
+            {
+                "person_id": 1,
+                "qualified_tuition_expenses": 4_000,
+                "age": 20,
+            }
+        ]
+    )
+    outputs = pd.DataFrame(
+        [
+            {
+                "person_id": 1,
+                "qualified_tuition_expenses": 4_000,
+                "american_opportunity_credit": 2_500,
+            }
+        ]
+    )
+
+    filtered = remove_output_columns_already_in_raw(
+        raw=raw,
+        outputs=outputs,
+        key="person_id",
+    )
+    merged = raw.merge(filtered, on="person_id", how="left", validate="one_to_one")
+
+    assert "qualified_tuition_expenses" in merged
+    assert "qualified_tuition_expenses_x" not in merged
+    assert "qualified_tuition_expenses_y" not in merged
+    assert merged.loc[0, "american_opportunity_credit"] == 2_500
 
 
 def test_run_axiom_program_compiles_through_canonical_repo_alias(
@@ -1366,6 +1406,188 @@ def test_build_cdcc_request_uses_person_to_tax_unit_relation_and_outputs():
     assert (
         input_values[
             (f"{CDCC_BASE}#input.is_cdcc_child_dependent", "tax_unit_1_person_1")
+        ]
+        is True
+    )
+
+
+def test_project_aotc_tax_unit_inputs_declares_credit_boundaries():
+    projected = project_aotc_tax_unit_inputs(
+        row={
+            "filing_status": "HEAD_OF_HOUSEHOLD",
+            "adjusted_gross_income": 68_000,
+            "income_tax_before_credits": 4_200,
+            "foreign_tax_credit": 100,
+            "cdcc": 750,
+        }
+    )
+
+    assert projected == {
+        "filing_status": 3,
+        "modified_adjusted_gross_income": 68_000,
+        "is_nonresident_alien": False,
+        "section_6013_resident_alien_election": False,
+        "taxpayer_is_section_1_g_child": False,
+        "income_tax_before_credits": 4_200,
+        "foreign_tax_credit": 100,
+        "cdcc": 750,
+    }
+
+
+def test_project_aotc_person_inputs_uses_ecps_education_leaves():
+    context = project_tax_unit_person_contexts(
+        [
+            {
+                "age": 42,
+                "is_tax_unit_head": True,
+                "is_tax_unit_spouse": False,
+                "ssn_card_type": "CITIZEN",
+            },
+            {
+                "age": 20,
+                "is_tax_unit_head": False,
+                "is_tax_unit_spouse": False,
+                "ssn_card_type": "CITIZEN",
+            },
+        ]
+    )[1]
+
+    projected = project_aotc_person_inputs(
+        {
+            "qualified_tuition_expenses": 4_500,
+            "educational_assistance": 500,
+            "is_pursuing_credential_for_american_opportunity_credit": True,
+            "attends_eligible_educational_institution_for_american_opportunity_credit": True,
+            "is_enrolled_at_least_half_time_for_american_opportunity_credit": True,
+            "american_opportunity_credit_claimed_prior_years": 1,
+            "has_completed_first_four_years_of_postsecondary_education": False,
+            "has_american_opportunity_credit_institution_ein": True,
+            "has_american_opportunity_credit_1098_t_or_exception": True,
+        },
+        context,
+    )
+
+    assert projected["qualified_tuition_and_related_expenses"] == 4_500
+    assert projected["excludable_educational_assistance"] == 500
+    assert projected["is_tax_unit_dependent"] is True
+    assert projected["meets_higher_education_act_student_requirements"] is True
+    assert projected["at_least_half_time_student"] is True
+    assert projected["aotc_prior_year_election_count"] == 1
+    assert projected["education_credit_identification_requirements_met"] is True
+    assert projected["institution_employer_identification_number_included"] is True
+    assert projected["payee_statement_received"] is True
+    assert projected["education_credit_election_in_effect"] is False
+
+
+def test_build_aotc_request_uses_person_to_tax_unit_relation_and_outputs():
+    pd = pytest.importorskip("pandas")
+    pe_data = {
+        "tax_units": pd.DataFrame(
+            [
+                {
+                    "tax_unit_id": 1,
+                    "filing_status": "JOINT",
+                    "adjusted_gross_income": 80_000,
+                    "income_tax_before_credits": 5_000,
+                    "foreign_tax_credit": 0,
+                    "cdcc": 600,
+                }
+            ]
+        ),
+        "persons": pd.DataFrame(
+            [
+                {
+                    "person_id": 7,
+                    "person_tax_unit_id": 1,
+                    "age": 44,
+                    "is_tax_unit_head": True,
+                    "is_tax_unit_spouse": False,
+                    "ssn_card_type": "CITIZEN",
+                    "qualified_tuition_expenses": 0,
+                },
+                {
+                    "person_id": 8,
+                    "person_tax_unit_id": 1,
+                    "age": 20,
+                    "is_tax_unit_head": False,
+                    "is_tax_unit_spouse": False,
+                    "ssn_card_type": "CITIZEN",
+                    "qualified_tuition_expenses": 4_000,
+                    "educational_assistance": 0,
+                    "is_pursuing_credential_for_american_opportunity_credit": True,
+                    "attends_eligible_educational_institution_for_american_opportunity_credit": True,
+                    "is_enrolled_at_least_half_time_for_american_opportunity_credit": True,
+                    "american_opportunity_credit_claimed_prior_years": 0,
+                    "has_completed_first_four_years_of_postsecondary_education": False,
+                    "has_american_opportunity_credit_institution_ein": True,
+                    "has_american_opportunity_credit_1098_t_or_exception": True,
+                },
+            ]
+        ),
+        "tax_unit_ids": [1],
+    }
+
+    request = build_aotc_request(pe_data=pe_data, year=2026)
+
+    assert request["queries"] == [
+        {
+            "entity_id": "tax_unit_1",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": [spec["axiom"] for spec in AOTC_OUTPUTS.values()],
+        }
+    ]
+    assert request["dataset"]["relations"] == [
+        {
+            "name": f"{AOTC_BASE}#relation.education_credit_member_of_tax_unit",
+            "tuple": ["tax_unit_1_person_0", "tax_unit_1"],
+            "interval": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+        },
+        {
+            "name": f"{AOTC_BASE}#relation.education_credit_member_of_tax_unit",
+            "tuple": ["tax_unit_1_person_1", "tax_unit_1"],
+            "interval": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+        },
+    ]
+    input_values = {
+        (item["name"], item["entity_id"]): item["value"]["value"]
+        for item in request["dataset"]["inputs"]
+    }
+    assert (
+        input_values[
+            (
+                f"{AOTC_BASE}#input.income_tax_before_credits",
+                "tax_unit_1",
+            )
+        ]
+        == "5000.0"
+    )
+    assert (
+        input_values[
+            (
+                f"{AOTC_BASE}#input.qualified_tuition_and_related_expenses",
+                "tax_unit_1_person_1",
+            )
+        ]
+        == "4000.0"
+    )
+    assert (
+        input_values[
+            (
+                f"{AOTC_BASE}#input.meets_higher_education_act_student_requirements",
+                "tax_unit_1_person_1",
+            )
         ]
         is True
     )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.540"
+version = "0.2.541"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Adds an ECPS comparison surface for 26 USC 25A American Opportunity Credit outputs. This is harness/projection wiring only; it does not manually encode law or feed PE's AOTC outputs into Axiom inputs.\n\nValidation:\n- uv run --extra dev --python 3.13 ruff check src/ tests/\n- uv run --extra dev --python 3.13 ruff format --check src/ tests/\n- uv run --extra dev --python 3.13 pytest tests/test_policyengine_ecps_tax.py -q\n- AOTC full ECPS: 7,039 tax units, 28,156 compared values, 0 mismatches\n\nNotes:\n- AOTC uses ECPS tuition, educational-assistance, enrollment, credential, institution, prior-claim, and SSN-card facts.\n- income_tax_before_credits, CDCC, and foreign_tax_credit remain explicit upstream boundary inputs until the full federal credit-ordering chain is encoded end-to-end.