### PR TITLE
Allow source-backed scalar validator exceptions

### DIFF
--- a/changelog.d/source-backed-ascii-fraction-validator.fixed.md
+++ b/changelog.d/source-backed-ascii-fraction-validator.fixed.md
@@ -1,0 +1,1 @@
+Allow source-backed ASCII fraction parameter formulas and extracted source-backed parameter equality checks through the embedded scalar literal guard.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.561"
+version = "0.2.562"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.561"
+__version__ = "0.2.562"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -569,6 +569,111 @@ SOURCE_TEXT_NUMBER_PATTERN = re.compile(
 SOURCE_TEXT_RATIO_NUMBER_PATTERN = re.compile(
     r"(?<![\w.])(\d{1,3})\s*/\s*(\d{1,3})(?![\w/])"
 )
+_SIMPLE_FRACTION_EXPRESSION = re.compile(
+    r"(?P<numerator>-?\d+)\s*/\s*(?P<denominator>\d+)"
+)
+_EXTRACTED_PARAMETER_SCALAR_COMPARISON = re.compile(
+    r"^(?:(?P<left_name>[A-Za-z_][A-Za-z0-9_]*)\s*==\s*(?P<right_value>-?[\d,]+(?:\.\d+)?)|(?P<left_value>-?[\d,]+(?:\.\d+)?)\s*==\s*(?P<right_name>[A-Za-z_][A-Za-z0-9_]*))$"
+)
+
+
+def _is_source_backed_simple_fraction_parameter(
+    rule: dict[str, Any],
+    expression: str,
+    source_text: str,
+) -> bool:
+    """Allow exact source-stated ASCII fractions as parameter formulas."""
+    if str(rule.get("kind") or "").lower() != "parameter":
+        return False
+    match = _SIMPLE_FRACTION_EXPRESSION.fullmatch(expression)
+    if not match:
+        return False
+    denominator = match.group("denominator")
+    if denominator == "0":
+        return False
+    fraction_text = f"{match.group('numerator')}/{denominator}"
+    normalized_source = re.sub(r"\s*/\s*", "/", source_text)
+    return bool(
+        re.search(
+            rf"(?<![\d./-]){re.escape(fraction_text)}(?![\d./])",
+            normalized_source,
+        )
+    )
+
+
+def _rule_has_source_proof(rule: dict[str, Any]) -> bool:
+    metadata = rule.get("metadata")
+    if not isinstance(metadata, dict):
+        return False
+    proof = metadata.get("proof")
+    if not isinstance(proof, dict):
+        return False
+    atoms = proof.get("atoms")
+    if not isinstance(atoms, list):
+        return False
+    for atom in atoms:
+        if not isinstance(atom, dict):
+            continue
+        source = atom.get("source")
+        if isinstance(source, dict) and (
+            source.get("corpus_citation_path")
+            or source.get("corpus_citation_paths")
+            or source.get("excerpt")
+        ):
+            return True
+    return False
+
+
+def _normalize_scalar_literal_text(value: str) -> str:
+    return value.strip().replace(",", "")
+
+
+def _source_backed_parameter_scalar_values(
+    rules: list[Any],
+) -> dict[str, set[str]]:
+    values: dict[str, set[str]] = {}
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").lower() != "parameter":
+            continue
+        name = str(rule.get("name") or "").strip()
+        if not name or not _rule_has_source_proof(rule):
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            normalized = _normalize_scalar_literal_text(formula)
+            if not _EMBEDDED_SCALAR_DIRECT_VALUE.fullmatch(normalized):
+                continue
+            values.setdefault(name, set()).add(normalized)
+    return values
+
+
+def _line_compares_extracted_parameter_to_own_scalar(
+    expression: str,
+    parameter_scalar_values: dict[str, set[str]],
+) -> bool:
+    normalized_expression = re.sub(r"^(?:and|or)\s+", "", expression.strip())
+    match = _EXTRACTED_PARAMETER_SCALAR_COMPARISON.fullmatch(normalized_expression)
+    if not match:
+        return False
+    name = match.group("left_name") or match.group("right_name")
+    value = match.group("right_value") or match.group("left_value")
+    if not name or not value:
+        return False
+    return _normalize_scalar_literal_text(value) in parameter_scalar_values.get(
+        name,
+        set(),
+    )
+
+
 _UNICODE_FRACTION_VALUES = {
     "¼": 0.25,
     "½": 0.5,
@@ -20709,6 +20814,10 @@ class ValidatorPipeline:
         if not isinstance(payload, dict) or not isinstance(payload.get("rules"), list):
             return []
         selector_table_keys = _rulespec_index_selector_keys(payload["rules"])
+        source_text = extract_embedded_source_text(content) or ""
+        parameter_scalar_values = _source_backed_parameter_scalar_values(
+            payload["rules"],
+        )
 
         for rule_index, rule in enumerate(payload["rules"], start=1):
             if not isinstance(rule, dict):
@@ -20725,11 +20834,23 @@ class ValidatorPipeline:
                     continue
                 if not isinstance(formula, str):
                     continue
-                if self._is_direct_scalar_expression(formula.strip()):
+                stripped_formula = formula.strip()
+                if self._is_direct_scalar_expression(stripped_formula):
+                    continue
+                if _is_source_backed_simple_fraction_parameter(
+                    rule,
+                    stripped_formula,
+                    source_text,
+                ):
                     continue
                 for line in formula.splitlines() or [formula]:
                     stripped = line.strip()
                     if not stripped:
+                        continue
+                    if _line_compares_extracted_parameter_to_own_scalar(
+                        stripped,
+                        parameter_scalar_values,
+                    ):
                         continue
                     issues.extend(
                         (rule_index, name, literal, stripped)

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -19106,6 +19106,131 @@ rules:
     assert pipeline._check_embedded_scalar_literals(rules_file) == []
 
 
+def test_embedded_formula_numeric_guard_allows_source_backed_ascii_fraction_parameters(
+    tmp_path,
+):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    content = """format: rulespec/v1
+module:
+  summary: The paper should be shredded into strips no wider than 5/16 inch. Microfilmed data must be shredded to a 1/35 inch by 3/8 inch strip.
+rules:
+  - name: paper_shredding_max_strip_width_inches
+    kind: parameter
+    dtype: Float
+    versions:
+      - effective_from: '2021-06-01'
+        formula: |-
+          5 / 16
+  - name: microfilmed_data_shredded_strip_width_inches
+    kind: parameter
+    dtype: Float
+    versions:
+      - effective_from: '2021-06-01'
+        formula: |-
+          1 / 35
+  - name: microfilmed_data_shredded_strip_length_inches
+    kind: parameter
+    dtype: Float
+    versions:
+      - effective_from: '2021-06-01'
+        formula: |-
+          3 / 8
+"""
+
+    assert pipeline._collect_embedded_scalar_literals(content) == []
+
+
+def test_embedded_formula_numeric_guard_allows_extracted_parameter_scalar_equality(
+    tmp_path,
+):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    content = """format: rulespec/v1
+rules:
+  - name: reapplication_verification_rate_after_qc_refusal
+    kind: parameter
+    dtype: Rate
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: amount
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-278
+              excerpt: "subject to 100% verification of eligibility requirements"
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          1.00
+  - name: reapplication_subject_to_full_verification_after_qc_refusal
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-sc/manual/dss/snap-policy-manual/page-278
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-sc:policies/dss/snap-policy-manual/page-278#reapplication_verification_rate_after_qc_refusal
+              output: reapplication_verification_rate_after_qc_refusal
+              hash: sha256:local
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          household_reapplies_after_refusal_to_cooperate_in_qc_review
+          and reapplication_verification_rate_after_qc_refusal == 1.00
+          and not household_is_eligible_for_expedited_service
+"""
+
+    assert pipeline._collect_embedded_scalar_literals(content) == []
+
+
+def test_embedded_formula_numeric_guard_rejects_unextracted_scalar_equality(
+    tmp_path,
+):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    content = """format: rulespec/v1
+rules:
+  - name: reapplication_subject_to_full_verification_after_qc_refusal
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          household_reapplies_after_refusal_to_cooperate_in_qc_review
+          and reapplication_verification_rate_after_qc_refusal == 1.00
+          and not household_is_eligible_for_expedited_service
+"""
+
+    assert pipeline._collect_embedded_scalar_literals(content) == [
+        (
+            1,
+            "reapplication_subject_to_full_verification_after_qc_refusal",
+            "1.00",
+            "and reapplication_verification_rate_after_qc_refusal == 1.00",
+        ),
+    ]
+
+
 def test_embedded_formula_numeric_guard_allows_map_arm_keys(tmp_path):
     rules_file = tmp_path / "rules.yaml"
     rules_file.write_text(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.561"
+version = "0.2.562"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Allows generated RuleSpecs to pass the embedded scalar literal guard when the scalar is already source-backed in one of two narrow forms:

- exact simple ASCII fraction parameter formulas where the same fraction appears in source text, covering NC FNS 160 page 10
- exact equality checks against a same-file source-backed extracted parameter value, covering SC SNAP manual page 278's 100% verification rate check

This avoids manually rewriting generated RuleSpecs while keeping the guard active for unextracted policy literals.

Validation:
- uv run --python 3.13 ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- uv run --python 3.13 ruff format --check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- uv run --python 3.13 --extra dev pytest tests/test_rulespec_validation.py::test_embedded_formula_numeric_guard_allows_source_backed_ascii_fraction_parameters tests/test_rulespec_validation.py::test_embedded_formula_numeric_guard_allows_extracted_parameter_scalar_equality tests/test_rulespec_validation.py::test_embedded_formula_numeric_guard_rejects_unextracted_scalar_equality tests/test_rulespec_validation.py::test_embedded_formula_numeric_guard_rejects_table_index_arithmetic_literal -q
- uv run --python 3.13 --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- Local SC failing file check: _check_embedded_scalar_literals(page-278.yaml) returned []