### PR TITLE
Match eval metadata for state corpus paths

### DIFF
--- a/changelog.d/state-corpus-metadata-match.fixed.md
+++ b/changelog.d/state-corpus-metadata-match.fixed.md
@@ -1,0 +1,1 @@
+Matched eval source metadata by corpus paths so state encodes do not validate against unrelated fallback manifests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.569"
+version = "0.2.570"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.569"
+__version__ = "0.2.570"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1177,12 +1177,18 @@ def _load_nearby_eval_source_metadata(rulespec_file: Path) -> dict[str, object] 
             if rulespec_norm is None:
                 continue
             citation_raw = payload.get("citation")
-            manifest_norm = (
-                _citation_to_normalized_target(citation_raw)
-                if isinstance(citation_raw, str)
-                else None
-            )
-            if manifest_norm == rulespec_norm:
+            manifest_norms: list[tuple[str, ...]] = []
+            for candidate in (
+                citation_raw,
+                metadata.get("requested_source"),
+                metadata.get("corpus_citation_path"),
+            ):
+                if not isinstance(candidate, str):
+                    continue
+                candidate_norm = _citation_to_normalized_target(candidate)
+                if candidate_norm is not None:
+                    manifest_norms.append(candidate_norm)
+            if rulespec_norm in manifest_norms:
                 return metadata
     return fallback
 
@@ -1241,6 +1247,9 @@ def _rulespec_file_normalized_target(rulespec_file: Path) -> tuple[str, ...] | N
 
 
 def _citation_to_normalized_target(citation: str) -> tuple[str, ...] | None:
+    corpus_target = _corpus_citation_to_normalized_target(citation)
+    if corpus_target is not None:
+        return corpus_target
     try:
         parts = parse_usc_citation(citation)
     except Exception:
@@ -1249,6 +1258,95 @@ def _citation_to_normalized_target(citation: str) -> tuple[str, ...] | None:
         return None
     pieces = ["statutes", parts.title, parts.section, *parts.fragments]
     return tuple(p.lower() for p in pieces if p)
+
+
+def _corpus_citation_to_normalized_target(citation: str) -> tuple[str, ...] | None:
+    """Map corpus citation paths to the corresponding RuleSpec file target.
+
+    Eval metadata stores state and policy targets as corpus paths such as
+    ``us-co/regulation/9-ccr-2503-6/3.606.3``. The generated RuleSpec file
+    lands at ``regulations/9-ccr-2503-6/3.606.3.yaml``. Normalize both shapes
+    before nearby metadata matching so unrelated workspaces are not used as a
+    fallback.
+    """
+    candidate = citation.strip()
+    if not candidate:
+        return None
+    target_ref = _parse_rulespec_target(candidate)
+    if target_ref is not None:
+        return _rulespec_relative_path_parts(target_ref.relative_path)
+    parts = [part.strip().lower() for part in candidate.split("/") if part.strip()]
+    if len(parts) < 3 or not (parts[0] == "us" or parts[0].startswith("us-")):
+        return None
+    class_part = parts[1]
+    tail = parts[2:]
+    if class_part in {"statute", "statutes"}:
+        return tuple(
+            ["statutes", *_normalized_corpus_tail_parts(parts[0], "statutes", tail)]
+        )
+    if class_part in {"regulation", "regulations"}:
+        if parts[0] == "us":
+            tail = _canonical_us_regulation_tail_for_normalization(tail)
+        return tuple(
+            [
+                "regulations",
+                *_normalized_corpus_tail_parts(parts[0], "regulations", tail),
+            ]
+        )
+    if class_part in {"policy", "policies"}:
+        return tuple(
+            ["policies", *_normalized_corpus_tail_parts(parts[0], "policies", tail)]
+        )
+    return None
+
+
+def _normalized_corpus_tail_parts(
+    jurisdiction: str,
+    root: str,
+    tail: list[str],
+) -> tuple[str, ...]:
+    if not tail:
+        return ()
+    if _preserve_state_statute_dotted_leaf_for_normalization(jurisdiction, root, tail):
+        return tuple(tail)
+    if _preserve_dotted_leaf_filename_for_normalization(tail):
+        return tuple(tail)
+    leaf_segments = [part for part in tail[-1].split(".") if part]
+    if not leaf_segments:
+        return tuple(tail[:-1])
+    return tuple([*tail[:-1], *leaf_segments])
+
+
+def _preserve_dotted_leaf_filename_for_normalization(tail: list[str]) -> bool:
+    if len(tail) < 2:
+        return False
+    return bool(
+        re.fullmatch(r"\d+-ccr-\d+-\d+", tail[0], flags=re.IGNORECASE)
+        and re.fullmatch(r"\d+(?:\.\d+)+", tail[-1])
+    )
+
+
+def _preserve_state_statute_dotted_leaf_for_normalization(
+    jurisdiction: str,
+    root: str,
+    tail: list[str],
+) -> bool:
+    if jurisdiction != "us-co" or root != "statutes" or len(tail) < 2:
+        return False
+    if len(tail) == 2 and tail[0].isdigit():
+        return bool(re.fullmatch(r"\d+(?:-\d+)+(?:\.\d+)+", tail[-1]))
+    if not re.fullmatch(r"\d+(?:\.\d+)+", tail[-1]):
+        return False
+    return bool(re.fullmatch(r"\d+(?:-\d+)+(?:\.\d+)?", tail[-2]))
+
+
+def _canonical_us_regulation_tail_for_normalization(tail: list[str]) -> list[str]:
+    if not tail:
+        return tail
+    title = tail[0].strip()
+    if title.isdigit():
+        return [f"{title}-cfr", *tail[1:]]
+    return tail
 
 
 _SOURCE_CITATION_SEPARATOR_RE = re.compile(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -19,6 +19,7 @@ from axiom_encode.harness.validator_pipeline import (
     _extract_json_object,
     _infer_us_state_code_from_rulespec_path,
     _load_applied_encoding_manifest_source_metadata,
+    _load_nearby_eval_source_metadata,
     _normalize_us_tax_filing_status,
     _policyengine_expected_float,
     _policyengine_period_string,
@@ -14958,6 +14959,121 @@ rules: []
     )
 
     assert issues == []
+
+
+def test_nearby_eval_source_metadata_matches_corpus_path_shapes(tmp_path):
+    output_root = tmp_path / "axiom-encode-encodings"
+    unrelated_workspace = (
+        output_root
+        / "_eval_workspaces"
+        / "codex-gpt-5.5"
+        / "26-USC-1402-a"
+        / "workspace"
+    )
+    unrelated_workspace.mkdir(parents=True)
+    (unrelated_workspace / "context-manifest.json").write_text(
+        json.dumps(
+            {
+                "citation": "26 USC 1402(a)",
+                "source_metadata": {
+                    "corpus_citation_path": "us/statute/26/1402/a",
+                    "corpus_source": "supabase",
+                    "requested_source": "26 USC 1402(a)",
+                },
+            }
+        )
+    )
+
+    colorado_workspace = (
+        output_root
+        / "_eval_workspaces"
+        / "codex-gpt-5.5"
+        / "us-co-regulation-9-ccr-2503-6-3.606.3"
+        / "workspace"
+    )
+    colorado_workspace.mkdir(parents=True)
+    colorado_metadata = {
+        "corpus_citation_path": "us-co/regulation/9-ccr-2503-6/3.606.3",
+        "corpus_source": "supabase",
+        "requested_source": "us-co/regulation/9-ccr-2503-6/3.606.3",
+    }
+    (colorado_workspace / "context-manifest.json").write_text(
+        json.dumps(
+            {
+                "citation": "9 CCR 2503-6 3.606.3",
+                "source_metadata": colorado_metadata,
+            }
+        )
+    )
+
+    rulespec_file = (
+        output_root / "codex-gpt-5.5" / "regulations/9-ccr-2503-6/3.606.3.yaml"
+    )
+    rulespec_file.parent.mkdir(parents=True)
+    rulespec_file.write_text("format: rulespec/v1\nrules: []\n")
+
+    assert _load_nearby_eval_source_metadata(rulespec_file) == colorado_metadata
+
+    federal_workspace = (
+        output_root
+        / "_eval_workspaces"
+        / "codex-gpt-5.5"
+        / "us-regulation-7-273-10"
+        / "workspace"
+    )
+    federal_workspace.mkdir(parents=True)
+    federal_metadata = {
+        "corpus_citation_path": "us/regulation/7/273/10",
+        "corpus_source": "supabase",
+        "requested_source": "us/regulation/7/273/10",
+    }
+    (federal_workspace / "context-manifest.json").write_text(
+        json.dumps(
+            {
+                "citation": "7 CFR 273.10",
+                "source_metadata": federal_metadata,
+            }
+        )
+    )
+    federal_rulespec_file = (
+        output_root / "codex-gpt-5.5" / "regulations/7-cfr/273/10.yaml"
+    )
+    federal_rulespec_file.parent.mkdir(parents=True)
+    federal_rulespec_file.write_text("format: rulespec/v1\nrules: []\n")
+
+    assert _load_nearby_eval_source_metadata(federal_rulespec_file) == federal_metadata
+
+    california_workspace = (
+        output_root
+        / "_eval_workspaces"
+        / "codex-gpt-5.5"
+        / "us-ca-regulation-mpp-63-503.132"
+        / "workspace"
+    )
+    california_workspace.mkdir(parents=True)
+    california_metadata = {
+        "corpus_citation_path": "us-ca/regulation/mpp/63-503.132",
+        "corpus_source": "supabase",
+        "requested_source": "us-ca/regulation/mpp/63-503.132",
+    }
+    (california_workspace / "context-manifest.json").write_text(
+        json.dumps(
+            {
+                "citation": "MPP 63-503.132",
+                "source_metadata": california_metadata,
+            }
+        )
+    )
+    california_rulespec_file = (
+        output_root / "codex-gpt-5.5" / "regulations/mpp/63-503/132.yaml"
+    )
+    california_rulespec_file.parent.mkdir(parents=True)
+    california_rulespec_file.write_text("format: rulespec/v1\nrules: []\n")
+
+    assert (
+        _load_nearby_eval_source_metadata(california_rulespec_file)
+        == california_metadata
+    )
 
 
 def test_source_subparagraph_coverage_without_requested_source_keeps_strict_scope():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.569"
+version = "0.2.570"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- match nearby eval source metadata using citation, requested_source, and corpus_citation_path
- normalize corpus paths like us-co/regulation/..., us/regulation/..., and us-ca/regulation/mpp/... to generated RuleSpec paths before falling back to unrelated manifests
- bump axiom-encode to 0.2.570
- add a towncrier fix fragment for the metadata matching repair

## Review cycle
- First independent review found the corpus-path normalizer was too narrow for canonical federal/state path shapes.
- Fixed by mirroring eval path canonicalization for federal CFR paths, Colorado dotted CCR leaves, and California MPP dotted leaves.
- Second independent review: No actionable findings.

## Checks
- uv run ruff check pyproject.toml src/axiom_encode scripts tests
- ruff format --check src/ tests/
- python -m compileall -q src/axiom_encode scripts
- uv run pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_rulespec_validation.py::test_nearby_eval_source_metadata_matches_corpus_path_shapes tests/test_rulespec_validation.py::test_source_subparagraph_coverage_uses_applied_manifest_requested_source

## Local full pytest
- uv run pytest: failed only in tests/test_repo_cross_statute_imports.py::test_repo_cross_statute_definitions_are_imported because the sibling /Users/pavelmakarchuk/rulespec-us checkout has existing cross-statute import gaps (for example 26/1/h -> 26/2/b and 26/1401 -> 26/7703). The focused tests for this change pass.