### PR TITLE
Classify payroll oracle coverage for generated RuleSpec outputs

### DIFF
--- a/changelog.d/pr388-payroll-oracle-coverage.changed.md
+++ b/changelog.d/pr388-payroll-oracle-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated payroll RuleSpec oracle coverage surfaces for PR 388.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.542"
+version = "0.2.543"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.542"
+__version__ = "0.2.543"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1922,6 +1922,12 @@ mappings:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose the section 1402(b) nonresident-alien, agreement, and territory-resident exclusion predicate as a one-to-one variable.
 
+  - legal_id: us:statutes/26/1402/b#individual_excluded_from_self_employment_income_definition
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the section 1402(b) nonresident-alien, agreement, and territory-resident exclusion predicate as a one-to-one variable.
+
   - legal_id: us:statutes/26/164/f#self_employment_tax_deduction_fraction
     country: us
     program: tax
@@ -2214,6 +2220,18 @@ mappings:
     mapping_type: not_comparable
     rationale: PolicyEngine models employee FICA payroll taxes and excess payroll tax withheld, but not Railroad Retirement Tax Act section 3201(b) tier 2 employee tax or the section 3241 applicable percentage as a comparable output.
 
+  - legal_id: us:statutes/26/3201#tier_1_tax_tier_number
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3201 tier numbers are structural labels for Railroad Retirement Tax Act computations, not one-to-one PolicyEngine outputs.
+
+  - legal_id: us:statutes/26/3201#tier_2_tax_tier_number
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3201 tier numbers are structural labels for Railroad Retirement Tax Act computations, not one-to-one PolicyEngine outputs.
+
   - legal_id: us:statutes/26/3201#tier_2_applicable_percentage
     country: us
     program: tax
@@ -2232,11 +2250,41 @@ mappings:
     mapping_type: not_comparable
     rationale: PolicyEngine models employer FICA payroll taxes, but not Railroad Retirement Tax Act section 3221(b) tier 2 employer tax or the section 3241 applicable percentage as a comparable output.
 
+  - legal_id: us:statutes/26/3221#tier_1_applicable_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine exposes component employer OASDI and Medicare payroll tax rates, but not the section 3221(a) Railroad Retirement Tax Act tier 1 applicable-rate helper as a one-to-one output.
+
+  - legal_id: us:statutes/26/3221#tier_1_tax_tier_identifier
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3221 tier identifiers are structural labels for Railroad Retirement Tax Act computations, not one-to-one PolicyEngine outputs.
+
   - legal_id: us:statutes/26/3221#tier_1_applicable_percentage
     country: us
     program: tax
     mapping_type: not_comparable
     rationale: PolicyEngine exposes component employer OASDI and Medicare payroll tax rates, but not the section 3221(a) Railroad Retirement Tax Act tier 1 applicable-percentage helper as a one-to-one output.
+
+  - legal_id: us:statutes/26/3221#tier_2_applicable_rate
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: PolicyEngine models employer FICA payroll taxes, but not the Railroad Retirement Tax Act section 3221(b) tier 2 applicable-rate helper as a one-to-one output.
+
+  - legal_id: us:statutes/26/3221#tier_2_tax_tier_identifier
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3221 tier identifiers are structural labels for Railroad Retirement Tax Act computations, not one-to-one PolicyEngine outputs.
+
+  - legal_id: us:statutes/26/3231#tips_compensation_deemed_paid_on_day_for_section_3201_taxes
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 3231(h) deems tip compensation paid on the day received for Railroad Retirement Tax Act section 3201 taxes; PolicyEngine does not expose this RRTA timing rule as a one-to-one output.
 
   - legal_id: us:statutes/26/3111/a#employer_oasdi_excise_tax_rate
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -5348,6 +5348,41 @@ rules:
     assert {item["policyengine_variable"] for item in items_by_id.values()} == {None}
 
 
+def test_policyengine_coverage_classifies_3201_employee_rrta_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3201.yaml",
+        """format: rulespec/v1
+rules:
+  - name: tier_1_tax_tier_number
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 1
+  - name: tier_2_tax_tier_number
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 2
+  - name: tier_2_employee_tax
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: tier_2_compensation * tier_2_rate
+  - name: tier_2_applicable_percentage
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: applicable_percentage
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 4}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
 def test_policyengine_coverage_classifies_3212_compensation_output(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/26/3212.yaml",
@@ -5370,6 +5405,51 @@ rules:
     )
     assert item["status"] == "known_not_comparable"
     assert item["policyengine_variable"] is None
+
+
+def test_policyengine_coverage_classifies_3221_employer_rrta_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3221.yaml",
+        """format: rulespec/v1
+rules:
+  - name: tier_1_applicable_rate
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: tier_1_rate
+  - name: tier_1_tax_tier_identifier
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: tier_1
+  - name: tier_1_applicable_percentage
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: tier_1_percentage
+  - name: tier_2_applicable_rate
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: tier_2_rate
+  - name: tier_2_tax_tier_identifier
+    kind: parameter
+    versions:
+      - effective_from: '1990-01-01'
+        formula: tier_2
+  - name: tier_2_employer_tax
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: tier_2_compensation * tier_2_rate
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 6}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["policyengine_variable"] for item in report["items"]} == {None}
 
 
 def test_policyengine_coverage_classifies_3241_a_applicable_percentage_outputs(
@@ -5439,6 +5519,30 @@ rules:
     assert report["status_counts"] == {"known_not_comparable": 5}
     assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
     assert {item["policyengine_variable"] for item in report["items"]} == {None}
+
+
+def test_policyengine_coverage_classifies_3231_tip_timing_output(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/3231.yaml",
+        """format: rulespec/v1
+rules:
+  - name: tips_compensation_deemed_paid_on_day_for_section_3201_taxes
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: tips_received_day
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == (
+        "us:statutes/26/3231#tips_compensation_deemed_paid_on_day_for_section_3201_taxes"
+    )
+    assert item["status"] == "known_not_comparable"
+    assert item["policyengine_variable"] is None
 
 
 def test_policyengine_coverage_classifies_3231_a_employer_definition_outputs(tmp_path):
@@ -7787,6 +7891,12 @@ rules:
     versions:
       - effective_from: '1990-01-01'
         formula: individual_is_nonresident_alien
+  - name: individual_excluded_from_self_employment_income_definition
+    kind: derived
+    entity: Person
+    versions:
+      - effective_from: '1990-01-01'
+        formula: individual_is_nonresident_alien
 """,
     )
     _write_rulespec_file(
@@ -7797,6 +7907,7 @@ rules:
     us:statutes/26/1402/b#self_employment_income: 923.5
     us:statutes/26/1402/b#self_employment_income_for_section_1401_a: 923.5
     us:statutes/26/1402/b#self_employment_income_excluded_for_taxpayer: false
+    us:statutes/26/1402/b#individual_excluded_from_self_employment_income_definition: false
 """,
     )
 
@@ -7804,7 +7915,7 @@ rules:
 
     assert report["status_counts"] == {
         "comparable": 1,
-        "known_not_comparable": 3,
+        "known_not_comparable": 4,
     }
     assert report["untested_comparable"] == 0
     items_by_id = {item["legal_id"]: item for item in report["items"]}
@@ -7828,6 +7939,12 @@ rules:
             "policyengine_variable"
         ]
         == "social_security_taxable_self_employment_income"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/1402/b#individual_excluded_from_self_employment_income_definition"
+        ]["status"]
+        == "known_not_comparable"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.542"
+version = "0.2.543"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add PolicyEngine not-comparable classifications for generated payroll outputs currently blocking rulespec-us PR #388 oracle coverage
- cover the new 1402(b), 3201, 3221, and 3231 classifications in policyengine coverage tests
- bump axiom-encode to 0.2.543 so the encoder-affecting registry change is behind a version bump
- add a changelog entry for the registry update

## Validation
- uv run python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3201_employee_rrta_outputs tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3221_employer_rrta_outputs tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_3231_tip_timing_output tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_section_1402_b_self_employment_outputs
- uv run python -m pytest tests/test_policyengine_coverage.py
- uv run python -m pytest tests/ -q (1,697 passed, 20 skipped)
- uv run ruff check tests/test_policyengine_coverage.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/eitc-seca-20260602 --fail-on-unmapped --program tax --json