### PR TITLE
Normalize escaped whitespace in numeric grounding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.572"
+version = "0.2.573"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.572"
+__version__ = "0.2.573"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -853,7 +853,7 @@ _MONTH_DAY_OF_MONTH_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _STRUCTURAL_SOURCE_SUBDIVISION_MARKER_PATTERN = re.compile(
-    r"(?<![A-Za-z0-9])\((?:[A-Za-z]|[ivxlcdmIVXLCDM]+|\d{1,2}(?:\.\d+)?)\)"
+    r"(?<![A-Za-z0-9])\((?:[A-Za-z]|[ivxlcdmIVXLCDM]+|0|[1-9]\d?(?:\.\d+)?)\)"
 )
 _TABLE_HEADING_PATTERN = re.compile(
     r"^\s*table\s+\d+[A-Za-z]?(?:\s*:.*)?$", re.IGNORECASE
@@ -2727,6 +2727,8 @@ def _span_overlaps(
 
 def _clean_source_text_for_numeric_extraction(text: str) -> str:
     """Strip structural source scaffolding before numeric extraction."""
+    text = re.sub(r"\\r\\n|\\n|\\r", "\n", text)
+    text = text.replace(r"\t", "\t")
     cleaned_lines: list[str] = []
     for line in text.splitlines():
         stripped = line.strip()

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5257,6 +5257,45 @@ rules:
     assert 1000000 in occurrences
 
 
+def test_rulespec_grounding_accepts_cardinal_words_split_by_escaped_newline():
+    content = """format: rulespec/v1
+rules:
+  - name: foreign_presence_period_day_count
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 548
+  - name: foreign_country_presence_day_threshold
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 450
+"""
+
+    source_text = (
+        "within any period of five hundred forty-eight consecutive days\\n"
+        "the taxpayer is present in a foreign country or countries for at least\\n"
+        "four hundred fifty days"
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    source_values = extract_numbers_from_text(source_text)
+    assert 548 in source_values
+    assert 450 in source_values
+
+
+def test_numeric_occurrence_extraction_treats_escaped_newline_as_line_break():
+    actual = "Table 1\n1 | 100\n2 | 200"
+    escaped = r"Table 1\n1 | 100\n2 | 200"
+
+    assert extract_numeric_occurrences_from_text(escaped) == (
+        extract_numeric_occurrences_from_text(actual)
+    )
+    assert extract_numbers_from_text(escaped) == extract_numbers_from_text(actual)
+
+
 def test_rulespec_grounding_treats_household_size_match_keys_as_structural():
     content = """format: rulespec/v1
 module:
@@ -19894,6 +19933,29 @@ rules:
 
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
     assert 15 in extract_numeric_occurrences_from_text(source_text)
+
+
+def test_ungrounded_numeric_preserves_zero_prefixed_decimal_parenthetical():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ny/statute/TAX/1310
+rules:
+  - name: city_eitc_phaseout_reduction_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2022-01-01'
+        formula: |-
+          0.002
+"""
+    source_text = (
+        "thirty percent reduced by the product of two-tenths of a percentage "
+        "point (0.002) and the amount of adjusted gross income in excess of $4,999"
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 0.002 in extract_numeric_occurrences_from_text(source_text)
 
 
 def test_ungrounded_numeric_accepts_source_mixed_unicode_fraction_percentage():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.572"
+version = "0.2.573"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Normalize escaped source whitespace before numeric grounding extraction so literal `\n`/`\r`/`\t` sequences do not break spelled-out statutory numbers.
- Add a regression for the NYC resident-definition phrasing that grounds both 548 and 450 from escaped source text.
- Bump axiom-encode to 0.2.573.

## Review cycle
- Independent review via codex read-only: no actionable findings.
- Reviewer check: `uv run pytest -q tests/test_rulespec_validation.py` -> 537 passed, 28 skipped.

## Local checks
- `uv run --python 3.13 --extra dev ruff check pyproject.toml src/axiom_encode scripts tests` -> passed.
- `python3.13 -m compileall -q src/axiom_encode scripts` -> passed.
- `uv run --python 3.13 --extra dev python -m pytest tests/test_rulespec_validation.py -k 'cardinal_words'` -> 2 passed.
- `uv run --python 3.13 --extra dev python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump` -> passed.
- Patched encoder validation of generated NY TAX 1305 candidate -> ci_pass true.
- `uv run --python 3.13 --extra dev pytest` -> 1740 passed, 59 skipped, 1 failed due local external rulespec-us cross-statute import drift unrelated to this PR (`tests/test_repo_cross_statute_imports.py::test_repo_cross_statute_definitions_are_imported`).
