### PR TITLE
Classify UK Class 1 NI oracle coverage

### DIFF
--- a/changelog.d/uk-ni-oracle-coverage.changed.md
+++ b/changelog.d/uk-ni-oracle-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated UK Class 1 National Insurance section 8 outputs in the PolicyEngine oracle coverage registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.544"
+version = "0.2.545"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.545"
+version = "0.2.546"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.545"
+__version__ = "0.2.546"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.544"
+__version__ = "0.2.545"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -90,6 +90,36 @@ mappings:
     comparison: money
     rationale: Same UK income tax personal allowance output.
 
+  - legal_id: uk:statutes/ukpga/1992/4/8#main_primary_percentage
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.national_insurance.class_1.rates.employee.main
+    period: week
+    comparison: rate
+    rationale: Same Class 1 employee main primary contribution percentage.
+
+  - legal_id: uk:statutes/ukpga/1992/4/8#additional_primary_percentage
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.national_insurance.class_1.rates.employee.additional
+    period: week
+    comparison: rate
+    rationale: Same Class 1 employee additional primary contribution percentage.
+
+  - legal_id: uk:statutes/ukpga/1992/4/8#primary_class_1_contribution
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: ni_class_1_employee
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    candidate_priority: P4
+    rationale: PolicyEngine UK exposes employee Class 1 NI as a monthly person variable composed from primary and additional monthly components; this generated RuleSpec output is a weekly source-level s.8 calculation with statutory displacement conditions and weekly threshold inputs, so it needs a period/composition adapter before direct oracle comparison.
+
   - legal_id: uk:regulations/uksi/2006/965/2#child_benefit_enhanced_weekly_rate
     country: uk
     program: child_benefit

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -733,6 +733,81 @@ rules:
     assert future_output["status"] == "unmapped"
 
 
+def test_policyengine_coverage_classifies_uk_class_1_ni_section_8_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/1992/4/8.yaml",
+        """format: rulespec/v1
+rules:
+  - name: main_primary_percentage
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2024-04-06'
+        formula: '0.08'
+  - name: additional_primary_percentage
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2011-04-06'
+        formula: '0.02'
+  - name: primary_class_1_contribution
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Week
+    unit: GBP
+    versions:
+      - effective_from: '2024-04-06'
+        formula: 68
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/1992/4/8.test.yaml",
+        """- name: class 1 employee ni
+  period:
+    period_kind: custom
+    name: tax_week
+    start: '2024-04-08'
+    end: '2024-04-14'
+  input: {}
+  output:
+    uk:statutes/ukpga/1992/4/8#main_primary_percentage: 0.08
+    uk:statutes/ukpga/1992/4/8#additional_primary_percentage: 0.02
+    uk:statutes/ukpga/1992/4/8#primary_class_1_contribution: 68
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {
+        "comparable": 2,
+        "known_not_comparable": 1,
+    }
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    main_rate = items_by_id["uk:statutes/ukpga/1992/4/8#main_primary_percentage"]
+    additional_rate = items_by_id[
+        "uk:statutes/ukpga/1992/4/8#additional_primary_percentage"
+    ]
+    contribution = items_by_id[
+        "uk:statutes/ukpga/1992/4/8#primary_class_1_contribution"
+    ]
+
+    assert (
+        main_rate["policyengine_parameter"]
+        == "gov.hmrc.national_insurance.class_1.rates.employee.main"
+    )
+    assert main_rate["tested"] is True
+    assert (
+        additional_rate["policyengine_parameter"]
+        == "gov.hmrc.national_insurance.class_1.rates.employee.additional"
+    )
+    assert additional_rate["tested"] is True
+    assert contribution["status"] == "known_not_comparable"
+    assert contribution["policyengine_variable"] == "ni_class_1_employee"
+    assert contribution["candidate_priority"] == "P4"
+
+
 def test_policyengine_coverage_counts_uk_aliases_as_tested(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-uk" / "regulations/uksi/2006/965/2.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.545"
+version = "0.2.546"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.544"
+version = "0.2.545"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map generated UK SSCBA section 8 employee NI rate outputs to PolicyEngine UK rate parameters
- classify the weekly section 8 contribution output as a reviewed adjacent PolicyEngine target rather than directly comparable
- add a coverage regression for the generated rulespec-UK section 8 outputs

## Tests
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q
- uv run ruff check tests/test_policyengine_coverage.py
- uv run ruff format --check tests/test_policyengine_coverage.py
- uv run python -c "from axiom_encode.oracles.policyengine.registry import load_policyengine_registry; load_policyengine_registry(); print(\"registry ok\")"
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run axiom-encode oracle-coverage --root <temp-copy-with-rulespec-uk> --program tax --fail-on-unmapped --fail-on-untested-comparable