### PR TITLE
Classify 1402(a)(12) tax oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.599"
+version = "0.2.600"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.599"
+__version__ = "0.2.600"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -15422,6 +15422,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 1402(a) net-earnings-from-self-employment intermediates use statutory trade-or-business gross income, deduction, partnership, and paragraph (12) components that PE folds into taxable_self_employment_income unless an exact mapping overrides this prefix.
 
+  - legal_id_prefix: us:statutes/26/1402/a/
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 1402(a) child provision outputs, including paragraph (12) self-employment-tax-equivalent deduction helpers, are source-specific net-earnings assembly intermediates that PolicyEngine folds into taxable_self_employment_income unless an exact mapping overrides this prefix.
+
   - legal_id_prefix: us:statutes/26/164/f#
     country: us
     program: tax

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2134,6 +2134,12 @@ def test_policyengine_registry_is_legal_id_keyed():
         country="us",
     )
     assert section_2014c_poverty_line_mapping.mapping_type == "not_comparable"
+    section_1402a12_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/1402/a/12#self_employment_tax_equivalent_deduction",
+        country="us",
+    )
+    assert section_1402a12_mapping.mapping_type == "not_comparable"
+    assert section_1402a12_mapping.program == "tax"
     assert section_2014c_poverty_line_mapping.policyengine_variable == "snap_fpg"
     ca_snap_benefit_mapping = registry.mapping_for_legal_id(
         "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_benefit",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.599"
+version = "0.2.600"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify `us:statutes/26/1402/a/` child outputs as tax `not_comparable` unless an exact mapping overrides them
- cover the new 26 USC 1402(a)(12) child prefix in the PolicyEngine registry test

## Context
rulespec-us PR #389 adds a signed encoder output for 26 USC 1402(a)(12). Its outputs are source-specific net-earnings assembly intermediates, not direct PolicyEngine variables, so the RuleSpec changed coverage gate should not leave them unmapped.

## Verification
- uv run --extra dev --python 3.13 pytest tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_policyengine_classifier.py -q
- uv run --extra dev --python 3.13 ruff check tests/test_rulespec_validation.py
- parsed src/axiom_encode/oracles/policyengine/mappings/us.yaml with yaml.safe_load