### PR TITLE
Add UK savings credit oracle surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.570"
+version = "0.2.571"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.570"
+__version__ = "0.2.571"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -54,6 +54,8 @@ BENEFIT_CAP_REGULATION_80A_PROGRAM_PATH = Path("regulations/uksi/2013/376/80A.ya
 BENEFIT_CAP_REGULATION_80A_BASE = "uk:regulations/uksi/2013/376/80A"
 STATE_PENSION_CREDIT_SECTION_1_PROGRAM_PATH = Path("statutes/ukpga/2002/16/1.yaml")
 STATE_PENSION_CREDIT_SECTION_1_BASE = "uk:statutes/ukpga/2002/16/1"
+STATE_PENSION_CREDIT_SECTION_3_PROGRAM_PATH = Path("statutes/ukpga/2002/16/3.yaml")
+STATE_PENSION_CREDIT_SECTION_3_BASE = "uk:statutes/ukpga/2002/16/3"
 PENSION_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2002/1792/6.yaml")
 PENSION_CREDIT_BASE = "uk:regulations/uksi/2002/1792/6"
 UNIVERSAL_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2013/376/36.yaml")
@@ -247,6 +249,14 @@ STATE_PENSION_CREDIT_QUALIFYING_AGE_OUTPUTS = {
             "#claimant_has_attained_qualifying_age"
         ),
         "pe": "is_SP_age",
+    },
+}
+
+STATE_PENSION_CREDIT_SAVINGS_CREDIT_OUTPUTS = {
+    "savings_credit": {
+        "axiom": f"{STATE_PENSION_CREDIT_SECTION_3_BASE}#savings_credit",
+        "pe": "savings_credit",
+        "tolerance": 0.1,
     },
 }
 
@@ -585,6 +595,20 @@ SURFACE_SPECS = {
             "gender",
             "is_SP_age",
             "state_pension_age",
+        ),
+    ),
+    "state-pension-credit-savings-credit": UKEFRSSurfaceSpec(
+        program=STATE_PENSION_CREDIT_SECTION_3_PROGRAM_PATH,
+        entity="benunit",
+        outputs=STATE_PENSION_CREDIT_SAVINGS_CREDIT_OUTPUTS,
+        pe_variables=(
+            "is_savings_credit_eligible",
+            "minimum_guarantee",
+            "pension_credit_income",
+            "relation_type",
+            "savings_credit",
+            "savings_credit_income",
+            "standard_minimum_guarantee",
         ),
     ),
     "pension-credit": UKEFRSSurfaceSpec(
@@ -2176,6 +2200,11 @@ def build_axiom_request(
             pe_data=pe_data,
             year=year,
         )
+    if surface == "state-pension-credit-savings-credit":
+        return build_state_pension_credit_savings_credit_request(
+            pe_data=pe_data,
+            year=year,
+        )
     if surface == "pension-credit":
         return build_pension_credit_request(pe_data=pe_data, year=year)
     if surface == "universal-credit-childcare-element":
@@ -2605,6 +2634,45 @@ def build_pension_credit_request(
                 "entity_id": entity_id,
                 "period": interval,
                 "outputs": [spec["axiom"] for spec in PENSION_CREDIT_OUTPUTS.values()],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_state_pension_credit_savings_credit_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = tax_year_interval(year)
+    parameters = policyengine_uk_savings_credit_parameters(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "state-pension-credit-savings-credit"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_state_pension_credit_savings_credit_inputs(
+            row,
+            parameters=parameters,
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{STATE_PENSION_CREDIT_SECTION_3_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in STATE_PENSION_CREDIT_SAVINGS_CREDIT_OUTPUTS.values()
+                ],
             }
         )
 
@@ -3219,6 +3287,33 @@ def project_pension_credit_inputs(row: Any) -> dict[str, Any]:
     }
 
 
+def project_state_pension_credit_savings_credit_inputs(
+    row: Any,
+    *,
+    parameters: dict[str, float],
+) -> dict[str, Any]:
+    relation_type = enum_name(row_value(row, "relation_type", "SINGLE")).upper()
+    threshold_key = "COUPLE" if relation_type == "COUPLE" else "SINGLE"
+    return {
+        "claimant_satisfies_savings_credit_first_condition": bool(
+            row_value(row, "is_savings_credit_eligible", False)
+        ),
+        "claimant_qualifying_income": money(row_value(row, "savings_credit_income", 0)),
+        "claimant_income": money(row_value(row, "pension_credit_income", 0)),
+        "savings_credit_threshold": parameters[
+            f"savings_credit_threshold_{threshold_key.lower()}"
+        ],
+        "prescribed_percentage_for_amount_a": parameters["phase_in_rate"],
+        "prescribed_percentage_for_amount_b": parameters["phase_out_rate"],
+        "prescribed_percentage_for_maximum_savings_credit": parameters["phase_in_rate"],
+        "standard_minimum_guarantee": money(
+            row_value(row, "standard_minimum_guarantee", 0)
+        ),
+        "appropriate_minimum_guarantee": money(row_value(row, "minimum_guarantee", 0)),
+        "maximum_savings_credit_taken_as_nil_by_regulations": False,
+    }
+
+
 def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, Any]]:
     persons = pe_data["persons"]
     if surface == "child-benefit":
@@ -3334,6 +3429,7 @@ def compare_outputs(
                         axiom_value=axiom_value,
                         policyengine_value=pe_value,
                         diff=diff,
+                        pe_row=pe_row,
                     )
                     if divergence is not None:
                         summary[summary_key]["oracle_divergences"] += 1
@@ -3412,6 +3508,14 @@ def compare_outputs(
             "PolicyEngine's is_SP_age boolean. Current PolicyEngine UK EFRS "
             "data exposes the modern equalized-age surface rather than "
             "historical sex-specific age transitions.",
+            "State Pension Credit Act section 3 savings-credit comparison "
+            "projects PolicyEngine's annual savings_credit_income as qualifying "
+            "income, pension_credit_income as claimant income, "
+            "standard_minimum_guarantee for the maximum-credit cap, and "
+            "minimum_guarantee for the amount B reduction. Rows where "
+            "PolicyEngine lets additional minimum-guarantee amounts increase "
+            "the savings-credit maximum are classified as a known PE oracle "
+            "divergence.",
             "Universal Credit Regulation 36 comparisons treat the generated "
             "RuleSpec outputs as component table amounts. PolicyEngine annual "
             "EFRS component outputs are divided by 12, and EFRS category "
@@ -3596,6 +3700,7 @@ def known_policyengine_divergence(
     axiom_value: float,
     policyengine_value: float,
     diff: float,
+    pe_row: Any | None = None,
 ) -> UKEFRSOracleDivergence | None:
     if (
         surface == "personal-allowance"
@@ -3690,6 +3795,29 @@ def known_policyengine_divergence(
                 "2026-27 weekly rates."
             ),
             issue_url="https://github.com/PolicyEngine/policyengine-uk/issues/1742",
+        )
+    if (
+        surface == "state-pension-credit-savings-credit"
+        and output == "savings_credit"
+        and pe_row is not None
+        and policyengine_value > axiom_value
+        and money(row_value(pe_row, "minimum_guarantee", 0))
+        > money(row_value(pe_row, "standard_minimum_guarantee", 0))
+    ):
+        return UKEFRSOracleDivergence(
+            surface=surface,
+            entity_id=entity_id,
+            output=output,
+            axiom=axiom_value,
+            policyengine=policyengine_value,
+            diff=diff,
+            reason=(
+                "PolicyEngine UK currently uses the full minimum_guarantee, "
+                "including additions, to compute the savings-credit maximum; "
+                "State Pension Credit Act 2002 s.3(7) bases that maximum on "
+                "the standard minimum guarantee."
+            ),
+            issue_url="https://github.com/PolicyEngine/policyengine-uk/issues/1753",
         )
     expected_uc_rate = UNIVERSAL_CREDIT_2026_RULESPEC_RATES.get(output)
     if (
@@ -3972,6 +4100,28 @@ def policyengine_uk_income_tax_section_13_parameters(year: int) -> dict[str, flo
         "dividend_ordinary_rate": money(income_tax_rates.dividends.rates[0]),
         "dividend_upper_rate": money(income_tax_rates.dividends.rates[1]),
         "dividend_additional_rate": money(income_tax_rates.dividends.rates[2]),
+    }
+
+
+def policyengine_uk_savings_credit_parameters(year: int) -> dict[str, float]:
+    require_policyengine_uk_versions()
+    try:
+        from policyengine_uk import CountryTaxBenefitSystem
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(policyengine_uk_install_message()) from exc
+
+    savings_credit = (
+        CountryTaxBenefitSystem()
+        .parameters(f"{year:04d}-04-06")
+        .gov.dwp.pension_credit.savings_credit
+    )
+    return {
+        "savings_credit_threshold_single": money(savings_credit.threshold.SINGLE)
+        * WEEKS_IN_YEAR,
+        "savings_credit_threshold_couple": money(savings_credit.threshold.COUPLE)
+        * WEEKS_IN_YEAR,
+        "phase_in_rate": money(savings_credit.rate.phase_in),
+        "phase_out_rate": money(savings_credit.rate.phase_out),
     }
 
 

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -488,6 +488,42 @@ mappings:
     candidate_priority: P3
     rationale: State Pension Credit Act section 1 tests whether the claimant has attained the statutory qualifying age at day granularity. The UK EFRS oracle compares RuleSpec's judgment output to PolicyEngine UK's annual is_SP_age predicate after supplying the same age and state_pension_age projection used for qualifying_age.
 
+  - legal_id: uk:statutes/ukpga/2002/16/3#savings_credit
+    country: uk
+    program: pension_credit
+    mapping_type: direct_variable
+    policyengine_variable: savings_credit
+    entity: benunit
+    period: year
+    unit: GBP
+    comparison: money
+    candidate_priority: P2
+    rationale: Same annual Pension Credit savings credit amount. The EFRS oracle projects section 3 inputs from PolicyEngine's savings-credit income, claimant income, minimum-guarantee, standard-minimum-guarantee, and prescribed threshold/rate parameters.
+
+  - legal_id: uk:statutes/ukpga/2002/16/3#maximum_savings_credit
+    country: uk
+    program: pension_credit
+    mapping_type: not_comparable
+    rationale: Source-law intermediate for State Pension Credit Act section 3. PolicyEngine UK exposes the final savings_credit amount, but not the section 3 maximum savings credit as a separate one-to-one variable.
+
+  - legal_id: uk:statutes/ukpga/2002/16/3#amount_a_for_savings_credit
+    country: uk
+    program: pension_credit
+    mapping_type: not_comparable
+    rationale: Source-law intermediate for State Pension Credit Act section 3 amount A. PolicyEngine UK exposes the final savings_credit amount, but not amount A separately.
+
+  - legal_id: uk:statutes/ukpga/2002/16/3#amount_b_for_savings_credit
+    country: uk
+    program: pension_credit
+    mapping_type: not_comparable
+    rationale: Source-law intermediate for State Pension Credit Act section 3 amount B. PolicyEngine UK exposes the final savings_credit amount, but not amount B separately.
+
+  - legal_id: uk:statutes/ukpga/2002/16/3#savings_credit_second_condition_satisfied
+    country: uk
+    program: pension_credit
+    mapping_type: not_comparable
+    rationale: Source-law entitlement predicate under State Pension Credit Act section 3(2). PolicyEngine UK has an eligibility variable, but it combines age and income conditions and is not a one-to-one match for this second condition.
+
   - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_single_under_25_amount
     country: uk
     program: universal_credit

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1180,6 +1180,100 @@ rules:
     assert attained_age["candidate_priority"] == "P3"
 
 
+def test_policyengine_coverage_classifies_uk_pension_credit_section_3_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2002/16/3.yaml",
+        """format: rulespec/v1
+rules:
+  - name: maximum_savings_credit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          10
+  - name: amount_a_for_savings_credit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          9
+  - name: amount_b_for_savings_credit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          2
+  - name: savings_credit_second_condition_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          amount_a_for_savings_credit > amount_b_for_savings_credit
+  - name: savings_credit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          amount_a_for_savings_credit - amount_b_for_savings_credit
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2002/16/3.test.yaml",
+        """- name: savings credit
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    uk:statutes/ukpga/2002/16/3#maximum_savings_credit: 10
+    uk:statutes/ukpga/2002/16/3#amount_a_for_savings_credit: 9
+    uk:statutes/ukpga/2002/16/3#amount_b_for_savings_credit: 2
+    uk:statutes/ukpga/2002/16/3#savings_credit_second_condition_satisfied: holds
+    uk:statutes/ukpga/2002/16/3#savings_credit: 7
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="pension_credit")
+
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 4,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    savings_credit = items_by_id["uk:statutes/ukpga/2002/16/3#savings_credit"]
+
+    assert savings_credit["policyengine_variable"] == "savings_credit"
+    assert savings_credit["status"] == "comparable"
+    assert savings_credit["mapping_type"] == "direct_variable"
+    assert savings_credit["candidate_priority"] == "P2"
+    assert (
+        items_by_id["uk:statutes/ukpga/2002/16/3#amount_a_for_savings_credit"]["status"]
+        == "known_not_comparable"
+    )
+
+
 def test_policyengine_coverage_counts_uk_aliases_as_tested(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-uk" / "regulations/uksi/2006/965/2.yaml",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -30,7 +30,9 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     PERSONAL_ALLOWANCE_OUTPUTS,
     PERSONAL_ALLOWANCE_PROGRAM_PATH,
     STATE_PENSION_CREDIT_QUALIFYING_AGE_OUTPUTS,
+    STATE_PENSION_CREDIT_SAVINGS_CREDIT_OUTPUTS,
     STATE_PENSION_CREDIT_SECTION_1_BASE,
+    STATE_PENSION_CREDIT_SECTION_3_BASE,
     UNIVERSAL_CREDIT_AWARD_OUTPUTS,
     UNIVERSAL_CREDIT_CHILD_ELEMENT_OUTPUTS,
     UNIVERSAL_CREDIT_CHILDCARE_ELEMENT_OUTPUTS,
@@ -56,6 +58,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_pension_credit_request,
     build_personal_allowance_request,
     build_state_pension_credit_qualifying_age_request,
+    build_state_pension_credit_savings_credit_request,
     build_uk_efrs_coverage_report,
     build_universal_credit_award_request,
     build_universal_credit_childcare_element_request,
@@ -79,6 +82,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_pension_credit_inputs,
     project_personal_allowance_inputs,
     project_state_pension_credit_qualifying_age_inputs,
+    project_state_pension_credit_savings_credit_inputs,
     project_universal_credit_award_inputs,
     project_universal_credit_childcare_element_inputs,
     project_universal_credit_housing_costs_inputs,
@@ -1003,6 +1007,96 @@ def test_pension_credit_request_projects_benefit_units():
     }
 
 
+def test_state_pension_credit_savings_credit_projection_uses_section_3_inputs():
+    projected = project_state_pension_credit_savings_credit_inputs(
+        {
+            "relation_type": "RelationType.COUPLE",
+            "is_savings_credit_eligible": True,
+            "savings_credit_income": 18_000,
+            "pension_credit_income": 18_600,
+            "standard_minimum_guarantee": 363.25 * WEEKS_IN_YEAR,
+            "minimum_guarantee": 410.50 * WEEKS_IN_YEAR,
+        },
+        parameters={
+            "savings_credit_threshold_single": 208.07 * WEEKS_IN_YEAR,
+            "savings_credit_threshold_couple": 329.75 * WEEKS_IN_YEAR,
+            "phase_in_rate": 0.6,
+            "phase_out_rate": 0.4,
+        },
+    )
+
+    assert projected == {
+        "claimant_satisfies_savings_credit_first_condition": True,
+        "claimant_qualifying_income": 18_000,
+        "claimant_income": 18_600,
+        "savings_credit_threshold": 329.75 * WEEKS_IN_YEAR,
+        "prescribed_percentage_for_amount_a": 0.6,
+        "prescribed_percentage_for_amount_b": 0.4,
+        "prescribed_percentage_for_maximum_savings_credit": 0.6,
+        "standard_minimum_guarantee": 363.25 * WEEKS_IN_YEAR,
+        "appropriate_minimum_guarantee": 410.50 * WEEKS_IN_YEAR,
+        "maximum_savings_credit_taken_as_nil_by_regulations": False,
+    }
+
+
+def test_state_pension_credit_savings_credit_request_projects_benefit_units(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        efrs_uk,
+        "policyengine_uk_savings_credit_parameters",
+        lambda year: {
+            "savings_credit_threshold_single": 208.07 * WEEKS_IN_YEAR,
+            "savings_credit_threshold_couple": 329.75 * WEEKS_IN_YEAR,
+            "phase_in_rate": 0.6,
+            "phase_out_rate": 0.4,
+        },
+    )
+
+    request = build_state_pension_credit_savings_credit_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 12,
+                    "benunit_weight": 1,
+                    "relation_type": "SINGLE",
+                    "is_savings_credit_eligible": True,
+                    "savings_credit": 12.5 * WEEKS_IN_YEAR,
+                    "savings_credit_income": 11_000,
+                    "pension_credit_income": 11_000,
+                    "standard_minimum_guarantee": 238.00 * WEEKS_IN_YEAR,
+                    "minimum_guarantee": 238.00 * WEEKS_IN_YEAR,
+                }
+            ],
+            "benunit_ids": [12],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_12",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": list(
+                output["axiom"]
+                for output in STATE_PENSION_CREDIT_SAVINGS_CREDIT_OUTPUTS.values()
+            ),
+        }
+    ]
+    assert {record["name"]: record["value"] for record in request["dataset"]["inputs"]}[
+        f"{STATE_PENSION_CREDIT_SECTION_3_BASE}#input.savings_credit_threshold"
+    ] == {
+        "kind": "decimal",
+        "value": str(208.07 * WEEKS_IN_YEAR),
+    }
+
+
 def test_universal_credit_request_queries_monthly_table_amounts():
     request = build_universal_credit_request(
         pe_data={
@@ -1755,6 +1849,17 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "num_carers",
         "relation_type",
         "severe_disability_minimum_guarantee_addition",
+        "standard_minimum_guarantee",
+    )
+    assert policyengine_benunit_variables_for_surfaces(
+        ["state-pension-credit-savings-credit"]
+    ) == (
+        "is_savings_credit_eligible",
+        "minimum_guarantee",
+        "pension_credit_income",
+        "relation_type",
+        "savings_credit",
+        "savings_credit_income",
         "standard_minimum_guarantee",
     )
     assert policyengine_benunit_variables_for_surfaces(
@@ -2889,6 +2994,42 @@ def test_compare_outputs_classifies_known_policyengine_pension_credit_rates():
     assert len(report.oracle_divergences) == 1
     assert report.oracle_divergences[0].entity_id == "benunit_11"
     assert report.oracle_divergences[0].issue_url.endswith("/issues/1740")
+
+
+def test_compare_outputs_classifies_policyengine_savings_credit_maximum_bug():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 79791,
+                    "savings_credit": 4022.257080078125,
+                    "standard_minimum_guarantee": 18889.0,
+                    "minimum_guarantee": 27838.2,
+                }
+            ],
+            "benunit_ids": [79791],
+        },
+        axiom_outputs_by_surface={
+            "state-pension-credit-savings-credit": [
+                {
+                    "outputs": {
+                        f"{STATE_PENSION_CREDIT_SECTION_3_BASE}#savings_credit": decimal_output(
+                            1045.2
+                        )
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=0,
+    )
+
+    assert report.mismatches == []
+    assert len(report.oracle_divergences) == 1
+    assert report.oracle_divergences[0].entity_id == "benunit_79791"
+    assert report.oracle_divergences[0].issue_url.endswith("/issues/1753")
 
 
 def test_compare_outputs_classifies_known_policyengine_pension_credit_additions():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.570"
+version = "0.2.571"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a PolicyEngine UK EFRS oracle surface for State Pension Credit Act 2002 section 3 savings credit
- map `uk:statutes/ukpga/2002/16/3#savings_credit` to PE UK's `savings_credit` and classify section 3 intermediates as not directly comparable
- classify rows affected by the PE maximum-savings-credit bug as known divergences linked to PolicyEngine/policyengine-uk#1753
- bump axiom-encode to 0.2.571

## Validation
- `uv run --python 3.13 ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py`
- `uv run --python 3.13 ruff format --check src/axiom_encode/__init__.py src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py`
- `uv run --with pytest --with pytest-cov --python 3.13 python -m pytest tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py -q` -> 319 passed, 1 existing pytest config warning
- `uv run --with pytest --with pytest-cov --python 3.13 python -m pytest tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py -k 'savings_credit or pension_credit_section_3 or policyengine_variables_for_surfaces' -q` -> 5 passed, 314 deselected, 1 existing pytest config warning
- local full EFRS surface compare for `state-pension-credit-savings-credit`: 1,000 benefit units, 0 mismatches, 13 known PE divergences linked to PolicyEngine/policyengine-uk#1753
