### PR TITLE
Classify UK pension credit section 1 oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.551"
+version = "0.2.552"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.551"
+__version__ = "0.2.552"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -236,6 +236,29 @@ mappings:
     comparison: money
     rationale: Same Pension Credit carer addition output after applying claimant circumstances.
 
+  - legal_id: uk:statutes/ukpga/2002/16/1#qualifying_age
+    country: uk
+    program: pension_credit
+    mapping_type: not_comparable
+    policyengine_variable: state_pension_age
+    entity: person
+    period: day
+    unit: year
+    comparison: count
+    candidate_priority: P3
+    rationale: State Pension Credit Act section 1 defines a source-level qualifying age at day granularity, including the man's woman-born-same-day rule. PolicyEngine UK exposes state_pension_age as a year-period person variable from state-pension age parameters, so this needs a period and historical-sex-rule adapter before direct oracle comparison.
+
+  - legal_id: uk:statutes/ukpga/2002/16/1#claimant_has_attained_qualifying_age
+    country: uk
+    program: pension_credit
+    mapping_type: not_comparable
+    policyengine_variable: is_SP_age
+    entity: person
+    period: day
+    comparison: boolean
+    candidate_priority: P3
+    rationale: State Pension Credit Act section 1 tests whether the claimant has attained the statutory qualifying age at day granularity. PolicyEngine UK exposes the nearby is_SP_age predicate annually and rolls Pension Credit eligibility up to benefit-unit entitlement conditions, so this needs a period/entity adapter before direct oracle comparison.
+
   - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_single_under_25_amount
     country: uk
     program: universal_credit

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -808,6 +808,64 @@ rules:
     assert contribution["candidate_priority"] == "P4"
 
 
+def test_policyengine_coverage_classifies_uk_pension_credit_section_1_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2002/16/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: qualifying_age
+    kind: derived
+    entity: Person
+    dtype: Count
+    period: Day
+    unit: year
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if claimant_is_woman: pensionable_age else: pensionable_age_for_woman_born_same_day
+  - name: claimant_has_attained_qualifying_age
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Day
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          claimant_age >= qualifying_age
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2002/16/1.test.yaml",
+        """- name: claimant at qualifying age
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-01-01'
+    end: '2026-01-01'
+  input: {}
+  output:
+    uk:statutes/ukpga/2002/16/1#qualifying_age: 66
+    uk:statutes/ukpga/2002/16/1#claimant_has_attained_qualifying_age: holds
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="pension_credit")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    qualifying_age = items_by_id["uk:statutes/ukpga/2002/16/1#qualifying_age"]
+    attained_age = items_by_id[
+        "uk:statutes/ukpga/2002/16/1#claimant_has_attained_qualifying_age"
+    ]
+
+    assert qualifying_age["policyengine_variable"] == "state_pension_age"
+    assert qualifying_age["candidate_priority"] == "P3"
+    assert attained_age["policyengine_variable"] == "is_SP_age"
+    assert attained_age["candidate_priority"] == "P3"
+
+
 def test_policyengine_coverage_counts_uk_aliases_as_tested(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-uk" / "regulations/uksi/2006/965/2.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.551"
+version = "0.2.552"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classifies State Pension Credit Act 2002 section 1 `qualifying_age` as known not-comparable, with nearby PE-UK variable `state_pension_age` recorded
- classifies section 1 `claimant_has_attained_qualifying_age` as known not-comparable, with nearby PE-UK variable `is_SP_age` recorded
- adds coverage regression for the two section 1 outputs

## Context
- unblocks TheAxiomFoundation/rulespec-uk#5, whose CI failed only on changed PolicyEngine oracle coverage classification
- keeps this complementary to Pavel’s merged Universal Credit work by touching only Pension Credit coverage mappings

## Validation
- `uv run ruff check tests/test_policyengine_coverage.py`
- `uv run python - <<PY ... load_policyengine_registry() ... PY`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_pension_credit_section_1_outputs`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py`
- local archive-layout oracle coverage check against rulespec-uk#5: both section 1 outputs are tested `known_not_comparable`