### PR TITLE
Guard in-lieu cited import guidance

### DIFF
--- a/changelog.d/1402-in-lieu-displacement-import.fixed.md
+++ b/changelog.d/1402-in-lieu-displacement-import.fixed.md
@@ -1,0 +1,1 @@
+Prevent cited-import prompt guidance from treating displaced `in lieu of` deduction references as mandatory final-amount imports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.548"
+version = "0.2.549"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.548"
+__version__ = "0.2.549"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2319,7 +2319,13 @@ def _select_cross_section_context_files(
         for candidate_rel in _cited_context_candidate_paths(cited_parts):
             if candidate_rel == target_rel:
                 continue
-            candidates = _cited_context_candidates(policy_root, candidate_rel)
+            candidates = _cited_context_candidates(
+                policy_root,
+                candidate_rel,
+                include_exporting_candidate_children=(
+                    _source_text_requests_cited_subsection_rates(source_text)
+                ),
+            )
             if not candidates:
                 continue
             for candidate in candidates:
@@ -2329,6 +2335,24 @@ def _select_cross_section_context_files(
                     seen.add(resolved)
             break
     return selected
+
+
+def _source_text_requests_cited_subsection_rates(source_text: str) -> bool:
+    """Return whether source asks for rates under cited section subsections."""
+    return bool(
+        re.search(
+            r"\b(?:rate|rates|percentage|percentages)\b.{0,120}"
+            r"\bsubsections?\b.{0,120}\bsection\b",
+            source_text,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+        or re.search(
+            r"\bsection\b.{0,120}\bsubsections?\b.{0,120}"
+            r"\b(?:rate|rates|percentage|percentages)\b",
+            source_text,
+            flags=re.IGNORECASE | re.DOTALL,
+        )
+    )
 
 
 def _cited_context_candidate_paths(cited_parts: CitationParts) -> list[Path]:
@@ -5388,12 +5412,20 @@ def _format_cited_context_import_guidance(
         references = ", ".join(f"`{item.import_path}#{name}`" for name in exports[:8])
         if len(exports) > 8:
             references += ", ..."
-        preferred_exports = _preferred_exports_for_cited_reference(
-            source_text,
-            citation,
-            exports,
-        )
+        preferred_exports: list[str] = []
         preferred_note = ""
+        if _source_text_citation_is_displacement_reference(source_text, citation):
+            preferred_note = (
+                " This citation appears in a displacement or replacement phrase; "
+                "use the cited file only as context for what is being displaced. "
+                "Do not import the cited final amount solely because it is named."
+            )
+        else:
+            preferred_exports = _preferred_exports_for_cited_reference(
+                source_text,
+                citation,
+                exports,
+            )
         if preferred_exports:
             preferred = ", ".join(
                 f"`{item.import_path}#{name}`" for name in preferred_exports
@@ -5419,6 +5451,10 @@ formula. Do not keep a local `_under_section_...` or `_under_subsection_...`
 input, or a local `_provided_in_section_...`, `_allowed_under_section_...`,
 `_deduction_under_section_...`, or `_credit_allowed_under_section_...` input,
 for an already copied RuleSpec context target.
+If a cited target appears in a displacement phrase such as `in lieu of`,
+`instead of`, or `in place of`, do not import the cited target's final amount
+solely because it is cited; encode the current source's replacement amount or
+rate from the current source text.
 """
 
 
@@ -5911,6 +5947,24 @@ def _preferred_exports_for_cited_reference(
             continue
         scored.append(((-score, len(export), exports.index(export), export), export))
     return [export for _sort_key, export in sorted(scored)[:3]]
+
+
+def _source_text_citation_is_displacement_reference(
+    source_text: str,
+    citation: _StatuteCitation,
+) -> bool:
+    """Return whether a cited provision is being displaced, not composed."""
+    window = _source_text_citation_window(source_text, citation).lower()
+    if not window:
+        return False
+    if not re.search(r"\b(?:in\s+lieu\s+of|instead\s+of|in\s+place\s+of)\b", window):
+        return False
+    return bool(
+        re.search(
+            r"\b(?:deduction|credit|allowance|exemption|rate|tax|amount)\b",
+            window,
+        )
+    )
 
 
 def _source_text_citation_window(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -5961,6 +5961,55 @@ rules:
         assert "`us:statutes/26/1211#other_taxpayer_capital_losses_allowed`" in prompt
         assert "Do not keep a local `_under_section_...`" in prompt
 
+    def test_build_eval_prompt_treats_in_lieu_citation_as_displaced_context(
+        self, tmp_path
+    ):
+        policy_repo_root = tmp_path / "rulespec-us"
+        cited_file = policy_repo_root / "statutes" / "26" / "164" / "f.yaml"
+        cited_file.parent.mkdir(parents=True)
+        cited_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: self_employment_tax_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: self_employment_tax * 0.5
+"""
+        )
+        workspace = prepare_eval_workspace(
+            citation="26 USC 1402(a)(12)",
+            runner=parse_runner_spec("codex:gpt-5.4"),
+            output_root=tmp_path / "out",
+            source_text=(
+                "In lieu of the deduction provided by section 164(f), there "
+                "shall be allowed a deduction equal to the product of the "
+                "taxpayer's net earnings from self-employment and one-half of "
+                "the rates imposed by section 1401."
+            ),
+            axiom_rules_path=policy_repo_root,
+            mode="repo-augmented",
+            extra_context_paths=[cited_file],
+        )
+
+        prompt = _build_eval_prompt(
+            "26 USC 1402(a)(12)",
+            "repo-augmented",
+            workspace,
+            workspace.context_files,
+            target_file_name="12.yaml",
+            target_ref_prefix="us:statutes/26/1402/a/12",
+            include_tests=True,
+        )
+
+        assert "Source cites `164(f)`" in prompt
+        assert "displacement or replacement phrase" in prompt
+        assert "Do not import the cited final amount" in prompt
+        assert "prefer the final imported output" not in prompt
+
     def test_build_eval_prompt_guides_excluded_child_branch_imports(self, tmp_path):
         policy_repo_root = tmp_path / "rulespec-us"
         parent_file = policy_repo_root / "statutes" / "26" / "1401.yaml"
@@ -8041,6 +8090,62 @@ rules:
         assert copied_sources[str(parent)]["import_path"] == "us:statutes/26/3101"
         assert copied_sources[str(oasdi)]["import_path"] == "us:statutes/26/3101/a"
         assert copied_sources[str(hi)]["import_path"] == "us:statutes/26/3101/b/1"
+
+    def test_prepare_eval_workspace_adds_child_rate_context_for_exporting_cited_parent(
+        self, tmp_path
+    ):
+        repo_root = tmp_path / "repos"
+        policy_repo_root = repo_root / "axiom-rules-engine"
+        policy_repo_root.mkdir(parents=True)
+        section_root = repo_root / "rulespec-us" / "statutes" / "26" / "1401"
+        section_root.mkdir(parents=True)
+        parent = section_root.with_suffix(".yaml")
+        parent.write_text(
+            "format: rulespec/v1\n"
+            "rules:\n"
+            "  - name: self_employment_oasdi_tax_rate\n"
+            "    kind: parameter\n"
+            "    versions:\n"
+            "      - effective_from: '1990-01-01'\n"
+            "        formula: '0.124'\n"
+        )
+        oasdi_rate = section_root / "a" / "rate.yaml"
+        oasdi_rate.parent.mkdir(parents=True)
+        oasdi_rate.write_text(
+            "format: rulespec/v1\n"
+            "rules:\n"
+            "  - name: old_age_survivors_and_disability_insurance_tax_rate\n"
+            "    kind: parameter\n"
+            "    versions:\n"
+            "      - effective_from: '1990-01-01'\n"
+            "        formula: '0.124'\n"
+        )
+        hi_rate = section_root / "b" / "1" / "rate.yaml"
+        hi_rate.parent.mkdir(parents=True)
+        hi_rate.write_text(
+            "format: rulespec/v1\n"
+            "rules:\n"
+            "  - name: self_employment_income_tax_rate\n"
+            "    kind: parameter\n"
+            "    versions:\n"
+            "      - effective_from: '1990-01-01'\n"
+            "        formula: '0.029'\n"
+        )
+        source_text = (
+            "There shall be allowed a deduction equal to the product of net "
+            "earnings and one-half of the sum of the rates imposed by "
+            "subsections (a) and (b) of section 1401."
+        )
+
+        selected = _select_cross_section_context_files(
+            "26 USC 1402(a)(12)",
+            source_text,
+            repo_root / "rulespec-us",
+        )
+
+        assert parent in selected
+        assert oasdi_rate in selected
+        assert hi_rate in selected
 
     def test_prepare_eval_workspace_adds_cross_section_list_and_parent_fallback_context(
         self, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.548"
+version = "0.2.549"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Tightens cited-context prompt guidance so displacement phrases like `in lieu of the deduction provided by section 164(f)` do not tell the model to import the displaced final amount.\n\nLocal checks:\n- `uv run --extra dev --python 3.13 ruff check src/axiom_encode/harness/evals.py tests/test_evals.py pyproject.toml src/axiom_encode/__init__.py`\n- `uv run --extra dev --python 3.13 ruff format --check src/axiom_encode/harness/evals.py tests/test_evals.py`\n- `uv run --extra dev --python 3.13 pytest tests/test_evals.py -k treats_in_lieu_citation_as_displaced_context -q`\n- `uv run --extra dev --python 3.13 pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`