### PR TITLE
Classify Colorado Works TANF oracle outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.565"
+version = "0.2.566"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.565"
+__version__ = "0.2.566"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -114,7 +114,6 @@ JURISDICTION_CONFIGS = {
         member_entity_type="Person",
         temp_prefix="co-snap-pe-ecps-",
         display_name="Colorado SNAP",
-        additional_relation_ids=("member_of_household",),
     ),
     "us-ca": JurisdictionConfig(
         jurisdiction="us-ca",

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -14355,6 +14355,27 @@ prefixes:
     candidate_priority: P4
     rationale: Colorado Works basic-cash-assistance outputs decompose certification periods, assistance-unit table selection, current need and grant standards, pregnancy allowance, earned-income reporting, and grant authorization. PolicyEngine-US exposes adjacent Colorado TANF variables built from its own annual parameter table, but does not expose these month-level legal helper boundaries one-to-one; its current grant-standard table also needs a 2025 update before direct oracle comparison.
 
+  - legal_id_prefix: us-co:regulations/9-ccr-2503-6/3.606.2#
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Colorado Works earned-income-disregard outputs are section-specific eligibility and payment intermediates for the Colorado TANF cash-assistance calculation. PolicyEngine-US exposes adjacent Colorado TANF variables built from its own annual parameter table, but does not expose these month-level 9 CCR 2503-6 Section 3.606.2 disregard tests, rates, or payment-disregard amounts one-to-one.
+
+  - legal_id_prefix: us-co:regulations/9-ccr-2503-6/3.606.6#
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Colorado Works time-limit and extension outputs are month-level legal predicates and thresholds for the 60-month Federal TANF limit, hardship and domestic-violence extensions, Indian Country exclusions, and the statewide extension allocation. PolicyEngine-US exposes adjacent Colorado TANF variables built from its own annual parameter table, but does not expose these 9 CCR 2503-6 Section 3.606.6 extension and time-limit determinations one-to-one.
+
+  - legal_id_prefix: us-co:policies/cdhs/colorado-works/basic-cash-assistance#
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Colorado Works basic-cash-assistance composition outputs are Axiom assembly points across encoded 9 CCR 2503-6 Section 3.606.1 and 3.606.2 provisions. PolicyEngine-US does not expose this exact composed monthly TANF legal slice one-to-one; direct oracle comparison should wait for an adapter that targets the same Colorado Works source boundaries and updated grant parameters.
+
   - legal_id_prefix: us-co:policies/cdhs/snap/
     country: us
     program: snap

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -193,11 +193,11 @@ def test_current_encoder_affecting_changes_are_behind_version_bump():
     assert provenance["version"] == AXIOM_ENCODE_TEST_VERSION
 
 
-def test_colorado_snap_ecps_projects_bare_member_relation_alias():
+def test_colorado_snap_ecps_uses_absolute_member_relation_only():
     config = JURISDICTION_CONFIGS["us-co"]
 
     assert config.relation_id == "us:statutes/7/2012/j#relation.member_of_household"
-    assert "member_of_household" in config.additional_relation_ids
+    assert config.additional_relation_ids == ()
 
 
 def _signed_manifest_payload(payload: dict) -> dict:

--- a/tests/test_policyengine_ecps_snap.py
+++ b/tests/test_policyengine_ecps_snap.py
@@ -235,7 +235,7 @@ def test_colorado_snap_outputs_use_composed_allotment_and_cfr_net_income():
         "us:regulations/7-cfr/273/10#snap_net_monthly_income"
     )
     assert config.relation_id == "us:statutes/7/2012/j#relation.member_of_household"
-    assert config.additional_relation_ids == ("member_of_household",)
+    assert config.additional_relation_ids == ()
 
 
 def test_projected_child_support_includes_gross_income_deduction():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.565"
+version = "0.2.566"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Colorado Works 3.606.2 earned-income-disregard outputs as PolicyEngine not-comparable
- classify the Colorado Works basic cash assistance composition outputs as PolicyEngine not-comparable
- fix the Colorado SNAP ECPS adapter so it does not emit a bare `member_of_household` runtime relation
- bump axiom-encode to 0.2.566 for the encoder-affecting changes provenance gate

## Checks
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `python -m compileall -q src/axiom_encode scripts`
- `uv run ruff format --check src tests`
- `uv run --python 3.13 --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_ecps_snap.py::test_colorado_snap_outputs_use_composed_allotment_and_cfr_net_income tests/test_cli.py::test_colorado_snap_ecps_uses_absolute_member_relation_only tests/test_encoder_backend.py::TestAgentSDKBackend::test_encode_async tests/test_encoder_backend.py::TestAgentSDKBackend::test_encode_batch_parallel tests/test_encoder_backend.py::TestAgentSDKBackend::test_encode_batch_respects_concurrency_limit tests/test_encoder_backend.py::TestAgentSDKBackendAdditional::test_encode_async_with_usage tests/test_encoder_backend.py::TestAgentSDKBackendAdditional::test_encode_async_reads_file_if_exists tests/test_encoder_backend.py::TestAgentSDKBackendAdditional::test_encode_async_import_error tests/test_encoder_backend.py::TestAgentSDKBackendAdditional::test_encode_async_generic_error -q`
- `uv run --python 3.13 axiom-encode oracle-coverage --root /Users/pavelmakarchuk --json` against rulespec-us-co PR #19: all 15 changed TANF outputs classify as `known_not_comparable`
- Full local `uv run --python 3.13 --with pytest --with pytest-cov python -m pytest` was attempted; async tests required dev deps and then passed separately, while `tests/test_repo_cross_statute_imports.py` failed because the local sibling `/Users/pavelmakarchuk/rulespec-us` checkout has existing cross-statute import gaps. That test should skip in CI when the sibling checkout is absent.

## Cycle
- `/cycle` requested in PR comments.
- Awaiting CI/review result after rebase onto current `main`.