### PR TITLE
Map UK UC schedule oracle outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.600"
+version = "0.2.601"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.600"
+__version__ = "0.2.601"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1742,6 +1742,18 @@ prefixes:
     mapping_type: not_comparable
     rationale: Universal Credit regulation 48 schedule 10 capital disregard period helpers are source-level disregard mechanics not exposed as one-to-one PolicyEngine UK variables.
 
+  - legal_id_prefix: uk:regulations/uksi/2013/376/schedule/4/
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    rationale: Universal Credit Schedule 4 renter housing-cost helper outputs are source-level rent payment, bedroom allocation, housing cost contribution, private and social rent calculation, under-occupancy, and specified-renter mechanics; PolicyEngine UK exposes downstream Universal Credit housing outcomes rather than these schedule-level legal helpers one-to-one.
+
+  - legal_id_prefix: uk:regulations/uksi/2013/376/schedule/10/
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    rationale: Universal Credit Schedule 10 capital-disregard premises helpers are source-level capital disregard mechanics not exposed as one-to-one PolicyEngine UK oracle variables or parameters.
+
   - legal_id_prefix: uk:regulations/uksi/2013/376/54#
     country: uk
     program: universal_credit

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1748,6 +1748,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Universal Credit Schedule 4 renter housing-cost helper outputs are source-level rent payment, bedroom allocation, housing cost contribution, private and social rent calculation, under-occupancy, and specified-renter mechanics; PolicyEngine UK exposes downstream Universal Credit housing outcomes rather than these schedule-level legal helpers one-to-one.
 
+  - legal_id_prefix: uk:regulations/uksi/2013/376/schedule/5/
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    rationale: Universal Credit Schedule 5 owner-occupier housing-cost helper outputs are source-level relevant-payment, qualifying-period, earned-income exclusion, and service-charge monthly-equivalent mechanics; PolicyEngine UK exposes downstream Universal Credit housing outcomes rather than these schedule-level legal helpers one-to-one.
+
   - legal_id_prefix: uk:regulations/uksi/2013/376/schedule/10/
     country: uk
     program: universal_credit

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -934,10 +934,25 @@ rules:
         formula: false
 """,
     )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2013/376/schedule/5/paragraph/9.yaml",
+        """format: rulespec/v1
+rules:
+  - name: owner_occupier_housing_costs_element_amount
+    kind: derived
+    entity: BenefitUnit
+    dtype: Money
+    period: Month
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+""",
+    )
 
     report = build_policyengine_coverage_report(tmp_path, program="universal_credit")
 
-    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert report["status_counts"] == {"known_not_comparable": 3}
     statuses = {item["legal_id"]: item["status"] for item in report["items"]}
     assert (
         statuses[
@@ -948,6 +963,12 @@ rules:
     assert (
         statuses[
             "uk:regulations/uksi/2013/376/schedule/10/paragraph/1#premises_treated_as_persons_home_for_paragraphs_1_to_5"
+        ]
+        == "known_not_comparable"
+    )
+    assert (
+        statuses[
+            "uk:regulations/uksi/2013/376/schedule/5/paragraph/9#owner_occupier_housing_costs_element_amount"
         ]
         == "known_not_comparable"
     )

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -902,6 +902,57 @@ rules:
     assert prescribed_limit["status"] == "known_not_comparable"
 
 
+def test_policyengine_coverage_classifies_uk_universal_credit_schedule_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2013/376/schedule/4/paragraph/36.yaml",
+        """format: rulespec/v1
+rules:
+  - name: under_occupancy_deduction_amount
+    kind: derived
+    entity: BenefitUnit
+    dtype: Money
+    period: Month
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2013/376/schedule/10/paragraph/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: premises_treated_as_persons_home_for_paragraphs_1_to_5
+    kind: derived
+    entity: BenefitUnit
+    dtype: Bool
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: false
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="universal_credit")
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    statuses = {item["legal_id"]: item["status"] for item in report["items"]}
+    assert (
+        statuses[
+            "uk:regulations/uksi/2013/376/schedule/4/paragraph/36#under_occupancy_deduction_amount"
+        ]
+        == "known_not_comparable"
+    )
+    assert (
+        statuses[
+            "uk:regulations/uksi/2013/376/schedule/10/paragraph/1#premises_treated_as_persons_home_for_paragraphs_1_to_5"
+        ]
+        == "known_not_comparable"
+    )
+
+
 def test_policyengine_coverage_classifies_uk_income_tax_section_23_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-uk" / "statutes/ukpga/2007/3/23.yaml",

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -906,7 +906,9 @@ def test_policyengine_coverage_classifies_uk_universal_credit_schedule_outputs(
     tmp_path,
 ):
     _write_rulespec_file(
-        tmp_path / "rulespec-uk" / "regulations/uksi/2013/376/schedule/4/paragraph/36.yaml",
+        tmp_path
+        / "rulespec-uk"
+        / "regulations/uksi/2013/376/schedule/4/paragraph/36.yaml",
         """format: rulespec/v1
 rules:
   - name: under_occupancy_deduction_amount
@@ -921,7 +923,9 @@ rules:
 """,
     )
     _write_rulespec_file(
-        tmp_path / "rulespec-uk" / "regulations/uksi/2013/376/schedule/10/paragraph/1.yaml",
+        tmp_path
+        / "rulespec-uk"
+        / "regulations/uksi/2013/376/schedule/10/paragraph/1.yaml",
         """format: rulespec/v1
 rules:
   - name: premises_treated_as_persons_home_for_paragraphs_1_to_5
@@ -935,7 +939,9 @@ rules:
 """,
     )
     _write_rulespec_file(
-        tmp_path / "rulespec-uk" / "regulations/uksi/2013/376/schedule/5/paragraph/9.yaml",
+        tmp_path
+        / "rulespec-uk"
+        / "regulations/uksi/2013/376/schedule/5/paragraph/9.yaml",
         """format: rulespec/v1
 rules:
   - name: owner_occupier_housing_costs_element_amount

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.600"
+version = "0.2.601"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify UK UC Schedule 4, Schedule 5, and Schedule 10 helper outputs for PolicyEngine coverage
- add regression coverage for Schedule 5 owner-occupier housing outputs
- bump axiom-encode to 0.2.555

## Checks
- uv run --python 3.13 --extra dev ruff check pyproject.toml src/axiom_encode scripts tests
- uv run --python 3.13 --extra dev python -m compileall -q src/axiom_encode scripts
- uv run --python 3.13 --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_universal_credit_schedule_outputs
- uv run --python 3.13 --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_universal_credit_schedule_outputs
- oracle coverage against generated UC tree: 313 outputs, 31 comparable, 282 known_not_comparable, 0 unmapped

## Known local baseline
- Full exact pytest previously hit an external sibling checkout scanner at /tmp/rulespec-us; that failure is unrelated to this PR and is tracked in the handoff. A clean broad run excluding only tests/test_repo_cross_statute_imports.py is running.