### PR TITLE
Classify UK UC housing schedule oracle coverage

### DIFF
--- a/changelog.d/uk-uc-housing-oracle-coverage.fixed.md
+++ b/changelog.d/uk-uc-housing-oracle-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify UK Universal Credit housing schedule helper outputs for PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.562"
+version = "0.2.563"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.562"
+__version__ = "0.2.563"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -610,6 +610,18 @@ prefixes:
     mapping_type: not_comparable
     rationale: Universal Credit helper outputs not listed above are statutory amount variants that PolicyEngine UK does not expose as one-to-one oracle parameters in the current model, including the protected pre-2026 LCWRA amount.
 
+  - legal_id_prefix: uk:regulations/uksi/2013/376/schedule/4/paragraph/
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    rationale: Universal Credit Schedule 4 housing-cost calculation helpers are source-level rent, bedroom, contribution, cap, and under-occupation intermediates; PolicyEngine UK exposes downstream UC housing element and award results rather than each statutory helper one-to-one.
+
+  - legal_id_prefix: uk:regulations/uksi/2013/376/schedule/10/paragraph/
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    rationale: Universal Credit Schedule 10 premises predicates are source-level housing occupation conditions used by Schedule 4 calculations; PolicyEngine UK does not expose them as one-to-one oracle variables.
+
   - legal_id_prefix: uk:regulations/uksi/2013/376/1#
     country: uk
     program: universal_credit

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -8980,3 +8980,52 @@ rules:
     assert item["program"] == "universal_credit"
     assert item["status"] == "known_not_comparable"
     assert item["mapping_type"] == "not_comparable"
+
+
+def test_universal_credit_housing_schedule_prefixes_are_classified(tmp_path):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-uk"
+        / "regulations/uksi/2013/376/schedule/4/paragraph/22.yaml",
+        """format: rulespec/v1
+rules:
+  - name: renters_housing_costs_element_calculated_under_this_part
+    kind: derived
+    versions:
+      - effective_from: '2026-04-01'
+        formula: renters_lower_rent_amount
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-uk"
+        / "regulations/uksi/2013/376/schedule/10/paragraph/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: premises_treated_as_persons_home_for_paragraphs_1_to_5
+    kind: derived
+    versions:
+      - effective_from: '2026-04-01'
+        formula: claimant_occupies_premises
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path)
+
+    assert report["total_outputs"] == 2
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    schedule_4 = items_by_id[
+        "uk:regulations/uksi/2013/376/schedule/4/paragraph/22#renters_housing_costs_element_calculated_under_this_part"
+    ]
+    schedule_10 = items_by_id[
+        "uk:regulations/uksi/2013/376/schedule/10/paragraph/1#premises_treated_as_persons_home_for_paragraphs_1_to_5"
+    ]
+    assert schedule_4["program"] == "universal_credit"
+    assert schedule_4["mapping_type"] == "not_comparable"
+    assert "Schedule 4 housing-cost calculation helpers" in str(
+        schedule_4["rationale"],
+    )
+    assert schedule_10["program"] == "universal_credit"
+    assert schedule_10["mapping_type"] == "not_comparable"
+    assert "Schedule 10 premises predicates" in str(schedule_10["rationale"])

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.562"
+version = "0.2.563"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Classifies UK Universal Credit Schedule 4 housing-cost helpers and Schedule 10 premises predicates as known not comparable for PolicyEngine oracle coverage. This unblocks the draft rulespec-uk UC housing schedules PR without changing generated RuleSpecs or pretending PE-UK exposes one-to-one variables for these source-level intermediates.

Validation:
- uv run --python 3.13 ruff check tests/test_policyengine_coverage.py pyproject.toml src/axiom_encode/__init__.py
- uv run --python 3.13 ruff format --check tests/test_policyengine_coverage.py
- uv run --python 3.13 --extra dev pytest tests/test_policyengine_coverage.py::test_universal_credit_housing_schedule_prefixes_are_classified tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- uv run --python 3.13 python -m axiom_encode.cli oracle-coverage --root /tmp --program universal_credit --json; Schedule 4/10 items: 53, unmapped: 0