### PR TITLE
Add UK section 11D savings oracle surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.559"
+version = "0.2.560"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.559"
+__version__ = "0.2.560"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -42,6 +42,8 @@ PERSONAL_ALLOWANCE_PROGRAM_PATH = Path("statutes/ukpga/2007/3/35.yaml")
 PERSONAL_ALLOWANCE_BASE = "uk:statutes/ukpga/2007/3/35"
 INCOME_TAX_SECTION_10_PROGRAM_PATH = Path("statutes/ukpga/2007/3/10.yaml")
 INCOME_TAX_SECTION_10_BASE = "uk:statutes/ukpga/2007/3/10"
+INCOME_TAX_SECTION_11D_PROGRAM_PATH = Path("statutes/ukpga/2007/3/11D.yaml")
+INCOME_TAX_SECTION_11D_BASE = "uk:statutes/ukpga/2007/3/11D"
 INCOME_TAX_SECTION_23_PROGRAM_PATH = Path("statutes/ukpga/2007/3/23.yaml")
 INCOME_TAX_SECTION_23_BASE = "uk:statutes/ukpga/2007/3/23"
 CHILD_BENEFIT_PROGRAM_PATH = Path("regulations/uksi/2006/965/2.yaml")
@@ -172,6 +174,34 @@ INCOME_TAX_SECTION_10_OUTPUTS = {
         "axiom": f"{INCOME_TAX_SECTION_10_BASE}#income_tax_on_section_10_income",
         "pe": "earned_income_tax",
         "applies": "non_scottish_income_tax",
+    },
+}
+
+INCOME_TAX_SECTION_11D_OUTPUTS = {
+    "savings_income_charged_at_savings_basic_rate": {
+        "axiom": f"{INCOME_TAX_SECTION_11D_BASE}#savings_income_charged_at_savings_basic_rate",
+        "pe": "basic_rate_savings_income",
+        "tolerance": 0.1,
+    },
+    "savings_income_charged_at_savings_higher_rate": {
+        "axiom": f"{INCOME_TAX_SECTION_11D_BASE}#savings_income_charged_at_savings_higher_rate",
+        "pe": "higher_rate_savings_income",
+        "tolerance": 0.1,
+    },
+    "savings_income_charged_at_savings_additional_rate": {
+        "axiom": f"{INCOME_TAX_SECTION_11D_BASE}#savings_income_charged_at_savings_additional_rate",
+        "pe": "add_rate_savings_income",
+        "tolerance": 0.1,
+    },
+    "savings_income_charged_under_section_11d": {
+        "axiom": f"{INCOME_TAX_SECTION_11D_BASE}#savings_income_charged_under_section_11d",
+        "pe": "taxed_savings_income",
+        "tolerance": 0.1,
+    },
+    "income_tax_on_section_11d_savings_income": {
+        "axiom": f"{INCOME_TAX_SECTION_11D_BASE}#income_tax_on_section_11d_savings_income",
+        "pe": "savings_income_tax",
+        "tolerance": 0.1,
     },
 }
 
@@ -478,6 +508,23 @@ SURFACE_SPECS = {
             "higher_rate_earned_income",
             "higher_rate_earned_income_tax",
             "pays_scottish_income_tax",
+        ),
+    ),
+    "income-tax-section-11d-savings-income": UKEFRSSurfaceSpec(
+        program=INCOME_TAX_SECTION_11D_PROGRAM_PATH,
+        entity="person",
+        outputs=INCOME_TAX_SECTION_11D_OUTPUTS,
+        pe_variables=(
+            "add_rate_savings_income",
+            "basic_rate_savings_income",
+            "earned_taxable_income",
+            "higher_rate_savings_income",
+            "received_allowances_savings_income",
+            "savings_allowance",
+            "savings_income_tax",
+            "savings_starter_rate_income",
+            "taxable_savings_interest_income",
+            "taxed_savings_income",
         ),
     ),
     "child-benefit": UKEFRSSurfaceSpec(
@@ -2084,6 +2131,8 @@ def build_axiom_request(
         return build_income_tax_income_base_request(pe_data=pe_data, year=year)
     if surface == "income-tax-section-10-earned-income":
         return build_income_tax_section_10_request(pe_data=pe_data, year=year)
+    if surface == "income-tax-section-11d-savings-income":
+        return build_income_tax_section_11d_request(pe_data=pe_data, year=year)
     if surface == "child-benefit":
         return build_child_benefit_request(pe_data=pe_data, year=year)
     if surface == "benefit-cap-relevant-amount":
@@ -2312,6 +2361,44 @@ def build_income_tax_section_10_request(
                 "period": interval,
                 "outputs": [
                     spec["axiom"] for spec in INCOME_TAX_SECTION_10_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_income_tax_section_11d_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = tax_year_interval(year)
+    parameters = policyengine_uk_income_tax_section_11d_parameters(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "income-tax-section-11d-savings-income"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_income_tax_section_11d_inputs(
+            row,
+            parameters=parameters,
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{INCOME_TAX_SECTION_11D_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in INCOME_TAX_SECTION_11D_OUTPUTS.values()
                 ],
             }
         )
@@ -2770,6 +2857,38 @@ def project_income_tax_section_10_inputs(
     }
 
 
+def project_income_tax_section_11d_inputs(
+    row: Any,
+    *,
+    parameters: dict[str, float],
+) -> dict[str, Any]:
+    savings_after_allowances = max(
+        0.0,
+        money(row_value(row, "taxable_savings_interest_income", 0))
+        - money(row_value(row, "received_allowances_savings_income", 0)),
+    )
+    zero_rate_savings = min(
+        savings_after_allowances,
+        money(row_value(row, "savings_allowance", 0))
+        + money(row_value(row, "savings_starter_rate_income", 0)),
+    )
+    return {
+        "income_already_charged_before_section_11d_savings_income": money(
+            row_value(row, "earned_taxable_income", 0)
+        )
+        + zero_rate_savings,
+        "savings_income_remaining_after_sections_12_and_12a": max(
+            0.0,
+            savings_after_allowances - zero_rate_savings,
+        ),
+        "basic_rate_limit": parameters["basic_rate_limit"],
+        "higher_rate_limit": parameters["higher_rate_limit"],
+        "savings_basic_rate": parameters["savings_basic_rate"],
+        "savings_higher_rate": parameters["savings_higher_rate"],
+        "savings_additional_rate": parameters["savings_additional_rate"],
+    }
+
+
 def project_child_benefit_inputs(row: Any) -> dict[str, Any]:
     child_index = int(row_value(row, "child_benefit_child_index", -1))
     is_eldest = child_index == 1
@@ -3100,7 +3219,7 @@ def compare_outputs(
                 if not within_tolerance(
                     axiom_value,
                     pe_value,
-                    absolute_tolerance=tolerance,
+                    absolute_tolerance=float(spec.get("tolerance", tolerance)),
                     relative_tolerance=relative_tolerance,
                 ):
                     divergence = known_policyengine_divergence(
@@ -3253,6 +3372,15 @@ def compare_outputs(
             "26 reductions input, because PolicyEngine exposes final income_tax "
             "and aggregate additive/subtractive components rather than exact "
             "section 23 step buckets.",
+            "Income Tax Act 2007 section 11D savings-income comparison projects "
+            "PolicyEngine's taxable_savings_interest_income net of "
+            "received_allowances_savings_income, then lets "
+            "savings_starter_rate_income and savings_allowance consume rate-band "
+            "capacity before the remaining section 11D savings income starts. "
+            "It uses UK income-tax thresholds and savings rates from "
+            "PolicyEngine parameters to compare the section 11D band amounts "
+            "and aggregate savings income tax, with a 10p output tolerance for "
+            "EFRS float precision in PolicyEngine's savings-income arrays.",
         ],
     )
 
@@ -3691,6 +3819,27 @@ def policyengine_uk_income_tax_section_10_parameters(year: int) -> dict[str, flo
         "basic_rate": money(uk_rates.rates[0]),
         "higher_rate": money(uk_rates.rates[1]),
         "additional_rate": money(uk_rates.rates[2]),
+    }
+
+
+def policyengine_uk_income_tax_section_11d_parameters(year: int) -> dict[str, float]:
+    require_policyengine_uk_versions()
+    try:
+        from policyengine_uk import CountryTaxBenefitSystem
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(policyengine_uk_install_message()) from exc
+
+    income_tax_rates = (
+        CountryTaxBenefitSystem()
+        .parameters(f"{year:04d}-04-06")
+        .gov.hmrc.income_tax.rates
+    )
+    return {
+        "basic_rate_limit": money(income_tax_rates.uk.thresholds[1]),
+        "higher_rate_limit": money(income_tax_rates.uk.thresholds[2]),
+        "savings_basic_rate": money(income_tax_rates.savings.basic),
+        "savings_higher_rate": money(income_tax_rates.savings.higher),
+        "savings_additional_rate": money(income_tax_rates.savings.additional),
     }
 
 

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -76,6 +76,79 @@ mappings:
     comparison: money
     rationale: Same UK income tax on ordinary earned income under section 10, with Scottish-rate rows excluded because PolicyEngine branches earned_income_tax to Scotland-specific rates.
 
+  - legal_id: uk:statutes/ukpga/2007/3/11D#savings_income_charged_at_savings_basic_rate
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: basic_rate_savings_income
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK savings income amount charged at the savings basic rate after starting-rate and savings nil-rate amounts are removed.
+
+  - legal_id: uk:statutes/ukpga/2007/3/11D#savings_income_charged_at_savings_higher_rate
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: higher_rate_savings_income
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK savings income amount charged at the savings higher rate after starting-rate and savings nil-rate amounts are removed.
+
+  - legal_id: uk:statutes/ukpga/2007/3/11D#savings_income_charged_at_savings_additional_rate
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: add_rate_savings_income
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK savings income amount charged at the savings additional rate after starting-rate and savings nil-rate amounts are removed.
+
+  - legal_id: uk:statutes/ukpga/2007/3/11D#savings_income_charged_under_section_11d
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: taxed_savings_income
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same aggregate savings income charged under section 11D after PolicyEngine's starting-rate and savings nil-rate deductions.
+
+  - legal_id: uk:statutes/ukpga/2007/3/11D#income_tax_on_section_11d_savings_income
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: savings_income_tax
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK income tax on savings income charged at the savings basic, higher, and additional rates.
+
+  - legal_id: uk:statutes/ukpga/2007/3/11D#tax_on_savings_income_charged_at_savings_basic_rate
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Per-rate tax helper for section 11D savings basic-rate income; PolicyEngine UK exposes the aggregate savings_income_tax rather than per-rate savings tax variables.
+
+  - legal_id: uk:statutes/ukpga/2007/3/11D#tax_on_savings_income_charged_at_savings_higher_rate
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Per-rate tax helper for section 11D savings higher-rate income; PolicyEngine UK exposes the aggregate savings_income_tax rather than per-rate savings tax variables.
+
+  - legal_id: uk:statutes/ukpga/2007/3/11D#tax_on_savings_income_charged_at_savings_additional_rate
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Per-rate tax helper for section 11D savings additional-rate income; PolicyEngine UK exposes the aggregate savings_income_tax rather than per-rate savings tax variables.
+
   - legal_id: uk:statutes/ukpga/2007/3/23#total_income
     country: uk
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -733,6 +733,150 @@ rules:
     assert future_output["status"] == "unmapped"
 
 
+def test_policyengine_coverage_classifies_uk_income_tax_section_11d_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2007/3/11D.yaml",
+        """format: rulespec/v1
+rules:
+  - name: savings_income_charged_at_savings_basic_rate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 1
+  - name: savings_income_charged_at_savings_higher_rate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: savings_income_charged_at_savings_additional_rate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3
+  - name: savings_income_charged_under_section_11d
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 6
+  - name: tax_on_savings_income_charged_at_savings_basic_rate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.2
+  - name: tax_on_savings_income_charged_at_savings_higher_rate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.8
+  - name: tax_on_savings_income_charged_at_savings_additional_rate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 1.35
+  - name: income_tax_on_section_11d_savings_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2.35
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2007/3/11D.test.yaml",
+        """- name: savings income tax
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    uk:statutes/ukpga/2007/3/11D#savings_income_charged_at_savings_basic_rate: 1
+    uk:statutes/ukpga/2007/3/11D#savings_income_charged_at_savings_higher_rate: 2
+    uk:statutes/ukpga/2007/3/11D#savings_income_charged_at_savings_additional_rate: 3
+    uk:statutes/ukpga/2007/3/11D#savings_income_charged_under_section_11d: 6
+    uk:statutes/ukpga/2007/3/11D#tax_on_savings_income_charged_at_savings_basic_rate: 0.2
+    uk:statutes/ukpga/2007/3/11D#tax_on_savings_income_charged_at_savings_higher_rate: 0.8
+    uk:statutes/ukpga/2007/3/11D#tax_on_savings_income_charged_at_savings_additional_rate: 1.35
+    uk:statutes/ukpga/2007/3/11D#income_tax_on_section_11d_savings_income: 2.35
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {
+        "comparable": 5,
+        "known_not_comparable": 3,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2007/3/11D#savings_income_charged_at_savings_basic_rate"
+        ]["policyengine_variable"]
+        == "basic_rate_savings_income"
+    )
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2007/3/11D#savings_income_charged_at_savings_higher_rate"
+        ]["policyengine_variable"]
+        == "higher_rate_savings_income"
+    )
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2007/3/11D#savings_income_charged_at_savings_additional_rate"
+        ]["policyengine_variable"]
+        == "add_rate_savings_income"
+    )
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2007/3/11D#savings_income_charged_under_section_11d"
+        ]["policyengine_variable"]
+        == "taxed_savings_income"
+    )
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2007/3/11D#income_tax_on_section_11d_savings_income"
+        ]["policyengine_variable"]
+        == "savings_income_tax"
+    )
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2007/3/11D#tax_on_savings_income_charged_at_savings_basic_rate"
+        ]["status"]
+        == "known_not_comparable"
+    )
+
+
 def test_policyengine_coverage_classifies_uk_class_1_ni_section_8_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-uk" / "statutes/ukpga/1992/4/8.yaml",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -15,6 +15,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     INCOME_TAX_INCOME_BASE_OUTPUTS,
     INCOME_TAX_SECTION_10_BASE,
     INCOME_TAX_SECTION_10_OUTPUTS,
+    INCOME_TAX_SECTION_11D_BASE,
+    INCOME_TAX_SECTION_11D_OUTPUTS,
     INCOME_TAX_SECTION_23_ADDITION_COMPONENTS,
     INCOME_TAX_SECTION_23_BASE,
     INCOME_TAX_SECTION_23_REDUCTION_COMPONENTS,
@@ -46,6 +48,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_child_benefit_request,
     build_income_tax_income_base_request,
     build_income_tax_section_10_request,
+    build_income_tax_section_11d_request,
     build_national_insurance_class_1_request,
     build_pension_credit_request,
     build_personal_allowance_request,
@@ -67,6 +70,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_child_benefit_inputs,
     project_income_tax_income_base_components,
     project_income_tax_section_10_inputs,
+    project_income_tax_section_11d_inputs,
     project_income_tax_section_23_inputs,
     project_pension_credit_inputs,
     project_personal_allowance_inputs,
@@ -303,6 +307,35 @@ def test_income_tax_section_10_projection_uses_pe_earned_income_and_rates():
     }
 
 
+def test_income_tax_section_11d_projection_removes_savings_deductions():
+    projected = project_income_tax_section_11d_inputs(
+        {
+            "earned_taxable_income": 37_000,
+            "taxable_savings_interest_income": 2_500,
+            "received_allowances_savings_income": 100,
+            "savings_allowance": 500,
+            "savings_starter_rate_income": 400,
+        },
+        parameters={
+            "basic_rate_limit": 37_700,
+            "higher_rate_limit": 125_140,
+            "savings_basic_rate": 0.2,
+            "savings_higher_rate": 0.4,
+            "savings_additional_rate": 0.45,
+        },
+    )
+
+    assert projected == {
+        "income_already_charged_before_section_11d_savings_income": 37_900,
+        "savings_income_remaining_after_sections_12_and_12a": 1_500,
+        "basic_rate_limit": 37_700,
+        "higher_rate_limit": 125_140,
+        "savings_basic_rate": 0.2,
+        "savings_higher_rate": 0.4,
+        "savings_additional_rate": 0.45,
+    }
+
+
 def test_income_tax_net_income_output_skips_negative_component_rows():
     spec = INCOME_TAX_INCOME_BASE_OUTPUTS["net_income"]
 
@@ -479,6 +512,93 @@ def test_income_tax_section_10_request_projects_earned_income_inputs(monkeypatch
         "value": "0.4",
     }
     assert inputs[f"{INCOME_TAX_SECTION_10_BASE}#input.additional_rate:person_7"] == {
+        "kind": "decimal",
+        "value": "0.45",
+    }
+
+
+def test_income_tax_section_11d_request_projects_savings_inputs(monkeypatch):
+    monkeypatch.setattr(
+        efrs_uk,
+        "policyengine_uk_income_tax_section_11d_parameters",
+        lambda year: {
+            "basic_rate_limit": 37_700,
+            "higher_rate_limit": 125_140,
+            "savings_basic_rate": 0.2,
+            "savings_higher_rate": 0.4,
+            "savings_additional_rate": 0.45,
+        },
+    )
+    request = build_income_tax_section_11d_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 7,
+                    "earned_taxable_income": 37_000,
+                    "taxable_savings_interest_income": 2_500,
+                    "received_allowances_savings_income": 100,
+                    "savings_allowance": 500,
+                    "savings_starter_rate_income": 400,
+                    "basic_rate_savings_income": 700,
+                    "higher_rate_savings_income": 800,
+                    "add_rate_savings_income": 0,
+                    "taxed_savings_income": 1_500,
+                    "savings_income_tax": 460,
+                }
+            ],
+            "person_ids": [7],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_7",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": list(
+                output["axiom"] for output in INCOME_TAX_SECTION_11D_OUTPUTS.values()
+            ),
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{INCOME_TAX_SECTION_11D_BASE}#input.income_already_charged_before_section_11d_savings_income:person_7"
+    ] == {"kind": "decimal", "value": "37900.0"}
+    assert inputs[
+        f"{INCOME_TAX_SECTION_11D_BASE}#input.savings_income_remaining_after_sections_12_and_12a:person_7"
+    ] == {"kind": "decimal", "value": "1500.0"}
+    assert inputs[f"{INCOME_TAX_SECTION_11D_BASE}#input.basic_rate_limit:person_7"] == {
+        "kind": "integer",
+        "value": 37700,
+    }
+    assert inputs[
+        f"{INCOME_TAX_SECTION_11D_BASE}#input.higher_rate_limit:person_7"
+    ] == {
+        "kind": "integer",
+        "value": 125140,
+    }
+    assert inputs[
+        f"{INCOME_TAX_SECTION_11D_BASE}#input.savings_basic_rate:person_7"
+    ] == {
+        "kind": "decimal",
+        "value": "0.2",
+    }
+    assert inputs[
+        f"{INCOME_TAX_SECTION_11D_BASE}#input.savings_higher_rate:person_7"
+    ] == {
+        "kind": "decimal",
+        "value": "0.4",
+    }
+    assert inputs[
+        f"{INCOME_TAX_SECTION_11D_BASE}#input.savings_additional_rate:person_7"
+    ] == {
         "kind": "decimal",
         "value": "0.45",
     }
@@ -1585,6 +1705,20 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "uc_assessable_capital",
         "uc_tariff_income",
     )
+    assert policyengine_person_variables_for_surfaces(
+        ["income-tax-section-11d-savings-income"]
+    ) == (
+        "add_rate_savings_income",
+        "basic_rate_savings_income",
+        "earned_taxable_income",
+        "higher_rate_savings_income",
+        "received_allowances_savings_income",
+        "savings_allowance",
+        "savings_income_tax",
+        "savings_starter_rate_income",
+        "taxable_savings_interest_income",
+        "taxed_savings_income",
+    )
 
 
 def test_uk_efrs_coverage_report_counts_computed_pe_backlog(tmp_path):
@@ -2238,6 +2372,55 @@ def test_compare_outputs_matches_income_tax_section_10_earned_income():
     )
 
     assert report.compared_values == 7
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_matches_income_tax_section_11d_savings_income():
+    report = compare_outputs(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 7,
+                    "basic_rate_savings_income": 700,
+                    "higher_rate_savings_income": 800,
+                    "add_rate_savings_income": 0,
+                    "taxed_savings_income": 1_500,
+                    "savings_income_tax": 460,
+                }
+            ],
+            "person_ids": [7],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        axiom_outputs_by_surface={
+            "income-tax-section-11d-savings-income": [
+                {
+                    "outputs": {
+                        INCOME_TAX_SECTION_11D_OUTPUTS[
+                            "savings_income_charged_at_savings_basic_rate"
+                        ]["axiom"]: decimal_output(700),
+                        INCOME_TAX_SECTION_11D_OUTPUTS[
+                            "savings_income_charged_at_savings_higher_rate"
+                        ]["axiom"]: decimal_output(800),
+                        INCOME_TAX_SECTION_11D_OUTPUTS[
+                            "savings_income_charged_at_savings_additional_rate"
+                        ]["axiom"]: decimal_output(0),
+                        INCOME_TAX_SECTION_11D_OUTPUTS[
+                            "savings_income_charged_under_section_11d"
+                        ]["axiom"]: decimal_output(1_500),
+                        INCOME_TAX_SECTION_11D_OUTPUTS[
+                            "income_tax_on_section_11d_savings_income"
+                        ]["axiom"]: decimal_output(460),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 5
     assert report.mismatches == []
     assert report.oracle_divergences == []
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.559"
+version = "0.2.560"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a UK EFRS oracle surface for Income Tax Act 2007 section 11D savings income
- map section 11D savings band outputs to PolicyEngine UK savings-income variables
- project starter-rate and personal-savings-allowance amounts as zero-rate savings that consume band capacity before section 11D taxable savings starts
- add output-level tolerance for PE EFRS float precision on the savings surface

## Validation
- `uv lock --check`
- `uv run --python 3.13 ruff check src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py`
- `uv run --with pytest --with pytest-cov --python 3.13 python -m pytest tests/test_policyengine_efrs_uk.py -q`
- `uv run --with pytest --with pytest-cov --python 3.13 python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --with policyengine-uk==2.88.40 --with policyengine-core==3.26.11 --python 3.13 axiom-encode uk-efrs-compare --root /Users/maxghenis/TheAxiomFoundation --rulespec-root /Users/maxghenis/_axiom-worktrees/rulespec-uk-next-pe-20260604 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine --dataset /Users/maxghenis/policyengine-model/policyengine-uk-data/policyengine_uk_data/storage/policybench_transfer_2025.h5 --surface income-tax-section-11d-savings-income --sample-size 0 --fail-on-mismatch --json`

EFRS comparison result: 2,050 people, 10,250 compared values, 0 mismatches.
