### PR TITLE
Classify NC and SC SNAP manual oracle coverage

### DIFF
--- a/changelog.d/nc-sc-snap-manual-oracle-coverage.fixed.md
+++ b/changelog.d/nc-sc-snap-manual-oracle-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify North Carolina and South Carolina SNAP manual RuleSpec outputs as known-not-comparable for PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.560"
+version = "0.2.561"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.560"
+__version__ = "0.2.561"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -14112,6 +14112,18 @@ prefixes:
     mapping_type: not_comparable
     rationale: Tennessee DHS SNAP manual pages encode state administrative procedures, verification rules, disqualification predicates, eligibility subtests, and other generated policy intermediates. PolicyEngine does not expose one-to-one variables for this manual-page surface; exact direct mappings should be added later only for individually verified outputs.
 
+  - legal_id_prefix: us-nc:policies/dhhs/fns/
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: North Carolina DHHS FNS manual sections encode state SNAP administrative procedures, verification rules, simplified nutrition assistance procedures, eligibility subtests, notices, and other generated policy intermediates. PolicyEngine does not expose one-to-one variables for this manual-page surface; exact direct mappings should be added later only for individually verified outputs.
+
+  - legal_id_prefix: us-sc:policies/dss/snap-policy-manual/
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    rationale: South Carolina DSS SNAP manual sections encode state administrative procedures, verification rules, work-requirement predicates, notices, disqualification branches, and other generated policy intermediates. PolicyEngine does not expose one-to-one variables for this manual-page surface; exact direct mappings should be added later only for individually verified outputs.
+
   - legal_id_prefix: us-al:policies/dhr/poe/
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -513,6 +513,49 @@ rules:
     assert "state income bridge" in str(exact_output["rationale"])
 
 
+def test_policyengine_coverage_classifies_nc_and_sc_snap_manual_prefixes(tmp_path):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-nc"
+        / "policies/dhhs/fns/fns-600-simplified-nutritional-assistance-program-snap/page-1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: person_eligible_for_snap
+    kind: derived
+    versions:
+      - effective_from: '2025-10-01'
+        formula: person_receives_ssi
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-sc" / "policies/dss/snap-policy-manual/page-100.yaml",
+        """format: rulespec/v1
+rules:
+  - name: snap_et_referral_required
+    kind: derived
+    versions:
+      - effective_from: '2025-10-01'
+        formula: person_subject_to_work_requirement
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="snap")
+
+    assert report["total_outputs"] == 2
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    nc_output = items_by_id[
+        "us-nc:policies/dhhs/fns/fns-600-simplified-nutritional-assistance-program-snap/page-1#person_eligible_for_snap"
+    ]
+    sc_output = items_by_id[
+        "us-sc:policies/dss/snap-policy-manual/page-100#snap_et_referral_required"
+    ]
+    assert nc_output["mapping_type"] == "not_comparable"
+    assert "North Carolina DHHS FNS manual sections" in str(nc_output["rationale"])
+    assert sc_output["mapping_type"] == "not_comparable"
+    assert "South Carolina DSS SNAP manual sections" in str(sc_output["rationale"])
+
+
 def test_policyengine_coverage_ignores_nested_axiom_dependency_checkout(tmp_path):
     content = """format: rulespec/v1
 rules:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.560"
+version = "0.2.561"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Classifies generated NC and SC SNAP manual policy-page outputs as known-not-comparable for PolicyEngine oracle coverage.\n\nThis is intentionally a coverage classification change, not a RuleSpec encoding change and not a PE-alignment override. These manual-page outputs are state administrative/intermediate policy surfaces without one-to-one PE variables.\n\nValidation:\n- uv run --python 3.13 ruff check pyproject.toml src/axiom_encode/oracles/policyengine/mappings tests/test_policyengine_coverage.py\n- uv run --python 3.13 --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_nc_and_sc_snap_manual_prefixes -q\n- uv run --python 3.13 --extra dev pytest tests/test_policyengine_coverage.py -q\n- uv run --python 3.13 python -m axiom_encode.cli oracle-coverage --root /Users/pavelmakarchuk --oracle policyengine --program snap --json