### PR TITLE
Update UK UC regulation 36 oracle mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.549"
+version = "0.2.550"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.549"
+__version__ = "0.2.550"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -16052,16 +16052,22 @@ def _fetch_local_corpus_source_text(citation_path: str) -> str | None:
         return None
 
     for provisions_root in _local_corpus_provisions_roots():
+        exact_records: list[dict[str, Any]] = []
         for provision_file in _candidate_local_corpus_provision_files(
             provisions_root,
             normalized_path,
         ):
-            source_text = _read_local_corpus_provision_file(
-                provision_file,
-                normalized_path,
+            exact_records.extend(
+                _read_local_corpus_provision_records(provision_file, normalized_path)
             )
-            if source_text is not None:
-                return source_text
+        source_text = _select_local_corpus_record_body(exact_records)
+        if source_text is not None:
+            return source_text
+
+        for provision_file in _candidate_local_corpus_provision_files(
+            provisions_root,
+            normalized_path,
+        ):
             source_text = _read_local_corpus_descendant_text(
                 provision_file,
                 normalized_path,
@@ -16147,14 +16153,15 @@ def _candidate_local_corpus_provision_files(
     return tuple(candidates)
 
 
-def _read_local_corpus_provision_file(
+def _read_local_corpus_provision_records(
     provision_file: Path,
     citation_path: str,
-) -> str | None:
+) -> list[dict[str, Any]]:
     try:
         lines = provision_file.read_text(encoding="utf-8").splitlines()
     except OSError:
-        return None
+        return []
+    records: list[dict[str, Any]] = []
     for line in lines:
         if not line.strip():
             continue
@@ -16164,9 +16171,33 @@ def _read_local_corpus_provision_file(
             continue
         if not isinstance(record, dict) or record.get("citation_path") != citation_path:
             continue
-        body = record.get("body")
-        return str(body) if body is not None else None
-    return None
+        records.append(record)
+    return records
+
+
+def _read_local_corpus_provision_file(
+    provision_file: Path,
+    citation_path: str,
+) -> str | None:
+    records = _read_local_corpus_provision_records(provision_file, citation_path)
+    return _select_local_corpus_record_body(records)
+
+
+def _select_local_corpus_record_body(records: list[dict[str, Any]]) -> str | None:
+    """Select the best body when local corpus files contain duplicate citations."""
+    body_records = [record for record in records if record.get("body") is not None]
+    if not body_records:
+        return None
+
+    def record_key(record: dict[str, Any]) -> tuple[str, int, str]:
+        source_as_of = str(record.get("source_as_of") or "")
+        source_format = str(record.get("source_format") or "")
+        official_source = 1 if source_format == "legislation.gov.uk-clml" else 0
+        version = str(record.get("version") or "")
+        return (source_as_of, official_source, version)
+
+    selected = max(body_records, key=record_key)
+    return str(selected["body"])
 
 
 def _read_local_corpus_descendant_text(

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -114,6 +114,7 @@ JURISDICTION_CONFIGS = {
         member_entity_type="Person",
         temp_prefix="co-snap-pe-ecps-",
         display_name="Colorado SNAP",
+        additional_relation_ids=("member_of_household",),
     ),
     "us-ca": JurisdictionConfig(
         jurisdiction="us-ca",

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -81,25 +81,25 @@ PENSION_CREDIT_OUTPUTS = {
 
 UNIVERSAL_CREDIT_STANDARD_ALLOWANCE_OUTPUTS = {
     "standard_allowance_single_under_25": {
-        "axiom": f"{UNIVERSAL_CREDIT_BASE}#standard_allowance_single_under_25",
+        "axiom": f"{UNIVERSAL_CREDIT_BASE}#standard_allowance_single_under_25_amount",
         "pe": "uc_standard_allowance",
         "pe_transform": "annual_to_monthly",
         "applies": ("uc_standard_allowance_claimant_type", "SINGLE_YOUNG"),
     },
     "standard_allowance_single_25_or_over": {
-        "axiom": f"{UNIVERSAL_CREDIT_BASE}#standard_allowance_single_25_or_over",
+        "axiom": f"{UNIVERSAL_CREDIT_BASE}#standard_allowance_single_25_or_over_amount",
         "pe": "uc_standard_allowance",
         "pe_transform": "annual_to_monthly",
         "applies": ("uc_standard_allowance_claimant_type", "SINGLE_OLD"),
     },
     "standard_allowance_joint_both_under_25": {
-        "axiom": f"{UNIVERSAL_CREDIT_BASE}#standard_allowance_joint_both_under_25",
+        "axiom": f"{UNIVERSAL_CREDIT_BASE}#standard_allowance_joint_both_under_25_amount",
         "pe": "uc_standard_allowance",
         "pe_transform": "annual_to_monthly",
         "applies": ("uc_standard_allowance_claimant_type", "COUPLE_YOUNG"),
     },
     "standard_allowance_joint_either_25_or_over": {
-        "axiom": f"{UNIVERSAL_CREDIT_BASE}#standard_allowance_joint_either_25_or_over",
+        "axiom": f"{UNIVERSAL_CREDIT_BASE}#standard_allowance_joint_either_25_or_over_amount",
         "pe": "uc_standard_allowance",
         "pe_transform": "annual_to_monthly",
         "applies": ("uc_standard_allowance_claimant_type", "COUPLE_OLD"),
@@ -108,25 +108,25 @@ UNIVERSAL_CREDIT_STANDARD_ALLOWANCE_OUTPUTS = {
 
 UNIVERSAL_CREDIT_CHILD_ELEMENT_OUTPUTS = {
     "child_element_first_child_or_qualifying_young_person": {
-        "axiom": f"{UNIVERSAL_CREDIT_BASE}#child_element_first_child_or_qualifying_young_person",
+        "axiom": f"{UNIVERSAL_CREDIT_BASE}#first_child_element_amount",
         "pe": "uc_individual_child_element",
         "pe_transform": "annual_to_monthly",
         "applies": "uc_first_child_element",
     },
     "child_element_second_and_each_subsequent_child_or_qualifying_young_person": {
-        "axiom": f"{UNIVERSAL_CREDIT_BASE}#child_element_second_and_each_subsequent_child_or_qualifying_young_person",
+        "axiom": f"{UNIVERSAL_CREDIT_BASE}#second_and_subsequent_child_element_amount",
         "pe": "uc_individual_child_element",
         "pe_transform": "annual_to_monthly",
         "applies": "uc_subsequent_child_element",
     },
     "disabled_child_additional_amount_lower_rate": {
-        "axiom": f"{UNIVERSAL_CREDIT_BASE}#disabled_child_additional_amount_lower_rate",
+        "axiom": f"{UNIVERSAL_CREDIT_BASE}#disabled_child_lower_rate_amount",
         "pe": "uc_individual_disabled_child_element",
         "pe_transform": "annual_to_monthly",
         "applies": "positive_pe_output",
     },
     "disabled_child_additional_amount_higher_rate": {
-        "axiom": f"{UNIVERSAL_CREDIT_BASE}#disabled_child_additional_amount_higher_rate",
+        "axiom": f"{UNIVERSAL_CREDIT_BASE}#disabled_child_higher_rate_amount",
         "pe": "uc_individual_severely_disabled_child_element",
         "pe_transform": "annual_to_monthly",
         "applies": "positive_pe_output",
@@ -135,13 +135,13 @@ UNIVERSAL_CREDIT_CHILD_ELEMENT_OUTPUTS = {
 
 UNIVERSAL_CREDIT_LCWRA_OUTPUTS = {
     "lcwra_element_standard_lcwra_claimant": {
-        "axiom": f"{UNIVERSAL_CREDIT_BASE}#lcwra_element_standard_lcwra_claimant",
+        "axiom": f"{UNIVERSAL_CREDIT_BASE}#lcwra_ordinary_claimant_amount",
         "pe": "uc_LCWRA_element",
         "pe_transform": "annual_to_monthly",
         "applies": "uc_lcwra_standard_amount",
     },
     "lcwra_element_pre_2026_severe_conditions_or_terminally_ill_claimant": {
-        "axiom": f"{UNIVERSAL_CREDIT_BASE}#lcwra_element_pre_2026_severe_conditions_or_terminally_ill_claimant",
+        "axiom": f"{UNIVERSAL_CREDIT_BASE}#lcwra_protected_claimant_amount",
         "pe": "uc_LCWRA_element",
         "pe_transform": "annual_to_monthly",
         "applies": "uc_lcwra_higher_amount",
@@ -150,7 +150,7 @@ UNIVERSAL_CREDIT_LCWRA_OUTPUTS = {
 
 UNIVERSAL_CREDIT_CARER_OUTPUTS = {
     "carer_element": {
-        "axiom": f"{UNIVERSAL_CREDIT_BASE}#carer_element",
+        "axiom": f"{UNIVERSAL_CREDIT_BASE}#carer_element_amount",
         "pe": "uc_carer_element",
         "pe_transform": "annual_to_monthly",
         "applies": "positive_pe_output",
@@ -159,13 +159,13 @@ UNIVERSAL_CREDIT_CARER_OUTPUTS = {
 
 UNIVERSAL_CREDIT_CHILDCARE_OUTPUTS = {
     "childcare_costs_element_maximum_one_child": {
-        "axiom": f"{UNIVERSAL_CREDIT_BASE}#childcare_costs_element_maximum_one_child",
+        "axiom": f"{UNIVERSAL_CREDIT_BASE}#childcare_costs_element_one_child_maximum_amount",
         "pe": "uc_maximum_childcare_element_amount",
         "pe_transform": "annual_to_monthly",
         "applies": ("uc_childcare_element_eligible_children", 1),
     },
     "childcare_costs_element_maximum_two_or_more_children": {
-        "axiom": f"{UNIVERSAL_CREDIT_BASE}#childcare_costs_element_maximum_two_or_more_children",
+        "axiom": f"{UNIVERSAL_CREDIT_BASE}#childcare_costs_element_two_or_more_children_maximum_amount",
         "pe": "uc_maximum_childcare_element_amount",
         "pe_transform": "annual_to_monthly",
         "applies": "uc_childcare_two_or_more_children",

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -236,7 +236,7 @@ mappings:
     comparison: money
     rationale: Same Pension Credit carer addition output after applying claimant circumstances.
 
-  - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_single_under_25
+  - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_single_under_25_amount
     country: uk
     program: universal_credit
     mapping_type: parameter_value
@@ -246,7 +246,7 @@ mappings:
     comparison: money
     rationale: Same Universal Credit standard allowance for a single claimant aged under 25.
 
-  - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_single_25_or_over
+  - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_single_25_or_over_amount
     country: uk
     program: universal_credit
     mapping_type: parameter_value
@@ -256,7 +256,7 @@ mappings:
     comparison: money
     rationale: Same Universal Credit standard allowance for a single claimant aged 25 or over.
 
-  - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_joint_both_under_25
+  - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_joint_both_under_25_amount
     country: uk
     program: universal_credit
     mapping_type: parameter_value
@@ -266,7 +266,7 @@ mappings:
     comparison: money
     rationale: Same Universal Credit standard allowance for joint claimants both aged under 25.
 
-  - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_joint_either_25_or_over
+  - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_joint_either_25_or_over_amount
     country: uk
     program: universal_credit
     mapping_type: parameter_value
@@ -276,7 +276,7 @@ mappings:
     comparison: money
     rationale: Same Universal Credit standard allowance for joint claimants where either is aged 25 or over.
 
-  - legal_id: uk:regulations/uksi/2013/376/36#child_element_first_child_or_qualifying_young_person
+  - legal_id: uk:regulations/uksi/2013/376/36#first_child_element_amount
     country: uk
     program: universal_credit
     mapping_type: parameter_value
@@ -286,7 +286,7 @@ mappings:
     comparison: money
     rationale: Same Universal Credit first-child child element amount.
 
-  - legal_id: uk:regulations/uksi/2013/376/36#child_element_second_and_each_subsequent_child_or_qualifying_young_person
+  - legal_id: uk:regulations/uksi/2013/376/36#second_and_subsequent_child_element_amount
     country: uk
     program: universal_credit
     mapping_type: parameter_value
@@ -296,7 +296,7 @@ mappings:
     comparison: money
     rationale: Same Universal Credit second and subsequent child element amount.
 
-  - legal_id: uk:regulations/uksi/2013/376/36#disabled_child_additional_amount_lower_rate
+  - legal_id: uk:regulations/uksi/2013/376/36#disabled_child_lower_rate_amount
     country: uk
     program: universal_credit
     mapping_type: parameter_value
@@ -306,7 +306,7 @@ mappings:
     comparison: money
     rationale: Same Universal Credit lower disabled-child addition amount.
 
-  - legal_id: uk:regulations/uksi/2013/376/36#disabled_child_additional_amount_higher_rate
+  - legal_id: uk:regulations/uksi/2013/376/36#disabled_child_higher_rate_amount
     country: uk
     program: universal_credit
     mapping_type: parameter_value
@@ -316,7 +316,7 @@ mappings:
     comparison: money
     rationale: Same Universal Credit higher disabled-child addition amount.
 
-  - legal_id: uk:regulations/uksi/2013/376/36#lcwra_element_standard_lcwra_claimant
+  - legal_id: uk:regulations/uksi/2013/376/36#lcwra_ordinary_claimant_amount
     country: uk
     program: universal_credit
     mapping_type: parameter_value
@@ -326,7 +326,7 @@ mappings:
     comparison: money
     rationale: Same Universal Credit standard limited capability for work and work-related activity element amount.
 
-  - legal_id: uk:regulations/uksi/2013/376/36#carer_element
+  - legal_id: uk:regulations/uksi/2013/376/36#carer_element_amount
     country: uk
     program: universal_credit
     mapping_type: parameter_value
@@ -336,7 +336,7 @@ mappings:
     comparison: money
     rationale: Same Universal Credit carer element amount.
 
-  - legal_id: uk:regulations/uksi/2013/376/36#childcare_costs_element_maximum_one_child
+  - legal_id: uk:regulations/uksi/2013/376/36#childcare_costs_element_one_child_maximum_amount
     country: uk
     program: universal_credit
     mapping_type: parameter_value
@@ -346,7 +346,7 @@ mappings:
     comparison: money
     rationale: Same Universal Credit maximum childcare costs element for one child.
 
-  - legal_id: uk:regulations/uksi/2013/376/36#childcare_costs_element_maximum_two_or_more_children
+  - legal_id: uk:regulations/uksi/2013/376/36#childcare_costs_element_two_or_more_children_maximum_amount
     country: uk
     program: universal_credit
     mapping_type: parameter_value

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,6 @@ import pytest
 import yaml
 
 from axiom_encode import __version__ as AXIOM_ENCODE_TEST_VERSION
-from axiom_encode.oracles.policyengine.ecps_snap import JURISDICTION_CONFIGS
 from axiom_encode.cli import (
     APPLIED_ENCODING_MANIFEST_SCHEMA,
     APPLIED_ENCODING_SIGNING_KEY_ENV,
@@ -161,6 +160,7 @@ from axiom_encode.harness.encoding_db import (
 )
 from axiom_encode.harness.evals import EvalArtifactMetrics
 from axiom_encode.harness.validator_pipeline import _load_nearby_eval_source_metadata
+from axiom_encode.oracles.policyengine.ecps_snap import JURISDICTION_CONFIGS
 from axiom_encode.statute import citation_to_citation_path, parse_usc_citation
 
 TEST_APPLY_SIGNING_KEY = "test-apply-signing-key"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ import pytest
 import yaml
 
 from axiom_encode import __version__ as AXIOM_ENCODE_TEST_VERSION
+from axiom_encode.oracles.policyengine.ecps_snap import JURISDICTION_CONFIGS
 from axiom_encode.cli import (
     APPLIED_ENCODING_MANIFEST_SCHEMA,
     APPLIED_ENCODING_SIGNING_KEY_ENV,
@@ -190,6 +191,13 @@ def test_current_encoder_affecting_changes_are_behind_version_bump():
     provenance = _require_axiom_encode_version_provenance(repo)
 
     assert provenance["version"] == AXIOM_ENCODE_TEST_VERSION
+
+
+def test_colorado_snap_ecps_projects_bare_member_relation_alias():
+    config = JURISDICTION_CONFIGS["us-co"]
+
+    assert config.relation_id == "us:statutes/7/2012/j#relation.member_of_household"
+    assert "member_of_household" in config.additional_relation_ids
 
 
 def _signed_manifest_payload(payload: dict) -> dict:

--- a/tests/test_policyengine_ecps_snap.py
+++ b/tests/test_policyengine_ecps_snap.py
@@ -235,7 +235,7 @@ def test_colorado_snap_outputs_use_composed_allotment_and_cfr_net_income():
         "us:regulations/7-cfr/273/10#snap_net_monthly_income"
     )
     assert config.relation_id == "us:statutes/7/2012/j#relation.member_of_household"
-    assert config.additional_relation_ids == ()
+    assert config.additional_relation_ids == ("member_of_household",)
 
 
 def test_projected_child_support_includes_gross_income_deduction():

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -317,7 +317,7 @@ def test_run_axiom_parameter_outputs_reads_generated_rulespec_parameters(tmp_pat
         """
 format: rulespec/v1
 rules:
-  - name: standard_allowance_single_under_25
+  - name: standard_allowance_single_under_25_amount
     kind: parameter
     dtype: Money
     period: Month
@@ -338,7 +338,7 @@ rules:
                 {
                     "period": {"start": "2026-04-01"},
                     "outputs": [
-                        "uk:regulations/uksi/2013/376/36#standard_allowance_single_under_25"
+                        "uk:regulations/uksi/2013/376/36#standard_allowance_single_under_25_amount"
                     ],
                 }
             ]
@@ -348,7 +348,7 @@ rules:
     assert results == [
         {
             "outputs": {
-                "uk:regulations/uksi/2013/376/36#standard_allowance_single_under_25": {
+                "uk:regulations/uksi/2013/376/36#standard_allowance_single_under_25_amount": {
                     "value": {"value": "338.58"}
                 }
             }

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -18478,6 +18478,43 @@ rules:
     assert issues == []
 
 
+def test_local_corpus_source_text_prefers_newer_official_duplicate(
+    monkeypatch, tmp_path: Path
+):
+    provisions = tmp_path / "data" / "corpus" / "provisions" / "uk" / "regulation"
+    provisions.mkdir(parents=True)
+    older = {
+        "citation_path": "uk/regulation/uksi/2013/376/22",
+        "body": "Older microsim text says £684.00.",
+        "source_as_of": "2026-06-01-uk-frs-microsim",
+        "source_format": "lex.lab.i.ai.gov.uk",
+        "version": "2026-06-01-uk-frs-microsim",
+    }
+    newer = {
+        "citation_path": "uk/regulation/uksi/2013/376/22",
+        "body": "Newer official text says £710.00.",
+        "source_as_of": "2026-06-03",
+        "source_format": "legislation.gov.uk-clml",
+        "version": "2026-06-03-uk-universal-credit",
+    }
+    (provisions / "2026-06-01-uk-frs-microsim.jsonl").write_text(
+        json.dumps(older) + "\n"
+    )
+    (provisions / "2026-06-03-uk-universal-credit.jsonl").write_text(
+        json.dumps(newer) + "\n"
+    )
+
+    monkeypatch.setenv("AXIOM_CORPUS_REPO", str(tmp_path))
+    validator_pipeline._fetch_local_corpus_source_text.cache_clear()
+
+    assert (
+        validator_pipeline._fetch_local_corpus_source_text(
+            "uk/regulation/uksi/2013/376/22"
+        )
+        == "Newer official text says £710.00."
+    )
+
+
 def test_source_verification_rejects_source_value_mismatch():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.549"
+version = "0.2.550"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Updates PolicyEngine UK mapping legal IDs for Universal Credit regulation 36 to match the generated `rulespec-uk` exports added in TheAxiomFoundation/rulespec-uk#4.
- Updates the EFRS UK oracle output IDs for the same generated regulation 36 names.
- Adjusts the focused EFRS UK RuleSpec parameter fixture to use the generated `standard_allowance_single_under_25_amount` export.
- Fixes local corpus source lookup so duplicate provision IDs prefer the newest official CLML-backed corpus row before falling back to descendant paths.
- Applies a mechanical ruff import-order fix in `tests/test_cli.py` so the configured lint job is green.

## Dependency chain
- TheAxiomFoundation/axiom-corpus#81 is merged and adds the UC corpus rows and CLML source files needed by TheAxiomFoundation/rulespec-uk#4.
- This PR is needed before TheAxiomFoundation/rulespec-uk#4 can go green on CI because the rulespec validator currently reads `axiom-encode@main`; the latest rulespec rerun is down to `regulations/uksi/2013/376/22.yaml` failing on the duplicate-source grounding issue fixed here.

## Checks
- PASS: `uv run pytest tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py -q`
  - 258 passed in 266.96s
- PASS: `uv run pytest tests/test_rulespec_validation.py::test_local_corpus_source_text_prefers_newer_official_duplicate tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py -q`
  - 259 passed in 272.21s before rebase
  - 263 passed in 276.96s after rebase onto `origin/main`
- PASS: `python -m compileall -q src/axiom_encode scripts`
- PASS: `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- PASS: `git diff --check`

## Review cycle
- Draft only. Per repo instructions, this still needs `/cycle` or an equivalent independent review-fix loop before it is marked ready for review or merged.