### PR TITLE
Add UK section 13 dividend oracle surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.568"
+version = "0.2.569"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.568"
+__version__ = "0.2.569"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -16150,7 +16150,7 @@ def _find_source_text_value_issues(
 
 @functools.lru_cache(maxsize=512)
 def _fetch_corpus_source_text(citation_path: str) -> str | None:
-    """Fetch a corpus.provisions body by exact citation path.
+    """Fetch a corpus.provisions body by citation path.
 
     Local corpus artifacts are preferred so encoder and CI runs verify against
     normalized source text without re-reading original PDFs or HTML pages.
@@ -16159,7 +16159,11 @@ def _fetch_corpus_source_text(citation_path: str) -> str | None:
     local_text = _fetch_local_corpus_source_text(citation_path)
     if local_text is not None:
         return local_text
-    return _fetch_supabase_corpus_source_text(citation_path)
+    for candidate_path in _candidate_corpus_source_paths(citation_path):
+        source_text = _fetch_supabase_corpus_source_text(candidate_path)
+        if source_text is not None:
+            return source_text
+    return None
 
 
 @functools.lru_cache(maxsize=512)
@@ -16169,29 +16173,83 @@ def _fetch_local_corpus_source_text(citation_path: str) -> str | None:
         return None
 
     for provisions_root in _local_corpus_provisions_roots():
-        exact_records: list[dict[str, Any]] = []
-        for provision_file in _candidate_local_corpus_provision_files(
-            provisions_root,
-            normalized_path,
-        ):
-            exact_records.extend(
-                _read_local_corpus_provision_records(provision_file, normalized_path)
-            )
-        source_text = _select_local_corpus_record_body(exact_records)
-        if source_text is not None:
-            return source_text
-
-        for provision_file in _candidate_local_corpus_provision_files(
-            provisions_root,
-            normalized_path,
-        ):
-            source_text = _read_local_corpus_descendant_text(
-                provision_file,
-                normalized_path,
-            )
+        for candidate_path in _candidate_corpus_source_paths(normalized_path):
+            exact_records: list[dict[str, Any]] = []
+            for provision_file in _candidate_local_corpus_provision_files(
+                provisions_root,
+                candidate_path,
+            ):
+                exact_records.extend(
+                    _read_local_corpus_provision_records(
+                        provision_file,
+                        candidate_path,
+                    )
+                )
+            source_text = _select_local_corpus_record_body(exact_records)
             if source_text is not None:
                 return source_text
+
+            for provision_file in _candidate_local_corpus_provision_files(
+                provisions_root,
+                candidate_path,
+            ):
+                source_text = _read_local_corpus_descendant_text(
+                    provision_file,
+                    candidate_path,
+                )
+                if source_text is not None:
+                    return source_text
     return None
+
+
+def _candidate_corpus_source_paths(citation_path: str) -> tuple[str, ...]:
+    normalized_path = citation_path.strip().strip("/")
+    if not normalized_path:
+        return ()
+
+    candidates = [normalized_path]
+    candidates.extend(_uk_legislation_gov_source_path_aliases(normalized_path))
+    return tuple(dict.fromkeys(candidates))
+
+
+def _uk_legislation_gov_source_path_aliases(citation_path: str) -> tuple[str, ...]:
+    parts = citation_path.split("/")
+    if (
+        len(parts) >= 6
+        and parts[0] == "uk"
+        and parts[1] == "statute"
+        and parts[2] != "legislation.gov.uk"
+    ):
+        source_type, year, chapter, *section_parts = parts[2:]
+        prefix = (
+            "uk",
+            "statute",
+            "legislation.gov.uk",
+            source_type,
+            year,
+            chapter,
+            "section",
+        )
+        candidates = [
+            "/".join(
+                (
+                    *prefix,
+                    *section_parts,
+                )
+            )
+        ]
+        lower_section_parts = [part.lower() for part in section_parts]
+        if lower_section_parts != section_parts:
+            candidates.append(
+                "/".join(
+                    (
+                        *prefix,
+                        *lower_section_parts,
+                    )
+                )
+            )
+        return tuple(candidates)
+    return ()
 
 
 def _local_corpus_provisions_roots() -> tuple[Path, ...]:

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -44,6 +44,8 @@ INCOME_TAX_SECTION_10_PROGRAM_PATH = Path("statutes/ukpga/2007/3/10.yaml")
 INCOME_TAX_SECTION_10_BASE = "uk:statutes/ukpga/2007/3/10"
 INCOME_TAX_SECTION_11D_PROGRAM_PATH = Path("statutes/ukpga/2007/3/11D.yaml")
 INCOME_TAX_SECTION_11D_BASE = "uk:statutes/ukpga/2007/3/11D"
+INCOME_TAX_SECTION_13_PROGRAM_PATH = Path("statutes/ukpga/2007/3/13.yaml")
+INCOME_TAX_SECTION_13_BASE = "uk:statutes/ukpga/2007/3/13"
 INCOME_TAX_SECTION_23_PROGRAM_PATH = Path("statutes/ukpga/2007/3/23.yaml")
 INCOME_TAX_SECTION_23_BASE = "uk:statutes/ukpga/2007/3/23"
 CHILD_BENEFIT_PROGRAM_PATH = Path("regulations/uksi/2006/965/2.yaml")
@@ -201,6 +203,19 @@ INCOME_TAX_SECTION_11D_OUTPUTS = {
     "income_tax_on_section_11d_savings_income": {
         "axiom": f"{INCOME_TAX_SECTION_11D_BASE}#income_tax_on_section_11d_savings_income",
         "pe": "savings_income_tax",
+        "tolerance": 0.1,
+    },
+}
+
+INCOME_TAX_SECTION_13_OUTPUTS = {
+    "dividend_income_charged_under_section_13": {
+        "axiom": f"{INCOME_TAX_SECTION_13_BASE}#dividend_income_charged_under_section_13",
+        "pe": "taxed_dividend_income",
+        "tolerance": 0.1,
+    },
+    "income_tax_on_section_13_dividend_income": {
+        "axiom": f"{INCOME_TAX_SECTION_13_BASE}#income_tax_on_section_13_dividend_income",
+        "pe": "dividend_income_tax",
         "tolerance": 0.1,
     },
 }
@@ -525,6 +540,20 @@ SURFACE_SPECS = {
             "savings_starter_rate_income",
             "taxable_savings_interest_income",
             "taxed_savings_income",
+        ),
+    ),
+    "income-tax-section-13-dividend-income": UKEFRSSurfaceSpec(
+        program=INCOME_TAX_SECTION_13_PROGRAM_PATH,
+        entity="person",
+        outputs=INCOME_TAX_SECTION_13_OUTPUTS,
+        pe_variables=(
+            "dividend_income_tax",
+            "earned_taxable_income",
+            "received_allowances_dividend_income",
+            "received_allowances_savings_income",
+            "taxable_dividend_income",
+            "taxable_savings_interest_income",
+            "taxed_dividend_income",
         ),
     ),
     "child-benefit": UKEFRSSurfaceSpec(
@@ -2133,6 +2162,8 @@ def build_axiom_request(
         return build_income_tax_section_10_request(pe_data=pe_data, year=year)
     if surface == "income-tax-section-11d-savings-income":
         return build_income_tax_section_11d_request(pe_data=pe_data, year=year)
+    if surface == "income-tax-section-13-dividend-income":
+        return build_income_tax_section_13_request(pe_data=pe_data, year=year)
     if surface == "child-benefit":
         return build_child_benefit_request(pe_data=pe_data, year=year)
     if surface == "benefit-cap-relevant-amount":
@@ -2399,6 +2430,44 @@ def build_income_tax_section_11d_request(
                 "period": interval,
                 "outputs": [
                     spec["axiom"] for spec in INCOME_TAX_SECTION_11D_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_income_tax_section_13_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = tax_year_interval(year)
+    parameters = policyengine_uk_income_tax_section_13_parameters(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "income-tax-section-13-dividend-income"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_income_tax_section_13_inputs(
+            row,
+            parameters=parameters,
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{INCOME_TAX_SECTION_13_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in INCOME_TAX_SECTION_13_OUTPUTS.values()
                 ],
             }
         )
@@ -2886,6 +2955,42 @@ def project_income_tax_section_11d_inputs(
         "savings_basic_rate": parameters["savings_basic_rate"],
         "savings_higher_rate": parameters["savings_higher_rate"],
         "savings_additional_rate": parameters["savings_additional_rate"],
+    }
+
+
+def project_income_tax_section_13_inputs(
+    row: Any,
+    *,
+    parameters: dict[str, float],
+) -> dict[str, Any]:
+    savings_after_income_allowances = max(
+        0.0,
+        money(row_value(row, "taxable_savings_interest_income", 0))
+        - money(row_value(row, "received_allowances_savings_income", 0)),
+    )
+    dividends_after_income_allowances = max(
+        0.0,
+        money(row_value(row, "taxable_dividend_income", 0))
+        - money(row_value(row, "received_allowances_dividend_income", 0)),
+    )
+    dividend_allowance_used = min(
+        parameters["dividend_allowance"],
+        dividends_after_income_allowances,
+    )
+    return {
+        "income_already_charged_before_section_13_dividend_income": money(
+            row_value(row, "earned_taxable_income", 0)
+        )
+        + savings_after_income_allowances
+        + dividend_allowance_used,
+        "dividend_income_subject_to_section_13_rates": money(
+            row_value(row, "taxed_dividend_income", 0)
+        ),
+        "basic_rate_limit": parameters["basic_rate_limit"],
+        "higher_rate_limit": parameters["higher_rate_limit"],
+        "dividend_ordinary_rate": parameters["dividend_ordinary_rate"],
+        "dividend_upper_rate": parameters["dividend_upper_rate"],
+        "dividend_additional_rate": parameters["dividend_additional_rate"],
     }
 
 
@@ -3381,6 +3486,12 @@ def compare_outputs(
             "PolicyEngine parameters to compare the section 11D band amounts "
             "and aggregate savings income tax, with a 10p output tolerance for "
             "EFRS float precision in PolicyEngine's savings-income arrays.",
+            "Income Tax Act 2007 section 13 dividend-income comparison projects "
+            "PolicyEngine's dividend tax formula directly: savings after income "
+            "allowances occupies rate-band capacity before dividends, the used "
+            "dividend allowance occupies nil-rate dividend band capacity, and "
+            "the remaining taxed_dividend_income is compared as the section 13 "
+            "charged amount and aggregate dividend income tax.",
         ],
     )
 
@@ -3840,6 +3951,27 @@ def policyengine_uk_income_tax_section_11d_parameters(year: int) -> dict[str, fl
         "savings_basic_rate": money(income_tax_rates.savings.basic),
         "savings_higher_rate": money(income_tax_rates.savings.higher),
         "savings_additional_rate": money(income_tax_rates.savings.additional),
+    }
+
+
+def policyengine_uk_income_tax_section_13_parameters(year: int) -> dict[str, float]:
+    require_policyengine_uk_versions()
+    try:
+        from policyengine_uk import CountryTaxBenefitSystem
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(policyengine_uk_install_message()) from exc
+
+    income_tax = (
+        CountryTaxBenefitSystem().parameters(f"{year:04d}-04-06").gov.hmrc.income_tax
+    )
+    income_tax_rates = income_tax.rates
+    return {
+        "basic_rate_limit": money(income_tax_rates.uk.thresholds[1]),
+        "higher_rate_limit": money(income_tax_rates.uk.thresholds[2]),
+        "dividend_allowance": money(income_tax.allowances.dividend_allowance),
+        "dividend_ordinary_rate": money(income_tax_rates.dividends.rates[0]),
+        "dividend_upper_rate": money(income_tax_rates.dividends.rates[1]),
+        "dividend_additional_rate": money(income_tax_rates.dividends.rates[2]),
     }
 
 

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -149,6 +149,64 @@ mappings:
     mapping_type: not_comparable
     rationale: Per-rate tax helper for section 11D savings additional-rate income; PolicyEngine UK exposes the aggregate savings_income_tax rather than per-rate savings tax variables.
 
+  - legal_id: uk:statutes/ukpga/2007/3/13#dividend_income_charged_under_section_13
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: taxed_dividend_income
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK dividend income remaining for dividend-rate taxation after personal allowances and the dividend allowance.
+
+  - legal_id: uk:statutes/ukpga/2007/3/13#income_tax_on_section_13_dividend_income
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: dividend_income_tax
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same UK income tax on dividend income charged at the dividend ordinary, upper, and additional rates.
+
+  - legal_id: uk:statutes/ukpga/2007/3/13#dividend_income_charged_at_dividend_ordinary_rate
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Per-rate dividend income helper for section 13; PolicyEngine UK exposes aggregate taxed_dividend_income and dividend_income_tax, not per-rate dividend-income variables.
+
+  - legal_id: uk:statutes/ukpga/2007/3/13#dividend_income_charged_at_dividend_upper_rate
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Per-rate dividend income helper for section 13; PolicyEngine UK exposes aggregate taxed_dividend_income and dividend_income_tax, not per-rate dividend-income variables.
+
+  - legal_id: uk:statutes/ukpga/2007/3/13#dividend_income_charged_at_dividend_additional_rate
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Per-rate dividend income helper for section 13; PolicyEngine UK exposes aggregate taxed_dividend_income and dividend_income_tax, not per-rate dividend-income variables.
+
+  - legal_id: uk:statutes/ukpga/2007/3/13#tax_on_dividend_income_charged_at_dividend_ordinary_rate
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Per-rate tax helper for section 13 dividend ordinary-rate income; PolicyEngine UK exposes the aggregate dividend_income_tax rather than per-rate dividend tax variables.
+
+  - legal_id: uk:statutes/ukpga/2007/3/13#tax_on_dividend_income_charged_at_dividend_upper_rate
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Per-rate tax helper for section 13 dividend upper-rate income; PolicyEngine UK exposes the aggregate dividend_income_tax rather than per-rate dividend tax variables.
+
+  - legal_id: uk:statutes/ukpga/2007/3/13#tax_on_dividend_income_charged_at_dividend_additional_rate
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Per-rate tax helper for section 13 dividend additional-rate income; PolicyEngine UK exposes the aggregate dividend_income_tax rather than per-rate dividend tax variables.
+
   - legal_id: uk:statutes/ukpga/2007/3/23#total_income
     country: uk
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -920,6 +920,132 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_uk_income_tax_section_13_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2007/3/13.yaml",
+        """format: rulespec/v1
+rules:
+  - name: dividend_income_charged_at_dividend_ordinary_rate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 1
+  - name: dividend_income_charged_at_dividend_upper_rate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: dividend_income_charged_at_dividend_additional_rate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 3
+  - name: dividend_income_charged_under_section_13
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 6
+  - name: tax_on_dividend_income_charged_at_dividend_ordinary_rate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.1075
+  - name: tax_on_dividend_income_charged_at_dividend_upper_rate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0.715
+  - name: tax_on_dividend_income_charged_at_dividend_additional_rate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 1.1805
+  - name: income_tax_on_section_13_dividend_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2.003
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2007/3/13.test.yaml",
+        """- name: dividend income tax
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    uk:statutes/ukpga/2007/3/13#dividend_income_charged_at_dividend_ordinary_rate: 1
+    uk:statutes/ukpga/2007/3/13#dividend_income_charged_at_dividend_upper_rate: 2
+    uk:statutes/ukpga/2007/3/13#dividend_income_charged_at_dividend_additional_rate: 3
+    uk:statutes/ukpga/2007/3/13#dividend_income_charged_under_section_13: 6
+    uk:statutes/ukpga/2007/3/13#tax_on_dividend_income_charged_at_dividend_ordinary_rate: 0.1075
+    uk:statutes/ukpga/2007/3/13#tax_on_dividend_income_charged_at_dividend_upper_rate: 0.715
+    uk:statutes/ukpga/2007/3/13#tax_on_dividend_income_charged_at_dividend_additional_rate: 1.1805
+    uk:statutes/ukpga/2007/3/13#income_tax_on_section_13_dividend_income: 2.003
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {
+        "comparable": 2,
+        "known_not_comparable": 6,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2007/3/13#dividend_income_charged_under_section_13"
+        ]["policyengine_variable"]
+        == "taxed_dividend_income"
+    )
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2007/3/13#income_tax_on_section_13_dividend_income"
+        ]["policyengine_variable"]
+        == "dividend_income_tax"
+    )
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2007/3/13#dividend_income_charged_at_dividend_ordinary_rate"
+        ]["status"]
+        == "known_not_comparable"
+    )
+
+
 def test_policyengine_coverage_classifies_uk_class_1_ni_section_8_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-uk" / "statutes/ukpga/1992/4/8.yaml",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -17,6 +17,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     INCOME_TAX_SECTION_10_OUTPUTS,
     INCOME_TAX_SECTION_11D_BASE,
     INCOME_TAX_SECTION_11D_OUTPUTS,
+    INCOME_TAX_SECTION_13_BASE,
+    INCOME_TAX_SECTION_13_OUTPUTS,
     INCOME_TAX_SECTION_23_ADDITION_COMPONENTS,
     INCOME_TAX_SECTION_23_BASE,
     INCOME_TAX_SECTION_23_REDUCTION_COMPONENTS,
@@ -49,6 +51,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_income_tax_income_base_request,
     build_income_tax_section_10_request,
     build_income_tax_section_11d_request,
+    build_income_tax_section_13_request,
     build_national_insurance_class_1_request,
     build_pension_credit_request,
     build_personal_allowance_request,
@@ -71,6 +74,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_income_tax_income_base_components,
     project_income_tax_section_10_inputs,
     project_income_tax_section_11d_inputs,
+    project_income_tax_section_13_inputs,
     project_income_tax_section_23_inputs,
     project_pension_credit_inputs,
     project_personal_allowance_inputs,
@@ -333,6 +337,37 @@ def test_income_tax_section_11d_projection_removes_savings_deductions():
         "savings_basic_rate": 0.2,
         "savings_higher_rate": 0.4,
         "savings_additional_rate": 0.45,
+    }
+
+
+def test_income_tax_section_13_projection_uses_taxed_dividends_and_rates():
+    projected = project_income_tax_section_13_inputs(
+        {
+            "earned_taxable_income": 37_000,
+            "taxable_savings_interest_income": 2_000,
+            "received_allowances_savings_income": 500,
+            "taxable_dividend_income": 3_000,
+            "received_allowances_dividend_income": 500,
+            "taxed_dividend_income": 2_000,
+        },
+        parameters={
+            "basic_rate_limit": 37_700,
+            "higher_rate_limit": 125_140,
+            "dividend_allowance": 500,
+            "dividend_ordinary_rate": 0.1075,
+            "dividend_upper_rate": 0.3575,
+            "dividend_additional_rate": 0.3935,
+        },
+    )
+
+    assert projected == {
+        "income_already_charged_before_section_13_dividend_income": 39_000,
+        "dividend_income_subject_to_section_13_rates": 2_000,
+        "basic_rate_limit": 37_700,
+        "higher_rate_limit": 125_140,
+        "dividend_ordinary_rate": 0.1075,
+        "dividend_upper_rate": 0.3575,
+        "dividend_additional_rate": 0.3935,
     }
 
 
@@ -601,6 +636,89 @@ def test_income_tax_section_11d_request_projects_savings_inputs(monkeypatch):
     ] == {
         "kind": "decimal",
         "value": "0.45",
+    }
+
+
+def test_income_tax_section_13_request_projects_dividend_inputs(monkeypatch):
+    monkeypatch.setattr(
+        efrs_uk,
+        "policyengine_uk_income_tax_section_13_parameters",
+        lambda year: {
+            "basic_rate_limit": 37_700,
+            "higher_rate_limit": 125_140,
+            "dividend_allowance": 500,
+            "dividend_ordinary_rate": 0.1075,
+            "dividend_upper_rate": 0.3575,
+            "dividend_additional_rate": 0.3935,
+        },
+    )
+    request = build_income_tax_section_13_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 7,
+                    "earned_taxable_income": 37_000,
+                    "taxable_savings_interest_income": 2_000,
+                    "received_allowances_savings_income": 500,
+                    "taxable_dividend_income": 3_000,
+                    "received_allowances_dividend_income": 500,
+                    "taxed_dividend_income": 2_000,
+                    "dividend_income_tax": 715,
+                }
+            ],
+            "person_ids": [7],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_7",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": list(
+                output["axiom"] for output in INCOME_TAX_SECTION_13_OUTPUTS.values()
+            ),
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{INCOME_TAX_SECTION_13_BASE}#input.income_already_charged_before_section_13_dividend_income:person_7"
+    ] == {"kind": "decimal", "value": "39000.0"}
+    assert inputs[
+        f"{INCOME_TAX_SECTION_13_BASE}#input.dividend_income_subject_to_section_13_rates:person_7"
+    ] == {"kind": "decimal", "value": "2000.0"}
+    assert inputs[f"{INCOME_TAX_SECTION_13_BASE}#input.basic_rate_limit:person_7"] == {
+        "kind": "integer",
+        "value": 37700,
+    }
+    assert inputs[f"{INCOME_TAX_SECTION_13_BASE}#input.higher_rate_limit:person_7"] == {
+        "kind": "integer",
+        "value": 125140,
+    }
+    assert inputs[
+        f"{INCOME_TAX_SECTION_13_BASE}#input.dividend_ordinary_rate:person_7"
+    ] == {
+        "kind": "decimal",
+        "value": "0.1075",
+    }
+    assert inputs[
+        f"{INCOME_TAX_SECTION_13_BASE}#input.dividend_upper_rate:person_7"
+    ] == {
+        "kind": "decimal",
+        "value": "0.3575",
+    }
+    assert inputs[
+        f"{INCOME_TAX_SECTION_13_BASE}#input.dividend_additional_rate:person_7"
+    ] == {
+        "kind": "decimal",
+        "value": "0.3935",
     }
 
 
@@ -1599,6 +1717,17 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
                 "total_income",
             )
         ),
+    )
+    assert policyengine_person_variables_for_surfaces(
+        ["income-tax-section-13-dividend-income"]
+    ) == (
+        "dividend_income_tax",
+        "earned_taxable_income",
+        "received_allowances_dividend_income",
+        "received_allowances_savings_income",
+        "taxable_dividend_income",
+        "taxable_savings_interest_income",
+        "taxed_dividend_income",
     )
     assert policyengine_person_variables_for_surfaces(
         ["national-insurance-class-1"]

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -12204,6 +12204,54 @@ rules:
     assert find_ungrounded_numeric_issues(content) == []
 
 
+def test_source_verification_resolves_compact_uk_statute_corpus_path(
+    tmp_path,
+    monkeypatch,
+):
+    provisions_dir = tmp_path / "data" / "corpus" / "provisions" / "uk" / "statute"
+    provisions_dir.mkdir(parents=True)
+    (provisions_dir / "uk-statute.jsonl").write_text(
+        json.dumps(
+            {
+                "citation_path": (
+                    "uk/statute/legislation.gov.uk/ukpga/2007/3/section/11d"
+                ),
+                "body": "Income tax is charged at the savings basic rate.",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AXIOM_CORPUS_REPO", str(tmp_path))
+    validator_pipeline._fetch_corpus_source_text.cache_clear()
+    validator_pipeline._fetch_local_corpus_source_text.cache_clear()
+
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: uk/statute/ukpga/2007/3/11D
+rules:
+  - name: savings_income_charged_at_savings_basic_rate
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2024-04-06'
+        formula: taxable_dividend_income
+"""
+
+    assert (
+        validator_pipeline._fetch_local_corpus_source_text(
+            "uk/statute/ukpga/2007/3/11D"
+        )
+        == "Income tax is charged at the savings basic rate."
+    )
+    assert find_source_verification_issues(content) == []
+
+
 def test_source_verification_reads_local_corpus_child_blocks(
     tmp_path,
     monkeypatch,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.568"
+version = "0.2.569"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add the UK Income Tax Act 2007 section 13 dividend oracle surface
- project PolicyEngine UK EFRS inputs for `taxed_dividend_income` and `dividend_income_tax` using the installed PE dividend formula
- classify section 13 outputs in the UK PolicyEngine mapping and add source-verification aliases for compact legislation.gov.uk paths

## Validation
- `ruff check src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py`
- `python -m pytest tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py -q` -> 313 passed
- `axiom-encode validate --skip-reviewers statutes/ukpga/2007/3/13.yaml`
- `axiom-encode uk-efrs-compare --surface income-tax-section-13-dividend-income --sample-size 0 --fail-on-mismatch --json` -> 2,050 persons, 4,100 compared values, 0 mismatches

## Notes
This avoids Pavel’s open UC housing work and supports a separate rulespec-uk section 13 encoding PR.