### PR TITLE
Tighten 1402(a)(12) person-scope encoding

### DIFF
--- a/changelog.d/eitc-1402a12-person-scope.fixed.md
+++ b/changelog.d/eitc-1402a12-person-scope.fixed.md
@@ -1,0 +1,1 @@
+Tighten encoder guidance and validation for 26 USC 1402(a)(12) so generated self-employment net-earnings deductions stay person-scoped instead of composing stale TaxUnit parent context.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.547"
+version = "0.2.548"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.547"
+__version__ = "0.2.548"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -7372,6 +7372,13 @@ _PERSON_SCOPED_DEFINITION_SOURCE_PATTERN = re.compile(
     flags=re.IGNORECASE,
 )
 
+_SECTION_1402_A_12_PERSON_BASE_PATTERN = re.compile(
+    r"\b(?:taxpayer'?s?\s+)?net\s+earnings?\s+from\s+self[-\s]?employment\b"
+    r"[\s\S]{0,220}\bdetermined\s+without\s+regard\s+to\s+"
+    r"(?:this\s+paragraph|paragraph\s*\(?12\)?)\b",
+    flags=re.IGNORECASE,
+)
+
 
 def find_person_scoped_definition_unit_issues(content: str) -> list[str]:
     """Flag unit-level derived definitions for person-scoped legal amounts."""
@@ -7400,15 +7407,29 @@ def find_person_scoped_definition_unit_issues(content: str) -> list[str]:
         scoped_source_text = " ".join(_rule_proof_source_excerpts(rule))
         if not scoped_source_text:
             scoped_source_text = _source_text_for_rule_source(source_text, rule_source)
+        if (
+            not _PERSON_SCOPED_DEFINITION_SOURCE_PATTERN.search(scoped_source_text)
+            and not _section_1402_a_12_person_base_applies(
+                scoped_source_text=scoped_source_text,
+                source_text=source_text,
+                rule_source=rule_source,
+                rule=rule,
+            )
+            and _person_scoped_definition_module_fallback_applies(
+                source_text=source_text,
+                rule_source=rule_source,
+                rule=rule,
+            )
+        ):
+            scoped_source_text = source_text
         if not _PERSON_SCOPED_DEFINITION_SOURCE_PATTERN.search(
             scoped_source_text
-        ) and _person_scoped_definition_module_fallback_applies(
+        ) and not _section_1402_a_12_person_base_applies(
+            scoped_source_text=scoped_source_text,
             source_text=source_text,
             rule_source=rule_source,
             rule=rule,
         ):
-            scoped_source_text = source_text
-        if not _PERSON_SCOPED_DEFINITION_SOURCE_PATTERN.search(scoped_source_text):
             continue
         if _formula_or_referenced_helpers_use_relation_aggregate(
             formula,
@@ -7562,6 +7583,34 @@ def _person_scoped_definition_module_fallback_applies(
             "self_employment_income",
             "paragraph_12_deduction",
         )
+    )
+
+
+def _section_1402_a_12_person_base_applies(
+    *,
+    scoped_source_text: str,
+    source_text: str,
+    rule_source: str,
+    rule: Mapping[str, Any],
+) -> bool:
+    source = str(rule_source).lower()
+    if "1402(a)(12" not in source and "1402(a), including paragraph (12" not in source:
+        return False
+    if str(rule.get("dtype") or "").strip().lower() == "rate":
+        return False
+    name = str(rule.get("name") or "").lower()
+    if not any(
+        marker in name
+        for marker in (
+            "net_earnings",
+            "self_employment",
+            "deduction",
+        )
+    ):
+        return False
+    return bool(
+        _SECTION_1402_A_12_PERSON_BASE_PATTERN.search(scoped_source_text)
+        or _SECTION_1402_A_12_PERSON_BASE_PATTERN.search(source_text)
     )
 
 
@@ -14421,6 +14470,32 @@ def _identifier_phrase_occurs(term: str, identifier: str) -> bool:
     return f"_{normalized_term}_" in f"_{normalized_identifier}_"
 
 
+def _same_section_term_overlap_is_rate_import(
+    local_term: str,
+    imported_symbol: str,
+    import_item: str,
+) -> bool:
+    """Return whether a term overlap is a cited rate, not a stand-in amount."""
+    normalized_local = _normalize_identifier(local_term)
+    normalized_symbol = _normalize_identifier(imported_symbol)
+    if not normalized_local or not normalized_symbol:
+        return False
+    if normalized_local.endswith(("_rate", "_tax_rate")):
+        return False
+    if not normalized_symbol.endswith(("_rate", "_tax_rate")):
+        return False
+    if normalized_symbol not in {
+        f"{normalized_local}_rate",
+        f"{normalized_local}_tax_rate",
+    }:
+        return False
+    import_path = import_item.split("#", 1)[0]
+    import_path_tokens = {
+        token for token in re.split(r"[^a-z0-9]+", import_path.lower()) if token
+    }
+    return "rate" in import_path_tokens or "rates" in import_path_tokens
+
+
 def _imported_rate_source_is_thresholded(content: str, rate_name: str) -> bool:
     """Return whether an imported rate file also encodes limited rate mechanics."""
     if rate_name not in _formula_local_identifiers(content):
@@ -19526,6 +19601,15 @@ class ValidatorPipeline:
                     if _identifier_phrase_occurs(local_term, symbol)
                 ]
                 if not overlapping_symbols:
+                    continue
+                if all(
+                    _same_section_term_overlap_is_rate_import(
+                        local_term,
+                        symbol,
+                        import_item,
+                    )
+                    for symbol in overlapping_symbols
+                ):
                     continue
                 if self._source_summary_cites_import_for_term(
                     source_text,

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -93,6 +93,22 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   Add an aggregate rule only when the same source defines how those person
   amounts roll up to a tax unit, household, family, or other unit. Do not let
   the word "taxpayer" erase a source-stated individual/person subject.
+- For 26 USC 1402(a)(12), the phrase "the taxpayer's net earnings from
+  self-employment ... determined without regard to this paragraph" is still the
+  1402(a) net-earnings term, whose parent definition is gross income "derived
+  by an individual" from a trade or business. Encode the paragraph (12)
+  deduction and its net-earnings base on `Person`, not `TaxUnit`, unless the
+  requested source separately states a filing-unit roll-up. If an existing
+  `us:statutes/26/1402/a#net_earnings_before_paragraph_12_adjustment` import is
+  unit-scoped, treat it as stale context; do not import it into a new
+  `TaxUnit` deduction. Use a lower-entity import when available, or expose a
+  person-level boundary input such as
+  `net_earnings_from_self_employment_determined_without_regard_to_paragraph_12`.
+  Import the section 1401(a) and section 1401(b)(1) rates when those rate files
+  are in context. Do not assert raw `parameter` outputs such as a one-half
+  fraction in companion tests. For paragraph (12), assert derived `Person`
+  outputs only, such as the derived deduction rate and derived deduction amount;
+  split tests by entity if any non-`Person` output remains.
 - When a tax definition says "earned income of an individual shall be
   computed" with exclusions for that individual's income, services, payments,
   status, or self-employment amounts, keep those earned-income components on

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -143,6 +143,17 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "treat the copied aggregate shape as a defect to repair" in ENCODER_PROMPT
     assert "Treat that import as stale aggregate context" in ENCODER_PROMPT
     assert "Do not build a TaxUnit/Household formula" in ENCODER_PROMPT
+    assert "For 26 USC 1402(a)(12)" in ENCODER_PROMPT
+    assert (
+        "paragraph (12)\n  deduction and its net-earnings base on `Person`"
+        in ENCODER_PROMPT
+    )
+    assert (
+        "net_earnings_from_self_employment_determined_without_regard_to_paragraph_12"
+        in ENCODER_PROMPT
+    )
+    assert "Do not assert raw `parameter` outputs" in ENCODER_PROMPT
+    assert "assert derived `Person`\n  outputs only" in ENCODER_PROMPT
     assert "earned income of an individual shall be\n  computed" in ENCODER_PROMPT
     assert "replaced by one aggregated boundary input" in ENCODER_PROMPT
     assert "current\n  requested source changes the basis" in ENCODER_PROMPT

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -554,6 +554,51 @@ rules:
     assert pipeline._check_unrelated_same_section_term_imports(rules_file) == []
 
 
+def test_unrelated_same_section_term_import_allows_cross_section_tax_rate(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    section_root = repo / "statutes/26/1402"
+    section_root.mkdir(parents=True)
+    (section_root / "b.yaml").write_text(
+        """format: rulespec/v1
+module:
+  summary: Definition of self-employment income.
+  deferred_outputs:
+    - output: us:statutes/26/1402/b#self_employment_income
+      reason: Needs trade-or-business income mechanics.
+rules: []
+"""
+    )
+    rules_file = section_root / "a/12.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+imports:
+  - us:statutes/26/1401/b/1/rate#self_employment_income_tax_rate
+module:
+  summary: Paragraph (12) uses one-half of the section 1401(b)(1) rate.
+rules:
+  - name: paragraph_12_deduction_rate
+    kind: derived
+    entity: Person
+    dtype: Rate
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: self_employment_income_tax_rate / 2
+"""
+    )
+
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    assert pipeline._check_unrelated_same_section_term_imports(rules_file) == []
+
+
 def test_rulespec_companion_runner_uses_rows_for_absolute_list_outputs(
     monkeypatch, tmp_path
 ):
@@ -13250,6 +13295,37 @@ rules:
     assert any("paragraph_12_deduction`" in issue for issue in issues)
     assert any("net_earnings_from_self_employment" in issue for issue in issues)
     assert not any("paragraph_12_deduction_rate" in issue for issue in issues)
+
+
+def test_person_scoped_definition_unit_rejects_section_1402a12_taxpayer_net_earnings_child_source():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    In lieu of the deduction provided by section 164(f), there shall be allowed
+    a deduction equal to the product of the taxpayer's net earnings from
+    self-employment for the taxable year, determined without regard to this
+    paragraph, and one-half of the sum of the rates imposed by subsections (a)
+    and (b) of section 1401.
+rules:
+  - name: deduction_in_lieu_of_section_164_f
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 1402(a)(12)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          net_earnings_from_self_employment_determined_without_regard_to_paragraph_12
+          * deduction_rate_in_lieu_of_section_164_f
+"""
+
+    issues = find_person_scoped_definition_unit_issues(content)
+
+    assert any("Person-scoped definition at unit scope" in issue for issue in issues)
+    assert "deduction_in_lieu_of_section_164_f" in issues[0]
+    assert "TaxUnit" in issues[0]
 
 
 def test_person_scoped_definition_unit_rejects_individual_eitc_earned_income():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.547"
+version = "0.2.548"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add targeted prompt guidance for 26 USC 1402(a)(12) so generated deductions stay person-scoped and do not reuse stale 1402(a) TaxUnit imports
- add validator coverage for child-source 1402(a)(12) artifacts that compute net-earnings deductions at TaxUnit scope
- bump axiom-encode to 0.2.548 with changelog fragment

## Context
- Prior no-apply runs showed the model either deferred broad 1402(a) or regenerated a TaxUnit 1402(a)(12) deduction from stale `us:statutes/26/1402/a#net_earnings_before_paragraph_12_adjustment`.
- PR #511 now blocks applying that stale-import shape; this PR makes the prompt/validator more explicit so generation moves toward the correct person-level artifact.

## Validation
- `uv run --extra dev --python 3.13 ruff check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/validator_pipeline.py tests/test_encoder_backend.py tests/test_rulespec_validation.py pyproject.toml src/axiom_encode/__init__.py`
- `uv run --extra dev --python 3.13 pytest tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_statutory_base_naming_guidance tests/test_rulespec_validation.py::test_person_scoped_definition_unit_rejects_section_1402a12_taxpayer_net_earnings_child_source tests/test_rulespec_validation.py::test_imported_person_scoped_definition_unit_rejects_stale_1402a_import tests/test_rulespec_validation.py::test_person_scoped_definition_unit_rejects_section_1402a_net_earnings_module_source tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`