### PR TITLE
Alias official UK legislation corpus paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.567"
+version = "0.2.568"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.567"
+__version__ = "0.2.568"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -60,6 +60,7 @@ from .harness.encoding_db import (
     ReviewResults,
 )
 from .harness.evals import (
+    _canonical_uk_legislation_tail,
     _eval_result_from_payload,
     evaluate_artifact,
     load_eval_suite_manifest,
@@ -22408,6 +22409,42 @@ def _read_corpus_citation_paths_from_rulespec(path: Path) -> set[str]:
     return declared
 
 
+def _canonical_corpus_citation_path_alias(citation_path: str) -> str:
+    """Return a comparable alias for corpus paths that name the same source."""
+    parts = [part for part in citation_path.strip().strip("/").split("/") if part]
+    if (
+        len(parts) >= 3
+        and parts[0] == "uk"
+        and parts[1]
+        in {
+            "regulation",
+            "regulations",
+            "statute",
+            "statutes",
+        }
+    ):
+        source_kind = {
+            "regulations": "regulation",
+            "statutes": "statute",
+        }.get(parts[1], parts[1])
+        tail = _canonical_uk_legislation_tail(parts[2:])
+        if tail:
+            return "/".join([parts[0], source_kind, *tail])
+    return citation_path.strip().strip("/")
+
+
+def _corpus_citation_paths_overlap(incoming: set[str], existing: set[str]) -> bool:
+    if incoming & existing:
+        return True
+    incoming_aliases = {
+        _canonical_corpus_citation_path_alias(path) for path in incoming
+    }
+    existing_aliases = {
+        _canonical_corpus_citation_path_alias(path) for path in existing
+    }
+    return bool(incoming_aliases & existing_aliases)
+
+
 def _enforce_no_apply_collision(*, source_file: Path, target_file: Path) -> None:
     """Refuse to overwrite an existing RuleSpec that encodes a different corpus citation.
 
@@ -22426,7 +22463,7 @@ def _enforce_no_apply_collision(*, source_file: Path, target_file: Path) -> None
     existing = _read_corpus_citation_paths_from_rulespec(target_file)
     if not incoming or not existing:
         return
-    if incoming & existing:
+    if _corpus_citation_paths_overlap(incoming, existing):
         return
     raise RuntimeError(
         "Refusing to overwrite "

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -145,6 +145,8 @@ _RULESPEC_OUTPUT_ROOT_BY_SOURCE_TOKEN = {
     "statute": "statutes",
     "statutes": "statutes",
 }
+_UK_LEGISLATION_DOMAIN_TOKEN = "legislation.gov.uk"
+_UK_LEGISLATION_SECTION_TOKENS = {"article", "regulation", "section"}
 _CODEX_DEFAULT_TIMEOUT_SECONDS = 600
 _CODEX_DEFAULT_IDLE_TIMEOUT_SECONDS = 300
 _CODEX_LONG_SOURCE_CHAR_THRESHOLD = 40_000
@@ -3351,6 +3353,8 @@ def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
         tail = parts[1:]
         if tail:
             root = _RULESPEC_OUTPUT_ROOT_BY_SOURCE_TOKEN.get(parts[0], parts[0])
+            if tail and tail[0] == _UK_LEGISLATION_DOMAIN_TOKEN:
+                tail = _canonical_uk_legislation_tail(tail)
             return Path(root) / _dotted_leaf_to_nested_yaml_path(tail)
     if len(parts) >= 3:
         root = _RULESPEC_OUTPUT_ROOT_BY_SOURCE_TOKEN.get(parts[1])
@@ -3358,6 +3362,8 @@ def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
             tail = parts[2:]
             if parts[0] == "us" and parts[1] in {"regulation", "regulations"}:
                 tail = _canonical_us_regulation_tail(tail)
+            if parts[0] == "uk":
+                tail = _canonical_uk_legislation_tail(tail)
             if tail:
                 if _preserve_state_statute_dotted_leaf(parts[0], root, tail):
                     return Path(root) / Path(*tail[:-1]) / f"{tail[-1]}.yaml"
@@ -3416,6 +3422,19 @@ def _canonical_us_regulation_tail(tail: list[str]) -> list[str]:
     if title.isdigit():
         return [f"{title}-cfr", *tail[1:]]
     return tail
+
+
+def _canonical_uk_legislation_tail(tail: list[str]) -> list[str]:
+    """Map official legislation.gov.uk corpus paths to canonical UK RuleSpec paths."""
+    normalized = list(tail)
+    if normalized and normalized[0] == _UK_LEGISLATION_DOMAIN_TOKEN:
+        normalized = normalized[1:]
+    if (
+        len(normalized) >= 2
+        and normalized[-2].lower() in _UK_LEGISLATION_SECTION_TOKENS
+    ):
+        normalized = [*normalized[:-2], normalized[-1]]
+    return normalized
 
 
 def _canonical_target_ref_prefix(

--- a/tests/test_encoder_path_collisions.py
+++ b/tests/test_encoder_path_collisions.py
@@ -162,6 +162,19 @@ def test_collision_guard_allows_overwrite_with_same_citation_path(tmp_path: Path
     _enforce_no_apply_collision(source_file=source, target_file=target)
 
 
+def test_collision_guard_allows_uk_legislation_gov_alias(tmp_path: Path):
+    source = _write_rulespec(
+        tmp_path / "src.yaml",
+        corpus_citation_path="uk/statute/ukpga/1992/4/8",
+    )
+    target = _write_rulespec(
+        tmp_path / "target.yaml",
+        corpus_citation_path="uk/statute/legislation.gov.uk/ukpga/1992/4/section/8",
+    )
+
+    _enforce_no_apply_collision(source_file=source, target_file=target)
+
+
 def test_collision_guard_refuses_overwrite_with_different_citation_path(
     tmp_path: Path,
 ):

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -321,6 +321,18 @@ def test_subparagraph_coverage_checklist_requires_exact_corpus_source_keys():
         ),
         ("us/statute/26/1/a/1", "statutes/26/1/a/1.yaml"),
         ("us/regulation/7/273/8", "regulations/7-cfr/273/8.yaml"),
+        (
+            "uk/statute/legislation.gov.uk/ukpga/1992/4/section/8",
+            "statutes/ukpga/1992/4/8.yaml",
+        ),
+        (
+            "uk/regulation/legislation.gov.uk/uksi/2013/376/regulation/36",
+            "regulations/uksi/2013/376/36.yaml",
+        ),
+        (
+            "uk/regulation/legislation.gov.uk/uksi/2013/376/schedule/5/paragraph/2",
+            "regulations/uksi/2013/376/schedule/5/paragraph/2.yaml",
+        ),
     ],
 )
 def test_source_identifier_handles_dotted_leaf_segments(citation, expected):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.567"
+version = "0.2.568"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Adds canonical path aliasing for official legislation.gov.uk UK corpus paths so encoder output and apply-collision checks route sources like `uk/statute/legislation.gov.uk/ukpga/1992/4/section/8` to the existing RuleSpec path `statutes/ukpga/1992/4/8.yaml` instead of creating a duplicate `statutes/legislation.gov.uk/...` tree.\n\nValidation run locally:\n- `uv run --python 3.13 --extra dev pytest tests/test_evals.py::test_source_identifier_handles_dotted_leaf_segments tests/test_encoder_path_collisions.py -q`\n- `uv run --python 3.13 --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::test_package_version_metadata_matches_pyproject -q`\n- `uv run --python 3.13 --extra dev ruff check src/axiom_encode/harness/evals.py src/axiom_encode/cli.py tests/test_evals.py tests/test_encoder_path_collisions.py`\n- `uv run --python 3.13 --extra dev ruff format --check src/axiom_encode/harness/evals.py src/axiom_encode/cli.py tests/test_evals.py tests/test_encoder_path_collisions.py`\n\nUsed this branch to re-run UK NI section 8 through encoder apply; it applied to `statutes/ukpga/1992/4/8.yaml`, passed validate with `AXIOM_CORPUS_REPO`, passed guard-generated, and compared cleanly to PE-UK NI on a 100-person EFRS sample.