### PR TITLE
Allow multiline selector result keys

### DIFF
--- a/changelog.d/selector-result-literal-guard.fixed.md
+++ b/changelog.d/selector-result-literal-guard.fixed.md
@@ -1,0 +1,1 @@
+Allow multiline source-table selector result keys when they are backed by indexed parameter table keys.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.571"
+version = "0.2.572"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.571"
+__version__ = "0.2.572"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -21057,26 +21057,37 @@ class ValidatorPipeline:
                     source_text,
                 ):
                     continue
+                structural_selector_keys = (
+                    selector_table_keys.get(name)
+                    if _is_structural_selector_rule(rule)
+                    else None
+                )
+                previous_stripped = ""
                 for line in formula.splitlines() or [formula]:
                     stripped = line.strip()
                     if not stripped:
                         continue
+                    expression = stripped
+                    if (
+                        structural_selector_keys
+                        and previous_stripped.endswith(":")
+                        and re.fullmatch(r"\d+(?:\.0+)?", stripped)
+                    ):
+                        expression = f"{previous_stripped} {stripped}"
                     if _line_compares_extracted_parameter_to_own_scalar(
                         stripped,
                         parameter_scalar_values,
                     ):
+                        previous_stripped = stripped
                         continue
                     issues.extend(
                         (rule_index, name, literal, stripped)
                         for literal in self._extract_embedded_scalar_literals(
-                            stripped,
-                            structural_selector_keys=(
-                                selector_table_keys.get(name)
-                                if _is_structural_selector_rule(rule)
-                                else None
-                            ),
+                            expression,
+                            structural_selector_keys=structural_selector_keys,
                         )
                     )
+                    previous_stripped = stripped
         return issues
 
     def _is_direct_scalar_expression(self, expression: str) -> bool:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -19270,6 +19270,48 @@ rules:
     assert pipeline._check_embedded_scalar_literals(rules_file) == []
 
 
+def test_embedded_formula_numeric_guard_allows_multiline_selector_result_keys(
+    tmp_path,
+):
+    rules_file = tmp_path / "rules.yaml"
+    rules_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: limit_by_band
+    kind: parameter
+    dtype: Money
+    indexed_by: income_band
+    versions:
+      - effective_from: '2024-01-01'
+        values:
+          0: 0
+          1: 15000
+          2: 20000
+          3: 25000
+          4: 30000
+  - name: income_band
+    kind: derived
+    entity: Household
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '2024-01-01'
+        formula: |-
+          if household_income < limit_by_band[1]:
+            1
+          else:
+            4
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+
+    assert pipeline._check_embedded_scalar_literals(rules_file) == []
+
+
 def test_embedded_formula_numeric_guard_allows_source_backed_ascii_fraction_parameters(
     tmp_path,
 ):
@@ -19616,6 +19658,51 @@ rules:
     assert "benefit_amount" in issues[0]
     assert "embeds 4" in issues[0]
     assert "embeds 8" not in issues[0]
+
+
+def test_embedded_formula_numeric_guard_rejects_multiline_call_argument_literal(
+    tmp_path,
+):
+    rules_file = tmp_path / "rules.yaml"
+    rules_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: limit_by_band
+    kind: parameter
+    dtype: Money
+    indexed_by: income_band
+    versions:
+      - effective_from: '2024-01-01'
+        values:
+          1: 100
+          4: 400
+  - name: income_band
+    kind: derived
+    entity: Household
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '2024-01-01'
+        formula: |-
+          if household_income > limit_by_band[1]:
+            other_func(
+              4
+            )
+          else:
+            1
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_embedded_scalar_literals(rules_file)
+
+    assert len(issues) == 1
+    assert "income_band" in issues[0]
+    assert "embeds 4" in issues[0]
 
 
 def test_embedded_formula_numeric_guard_is_occurrence_aware(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.571"
+version = "0.2.572"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- allow multiline structural selector result literals when the value is an indexed table key
- add regression coverage for block-style selector formulas returning table-backed keys
- bump axiom-encode to 0.2.571 and add changelog fragment

## Local checks
- PASS: `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- PASS: `python -m compileall -q src/axiom_encode scripts`
- PASS: `uv run --python 3.13 pytest tests/test_rulespec_validation.py -k "embedded_formula_numeric_guard"`
- PASS: `uv run --python 3.13 pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- PASS: temp-installed NY Tax Law 1304 generated candidate validates with `ci_pass: true`
- NOTE: full `uv run pytest` currently fails only in `tests/test_repo_cross_statute_imports.py::test_repo_cross_statute_definitions_are_imported` due existing `rulespec-us` cross-statute import gaps; rerun confirms the same unrelated failure.

## Review cycle
- Pending independent review before ready for review.
