### PR TITLE
Add UK EFRS income, NI, pension credit, and UC oracle surfaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.558"
+version = "0.2.559"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.555"
+version = "0.2.556"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.556"
+version = "0.2.557"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.557"
+version = "0.2.558"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.554"
+version = "0.2.555"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.557"
+__version__ = "0.2.558"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.556"
+__version__ = "0.2.557"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.555"
+__version__ = "0.2.556"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.558"
+__version__ = "0.2.559"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.554"
+__version__ = "0.2.555"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -54,6 +54,8 @@ UNIVERSAL_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2013/376/36.yaml")
 UNIVERSAL_CREDIT_BASE = "uk:regulations/uksi/2013/376/36"
 UNIVERSAL_CREDIT_REGULATION_22_PROGRAM_PATH = Path("regulations/uksi/2013/376/22.yaml")
 UNIVERSAL_CREDIT_REGULATION_22_BASE = "uk:regulations/uksi/2013/376/22"
+UNIVERSAL_CREDIT_REGULATION_34_PROGRAM_PATH = Path("regulations/uksi/2013/376/34.yaml")
+UNIVERSAL_CREDIT_REGULATION_34_BASE = "uk:regulations/uksi/2013/376/34"
 WELFARE_REFORM_ACT_SECTION_8_PROGRAM_PATH = Path("statutes/ukpga/2012/5/8.yaml")
 WELFARE_REFORM_ACT_SECTION_8_BASE = "uk:statutes/ukpga/2012/5/8"
 WELFARE_REFORM_ACT_SECTION_11_PROGRAM_PATH = Path("statutes/ukpga/2012/5/11.yaml")
@@ -270,6 +272,14 @@ UNIVERSAL_CREDIT_CHILDCARE_OUTPUTS = {
     },
 }
 
+UNIVERSAL_CREDIT_CHILDCARE_ELEMENT_OUTPUTS = {
+    "childcare_costs_element_amount": {
+        "axiom": f"{UNIVERSAL_CREDIT_REGULATION_34_BASE}#childcare_costs_element_amount",
+        "pe": "uc_childcare_element",
+        "pe_transform": "annual_to_monthly",
+    },
+}
+
 UNIVERSAL_CREDIT_AWARD_OUTPUTS = {
     "universal_credit_maximum_amount": {
         "axiom": f"{WELFARE_REFORM_ACT_SECTION_8_BASE}#universal_credit_maximum_amount",
@@ -326,6 +336,7 @@ UNIVERSAL_CREDIT_2026_RULESPEC_RATES = {
     "carer_element": 209.34,
     "childcare_costs_element_maximum_one_child": 1071.09,
     "childcare_costs_element_maximum_two_or_more_children": 1836.16,
+    "childcare_costs_element_reimbursement_rate": 0.85,
 }
 
 
@@ -457,6 +468,15 @@ SURFACE_SPECS = {
         outputs=UNIVERSAL_CREDIT_CHILDCARE_OUTPUTS,
         pe_variables=(
             "uc_childcare_element_eligible_children",
+            "uc_maximum_childcare_element_amount",
+        ),
+    ),
+    "universal-credit-childcare-element": UKEFRSSurfaceSpec(
+        program=UNIVERSAL_CREDIT_REGULATION_34_PROGRAM_PATH,
+        entity="benunit",
+        outputs=UNIVERSAL_CREDIT_CHILDCARE_ELEMENT_OUTPUTS,
+        pe_variables=(
+            "uc_childcare_element",
             "uc_maximum_childcare_element_amount",
         ),
     ),
@@ -1955,6 +1975,11 @@ def build_axiom_request(
         )
     if surface == "pension-credit":
         return build_pension_credit_request(pe_data=pe_data, year=year)
+    if surface == "universal-credit-childcare-element":
+        return build_universal_credit_childcare_element_request(
+            pe_data=pe_data,
+            year=year,
+        )
     if surface == "universal-credit-award":
         return build_universal_credit_award_request(pe_data=pe_data, year=year)
     if surface == "universal-credit-housing-costs":
@@ -2289,6 +2314,43 @@ def build_universal_credit_request(
     }
 
 
+def build_universal_credit_childcare_element_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = benefit_month_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "universal-credit-childcare-element"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_universal_credit_childcare_element_inputs(
+            row
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{UNIVERSAL_CREDIT_REGULATION_34_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in UNIVERSAL_CREDIT_CHILDCARE_ELEMENT_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def build_universal_credit_award_request(
     *, pe_data: dict[str, Any], year: int
 ) -> dict[str, Any]:
@@ -2519,6 +2581,35 @@ def project_universal_credit_award_inputs(row: Any) -> dict[str, Any]:
             "uc_income_reduction"
         ),
         "unearned_income_deduction_calculated_in_prescribed_manner": 0.0,
+    }
+
+
+def project_universal_credit_childcare_element_inputs(row: Any) -> dict[str, Any]:
+    monthly_childcare_element = money(row_value(row, "uc_childcare_element", 0)) / (
+        MONTHS_IN_YEAR
+    )
+    monthly_childcare_maximum = (
+        money(row_value(row, "uc_maximum_childcare_element_amount", 0)) / MONTHS_IN_YEAR
+    )
+    relevant_charges = (
+        monthly_childcare_element
+        / UNIVERSAL_CREDIT_2026_RULESPEC_RATES[
+            "childcare_costs_element_reimbursement_rate"
+        ]
+        if monthly_childcare_element
+        else 0.0
+    )
+    return {
+        "charges_paid_for_relevant_childcare_attributable_to_assessment_period": relevant_charges,
+        "amount_considered_excessive_having_regard_to_paid_work_extent": 0.0,
+        "amount_met_or_reimbursed_by_employer_or_some_other_person": 0.0,
+        "secretary_of_state_work_transition_childcare_payment_meets_non_other_relevant_support_conditions": False,
+        "amount_from_funds_provided_by_secretary_of_state_or_scottish_or_welsh_ministers_for_work_related_activity_or_training": 0.0,
+        "secretary_of_state_work_transition_childcare_payment_amount": 0.0,
+        "maximum_amount_specified_in_table_in_regulation_36": max(
+            0.0,
+            monthly_childcare_maximum,
+        ),
     }
 
 
@@ -2808,6 +2899,13 @@ def compare_outputs(
             "higher/lower work-allowance case split, then compares the monthly "
             "RuleSpec allowance against PolicyEngine's annual uc_work_allowance "
             "divided by 12.",
+            "Universal Credit Regulation 34 childcare-costs element comparison "
+            "projects PolicyEngine's annual uc_childcare_element into monthly "
+            "relevant childcare charges by reversing the statutory 85 percent "
+            "reimbursement rate, supplies PolicyEngine's annual "
+            "uc_maximum_childcare_element_amount divided by 12 as the regulation "
+            "36 maximum, and projects excluded, reimbursed, and other-support "
+            "amounts to zero.",
             "The protected LCWRA Regulation 36 table amount is compared only "
             "when PolicyEngine exposes the raw protected amount. Current "
             "PolicyEngine UK EFRS outputs apply the July 2025 UC rebalancing "

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -23,7 +23,6 @@ import yaml
 
 from .ecps_tax import (
     POLICYENGINE_CORE_VERSION,
-    POLICYENGINE_VERSION,
     input_record,
     money,
     output_number,
@@ -35,7 +34,7 @@ from .ecps_tax import (
 DEFAULT_DATASET = "enhanced_frs_2023_24"
 WEEKS_IN_YEAR = 52
 MONTHS_IN_YEAR = 12
-POLICYENGINE_UK_VERSION = "2.88.20"
+POLICYENGINE_UK_VERSION = "2.88.40"
 
 NATIONAL_INSURANCE_SECTION_8_PROGRAM_PATH = Path("statutes/ukpga/1992/4/8.yaml")
 NATIONAL_INSURANCE_SECTION_8_BASE = "uk:statutes/ukpga/1992/4/8"
@@ -773,54 +772,61 @@ def load_policyengine_uk_data(
     ].pe_variables,
     benunit_variables: tuple[str, ...] = (),
 ) -> dict[str, Any]:
-    require_policyengine_uk_versions()
+    local_dataset = local_policyengine_uk_dataset_path(dataset)
+    if local_dataset is not None:
+        return load_local_policyengine_uk_data(
+            local_path=local_dataset,
+            year=year,
+            sample_size=sample_size,
+            person_ids=person_ids,
+            person_variables=person_variables,
+            benunit_variables=benunit_variables,
+        )
 
+    raise SystemExit(
+        "uk-efrs-compare with current PolicyEngine UK requires a local .h5 "
+        f"--dataset path. {policyengine_uk_install_message()}"
+    )
+
+
+def load_local_policyengine_uk_data(
+    *,
+    local_path: Path,
+    year: int,
+    sample_size: int,
+    person_ids: tuple[int, ...],
+    person_variables: tuple[str, ...],
+    benunit_variables: tuple[str, ...],
+) -> dict[str, Any]:
+    require_policyengine_uk_versions()
     try:
-        from policyengine.core import Simulation
-        from policyengine.provenance.manifest import dataset_logical_name
-        from policyengine.tax_benefit_models.uk import ensure_datasets, uk_latest
+        import pandas as pd
+        from policyengine_uk import Microsimulation
+        from policyengine_uk.data import UKSingleYearDataset
     except ImportError as exc:  # pragma: no cover - optional runtime dependency
         raise SystemExit(policyengine_uk_install_message()) from exc
 
-    log("Loading PolicyEngine UK EFRS...")
-    local_dataset = local_policyengine_uk_dataset(
-        dataset=dataset,
-        year=year,
-    )
-    if local_dataset is not None:
-        pe_dataset = local_dataset
-    else:
-        resolved_dataset = resolve_policyengine_uk_dataset_reference(dataset)
-        datasets = ensure_datasets(
-            datasets=[resolved_dataset],
-            years=[year],
-            data_folder=str(data_folder),
-        )
-        pe_dataset = datasets[f"{dataset_logical_name(resolved_dataset)}_{year}"]
-    extra_variables: dict[str, list[str]] = {}
-    if person_variables:
-        extra_variables["person"] = list(person_variables)
-    if benunit_variables:
-        extra_variables["benunit"] = list(benunit_variables)
-    sim = Simulation(
-        dataset=pe_dataset,
-        tax_benefit_model_version=uk_latest,
-        extra_variables=extra_variables,
-    )
-    log("Running PolicyEngine UK outputs...")
-    sim.run()
+    log("Loading local PolicyEngine UK EFRS...")
+    pe_dataset = UKSingleYearDataset(file_path=str(local_path))
+    sim = Microsimulation(dataset=pe_dataset)
 
+    with pd.HDFStore(local_path, mode="r") as store:
+        raw_person = store["person"].copy()
+        raw_benunit = store["benunit"].copy()
+        household = store["household"].copy()
+
+    person = add_policyengine_uk_person_weights(raw_person, household)
     person_columns = ["person_id", "person_weight"]
-    if "person_benunit_id" in pe_dataset.data.person.columns:
+    if "person_benunit_id" in person.columns:
         person_columns.append("person_benunit_id")
-    raw_persons = pe_dataset.data.person[person_columns].copy()
-    person_outputs = sim.output_dataset.data.person[["person_id", *person_variables]]
-    merged = raw_persons.merge(
-        person_outputs,
-        on="person_id",
-        how="left",
-        validate="one_to_one",
-    )
+    merged = person[person_columns].copy()
+    log("Running PolicyEngine UK person outputs...")
+    for variable in person_variables:
+        merged[variable] = sim.calculate(
+            variable,
+            period=year,
+            map_to="person",
+        ).values
     records = table_records(merged)
     selected_indices = select_person_indices(
         records,
@@ -828,19 +834,21 @@ def load_policyengine_uk_data(
         person_ids=person_ids,
     )
     selected = [records[index] for index in selected_indices]
-    benunit_records: list[dict[str, Any]] = []
     selected_benunits: list[dict[str, Any]] = []
     if benunit_variables:
-        raw_benunits = pe_dataset.data.benunit[["benunit_id", "benunit_weight"]].copy()
-        benunit_outputs = sim.output_dataset.data.benunit[
-            ["benunit_id", *benunit_variables]
-        ]
-        merged_benunits = raw_benunits.merge(
-            benunit_outputs,
-            on="benunit_id",
-            how="left",
-            validate="one_to_one",
+        benunit = add_policyengine_uk_benunit_weights(
+            raw_benunit,
+            raw_person,
+            household,
         )
+        merged_benunits = benunit[["benunit_id", "benunit_weight"]].copy()
+        log("Running PolicyEngine UK benefit-unit outputs...")
+        for variable in benunit_variables:
+            merged_benunits[variable] = sim.calculate(
+                variable,
+                period=year,
+                map_to="benunit",
+            ).values
         benunit_records = table_records(merged_benunits)
         selected_benunit_ids = ()
         if person_ids:
@@ -865,6 +873,48 @@ def load_policyengine_uk_data(
         "benunits": selected_benunits,
         "benunit_ids": [int(row_value(row, "benunit_id")) for row in selected_benunits],
     }
+
+
+def add_policyengine_uk_person_weights(raw_person: Any, household: Any) -> Any:
+    person = raw_person.merge(
+        household[["household_id", "household_weight"]],
+        left_on="person_household_id",
+        right_on="household_id",
+        how="left",
+    )
+    return person.rename(columns={"household_weight": "person_weight"}).drop(
+        columns=["household_id"],
+    )
+
+
+def add_policyengine_uk_benunit_weights(
+    raw_benunit: Any,
+    raw_person: Any,
+    household: Any,
+) -> Any:
+    benunit_household_map = raw_person[
+        ["person_benunit_id", "person_household_id"]
+    ].drop_duplicates()
+    benunit = raw_benunit.merge(
+        benunit_household_map,
+        left_on="benunit_id",
+        right_on="person_benunit_id",
+        how="left",
+    )
+    benunit = benunit.merge(
+        household[["household_id", "household_weight"]],
+        left_on="person_household_id",
+        right_on="household_id",
+        how="left",
+    )
+    return benunit.rename(columns={"household_weight": "benunit_weight"}).drop(
+        columns=[
+            "person_benunit_id",
+            "person_household_id",
+            "household_id",
+        ],
+        errors="ignore",
+    )
 
 
 def resolve_policyengine_uk_dataset_reference(dataset: str) -> str:
@@ -1279,18 +1329,14 @@ def policyengine_uk_variables_source_root(*, required: bool = True) -> Path | No
 
 
 def policyengine_uk_versions() -> dict[str, str]:
-    try:
-        return {
-            "policyengine": version("policyengine"),
-            "policyengine-core": version("policyengine-core"),
-            "policyengine-uk": version("policyengine-uk"),
-        }
-    except PackageNotFoundError:
-        return {
-            "policyengine": "not installed",
-            "policyengine-core": "not installed",
-            "policyengine-uk": "not installed",
-        }
+    packages = ("policyengine", "policyengine-core", "policyengine-uk")
+    versions: dict[str, str] = {}
+    for package in packages:
+        try:
+            versions[package] = version(package)
+        except PackageNotFoundError:
+            versions[package] = "not installed"
+    return versions
 
 
 def policyengine_uk_efrs_activity(
@@ -1304,24 +1350,35 @@ def policyengine_uk_efrs_activity(
     try:
         import numpy as np
         import pandas as pd
-        from policyengine.core import Simulation
-        from policyengine.provenance.manifest import dataset_logical_name
-        from policyengine.tax_benefit_models.uk import ensure_datasets, uk_latest
+        from policyengine_uk import Microsimulation
+        from policyengine_uk.data import UKSingleYearDataset
     except ImportError as exc:  # pragma: no cover - optional runtime dependency
         raise SystemExit(policyengine_uk_install_message("uk-efrs-coverage")) from exc
 
-    log("Loading PolicyEngine UK EFRS...")
-    local_dataset = local_policyengine_uk_dataset(dataset=dataset, year=year)
-    if local_dataset is not None:
-        pe_dataset = local_dataset
-    else:
-        resolved_dataset = resolve_policyengine_uk_dataset_reference(dataset)
-        datasets = ensure_datasets(
-            datasets=[resolved_dataset],
-            years=[year],
-            data_folder=str(data_folder),
+    local_dataset = local_policyengine_uk_dataset_path(dataset)
+    if local_dataset is None:
+        raise SystemExit(
+            "uk-efrs-coverage --with-efrs-activity with current PolicyEngine UK "
+            f"requires a local .h5 --dataset path. "
+            f"{policyengine_uk_install_message('uk-efrs-coverage')}"
         )
-        pe_dataset = datasets[f"{dataset_logical_name(resolved_dataset)}_{year}"]
+
+    log("Loading local PolicyEngine UK EFRS for coverage activity...")
+    pe_dataset = UKSingleYearDataset(file_path=str(local_dataset))
+    sim = Microsimulation(dataset=pe_dataset)
+    with pd.HDFStore(local_dataset, mode="r") as store:
+        raw_person = store["person"].copy()
+        raw_benunit = store["benunit"].copy()
+        household = store["household"].copy()
+    raw_tables = {
+        "person": add_policyengine_uk_person_weights(raw_person, household),
+        "benunit": add_policyengine_uk_benunit_weights(
+            raw_benunit,
+            raw_person,
+            household,
+        ),
+        "household": household,
+    }
 
     extra_variables: dict[str, list[str]] = defaultdict(list)
     variables_by_name = {variable.name: variable for variable in variables}
@@ -1330,18 +1387,11 @@ def policyengine_uk_efrs_activity(
             extra_variables[variable.entity].append(variable.name)
 
     log("Running PolicyEngine UK outputs for coverage activity...")
-    sim = Simulation(
-        dataset=pe_dataset,
-        tax_benefit_model_version=uk_latest,
-        extra_variables=dict(extra_variables),
-    )
-    sim.run()
 
     activity: list[UKEFRSVariableActivity] = []
     errors: list[dict[str, str]] = []
     for entity, names in sorted(extra_variables.items()):
-        output_table = getattr(sim.output_dataset.data, entity)
-        raw_table = getattr(pe_dataset.data, entity)
+        raw_table = raw_tables[entity]
         weight_column = ENTITY_WEIGHT_COLUMNS[entity]
         id_column = ENTITY_ID_COLUMNS[entity]
         if weight_column not in raw_table.columns:
@@ -1353,7 +1403,7 @@ def policyengine_uk_efrs_activity(
                 }
             )
             continue
-        if id_column not in raw_table.columns or id_column not in output_table.columns:
+        if id_column not in raw_table.columns:
             errors.append(
                 {
                     "entity": entity,
@@ -1362,6 +1412,22 @@ def policyengine_uk_efrs_activity(
                 }
             )
             continue
+        output_table = raw_table[[id_column]].copy()
+        for name in sorted(names):
+            try:
+                output_table[name] = sim.calculate(
+                    name,
+                    period=year,
+                    map_to=entity,
+                ).values
+            except Exception as exc:  # pragma: no cover - depends on PE variable graph
+                errors.append(
+                    {
+                        "entity": entity,
+                        "variable": name,
+                        "error": str(exc),
+                    }
+                )
         raw_weights = raw_table[[id_column, weight_column]].copy()
         output_ids = output_table[[id_column]].copy()
         aligned_weights = output_ids.merge(
@@ -2223,6 +2289,11 @@ def compare_outputs(
             "EFRS component outputs are divided by 12, and EFRS category "
             "variables select the matching standard-allowance, child-element, "
             "carer, LCWRA, and childcare-cap rows.",
+            "The protected LCWRA Regulation 36 table amount is compared only "
+            "when PolicyEngine exposes the raw protected amount. Current "
+            "PolicyEngine UK EFRS outputs apply the July 2025 UC rebalancing "
+            "scenario for existing claimants, so those rebalanced health-element "
+            "values are not treated as the same surface.",
             "Income Tax Act 2007 section 23 final-liability comparison collapses "
             "PolicyEngine's income_tax_additions into the RuleSpec step-4 tax "
             "input and PolicyEngine's income_tax_subtractions into the section "
@@ -2276,7 +2347,10 @@ def output_applies(spec: dict[str, Any], row: Any) -> bool:
         return 0 < monthly_value < 300
     if applies == "uc_lcwra_higher_amount":
         monthly_value = policyengine_output_value(spec, row)
-        return 300 <= monthly_value < 600
+        expected = UNIVERSAL_CREDIT_2026_RULESPEC_RATES[
+            "lcwra_element_pre_2026_severe_conditions_or_terminally_ill_claimant"
+        ]
+        return math.isclose(monthly_value, expected, abs_tol=0.01)
     if applies == "uc_childcare_two_or_more_children":
         return int(row_value(row, "uc_childcare_element_eligible_children", 0)) >= 2
     if isinstance(applies, tuple) and len(applies) == 2:
@@ -2578,16 +2652,10 @@ def resolve_workspace_root(root: Path | None) -> Path:
 
 def require_policyengine_uk_versions(command: str = "uk-efrs-compare") -> None:
     try:
-        policyengine_version = version("policyengine")
         policyengine_core_version = version("policyengine-core")
         policyengine_uk_version = version("policyengine-uk")
     except PackageNotFoundError as exc:
         raise SystemExit(policyengine_uk_install_message(command)) from exc
-    if policyengine_version != POLICYENGINE_VERSION:
-        raise SystemExit(
-            f"policyengine=={POLICYENGINE_VERSION} required; found "
-            f"{policyengine_version}. {policyengine_uk_install_message(command)}"
-        )
     if policyengine_core_version != POLICYENGINE_CORE_VERSION:
         raise SystemExit(
             f"policyengine-core=={POLICYENGINE_CORE_VERSION} required; found "
@@ -2621,7 +2689,7 @@ def policyengine_uk_class_1_weekly_parameters(year: int) -> dict[str, float]:
 def policyengine_uk_install_message(command: str = "uk-efrs-compare") -> str:
     return (
         "Run with: uv run "
-        f"--with 'policyengine[uk]=={POLICYENGINE_VERSION}' "
+        f"--with policyengine-uk=={POLICYENGINE_UK_VERSION} "
         f"axiom-encode {command}"
     )
 

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -105,6 +105,11 @@ INCOME_TAX_INCOME_BASE_OUTPUTS = {
         "axiom": f"{INCOME_TAX_SECTION_23_BASE}#total_income",
         "pe": "total_income",
     },
+    "net_income": {
+        "axiom": f"{INCOME_TAX_SECTION_23_BASE}#net_income",
+        "pe": "adjusted_net_income",
+        "applies": "income_tax_net_income_comparable",
+    },
     "income_tax_liability": {
         "axiom": f"{INCOME_TAX_SECTION_23_BASE}#income_tax_liability",
         "pe": "income_tax",
@@ -297,6 +302,7 @@ SURFACE_SPECS = {
         entity="person",
         outputs=INCOME_TAX_INCOME_BASE_OUTPUTS,
         pe_variables=(
+            "adjusted_net_income",
             *INCOME_TAX_INCOME_BASE_COMPONENTS,
             *INCOME_TAX_SECTION_23_ADDITION_COMPONENTS,
             *INCOME_TAX_SECTION_23_REDUCTION_COMPONENTS,
@@ -1954,6 +1960,14 @@ def build_income_tax_income_base_request(
                     money(component["amount_charged_to_income_tax"]),
                 )
             )
+            inputs.append(
+                input_record(
+                    f"{INCOME_TAX_SECTION_23_BASE}#input.relief_deducted_under_section_24",
+                    payment_id,
+                    interval,
+                    money(component["relief_deducted_under_section_24"]),
+                )
+            )
         for name, value in project_income_tax_section_23_inputs(row).items():
             inputs.append(
                 input_record(
@@ -2122,14 +2136,27 @@ def project_income_tax_income_base_components(row: Any) -> list[dict[str, Any]]:
         {
             "name": name,
             "amount_charged_to_income_tax": money(row_value(row, name, 0)),
+            "relief_deducted_under_section_24": 0.0,
         }
         for name in INCOME_TAX_INCOME_BASE_COMPONENTS
     ]
-    return [
+    nonzero_components = [
         component
         for component in components
         if money(component["amount_charged_to_income_tax"])
     ]
+    if not nonzero_components:
+        return []
+    total_income = sum(
+        money(component["amount_charged_to_income_tax"])
+        for component in nonzero_components
+    )
+    adjusted_net_income = money(row_value(row, "adjusted_net_income", total_income))
+    nonzero_components[0]["relief_deducted_under_section_24"] = max(
+        0.0,
+        total_income - adjusted_net_income,
+    )
+    return nonzero_components
 
 
 def project_income_tax_section_23_inputs(row: Any) -> dict[str, Any]:
@@ -2142,6 +2169,7 @@ def project_income_tax_section_23_inputs(row: Any) -> dict[str, Any]:
         for name in INCOME_TAX_SECTION_23_REDUCTION_COMPONENTS
     )
     return {
+        "net_income_taken_as_zero_under_section_24b": False,
         "tax_calculated_at_applicable_rates_on_income_remaining_after_allowances": additions,
         "tax_reductions_listed_in_section_26": reductions,
         "additional_tax_amounts_listed_in_section_30": 0.0,
@@ -2384,6 +2412,12 @@ def compare_outputs(
             "PolicyEngine UK EFRS outputs apply the July 2025 UC rebalancing "
             "scenario for existing claimants, so those rebalanced health-element "
             "values are not treated as the same surface.",
+            "Income Tax Act 2007 section 23 net-income comparison projects "
+            "PolicyEngine UK's adjusted_net_income into section 24 reliefs only "
+            "for rows with non-negative income components where adjusted net "
+            "income does not exceed total income. Rows with loss semantics are "
+            "skipped because RuleSpec section 23 net_income cannot exceed the "
+            "section 23 total_income output.",
             "Income Tax Act 2007 section 23 final-liability comparison collapses "
             "PolicyEngine's income_tax_additions into the RuleSpec step-4 tax "
             "input and PolicyEngine's income_tax_subtractions into the section "
@@ -2421,6 +2455,13 @@ def output_applies(spec: dict[str, Any], row: Any) -> bool:
         return True
     if applies == "positive_pe_output":
         return policyengine_output_value(spec, row) > 0
+    if applies == "income_tax_net_income_comparable":
+        return all(
+            money(row_value(row, name, 0)) >= 0
+            for name in INCOME_TAX_INCOME_BASE_COMPONENTS
+        ) and money(row_value(row, "adjusted_net_income", 0)) <= money(
+            row_value(row, "total_income", 0)
+        )
     if applies == "uc_first_child_element":
         return (
             policyengine_output_value(spec, row) > 0

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -124,6 +124,13 @@ STATE_PENSION_CREDIT_QUALIFYING_AGE_OUTPUTS = {
         "axiom": f"{STATE_PENSION_CREDIT_SECTION_1_BASE}#qualifying_age",
         "pe": "state_pension_age",
     },
+    "claimant_has_attained_qualifying_age": {
+        "axiom": (
+            f"{STATE_PENSION_CREDIT_SECTION_1_BASE}"
+            "#claimant_has_attained_qualifying_age"
+        ),
+        "pe": "is_SP_age",
+    },
 }
 
 PENSION_CREDIT_OUTPUTS = {
@@ -313,6 +320,7 @@ SURFACE_SPECS = {
         pe_variables=(
             "age",
             "gender",
+            "is_SP_age",
             "state_pension_age",
         ),
     ),
@@ -2361,9 +2369,11 @@ def compare_outputs(
             "State Pension Credit Act section 1 qualifying-age comparison "
             "queries RuleSpec's day-level qualifying_age on a representative "
             "day and supplies PolicyEngine's annual state_pension_age for both "
-            "the pensionable-age leaf and the woman-born-same-day leaf. Current "
-            "PolicyEngine UK EFRS data exposes the modern equalized-age surface "
-            "rather than historical sex-specific age transitions.",
+            "the pensionable-age leaf and the woman-born-same-day leaf. The "
+            "same projection compares the attained-age judgment against "
+            "PolicyEngine's is_SP_age boolean. Current PolicyEngine UK EFRS "
+            "data exposes the modern equalized-age surface rather than "
+            "historical sex-specific age transitions.",
             "Universal Credit Regulation 36 comparisons treat the generated "
             "RuleSpec outputs as component table amounts. PolicyEngine annual "
             "EFRS component outputs are divided by 12, and EFRS category "

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -1194,10 +1194,10 @@ def discover_policyengine_uk_variables(
 def load_policyengine_uk_variables() -> list[Any]:
     require_policyengine_uk_versions(command="uk-efrs-coverage")
     try:
-        from policyengine.tax_benefit_models.uk import uk_latest
+        from policyengine_uk import CountryTaxBenefitSystem
     except ImportError as exc:  # pragma: no cover - optional runtime dependency
         raise SystemExit(policyengine_uk_install_message("uk-efrs-coverage")) from exc
-    return list(uk_latest.variables)
+    return list(CountryTaxBenefitSystem().variables.values())
 
 
 def parse_policyengine_uk_variable_sources(
@@ -1275,6 +1275,8 @@ def variable_attribute(raw_variable: Any, name: str, default: Any = None) -> Any
 
 
 def normalize_policyengine_entity(value: Any) -> str:
+    if hasattr(value, "key"):
+        return str(value.key).strip().lower()
     text = str(value or "").strip()
     if "." in text:
         text = text.rsplit(".", 1)[-1]

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -76,6 +76,11 @@ NATIONAL_INSURANCE_CLASS_1_OUTPUTS = {
         "pe": "ni_class_1_employee",
         "pe_transform": "annual_to_weekly",
     },
+    "employee_national_insurance": {
+        "axiom": f"{NATIONAL_INSURANCE_SECTION_8_BASE}#primary_class_1_contribution",
+        "pe": "ni_employee",
+        "pe_transform": "annual_to_weekly",
+    },
 }
 
 INCOME_TAX_INCOME_BASE_COMPONENTS = (
@@ -284,6 +289,7 @@ SURFACE_SPECS = {
             "ni_class_1_employee_additional",
             "ni_class_1_employee_primary",
             "ni_class_1_income",
+            "ni_employee",
             "ni_liable",
         ),
     ),
@@ -2371,6 +2377,9 @@ def compare_outputs(
             "PolicyEngine weekly primary threshold and upper earnings limit, "
             "compares RuleSpec's weekly section 8 aggregate output against "
             "PolicyEngine's annual ni_class_1_employee divided by 52, and "
+            "also compares the same aggregate against PolicyEngine's "
+            "ni_employee wrapper because PE-UK defines ni_employee as an "
+            "aggregate containing only ni_class_1_employee. It "
             "compares the main/additional component outputs on ni_liable rows "
             "because PolicyEngine's component formulas are not masked by that "
             "liability predicate.",

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -58,6 +58,18 @@ PERSONAL_ALLOWANCE_OUTPUTS = {
 }
 
 NATIONAL_INSURANCE_CLASS_1_OUTPUTS = {
+    "main_primary_class_1_contribution": {
+        "axiom": f"{NATIONAL_INSURANCE_SECTION_8_BASE}#main_primary_class_1_contribution",
+        "pe": "ni_class_1_employee_primary",
+        "pe_transform": "annual_to_weekly",
+        "applies": ("ni_liable", True),
+    },
+    "additional_primary_class_1_contribution": {
+        "axiom": f"{NATIONAL_INSURANCE_SECTION_8_BASE}#additional_primary_class_1_contribution",
+        "pe": "ni_class_1_employee_additional",
+        "pe_transform": "annual_to_weekly",
+        "applies": ("ni_liable", True),
+    },
     "primary_class_1_contribution": {
         "axiom": f"{NATIONAL_INSURANCE_SECTION_8_BASE}#primary_class_1_contribution",
         "pe": "ni_class_1_employee",
@@ -234,6 +246,8 @@ SURFACE_SPECS = {
         outputs=NATIONAL_INSURANCE_CLASS_1_OUTPUTS,
         pe_variables=(
             "ni_class_1_employee",
+            "ni_class_1_employee_additional",
+            "ni_class_1_employee_primary",
             "ni_class_1_income",
             "ni_liable",
         ),
@@ -2136,8 +2150,11 @@ def compare_outputs(
             "National Insurance Class 1 comparison projects annual PolicyEngine "
             "NI Class 1 income into a representative tax week, supplies the "
             "PolicyEngine weekly primary threshold and upper earnings limit, "
-            "and compares RuleSpec's weekly section 8 output against "
-            "PolicyEngine's annual ni_class_1_employee divided by 52.",
+            "compares RuleSpec's weekly section 8 aggregate output against "
+            "PolicyEngine's annual ni_class_1_employee divided by 52, and "
+            "compares the main/additional component outputs on ni_liable rows "
+            "because PolicyEngine's component formulas are not masked by that "
+            "liability predicate.",
             "Child Benefit comparison filters to positive PolicyEngine "
             "child_benefit_respective_amount rows, divides that annualized "
             "PolicyEngine output by 52 to compare against the RuleSpec weekly "

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -37,6 +37,8 @@ WEEKS_IN_YEAR = 52
 MONTHS_IN_YEAR = 12
 POLICYENGINE_UK_VERSION = "2.88.20"
 
+NATIONAL_INSURANCE_SECTION_8_PROGRAM_PATH = Path("statutes/ukpga/1992/4/8.yaml")
+NATIONAL_INSURANCE_SECTION_8_BASE = "uk:statutes/ukpga/1992/4/8"
 PERSONAL_ALLOWANCE_PROGRAM_PATH = Path("statutes/ukpga/2007/3/35.yaml")
 PERSONAL_ALLOWANCE_BASE = "uk:statutes/ukpga/2007/3/35"
 INCOME_TAX_SECTION_23_PROGRAM_PATH = Path("statutes/ukpga/2007/3/23.yaml")
@@ -52,6 +54,14 @@ PERSONAL_ALLOWANCE_OUTPUTS = {
     "personal_allowance": {
         "axiom": f"{PERSONAL_ALLOWANCE_BASE}#personal_allowance",
         "pe": "personal_allowance",
+    },
+}
+
+NATIONAL_INSURANCE_CLASS_1_OUTPUTS = {
+    "primary_class_1_contribution": {
+        "axiom": f"{NATIONAL_INSURANCE_SECTION_8_BASE}#primary_class_1_contribution",
+        "pe": "ni_class_1_employee",
+        "pe_transform": "annual_to_weekly",
     },
 }
 
@@ -218,6 +228,16 @@ class UKEFRSSurfaceSpec:
 
 
 SURFACE_SPECS = {
+    "national-insurance-class-1": UKEFRSSurfaceSpec(
+        program=NATIONAL_INSURANCE_SECTION_8_PROGRAM_PATH,
+        entity="person",
+        outputs=NATIONAL_INSURANCE_CLASS_1_OUTPUTS,
+        pe_variables=(
+            "ni_class_1_employee",
+            "ni_class_1_income",
+            "ni_liable",
+        ),
+    ),
     "personal-allowance": UKEFRSSurfaceSpec(
         program=PERSONAL_ALLOWANCE_PROGRAM_PATH,
         entity="person",
@@ -1666,6 +1686,8 @@ def build_axiom_request(
     year: int,
     surface: str = "personal-allowance",
 ) -> dict[str, Any]:
+    if surface == "national-insurance-class-1":
+        return build_national_insurance_class_1_request(pe_data=pe_data, year=year)
     if surface == "personal-allowance":
         return build_personal_allowance_request(pe_data=pe_data, year=year)
     if surface == "income-tax-income-base":
@@ -1681,6 +1703,59 @@ def build_axiom_request(
             surface=surface,
         )
     raise ValueError(f"unsupported UK EFRS surface: {surface}")
+
+
+def build_national_insurance_class_1_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = tax_week_interval(year)
+    parameters = policyengine_uk_class_1_weekly_parameters(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "national-insurance-class-1"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        projected = {
+            "primary_class_1_contribution_payable_as_mentioned_in_section_6_1_a": bool(
+                row_value(row, "ni_liable", True)
+            ),
+            "regulations_under_section_6_6_do_not_displace_calculation": True,
+            "regulations_under_sections_116_to_120_do_not_displace_calculation": True,
+            "earnings_paid_in_tax_week_in_respect_of_employment": money(
+                row_value(row, "ni_class_1_income", 0)
+            )
+            / WEEKS_IN_YEAR,
+            "current_primary_threshold_or_prescribed_equivalent": parameters[
+                "primary_threshold"
+            ],
+            "current_upper_earnings_limit_or_prescribed_equivalent": parameters[
+                "upper_earnings_limit"
+            ],
+        }
+        for name, value in projected.items():
+            inputs.append(
+                input_record(
+                    f"{NATIONAL_INSURANCE_SECTION_8_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in NATIONAL_INSURANCE_CLASS_1_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
 
 
 def build_personal_allowance_request(
@@ -2058,6 +2133,11 @@ def compare_outputs(
             "meeting the Section 56 residence/citizenship-condition boundary "
             "facts, matching the usual PolicyEngine UK EFRS personal allowance "
             "surface until those upstream legal predicates are encoded.",
+            "National Insurance Class 1 comparison projects annual PolicyEngine "
+            "NI Class 1 income into a representative tax week, supplies the "
+            "PolicyEngine weekly primary threshold and upper earnings limit, "
+            "and compares RuleSpec's weekly section 8 output against "
+            "PolicyEngine's annual ni_class_1_employee divided by 52.",
             "Child Benefit comparison filters to positive PolicyEngine "
             "child_benefit_respective_amount rows, divides that annualized "
             "PolicyEngine output by 52 to compare against the RuleSpec weekly "
@@ -2388,6 +2468,15 @@ def benefit_week_interval(year: int) -> dict[str, str]:
     }
 
 
+def tax_week_interval(year: int) -> dict[str, str]:
+    return {
+        "period_kind": "custom",
+        "name": "tax_week",
+        "start": f"{year:04d}-04-06",
+        "end": f"{year:04d}-04-12",
+    }
+
+
 def benefit_month_interval(year: int) -> dict[str, str]:
     return {
         "period_kind": "month",
@@ -2443,6 +2532,24 @@ def require_policyengine_uk_versions(command: str = "uk-efrs-compare") -> None:
             f"policyengine-uk=={POLICYENGINE_UK_VERSION} required; found "
             f"{policyengine_uk_version}. {policyengine_uk_install_message(command)}"
         )
+
+
+def policyengine_uk_class_1_weekly_parameters(year: int) -> dict[str, float]:
+    require_policyengine_uk_versions()
+    try:
+        from policyengine_uk import CountryTaxBenefitSystem
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(policyengine_uk_install_message()) from exc
+
+    class_1 = (
+        CountryTaxBenefitSystem()
+        .parameters(f"{year:04d}-04-06")
+        .gov.hmrc.national_insurance.class_1
+    )
+    return {
+        "primary_threshold": money(class_1.thresholds.primary_threshold),
+        "upper_earnings_limit": money(class_1.thresholds.upper_earnings_limit),
+    }
 
 
 def policyengine_uk_install_message(command: str = "uk-efrs-compare") -> str:

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -40,6 +40,8 @@ NATIONAL_INSURANCE_SECTION_8_PROGRAM_PATH = Path("statutes/ukpga/1992/4/8.yaml")
 NATIONAL_INSURANCE_SECTION_8_BASE = "uk:statutes/ukpga/1992/4/8"
 PERSONAL_ALLOWANCE_PROGRAM_PATH = Path("statutes/ukpga/2007/3/35.yaml")
 PERSONAL_ALLOWANCE_BASE = "uk:statutes/ukpga/2007/3/35"
+INCOME_TAX_SECTION_10_PROGRAM_PATH = Path("statutes/ukpga/2007/3/10.yaml")
+INCOME_TAX_SECTION_10_BASE = "uk:statutes/ukpga/2007/3/10"
 INCOME_TAX_SECTION_23_PROGRAM_PATH = Path("statutes/ukpga/2007/3/23.yaml")
 INCOME_TAX_SECTION_23_BASE = "uk:statutes/ukpga/2007/3/23"
 CHILD_BENEFIT_PROGRAM_PATH = Path("regulations/uksi/2006/965/2.yaml")
@@ -130,6 +132,46 @@ INCOME_TAX_INCOME_BASE_OUTPUTS = {
     "income_tax_liability": {
         "axiom": f"{INCOME_TAX_SECTION_23_BASE}#income_tax_liability",
         "pe": "income_tax",
+    },
+}
+
+INCOME_TAX_SECTION_10_OUTPUTS = {
+    "income_charged_at_basic_rate": {
+        "axiom": f"{INCOME_TAX_SECTION_10_BASE}#income_charged_at_basic_rate",
+        "pe": "basic_rate_earned_income",
+        "applies": "non_scottish_income_tax",
+    },
+    "income_charged_at_higher_rate": {
+        "axiom": f"{INCOME_TAX_SECTION_10_BASE}#income_charged_at_higher_rate",
+        "pe": "higher_rate_earned_income",
+        "applies": "non_scottish_income_tax",
+    },
+    "income_charged_at_additional_rate": {
+        "axiom": f"{INCOME_TAX_SECTION_10_BASE}#income_charged_at_additional_rate",
+        "pe": "add_rate_earned_income",
+        "applies": "non_scottish_income_tax",
+    },
+    "tax_on_income_charged_at_basic_rate": {
+        "axiom": f"{INCOME_TAX_SECTION_10_BASE}#tax_on_income_charged_at_basic_rate",
+        "pe": "basic_rate_earned_income_tax",
+        "applies": "non_scottish_income_tax",
+    },
+    "tax_on_income_charged_at_higher_rate": {
+        "axiom": f"{INCOME_TAX_SECTION_10_BASE}#tax_on_income_charged_at_higher_rate",
+        "pe": "higher_rate_earned_income_tax",
+        "applies": "non_scottish_income_tax",
+    },
+    "tax_on_income_charged_at_additional_rate": {
+        "axiom": (
+            f"{INCOME_TAX_SECTION_10_BASE}#tax_on_income_charged_at_additional_rate"
+        ),
+        "pe": "add_rate_earned_income_tax",
+        "applies": "non_scottish_income_tax",
+    },
+    "income_tax_on_section_10_income": {
+        "axiom": f"{INCOME_TAX_SECTION_10_BASE}#income_tax_on_section_10_income",
+        "pe": "earned_income_tax",
+        "applies": "non_scottish_income_tax",
     },
 }
 
@@ -420,6 +462,22 @@ SURFACE_SPECS = {
             *INCOME_TAX_SECTION_23_REDUCTION_COMPONENTS,
             "income_tax",
             "total_income",
+        ),
+    ),
+    "income-tax-section-10-earned-income": UKEFRSSurfaceSpec(
+        program=INCOME_TAX_SECTION_10_PROGRAM_PATH,
+        entity="person",
+        outputs=INCOME_TAX_SECTION_10_OUTPUTS,
+        pe_variables=(
+            "add_rate_earned_income",
+            "add_rate_earned_income_tax",
+            "basic_rate_earned_income",
+            "basic_rate_earned_income_tax",
+            "earned_income_tax",
+            "earned_taxable_income",
+            "higher_rate_earned_income",
+            "higher_rate_earned_income_tax",
+            "pays_scottish_income_tax",
         ),
     ),
     "child-benefit": UKEFRSSurfaceSpec(
@@ -2024,6 +2082,8 @@ def build_axiom_request(
         return build_personal_allowance_request(pe_data=pe_data, year=year)
     if surface == "income-tax-income-base":
         return build_income_tax_income_base_request(pe_data=pe_data, year=year)
+    if surface == "income-tax-section-10-earned-income":
+        return build_income_tax_section_10_request(pe_data=pe_data, year=year)
     if surface == "child-benefit":
         return build_child_benefit_request(pe_data=pe_data, year=year)
     if surface == "benefit-cap-relevant-amount":
@@ -2221,6 +2281,44 @@ def build_income_tax_income_base_request(
     return {
         "mode": "explain",
         "dataset": {"inputs": inputs, "relations": relations},
+        "queries": queries,
+    }
+
+
+def build_income_tax_section_10_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = tax_year_interval(year)
+    parameters = policyengine_uk_income_tax_section_10_parameters(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "income-tax-section-10-earned-income"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_income_tax_section_10_inputs(
+            row,
+            parameters=parameters,
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{INCOME_TAX_SECTION_10_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in INCOME_TAX_SECTION_10_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
         "queries": queries,
     }
 
@@ -2652,6 +2750,23 @@ def project_income_tax_section_23_inputs(row: Any) -> dict[str, Any]:
         "tax_calculated_at_applicable_rates_on_income_remaining_after_allowances": additions,
         "tax_reductions_listed_in_section_26": reductions,
         "additional_tax_amounts_listed_in_section_30": 0.0,
+    }
+
+
+def project_income_tax_section_10_inputs(
+    row: Any,
+    *,
+    parameters: dict[str, float],
+) -> dict[str, Any]:
+    return {
+        "income_charged_under_section_10": money(
+            row_value(row, "earned_taxable_income", 0)
+        ),
+        "basic_rate_limit": parameters["basic_rate_limit"],
+        "higher_rate_limit": parameters["higher_rate_limit"],
+        "basic_rate": parameters["basic_rate"],
+        "higher_rate": parameters["higher_rate"],
+        "additional_rate": parameters["additional_rate"],
     }
 
 
@@ -3176,6 +3291,8 @@ def output_applies(spec: dict[str, Any], row: Any) -> bool:
         ) and money(row_value(row, "adjusted_net_income", 0)) <= money(
             row_value(row, "total_income", 0)
         )
+    if applies == "non_scottish_income_tax":
+        return not bool(row_value(row, "pays_scottish_income_tax", False))
     if applies == "uc_first_child_element":
         return (
             policyengine_output_value(spec, row) > 0
@@ -3553,6 +3670,27 @@ def policyengine_uk_class_1_weekly_parameters(year: int) -> dict[str, float]:
     return {
         "primary_threshold": money(class_1.thresholds.primary_threshold),
         "upper_earnings_limit": money(class_1.thresholds.upper_earnings_limit),
+    }
+
+
+def policyengine_uk_income_tax_section_10_parameters(year: int) -> dict[str, float]:
+    require_policyengine_uk_versions()
+    try:
+        from policyengine_uk import CountryTaxBenefitSystem
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(policyengine_uk_install_message()) from exc
+
+    uk_rates = (
+        CountryTaxBenefitSystem()
+        .parameters(f"{year:04d}-04-06")
+        .gov.hmrc.income_tax.rates.uk
+    )
+    return {
+        "basic_rate_limit": money(uk_rates.thresholds[1]),
+        "higher_rate_limit": money(uk_rates.thresholds[2]),
+        "basic_rate": money(uk_rates.rates[0]),
+        "higher_rate": money(uk_rates.rates[1]),
+        "additional_rate": money(uk_rates.rates[2]),
     }
 
 

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -44,14 +44,20 @@ INCOME_TAX_SECTION_23_PROGRAM_PATH = Path("statutes/ukpga/2007/3/23.yaml")
 INCOME_TAX_SECTION_23_BASE = "uk:statutes/ukpga/2007/3/23"
 CHILD_BENEFIT_PROGRAM_PATH = Path("regulations/uksi/2006/965/2.yaml")
 CHILD_BENEFIT_BASE = "uk:regulations/uksi/2006/965/2"
+BENEFIT_CAP_REGULATION_80A_PROGRAM_PATH = Path("regulations/uksi/2013/376/80A.yaml")
+BENEFIT_CAP_REGULATION_80A_BASE = "uk:regulations/uksi/2013/376/80A"
 STATE_PENSION_CREDIT_SECTION_1_PROGRAM_PATH = Path("statutes/ukpga/2002/16/1.yaml")
 STATE_PENSION_CREDIT_SECTION_1_BASE = "uk:statutes/ukpga/2002/16/1"
 PENSION_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2002/1792/6.yaml")
 PENSION_CREDIT_BASE = "uk:regulations/uksi/2002/1792/6"
 UNIVERSAL_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2013/376/36.yaml")
 UNIVERSAL_CREDIT_BASE = "uk:regulations/uksi/2013/376/36"
+UNIVERSAL_CREDIT_REGULATION_22_PROGRAM_PATH = Path("regulations/uksi/2013/376/22.yaml")
+UNIVERSAL_CREDIT_REGULATION_22_BASE = "uk:regulations/uksi/2013/376/22"
 WELFARE_REFORM_ACT_SECTION_8_PROGRAM_PATH = Path("statutes/ukpga/2012/5/8.yaml")
 WELFARE_REFORM_ACT_SECTION_8_BASE = "uk:statutes/ukpga/2012/5/8"
+WELFARE_REFORM_ACT_SECTION_11_PROGRAM_PATH = Path("statutes/ukpga/2012/5/11.yaml")
+WELFARE_REFORM_ACT_SECTION_11_BASE = "uk:statutes/ukpga/2012/5/11"
 
 PERSONAL_ALLOWANCE_OUTPUTS = {
     "personal_allowance": {
@@ -128,6 +134,14 @@ CHILD_BENEFIT_OUTPUTS = {
         "axiom": f"{CHILD_BENEFIT_BASE}#child_benefit_weekly_rate",
         "pe": "child_benefit_respective_amount",
         "pe_transform": "annual_to_weekly",
+    },
+}
+
+BENEFIT_CAP_RELEVANT_AMOUNT_OUTPUTS = {
+    "benefit_cap_relevant_amount": {
+        "axiom": f"{BENEFIT_CAP_REGULATION_80A_BASE}#benefit_cap_relevant_amount",
+        "pe": "benefit_cap",
+        "pe_transform": "annual_to_monthly",
     },
 }
 
@@ -277,6 +291,27 @@ UNIVERSAL_CREDIT_AWARD_OUTPUTS = {
     },
 }
 
+UNIVERSAL_CREDIT_HOUSING_COSTS_OUTPUTS = {
+    "section_11_amount_for_accommodation_payments": {
+        "axiom": (
+            f"{WELFARE_REFORM_ACT_SECTION_11_BASE}"
+            "#section_11_amount_for_accommodation_payments"
+        ),
+        "pe": "uc_housing_costs_element",
+        "pe_transform": "annual_to_monthly",
+    },
+}
+
+UNIVERSAL_CREDIT_WORK_ALLOWANCE_OUTPUTS = {
+    "applicable_work_allowance_amount": {
+        "axiom": (
+            f"{UNIVERSAL_CREDIT_REGULATION_22_BASE}#applicable_work_allowance_amount"
+        ),
+        "pe": "uc_work_allowance",
+        "pe_transform": "annual_to_monthly",
+    },
+}
+
 UNIVERSAL_CREDIT_2026_RULESPEC_RATES = {
     "standard_allowance_single_under_25": 338.58,
     "standard_allowance_single_25_or_over": 424.90,
@@ -346,6 +381,17 @@ SURFACE_SPECS = {
         pe_variables=(
             "child_benefit_child_index",
             "child_benefit_respective_amount",
+        ),
+    ),
+    "benefit-cap-relevant-amount": UKEFRSSurfaceSpec(
+        program=BENEFIT_CAP_REGULATION_80A_PROGRAM_PATH,
+        entity="benunit",
+        outputs=BENEFIT_CAP_RELEVANT_AMOUNT_OUTPUTS,
+        pe_variables=(
+            "benefit_cap",
+            "benunit_region",
+            "num_adults",
+            "num_children",
         ),
     ),
     "state-pension-credit-qualifying-age": UKEFRSSurfaceSpec(
@@ -429,6 +475,24 @@ SURFACE_SPECS = {
             "uc_maximum_amount",
             "uc_standard_allowance",
             "universal_credit_pre_benefit_cap",
+        ),
+    ),
+    "universal-credit-housing-costs": UKEFRSSurfaceSpec(
+        program=WELFARE_REFORM_ACT_SECTION_11_PROGRAM_PATH,
+        entity="benunit",
+        outputs=UNIVERSAL_CREDIT_HOUSING_COSTS_OUTPUTS,
+        pe_variables=("uc_housing_costs_element",),
+    ),
+    "universal-credit-work-allowance": UKEFRSSurfaceSpec(
+        program=UNIVERSAL_CREDIT_REGULATION_22_PROGRAM_PATH,
+        entity="benunit",
+        outputs=UNIVERSAL_CREDIT_WORK_ALLOWANCE_OUTPUTS,
+        pe_variables=(
+            "is_uc_work_allowance_eligible",
+            "num_adults",
+            "num_children",
+            "uc_housing_costs_element",
+            "uc_work_allowance",
         ),
     ),
 }
@@ -1879,6 +1943,11 @@ def build_axiom_request(
         return build_income_tax_income_base_request(pe_data=pe_data, year=year)
     if surface == "child-benefit":
         return build_child_benefit_request(pe_data=pe_data, year=year)
+    if surface == "benefit-cap-relevant-amount":
+        return build_benefit_cap_relevant_amount_request(
+            pe_data=pe_data,
+            year=year,
+        )
     if surface == "state-pension-credit-qualifying-age":
         return build_state_pension_credit_qualifying_age_request(
             pe_data=pe_data,
@@ -1888,6 +1957,16 @@ def build_axiom_request(
         return build_pension_credit_request(pe_data=pe_data, year=year)
     if surface == "universal-credit-award":
         return build_universal_credit_award_request(pe_data=pe_data, year=year)
+    if surface == "universal-credit-housing-costs":
+        return build_universal_credit_housing_costs_request(
+            pe_data=pe_data,
+            year=year,
+        )
+    if surface == "universal-credit-work-allowance":
+        return build_universal_credit_work_allowance_request(
+            pe_data=pe_data,
+            year=year,
+        )
     if surface in UNIVERSAL_CREDIT_REGULATION_36_SURFACES:
         return build_universal_credit_request(
             pe_data=pe_data,
@@ -2080,6 +2159,41 @@ def build_child_benefit_request(
     }
 
 
+def build_benefit_cap_relevant_amount_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = benefit_month_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "benefit-cap-relevant-amount"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_benefit_cap_relevant_amount_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{BENEFIT_CAP_REGULATION_80A_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in BENEFIT_CAP_RELEVANT_AMOUNT_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def build_state_pension_credit_qualifying_age_request(
     *, pe_data: dict[str, Any], year: int
 ) -> dict[str, Any]:
@@ -2209,6 +2323,76 @@ def build_universal_credit_award_request(
     }
 
 
+def build_universal_credit_housing_costs_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = benefit_month_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "universal-credit-housing-costs"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_universal_credit_housing_costs_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{WELFARE_REFORM_ACT_SECTION_11_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in UNIVERSAL_CREDIT_HOUSING_COSTS_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_universal_credit_work_allowance_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = benefit_month_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "universal-credit-work-allowance"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_universal_credit_work_allowance_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{UNIVERSAL_CREDIT_REGULATION_22_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in UNIVERSAL_CREDIT_WORK_ALLOWANCE_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def project_personal_allowance_inputs(row: Any) -> dict[str, Any]:
     adjusted_net_income = money(row_value(row, "adjusted_net_income"))
     gift_aid_grossed_up = money(row_value(row, "gift_aid_grossed_up", 0))
@@ -2280,6 +2464,22 @@ def project_child_benefit_inputs(row: Any) -> dict[str, Any]:
     }
 
 
+def project_benefit_cap_relevant_amount_inputs(row: Any) -> dict[str, Any]:
+    num_adults = int(money(row_value(row, "num_adults", 0)))
+    num_children = int(money(row_value(row, "num_children", 0)))
+    in_london = enum_name(row_value(row, "benunit_region", "")).upper() == "LONDON"
+    return {
+        "claim_is_for_joint_claimants": num_adults > 1,
+        "responsible_for_child_or_qualifying_young_person": num_children > 0,
+        "award_contains_housing_costs_element": False,
+        "accommodation_in_respect_of_which_claimant_meets_occupation_condition_is_in_greater_london": False,
+        "claimant_receives_housing_benefit_for_dwelling_in_greater_london": False,
+        "claimant_has_accommodation_normally_occupied_as_home": True,
+        "accommodation_normally_occupied_as_home_is_in_greater_london": in_london,
+        "jobcentre_plus_office_allocated_to_claim_is_in_greater_london": False,
+    }
+
+
 def project_state_pension_credit_qualifying_age_inputs(row: Any) -> dict[str, Any]:
     state_pension_age = money(row_value(row, "state_pension_age", 0))
     return {
@@ -2322,6 +2522,55 @@ def project_universal_credit_award_inputs(row: Any) -> dict[str, Any]:
     }
 
 
+def project_universal_credit_housing_costs_inputs(row: Any) -> dict[str, Any]:
+    monthly_housing_costs = money(row_value(row, "uc_housing_costs_element", 0)) / (
+        MONTHS_IN_YEAR
+    )
+    return {
+        "payments_are_in_respect_of_accommodation_for_section_11": True,
+        "accommodation_is_in_great_britain": True,
+        "accommodation_is_residential_accommodation": True,
+        "claimant_is_liable_to_make_accommodation_payments": True,
+        "claimant_is_treated_as_liable_to_make_accommodation_payments_by_regulations": False,
+        "claimant_is_treated_as_not_liable_to_make_accommodation_payments_by_regulations": False,
+        "claimant_occupies_accommodation_as_home": True,
+        "claimant_is_treated_as_occupying_accommodation_as_home_by_regulations": False,
+        "claimant_is_treated_as_not_occupying_accommodation_as_home_by_regulations": False,
+        "section_11_exception_to_accommodation_amount_applies_by_regulations": False,
+        "section_11_inclusion_has_ended_at_prescribed_time_by_regulations": False,
+        "section_11_inclusion_has_not_started_until_prescribed_time_by_regulations": False,
+        "amount_determined_or_calculated_by_regulations_under_section_11": monthly_housing_costs,
+    }
+
+
+def project_universal_credit_work_allowance_inputs(row: Any) -> dict[str, Any]:
+    num_adults = int(money(row_value(row, "num_adults", 0)))
+    num_children = int(money(row_value(row, "num_children", 0)))
+    joint_claim = num_adults > 1
+    has_child = num_children > 0
+    eligible = bool(row_value(row, "is_uc_work_allowance_eligible", False))
+    has_limited_capability = eligible and not has_child
+    return {
+        "claim_is_for_joint_claimants": joint_claim,
+        "claimant_is_member_of_couple": False,
+        "claimant_makes_claim_as_single_person": False,
+        "joint_claimants_responsible_for_child_or_qualifying_young_person": joint_claim
+        and has_child,
+        "one_or_both_joint_claimants_have_limited_capability_for_work": joint_claim
+        and has_limited_capability,
+        "single_claimant_responsible_for_child_or_qualifying_young_person": (
+            not joint_claim and has_child
+        ),
+        "single_claimant_has_limited_capability_for_work": (
+            not joint_claim and has_limited_capability
+        ),
+        "award_contains_housing_costs_element": money(
+            row_value(row, "uc_housing_costs_element", 0)
+        )
+        > 0,
+    }
+
+
 def project_pension_credit_inputs(row: Any) -> dict[str, Any]:
     relation_type = str(row_value(row, "relation_type", "")).upper()
     is_couple = bool(row_value(row, "is_couple", False)) or relation_type == "COUPLE"
@@ -2351,6 +2600,13 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             for row in persons
             if money(row_value(row, "child_benefit_respective_amount", 0)) > 0
         ]
+    benunits = pe_data.get("benunits", [])
+    if surface == "benefit-cap-relevant-amount":
+        return [
+            row
+            for row in benunits
+            if math.isfinite(money(row_value(row, "benefit_cap", math.inf)))
+        ]
     if surface == "universal-credit-child-element":
         return [
             row
@@ -2360,7 +2616,6 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             or money(row_value(row, "uc_individual_severely_disabled_child_element", 0))
             > 0
         ]
-    benunits = pe_data.get("benunits", [])
     if surface == "universal-credit-standard-allowance":
         return [
             row
@@ -2505,6 +2760,12 @@ def compare_outputs(
             "specified-benefit, and polygamous-marriage branches are projected "
             "false because PolicyEngine UK's child_benefit_respective_amount "
             "does not expose those legal predicates separately.",
+            "Universal Credit Regulation 80A benefit-cap relevant-amount "
+            "comparison filters to finite PolicyEngine benefit_cap rows, "
+            "divides the annual PE cap by 12, and projects the annual-limit "
+            "case from PolicyEngine's num_adults, num_children, and "
+            "benunit_region. PolicyEngine uses infinity for exempt benunits, "
+            "which are outside the finite relevant-amount comparison.",
             "Pension Credit standard minimum guarantee comparison runs at "
             "benefit-unit level, divides PolicyEngine's annual output by 52, "
             "and projects claimant_has_partner from PolicyEngine's relation_type "
@@ -2536,6 +2797,17 @@ def compare_outputs(
             "and projects PolicyEngine's capped uc_income_reduction as the "
             "prescribed income deduction because PolicyEngine exposes the final "
             "deduction rather than the exact statutory earned/unearned split.",
+            "Welfare Reform Act 2012 section 11 Universal Credit housing-costs "
+            "comparison projects PolicyEngine's annual uc_housing_costs_element "
+            "into the monthly amount determined or calculated by regulations, "
+            "with ordinary Great Britain residential-accommodation eligibility "
+            "predicates projected true and exception/timing predicates false.",
+            "Universal Credit Regulation 22 work-allowance comparison projects "
+            "PolicyEngine's is_uc_work_allowance_eligible, num_adults, "
+            "num_children, and uc_housing_costs_element into the statutory "
+            "higher/lower work-allowance case split, then compares the monthly "
+            "RuleSpec allowance against PolicyEngine's annual uc_work_allowance "
+            "divided by 12.",
             "The protected LCWRA Regulation 36 table amount is compared only "
             "when PolicyEngine exposes the raw protected amount. Current "
             "PolicyEngine UK EFRS outputs apply the July 2025 UC rebalancing "

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -50,6 +50,8 @@ PENSION_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2002/1792/6.yaml")
 PENSION_CREDIT_BASE = "uk:regulations/uksi/2002/1792/6"
 UNIVERSAL_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2013/376/36.yaml")
 UNIVERSAL_CREDIT_BASE = "uk:regulations/uksi/2013/376/36"
+WELFARE_REFORM_ACT_SECTION_8_PROGRAM_PATH = Path("statutes/ukpga/2012/5/8.yaml")
+WELFARE_REFORM_ACT_SECTION_8_BASE = "uk:statutes/ukpga/2012/5/8"
 
 PERSONAL_ALLOWANCE_OUTPUTS = {
     "personal_allowance": {
@@ -254,6 +256,27 @@ UNIVERSAL_CREDIT_CHILDCARE_OUTPUTS = {
     },
 }
 
+UNIVERSAL_CREDIT_AWARD_OUTPUTS = {
+    "universal_credit_maximum_amount": {
+        "axiom": f"{WELFARE_REFORM_ACT_SECTION_8_BASE}#universal_credit_maximum_amount",
+        "pe": "uc_maximum_amount",
+        "pe_transform": "annual_to_monthly",
+    },
+    "universal_credit_amounts_to_be_deducted": {
+        "axiom": (
+            f"{WELFARE_REFORM_ACT_SECTION_8_BASE}"
+            "#universal_credit_amounts_to_be_deducted"
+        ),
+        "pe": "uc_income_reduction",
+        "pe_transform": "annual_to_monthly",
+    },
+    "universal_credit_award_amount": {
+        "axiom": f"{WELFARE_REFORM_ACT_SECTION_8_BASE}#universal_credit_award_amount",
+        "pe": "universal_credit_pre_benefit_cap",
+        "pe_transform": "annual_to_monthly",
+    },
+}
+
 UNIVERSAL_CREDIT_2026_RULESPEC_RATES = {
     "standard_allowance_single_under_25": 338.58,
     "standard_allowance_single_25_or_over": 424.90,
@@ -391,7 +414,30 @@ SURFACE_SPECS = {
             "uc_maximum_childcare_element_amount",
         ),
     ),
+    "universal-credit-award": UKEFRSSurfaceSpec(
+        program=WELFARE_REFORM_ACT_SECTION_8_PROGRAM_PATH,
+        entity="benunit",
+        outputs=UNIVERSAL_CREDIT_AWARD_OUTPUTS,
+        pe_variables=(
+            "is_uc_eligible",
+            "uc_carer_element",
+            "uc_child_element",
+            "uc_childcare_element",
+            "uc_disability_elements",
+            "uc_housing_costs_element",
+            "uc_income_reduction",
+            "uc_maximum_amount",
+            "uc_standard_allowance",
+            "universal_credit_pre_benefit_cap",
+        ),
+    ),
 }
+
+UNIVERSAL_CREDIT_REGULATION_36_SURFACES = frozenset(
+    surface
+    for surface, spec in SURFACE_SPECS.items()
+    if spec.program == UNIVERSAL_CREDIT_PROGRAM_PATH
+)
 
 SKIPPED_SURFACES: list[dict[str, str]] = []
 
@@ -771,7 +817,7 @@ def compare_uk_efrs(
     for selected_surface in surfaces:
         spec = SURFACE_SPECS[selected_surface]
         if (
-            selected_surface.startswith("universal-credit-")
+            selected_surface in UNIVERSAL_CREDIT_REGULATION_36_SURFACES
             and universal_credit_program is not None
         ):
             program = universal_credit_program.resolve()
@@ -1682,7 +1728,7 @@ def run_axiom_surface(
     axiom_rules_path: Path,
     surface: str,
 ) -> list[dict[str, Any]]:
-    if surface.startswith("universal-credit-"):
+    if surface in UNIVERSAL_CREDIT_REGULATION_36_SURFACES:
         return run_axiom_parameter_outputs(
             program=program,
             request=request,
@@ -1840,7 +1886,9 @@ def build_axiom_request(
         )
     if surface == "pension-credit":
         return build_pension_credit_request(pe_data=pe_data, year=year)
-    if surface.startswith("universal-credit-"):
+    if surface == "universal-credit-award":
+        return build_universal_credit_award_request(pe_data=pe_data, year=year)
+    if surface in UNIVERSAL_CREDIT_REGULATION_36_SURFACES:
         return build_universal_credit_request(
             pe_data=pe_data,
             year=year,
@@ -2127,6 +2175,40 @@ def build_universal_credit_request(
     }
 
 
+def build_universal_credit_award_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = benefit_month_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "universal-credit-award"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_universal_credit_award_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{WELFARE_REFORM_ACT_SECTION_8_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in UNIVERSAL_CREDIT_AWARD_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def project_personal_allowance_inputs(row: Any) -> dict[str, Any]:
     adjusted_net_income = money(row_value(row, "adjusted_net_income"))
     gift_aid_grossed_up = money(row_value(row, "gift_aid_grossed_up", 0))
@@ -2206,6 +2288,37 @@ def project_state_pension_credit_qualifying_age_inputs(row: Any) -> dict[str, An
         "pensionable_age": state_pension_age,
         "pensionable_age_for_woman_born_same_day": state_pension_age,
         "claimant_age": money(row_value(row, "age", 0)),
+    }
+
+
+def project_universal_credit_award_inputs(row: Any) -> dict[str, Any]:
+    is_uc_eligible = bool(row_value(row, "is_uc_eligible", False))
+
+    def monthly(name: str) -> float:
+        return money(row_value(row, name, 0)) / MONTHS_IN_YEAR
+
+    def eligible_monthly(name: str) -> float:
+        return monthly(name) if is_uc_eligible else 0.0
+
+    return {
+        "amount_included_under_section_9_standard_allowance": eligible_monthly(
+            "uc_standard_allowance"
+        ),
+        "amount_included_under_section_10_responsibility_for_children_and_young_persons": eligible_monthly(
+            "uc_child_element"
+        ),
+        "amount_included_under_section_11_housing_costs": eligible_monthly(
+            "uc_housing_costs_element"
+        ),
+        "amount_included_under_section_12_other_particular_needs_or_circumstances": (
+            eligible_monthly("uc_disability_elements")
+            + eligible_monthly("uc_childcare_element")
+            + eligible_monthly("uc_carer_element")
+        ),
+        "earned_income_deduction_calculated_in_prescribed_manner": eligible_monthly(
+            "uc_income_reduction"
+        ),
+        "unearned_income_deduction_calculated_in_prescribed_manner": 0.0,
     }
 
 
@@ -2416,6 +2529,13 @@ def compare_outputs(
             "EFRS component outputs are divided by 12, and EFRS category "
             "variables select the matching standard-allowance, child-element, "
             "carer, LCWRA, and childcare-cap rows.",
+            "Welfare Reform Act 2012 section 8 Universal Credit award "
+            "comparison projects annual PolicyEngine component outputs into "
+            "monthly section 8 maximum-amount buckets, gates those buckets by "
+            "PolicyEngine's is_uc_eligible predicate to match uc_maximum_amount, "
+            "and projects PolicyEngine's capped uc_income_reduction as the "
+            "prescribed income deduction because PolicyEngine exposes the final "
+            "deduction rather than the exact statutory earned/unearned split.",
             "The protected LCWRA Regulation 36 table amount is compared only "
             "when PolicyEngine exposes the raw protected amount. Current "
             "PolicyEngine UK EFRS outputs apply the July 2025 UC rebalancing "

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -88,10 +88,25 @@ INCOME_TAX_INCOME_BASE_COMPONENTS = (
     "miscellaneous_income",
 )
 
+INCOME_TAX_SECTION_23_ADDITION_COMPONENTS = (
+    "income_tax_pre_charges",
+    "CB_HITC",
+    "personal_pension_contributions_tax",
+)
+
+INCOME_TAX_SECTION_23_REDUCTION_COMPONENTS = (
+    "capped_mcad",
+    "other_tax_credits",
+)
+
 INCOME_TAX_INCOME_BASE_OUTPUTS = {
     "total_income": {
         "axiom": f"{INCOME_TAX_SECTION_23_BASE}#total_income",
         "pe": "total_income",
+    },
+    "income_tax_liability": {
+        "axiom": f"{INCOME_TAX_SECTION_23_BASE}#income_tax_liability",
+        "pe": "income_tax",
     },
 }
 
@@ -268,6 +283,9 @@ SURFACE_SPECS = {
         outputs=INCOME_TAX_INCOME_BASE_OUTPUTS,
         pe_variables=(
             *INCOME_TAX_INCOME_BASE_COMPONENTS,
+            *INCOME_TAX_SECTION_23_ADDITION_COMPONENTS,
+            *INCOME_TAX_SECTION_23_REDUCTION_COMPONENTS,
+            "income_tax",
             "total_income",
         ),
     ),
@@ -1836,6 +1854,15 @@ def build_income_tax_income_base_request(
                     money(component["amount_charged_to_income_tax"]),
                 )
             )
+        for name, value in project_income_tax_section_23_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{INCOME_TAX_SECTION_23_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
         queries.append(
             {
                 "entity_id": entity_id,
@@ -1966,6 +1993,22 @@ def project_income_tax_income_base_components(row: Any) -> list[dict[str, Any]]:
         for component in components
         if money(component["amount_charged_to_income_tax"])
     ]
+
+
+def project_income_tax_section_23_inputs(row: Any) -> dict[str, Any]:
+    additions = sum(
+        money(row_value(row, name, 0))
+        for name in INCOME_TAX_SECTION_23_ADDITION_COMPONENTS
+    )
+    reductions = sum(
+        money(row_value(row, name, 0))
+        for name in INCOME_TAX_SECTION_23_REDUCTION_COMPONENTS
+    )
+    return {
+        "tax_calculated_at_applicable_rates_on_income_remaining_after_allowances": additions,
+        "tax_reductions_listed_in_section_26": reductions,
+        "additional_tax_amounts_listed_in_section_30": 0.0,
+    }
 
 
 def project_child_benefit_inputs(row: Any) -> dict[str, Any]:
@@ -2180,6 +2223,12 @@ def compare_outputs(
             "EFRS component outputs are divided by 12, and EFRS category "
             "variables select the matching standard-allowance, child-element, "
             "carer, LCWRA, and childcare-cap rows.",
+            "Income Tax Act 2007 section 23 final-liability comparison collapses "
+            "PolicyEngine's income_tax_additions into the RuleSpec step-4 tax "
+            "input and PolicyEngine's income_tax_subtractions into the section "
+            "26 reductions input, because PolicyEngine exposes final income_tax "
+            "and aggregate additive/subtractive components rather than exact "
+            "section 23 step buckets.",
         ],
     )
 

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -56,6 +56,8 @@ UNIVERSAL_CREDIT_REGULATION_22_PROGRAM_PATH = Path("regulations/uksi/2013/376/22
 UNIVERSAL_CREDIT_REGULATION_22_BASE = "uk:regulations/uksi/2013/376/22"
 UNIVERSAL_CREDIT_REGULATION_34_PROGRAM_PATH = Path("regulations/uksi/2013/376/34.yaml")
 UNIVERSAL_CREDIT_REGULATION_34_BASE = "uk:regulations/uksi/2013/376/34"
+UNIVERSAL_CREDIT_REGULATION_72_PROGRAM_PATH = Path("regulations/uksi/2013/376/72.yaml")
+UNIVERSAL_CREDIT_REGULATION_72_BASE = "uk:regulations/uksi/2013/376/72"
 WELFARE_REFORM_ACT_SECTION_8_PROGRAM_PATH = Path("statutes/ukpga/2012/5/8.yaml")
 WELFARE_REFORM_ACT_SECTION_8_BASE = "uk:statutes/ukpga/2012/5/8"
 WELFARE_REFORM_ACT_SECTION_11_PROGRAM_PATH = Path("statutes/ukpga/2012/5/11.yaml")
@@ -347,6 +349,15 @@ UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS = {
     },
 }
 
+UNIVERSAL_CREDIT_TARIFF_INCOME_OUTPUTS = {
+    "capital_tariff_monthly_income": {
+        "axiom": f"{UNIVERSAL_CREDIT_REGULATION_72_BASE}#capital_tariff_monthly_income",
+        "pe": "uc_tariff_income",
+        "pe_transform": "annual_to_monthly",
+        "applies": "uc_tariff_income_defined",
+    },
+}
+
 UNIVERSAL_CREDIT_2026_RULESPEC_RATES = {
     "standard_allowance_single_under_25": 338.58,
     "standard_allowance_single_25_or_over": 424.90,
@@ -555,6 +566,16 @@ SURFACE_SPECS = {
             "uc_maximum_amount",
             "uc_unearned_income",
             "uc_work_allowance",
+        ),
+    ),
+    "universal-credit-tariff-income": UKEFRSSurfaceSpec(
+        program=UNIVERSAL_CREDIT_REGULATION_72_PROGRAM_PATH,
+        entity="benunit",
+        outputs=UNIVERSAL_CREDIT_TARIFF_INCOME_OUTPUTS,
+        pe_variables=(
+            "is_uc_eligible",
+            "uc_assessable_capital",
+            "uc_tariff_income",
         ),
     ),
 }
@@ -2034,6 +2055,11 @@ def build_axiom_request(
             pe_data=pe_data,
             year=year,
         )
+    if surface == "universal-credit-tariff-income":
+        return build_universal_credit_tariff_income_request(
+            pe_data=pe_data,
+            year=year,
+        )
     if surface == "universal-credit-work-allowance":
         return build_universal_credit_work_allowance_request(
             pe_data=pe_data,
@@ -2504,6 +2530,41 @@ def build_universal_credit_income_deduction_request(
     }
 
 
+def build_universal_credit_tariff_income_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = benefit_month_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "universal-credit-tariff-income"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_universal_credit_tariff_income_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{UNIVERSAL_CREDIT_REGULATION_72_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in UNIVERSAL_CREDIT_TARIFF_INCOME_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def build_universal_credit_work_allowance_request(
     *, pe_data: dict[str, Any], year: int
 ) -> dict[str, Any]:
@@ -2757,6 +2818,16 @@ def project_universal_credit_income_deduction_inputs(row: Any) -> dict[str, Any]
         "joint_claimants_combined_earned_income_in_assessment_period": joint_earned_income,
         "claimant_unearned_income_in_assessment_period": claimant_unearned_income,
         "joint_claimants_combined_unearned_income_in_assessment_period": joint_unearned_income,
+    }
+
+
+def project_universal_credit_tariff_income_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "person_capital": money(row_value(row, "uc_assessable_capital", 0)),
+        "capital_is_disregarded": False,
+        "actual_income_from_capital_taken_into_account_under_regulation_66_1_i_annuity": False,
+        "actual_income_from_capital_taken_into_account_under_regulation_66_1_j_trust": False,
+        "actual_income_derived_from_that_capital_due_to_be_paid_to_person_on_day_amount": 0.0,
     }
 
 
@@ -3036,6 +3107,13 @@ def compare_outputs(
             "and PolicyEngine's negative-unearned-income treatment does not "
             "differ from Regulation 22's non-negative unearned-income "
             "deduction.",
+            "Universal Credit Regulation 72 tariff-income comparison projects "
+            "PolicyEngine's annual uc_assessable_capital stock into the "
+            "RuleSpec person_capital leaf, projects capital disregards and "
+            "actual-capital-income exceptions false, compares the monthly "
+            "RuleSpec tariff income against PolicyEngine's annual "
+            "uc_tariff_income divided by 12, and only counts rows where "
+            "PolicyEngine defines UC eligibility.",
             "Universal Credit Regulation 34 childcare-costs element comparison "
             "projects PolicyEngine's annual uc_childcare_element into monthly "
             "relevant childcare charges by reversing the statutory 85 percent "
@@ -3134,6 +3212,8 @@ def output_applies(spec: dict[str, Any], row: Any) -> bool:
             and annual_uncapped_reduction <= maximum_credit + 0.01
             and math.isclose(pe_reduction, annual_uncapped_reduction, abs_tol=0.01)
         )
+    if applies == "uc_tariff_income_defined":
+        return bool(row_value(row, "is_uc_eligible", False))
     if isinstance(applies, tuple) and len(applies) == 2:
         name, expected = applies
         value = row_value(row, name)

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -322,6 +322,31 @@ UNIVERSAL_CREDIT_WORK_ALLOWANCE_OUTPUTS = {
     },
 }
 
+UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS = {
+    "earned_income_amount_subject_to_taper": {
+        "axiom": (
+            f"{UNIVERSAL_CREDIT_REGULATION_22_BASE}"
+            "#earned_income_amount_subject_to_taper"
+        ),
+        "pe": "uc_earned_income",
+        "pe_transform": "annual_to_monthly",
+    },
+    "unearned_income_for_deduction": {
+        "axiom": f"{UNIVERSAL_CREDIT_REGULATION_22_BASE}#unearned_income_for_deduction",
+        "pe": "uc_unearned_income",
+        "pe_transform": "annual_to_monthly",
+    },
+    "universal_credit_award_deduction_from_maximum_amount": {
+        "axiom": (
+            f"{UNIVERSAL_CREDIT_REGULATION_22_BASE}"
+            "#universal_credit_award_deduction_from_maximum_amount"
+        ),
+        "pe": "uc_income_reduction",
+        "pe_transform": "annual_to_monthly",
+        "applies": "uc_income_reduction_uncapped",
+    },
+}
+
 UNIVERSAL_CREDIT_2026_RULESPEC_RATES = {
     "standard_allowance_single_under_25": 338.58,
     "standard_allowance_single_25_or_over": 424.90,
@@ -337,6 +362,7 @@ UNIVERSAL_CREDIT_2026_RULESPEC_RATES = {
     "childcare_costs_element_maximum_one_child": 1071.09,
     "childcare_costs_element_maximum_two_or_more_children": 1836.16,
     "childcare_costs_element_reimbursement_rate": 0.85,
+    "earned_income_taper_rate": 0.55,
 }
 
 
@@ -512,6 +538,22 @@ SURFACE_SPECS = {
             "num_adults",
             "num_children",
             "uc_housing_costs_element",
+            "uc_work_allowance",
+        ),
+    ),
+    "universal-credit-income-deduction": UKEFRSSurfaceSpec(
+        program=UNIVERSAL_CREDIT_REGULATION_22_PROGRAM_PATH,
+        entity="benunit",
+        outputs=UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS,
+        pe_variables=(
+            "is_uc_work_allowance_eligible",
+            "num_adults",
+            "num_children",
+            "uc_earned_income",
+            "uc_housing_costs_element",
+            "uc_income_reduction",
+            "uc_maximum_amount",
+            "uc_unearned_income",
             "uc_work_allowance",
         ),
     ),
@@ -1987,6 +2029,11 @@ def build_axiom_request(
             pe_data=pe_data,
             year=year,
         )
+    if surface == "universal-credit-income-deduction":
+        return build_universal_credit_income_deduction_request(
+            pe_data=pe_data,
+            year=year,
+        )
     if surface == "universal-credit-work-allowance":
         return build_universal_credit_work_allowance_request(
             pe_data=pe_data,
@@ -2420,6 +2467,43 @@ def build_universal_credit_housing_costs_request(
     }
 
 
+def build_universal_credit_income_deduction_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = benefit_month_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "universal-credit-income-deduction"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_universal_credit_income_deduction_inputs(
+            row
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{UNIVERSAL_CREDIT_REGULATION_22_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def build_universal_credit_work_allowance_request(
     *, pe_data: dict[str, Any], year: int
 ) -> dict[str, Any]:
@@ -2631,6 +2715,48 @@ def project_universal_credit_housing_costs_inputs(row: Any) -> dict[str, Any]:
         "section_11_inclusion_has_ended_at_prescribed_time_by_regulations": False,
         "section_11_inclusion_has_not_started_until_prescribed_time_by_regulations": False,
         "amount_determined_or_calculated_by_regulations_under_section_11": monthly_housing_costs,
+    }
+
+
+def project_universal_credit_income_deduction_inputs(row: Any) -> dict[str, Any]:
+    work_allowance_inputs = project_universal_credit_work_allowance_inputs(row)
+    work_allowance_specified = (
+        work_allowance_inputs[
+            "joint_claimants_responsible_for_child_or_qualifying_young_person"
+        ]
+        or work_allowance_inputs[
+            "one_or_both_joint_claimants_have_limited_capability_for_work"
+        ]
+        or work_allowance_inputs[
+            "single_claimant_responsible_for_child_or_qualifying_young_person"
+        ]
+        or work_allowance_inputs["single_claimant_has_limited_capability_for_work"]
+    )
+    monthly_earned_subject_to_taper = (
+        money(row_value(row, "uc_earned_income", 0)) / MONTHS_IN_YEAR
+    )
+    monthly_work_allowance = (
+        money(row_value(row, "uc_work_allowance", 0)) / MONTHS_IN_YEAR
+        if work_allowance_specified
+        else 0.0
+    )
+    monthly_earned_income_for_deduction = (
+        monthly_earned_subject_to_taper + monthly_work_allowance
+    )
+    monthly_unearned_income = (
+        money(row_value(row, "uc_unearned_income", 0)) / MONTHS_IN_YEAR
+    )
+    joint_claim = bool(work_allowance_inputs["claim_is_for_joint_claimants"])
+    claimant_earned_income = 0.0 if joint_claim else monthly_earned_income_for_deduction
+    joint_earned_income = monthly_earned_income_for_deduction if joint_claim else 0.0
+    claimant_unearned_income = 0.0 if joint_claim else monthly_unearned_income
+    joint_unearned_income = monthly_unearned_income if joint_claim else 0.0
+    return {
+        **work_allowance_inputs,
+        "claimant_earned_income_in_assessment_period": claimant_earned_income,
+        "joint_claimants_combined_earned_income_in_assessment_period": joint_earned_income,
+        "claimant_unearned_income_in_assessment_period": claimant_unearned_income,
+        "joint_claimants_combined_unearned_income_in_assessment_period": joint_unearned_income,
     }
 
 
@@ -2899,6 +3025,17 @@ def compare_outputs(
             "higher/lower work-allowance case split, then compares the monthly "
             "RuleSpec allowance against PolicyEngine's annual uc_work_allowance "
             "divided by 12.",
+            "Universal Credit Regulation 22 income-deduction comparison "
+            "projects PolicyEngine's annual uc_earned_income divided by 12 as "
+            "the post-work-allowance amount subject to taper, adds back the "
+            "monthly uc_work_allowance when Regulation 22 specifies one to "
+            "supply the pre-allowance earned-income leaf, projects annual "
+            "uc_unearned_income divided by 12 as the unearned-income leaf, and "
+            "compares the final Regulation 22 deduction to uc_income_reduction "
+            "only on rows where PolicyEngine's maximum-credit cap is not binding "
+            "and PolicyEngine's negative-unearned-income treatment does not "
+            "differ from Regulation 22's non-negative unearned-income "
+            "deduction.",
             "Universal Credit Regulation 34 childcare-costs element comparison "
             "projects PolicyEngine's annual uc_childcare_element into monthly "
             "relevant childcare charges by reversing the statutory 85 percent "
@@ -2983,6 +3120,20 @@ def output_applies(spec: dict[str, Any], row: Any) -> bool:
         return math.isclose(monthly_value, expected, abs_tol=0.01)
     if applies == "uc_childcare_two_or_more_children":
         return int(row_value(row, "uc_childcare_element_eligible_children", 0)) >= 2
+    if applies == "uc_income_reduction_uncapped":
+        annual_uncapped_reduction = UNIVERSAL_CREDIT_2026_RULESPEC_RATES[
+            "earned_income_taper_rate"
+        ] * money(row_value(row, "uc_earned_income", 0)) + max(
+            0.0,
+            money(row_value(row, "uc_unearned_income", 0)),
+        )
+        pe_reduction = money(row_value(row, "uc_income_reduction", 0))
+        maximum_credit = money(row_value(row, "uc_maximum_amount", 0))
+        return (
+            pe_reduction >= 0
+            and annual_uncapped_reduction <= maximum_credit + 0.01
+            and math.isclose(pe_reduction, annual_uncapped_reduction, abs_tol=0.01)
+        )
     if isinstance(applies, tuple) and len(applies) == 2:
         name, expected = applies
         value = row_value(row, name)

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -39,6 +39,8 @@ POLICYENGINE_UK_VERSION = "2.88.20"
 
 PERSONAL_ALLOWANCE_PROGRAM_PATH = Path("statutes/ukpga/2007/3/35.yaml")
 PERSONAL_ALLOWANCE_BASE = "uk:statutes/ukpga/2007/3/35"
+INCOME_TAX_SECTION_23_PROGRAM_PATH = Path("statutes/ukpga/2007/3/23.yaml")
+INCOME_TAX_SECTION_23_BASE = "uk:statutes/ukpga/2007/3/23"
 CHILD_BENEFIT_PROGRAM_PATH = Path("regulations/uksi/2006/965/2.yaml")
 CHILD_BENEFIT_BASE = "uk:regulations/uksi/2006/965/2"
 PENSION_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2002/1792/6.yaml")
@@ -50,6 +52,24 @@ PERSONAL_ALLOWANCE_OUTPUTS = {
     "personal_allowance": {
         "axiom": f"{PERSONAL_ALLOWANCE_BASE}#personal_allowance",
         "pe": "personal_allowance",
+    },
+}
+
+INCOME_TAX_INCOME_BASE_COMPONENTS = (
+    "employment_income",
+    "private_pension_income",
+    "social_security_income",
+    "self_employment_income",
+    "property_income",
+    "savings_interest_income",
+    "dividend_income",
+    "miscellaneous_income",
+)
+
+INCOME_TAX_INCOME_BASE_OUTPUTS = {
+    "total_income": {
+        "axiom": f"{INCOME_TAX_SECTION_23_BASE}#total_income",
+        "pe": "total_income",
     },
 }
 
@@ -206,6 +226,15 @@ SURFACE_SPECS = {
             "adjusted_net_income",
             "gift_aid_grossed_up",
             "personal_allowance",
+        ),
+    ),
+    "income-tax-income-base": UKEFRSSurfaceSpec(
+        program=INCOME_TAX_SECTION_23_PROGRAM_PATH,
+        entity="person",
+        outputs=INCOME_TAX_INCOME_BASE_OUTPUTS,
+        pe_variables=(
+            *INCOME_TAX_INCOME_BASE_COMPONENTS,
+            "total_income",
         ),
     ),
     "child-benefit": UKEFRSSurfaceSpec(
@@ -1639,6 +1668,8 @@ def build_axiom_request(
 ) -> dict[str, Any]:
     if surface == "personal-allowance":
         return build_personal_allowance_request(pe_data=pe_data, year=year)
+    if surface == "income-tax-income-base":
+        return build_income_tax_income_base_request(pe_data=pe_data, year=year)
     if surface == "child-benefit":
         return build_child_benefit_request(pe_data=pe_data, year=year)
     if surface == "pension-credit":
@@ -1682,6 +1713,53 @@ def build_personal_allowance_request(
     return {
         "mode": "explain",
         "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_income_tax_income_base_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    relations: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "income-tax-income-base"):
+        person_id = int(row_value(row, "person_id"))
+        entity_id = person_entity_id(person_id)
+        for component in project_income_tax_income_base_components(row):
+            payment_id = income_tax_component_entity_id(
+                person_id,
+                str(component["name"]),
+            )
+            relations.append(
+                {
+                    "name": f"{INCOME_TAX_SECTION_23_BASE}#relation.income_component_of_taxpayer",
+                    "tuple": [payment_id, entity_id],
+                    "interval": interval,
+                }
+            )
+            inputs.append(
+                input_record(
+                    f"{INCOME_TAX_SECTION_23_BASE}#input.amount_charged_to_income_tax",
+                    payment_id,
+                    interval,
+                    money(component["amount_charged_to_income_tax"]),
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in INCOME_TAX_INCOME_BASE_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": relations},
         "queries": queries,
     }
 
@@ -1784,6 +1862,21 @@ def project_personal_allowance_inputs(row: Any) -> dict[str, Any]:
         "individual_meets_requirements_under_section_56": True,
         "adjusted_net_income": max(0.0, adjusted_net_income - gift_aid_grossed_up),
     }
+
+
+def project_income_tax_income_base_components(row: Any) -> list[dict[str, Any]]:
+    components = [
+        {
+            "name": name,
+            "amount_charged_to_income_tax": money(row_value(row, name, 0)),
+        }
+        for name in INCOME_TAX_INCOME_BASE_COMPONENTS
+    ]
+    return [
+        component
+        for component in components
+        if money(component["amount_charged_to_income_tax"])
+    ]
 
 
 def project_child_benefit_inputs(row: Any) -> dict[str, Any]:
@@ -2306,6 +2399,10 @@ def benefit_month_interval(year: int) -> dict[str, str]:
 
 def person_entity_id(person_id: int) -> str:
     return f"person_{person_id}"
+
+
+def income_tax_component_entity_id(person_id: int, component: str) -> str:
+    return f"{person_entity_id(person_id)}_income_{component}"
 
 
 def benunit_entity_id(benunit_id: int) -> str:

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -44,6 +44,8 @@ INCOME_TAX_SECTION_23_PROGRAM_PATH = Path("statutes/ukpga/2007/3/23.yaml")
 INCOME_TAX_SECTION_23_BASE = "uk:statutes/ukpga/2007/3/23"
 CHILD_BENEFIT_PROGRAM_PATH = Path("regulations/uksi/2006/965/2.yaml")
 CHILD_BENEFIT_BASE = "uk:regulations/uksi/2006/965/2"
+STATE_PENSION_CREDIT_SECTION_1_PROGRAM_PATH = Path("statutes/ukpga/2002/16/1.yaml")
+STATE_PENSION_CREDIT_SECTION_1_BASE = "uk:statutes/ukpga/2002/16/1"
 PENSION_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2002/1792/6.yaml")
 PENSION_CREDIT_BASE = "uk:regulations/uksi/2002/1792/6"
 UNIVERSAL_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2013/376/36.yaml")
@@ -114,6 +116,13 @@ CHILD_BENEFIT_OUTPUTS = {
         "axiom": f"{CHILD_BENEFIT_BASE}#child_benefit_weekly_rate",
         "pe": "child_benefit_respective_amount",
         "pe_transform": "annual_to_weekly",
+    },
+}
+
+STATE_PENSION_CREDIT_QUALIFYING_AGE_OUTPUTS = {
+    "qualifying_age": {
+        "axiom": f"{STATE_PENSION_CREDIT_SECTION_1_BASE}#qualifying_age",
+        "pe": "state_pension_age",
     },
 }
 
@@ -295,6 +304,16 @@ SURFACE_SPECS = {
         pe_variables=(
             "child_benefit_child_index",
             "child_benefit_respective_amount",
+        ),
+    ),
+    "state-pension-credit-qualifying-age": UKEFRSSurfaceSpec(
+        program=STATE_PENSION_CREDIT_SECTION_1_PROGRAM_PATH,
+        entity="person",
+        outputs=STATE_PENSION_CREDIT_QUALIFYING_AGE_OUTPUTS,
+        pe_variables=(
+            "age",
+            "gender",
+            "state_pension_age",
         ),
     ),
     "pension-credit": UKEFRSSurfaceSpec(
@@ -1794,6 +1813,11 @@ def build_axiom_request(
         return build_income_tax_income_base_request(pe_data=pe_data, year=year)
     if surface == "child-benefit":
         return build_child_benefit_request(pe_data=pe_data, year=year)
+    if surface == "state-pension-credit-qualifying-age":
+        return build_state_pension_credit_qualifying_age_request(
+            pe_data=pe_data,
+            year=year,
+        )
     if surface == "pension-credit":
         return build_pension_credit_request(pe_data=pe_data, year=year)
     if surface.startswith("universal-credit-"):
@@ -1980,6 +2004,43 @@ def build_child_benefit_request(
     }
 
 
+def build_state_pension_credit_qualifying_age_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = day_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "state-pension-credit-qualifying-age"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_state_pension_credit_qualifying_age_inputs(
+            row
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{STATE_PENSION_CREDIT_SECTION_1_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in STATE_PENSION_CREDIT_QUALIFYING_AGE_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def build_pension_credit_request(
     *, pe_data: dict[str, Any], year: int
 ) -> dict[str, Any]:
@@ -2092,6 +2153,17 @@ def project_child_benefit_inputs(row: Any) -> dict[str, Any]:
         "child_or_qualifying_young_person_is_elder_or_eldest_among_paragraph_2_children": is_eldest,
         "payee_is_voluntary_organisation": False,
         "payee_resides_with_parent_otherwise_than_paragraph_2_a": False,
+    }
+
+
+def project_state_pension_credit_qualifying_age_inputs(row: Any) -> dict[str, Any]:
+    state_pension_age = money(row_value(row, "state_pension_age", 0))
+    return {
+        "claimant_is_woman": enum_name(row_value(row, "gender", "")).upper()
+        == "FEMALE",
+        "pensionable_age": state_pension_age,
+        "pensionable_age_for_woman_born_same_day": state_pension_age,
+        "claimant_age": money(row_value(row, "age", 0)),
     }
 
 
@@ -2286,6 +2358,12 @@ def compare_outputs(
             "divided by num_carers and 52. The EFRS oracle has no positive "
             "severe-disability addition rows, so that branch is currently a "
             "zero-row guard rather than a positive-eligibility validation.",
+            "State Pension Credit Act section 1 qualifying-age comparison "
+            "queries RuleSpec's day-level qualifying_age on a representative "
+            "day and supplies PolicyEngine's annual state_pension_age for both "
+            "the pensionable-age leaf and the woman-born-same-day leaf. Current "
+            "PolicyEngine UK EFRS data exposes the modern equalized-age surface "
+            "rather than historical sex-specific age transitions.",
             "Universal Credit Regulation 36 comparisons treat the generated "
             "RuleSpec outputs as component table amounts. PolicyEngine annual "
             "EFRS component outputs are divided by 12, and EFRS category "
@@ -2598,6 +2676,15 @@ def tax_year_interval(year: int) -> dict[str, str]:
         "period_kind": "tax_year",
         "start": f"{year:04d}-01-01",
         "end": f"{year:04d}-12-31",
+    }
+
+
+def day_interval(year: int) -> dict[str, str]:
+    return {
+        "period_kind": "custom",
+        "name": "day",
+        "start": f"{year:04d}-04-06",
+        "end": f"{year:04d}-04-06",
     }
 
 

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -272,13 +272,13 @@ mappings:
   - legal_id: uk:statutes/ukpga/2002/16/1#claimant_has_attained_qualifying_age
     country: uk
     program: pension_credit
-    mapping_type: not_comparable
+    mapping_type: direct_variable
     policyengine_variable: is_SP_age
     entity: person
     period: day
     comparison: boolean
     candidate_priority: P3
-    rationale: State Pension Credit Act section 1 tests whether the claimant has attained the statutory qualifying age at day granularity. PolicyEngine UK exposes the nearby is_SP_age predicate annually and rolls Pension Credit eligibility up to benefit-unit entitlement conditions, so this needs a period/entity adapter before direct oracle comparison.
+    rationale: State Pension Credit Act section 1 tests whether the claimant has attained the statutory qualifying age at day granularity. The UK EFRS oracle compares RuleSpec's judgment output to PolicyEngine UK's annual is_SP_age predicate after supplying the same age and state_pension_age projection used for qualifying_age.
 
   - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_single_under_25_amount
     country: uk

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1,4 +1,81 @@
 mappings:
+  - legal_id: uk:statutes/ukpga/2007/3/10#income_charged_at_basic_rate
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: basic_rate_earned_income
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK income tax earned-income amount charged at the basic rate under section 10, with the EFRS oracle comparing only the ordinary non-Scottish UK-rate branch.
+
+  - legal_id: uk:statutes/ukpga/2007/3/10#income_charged_at_higher_rate
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: higher_rate_earned_income
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK income tax earned-income amount charged at the higher rate under section 10, with the EFRS oracle comparing only the ordinary non-Scottish UK-rate branch.
+
+  - legal_id: uk:statutes/ukpga/2007/3/10#income_charged_at_additional_rate
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: add_rate_earned_income
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK income tax earned-income amount charged at the additional rate under section 10, with the EFRS oracle comparing only the ordinary non-Scottish UK-rate branch.
+
+  - legal_id: uk:statutes/ukpga/2007/3/10#tax_on_income_charged_at_basic_rate
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: basic_rate_earned_income_tax
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK income tax on earned income charged at the basic rate under section 10, with the EFRS oracle comparing only the ordinary non-Scottish UK-rate branch.
+
+  - legal_id: uk:statutes/ukpga/2007/3/10#tax_on_income_charged_at_higher_rate
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: higher_rate_earned_income_tax
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK income tax on earned income charged at the higher rate under section 10, with the EFRS oracle comparing only the ordinary non-Scottish UK-rate branch.
+
+  - legal_id: uk:statutes/ukpga/2007/3/10#tax_on_income_charged_at_additional_rate
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: add_rate_earned_income_tax
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK income tax on earned income charged at the additional rate under section 10, with the EFRS oracle comparing only the ordinary non-Scottish UK-rate branch.
+
+  - legal_id: uk:statutes/ukpga/2007/3/10#income_tax_on_section_10_income
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: earned_income_tax
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK income tax on ordinary earned income under section 10, with Scottish-rate rows excluded because PolicyEngine branches earned_income_tax to Scotland-specific rates.
+
   - legal_id: uk:statutes/ukpga/2007/3/23#total_income
     country: uk
     program: tax

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -260,14 +260,14 @@ mappings:
   - legal_id: uk:statutes/ukpga/2002/16/1#qualifying_age
     country: uk
     program: pension_credit
-    mapping_type: not_comparable
+    mapping_type: direct_variable
     policyengine_variable: state_pension_age
     entity: person
     period: day
     unit: year
     comparison: count
     candidate_priority: P3
-    rationale: State Pension Credit Act section 1 defines a source-level qualifying age at day granularity, including the man's woman-born-same-day rule. PolicyEngine UK exposes state_pension_age as a year-period person variable from state-pension age parameters, so this needs a period and historical-sex-rule adapter before direct oracle comparison.
+    rationale: State Pension Credit Act section 1 defines a source-level qualifying age at day granularity. The UK EFRS oracle supplies PolicyEngine UK's state_pension_age to both statutory pensionable-age leaves on a representative day, matching the modern equalized-age surface exposed by PolicyEngine.
 
   - legal_id: uk:statutes/ukpga/2002/16/1#claimant_has_attained_qualifying_age
     country: uk

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -424,6 +424,17 @@ mappings:
     comparison: money
     rationale: Same Universal Credit maximum childcare costs element for two or more children. Companion tests exercise it through the branch-selected childcare cap output.
 
+  - legal_id: uk:regulations/uksi/2013/376/72#capital_tariff_monthly_income
+    country: uk
+    program: universal_credit
+    mapping_type: direct_variable
+    policyengine_variable: uc_tariff_income
+    entity: benunit
+    period: month
+    unit: GBP
+    comparison: money
+    rationale: Same Universal Credit tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit assessed capital to the Regulation 72 capital leaf and converts PolicyEngine's annual output to a monthly amount.
+
 prefixes:
   - legal_id_prefix: uk:statutes/ukpga/2007/3/35#
     country: uk
@@ -567,7 +578,7 @@ prefixes:
     country: uk
     program: universal_credit
     mapping_type: not_comparable
-    rationale: Universal Credit regulation 72 tariff-income helpers are source-level capital-to-income conversion mechanics not exposed as one-to-one PolicyEngine UK variables.
+    rationale: Remaining Universal Credit regulation 72 tariff-income helpers are source-level capital-to-income conversion mechanics not exposed as one-to-one PolicyEngine UK variables.
 
   - legal_id_prefix: uk:regulations/uksi/2013/376/77#
     country: uk

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -111,14 +111,35 @@ mappings:
   - legal_id: uk:statutes/ukpga/1992/4/8#primary_class_1_contribution
     country: uk
     program: tax
-    mapping_type: not_comparable
+    mapping_type: direct_variable
     policyengine_variable: ni_class_1_employee
     entity: person
     period: week
     unit: GBP
     comparison: money
-    candidate_priority: P4
-    rationale: PolicyEngine UK exposes employee Class 1 NI as a monthly person variable composed from primary and additional monthly components; this generated RuleSpec output is a weekly source-level s.8 calculation with statutory displacement conditions and weekly threshold inputs, so it needs a period/composition adapter before direct oracle comparison.
+    rationale: Same employee Class 1 NI aggregate after the UK EFRS adapter projects weekly section 8 inputs, PolicyEngine ni_liable, and converts PolicyEngine's annual output to a weekly value.
+
+  - legal_id: uk:statutes/ukpga/1992/4/8#main_primary_class_1_contribution
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ni_class_1_employee_primary
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same main-band employee Class 1 NI component after the UK EFRS adapter projects weekly section 8 inputs and compares on PolicyEngine ni_liable rows.
+
+  - legal_id: uk:statutes/ukpga/1992/4/8#additional_primary_class_1_contribution
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ni_class_1_employee_additional
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same additional-band employee Class 1 NI component after the UK EFRS adapter projects weekly section 8 inputs and compares on PolicyEngine ni_liable rows.
 
   - legal_id: uk:regulations/uksi/2006/965/2#child_benefit_enhanced_weekly_rate
     country: uk

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -779,10 +779,7 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path, program="tax")
 
-    assert report["status_counts"] == {
-        "comparable": 2,
-        "known_not_comparable": 1,
-    }
+    assert report["status_counts"] == {"comparable": 3}
     assert report["untested_comparable"] == 0
     items_by_id = {item["legal_id"]: item for item in report["items"]}
     main_rate = items_by_id["uk:statutes/ukpga/1992/4/8#main_primary_percentage"]
@@ -803,9 +800,9 @@ rules:
         == "gov.hmrc.national_insurance.class_1.rates.employee.additional"
     )
     assert additional_rate["tested"] is True
-    assert contribution["status"] == "known_not_comparable"
+    assert contribution["status"] == "comparable"
     assert contribution["policyengine_variable"] == "ni_class_1_employee"
-    assert contribution["candidate_priority"] == "P4"
+    assert contribution["tested"] is True
 
 
 def test_policyengine_coverage_classifies_uk_pension_credit_section_1_outputs(

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -853,10 +853,7 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path, program="pension_credit")
 
-    assert report["status_counts"] == {
-        "comparable": 1,
-        "known_not_comparable": 1,
-    }
+    assert report["status_counts"] == {"comparable": 2}
     items_by_id = {item["legal_id"]: item for item in report["items"]}
     qualifying_age = items_by_id["uk:statutes/ukpga/2002/16/1#qualifying_age"]
     attained_age = items_by_id[
@@ -868,7 +865,8 @@ rules:
     assert qualifying_age["mapping_type"] == "direct_variable"
     assert qualifying_age["candidate_priority"] == "P3"
     assert attained_age["policyengine_variable"] == "is_SP_age"
-    assert attained_age["status"] == "known_not_comparable"
+    assert attained_age["status"] == "comparable"
+    assert attained_age["mapping_type"] == "direct_variable"
     assert attained_age["candidate_priority"] == "P3"
 
 

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -853,7 +853,10 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path, program="pension_credit")
 
-    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 1,
+    }
     items_by_id = {item["legal_id"]: item for item in report["items"]}
     qualifying_age = items_by_id["uk:statutes/ukpga/2002/16/1#qualifying_age"]
     attained_age = items_by_id[
@@ -861,8 +864,11 @@ rules:
     ]
 
     assert qualifying_age["policyengine_variable"] == "state_pension_age"
+    assert qualifying_age["status"] == "comparable"
+    assert qualifying_age["mapping_type"] == "direct_variable"
     assert qualifying_age["candidate_priority"] == "P3"
     assert attained_age["policyengine_variable"] == "is_SP_age"
+    assert attained_age["status"] == "known_not_comparable"
     assert attained_age["candidate_priority"] == "P3"
 
 

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -599,6 +599,8 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         ["national-insurance-class-1"]
     ) == (
         "ni_class_1_employee",
+        "ni_class_1_employee_additional",
+        "ni_class_1_employee_primary",
         "ni_class_1_income",
         "ni_liable",
     )

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -33,6 +33,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_universal_credit_request,
     compare_outputs,
     compare_uk_efrs,
+    normalize_policyengine_entity,
     policyengine_benunit_variables_for_surfaces,
     policyengine_person_variables_for_surfaces,
     project_child_benefit_inputs,
@@ -113,6 +114,14 @@ class FakePolicyEngineVariable:
         self.entity = entity
         self.adds = adds
         self.subtracts = subtracts
+
+
+class FakePolicyEngineEntity:
+    key = "benunit"
+
+
+def test_normalize_policyengine_entity_accepts_entity_objects():
+    assert normalize_policyengine_entity(FakePolicyEngineEntity()) == "benunit"
 
 
 def test_personal_allowance_projection_matches_policyengine_gift_aid_taper():

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -1,4 +1,5 @@
 import argparse
+import math
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 
@@ -6,6 +7,8 @@ import pytest
 
 import axiom_encode.oracles.policyengine.efrs_uk as efrs_uk
 from axiom_encode.oracles.policyengine.efrs_uk import (
+    BENEFIT_CAP_REGULATION_80A_BASE,
+    BENEFIT_CAP_RELEVANT_AMOUNT_OUTPUTS,
     CHILD_BENEFIT_BASE,
     CHILD_BENEFIT_OUTPUTS,
     INCOME_TAX_INCOME_BASE_COMPONENTS,
@@ -24,10 +27,15 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     STATE_PENSION_CREDIT_SECTION_1_BASE,
     UNIVERSAL_CREDIT_AWARD_OUTPUTS,
     UNIVERSAL_CREDIT_CHILD_ELEMENT_OUTPUTS,
+    UNIVERSAL_CREDIT_HOUSING_COSTS_OUTPUTS,
     UNIVERSAL_CREDIT_LCWRA_OUTPUTS,
+    UNIVERSAL_CREDIT_REGULATION_22_BASE,
     UNIVERSAL_CREDIT_STANDARD_ALLOWANCE_OUTPUTS,
+    UNIVERSAL_CREDIT_WORK_ALLOWANCE_OUTPUTS,
     WEEKS_IN_YEAR,
     WELFARE_REFORM_ACT_SECTION_8_BASE,
+    WELFARE_REFORM_ACT_SECTION_11_BASE,
+    build_benefit_cap_relevant_amount_request,
     build_child_benefit_request,
     build_income_tax_income_base_request,
     build_national_insurance_class_1_request,
@@ -36,12 +44,15 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_state_pension_credit_qualifying_age_request,
     build_uk_efrs_coverage_report,
     build_universal_credit_award_request,
+    build_universal_credit_housing_costs_request,
     build_universal_credit_request,
+    build_universal_credit_work_allowance_request,
     compare_outputs,
     compare_uk_efrs,
     normalize_policyengine_entity,
     policyengine_benunit_variables_for_surfaces,
     policyengine_person_variables_for_surfaces,
+    project_benefit_cap_relevant_amount_inputs,
     project_child_benefit_inputs,
     project_income_tax_income_base_components,
     project_income_tax_section_23_inputs,
@@ -49,6 +60,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_personal_allowance_inputs,
     project_state_pension_credit_qualifying_age_inputs,
     project_universal_credit_award_inputs,
+    project_universal_credit_housing_costs_inputs,
+    project_universal_credit_work_allowance_inputs,
     require_policyengine_uk_versions,
     select_person_indices,
 )
@@ -420,6 +433,91 @@ def test_child_benefit_request_filters_to_positive_respective_amount_rows():
     }
 
 
+def test_benefit_cap_relevant_amount_projection_uses_pe_case_inputs():
+    projected = project_benefit_cap_relevant_amount_inputs(
+        {
+            "num_adults": 1,
+            "num_children": 0,
+            "benunit_region": "LONDON",
+        }
+    )
+
+    assert projected == {
+        "claim_is_for_joint_claimants": False,
+        "responsible_for_child_or_qualifying_young_person": False,
+        "award_contains_housing_costs_element": False,
+        "accommodation_in_respect_of_which_claimant_meets_occupation_condition_is_in_greater_london": False,
+        "claimant_receives_housing_benefit_for_dwelling_in_greater_london": False,
+        "claimant_has_accommodation_normally_occupied_as_home": True,
+        "accommodation_normally_occupied_as_home_is_in_greater_london": True,
+        "jobcentre_plus_office_allocated_to_claim_is_in_greater_london": False,
+    }
+
+    assert (
+        project_benefit_cap_relevant_amount_inputs(
+            {
+                "num_adults": 2,
+                "num_children": 0,
+                "benunit_region": "WALES",
+            }
+        )["claim_is_for_joint_claimants"]
+        is True
+    )
+
+
+def test_benefit_cap_relevant_amount_request_filters_to_finite_caps():
+    request = build_benefit_cap_relevant_amount_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "benefit_cap": math.inf,
+                    "num_adults": 1,
+                    "num_children": 0,
+                    "benunit_region": "LONDON",
+                },
+                {
+                    "benunit_id": 12,
+                    "benefit_cap": 22_020,
+                    "num_adults": 2,
+                    "num_children": 0,
+                    "benunit_region": "WALES",
+                },
+            ],
+            "benunit_ids": [11, 12],
+        },
+        year=2026,
+    )
+
+    assert request["mode"] == "explain"
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_12",
+            "period": {
+                "period_kind": "month",
+                "name": "benefit_month",
+                "start": "2026-04-01",
+                "end": "2026-04-30",
+            },
+            "outputs": list(
+                output["axiom"]
+                for output in BENEFIT_CAP_RELEVANT_AMOUNT_OUTPUTS.values()
+            ),
+        }
+    ]
+    inputs_by_name = {
+        record["name"]: record["value"] for record in request["dataset"]["inputs"]
+    }
+    assert inputs_by_name[
+        f"{BENEFIT_CAP_REGULATION_80A_BASE}#input.claim_is_for_joint_claimants"
+    ] == {
+        "kind": "bool",
+        "value": True,
+    }
+
+
 def test_pension_credit_projection_uses_relation_type():
     assert project_pension_credit_inputs(
         {
@@ -676,6 +774,152 @@ def test_universal_credit_award_request_projects_section_8_inputs():
     }
 
 
+def test_universal_credit_housing_costs_projection_uses_monthly_amount():
+    projected = project_universal_credit_housing_costs_inputs(
+        {"uc_housing_costs_element": 360}
+    )
+
+    assert projected["payments_are_in_respect_of_accommodation_for_section_11"] is True
+    assert projected["accommodation_is_in_great_britain"] is True
+    assert projected["accommodation_is_residential_accommodation"] is True
+    assert projected["claimant_is_liable_to_make_accommodation_payments"] is True
+    assert (
+        projected[
+            "claimant_is_treated_as_not_liable_to_make_accommodation_payments_by_regulations"
+        ]
+        is False
+    )
+    assert (
+        projected["amount_determined_or_calculated_by_regulations_under_section_11"]
+        == 30
+    )
+
+
+def test_universal_credit_housing_costs_request_projects_section_11_inputs():
+    request = build_universal_credit_housing_costs_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "benunit_weight": 1,
+                    "uc_housing_costs_element": 360,
+                }
+            ],
+            "benunit_ids": [11],
+        },
+        year=2026,
+    )
+
+    assert request["mode"] == "explain"
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_11",
+            "period": {
+                "period_kind": "month",
+                "name": "benefit_month",
+                "start": "2026-04-01",
+                "end": "2026-04-30",
+            },
+            "outputs": list(
+                output["axiom"]
+                for output in UNIVERSAL_CREDIT_HOUSING_COSTS_OUTPUTS.values()
+            ),
+        }
+    ]
+    inputs_by_name = {
+        record["name"]: record["value"] for record in request["dataset"]["inputs"]
+    }
+    assert inputs_by_name[
+        f"{WELFARE_REFORM_ACT_SECTION_11_BASE}#input.amount_determined_or_calculated_by_regulations_under_section_11"
+    ] == {
+        "kind": "decimal",
+        "value": "30.0",
+    }
+
+
+def test_universal_credit_work_allowance_projection_uses_regulation_22_case_inputs():
+    projected = project_universal_credit_work_allowance_inputs(
+        {
+            "num_adults": 1,
+            "num_children": 1,
+            "is_uc_work_allowance_eligible": True,
+            "uc_housing_costs_element": 360,
+        }
+    )
+
+    assert projected == {
+        "claim_is_for_joint_claimants": False,
+        "claimant_is_member_of_couple": False,
+        "claimant_makes_claim_as_single_person": False,
+        "joint_claimants_responsible_for_child_or_qualifying_young_person": False,
+        "one_or_both_joint_claimants_have_limited_capability_for_work": False,
+        "single_claimant_responsible_for_child_or_qualifying_young_person": True,
+        "single_claimant_has_limited_capability_for_work": False,
+        "award_contains_housing_costs_element": True,
+    }
+
+    assert (
+        project_universal_credit_work_allowance_inputs(
+            {
+                "num_adults": 2,
+                "num_children": 0,
+                "is_uc_work_allowance_eligible": True,
+                "uc_housing_costs_element": 0,
+            }
+        )["one_or_both_joint_claimants_have_limited_capability_for_work"]
+        is True
+    )
+
+
+def test_universal_credit_work_allowance_request_projects_regulation_22_inputs():
+    request = build_universal_credit_work_allowance_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "num_adults": 1,
+                    "num_children": 1,
+                    "is_uc_work_allowance_eligible": True,
+                    "uc_housing_costs_element": 360,
+                    "uc_work_allowance": 5_124,
+                }
+            ],
+            "benunit_ids": [11],
+        },
+        year=2026,
+    )
+
+    assert request["mode"] == "explain"
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_11",
+            "period": {
+                "period_kind": "month",
+                "name": "benefit_month",
+                "start": "2026-04-01",
+                "end": "2026-04-30",
+            },
+            "outputs": list(
+                output["axiom"]
+                for output in UNIVERSAL_CREDIT_WORK_ALLOWANCE_OUTPUTS.values()
+            ),
+        }
+    ]
+    inputs_by_name = {
+        record["name"]: record["value"] for record in request["dataset"]["inputs"]
+    }
+    assert inputs_by_name[
+        f"{UNIVERSAL_CREDIT_REGULATION_22_BASE}#input.award_contains_housing_costs_element"
+    ] == {
+        "kind": "bool",
+        "value": True,
+    }
+
+
 def test_universal_credit_child_element_request_filters_to_positive_rows():
     request = build_universal_credit_request(
         pe_data={
@@ -887,6 +1131,14 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "severe_disability_minimum_guarantee_addition",
         "standard_minimum_guarantee",
     )
+    assert policyengine_benunit_variables_for_surfaces(
+        ["benefit-cap-relevant-amount"]
+    ) == (
+        "benefit_cap",
+        "benunit_region",
+        "num_adults",
+        "num_children",
+    )
     assert policyengine_person_variables_for_surfaces(
         ["universal-credit-child-element"]
     ) == (
@@ -917,6 +1169,18 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "uc_maximum_amount",
         "uc_standard_allowance",
         "universal_credit_pre_benefit_cap",
+    )
+    assert policyengine_benunit_variables_for_surfaces(
+        ["universal-credit-housing-costs"]
+    ) == ("uc_housing_costs_element",)
+    assert policyengine_benunit_variables_for_surfaces(
+        ["universal-credit-work-allowance"]
+    ) == (
+        "is_uc_work_allowance_eligible",
+        "num_adults",
+        "num_children",
+        "uc_housing_costs_element",
+        "uc_work_allowance",
     )
 
 
@@ -1217,6 +1481,38 @@ def test_compare_outputs_compares_child_benefit_weekly_rate():
     assert report.output_summary[0]["compared"] == 1
 
 
+def test_compare_outputs_transforms_benefit_cap_relevant_amount_monthly():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "benefit_cap": 22_020,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "benefit-cap-relevant-amount": [
+                {
+                    "outputs": {
+                        BENEFIT_CAP_RELEVANT_AMOUNT_OUTPUTS[
+                            "benefit_cap_relevant_amount"
+                        ]["axiom"]: decimal_output(1_835),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+
+
 def test_compare_outputs_compares_applicable_universal_credit_standard_allowance():
     report = compare_outputs(
         pe_data={
@@ -1343,7 +1639,71 @@ def test_compare_outputs_transforms_universal_credit_award_outputs_monthly():
 
     assert report.compared_values == 3
     assert report.mismatches == []
+
+
+def test_compare_outputs_transforms_universal_credit_housing_costs_monthly():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "uc_housing_costs_element": 360,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "universal-credit-housing-costs": [
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_HOUSING_COSTS_OUTPUTS[
+                            "section_11_amount_for_accommodation_payments"
+                        ]["axiom"]: decimal_output(30),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
     assert report.oracle_divergences == []
+
+
+def test_compare_outputs_transforms_universal_credit_work_allowance_monthly():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "uc_work_allowance": 5_124,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "universal-credit-work-allowance": [
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_WORK_ALLOWANCE_OUTPUTS[
+                            "applicable_work_allowance_amount"
+                        ]["axiom"]: decimal_output(427),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
 
 
 def test_compare_outputs_skips_rebalanced_universal_credit_lcwra_health_element():

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -29,6 +29,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     UNIVERSAL_CREDIT_CHILD_ELEMENT_OUTPUTS,
     UNIVERSAL_CREDIT_CHILDCARE_ELEMENT_OUTPUTS,
     UNIVERSAL_CREDIT_HOUSING_COSTS_OUTPUTS,
+    UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS,
     UNIVERSAL_CREDIT_LCWRA_OUTPUTS,
     UNIVERSAL_CREDIT_REGULATION_22_BASE,
     UNIVERSAL_CREDIT_REGULATION_34_BASE,
@@ -48,6 +49,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_universal_credit_award_request,
     build_universal_credit_childcare_element_request,
     build_universal_credit_housing_costs_request,
+    build_universal_credit_income_deduction_request,
     build_universal_credit_request,
     build_universal_credit_work_allowance_request,
     compare_outputs,
@@ -65,6 +67,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_universal_credit_award_inputs,
     project_universal_credit_childcare_element_inputs,
     project_universal_credit_housing_costs_inputs,
+    project_universal_credit_income_deduction_inputs,
     project_universal_credit_work_allowance_inputs,
     require_policyengine_uk_versions,
     select_person_indices,
@@ -1007,6 +1010,116 @@ def test_universal_credit_work_allowance_request_projects_regulation_22_inputs()
     }
 
 
+def test_universal_credit_income_deduction_projection_uses_regulation_22_inputs():
+    projected = project_universal_credit_income_deduction_inputs(
+        {
+            "num_adults": 1,
+            "num_children": 1,
+            "is_uc_work_allowance_eligible": True,
+            "uc_housing_costs_element": 360,
+            "uc_work_allowance": 5_124,
+            "uc_earned_income": 6_876,
+            "uc_unearned_income": 600,
+        }
+    )
+
+    assert projected == {
+        "claim_is_for_joint_claimants": False,
+        "claimant_is_member_of_couple": False,
+        "claimant_makes_claim_as_single_person": False,
+        "joint_claimants_responsible_for_child_or_qualifying_young_person": False,
+        "one_or_both_joint_claimants_have_limited_capability_for_work": False,
+        "single_claimant_responsible_for_child_or_qualifying_young_person": True,
+        "single_claimant_has_limited_capability_for_work": False,
+        "award_contains_housing_costs_element": True,
+        "claimant_earned_income_in_assessment_period": 1_000,
+        "joint_claimants_combined_earned_income_in_assessment_period": 0.0,
+        "claimant_unearned_income_in_assessment_period": 50,
+        "joint_claimants_combined_unearned_income_in_assessment_period": 0.0,
+    }
+
+    joint_projection = project_universal_credit_income_deduction_inputs(
+        {
+            "num_adults": 2,
+            "num_children": 0,
+            "is_uc_work_allowance_eligible": True,
+            "uc_housing_costs_element": 0,
+            "uc_work_allowance": 8_520,
+            "uc_earned_income": 15_480,
+            "uc_unearned_income": 3_600,
+        }
+    )
+    assert (
+        joint_projection["joint_claimants_combined_earned_income_in_assessment_period"]
+        == 2_000
+    )
+    assert (
+        joint_projection[
+            "joint_claimants_combined_unearned_income_in_assessment_period"
+        ]
+        == 300
+    )
+    assert (
+        joint_projection["one_or_both_joint_claimants_have_limited_capability_for_work"]
+        is True
+    )
+
+
+def test_universal_credit_income_deduction_request_projects_regulation_22_inputs():
+    request = build_universal_credit_income_deduction_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "num_adults": 1,
+                    "num_children": 1,
+                    "is_uc_work_allowance_eligible": True,
+                    "uc_housing_costs_element": 360,
+                    "uc_work_allowance": 5_124,
+                    "uc_earned_income": 6_876,
+                    "uc_unearned_income": 600,
+                }
+            ],
+            "benunit_ids": [11],
+        },
+        year=2026,
+    )
+
+    assert request["mode"] == "explain"
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_11",
+            "period": {
+                "period_kind": "month",
+                "name": "benefit_month",
+                "start": "2026-04-01",
+                "end": "2026-04-30",
+            },
+            "outputs": list(
+                output["axiom"]
+                for output in UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS.values()
+            ),
+        }
+    ]
+    inputs_by_name = {
+        record["name"]: record["value"] for record in request["dataset"]["inputs"]
+    }
+    assert inputs_by_name[
+        f"{UNIVERSAL_CREDIT_REGULATION_22_BASE}#input.claimant_earned_income_in_assessment_period"
+    ] == {
+        "kind": "decimal",
+        "value": "1000.0",
+    }
+    assert inputs_by_name[
+        f"{UNIVERSAL_CREDIT_REGULATION_22_BASE}#input.claimant_unearned_income_in_assessment_period"
+    ] == {
+        "kind": "decimal",
+        "value": "50.0",
+    }
+
+
 def test_universal_credit_child_element_request_filters_to_positive_rows():
     request = build_universal_credit_request(
         pe_data={
@@ -1273,6 +1386,19 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "num_adults",
         "num_children",
         "uc_housing_costs_element",
+        "uc_work_allowance",
+    )
+    assert policyengine_benunit_variables_for_surfaces(
+        ["universal-credit-income-deduction"]
+    ) == (
+        "is_uc_work_allowance_eligible",
+        "num_adults",
+        "num_children",
+        "uc_earned_income",
+        "uc_housing_costs_element",
+        "uc_income_reduction",
+        "uc_maximum_amount",
+        "uc_unearned_income",
         "uc_work_allowance",
     )
 
@@ -1830,6 +1956,132 @@ def test_compare_outputs_transforms_universal_credit_work_allowance_monthly():
 
     assert report.compared_values == 1
     assert report.mismatches == []
+
+
+def test_compare_outputs_transforms_universal_credit_income_deduction_monthly():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "uc_earned_income": 6_876,
+                    "uc_unearned_income": 600,
+                    "uc_income_reduction": 4_381.8,
+                    "uc_maximum_amount": 12_000,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "universal-credit-income-deduction": [
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS[
+                            "earned_income_amount_subject_to_taper"
+                        ]["axiom"]: decimal_output(573),
+                        UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS[
+                            "unearned_income_for_deduction"
+                        ]["axiom"]: decimal_output(50),
+                        UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS[
+                            "universal_credit_award_deduction_from_maximum_amount"
+                        ]["axiom"]: decimal_output(365.15),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 3
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_skips_capped_universal_credit_income_deduction_final():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "uc_earned_income": 12_000,
+                    "uc_unearned_income": 0,
+                    "uc_income_reduction": 3_000,
+                    "uc_maximum_amount": 3_000,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "universal-credit-income-deduction": [
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS[
+                            "earned_income_amount_subject_to_taper"
+                        ]["axiom"]: decimal_output(1_000),
+                        UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS[
+                            "unearned_income_for_deduction"
+                        ]["axiom"]: decimal_output(0),
+                        UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS[
+                            "universal_credit_award_deduction_from_maximum_amount"
+                        ]["axiom"]: decimal_output(550),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 2
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_skips_negative_unearned_income_deduction_final():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "uc_earned_income": 24_000,
+                    "uc_unearned_income": -1_200,
+                    "uc_income_reduction": 12_000,
+                    "uc_maximum_amount": 20_000,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "universal-credit-income-deduction": [
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS[
+                            "earned_income_amount_subject_to_taper"
+                        ]["axiom"]: decimal_output(2_000),
+                        UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS[
+                            "unearned_income_for_deduction"
+                        ]["axiom"]: decimal_output(-100),
+                        UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS[
+                            "universal_credit_award_deduction_from_maximum_amount"
+                        ]["axiom"]: decimal_output(1_100),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 2
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
 
 
 def test_compare_outputs_skips_rebalanced_universal_credit_lcwra_health_element():

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -10,7 +10,9 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     CHILD_BENEFIT_OUTPUTS,
     INCOME_TAX_INCOME_BASE_COMPONENTS,
     INCOME_TAX_INCOME_BASE_OUTPUTS,
+    INCOME_TAX_SECTION_23_ADDITION_COMPONENTS,
     INCOME_TAX_SECTION_23_BASE,
+    INCOME_TAX_SECTION_23_REDUCTION_COMPONENTS,
     NATIONAL_INSURANCE_CLASS_1_OUTPUTS,
     NATIONAL_INSURANCE_SECTION_8_BASE,
     PENSION_CREDIT_BASE,
@@ -34,6 +36,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     policyengine_person_variables_for_surfaces,
     project_child_benefit_inputs,
     project_income_tax_income_base_components,
+    project_income_tax_section_23_inputs,
     project_pension_credit_inputs,
     project_personal_allowance_inputs,
     require_policyengine_uk_versions,
@@ -197,6 +200,24 @@ def test_income_tax_income_base_projection_uses_income_components():
     ]
 
 
+def test_income_tax_section_23_projection_uses_pe_liability_components():
+    projected = project_income_tax_section_23_inputs(
+        {
+            "income_tax_pre_charges": 4_500,
+            "CB_HITC": 300,
+            "personal_pension_contributions_tax": 200,
+            "capped_mcad": 100,
+            "other_tax_credits": 50,
+        }
+    )
+
+    assert projected == {
+        "tax_calculated_at_applicable_rates_on_income_remaining_after_allowances": 5_000,
+        "tax_reductions_listed_in_section_26": 150,
+        "additional_tax_amounts_listed_in_section_30": 0.0,
+    }
+
+
 def test_income_tax_income_base_request_projects_section_23_relation():
     request = build_income_tax_income_base_request(
         pe_data={
@@ -205,6 +226,12 @@ def test_income_tax_income_base_request_projects_section_23_relation():
                     "person_id": 7,
                     "employment_income": 30_000,
                     "private_pension_income": 2_000,
+                    "income_tax_pre_charges": 4_500,
+                    "CB_HITC": 300,
+                    "personal_pension_contributions_tax": 200,
+                    "capped_mcad": 100,
+                    "other_tax_credits": 50,
+                    "income_tax": 4_850,
                     "total_income": 32_000,
                 }
             ],
@@ -253,6 +280,15 @@ def test_income_tax_income_base_request_projects_section_23_relation():
     assert inputs[
         f"{INCOME_TAX_SECTION_23_BASE}#input.amount_charged_to_income_tax:person_7_income_employment_income"
     ] == {"kind": "decimal", "value": "30000.0"}
+    assert inputs[
+        f"{INCOME_TAX_SECTION_23_BASE}#input.tax_calculated_at_applicable_rates_on_income_remaining_after_allowances:person_7"
+    ] == {"kind": "decimal", "value": "5000.0"}
+    assert inputs[
+        f"{INCOME_TAX_SECTION_23_BASE}#input.tax_reductions_listed_in_section_26:person_7"
+    ] == {"kind": "decimal", "value": "150.0"}
+    assert inputs[
+        f"{INCOME_TAX_SECTION_23_BASE}#input.additional_tax_amounts_listed_in_section_30:person_7"
+    ] == {"kind": "decimal", "value": "0.0"}
 
 
 def test_child_benefit_projection_uses_child_index():
@@ -591,6 +627,9 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         *sorted(
             (
                 *INCOME_TAX_INCOME_BASE_COMPONENTS,
+                *INCOME_TAX_SECTION_23_ADDITION_COMPONENTS,
+                *INCOME_TAX_SECTION_23_REDUCTION_COMPONENTS,
+                "income_tax",
                 "total_income",
             )
         ),
@@ -687,10 +726,9 @@ class age(Variable):
     assert report.computed_variables_total == 3
     assert report.computed_variables_by_entity == {"person": 3}
     assert report.computed_variables_by_domain == {"gov": 2, "input": 1}
-    assert report.computed_covered_variables == ["personal_allowance"]
-    assert report.missing_variables_total == 2
+    assert report.computed_covered_variables == ["income_tax", "personal_allowance"]
+    assert report.missing_variables_total == 1
     assert [variable.name for variable in report.missing_variables] == [
-        "income_tax",
         "employment_income",
     ]
 
@@ -762,8 +800,9 @@ class income_tax(Variable):
     )
 
     payload = report.to_json()
-    assert payload["missing_variables_total"] == 1
-    assert payload["missing_variables"][0]["name"] == "income_tax"
+    assert payload["missing_variables_total"] == 0
+    assert payload["missing_variables"] == []
+    assert "income_tax" in payload["covered_output_variables"]
     assert "personal_allowance" in payload["covered_output_variables"]
 
 

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -20,6 +20,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     PERSONAL_ALLOWANCE_BASE,
     PERSONAL_ALLOWANCE_OUTPUTS,
     PERSONAL_ALLOWANCE_PROGRAM_PATH,
+    STATE_PENSION_CREDIT_QUALIFYING_AGE_OUTPUTS,
+    STATE_PENSION_CREDIT_SECTION_1_BASE,
     UNIVERSAL_CREDIT_CHILD_ELEMENT_OUTPUTS,
     UNIVERSAL_CREDIT_LCWRA_OUTPUTS,
     UNIVERSAL_CREDIT_STANDARD_ALLOWANCE_OUTPUTS,
@@ -29,6 +31,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_national_insurance_class_1_request,
     build_pension_credit_request,
     build_personal_allowance_request,
+    build_state_pension_credit_qualifying_age_request,
     build_uk_efrs_coverage_report,
     build_universal_credit_request,
     compare_outputs,
@@ -41,6 +44,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_income_tax_section_23_inputs,
     project_pension_credit_inputs,
     project_personal_allowance_inputs,
+    project_state_pension_credit_qualifying_age_inputs,
     require_policyengine_uk_versions,
     select_person_indices,
 )
@@ -380,6 +384,72 @@ def test_pension_credit_projection_uses_relation_type():
     }
 
 
+def test_state_pension_credit_qualifying_age_projection_uses_equalized_age():
+    assert project_state_pension_credit_qualifying_age_inputs(
+        {
+            "gender": "FEMALE",
+            "state_pension_age": 66,
+            "age": 67,
+        }
+    ) == {
+        "claimant_is_woman": True,
+        "pensionable_age": 66,
+        "pensionable_age_for_woman_born_same_day": 66,
+        "claimant_age": 67,
+    }
+    assert (
+        project_state_pension_credit_qualifying_age_inputs(
+            {
+                "gender": "Gender.MALE",
+                "state_pension_age": 66,
+                "age": 65,
+            }
+        )["claimant_is_woman"]
+        is False
+    )
+
+
+def test_state_pension_credit_qualifying_age_request_projects_people():
+    request = build_state_pension_credit_qualifying_age_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 7,
+                    "gender": "FEMALE",
+                    "state_pension_age": 66,
+                    "age": 67,
+                }
+            ],
+            "person_ids": [7],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_7",
+            "period": {
+                "period_kind": "custom",
+                "name": "day",
+                "start": "2026-04-06",
+                "end": "2026-04-06",
+            },
+            "outputs": list(
+                output["axiom"]
+                for output in STATE_PENSION_CREDIT_QUALIFYING_AGE_OUTPUTS.values()
+            ),
+        }
+    ]
+    assert {record["name"]: record["value"] for record in request["dataset"]["inputs"]}[
+        f"{STATE_PENSION_CREDIT_SECTION_1_BASE}#input.claimant_is_woman"
+    ] == {
+        "kind": "bool",
+        "value": True,
+    }
+
+
 def test_pension_credit_request_projects_benefit_units():
     request = build_pension_credit_request(
         pe_data={
@@ -653,6 +723,13 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "ni_class_1_income",
         "ni_liable",
     )
+    assert policyengine_person_variables_for_surfaces(
+        ["state-pension-credit-qualifying-age"]
+    ) == (
+        "age",
+        "gender",
+        "state_pension_age",
+    )
     assert policyengine_benunit_variables_for_surfaces(
         ["personal-allowance", "pension-credit"]
     ) == (
@@ -736,7 +813,10 @@ class age(Variable):
     assert report.computed_variables_total == 3
     assert report.computed_variables_by_entity == {"person": 3}
     assert report.computed_variables_by_domain == {"gov": 2, "input": 1}
-    assert report.computed_covered_variables == ["income_tax", "personal_allowance"]
+    assert report.computed_covered_variables == [
+        "income_tax",
+        "personal_allowance",
+    ]
     assert report.missing_variables_total == 1
     assert [variable.name for variable in report.missing_variables] == [
         "employment_income",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -772,6 +772,7 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "ni_class_1_employee_additional",
         "ni_class_1_employee_primary",
         "ni_class_1_income",
+        "ni_employee",
         "ni_liable",
     )
     assert policyengine_person_variables_for_surfaces(

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -728,6 +728,7 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
     ) == (
         "age",
         "gender",
+        "is_SP_age",
         "state_pension_age",
     )
     assert policyengine_benunit_variables_for_surfaces(

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -21,6 +21,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     PERSONAL_ALLOWANCE_OUTPUTS,
     PERSONAL_ALLOWANCE_PROGRAM_PATH,
     UNIVERSAL_CREDIT_CHILD_ELEMENT_OUTPUTS,
+    UNIVERSAL_CREDIT_LCWRA_OUTPUTS,
     UNIVERSAL_CREDIT_STANDARD_ALLOWANCE_OUTPUTS,
     WEEKS_IN_YEAR,
     build_child_benefit_request,
@@ -809,22 +810,20 @@ class income_tax(Variable):
 def test_policyengine_uk_version_guard_rejects_unpinned_version(monkeypatch):
     def fake_version(package):
         versions = {
-            "policyengine": efrs_uk.POLICYENGINE_VERSION,
             "policyengine-core": efrs_uk.POLICYENGINE_CORE_VERSION,
-            "policyengine-uk": "2.88.19",
+            "policyengine-uk": "2.88.39",
         }
         return versions[package]
 
     monkeypatch.setattr(efrs_uk, "version", fake_version)
 
-    with pytest.raises(SystemExit, match="policyengine-uk==2.88.20 required"):
+    with pytest.raises(SystemExit, match="policyengine-uk==2.88.40 required"):
         require_policyengine_uk_versions()
 
 
 def test_policyengine_uk_version_guard_allows_pinned_versions(monkeypatch):
     def fake_version(package):
         versions = {
-            "policyengine": efrs_uk.POLICYENGINE_VERSION,
             "policyengine-core": efrs_uk.POLICYENGINE_CORE_VERSION,
             "policyengine-uk": efrs_uk.POLICYENGINE_UK_VERSION,
         }
@@ -1010,6 +1009,88 @@ def test_compare_outputs_compares_applicable_universal_credit_standard_allowance
         for item in report.output_summary
         if item["compared"]
     ] == [("standard_allowance_single_under_25", 1)]
+
+
+def test_compare_outputs_compares_raw_protected_universal_credit_lcwra_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "uc_LCWRA_element": 429.80 * 12,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "universal-credit-lcwra-element": [
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_LCWRA_OUTPUTS[
+                            "lcwra_element_standard_lcwra_claimant"
+                        ]["axiom"]: decimal_output(217.26),
+                        UNIVERSAL_CREDIT_LCWRA_OUTPUTS[
+                            "lcwra_element_pre_2026_severe_conditions_or_terminally_ill_claimant"
+                        ]["axiom"]: decimal_output(429.80),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+    assert [
+        (item["output"], item["compared"])
+        for item in report.output_summary
+        if item["compared"]
+    ] == [
+        (
+            "lcwra_element_pre_2026_severe_conditions_or_terminally_ill_claimant",
+            1,
+        )
+    ]
+
+
+def test_compare_outputs_skips_rebalanced_universal_credit_lcwra_health_element():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "uc_LCWRA_element": 426.5063 * 12,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "universal-credit-lcwra-element": [
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_LCWRA_OUTPUTS[
+                            "lcwra_element_standard_lcwra_claimant"
+                        ]["axiom"]: decimal_output(217.26),
+                        UNIVERSAL_CREDIT_LCWRA_OUTPUTS[
+                            "lcwra_element_pre_2026_severe_conditions_or_terminally_ill_claimant"
+                        ]["axiom"]: decimal_output(429.80),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 0
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
 
 
 def test_compare_outputs_classifies_known_policyengine_universal_credit_rates():

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -202,16 +202,32 @@ def test_income_tax_income_base_projection_uses_income_components():
         {
             "name": "employment_income",
             "amount_charged_to_income_tax": 30_000,
+            "relief_deducted_under_section_24": 0.0,
         },
         {
             "name": "private_pension_income",
             "amount_charged_to_income_tax": 2_000,
+            "relief_deducted_under_section_24": 0.0,
         },
         {
             "name": "savings_interest_income",
             "amount_charged_to_income_tax": 100,
+            "relief_deducted_under_section_24": 0.0,
         },
     ]
+
+
+def test_income_tax_income_base_projection_projects_net_income_relief():
+    components = project_income_tax_income_base_components(
+        {
+            "employment_income": 30_000,
+            "private_pension_income": 2_000,
+            "adjusted_net_income": 31_250,
+        }
+    )
+
+    assert components[0]["relief_deducted_under_section_24"] == 750
+    assert components[1]["relief_deducted_under_section_24"] == 0.0
 
 
 def test_income_tax_section_23_projection_uses_pe_liability_components():
@@ -226,10 +242,34 @@ def test_income_tax_section_23_projection_uses_pe_liability_components():
     )
 
     assert projected == {
+        "net_income_taken_as_zero_under_section_24b": False,
         "tax_calculated_at_applicable_rates_on_income_remaining_after_allowances": 5_000,
         "tax_reductions_listed_in_section_26": 150,
         "additional_tax_amounts_listed_in_section_30": 0.0,
     }
+
+
+def test_income_tax_net_income_output_skips_negative_component_rows():
+    spec = INCOME_TAX_INCOME_BASE_OUTPUTS["net_income"]
+
+    assert efrs_uk.output_applies(
+        spec,
+        {
+            "total_income": 31_250,
+            "adjusted_net_income": 31_250,
+            "employment_income": 30_000,
+            "private_pension_income": 1_250,
+        },
+    )
+    assert not efrs_uk.output_applies(
+        spec,
+        {
+            "total_income": 14_483.34,
+            "adjusted_net_income": 17_287.67,
+            "employment_income": 17_287.67,
+            "self_employment_income": -2_804.33,
+        },
+    )
 
 
 def test_income_tax_income_base_request_projects_section_23_relation():
@@ -240,6 +280,7 @@ def test_income_tax_income_base_request_projects_section_23_relation():
                     "person_id": 7,
                     "employment_income": 30_000,
                     "private_pension_income": 2_000,
+                    "adjusted_net_income": 31_250,
                     "income_tax_pre_charges": 4_500,
                     "CB_HITC": 300,
                     "personal_pension_contributions_tax": 200,
@@ -294,6 +335,15 @@ def test_income_tax_income_base_request_projects_section_23_relation():
     assert inputs[
         f"{INCOME_TAX_SECTION_23_BASE}#input.amount_charged_to_income_tax:person_7_income_employment_income"
     ] == {"kind": "decimal", "value": "30000.0"}
+    assert inputs[
+        f"{INCOME_TAX_SECTION_23_BASE}#input.relief_deducted_under_section_24:person_7_income_employment_income"
+    ] == {"kind": "decimal", "value": "750.0"}
+    assert inputs[
+        f"{INCOME_TAX_SECTION_23_BASE}#input.relief_deducted_under_section_24:person_7_income_private_pension_income"
+    ] == {"kind": "decimal", "value": "0.0"}
+    assert inputs[
+        f"{INCOME_TAX_SECTION_23_BASE}#input.net_income_taken_as_zero_under_section_24b:person_7"
+    ] == {"kind": "bool", "value": False}
     assert inputs[
         f"{INCOME_TAX_SECTION_23_BASE}#input.tax_calculated_at_applicable_rates_on_income_remaining_after_allowances:person_7"
     ] == {"kind": "decimal", "value": "5000.0"}
@@ -709,6 +759,7 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
                 *INCOME_TAX_INCOME_BASE_COMPONENTS,
                 *INCOME_TAX_SECTION_23_ADDITION_COMPONENTS,
                 *INCOME_TAX_SECTION_23_REDUCTION_COMPONENTS,
+                "adjusted_net_income",
                 "income_tax",
                 "total_income",
             )

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -27,9 +27,11 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     STATE_PENSION_CREDIT_SECTION_1_BASE,
     UNIVERSAL_CREDIT_AWARD_OUTPUTS,
     UNIVERSAL_CREDIT_CHILD_ELEMENT_OUTPUTS,
+    UNIVERSAL_CREDIT_CHILDCARE_ELEMENT_OUTPUTS,
     UNIVERSAL_CREDIT_HOUSING_COSTS_OUTPUTS,
     UNIVERSAL_CREDIT_LCWRA_OUTPUTS,
     UNIVERSAL_CREDIT_REGULATION_22_BASE,
+    UNIVERSAL_CREDIT_REGULATION_34_BASE,
     UNIVERSAL_CREDIT_STANDARD_ALLOWANCE_OUTPUTS,
     UNIVERSAL_CREDIT_WORK_ALLOWANCE_OUTPUTS,
     WEEKS_IN_YEAR,
@@ -44,6 +46,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_state_pension_credit_qualifying_age_request,
     build_uk_efrs_coverage_report,
     build_universal_credit_award_request,
+    build_universal_credit_childcare_element_request,
     build_universal_credit_housing_costs_request,
     build_universal_credit_request,
     build_universal_credit_work_allowance_request,
@@ -60,6 +63,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_personal_allowance_inputs,
     project_state_pension_credit_qualifying_age_inputs,
     project_universal_credit_award_inputs,
+    project_universal_credit_childcare_element_inputs,
     project_universal_credit_housing_costs_inputs,
     project_universal_credit_work_allowance_inputs,
     require_policyengine_uk_versions,
@@ -774,6 +778,89 @@ def test_universal_credit_award_request_projects_section_8_inputs():
     }
 
 
+def test_universal_credit_childcare_element_projection_reverses_rate_and_cap():
+    projected = project_universal_credit_childcare_element_inputs(
+        {
+            "uc_childcare_element": 1_020,
+            "uc_maximum_childcare_element_amount": 1_800,
+        }
+    )
+
+    assert projected == {
+        "charges_paid_for_relevant_childcare_attributable_to_assessment_period": 100,
+        "amount_considered_excessive_having_regard_to_paid_work_extent": 0.0,
+        "amount_met_or_reimbursed_by_employer_or_some_other_person": 0.0,
+        "secretary_of_state_work_transition_childcare_payment_meets_non_other_relevant_support_conditions": False,
+        "amount_from_funds_provided_by_secretary_of_state_or_scottish_or_welsh_ministers_for_work_related_activity_or_training": 0.0,
+        "secretary_of_state_work_transition_childcare_payment_amount": 0.0,
+        "maximum_amount_specified_in_table_in_regulation_36": 150,
+    }
+    assert project_universal_credit_childcare_element_inputs(
+        {
+            "uc_childcare_element": 0,
+            "uc_maximum_childcare_element_amount": 0,
+        }
+    ) == {
+        "charges_paid_for_relevant_childcare_attributable_to_assessment_period": 0.0,
+        "amount_considered_excessive_having_regard_to_paid_work_extent": 0.0,
+        "amount_met_or_reimbursed_by_employer_or_some_other_person": 0.0,
+        "secretary_of_state_work_transition_childcare_payment_meets_non_other_relevant_support_conditions": False,
+        "amount_from_funds_provided_by_secretary_of_state_or_scottish_or_welsh_ministers_for_work_related_activity_or_training": 0.0,
+        "secretary_of_state_work_transition_childcare_payment_amount": 0.0,
+        "maximum_amount_specified_in_table_in_regulation_36": 0.0,
+    }
+
+
+def test_universal_credit_childcare_element_request_projects_regulation_34_inputs():
+    request = build_universal_credit_childcare_element_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "uc_childcare_element": 1_020,
+                    "uc_maximum_childcare_element_amount": 1_800,
+                }
+            ],
+            "benunit_ids": [11],
+        },
+        year=2026,
+    )
+
+    assert request["mode"] == "explain"
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_11",
+            "period": {
+                "period_kind": "month",
+                "name": "benefit_month",
+                "start": "2026-04-01",
+                "end": "2026-04-30",
+            },
+            "outputs": list(
+                output["axiom"]
+                for output in UNIVERSAL_CREDIT_CHILDCARE_ELEMENT_OUTPUTS.values()
+            ),
+        }
+    ]
+    inputs_by_name = {
+        record["name"]: record["value"] for record in request["dataset"]["inputs"]
+    }
+    assert inputs_by_name[
+        f"{UNIVERSAL_CREDIT_REGULATION_34_BASE}#input.charges_paid_for_relevant_childcare_attributable_to_assessment_period"
+    ] == {
+        "kind": "decimal",
+        "value": "100.0",
+    }
+    assert inputs_by_name[
+        f"{UNIVERSAL_CREDIT_REGULATION_34_BASE}#input.maximum_amount_specified_in_table_in_regulation_36"
+    ] == {
+        "kind": "decimal",
+        "value": "150.0",
+    }
+
+
 def test_universal_credit_housing_costs_projection_uses_monthly_amount():
     projected = project_universal_credit_housing_costs_inputs(
         {"uc_housing_costs_element": 360}
@@ -1173,6 +1260,12 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
     assert policyengine_benunit_variables_for_surfaces(
         ["universal-credit-housing-costs"]
     ) == ("uc_housing_costs_element",)
+    assert policyengine_benunit_variables_for_surfaces(
+        ["universal-credit-childcare-element"]
+    ) == (
+        "uc_childcare_element",
+        "uc_maximum_childcare_element_amount",
+    )
     assert policyengine_benunit_variables_for_surfaces(
         ["universal-credit-work-allowance"]
     ) == (
@@ -1661,6 +1754,39 @@ def test_compare_outputs_transforms_universal_credit_housing_costs_monthly():
                         UNIVERSAL_CREDIT_HOUSING_COSTS_OUTPUTS[
                             "section_11_amount_for_accommodation_payments"
                         ]["axiom"]: decimal_output(30),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_transforms_universal_credit_childcare_element_monthly():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "uc_childcare_element": 1_020,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "universal-credit-childcare-element": [
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_CHILDCARE_ELEMENT_OUTPUTS[
+                            "childcare_costs_element_amount"
+                        ]["axiom"]: decimal_output(85),
                     }
                 }
             ]

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -11,6 +11,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     INCOME_TAX_INCOME_BASE_COMPONENTS,
     INCOME_TAX_INCOME_BASE_OUTPUTS,
     INCOME_TAX_SECTION_23_BASE,
+    NATIONAL_INSURANCE_CLASS_1_OUTPUTS,
+    NATIONAL_INSURANCE_SECTION_8_BASE,
     PENSION_CREDIT_BASE,
     PENSION_CREDIT_OUTPUTS,
     PERSONAL_ALLOWANCE_BASE,
@@ -21,6 +23,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     WEEKS_IN_YEAR,
     build_child_benefit_request,
     build_income_tax_income_base_request,
+    build_national_insurance_class_1_request,
     build_pension_credit_request,
     build_personal_allowance_request,
     build_uk_efrs_coverage_report,
@@ -40,6 +43,64 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
 
 def decimal_output(value):
     return {"value": {"value": str(value)}}
+
+
+def test_national_insurance_class_1_request_projects_weekly_inputs(monkeypatch):
+    monkeypatch.setattr(
+        efrs_uk,
+        "policyengine_uk_class_1_weekly_parameters",
+        lambda year: {
+            "primary_threshold": 241.73,
+            "upper_earnings_limit": 966.73,
+        },
+    )
+
+    request = build_national_insurance_class_1_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 7,
+                    "ni_class_1_income": 52_000,
+                    "ni_class_1_employee": 3_356.12,
+                    "ni_liable": True,
+                }
+            ],
+            "person_ids": [7],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_7",
+            "period": {
+                "period_kind": "custom",
+                "name": "tax_week",
+                "start": "2026-04-06",
+                "end": "2026-04-12",
+            },
+            "outputs": list(
+                output["axiom"]
+                for output in NATIONAL_INSURANCE_CLASS_1_OUTPUTS.values()
+            ),
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{NATIONAL_INSURANCE_SECTION_8_BASE}#input.primary_class_1_contribution_payable_as_mentioned_in_section_6_1_a:person_7"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{NATIONAL_INSURANCE_SECTION_8_BASE}#input.earnings_paid_in_tax_week_in_respect_of_employment:person_7"
+    ] == {"kind": "decimal", "value": "1000.0"}
+    assert inputs[
+        f"{NATIONAL_INSURANCE_SECTION_8_BASE}#input.current_primary_threshold_or_prescribed_equivalent:person_7"
+    ] == {"kind": "decimal", "value": "241.73"}
+    assert inputs[
+        f"{NATIONAL_INSURANCE_SECTION_8_BASE}#input.current_upper_earnings_limit_or_prescribed_equivalent:person_7"
+    ] == {"kind": "decimal", "value": "966.73"}
 
 
 class FakePolicyEngineVariable:
@@ -533,6 +594,13 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
                 "total_income",
             )
         ),
+    )
+    assert policyengine_person_variables_for_surfaces(
+        ["national-insurance-class-1"]
+    ) == (
+        "ni_class_1_employee",
+        "ni_class_1_income",
+        "ni_liable",
     )
     assert policyengine_benunit_variables_for_surfaces(
         ["personal-allowance", "pension-credit"]

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -13,6 +13,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     CHILD_BENEFIT_OUTPUTS,
     INCOME_TAX_INCOME_BASE_COMPONENTS,
     INCOME_TAX_INCOME_BASE_OUTPUTS,
+    INCOME_TAX_SECTION_10_BASE,
+    INCOME_TAX_SECTION_10_OUTPUTS,
     INCOME_TAX_SECTION_23_ADDITION_COMPONENTS,
     INCOME_TAX_SECTION_23_BASE,
     INCOME_TAX_SECTION_23_REDUCTION_COMPONENTS,
@@ -43,6 +45,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_benefit_cap_relevant_amount_request,
     build_child_benefit_request,
     build_income_tax_income_base_request,
+    build_income_tax_section_10_request,
     build_national_insurance_class_1_request,
     build_pension_credit_request,
     build_personal_allowance_request,
@@ -63,6 +66,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_benefit_cap_relevant_amount_inputs,
     project_child_benefit_inputs,
     project_income_tax_income_base_components,
+    project_income_tax_section_10_inputs,
     project_income_tax_section_23_inputs,
     project_pension_credit_inputs,
     project_personal_allowance_inputs,
@@ -277,6 +281,28 @@ def test_income_tax_section_23_projection_uses_pe_liability_components():
     }
 
 
+def test_income_tax_section_10_projection_uses_pe_earned_income_and_rates():
+    projected = project_income_tax_section_10_inputs(
+        {"earned_taxable_income": 60_000},
+        parameters={
+            "basic_rate_limit": 37_700,
+            "higher_rate_limit": 125_140,
+            "basic_rate": 0.2,
+            "higher_rate": 0.4,
+            "additional_rate": 0.45,
+        },
+    )
+
+    assert projected == {
+        "income_charged_under_section_10": 60_000,
+        "basic_rate_limit": 37_700,
+        "higher_rate_limit": 125_140,
+        "basic_rate": 0.2,
+        "higher_rate": 0.4,
+        "additional_rate": 0.45,
+    }
+
+
 def test_income_tax_net_income_output_skips_negative_component_rows():
     spec = INCOME_TAX_INCOME_BASE_OUTPUTS["net_income"]
 
@@ -381,6 +407,88 @@ def test_income_tax_income_base_request_projects_section_23_relation():
     assert inputs[
         f"{INCOME_TAX_SECTION_23_BASE}#input.additional_tax_amounts_listed_in_section_30:person_7"
     ] == {"kind": "decimal", "value": "0.0"}
+
+
+def test_income_tax_section_10_request_projects_earned_income_inputs(monkeypatch):
+    monkeypatch.setattr(
+        efrs_uk,
+        "policyengine_uk_income_tax_section_10_parameters",
+        lambda year: {
+            "basic_rate_limit": 37_700,
+            "higher_rate_limit": 125_140,
+            "basic_rate": 0.2,
+            "higher_rate": 0.4,
+            "additional_rate": 0.45,
+        },
+    )
+    request = build_income_tax_section_10_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 7,
+                    "earned_taxable_income": 60_000,
+                    "pays_scottish_income_tax": False,
+                    "basic_rate_earned_income": 37_700,
+                    "higher_rate_earned_income": 22_300,
+                    "add_rate_earned_income": 0,
+                    "basic_rate_earned_income_tax": 7_540,
+                    "higher_rate_earned_income_tax": 8_920,
+                    "add_rate_earned_income_tax": 0,
+                    "earned_income_tax": 16_460,
+                }
+            ],
+            "person_ids": [7],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_7",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": list(
+                output["axiom"] for output in INCOME_TAX_SECTION_10_OUTPUTS.values()
+            ),
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{INCOME_TAX_SECTION_10_BASE}#input.income_charged_under_section_10:person_7"
+    ] == {"kind": "decimal", "value": "60000.0"}
+    assert inputs[f"{INCOME_TAX_SECTION_10_BASE}#input.basic_rate_limit:person_7"] == {
+        "kind": "integer",
+        "value": 37700,
+    }
+    assert inputs[f"{INCOME_TAX_SECTION_10_BASE}#input.higher_rate_limit:person_7"] == {
+        "kind": "integer",
+        "value": 125140,
+    }
+    assert inputs[f"{INCOME_TAX_SECTION_10_BASE}#input.basic_rate:person_7"] == {
+        "kind": "decimal",
+        "value": "0.2",
+    }
+    assert inputs[f"{INCOME_TAX_SECTION_10_BASE}#input.higher_rate:person_7"] == {
+        "kind": "decimal",
+        "value": "0.4",
+    }
+    assert inputs[f"{INCOME_TAX_SECTION_10_BASE}#input.additional_rate:person_7"] == {
+        "kind": "decimal",
+        "value": "0.45",
+    }
+
+
+def test_income_tax_section_10_output_skips_scottish_income_tax_rows():
+    spec = INCOME_TAX_SECTION_10_OUTPUTS["income_tax_on_section_10_income"]
+
+    assert efrs_uk.output_applies(spec, {"pays_scottish_income_tax": False})
+    assert not efrs_uk.output_applies(spec, {"pays_scottish_income_tax": True})
 
 
 def test_child_benefit_projection_uses_child_index():
@@ -2074,6 +2182,97 @@ def test_compare_outputs_transforms_universal_credit_income_deduction_monthly():
     assert report.compared_values == 3
     assert report.mismatches == []
     assert report.oracle_divergences == []
+
+
+def test_compare_outputs_matches_income_tax_section_10_earned_income():
+    report = compare_outputs(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 7,
+                    "pays_scottish_income_tax": False,
+                    "basic_rate_earned_income": 37_700,
+                    "higher_rate_earned_income": 22_300,
+                    "add_rate_earned_income": 0,
+                    "basic_rate_earned_income_tax": 7_540,
+                    "higher_rate_earned_income_tax": 8_920,
+                    "add_rate_earned_income_tax": 0,
+                    "earned_income_tax": 16_460,
+                }
+            ],
+            "person_ids": [7],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        axiom_outputs_by_surface={
+            "income-tax-section-10-earned-income": [
+                {
+                    "outputs": {
+                        INCOME_TAX_SECTION_10_OUTPUTS["income_charged_at_basic_rate"][
+                            "axiom"
+                        ]: decimal_output(37_700),
+                        INCOME_TAX_SECTION_10_OUTPUTS["income_charged_at_higher_rate"][
+                            "axiom"
+                        ]: decimal_output(22_300),
+                        INCOME_TAX_SECTION_10_OUTPUTS[
+                            "income_charged_at_additional_rate"
+                        ]["axiom"]: decimal_output(0),
+                        INCOME_TAX_SECTION_10_OUTPUTS[
+                            "tax_on_income_charged_at_basic_rate"
+                        ]["axiom"]: decimal_output(7_540),
+                        INCOME_TAX_SECTION_10_OUTPUTS[
+                            "tax_on_income_charged_at_higher_rate"
+                        ]["axiom"]: decimal_output(8_920),
+                        INCOME_TAX_SECTION_10_OUTPUTS[
+                            "tax_on_income_charged_at_additional_rate"
+                        ]["axiom"]: decimal_output(0),
+                        INCOME_TAX_SECTION_10_OUTPUTS[
+                            "income_tax_on_section_10_income"
+                        ]["axiom"]: decimal_output(16_460),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 7
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_skips_scottish_income_tax_section_10_rows():
+    report = compare_outputs(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 7,
+                    "pays_scottish_income_tax": True,
+                    "earned_income_tax": 17_000,
+                }
+            ],
+            "person_ids": [7],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        axiom_outputs_by_surface={
+            "income-tax-section-10-earned-income": [
+                {
+                    "outputs": {
+                        INCOME_TAX_SECTION_10_OUTPUTS[
+                            "income_tax_on_section_10_income"
+                        ]["axiom"]: decimal_output(16_460),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 0
+    assert report.mismatches == []
 
 
 def test_compare_outputs_skips_capped_universal_credit_income_deduction_final():

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -22,10 +22,12 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     PERSONAL_ALLOWANCE_PROGRAM_PATH,
     STATE_PENSION_CREDIT_QUALIFYING_AGE_OUTPUTS,
     STATE_PENSION_CREDIT_SECTION_1_BASE,
+    UNIVERSAL_CREDIT_AWARD_OUTPUTS,
     UNIVERSAL_CREDIT_CHILD_ELEMENT_OUTPUTS,
     UNIVERSAL_CREDIT_LCWRA_OUTPUTS,
     UNIVERSAL_CREDIT_STANDARD_ALLOWANCE_OUTPUTS,
     WEEKS_IN_YEAR,
+    WELFARE_REFORM_ACT_SECTION_8_BASE,
     build_child_benefit_request,
     build_income_tax_income_base_request,
     build_national_insurance_class_1_request,
@@ -33,6 +35,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_personal_allowance_request,
     build_state_pension_credit_qualifying_age_request,
     build_uk_efrs_coverage_report,
+    build_universal_credit_award_request,
     build_universal_credit_request,
     compare_outputs,
     compare_uk_efrs,
@@ -45,6 +48,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_pension_credit_inputs,
     project_personal_allowance_inputs,
     project_state_pension_credit_qualifying_age_inputs,
+    project_universal_credit_award_inputs,
     require_policyengine_uk_versions,
     select_person_indices,
 )
@@ -582,6 +586,96 @@ def test_universal_credit_request_queries_monthly_table_amounts():
     ]
 
 
+def test_universal_credit_award_projection_uses_monthly_eligible_components():
+    projected = project_universal_credit_award_inputs(
+        {
+            "is_uc_eligible": True,
+            "uc_standard_allowance": 1_200,
+            "uc_child_element": 2_400,
+            "uc_disability_elements": 600,
+            "uc_housing_costs_element": 360,
+            "uc_childcare_element": 120,
+            "uc_carer_element": 60,
+            "uc_income_reduction": 300,
+        }
+    )
+
+    assert projected == {
+        "amount_included_under_section_9_standard_allowance": 100,
+        "amount_included_under_section_10_responsibility_for_children_and_young_persons": 200,
+        "amount_included_under_section_11_housing_costs": 30,
+        "amount_included_under_section_12_other_particular_needs_or_circumstances": 65,
+        "earned_income_deduction_calculated_in_prescribed_manner": 25,
+        "unearned_income_deduction_calculated_in_prescribed_manner": 0.0,
+    }
+
+    assert project_universal_credit_award_inputs(
+        {
+            "is_uc_eligible": False,
+            "uc_standard_allowance": 1_200,
+            "uc_child_element": 2_400,
+            "uc_income_reduction": 300,
+        }
+    ) == {
+        "amount_included_under_section_9_standard_allowance": 0.0,
+        "amount_included_under_section_10_responsibility_for_children_and_young_persons": 0.0,
+        "amount_included_under_section_11_housing_costs": 0.0,
+        "amount_included_under_section_12_other_particular_needs_or_circumstances": 0.0,
+        "earned_income_deduction_calculated_in_prescribed_manner": 0.0,
+        "unearned_income_deduction_calculated_in_prescribed_manner": 0.0,
+    }
+
+
+def test_universal_credit_award_request_projects_section_8_inputs():
+    request = build_universal_credit_award_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "benunit_weight": 1,
+                    "is_uc_eligible": True,
+                    "uc_standard_allowance": 1_200,
+                    "uc_child_element": 2_400,
+                    "uc_disability_elements": 600,
+                    "uc_housing_costs_element": 360,
+                    "uc_childcare_element": 120,
+                    "uc_carer_element": 60,
+                    "uc_income_reduction": 300,
+                }
+            ],
+            "benunit_ids": [11],
+        },
+        year=2026,
+    )
+
+    assert request["mode"] == "explain"
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_11",
+            "period": {
+                "period_kind": "month",
+                "name": "benefit_month",
+                "start": "2026-04-01",
+                "end": "2026-04-30",
+            },
+            "outputs": list(
+                output["axiom"] for output in UNIVERSAL_CREDIT_AWARD_OUTPUTS.values()
+            ),
+        }
+    ]
+    inputs_by_name = {
+        record["name"]: record["value"] for record in request["dataset"]["inputs"]
+    }
+    assert inputs_by_name[
+        f"{WELFARE_REFORM_ACT_SECTION_8_BASE}#input.amount_included_under_section_12_other_particular_needs_or_circumstances"
+    ] == {
+        "kind": "decimal",
+        "value": "65.0",
+    }
+
+
 def test_universal_credit_child_element_request_filters_to_positive_rows():
     request = build_universal_credit_request(
         pe_data={
@@ -811,6 +905,18 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "uc_carer_element",
         "uc_standard_allowance",
         "uc_standard_allowance_claimant_type",
+    )
+    assert policyengine_benunit_variables_for_surfaces(["universal-credit-award"]) == (
+        "is_uc_eligible",
+        "uc_carer_element",
+        "uc_child_element",
+        "uc_childcare_element",
+        "uc_disability_elements",
+        "uc_housing_costs_element",
+        "uc_income_reduction",
+        "uc_maximum_amount",
+        "uc_standard_allowance",
+        "universal_credit_pre_benefit_cap",
     )
 
 
@@ -1197,6 +1303,47 @@ def test_compare_outputs_compares_raw_protected_universal_credit_lcwra_amount():
             1,
         )
     ]
+
+
+def test_compare_outputs_transforms_universal_credit_award_outputs_monthly():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "uc_maximum_amount": 12_000,
+                    "uc_income_reduction": 3_600,
+                    "universal_credit_pre_benefit_cap": 8_400,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "universal-credit-award": [
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_AWARD_OUTPUTS[
+                            "universal_credit_maximum_amount"
+                        ]["axiom"]: decimal_output(1_000),
+                        UNIVERSAL_CREDIT_AWARD_OUTPUTS[
+                            "universal_credit_amounts_to_be_deducted"
+                        ]["axiom"]: decimal_output(300),
+                        UNIVERSAL_CREDIT_AWARD_OUTPUTS["universal_credit_award_amount"][
+                            "axiom"
+                        ]: decimal_output(700),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 3
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
 
 
 def test_compare_outputs_skips_rebalanced_universal_credit_lcwra_health_element():

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -8,6 +8,9 @@ import axiom_encode.oracles.policyengine.efrs_uk as efrs_uk
 from axiom_encode.oracles.policyengine.efrs_uk import (
     CHILD_BENEFIT_BASE,
     CHILD_BENEFIT_OUTPUTS,
+    INCOME_TAX_INCOME_BASE_COMPONENTS,
+    INCOME_TAX_INCOME_BASE_OUTPUTS,
+    INCOME_TAX_SECTION_23_BASE,
     PENSION_CREDIT_BASE,
     PENSION_CREDIT_OUTPUTS,
     PERSONAL_ALLOWANCE_BASE,
@@ -17,6 +20,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     UNIVERSAL_CREDIT_STANDARD_ALLOWANCE_OUTPUTS,
     WEEKS_IN_YEAR,
     build_child_benefit_request,
+    build_income_tax_income_base_request,
     build_pension_credit_request,
     build_personal_allowance_request,
     build_uk_efrs_coverage_report,
@@ -26,6 +30,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     policyengine_benunit_variables_for_surfaces,
     policyengine_person_variables_for_surfaces,
     project_child_benefit_inputs,
+    project_income_tax_income_base_components,
     project_pension_credit_inputs,
     project_personal_allowance_inputs,
     require_policyengine_uk_versions,
@@ -104,6 +109,89 @@ def test_personal_allowance_request_projects_efrs_people():
             "value": "20000.0",
         },
     }
+
+
+def test_income_tax_income_base_projection_uses_income_components():
+    components = project_income_tax_income_base_components(
+        {
+            "employment_income": 30_000,
+            "private_pension_income": 2_000,
+            "savings_interest_income": 100,
+        }
+    )
+
+    assert components == [
+        {
+            "name": "employment_income",
+            "amount_charged_to_income_tax": 30_000,
+        },
+        {
+            "name": "private_pension_income",
+            "amount_charged_to_income_tax": 2_000,
+        },
+        {
+            "name": "savings_interest_income",
+            "amount_charged_to_income_tax": 100,
+        },
+    ]
+
+
+def test_income_tax_income_base_request_projects_section_23_relation():
+    request = build_income_tax_income_base_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 7,
+                    "employment_income": 30_000,
+                    "private_pension_income": 2_000,
+                    "total_income": 32_000,
+                }
+            ],
+            "person_ids": [7],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_7",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": list(
+                output["axiom"] for output in INCOME_TAX_INCOME_BASE_OUTPUTS.values()
+            ),
+        }
+    ]
+    assert request["dataset"]["relations"] == [
+        {
+            "name": f"{INCOME_TAX_SECTION_23_BASE}#relation.income_component_of_taxpayer",
+            "tuple": ["person_7_income_employment_income", "person_7"],
+            "interval": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+        },
+        {
+            "name": f"{INCOME_TAX_SECTION_23_BASE}#relation.income_component_of_taxpayer",
+            "tuple": ["person_7_income_private_pension_income", "person_7"],
+            "interval": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+        },
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{INCOME_TAX_SECTION_23_BASE}#input.amount_charged_to_income_tax:person_7_income_employment_income"
+    ] == {"kind": "decimal", "value": "30000.0"}
 
 
 def test_child_benefit_projection_uses_child_index():
@@ -437,6 +525,14 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "child_benefit_respective_amount",
         "gift_aid_grossed_up",
         "personal_allowance",
+    )
+    assert policyengine_person_variables_for_surfaces(["income-tax-income-base"]) == (
+        *sorted(
+            (
+                *INCOME_TAX_INCOME_BASE_COMPONENTS,
+                "total_income",
+            )
+        ),
     )
     assert policyengine_benunit_variables_for_surfaces(
         ["personal-allowance", "pension-credit"]

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -33,7 +33,9 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     UNIVERSAL_CREDIT_LCWRA_OUTPUTS,
     UNIVERSAL_CREDIT_REGULATION_22_BASE,
     UNIVERSAL_CREDIT_REGULATION_34_BASE,
+    UNIVERSAL_CREDIT_REGULATION_72_BASE,
     UNIVERSAL_CREDIT_STANDARD_ALLOWANCE_OUTPUTS,
+    UNIVERSAL_CREDIT_TARIFF_INCOME_OUTPUTS,
     UNIVERSAL_CREDIT_WORK_ALLOWANCE_OUTPUTS,
     WEEKS_IN_YEAR,
     WELFARE_REFORM_ACT_SECTION_8_BASE,
@@ -51,6 +53,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_universal_credit_housing_costs_request,
     build_universal_credit_income_deduction_request,
     build_universal_credit_request,
+    build_universal_credit_tariff_income_request,
     build_universal_credit_work_allowance_request,
     compare_outputs,
     compare_uk_efrs,
@@ -68,6 +71,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_universal_credit_childcare_element_inputs,
     project_universal_credit_housing_costs_inputs,
     project_universal_credit_income_deduction_inputs,
+    project_universal_credit_tariff_income_inputs,
     project_universal_credit_work_allowance_inputs,
     require_policyengine_uk_versions,
     select_person_indices,
@@ -1120,6 +1124,71 @@ def test_universal_credit_income_deduction_request_projects_regulation_22_inputs
     }
 
 
+def test_universal_credit_tariff_income_projection_uses_regulation_72_inputs():
+    assert project_universal_credit_tariff_income_inputs(
+        {
+            "uc_assessable_capital": 6_001,
+        }
+    ) == {
+        "person_capital": 6_001,
+        "capital_is_disregarded": False,
+        "actual_income_from_capital_taken_into_account_under_regulation_66_1_i_annuity": False,
+        "actual_income_from_capital_taken_into_account_under_regulation_66_1_j_trust": False,
+        "actual_income_derived_from_that_capital_due_to_be_paid_to_person_on_day_amount": 0.0,
+    }
+
+
+def test_universal_credit_tariff_income_request_projects_regulation_72_inputs():
+    request = build_universal_credit_tariff_income_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "is_uc_eligible": True,
+                    "uc_assessable_capital": 6_001,
+                    "uc_tariff_income": 52.20,
+                }
+            ],
+            "benunit_ids": [11],
+        },
+        year=2026,
+    )
+
+    assert request["mode"] == "explain"
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_11",
+            "period": {
+                "period_kind": "month",
+                "name": "benefit_month",
+                "start": "2026-04-01",
+                "end": "2026-04-30",
+            },
+            "outputs": list(
+                output["axiom"]
+                for output in UNIVERSAL_CREDIT_TARIFF_INCOME_OUTPUTS.values()
+            ),
+        }
+    ]
+    inputs_by_name = {
+        record["name"]: record["value"] for record in request["dataset"]["inputs"]
+    }
+    assert inputs_by_name[
+        f"{UNIVERSAL_CREDIT_REGULATION_72_BASE}#input.person_capital"
+    ] == {
+        "kind": "decimal",
+        "value": "6001.0",
+    }
+    assert inputs_by_name[
+        f"{UNIVERSAL_CREDIT_REGULATION_72_BASE}#input.capital_is_disregarded"
+    ] == {
+        "kind": "bool",
+        "value": False,
+    }
+
+
 def test_universal_credit_child_element_request_filters_to_positive_rows():
     request = build_universal_credit_request(
         pe_data={
@@ -1400,6 +1469,13 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "uc_maximum_amount",
         "uc_unearned_income",
         "uc_work_allowance",
+    )
+    assert policyengine_benunit_variables_for_surfaces(
+        ["universal-credit-tariff-income"]
+    ) == (
+        "is_uc_eligible",
+        "uc_assessable_capital",
+        "uc_tariff_income",
     )
 
 
@@ -2080,6 +2156,76 @@ def test_compare_outputs_skips_negative_unearned_income_deduction_final():
     )
 
     assert report.compared_values == 2
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_transforms_universal_credit_tariff_income_monthly():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "is_uc_eligible": True,
+                    "uc_assessable_capital": 6_001,
+                    "uc_tariff_income": 52.20,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "universal-credit-tariff-income": [
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_TARIFF_INCOME_OUTPUTS[
+                            "capital_tariff_monthly_income"
+                        ]["axiom"]: decimal_output(4.35),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_skips_undefined_universal_credit_tariff_income():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "is_uc_eligible": False,
+                    "uc_assessable_capital": 20_000,
+                    "uc_tariff_income": 0,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "universal-credit-tariff-income": [
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_TARIFF_INCOME_OUTPUTS[
+                            "capital_tariff_monthly_income"
+                        ]["axiom"]: decimal_output(243.60),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 0
     assert report.mismatches == []
     assert report.oracle_divergences == []
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.557"
+version = "0.2.558"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.558"
+version = "0.2.559"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.556"
+version = "0.2.557"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.555"
+version = "0.2.556"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.554"
+version = "0.2.555"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Add UK EFRS oracle surfaces for Income Tax Act 2007 s.10 earned-income banding and tax at the basic, higher, and additional UK rates.
- Add UK EFRS oracle surfaces for Income Tax Act 2007 s.23 total income, net income, and final income tax liability.
- Add UK EFRS oracle surfaces for National Insurance Class 1 aggregate, main, and additional employee contributions, including the `ni_employee` PE wrapper that currently aggregates only `ni_class_1_employee`.
- Add a State Pension Credit Act 2002 s.1 qualifying-age oracle surface mapped to PolicyEngine UK's `state_pension_age` and attained-age judgment mapped to `is_SP_age`.
- Add Welfare Reform Act 2012 s.8 Universal Credit award, s.11 housing costs, Universal Credit Regulations 2013 reg. 22 work allowance and income deduction, reg. 34 childcare costs element, reg. 72 tariff income, and reg. 80A benefit-cap relevant amount oracle surfaces.
- Bump `axiom-encode` to `0.2.559` so encoder-affecting oracle changes satisfy the apply provenance gate.
- Treat PE-UK July 2025 UC rebalanced existing-claimant health-element outputs as non-comparable to the raw Regulation 36 protected LCWRA table amount.

## Local validation
- `uv run --python 3.13 ruff format src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py`
- `uv run --python 3.13 ruff check src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py`
- `uv lock --check`
- `uv run --python 3.13 pytest tests/test_policyengine_efrs_uk.py -q`
- `uv run --python 3.13 pytest tests/test_policyengine_coverage.py -q`
- `uv run --python 3.13 pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
- `AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/axiom-corpus-wave1 uv run --python 3.13 axiom-encode validate --skip-reviewers /Users/maxghenis/_axiom-worktrees/rulespec-uk-pe-coverage-20260604/statutes/ukpga/2007/3/10.yaml`
- `AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/axiom-corpus-wave1 uv run --python 3.13 axiom-encode proof-validate /Users/maxghenis/_axiom-worktrees/rulespec-uk-pe-coverage-20260604/statutes/ukpga/2007/3/10.yaml`
- `AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/axiom-corpus-wave1 uv run --python 3.13 axiom-encode test --root /Users/maxghenis/_axiom-worktrees/rulespec-uk-pe-coverage-20260604 /Users/maxghenis/_axiom-worktrees/rulespec-uk-pe-coverage-20260604/statutes/ukpga/2007/3/10.test.yaml`
- `uv run --with policyengine-uk==2.88.40 axiom-encode uk-efrs-compare --root /Users/maxghenis/TheAxiomFoundation --rulespec-root /Users/maxghenis/_axiom-worktrees/rulespec-uk-pe-coverage-20260604 --dataset /Users/maxghenis/policyengine-model/policyengine-uk-data/policyengine_uk_data/storage/policybench_transfer_2025.h5 --surface income-tax-section-10-earned-income --sample-size 0 --json`
- `uv run --with policyengine-uk==2.88.40 axiom-encode uk-efrs-compare --root /Users/maxghenis/TheAxiomFoundation --rulespec-root /Users/maxghenis/_axiom-worktrees/rulespec-uk-pe-coverage-20260604 --dataset /Users/maxghenis/policyengine-model/policyengine-uk-data/policyengine_uk_data/storage/policybench_transfer_2025.h5 --surface all --sample-size 0 --json`
- `uv run --with 'policyengine-uk @ git+https://github.com/PolicyEngine/policyengine-uk.git@main' axiom-encode uk-efrs-compare --root /Users/maxghenis/TheAxiomFoundation --rulespec-root /Users/maxghenis/_axiom-worktrees/rulespec-uk-pe-coverage-20260604 --dataset /Users/maxghenis/policyengine-model/policyengine-uk-data/policyengine_uk_data/storage/policybench_transfer_2025.h5 --surface all --sample-size 0 --json`
- `uv run --with policyengine-uk==2.88.40 axiom-encode uk-efrs-coverage --dataset /Users/maxghenis/policyengine-model/policyengine-uk-data/policyengine_uk_data/storage/policybench_transfer_2025.h5 --with-efrs-activity --top 80`

## Local oracle results
- UK EFRS computed-variable coverage on policyengine-uk 2.88.40: 38 direct Axiom-covered PE outputs, 575 missing computed PE outputs, 613 computed PE variables in scope.
- Income Tax Act 2007 s.10 earned-income surface on policyengine-uk 2.88.40: 2,050 persons, 13,454 compared person values, 0 mismatches, 0 known PE divergences.
- Full local policybench comparison against current PolicyEngine UK `main`: 2,050 persons, 1,000 benefit units, 46,306 compared values, 0 mismatches, 0 known PE divergences.
- Full local policybench comparison on policyengine-uk 2.88.40: 2,050 persons, 1,000 benefit units, 46,306 compared values, 0 mismatches, 57 known PE divergences, all personal-allowance rounding under PolicyEngine/policyengine-uk#1738.
- Earlier focused surfaces on policyengine-uk 2.88.40 all matched with 0 mismatches and 0 known PE divergences: National Insurance Class 1, child benefit, State Pension Credit qualifying age, pension credit, Welfare Reform Act 2012 s.8 UC award, s.11 UC housing costs, UC reg. 22 work allowance and income deduction, UC reg. 34 childcare costs, UC reg. 72 tariff income, UC reg. 80A benefit-cap relevant amount, and Income Tax Act 2007 s.23.
