### PR TITLE
Extract Colorado SNAP repair table bounds

### DIFF
--- a/changelog.d/co-snap-boarder-table-bound.fixed.md
+++ b/changelog.d/co-snap-boarder-table-bound.fixed.md
@@ -1,0 +1,1 @@
+Extract Colorado SNAP boarder table bounds in deterministic repair output.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.565"
+version = "0.2.566"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.565"
+__version__ = "0.2.566"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -4270,6 +4270,49 @@ def _repair_colorado_snap_policy_composition(path: Path) -> None:
         "us-co:regulations/10-ccr-2506-1/4.407.6",
         before_import="us-co:regulations/10-ccr-2506-1/4.407.61",
     )
+    content = _upsert_rule_text(
+        content,
+        {
+            "name": "snap_maximum_allotment_table_max_household_size",
+            "kind": "parameter",
+            "dtype": "Count",
+            "source": "Colorado SNAP FY 2026 benefit calculation composition",
+            "versions": [
+                {
+                    "effective_from": "2025-10-01",
+                    "formula": "8",
+                }
+            ],
+        },
+        before_rule="max_allotment_for_number_of_boarders",
+    )
+    content = _upsert_rule_text(
+        content,
+        {
+            "name": "max_allotment_for_number_of_boarders",
+            "kind": "derived",
+            "entity": "Household",
+            "dtype": "Money",
+            "period": "Month",
+            "unit": "USD",
+            "source": "Colorado SNAP FY 2026 benefit calculation composition",
+            "versions": [
+                {
+                    "effective_from": "2025-10-01",
+                    "formula": (
+                        "if number_of_boarders <= 0:\n"
+                        "    0\n"
+                        "else:\n"
+                        "    snap_maximum_allotment_table[max(min(number_of_boarders, "
+                        "snap_maximum_allotment_table_max_household_size), 1)]\n"
+                        "    + (max(number_of_boarders - "
+                        "snap_maximum_allotment_table_max_household_size, 0) * "
+                        "snap_maximum_allotment_additional_member)"
+                    ),
+                }
+            ],
+        },
+    )
     content = _upsert_rules_text(
         content,
         _colorado_snap_federal_bridge_rules(include_allotment_bridges=False),
@@ -4352,6 +4395,10 @@ def _repair_colorado_snap_2072(path: Path) -> None:
 
 def _repair_colorado_snap_401(path: Path) -> None:
     content = path.read_text()
+    content, _ = _remove_rulespec_rule_by_name(
+        content,
+        "snap_gross_income_limit_165_percent_fpl_table_max_household_size",
+    )
     content = _upsert_rule_text(
         content,
         {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,6 +59,7 @@ from axiom_encode.cli import (
     _repair_colorado_snap_401_tests,
     _repair_colorado_snap_2072,
     _repair_colorado_snap_2072_tests,
+    _repair_colorado_snap_policy_composition,
     _repair_colorado_snap_program_tests,
     _repair_employer_scoped_entities,
     _repair_float_keyed_indexed_parameter_values,
@@ -6988,6 +6989,14 @@ rules:
 imports:
   - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards
 rules:
+  - name: snap_gross_income_limit_165_percent_fpl_table_max_household_size
+    kind: parameter
+    dtype: Count
+    source: 10 CCR 2506-1 section 4.401(A)(4)
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          8
   - name: snap_elderly_disabled_separate_household_allowed
     kind: derived
     entity: Person
@@ -7005,6 +7014,11 @@ rules:
         _repair_colorado_snap_401(rules_file)
 
         payload = yaml.safe_load(rules_file.read_text())
+        assert not any(
+            item["name"]
+            == "snap_gross_income_limit_165_percent_fpl_table_max_household_size"
+            for item in payload["rules"]
+        )
         limit_rule = next(
             item
             for item in payload["rules"]
@@ -7038,6 +7052,55 @@ rules:
             "and co_resident_gross_income <= "
             "co_resident_gross_income_limit_165_percent_fpl_48_states_dc"
         )
+
+    def test_repair_colorado_snap_policy_composition_extracts_boarder_table_bound(
+        self, tmp_path
+    ):
+        rules_file = tmp_path / "fy-2026-benefit-calculation.yaml"
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:regulations/7-cfr/273/6
+  - us-co:regulations/10-ccr-2506-1/4.407.61
+rules:
+  - name: max_allotment_for_number_of_boarders
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Colorado SNAP FY 2026 benefit calculation composition
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          if number_of_boarders <= 0:
+              0
+          else:
+              snap_maximum_allotment_table[max(min(number_of_boarders, 8), 1)]
+              + (max(number_of_boarders - 8, 0) * snap_maximum_allotment_additional_member)
+"""
+        )
+
+        _repair_colorado_snap_policy_composition(rules_file)
+
+        payload = yaml.safe_load(rules_file.read_text())
+        max_size_rule = next(
+            item
+            for item in payload["rules"]
+            if item["name"] == "snap_maximum_allotment_table_max_household_size"
+        )
+        assert max_size_rule["kind"] == "parameter"
+        assert max_size_rule["dtype"] == "Count"
+        assert max_size_rule["versions"][0]["formula"] == "8"
+        boarder_rule = next(
+            item
+            for item in payload["rules"]
+            if item["name"] == "max_allotment_for_number_of_boarders"
+        )
+        formula = boarder_rule["versions"][0]["formula"]
+        assert "number_of_boarders, 8" not in formula
+        assert "number_of_boarders - 8" not in formula
+        assert "snap_maximum_allotment_table_max_household_size" in formula
 
     def test_repair_colorado_snap_401_tests_uses_co_resident_group_size(self, tmp_path):
         test_file = tmp_path / "4.401.test.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.565"
+version = "0.2.566"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Updates the Colorado SNAP deterministic repair so table upper bounds are emitted as named Count parameters instead of embedded scalar literals.\n\nThis unblocks CO SNAP dependent validation when applying generated 4.402.2 artifacts under the current scalar guard.\n\nValidation:\n- uv run --python 3.13 pytest tests/test_cli.py -k 'repair_colorado_snap_401_uses_household_scope or repair_colorado_snap_policy_composition_extracts_boarder_table_bound or current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject' -q\n- uv run --python 3.13 ruff check src/axiom_encode/cli.py tests/test_cli.py\n- uv run --python 3.13 ruff format --check src/axiom_encode/cli.py tests/test_cli.py