### PR TITLE
Allow UK EFRS UC comparison to use composed programs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.552"
+version = "0.2.553"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.551"
+version = "0.2.552"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.552"
+version = "0.2.551"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.552"
+__version__ = "0.2.553"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.552"
+__version__ = "0.2.551"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.551"
+__version__ = "0.2.552"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -496,6 +496,16 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         help="PolicyEngine dataset cache folder",
     )
     parser.add_argument(
+        "--universal-credit-program",
+        type=Path,
+        default=None,
+        help=(
+            "Optional RuleSpec program to use for Universal Credit surfaces. "
+            "This lets oracle runs compare a composed axiom-programs package "
+            "while keeping non-UC UK surfaces on their source RuleSpec files."
+        ),
+    )
+    parser.add_argument(
         "--tolerance",
         type=float,
         default=0.01,
@@ -530,6 +540,7 @@ def main(args: argparse.Namespace) -> int:
         data_folder=args.data_folder,
         tolerance=args.tolerance,
         relative_tolerance=args.relative_tolerance,
+        universal_credit_program=getattr(args, "universal_credit_program", None),
         person_ids=tuple(args.person_ids or ()),
     )
     if args.json:
@@ -620,6 +631,7 @@ def compare_uk_efrs(
     data_folder: Path,
     tolerance: float,
     relative_tolerance: float,
+    universal_credit_program: Path | None = None,
     person_ids: tuple[int, ...] = (),
 ) -> UKEFRSComparisonReport:
     resolved_rulespec_root = (rulespec_root or workspace_root / "rulespec-uk").resolve()
@@ -639,7 +651,13 @@ def compare_uk_efrs(
     surface_results: dict[str, list[dict[str, Any]]] = {}
     for selected_surface in surfaces:
         spec = SURFACE_SPECS[selected_surface]
-        program = resolved_rulespec_root / spec.program
+        if (
+            selected_surface.startswith("universal-credit-")
+            and universal_credit_program is not None
+        ):
+            program = universal_credit_program.resolve()
+        else:
+            program = resolved_rulespec_root / spec.program
         if not program.exists():
             raise SystemExit(f"{selected_surface} RuleSpec not found: {program}")
         request = build_axiom_request(
@@ -1477,7 +1495,11 @@ def run_axiom_surface(
     surface: str,
 ) -> list[dict[str, Any]]:
     if surface.startswith("universal-credit-"):
-        return run_axiom_parameter_outputs(program=program, request=request)
+        return run_axiom_parameter_outputs(
+            program=program,
+            request=request,
+            rulespec_root=rulespec_root,
+        )
     return run_axiom_program(
         program=program,
         request=request,
@@ -1490,6 +1512,7 @@ def run_axiom_parameter_outputs(
     *,
     program: Path,
     request: dict[str, Any],
+    rulespec_root: Path,
 ) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     parameter_cache: dict[str, dict[str, float]] = {}
@@ -1498,6 +1521,7 @@ def run_axiom_parameter_outputs(
         if period_start not in parameter_cache:
             parameter_cache[period_start] = rulespec_scalar_parameter_values(
                 program,
+                rulespec_root=rulespec_root,
                 period_start=period_start,
             )
         parameter_values = parameter_cache[period_start]
@@ -1511,13 +1535,36 @@ def run_axiom_parameter_outputs(
 
 
 def rulespec_scalar_parameter_values(
-    program: Path, *, period_start: str
+    program: Path, *, rulespec_root: Path, period_start: str
 ) -> dict[str, float]:
+    return _rulespec_scalar_parameter_values(
+        program.resolve(),
+        rulespec_root=rulespec_root.resolve(),
+        period_start=period_start,
+        seen=set(),
+    )
+
+
+def _rulespec_scalar_parameter_values(
+    program: Path,
+    *,
+    rulespec_root: Path,
+    period_start: str,
+    seen: set[Path],
+) -> dict[str, float]:
+    if program in seen:
+        return {}
+    seen.add(program)
     payload = yaml.safe_load(program.read_text()) or {}
-    base = rule_base_from_program(program)
     values: dict[str, float] = {}
+    try:
+        base = rule_base_from_program(program)
+    except ValueError:
+        base = None
     for rule in payload.get("rules") or []:
         if str(rule.get("kind") or "").strip() != "parameter":
+            continue
+        if base is None:
             continue
         version = effective_parameter_version(rule.get("versions") or [], period_start)
         if version is None:
@@ -1528,7 +1575,35 @@ def rulespec_scalar_parameter_values(
         except ValueError:
             continue
         values[f"{base}#{rule['name']}"] = value
+    for import_ref in payload.get("imports") or []:
+        imported = resolve_rulespec_import(import_ref, rulespec_root=rulespec_root)
+        if imported is None:
+            continue
+        values.update(
+            _rulespec_scalar_parameter_values(
+                imported,
+                rulespec_root=rulespec_root,
+                period_start=period_start,
+                seen=seen,
+            )
+        )
     return values
+
+
+def resolve_rulespec_import(import_ref: Any, *, rulespec_root: Path) -> Path | None:
+    raw = str(import_ref or "").strip()
+    if not raw:
+        return None
+    if ":" in raw:
+        repo_prefix, path_ref = raw.split(":", 1)
+        if repo_prefix != "uk":
+            return None
+    else:
+        path_ref = raw
+    candidate = rulespec_root / f"{path_ref}.yaml"
+    if candidate.exists():
+        return candidate.resolve()
+    return None
 
 
 def effective_parameter_version(

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -333,6 +333,7 @@ rules:
 
     results = efrs_uk.run_axiom_parameter_outputs(
         program=program,
+        rulespec_root=tmp_path,
         request={
             "queries": [
                 {
@@ -350,6 +351,62 @@ rules:
             "outputs": {
                 "uk:regulations/uksi/2013/376/36#standard_allowance_single_under_25_amount": {
                     "value": {"value": "338.58"}
+                }
+            }
+        }
+    ]
+
+
+def test_run_axiom_parameter_outputs_resolves_composed_program_imports(tmp_path):
+    rulespec_root = tmp_path / "rulespec-uk"
+    source = rulespec_root / "regulations" / "uksi" / "2013" / "376" / "36.yaml"
+    source.parent.mkdir(parents=True)
+    source.write_text(
+        """
+format: rulespec/v1
+rules:
+  - name: carer_element_amount
+    kind: parameter
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          200
+      - effective_from: '2026-04-01'
+        formula: |-
+          209.34
+""".strip()
+    )
+    composed = tmp_path / "uk-uc-composed.yaml"
+    composed.write_text(
+        """
+format: rulespec/v1
+module:
+  kind: composition
+imports:
+  - uk:regulations/uksi/2013/376/36
+""".strip()
+    )
+
+    results = efrs_uk.run_axiom_parameter_outputs(
+        program=composed,
+        rulespec_root=rulespec_root,
+        request={
+            "queries": [
+                {
+                    "period": {"start": "2026-04-01"},
+                    "outputs": ["uk:regulations/uksi/2013/376/36#carer_element_amount"],
+                }
+            ]
+        },
+    )
+
+    assert results == [
+        {
+            "outputs": {
+                "uk:regulations/uksi/2013/376/36#carer_element_amount": {
+                    "value": {"value": "209.34"}
                 }
             }
         }

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.551"
+version = "0.2.552"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.552"
+version = "0.2.553"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.552"
+version = "0.2.551"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Adds a Universal Credit program override to the UK EFRS PolicyEngine comparator so oracle runs can compare a composed axiom-programs package instead of only the raw Reg. 36 RuleSpec file.\n\nChanges:\n- adds --universal-credit-program to uk-efrs-compare\n- resolves scalar parameter outputs through imported RuleSpec modules\n- keeps existing raw RuleSpec UC comparison behavior working\n\nLocal verification:\n- uv run pytest tests/test_policyengine_efrs_uk.py -q