### PR TITLE
Allow imported source-backed scalar equality

### DIFF
--- a/changelog.d/imported-parameter-scalar-equality.fixed.md
+++ b/changelog.d/imported-parameter-scalar-equality.fixed.md
@@ -1,0 +1,1 @@
+Allow equality checks against imported source-backed scalar parameters through the embedded scalar literal guard.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.563"
+version = "0.2.564"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.563"
+__version__ = "0.2.564"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -628,6 +628,20 @@ def _normalize_scalar_literal_text(value: str) -> str:
     return value.strip().replace(",", "")
 
 
+def _scalar_formula_value_text(formula: Any) -> str | None:
+    if isinstance(formula, bool):
+        return None
+    if isinstance(formula, int):
+        return str(formula)
+    if isinstance(formula, float):
+        return ("%f" % formula).rstrip("0").rstrip(".")
+    if isinstance(formula, str):
+        normalized = _normalize_scalar_literal_text(formula)
+        if _EMBEDDED_SCALAR_DIRECT_VALUE.fullmatch(normalized):
+            return normalized
+    return None
+
+
 def _source_backed_parameter_scalar_values(
     rules: list[Any],
 ) -> dict[str, set[str]]:
@@ -647,10 +661,8 @@ def _source_backed_parameter_scalar_values(
             if not isinstance(version, dict):
                 continue
             formula = version.get("formula")
-            if not isinstance(formula, str):
-                continue
-            normalized = _normalize_scalar_literal_text(formula)
-            if not _EMBEDDED_SCALAR_DIRECT_VALUE.fullmatch(normalized):
+            normalized = _scalar_formula_value_text(formula)
+            if normalized is None:
                 continue
             values.setdefault(name, set()).add(normalized)
     return values
@@ -20550,18 +20562,60 @@ class ValidatorPipeline:
     def _check_embedded_scalar_literals(self, rulespec_file: Path) -> list[str]:
         """Flag substantive scalar literals embedded inside formulas."""
         issues: list[str] = []
+        content = rulespec_file.read_text()
+        imported_parameter_scalar_values = (
+            self._imported_source_backed_parameter_scalar_values(
+                rulespec_file,
+                content,
+            )
+        )
         for (
             line_number,
             name,
             literal,
             expression,
-        ) in self._collect_embedded_scalar_literals(rulespec_file.read_text()):
+        ) in self._collect_embedded_scalar_literals(
+            content,
+            imported_parameter_scalar_values=imported_parameter_scalar_values,
+        ):
             issues.append(
                 "Embedded scalar literal: "
                 f"{name} line {line_number} embeds {literal} in `{expression}`; "
                 "extract the value to its own named numeric concept or indexed table/grid value"
             )
         return issues
+
+    def _imported_source_backed_parameter_scalar_values(
+        self,
+        rulespec_file: Path,
+        content: str,
+    ) -> dict[str, set[str]]:
+        """Return scalar values for source-backed parameters imported by this file."""
+        source_root = self._validation_source_root(rulespec_file)
+        values: dict[str, set[str]] = {}
+        for item in self._extract_import_items(content):
+            base, separator, symbol = item.partition("#")
+            if not separator:
+                continue
+            symbol = symbol.strip()
+            if not symbol:
+                continue
+            target = source_root / self._import_to_relative_rulespec_path(base)
+            if not target.exists():
+                continue
+            try:
+                payload = yaml.safe_load(target.read_text())
+            except (OSError, yaml.YAMLError, ValueError):
+                continue
+            if not isinstance(payload, dict) or not isinstance(
+                payload.get("rules"),
+                list,
+            ):
+                continue
+            imported_values = _source_backed_parameter_scalar_values(payload["rules"])
+            if symbol in imported_values:
+                values.setdefault(symbol, set()).update(imported_values[symbol])
+        return values
 
     def _check_decomposed_date_scalars(self, rulespec_file: Path) -> list[str]:
         """Flag numeric year/month/day scalars derived from non-substantive date references."""
@@ -20804,6 +20858,8 @@ class ValidatorPipeline:
     def _collect_embedded_scalar_literals(
         self,
         content: str,
+        *,
+        imported_parameter_scalar_values: dict[str, set[str]] | None = None,
     ) -> list[tuple[int, str, str, str]]:
         """Return embedded substantive scalar literals found in RuleSpec formulas."""
         issues: list[tuple[int, str, str, str]] = []
@@ -20818,6 +20874,8 @@ class ValidatorPipeline:
         parameter_scalar_values = _source_backed_parameter_scalar_values(
             payload["rules"],
         )
+        for name, values in (imported_parameter_scalar_values or {}).items():
+            parameter_scalar_values.setdefault(name, set()).update(values)
 
         for rule_index, rule in enumerate(payload["rules"], start=1):
             if not isinstance(rule, dict):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -19231,6 +19231,76 @@ rules:
     ]
 
 
+def test_embedded_formula_numeric_guard_allows_imported_parameter_scalar_equality(
+    tmp_path,
+):
+    imported_file = (
+        tmp_path / "policies/dhhs/fns/fns-227-non-citizen-requirements/page-1.yaml"
+    )
+    imported_file.parent.mkdir(parents=True)
+    imported_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: lpr_waiting_period_years
+    kind: parameter
+    dtype: Count
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us-nc/manual/dhhs/fns/fns-227-non-citizen-requirements/page-1
+              excerpt: "Subject to 5-year waiting period unless exempt"
+    versions:
+      - effective_from: '2026-02-01'
+        formula: |-
+          5
+""",
+    )
+    rules_file = (
+        tmp_path / "policies/dhhs/fns/fns-227-non-citizen-requirements/page-12.yaml"
+    )
+    rules_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: lpr_adjusted_status_subject_to_five_year_waiting_period_due_to_prior_status
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-nc/manual/dhhs/fns/fns-227-non-citizen-requirements/page-12
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us-nc:policies/dhhs/fns/fns-227-non-citizen-requirements/page-1#lpr_waiting_period_years
+              output: lpr_waiting_period_years
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-02-01'
+        formula: |-
+          adjusted_status_to_lpr
+          and not otherwise_exempt_from_lpr_five_year_waiting_period
+          and lpr_waiting_period_years == 5
+imports:
+  - us-nc:policies/dhhs/fns/fns-227-non-citizen-requirements/page-1#lpr_waiting_period_years
+""",
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+
+    assert pipeline._check_embedded_scalar_literals(rules_file) == []
+
+
 def test_embedded_formula_numeric_guard_allows_map_arm_keys(tmp_path):
     rules_file = tmp_path / "rules.yaml"
     rules_file.write_text(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.563"
+version = "0.2.564"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- allow embedded scalar guard equality checks against imported source-backed parameter values
- preserve rejection of unextracted scalar equality literals
- bump axiom-encode to 0.2.564

## Validation
- uv run --python 3.13 pytest tests/test_rulespec_validation.py::test_embedded_formula_numeric_guard_allows_extracted_parameter_scalar_equality tests/test_rulespec_validation.py::test_embedded_formula_numeric_guard_allows_imported_parameter_scalar_equality tests/test_rulespec_validation.py::test_embedded_formula_numeric_guard_rejects_unextracted_scalar_equality -q
- uv run --python 3.13 --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- local NC full validation running separately