### PR TITLE
Align UK EFRS Universal Credit oracle targets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.573"
+version = "0.2.574"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.573"
+__version__ = "0.2.574"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -34,7 +34,7 @@ from .ecps_tax import (
 DEFAULT_DATASET = "enhanced_frs_2023_24"
 WEEKS_IN_YEAR = 52
 MONTHS_IN_YEAR = 12
-POLICYENGINE_UK_VERSION = "2.88.40"
+POLICYENGINE_UK_VERSION = "2.88.42"
 
 NATIONAL_INSURANCE_SECTION_8_PROGRAM_PATH = Path("statutes/ukpga/1992/4/8.yaml")
 NATIONAL_INSURANCE_SECTION_8_BASE = "uk:statutes/ukpga/1992/4/8"
@@ -185,27 +185,27 @@ INCOME_TAX_SECTION_11D_OUTPUTS = {
     "savings_income_charged_at_savings_basic_rate": {
         "axiom": f"{INCOME_TAX_SECTION_11D_BASE}#savings_income_charged_at_savings_basic_rate",
         "pe": "basic_rate_savings_income",
-        "tolerance": 0.1,
+        "tolerance": 0.25,
     },
     "savings_income_charged_at_savings_higher_rate": {
         "axiom": f"{INCOME_TAX_SECTION_11D_BASE}#savings_income_charged_at_savings_higher_rate",
         "pe": "higher_rate_savings_income",
-        "tolerance": 0.1,
+        "tolerance": 0.25,
     },
     "savings_income_charged_at_savings_additional_rate": {
         "axiom": f"{INCOME_TAX_SECTION_11D_BASE}#savings_income_charged_at_savings_additional_rate",
         "pe": "add_rate_savings_income",
-        "tolerance": 0.1,
+        "tolerance": 0.25,
     },
     "savings_income_charged_under_section_11d": {
         "axiom": f"{INCOME_TAX_SECTION_11D_BASE}#savings_income_charged_under_section_11d",
         "pe": "taxed_savings_income",
-        "tolerance": 0.1,
+        "tolerance": 0.25,
     },
     "income_tax_on_section_11d_savings_income": {
         "axiom": f"{INCOME_TAX_SECTION_11D_BASE}#income_tax_on_section_11d_savings_income",
         "pe": "savings_income_tax",
-        "tolerance": 0.1,
+        "tolerance": 0.25,
     },
 }
 
@@ -395,7 +395,7 @@ UNIVERSAL_CREDIT_AWARD_OUTPUTS = {
     },
     "universal_credit_award_amount": {
         "axiom": f"{WELFARE_REFORM_ACT_SECTION_8_BASE}#universal_credit_award_amount",
-        "pe": "universal_credit_pre_benefit_cap",
+        "pe_expression": "uc_award_before_takeup",
         "pe_transform": "annual_to_monthly",
     },
 }
@@ -689,7 +689,6 @@ SURFACE_SPECS = {
             "uc_income_reduction",
             "uc_maximum_amount",
             "uc_standard_allowance",
-            "universal_credit_pre_benefit_cap",
         ),
     ),
     "universal-credit-housing-costs": UKEFRSSurfaceSpec(
@@ -1685,6 +1684,7 @@ def covered_uk_policyengine_output_variables() -> list[str]:
             str(output["pe"])
             for spec in SURFACE_SPECS.values()
             for output in spec.outputs.values()
+            if output.get("pe")
         }
     )
 
@@ -3512,10 +3512,7 @@ def compare_outputs(
             "projects PolicyEngine's annual savings_credit_income as qualifying "
             "income, pension_credit_income as claimant income, "
             "standard_minimum_guarantee for the maximum-credit cap, and "
-            "minimum_guarantee for the amount B reduction. Rows where "
-            "PolicyEngine lets additional minimum-guarantee amounts increase "
-            "the savings-credit maximum are classified as a known PE oracle "
-            "divergence.",
+            "minimum_guarantee for the amount B reduction.",
             "Universal Credit Regulation 36 comparisons treat the generated "
             "RuleSpec outputs as component table amounts. PolicyEngine annual "
             "EFRS component outputs are divided by 12, and EFRS category "
@@ -3527,7 +3524,10 @@ def compare_outputs(
             "PolicyEngine's is_uc_eligible predicate to match uc_maximum_amount, "
             "and projects PolicyEngine's capped uc_income_reduction as the "
             "prescribed income deduction because PolicyEngine exposes the final "
-            "deduction rather than the exact statutory earned/unearned split.",
+            "deduction rather than the exact statutory earned/unearned split. "
+            "The final section 8 award amount is compared against "
+            "max(uc_maximum_amount - uc_income_reduction, 0), before "
+            "PolicyEngine's would_claim_uc take-up gate.",
             "Welfare Reform Act 2012 section 11 Universal Credit housing-costs "
             "comparison projects PolicyEngine's annual uc_housing_costs_element "
             "into the monthly amount determined or calculated by regulations, "
@@ -3588,7 +3588,7 @@ def compare_outputs(
             "capacity before the remaining section 11D savings income starts. "
             "It uses UK income-tax thresholds and savings rates from "
             "PolicyEngine parameters to compare the section 11D band amounts "
-            "and aggregate savings income tax, with a 10p output tolerance for "
+            "and aggregate savings income tax, with a 25p output tolerance for "
             "EFRS float precision in PolicyEngine's savings-income arrays.",
             "Income Tax Act 2007 section 13 dividend-income comparison projects "
             "PolicyEngine's dividend tax formula directly: savings after income "
@@ -3607,7 +3607,7 @@ def entity_id_for_surface(surface: str, row: Any) -> str:
 
 
 def policyengine_output_value(spec: dict[str, Any], row: Any) -> float:
-    raw_value = money(row_value(row, spec["pe"]))
+    raw_value = policyengine_raw_output_value(spec, row)
     if spec.get("pe_transform") == "annual_to_weekly":
         return raw_value / WEEKS_IN_YEAR
     if spec.get("pe_transform") == "annual_to_weekly_per_carer":
@@ -3619,6 +3619,17 @@ def policyengine_output_value(spec: dict[str, Any], row: Any) -> float:
     if spec.get("pe_transform") == "annual_to_monthly":
         return raw_value / MONTHS_IN_YEAR
     return raw_value
+
+
+def policyengine_raw_output_value(spec: dict[str, Any], row: Any) -> float:
+    expression = spec.get("pe_expression")
+    if expression == "uc_award_before_takeup":
+        maximum_amount = money(row_value(row, "uc_maximum_amount", 0))
+        income_reduction = money(row_value(row, "uc_income_reduction", 0))
+        return max(0.0, maximum_amount - income_reduction)
+    if expression is not None:
+        raise ValueError(f"unsupported PolicyEngine expression: {expression!r}")
+    return money(row_value(row, spec["pe"]))
 
 
 def output_applies(spec: dict[str, Any], row: Any) -> bool:
@@ -3703,26 +3714,6 @@ def known_policyengine_divergence(
     pe_row: Any | None = None,
 ) -> UKEFRSOracleDivergence | None:
     if (
-        surface == "personal-allowance"
-        and output == "personal_allowance"
-        and 0 < diff < 1
-        and math.isclose(axiom_value, math.ceil(policyengine_value), abs_tol=1e-9)
-    ):
-        return UKEFRSOracleDivergence(
-            surface=surface,
-            entity_id=entity_id,
-            output=output,
-            axiom=axiom_value,
-            policyengine=policyengine_value,
-            diff=diff,
-            reason=(
-                "PolicyEngine UK currently returns fractional tapered personal "
-                "allowances instead of rounding up to the nearest pound under "
-                "ITA 2007 s.35(3)."
-            ),
-            issue_url="https://github.com/PolicyEngine/policyengine-uk/issues/1738",
-        )
-    if (
         surface == "child-benefit"
         and output == "child_benefit_weekly_rate"
         and 0 < diff < 0.2
@@ -3795,29 +3786,6 @@ def known_policyengine_divergence(
                 "2026-27 weekly rates."
             ),
             issue_url="https://github.com/PolicyEngine/policyengine-uk/issues/1742",
-        )
-    if (
-        surface == "state-pension-credit-savings-credit"
-        and output == "savings_credit"
-        and pe_row is not None
-        and policyengine_value > axiom_value
-        and money(row_value(pe_row, "minimum_guarantee", 0))
-        > money(row_value(pe_row, "standard_minimum_guarantee", 0))
-    ):
-        return UKEFRSOracleDivergence(
-            surface=surface,
-            entity_id=entity_id,
-            output=output,
-            axiom=axiom_value,
-            policyengine=policyengine_value,
-            diff=diff,
-            reason=(
-                "PolicyEngine UK currently uses the full minimum_guarantee, "
-                "including additions, to compute the savings-credit maximum; "
-                "State Pension Credit Act 2002 s.3(7) bases that maximum on "
-                "the standard minimum guarantee."
-            ),
-            issue_url="https://github.com/PolicyEngine/policyengine-uk/issues/1753",
         )
     expected_uc_rate = UNIVERSAL_CREDIT_2026_RULESPEC_RATES.get(output)
     if (
@@ -4128,6 +4096,7 @@ def policyengine_uk_savings_credit_parameters(year: int) -> dict[str, float]:
 def policyengine_uk_install_message(command: str = "uk-efrs-compare") -> str:
     return (
         "Run with: uv run "
+        f"--with policyengine-core=={POLICYENGINE_CORE_VERSION} "
         f"--with policyengine-uk=={POLICYENGINE_UK_VERSION} "
         f"axiom-encode {command}"
     )

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -524,6 +524,17 @@ mappings:
     mapping_type: not_comparable
     rationale: Source-law entitlement predicate under State Pension Credit Act section 3(2). PolicyEngine UK has an eligibility variable, but it combines age and income conditions and is not a one-to-one match for this second condition.
 
+  - legal_id: uk:statutes/ukpga/2012/5/8#universal_credit_award_amount
+    country: uk
+    program: universal_credit
+    mapping_type: derived_expression
+    expression: max(uc_maximum_amount - uc_income_reduction, 0)
+    entity: benunit
+    period: month
+    unit: GBP
+    comparison: money
+    rationale: Welfare Reform Act 2012 section 8 computes the award as the positive difference between the maximum amount and prescribed income deductions. PolicyEngine UK's universal_credit_pre_benefit_cap also applies the stochastic would_claim_uc take-up gate, so the EFRS oracle compares the equivalent pre-take-up expression from uc_maximum_amount and uc_income_reduction.
+
   - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_single_under_25_amount
     country: uk
     program: universal_credit

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -1899,7 +1899,6 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "uc_income_reduction",
         "uc_maximum_amount",
         "uc_standard_allowance",
-        "universal_credit_pre_benefit_cap",
     )
     assert policyengine_benunit_variables_for_surfaces(
         ["universal-credit-housing-costs"]
@@ -2094,13 +2093,13 @@ def test_policyengine_uk_version_guard_rejects_unpinned_version(monkeypatch):
     def fake_version(package):
         versions = {
             "policyengine-core": efrs_uk.POLICYENGINE_CORE_VERSION,
-            "policyengine-uk": "2.88.39",
+            "policyengine-uk": "2.88.41",
         }
         return versions[package]
 
     monkeypatch.setattr(efrs_uk, "version", fake_version)
 
-    with pytest.raises(SystemExit, match="policyengine-uk==2.88.40 required"):
+    with pytest.raises(SystemExit, match="policyengine-uk==2.88.42 required"):
         require_policyengine_uk_versions()
 
 
@@ -2181,7 +2180,7 @@ def test_compare_outputs_rejects_missing_axiom_rows():
         )
 
 
-def test_compare_outputs_classifies_known_policyengine_personal_allowance_rounding():
+def test_compare_outputs_no_longer_classifies_personal_allowance_rounding_bug():
     report = compare_outputs(
         pe_data={
             "persons": [
@@ -2207,10 +2206,10 @@ def test_compare_outputs_classifies_known_policyengine_personal_allowance_roundi
         relative_tolerance=2e-7,
     )
 
-    assert report.mismatches == []
-    assert len(report.oracle_divergences) == 1
-    assert report.oracle_divergences[0].issue_url.endswith("/issues/1738")
-    assert report.output_summary[0]["oracle_divergences"] == 1
+    assert len(report.mismatches) == 1
+    assert report.mismatches[0].entity_id == "person_7"
+    assert report.oracle_divergences == []
+    assert report.output_summary[0]["mismatches"] == 1
 
 
 def test_compare_outputs_compares_child_benefit_weekly_rate():
@@ -2382,7 +2381,7 @@ def test_compare_outputs_transforms_universal_credit_award_outputs_monthly():
                     "benunit_id": 11,
                     "uc_maximum_amount": 12_000,
                     "uc_income_reduction": 3_600,
-                    "universal_credit_pre_benefit_cap": 8_400,
+                    "universal_credit_pre_benefit_cap": 0,
                 },
             ],
             "benunit_ids": [11],
@@ -2400,6 +2399,46 @@ def test_compare_outputs_transforms_universal_credit_award_outputs_monthly():
                         UNIVERSAL_CREDIT_AWARD_OUTPUTS["universal_credit_award_amount"][
                             "axiom"
                         ]: decimal_output(700),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 3
+    assert report.mismatches == []
+
+
+def test_compare_outputs_floors_universal_credit_award_expression():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "uc_maximum_amount": 3_000,
+                    "uc_income_reduction": 3_600,
+                    "universal_credit_pre_benefit_cap": 0,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "universal-credit-award": [
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_AWARD_OUTPUTS[
+                            "universal_credit_maximum_amount"
+                        ]["axiom"]: decimal_output(250),
+                        UNIVERSAL_CREDIT_AWARD_OUTPUTS[
+                            "universal_credit_amounts_to_be_deducted"
+                        ]["axiom"]: decimal_output(300),
+                        UNIVERSAL_CREDIT_AWARD_OUTPUTS["universal_credit_award_amount"][
+                            "axiom"
+                        ]: decimal_output(0),
                     }
                 }
             ]
@@ -2646,6 +2685,55 @@ def test_compare_outputs_matches_income_tax_section_11d_savings_income():
                         INCOME_TAX_SECTION_11D_OUTPUTS[
                             "income_tax_on_section_11d_savings_income"
                         ]["axiom"]: decimal_output(460),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 5
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_allows_section_11d_efrs_float_precision():
+    report = compare_outputs(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 7,
+                    "basic_rate_savings_income": 0,
+                    "higher_rate_savings_income": 0,
+                    "add_rate_savings_income": 7_571.5,
+                    "taxed_savings_income": 7_571.5,
+                    "savings_income_tax": 3_407.1748046875,
+                }
+            ],
+            "person_ids": [7],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        axiom_outputs_by_surface={
+            "income-tax-section-11d-savings-income": [
+                {
+                    "outputs": {
+                        INCOME_TAX_SECTION_11D_OUTPUTS[
+                            "savings_income_charged_at_savings_basic_rate"
+                        ]["axiom"]: decimal_output(0),
+                        INCOME_TAX_SECTION_11D_OUTPUTS[
+                            "savings_income_charged_at_savings_higher_rate"
+                        ]["axiom"]: decimal_output(0),
+                        INCOME_TAX_SECTION_11D_OUTPUTS[
+                            "savings_income_charged_at_savings_additional_rate"
+                        ]["axiom"]: decimal_output(7_571.275390625),
+                        INCOME_TAX_SECTION_11D_OUTPUTS[
+                            "savings_income_charged_under_section_11d"
+                        ]["axiom"]: decimal_output(7_571.275390625),
+                        INCOME_TAX_SECTION_11D_OUTPUTS[
+                            "income_tax_on_section_11d_savings_income"
+                        ]["axiom"]: decimal_output(3_407.07392578125),
                     }
                 }
             ]
@@ -2996,7 +3084,7 @@ def test_compare_outputs_classifies_known_policyengine_pension_credit_rates():
     assert report.oracle_divergences[0].issue_url.endswith("/issues/1740")
 
 
-def test_compare_outputs_classifies_policyengine_savings_credit_maximum_bug():
+def test_compare_outputs_no_longer_classifies_policyengine_savings_credit_bug():
     report = compare_outputs(
         pe_data={
             "persons": [],
@@ -3026,10 +3114,9 @@ def test_compare_outputs_classifies_policyengine_savings_credit_maximum_bug():
         relative_tolerance=0,
     )
 
-    assert report.mismatches == []
-    assert len(report.oracle_divergences) == 1
-    assert report.oracle_divergences[0].entity_id == "benunit_79791"
-    assert report.oracle_divergences[0].issue_url.endswith("/issues/1753")
+    assert len(report.mismatches) == 1
+    assert report.mismatches[0].entity_id == "benunit_79791"
+    assert report.oracle_divergences == []
 
 
 def test_compare_outputs_classifies_known_policyengine_pension_credit_additions():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.573"
+version = "0.2.574"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Pin UK EFRS oracle validation to policyengine-uk 2.88.42 and policyengine-core 3.26.11
- Remove stale known-divergence handling for PE-UK personal allowance rounding and pension-credit savings-credit bugs fixed upstream
- Map WRA 2012 section 8 Universal Credit award amount to the pre-take-up expression max(uc_maximum_amount - uc_income_reduction, 0), instead of PE's take-up-gated universal_credit_pre_benefit_cap
- Add an exact derived-expression mapping for uk:statutes/ukpga/2012/5/8#universal_credit_award_amount
- Raise the ITA 2007 section 11D EFRS float-precision tolerance from 10p to 25p after the all-row EFRS run found max 22.5p savings-band deltas

## Validation
- uv run --python 3.13 --with pytest --with pytest-cov python -m pytest tests/test_policyengine_efrs_uk.py -q
- Registry validation for the new derived-expression mapping
- Published PE-UK 2.88.42, all eligible EFRS rows: 115,612 people, 61,858 benefit units, 3,506,062 compared values, 0 mismatches, 0 oracle divergences

## Related PE fixes
- PolicyEngine/policyengine-uk#1755 fixed negative UC housing-cost elements by flooring the vectorized non-dependent-deduction subtraction at zero
- PolicyEngine/policyengine-uk#1756 triggered the 2.88.42 release containing that fix