### PR TITLE
Classify UK UC Schedule 5 oracle coverage

### DIFF
--- a/changelog.d/uk-uc-schedule5-oracle-coverage.fixed.md
+++ b/changelog.d/uk-uc-schedule5-oracle-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify UK Universal Credit Schedule 5 owner-occupier housing-cost helpers in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.564"
+version = "0.2.565"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.564"
+__version__ = "0.2.565"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -616,6 +616,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Universal Credit Schedule 4 housing-cost calculation helpers are source-level rent, bedroom, contribution, cap, and under-occupation intermediates; PolicyEngine UK exposes downstream UC housing element and award results rather than each statutory helper one-to-one.
 
+  - legal_id_prefix: uk:regulations/uksi/2013/376/schedule/5/paragraph/
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    rationale: Universal Credit Schedule 5 owner-occupier housing-cost helpers are source-level relevant-payment, qualifying-period, and service-charge intermediates; PolicyEngine UK exposes downstream UC housing element and award results rather than each statutory helper one-to-one.
+
   - legal_id_prefix: uk:regulations/uksi/2013/376/schedule/10/paragraph/
     country: uk
     program: universal_credit

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -8999,6 +8999,19 @@ rules:
     _write_rulespec_file(
         tmp_path
         / "rulespec-uk"
+        / "regulations/uksi/2013/376/schedule/5/paragraph/9.yaml",
+        """format: rulespec/v1
+rules:
+  - name: owner_occupier_housing_costs_element_amount
+    kind: derived
+    versions:
+      - effective_from: '2026-04-01'
+        formula: relevant_payment_amount
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-uk"
         / "regulations/uksi/2013/376/schedule/10/paragraph/1.yaml",
         """format: rulespec/v1
 rules:
@@ -9012,11 +9025,14 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path)
 
-    assert report["total_outputs"] == 2
-    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert report["total_outputs"] == 3
+    assert report["status_counts"] == {"known_not_comparable": 3}
     items_by_id = {item["legal_id"]: item for item in report["items"]}
     schedule_4 = items_by_id[
         "uk:regulations/uksi/2013/376/schedule/4/paragraph/22#renters_housing_costs_element_calculated_under_this_part"
+    ]
+    schedule_5 = items_by_id[
+        "uk:regulations/uksi/2013/376/schedule/5/paragraph/9#owner_occupier_housing_costs_element_amount"
     ]
     schedule_10 = items_by_id[
         "uk:regulations/uksi/2013/376/schedule/10/paragraph/1#premises_treated_as_persons_home_for_paragraphs_1_to_5"
@@ -9025,6 +9041,11 @@ rules:
     assert schedule_4["mapping_type"] == "not_comparable"
     assert "Schedule 4 housing-cost calculation helpers" in str(
         schedule_4["rationale"],
+    )
+    assert schedule_5["program"] == "universal_credit"
+    assert schedule_5["mapping_type"] == "not_comparable"
+    assert "Schedule 5 owner-occupier housing-cost helpers" in str(
+        schedule_5["rationale"],
     )
     assert schedule_10["program"] == "universal_credit"
     assert schedule_10["mapping_type"] == "not_comparable"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.564"
+version = "0.2.565"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify UK Universal Credit Schedule 5 owner-occupier housing-cost helpers as known not comparable in PolicyEngine oracle coverage
- extend the UC housing schedule coverage fixture for Schedule 5
- bump axiom-encode to 0.2.565

## Validation
- uv run --python 3.13 pytest tests/test_policyengine_coverage.py::test_universal_credit_housing_schedule_prefixes_are_classified -q
- uv run --python 3.13 ruff check tests/test_policyengine_coverage.py && uv run --python 3.13 ruff format --check tests/test_policyengine_coverage.py
- python YAML parse of src/axiom_encode/oracles/policyengine/mappings/uk.yaml
- uv run --python 3.13 python -m axiom_encode.cli oracle-coverage --root /tmp --program universal_credit --json: 277 outputs, 0 unmapped
- uv run --python 3.13 --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q