### PR TITLE
Tighten EITC person-scope validation

### DIFF
--- a/changelog.d/eitc-person-scope-parent.fixed.md
+++ b/changelog.d/eitc-person-scope-parent.fixed.md
@@ -1,0 +1,1 @@
+Tighten EITC parent composition guidance and flag stale TaxUnit-shaped 26 USC 1402(a) net-earnings outputs that should be encoded at person scope before relation rollups.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.544"
+version = "0.2.545"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.544"
+__version__ = "0.2.545"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -4194,9 +4194,12 @@ RuleSpec requirements:
 - When source text says an exemption, exclusion, or adjustment applies
   `to the extent` of an amount, do not model it as all-or-nothing zeroing such as
   `if exempt_amount > 0: 0 else: tax`. Subtract or apportion the stated amount.
-  If imported child calculations cannot receive the adjusted basis faithfully
-  under the current executable schema, emit `module.status: entity_not_supported`
-  or `deferred` instead of an approximate executable formula.
+  Emit `module.status: entity_not_supported` or `deferred` only when the current
+  requested source changes the basis that would need to be passed into an
+  already-imported child result and the schema cannot wire that adjusted basis
+  into the child. Do not defer a parent merely because an imported terminal
+  child output internally handled its own `to the extent` exclusion; import and
+  compose that terminal child output at the parent scope instead.
 - If the source has a cross-reference such as `For application of different
   contribution bases ... see section X`, do not repair it by keeping tax,
   amount, or rate-times-compensation formulas on the raw wage, compensation,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 import yaml
 
@@ -7356,6 +7356,10 @@ _PERSON_SCOPED_DEFINITION_SOURCE_PATTERN = re.compile(
     r"[\s\S]{0,180}\bderived\s+by\s+(?:an?|the|such)\s+"
     r"(?:individual|person|employee|member)\b"
     r"|"
+    r"\bterm\s+[\"'“”‘’]?net\s+earnings?\b[\s\S]{0,160}\bmeans\b"
+    r"[\s\S]{0,260}\bderived\s+by\s+(?:an?|the|such)\s+"
+    r"(?:individual|person|employee|member)\b"
+    r"|"
     r"\bearned\s+income\s+of\s+(?:an?|the|such)\s+individual\b"
     r"[\s\S]{0,220}\bcomputed\b"
     r"|"
@@ -7396,6 +7400,14 @@ def find_person_scoped_definition_unit_issues(content: str) -> list[str]:
         scoped_source_text = " ".join(_rule_proof_source_excerpts(rule))
         if not scoped_source_text:
             scoped_source_text = _source_text_for_rule_source(source_text, rule_source)
+        if not _PERSON_SCOPED_DEFINITION_SOURCE_PATTERN.search(
+            scoped_source_text
+        ) and _person_scoped_definition_module_fallback_applies(
+            source_text=source_text,
+            rule_source=rule_source,
+            rule=rule,
+        ):
+            scoped_source_text = source_text
         if not _PERSON_SCOPED_DEFINITION_SOURCE_PATTERN.search(scoped_source_text):
             continue
         if _formula_or_referenced_helpers_use_relation_aggregate(
@@ -7413,6 +7425,31 @@ def find_person_scoped_definition_unit_issues(content: str) -> list[str]:
             "roll-up."
         )
     return issues
+
+
+def _person_scoped_definition_module_fallback_applies(
+    *,
+    source_text: str,
+    rule_source: str,
+    rule: Mapping[str, Any],
+) -> bool:
+    if not source_text:
+        return False
+    if not _PERSON_SCOPED_DEFINITION_SOURCE_PATTERN.search(source_text):
+        return False
+    if "1402(a)" not in str(rule_source).lower():
+        return False
+    if str(rule.get("dtype") or "").strip().lower() == "rate":
+        return False
+    name = str(rule.get("name") or "").lower()
+    return any(
+        marker in name
+        for marker in (
+            "net_earnings",
+            "self_employment_income",
+            "paragraph_12_deduction",
+        )
+    )
 
 
 def find_employer_scoped_entity_issues(content: str) -> list[str]:

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -347,9 +347,12 @@ Hard requirements:
 - When source text says an exemption, exclusion, or adjustment applies
   `to the extent` of an amount, do not model it as all-or-nothing zeroing such as
   `if exempt_amount > 0: 0 else: tax`. Subtract or apportion the stated amount.
-  If imported child calculations cannot receive the adjusted basis faithfully
-  under the current executable schema, emit `module.status: entity_not_supported`
-  or `deferred` instead of an approximate executable formula.
+  Emit `module.status: entity_not_supported` or `deferred` only when the current
+  requested source changes the basis that would need to be passed into an
+  already-imported child result and the schema cannot wire that adjusted basis
+  into the child. Do not defer a parent merely because an imported terminal
+  child output internally handled its own `to the extent` exclusion; import and
+  compose that terminal child output at the parent scope instead.
 - Never emit `rules: []` without an explicit non-executable `module.status`.
   If the source has operative text, encode at least one source-backed rule
   instead of silently returning an empty module.

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -141,6 +141,8 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "treat the copied aggregate shape as a defect to repair" in ENCODER_PROMPT
     assert "earned income of an individual shall be\n  computed" in ENCODER_PROMPT
     assert "replaced by one aggregated boundary input" in ENCODER_PROMPT
+    assert "current\n  requested source changes the basis" in ENCODER_PROMPT
+    assert "internally handled its own `to the extent` exclusion" in ENCODER_PROMPT
     assert "Never drop the jurisdiction prefix" in ENCODER_PROMPT
     assert "listed under invalid copied local inputs" in ENCODER_PROMPT
     assert "do not preserve, rename, or recreate" in ENCODER_PROMPT

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -5912,6 +5912,8 @@ rules:
         assert "Importing a child rate or threshold is not enough" in prompt
         assert "`to the extent`" in prompt
         assert "all-or-nothing zeroing" in prompt
+        assert "current\n  requested source changes the basis" in prompt
+        assert "internally handled its own `to the extent` exclusion" in prompt
 
     def test_build_eval_prompt_highlights_cited_context_import_exports(self, tmp_path):
         policy_repo_root = tmp_path / "rulespec-us"
@@ -6224,6 +6226,65 @@ rules:
         assert "entity_not_supported" in prompt
         assert "`rules: []`" in prompt
         assert "`*_before_exemption`" in prompt
+
+    def test_build_eval_prompt_does_not_defer_parent_for_child_internal_extent(
+        self, tmp_path
+    ):
+        policy_repo_root = tmp_path / "rulespec-us"
+        child_file = policy_repo_root / "statutes" / "26" / "32" / "c" / "2.yaml"
+        child_file.parent.mkdir(parents=True, exist_ok=True)
+        child_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: |-
+    Earned income excludes subsidized work-activity amounts only to the extent
+    subsidized under the State program.
+rules:
+  - name: earned_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 32(c)(2)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: max(0, wages - subsidized_state_work_activity_amounts_received)
+"""
+        )
+        workspace = prepare_eval_workspace(
+            citation="26 USC 32",
+            runner=parse_runner_spec("openai:gpt-5.4"),
+            output_root=tmp_path / "out",
+            source_text=(
+                "(a) In the case of an eligible individual, there shall be "
+                "allowed as a credit an amount equal to the credit percentage "
+                "of so much of the taxpayer's earned income as does not exceed "
+                "the earned income amount. (c)(2) The term earned income means "
+                "employee compensation plus self-employment income, and no "
+                "amount received for work activities shall be taken into "
+                "account, but only to the extent such amount is subsidized "
+                "under such State program."
+            ),
+            axiom_rules_path=policy_repo_root,
+            mode="repo-augmented",
+            extra_context_paths=[child_file],
+        )
+
+        prompt = _build_eval_prompt(
+            "26 USC 32",
+            "repo-augmented",
+            workspace,
+            workspace.context_files,
+            target_file_name="32.yaml",
+            target_ref_prefix="us:statutes/26/32",
+            include_tests=True,
+        )
+
+        assert "Target-specific schema limit" not in prompt
+        assert "Aggregate parent child outputs detected" in prompt
+        assert "`us:statutes/26/32/c/2#earned_income`" in prompt
+        assert "internally handled its own `to the extent` exclusion" in prompt
 
     def test_build_eval_prompt_does_not_defer_amount_adjustment_parent_list(
         self, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -13126,6 +13126,69 @@ rules:
     assert "TaxUnit" in issues[0]
 
 
+def test_person_scoped_definition_unit_rejects_section_1402a_net_earnings_module_source():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    (a) Net earnings from self-employment The term net earnings from
+    self-employment means the gross income derived by an individual from any
+    trade or business carried on by such individual, less deductions. (12) in
+    lieu of the deduction provided by section 164(f), there shall be allowed a
+    deduction equal to the product of the taxpayer's net earnings and one-half
+    of the section 1401 rates.
+rules:
+  - name: net_earnings_before_paragraph_12_adjustment
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 1402(a), before paragraph (12)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          self_employment_trade_or_business_gross_income
+          - self_employment_trade_or_business_deductions
+  - name: paragraph_12_deduction_rate
+    kind: derived
+    entity: TaxUnit
+    dtype: Rate
+    period: Year
+    source: 26 USC 1402(a)(12)(B)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.0765
+  - name: paragraph_12_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 1402(a)(12)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: net_earnings_before_paragraph_12_adjustment * paragraph_12_deduction_rate
+  - name: net_earnings_from_self_employment
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 1402(a), including paragraph (12)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: net_earnings_before_paragraph_12_adjustment - paragraph_12_deduction
+"""
+
+    issues = find_person_scoped_definition_unit_issues(content)
+
+    assert len(issues) == 3
+    assert "net_earnings_before_paragraph_12_adjustment" in issues[0]
+    assert any("paragraph_12_deduction`" in issue for issue in issues)
+    assert any("net_earnings_from_self_employment" in issue for issue in issues)
+    assert not any("paragraph_12_deduction_rate" in issue for issue in issues)
+
+
 def test_person_scoped_definition_unit_rejects_individual_eitc_earned_income():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.544"
+version = "0.2.545"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- narrow parent `to the extent` deferral guidance so parent encodes can compose imported terminal child outputs instead of deferring just because a child handled its own internal exclusion
- extend person-scope validation to catch quoted `26 USC 1402(a)` net-earnings definitions left on `TaxUnit` money outputs
- add regressions for EITC child internal `to the extent` handling and stale TaxUnit-shaped 1402(a) net-earnings outputs

## Validation
- `uv run --extra dev --python 3.13 ruff format src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_encoder_backend.py tests/test_evals.py tests/test_rulespec_validation.py`
- `uv run --extra dev --python 3.13 ruff check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_encoder_backend.py tests/test_evals.py tests/test_rulespec_validation.py`
- `uv run --extra dev --python 3.13 pytest tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_statutory_base_naming_guidance tests/test_evals.py::test_build_eval_prompt_targets_rulespec_yaml tests/test_evals.py::TestEvalPrompt::test_build_eval_prompt_forces_partial_extent_child_parent_defer tests/test_evals.py::TestEvalPrompt::test_build_eval_prompt_does_not_defer_parent_for_child_internal_extent tests/test_evals.py::TestEvalPrompt::test_build_eval_prompt_does_not_defer_amount_adjustment_parent_list tests/test_rulespec_validation.py::test_person_scoped_definition_unit_rejects_individual_income_definition tests/test_rulespec_validation.py::test_person_scoped_definition_unit_rejects_section_1402a_net_earnings_module_source tests/test_rulespec_validation.py::test_person_scoped_definition_unit_rejects_individual_eitc_earned_income tests/test_rulespec_validation.py::test_person_scoped_definition_unit_accepts_relation_rollup -q`

## Encode observations
- `26 USC 1402(a)` repo-augmented rerun: `compile=yes`, `ci=yes`, but emitted `module.status: deferred` for final net earnings rather than a usable person-scoped artifact
- direct validator check against current live `statutes/26/1402/a.yaml` now flags the three stale TaxUnit money outputs: `net_earnings_before_paragraph_12_adjustment`, `paragraph_12_deduction`, and `net_earnings_from_self_employment`
