### PR TITLE
Reject stale person-scope imports

### DIFF
--- a/changelog.d/eitc-imported-person-scope.fixed.md
+++ b/changelog.d/eitc-imported-person-scope.fixed.md
@@ -1,0 +1,1 @@
+Reject generated EITC/self-employment tax artifacts that compose stale unit-scoped imports for person-scoped statutory definitions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.546"
+version = "0.2.547"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.546"
+__version__ = "0.2.547"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -7427,6 +7427,119 @@ def find_person_scoped_definition_unit_issues(content: str) -> list[str]:
     return issues
 
 
+def find_imported_person_scoped_definition_unit_issues(
+    content: str,
+    *,
+    rules_file: Path,
+    policy_repo_path: Path,
+) -> list[str]:
+    """Flag unit-scope formulas that compose stale imported person-scope definitions."""
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+
+    bad_imported_symbols: dict[str, str] = {}
+    for import_item in _extract_import_items_from_content(content):
+        import_base, separator, imported_symbol = import_item.partition("#")
+        imported_symbol = imported_symbol.strip()
+        if not separator or not imported_symbol:
+            continue
+        import_file = _resolve_rulespec_import_file_static(
+            import_base,
+            rules_file=rules_file,
+            policy_repo_path=policy_repo_path,
+        )
+        if import_file is None:
+            continue
+        imported_content = import_file.read_text()
+        if not _imported_symbol_is_person_scoped_definition_at_unit_scope(
+            imported_content,
+            imported_symbol,
+        ):
+            continue
+        bad_imported_symbols[imported_symbol] = import_item
+
+    if not bad_imported_symbols:
+        return []
+
+    formula_records = _rulespec_rule_formula_rule_records(payload)
+    formula_by_name = {
+        name: formula
+        for name, kind, formula, _source, _rule in formula_records
+        if kind == "derived"
+    }
+    issues: list[str] = []
+    for name, kind, formula, _rule_source, rule in formula_records:
+        if kind != "derived":
+            continue
+        entity = str(rule.get("entity") or "").strip()
+        if entity.lower() not in _UNIT_SCOPED_ENTITY_NAMES:
+            continue
+        dtype = str(rule.get("dtype") or "").strip().lower()
+        if dtype not in {"money", "decimal"}:
+            continue
+        imported_dependencies = sorted(
+            _formula_local_identifiers(formula) & set(bad_imported_symbols)
+        )
+        if not imported_dependencies:
+            continue
+        if _formula_or_referenced_helpers_use_relation_aggregate(
+            formula,
+            formula_by_name=formula_by_name,
+        ):
+            continue
+        formatted = ", ".join(
+            f"`{bad_imported_symbols[symbol]}`" for symbol in imported_dependencies
+        )
+        issues.append(
+            "Imported person-scoped definition at unit scope: "
+            f"`{name}` is declared on `{entity}` and composes imported "
+            f"{formatted}, whose source defines a lower-entity amount while "
+            "the imported RuleSpec exports it at unit scope. Re-encode/import "
+            "the upstream definition at the lower entity first, then aggregate "
+            "through an explicit relation; do not build new unit-scope formulas "
+            "on top of stale aggregate imports."
+        )
+    return issues
+
+
+def _imported_symbol_is_person_scoped_definition_at_unit_scope(
+    content: str,
+    symbol: str,
+) -> bool:
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return False
+    source_text = extract_embedded_source_text(content)
+    if not source_text:
+        source_text = _extract_source_verification_text(content)
+    if not source_text:
+        return False
+
+    for name, kind, _formula, rule_source, rule in _rulespec_rule_formula_rule_records(
+        payload
+    ):
+        if name != symbol or kind != "derived":
+            continue
+        entity = str(rule.get("entity") or "").strip().lower()
+        if entity not in _UNIT_SCOPED_ENTITY_NAMES:
+            return False
+        dtype = str(rule.get("dtype") or "").strip().lower()
+        if dtype not in {"money", "decimal"}:
+            return False
+        scoped_source_text = " ".join(_rule_proof_source_excerpts(rule))
+        if not scoped_source_text:
+            scoped_source_text = _source_text_for_rule_source(source_text, rule_source)
+        if _PERSON_SCOPED_DEFINITION_SOURCE_PATTERN.search(scoped_source_text):
+            return True
+        return _person_scoped_definition_module_fallback_applies(
+            source_text=source_text,
+            rule_source=rule_source,
+            rule=rule,
+        )
+    return False
+
+
 def _person_scoped_definition_module_fallback_applies(
     *,
     source_text: str,
@@ -14329,6 +14442,35 @@ def _imported_rate_source_is_thresholded(content: str, rate_name: str) -> bool:
     )
 
 
+_SOURCE_STATED_COMPOSITE_RATE_PATTERN = re.compile(
+    r"\b(?:one-half|half|sum)\b[\s\S]{0,160}\b"
+    r"rates?\s+imposed\s+by\b"
+    r"|"
+    r"\brates?\s+imposed\s+by\b[\s\S]{0,160}\b(?:one-half|half|sum)\b",
+    flags=re.IGNORECASE,
+)
+
+
+def _block_is_source_stated_composite_rate(
+    block: Mapping[str, object],
+    source_text: str,
+) -> bool:
+    """Allow Rate rules when the source itself asks for a sum of imported rates."""
+    if str(block.get("dtype") or "").strip().lower() != "rate":
+        return False
+    proof_excerpts = block.get("proof_excerpts")
+    scoped_text = (
+        " ".join(str(item) for item in proof_excerpts)
+        if isinstance(proof_excerpts, list)
+        else ""
+    ).strip()
+    if not scoped_text:
+        scoped_text = str(block.get("source") or "")
+    if not scoped_text:
+        scoped_text = source_text
+    return bool(_SOURCE_STATED_COMPOSITE_RATE_PATTERN.search(scoped_text))
+
+
 def _formula_preserves_thresholded_rate_mechanics(formula: str) -> bool:
     """Return whether a local formula appears to preserve limited-rate mechanics."""
     normalized = _normalize_identifier(formula)
@@ -18465,6 +18607,13 @@ class ValidatorPipeline:
         issues.extend(find_shared_statutory_rate_entity_suffix_name_issues(content))
         issues.extend(find_person_scoped_rate_base_unit_issues(content))
         issues.extend(find_person_scoped_definition_unit_issues(content))
+        issues.extend(
+            find_imported_person_scoped_definition_unit_issues(
+                content,
+                rules_file=rules_file,
+                policy_repo_path=self.policy_repo_path,
+            )
+        )
         issues.extend(find_helper_only_definition_issues(content))
         issues.extend(find_deferred_output_issues(content))
         # Read the requested-source target from the nearby eval workspace or
@@ -19265,6 +19414,7 @@ class ValidatorPipeline:
     ) -> list[str]:
         """Reject formulas that flatten thresholded imported rates into flat rates."""
         content = rulespec_file.read_text()
+        source_text = extract_embedded_source_text(content)
         imported_rate_sources: dict[str, str] = {}
         for import_item in self._extract_import_items(content):
             fragment = self._import_item_fragment(import_item)
@@ -19294,6 +19444,8 @@ class ValidatorPipeline:
             identifiers = _formula_local_identifiers(formula)
             for rate_name, import_item in sorted(imported_rate_sources.items()):
                 if rate_name not in identifiers:
+                    continue
+                if _block_is_source_stated_composite_rate(block, source_text):
                     continue
                 if _formula_preserves_thresholded_rate_mechanics(formula):
                     continue

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -45,6 +45,16 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   definition is currently encoded at a filing-unit, tax-unit, household, or
   other unit boundary. Only add a unit-level roll-up when this source text
   itself states that aggregate.
+- Do not compose a new unit-scope Money/Decimal formula from an imported
+  output whose copied source summary or proof defines the base as a
+  lower-entity amount, such as net earnings "derived by an individual",
+  self-employment income "of every individual", wages paid to an employee, or
+  earned income of an individual. Treat that import as stale aggregate context:
+  use an available lower-entity import, expose a lower-entity boundary input
+  for the named legal base and compute the current amount at that lower entity,
+  or defer the current executable output if the required lower-entity shape and
+  relation cannot be represented. Do not build a TaxUnit/Household formula on
+  top of the stale aggregate import.
 - If the only unavailable dependency for that lower-entity rate-applied result
   is the value of a named legal base, keep the result executable by exposing a
   local boundary input for that base instead of deferring the tax, credit,
@@ -304,6 +314,11 @@ Hard requirements:
   the canonical home for the scalar. Import the exact child export and use it
   in the current formula; do not emit a duplicate local `parameter` with the
   same value or name in the parent/composition file.
+- When encoding a child fragment or subparagraph, also check copied parent and
+  sibling context for exported helper, parameter, and amount names. Do not emit
+  a local rule with the same name as a copied parent or sibling export. Import
+  and use that export if it is the same legal concept, or choose a
+  source-specific name for the new child concept if the legal meaning differs.
 - Before using any imported output in arithmetic, check the copied context
   export's `dtype:`. An imported `dtype: Judgment` is a predicate, not a scalar
   amount, rate, or base. Never multiply, add, subtract, divide, `min`, or `max`
@@ -571,6 +586,13 @@ Hard requirements:
   not import an unrelated output from that file as a stand-in; encode the proper
   upstream source slice first, split the unresolved branch, or emit a deferred
   status when the requested file cannot compute faithfully without it.
+- If the source says the current deduction, tax, rate, or amount applies "in
+  lieu of" another section's amount, or parenthetically says another section is
+  "relating to" that displaced amount, do not import the displaced section
+  unless the current formula actually uses an exported value from it. The
+  replacement formula must be based on the current source's stated base, rate,
+  and conditions; a top-level import used only to acknowledge the displaced
+  section is an unused/proof-only import and is invalid.
 - When the requested source imposes a rate, tax, deduction, credit, cap, or
   threshold on a legal term that is defined by an available upstream RuleSpec
   file, import that upstream definition and use it in the formula. Do not leave

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -93,6 +93,8 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "Importing an adjacent upstream output only as proof" in ENCODER_PROMPT
     assert "does not satisfy the dependency" in ENCODER_PROMPT
     assert "is not an executable dependency" in ENCODER_PROMPT
+    assert "same name as a copied parent or sibling export" in ENCODER_PROMPT
+    assert "unused/proof-only import" in ENCODER_PROMPT
     assert "directly or transitively" in ENCODER_PROMPT
     assert "numeric boundary input" in ENCODER_PROMPT
     assert "rate-bearing source" in ENCODER_PROMPT
@@ -139,6 +141,8 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
         "Existing target or repository-precedent files are not entity-scope authority"
     ) in ENCODER_PROMPT
     assert "treat the copied aggregate shape as a defect to repair" in ENCODER_PROMPT
+    assert "Treat that import as stale aggregate context" in ENCODER_PROMPT
+    assert "Do not build a TaxUnit/Household formula" in ENCODER_PROMPT
     assert "earned income of an individual shall be\n  computed" in ENCODER_PROMPT
     assert "replaced by one aggregated boundary input" in ENCODER_PROMPT
     assert "current\n  requested source changes the basis" in ENCODER_PROMPT
@@ -202,6 +206,8 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "Importing an adjacent upstream output only as proof" in prompt
     assert "does not satisfy the dependency" in prompt
     assert "is not an executable dependency" in prompt
+    assert "same name as a copied parent or sibling export" in prompt
+    assert "unused/proof-only import" in prompt
     assert "Do not treat a missing\n  deferred child branch as zero" in prompt
     assert "purpose-limited replacement rate" in prompt
     assert "computed at" in prompt
@@ -214,6 +220,8 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "toggle each gate at least once" in prompt
     assert "rate-applied result at the source-stated lower entity" in prompt
     assert "unit-level placeholder or aggregate base by the rate" in prompt
+    assert "Treat that import as stale aggregate context" in prompt
+    assert "Do not build a TaxUnit/Household formula" in prompt
     assert "Never drop the jurisdiction prefix" in prompt
     assert "listed under invalid copied local inputs" in prompt
     assert "do not preserve, rename, or recreate" in prompt

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -49,6 +49,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_helper_only_definition_issues,
     find_import_shape_issues,
     find_imported_deferred_branch_composition_issues,
+    find_imported_person_scoped_definition_unit_issues,
     find_interval_table_reencoding_candidates,
     find_interval_table_reencoding_issues,
     find_judgment_conditional_formula_issues,
@@ -8532,6 +8533,68 @@ rules:
     assert issues == []
 
 
+def test_thresholded_imported_rate_allows_source_stated_composite_rate(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    imported_file = repo / "statutes" / "26" / "1401.yaml"
+    rules_file = repo / "statutes" / "26" / "1402" / "a" / "12.yaml"
+    imported_file.parent.mkdir(parents=True)
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    imported_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: self_employment_oasdi_tax_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '1990-01-01'
+        formula: 0.124
+  - name: self_employment_oasdi_wage_base
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 184500
+"""
+    )
+    rules_file.write_text(
+        """format: rulespec/v1
+imports:
+  - us:statutes/26/1401#self_employment_oasdi_tax_rate
+module:
+  summary: |-
+    There shall be allowed a deduction equal to the product of the taxpayer's
+    net earnings from self-employment and one-half of the sum of the rates
+    imposed by subsections (a) and (b) of section 1401.
+rules:
+  - name: paragraph_12_deduction_rate
+    kind: derived
+    entity: Person
+    dtype: Rate
+    period: Year
+    source: 26 USC 1402(a)(12)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              excerpt: one-half of the sum of the rates imposed by subsections (a) and (b) of section 1401
+    versions:
+      - effective_from: '1990-01-01'
+        formula: self_employment_oasdi_tax_rate / 2
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_flattened_thresholded_imported_rates(rules_file)
+
+    assert issues == []
+
+
 def test_cross_reference_base_mechanics_raw_compensation_tax_is_rejected(tmp_path):
     repo = tmp_path / "rulespec-us"
     rules_file = repo / "statutes" / "26" / "3201.yaml"
@@ -13252,6 +13315,70 @@ rules:
 """
 
     assert find_person_scoped_definition_unit_issues(content) == []
+
+
+def test_imported_person_scoped_definition_unit_rejects_stale_1402a_import(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    imported_file = repo / "statutes" / "26" / "1402" / "a.yaml"
+    imported_file.parent.mkdir(parents=True)
+    imported_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    (a) Net earnings from self-employment The term net earnings from
+    self-employment means the gross income derived by an individual from any
+    trade or business carried on by such individual, less deductions. (12) in
+    lieu of the deduction provided by section 164(f), there shall be allowed a
+    deduction equal to the product of the taxpayer's net earnings and one-half
+    of the section 1401 rates.
+rules:
+  - name: net_earnings_before_paragraph_12_adjustment
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 1402(a), before paragraph (12)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: self_employment_trade_or_business_gross_income - self_employment_trade_or_business_deductions
+"""
+    )
+    content = """format: rulespec/v1
+imports:
+  - us:statutes/26/1402/a#net_earnings_before_paragraph_12_adjustment
+module:
+  summary: |-
+    In lieu of the deduction provided by section 164(f), a deduction is allowed
+    equal to the product of the taxpayer's net earnings from self-employment
+    for the taxable year, determined without regard to paragraph (12), and
+    one-half of the section 1401 rates.
+rules:
+  - name: paragraph_12_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 1402(a)(12)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: max(0, net_earnings_before_paragraph_12_adjustment) * paragraph_12_deduction_rate
+"""
+    rules_file = repo / "statutes" / "26" / "1402" / "a" / "12.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(content)
+
+    issues = find_imported_person_scoped_definition_unit_issues(
+        content,
+        rules_file=rules_file,
+        policy_repo_path=repo,
+    )
+
+    assert len(issues) == 1
+    assert "Imported person-scoped definition at unit scope" in issues[0]
+    assert "paragraph_12_deduction" in issues[0]
+    assert "net_earnings_before_paragraph_12_adjustment" in issues[0]
 
 
 def test_employer_scoped_entity_rejects_tax_unit():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.546"
+version = "0.2.547"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a validator check that blocks unit-scope formulas from composing imported outputs whose source defines a person/lower-entity amount but whose imported RuleSpec still exports that amount at unit scope
- cover the observed 26 USC 1402(a)(12) failure mode where the generated paragraph artifact imports stale TaxUnit-shaped 1402(a)#net_earnings_before_paragraph_12_adjustment
- bump axiom-encode to 0.2.546 and add changelog entry

## Validation
- uv run --extra dev --python 3.13 ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py pyproject.toml src/axiom_encode/__init__.py
- uv run --extra dev --python 3.13 pytest tests/test_rulespec_validation.py::test_imported_person_scoped_definition_unit_rejects_stale_1402a_import tests/test_rulespec_validation.py::test_person_scoped_definition_unit_rejects_section_1402a_net_earnings_module_source tests/test_rulespec_validation.py::test_person_scoped_definition_unit_rejects_individual_income_definition tests/test_rulespec_validation.py::test_person_scoped_definition_unit_rejects_individual_eitc_earned_income tests/test_rulespec_validation.py::test_person_scoped_definition_unit_accepts_relation_rollup -q
- direct probe of /tmp/axiom-encode-encodings/codex-gpt-5.5/statutes/26/1402/a/12.yaml reports one Imported person-scoped definition at unit scope issue for paragraph_12_deduction
