### PR TITLE
Classify Arizona SNAP benefit outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.551"
+version = "0.2.552"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.551"
+__version__ = "0.2.552"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -14194,6 +14194,18 @@ prefixes:
     mapping_type: not_comparable
     rationale: Arizona manual shelter deduction helper outputs cover source-specific allowable shelter expenses, utility composition, uncapped excess amounts, and state manual cap mechanics; exact PolicyEngine mappings are registered only where the output boundary is comparable.
 
+  - legal_id_prefix: us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Arizona manual benefit-amount outputs decompose AZTECS net-income reduction, allotment-test, minimum-allotment round-up, and initial-month proration status mechanics; PolicyEngine exposes final SNAP benefit calculations rather than these source-specific intermediate Arizona manual boundaries as one-to-one outputs.
+
+  - legal_id_prefix: us-az:policies/des/faa5/na-eligibility-and-benefit-determination/net-income-test#
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: Arizona manual net-income-test outputs decompose earned-income deduction, net-income construction, income-standard pass/fail, and denial predicates; PolicyEngine computes SNAP income eligibility through its own scenario and program variables rather than exposing these FAA5 source-slice helper outputs as one-to-one oracle targets.
+
   - legal_id_prefix: us:statutes/26/3102/a#
     country: us
     program: tax

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.551"
+version = "0.2.552"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary\n- Add PolicyEngine oracle coverage classifications for new Arizona FAA5 NA benefit amount outputs.\n- Add PolicyEngine oracle coverage classifications for new Arizona FAA5 NA net income test outputs.\n\n## Checks\n- uv run axiom-encode oracle-coverage --root /Users/pavelmakarchuk --json, filtered to the changed Arizona files: 12 outputs, 0 failures\n- uv run pytest tests/test_policyengine_coverage.py -q (233 passed)\n\n## Review cycle\n- Classification mirrors existing Arizona SNAP not-comparable prefix pattern.\n- No exact PolicyEngine one-to-one target exists for these source-slice helper outputs; the final PolicyEngine SNAP calculations use different scenario/program boundaries.