### PR TITLE
Add UK UC childcare work-condition oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.575"
+version = "0.2.576"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.574"
+version = "0.2.575"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.575"
+__version__ = "0.2.576"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.574"
+__version__ = "0.2.575"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -34,7 +34,7 @@ from .ecps_tax import (
 DEFAULT_DATASET = "enhanced_frs_2023_24"
 WEEKS_IN_YEAR = 52
 MONTHS_IN_YEAR = 12
-POLICYENGINE_UK_VERSION = "2.88.42"
+POLICYENGINE_UK_VERSION = "2.88.43"
 
 NATIONAL_INSURANCE_SECTION_8_PROGRAM_PATH = Path("statutes/ukpga/1992/4/8.yaml")
 NATIONAL_INSURANCE_SECTION_8_BASE = "uk:statutes/ukpga/1992/4/8"
@@ -62,6 +62,8 @@ UNIVERSAL_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2013/376/36.yaml")
 UNIVERSAL_CREDIT_BASE = "uk:regulations/uksi/2013/376/36"
 UNIVERSAL_CREDIT_REGULATION_22_PROGRAM_PATH = Path("regulations/uksi/2013/376/22.yaml")
 UNIVERSAL_CREDIT_REGULATION_22_BASE = "uk:regulations/uksi/2013/376/22"
+UNIVERSAL_CREDIT_REGULATION_32_PROGRAM_PATH = Path("regulations/uksi/2013/376/32.yaml")
+UNIVERSAL_CREDIT_REGULATION_32_BASE = "uk:regulations/uksi/2013/376/32"
 UNIVERSAL_CREDIT_REGULATION_34_PROGRAM_PATH = Path("regulations/uksi/2013/376/34.yaml")
 UNIVERSAL_CREDIT_REGULATION_34_BASE = "uk:regulations/uksi/2013/376/34"
 UNIVERSAL_CREDIT_REGULATION_72_PROGRAM_PATH = Path("regulations/uksi/2013/376/72.yaml")
@@ -371,6 +373,16 @@ UNIVERSAL_CREDIT_CHILDCARE_OUTPUTS = {
     },
 }
 
+UNIVERSAL_CREDIT_CHILDCARE_WORK_CONDITION_OUTPUTS = {
+    "work_condition_met_for_assessment_period": {
+        "axiom": (
+            f"{UNIVERSAL_CREDIT_REGULATION_32_BASE}"
+            "#work_condition_met_for_assessment_period"
+        ),
+        "pe": "uc_childcare_work_condition",
+    },
+}
+
 UNIVERSAL_CREDIT_CHILDCARE_ELEMENT_OUTPUTS = {
     "childcare_costs_element_amount": {
         "axiom": f"{UNIVERSAL_CREDIT_REGULATION_34_BASE}#childcare_costs_element_amount",
@@ -480,6 +492,7 @@ class UKEFRSSurfaceSpec:
     entity: str
     outputs: dict[str, dict[str, Any]]
     pe_variables: tuple[str, ...]
+    projection_person_variables: tuple[str, ...] = ()
 
 
 SURFACE_SPECS = {
@@ -664,6 +677,16 @@ SURFACE_SPECS = {
         pe_variables=(
             "uc_childcare_element_eligible_children",
             "uc_maximum_childcare_element_amount",
+        ),
+    ),
+    "universal-credit-childcare-work-condition": UKEFRSSurfaceSpec(
+        program=UNIVERSAL_CREDIT_REGULATION_32_PROGRAM_PATH,
+        entity="benunit",
+        outputs=UNIVERSAL_CREDIT_CHILDCARE_WORK_CONDITION_OUTPUTS,
+        pe_variables=("uc_childcare_work_condition",),
+        projection_person_variables=(
+            "in_work",
+            "is_adult",
         ),
     ),
     "universal-credit-childcare-element": UKEFRSSurfaceSpec(
@@ -1238,6 +1261,10 @@ def load_local_policyengine_uk_data(
                 period=year,
                 map_to="benunit",
             ).values
+        merged_benunits = add_universal_credit_childcare_work_projection_columns(
+            merged_benunits,
+            merged,
+        )
         benunit_records = table_records(merged_benunits)
         selected_benunit_ids = ()
         if person_ids:
@@ -1304,6 +1331,51 @@ def add_policyengine_uk_benunit_weights(
         ],
         errors="ignore",
     )
+
+
+def add_universal_credit_childcare_work_projection_columns(
+    benunit: Any,
+    person: Any,
+) -> Any:
+    required = {"person_benunit_id", "is_adult", "in_work"}
+    if not required.issubset(set(person.columns)):
+        return benunit
+    projection = person[["person_benunit_id"]].copy()
+    is_adult = person["is_adult"].astype(bool)
+    in_work = person["in_work"].astype(bool)
+    projection["uc_childcare_adult_count"] = is_adult.astype(int)
+    projection["uc_childcare_adult_in_work_count"] = (is_adult & in_work).astype(int)
+    projection["uc_childcare_adult_not_in_work_count"] = (is_adult & ~in_work).astype(
+        int
+    )
+    by_benunit = projection.groupby("person_benunit_id", dropna=False).sum()
+    by_benunit["uc_childcare_any_adult_in_work"] = (
+        by_benunit["uc_childcare_adult_in_work_count"] > 0
+    )
+    by_benunit["uc_childcare_all_adults_in_work"] = (
+        by_benunit["uc_childcare_adult_not_in_work_count"] == 0
+    )
+    by_benunit = by_benunit[
+        [
+            "uc_childcare_adult_count",
+            "uc_childcare_any_adult_in_work",
+            "uc_childcare_all_adults_in_work",
+        ]
+    ].reset_index()
+    merged = benunit.merge(
+        by_benunit,
+        left_on="benunit_id",
+        right_on="person_benunit_id",
+        how="left",
+    ).drop(columns=["person_benunit_id"], errors="ignore")
+    merged["uc_childcare_adult_count"] = merged["uc_childcare_adult_count"].fillna(0)
+    merged["uc_childcare_any_adult_in_work"] = merged[
+        "uc_childcare_any_adult_in_work"
+    ].fillna(False)
+    merged["uc_childcare_all_adults_in_work"] = merged[
+        "uc_childcare_all_adults_in_work"
+    ].fillna(True)
+    return merged
 
 
 def resolve_policyengine_uk_dataset_reference(dataset: str) -> str:
@@ -1434,6 +1506,8 @@ def policyengine_variables_for_surfaces(
         spec = SURFACE_SPECS[surface]
         if spec.entity == entity:
             variables.update(spec.pe_variables)
+        if entity == "person":
+            variables.update(spec.projection_person_variables)
     return tuple(sorted(variables))
 
 
@@ -2212,6 +2286,11 @@ def build_axiom_request(
             pe_data=pe_data,
             year=year,
         )
+    if surface == "universal-credit-childcare-work-condition":
+        return build_universal_credit_childcare_work_condition_request(
+            pe_data=pe_data,
+            year=year,
+        )
     if surface == "universal-credit-award":
         return build_universal_credit_award_request(pe_data=pe_data, year=year)
     if surface == "universal-credit-housing-costs":
@@ -2746,6 +2825,43 @@ def build_universal_credit_childcare_element_request(
     }
 
 
+def build_universal_credit_childcare_work_condition_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = benefit_month_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "universal-credit-childcare-work-condition"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_universal_credit_childcare_work_condition_inputs(
+            row
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{UNIVERSAL_CREDIT_REGULATION_32_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in UNIVERSAL_CREDIT_CHILDCARE_WORK_CONDITION_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def build_universal_credit_award_request(
     *, pe_data: dict[str, Any], year: int
 ) -> dict[str, Any]:
@@ -3165,6 +3281,37 @@ def project_universal_credit_childcare_element_inputs(row: Any) -> dict[str, Any
     }
 
 
+def project_universal_credit_childcare_work_condition_inputs(
+    row: Any,
+) -> dict[str, Any]:
+    adult_count = int(money(row_value(row, "uc_childcare_adult_count", 0)))
+    return {
+        "claimant_in_paid_work": bool(
+            row_value(row, "uc_childcare_any_adult_in_work", False)
+        ),
+        "claimant_ceased_paid_work_in_assessment_period": False,
+        "claimant_ceased_paid_work_in_previous_assessment_period": False,
+        "assessment_period_is_first_or_second_assessment_period_in_relation_to_award": False,
+        "claimant_ceased_paid_work_in_month_immediately_preceding_award_commencement": False,
+        "claimant_receiving_statutory_sick_pay": False,
+        "claimant_receiving_statutory_maternity_pay": False,
+        "claimant_receiving_statutory_paternity_pay": False,
+        "claimant_receiving_statutory_adoption_pay": False,
+        "claimant_receiving_statutory_shared_parental_pay": False,
+        "claimant_receiving_statutory_parental_bereavement_pay": False,
+        "claimant_receiving_statutory_neonatal_care_pay": False,
+        "claimant_receiving_maternity_allowance": False,
+        "claimant_has_offer_of_paid_work_due_to_start_before_end_of_next_assessment_period": False,
+        "claimant_is_member_of_couple": adult_count > 1,
+        "other_member_in_paid_work": bool(
+            row_value(row, "uc_childcare_all_adults_in_work", False)
+        ),
+        "other_member_has_limited_capability_for_work": False,
+        "other_member_has_regular_and_substantial_caring_responsibilities_for_severely_disabled_person": False,
+        "other_member_temporarily_absent_from_claimants_household": False,
+    }
+
+
 def project_universal_credit_housing_costs_inputs(row: Any) -> dict[str, Any]:
     monthly_housing_costs = money(row_value(row, "uc_housing_costs_element", 0)) / (
         MONTHS_IN_YEAR
@@ -3564,6 +3711,12 @@ def compare_outputs(
             "uc_maximum_childcare_element_amount divided by 12 as the regulation "
             "36 maximum, and projects excluded, reimbursed, and other-support "
             "amounts to zero.",
+            "Universal Credit Regulation 32 childcare work-condition comparison "
+            "aggregates PolicyEngine person-level is_adult and in_work outputs "
+            "within each benefit unit, projects statutory treated-as-in-work and "
+            "other-unable-to-provide-childcare exceptions false, and compares "
+            "the resulting RuleSpec work-condition judgment against "
+            "PolicyEngine's uc_childcare_work_condition.",
             "The protected LCWRA Regulation 36 table amount is compared only "
             "when PolicyEngine exposes the raw protected amount. Current "
             "PolicyEngine UK EFRS outputs apply the July 2025 UC rebalancing "

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -690,6 +690,17 @@ mappings:
     comparison: money
     rationale: Same Universal Credit tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit assessed capital to the Regulation 72 capital leaf and converts PolicyEngine's annual output to a monthly amount.
 
+  - legal_id: uk:regulations/uksi/2013/376/32#work_condition_met_for_assessment_period
+    country: uk
+    program: universal_credit
+    mapping_type: direct_variable
+    policyengine_variable: uc_childcare_work_condition
+    entity: benunit
+    period: month
+    unit: bool
+    comparison: bool
+    rationale: Same Universal Credit childcare work-condition predicate, with the EFRS oracle projecting person-level adult work status into the Regulation 32 claimant and other-member work leaves.
+
 prefixes:
   - legal_id_prefix: uk:statutes/ukpga/2007/3/35#
     country: uk
@@ -792,17 +803,6 @@ prefixes:
     program: universal_credit
     mapping_type: not_comparable
     rationale: Universal Credit regulation 31 childcare cost element inclusion is a source-level gate; PolicyEngine UK exposes downstream element amounts rather than this predicate separately.
-
-  - legal_id: uk:regulations/uksi/2013/376/32#work_condition_met_for_assessment_period
-    country: uk
-    program: universal_credit
-    mapping_type: direct_variable
-    policyengine_variable: uc_childcare_work_condition
-    entity: benunit
-    period: month
-    unit: bool
-    comparison: bool
-    rationale: Same Universal Credit childcare work-condition predicate, with the EFRS oracle projecting person-level adult work status into the Regulation 32 claimant and other-member work leaves.
 
   - legal_id_prefix: uk:regulations/uksi/2013/376/32#
     country: uk

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -793,11 +793,22 @@ prefixes:
     mapping_type: not_comparable
     rationale: Universal Credit regulation 31 childcare cost element inclusion is a source-level gate; PolicyEngine UK exposes downstream element amounts rather than this predicate separately.
 
+  - legal_id: uk:regulations/uksi/2013/376/32#work_condition_met_for_assessment_period
+    country: uk
+    program: universal_credit
+    mapping_type: direct_variable
+    policyengine_variable: uc_childcare_work_condition
+    entity: benunit
+    period: month
+    unit: bool
+    comparison: bool
+    rationale: Same Universal Credit childcare work-condition predicate, with the EFRS oracle projecting person-level adult work status into the Regulation 32 claimant and other-member work leaves.
+
   - legal_id_prefix: uk:regulations/uksi/2013/376/32#
     country: uk
     program: universal_credit
     mapping_type: not_comparable
-    rationale: Universal Credit regulation 32 paid-work and unable-to-provide-childcare predicates are source-level childcare work-condition tests not exposed as one-to-one PolicyEngine UK variables.
+    rationale: Remaining Universal Credit regulation 32 paid-work, treated-as-in-work, and unable-to-provide-childcare helper predicates are source-level childcare work-condition inputs not exposed as one-to-one PolicyEngine UK variables.
 
   - legal_id_prefix: uk:regulations/uksi/2013/376/33#
     country: uk

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -36,10 +36,12 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     UNIVERSAL_CREDIT_AWARD_OUTPUTS,
     UNIVERSAL_CREDIT_CHILD_ELEMENT_OUTPUTS,
     UNIVERSAL_CREDIT_CHILDCARE_ELEMENT_OUTPUTS,
+    UNIVERSAL_CREDIT_CHILDCARE_WORK_CONDITION_OUTPUTS,
     UNIVERSAL_CREDIT_HOUSING_COSTS_OUTPUTS,
     UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS,
     UNIVERSAL_CREDIT_LCWRA_OUTPUTS,
     UNIVERSAL_CREDIT_REGULATION_22_BASE,
+    UNIVERSAL_CREDIT_REGULATION_32_BASE,
     UNIVERSAL_CREDIT_REGULATION_34_BASE,
     UNIVERSAL_CREDIT_REGULATION_72_BASE,
     UNIVERSAL_CREDIT_STANDARD_ALLOWANCE_OUTPUTS,
@@ -62,6 +64,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_uk_efrs_coverage_report,
     build_universal_credit_award_request,
     build_universal_credit_childcare_element_request,
+    build_universal_credit_childcare_work_condition_request,
     build_universal_credit_housing_costs_request,
     build_universal_credit_income_deduction_request,
     build_universal_credit_request,
@@ -85,6 +88,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_state_pension_credit_savings_credit_inputs,
     project_universal_credit_award_inputs,
     project_universal_credit_childcare_element_inputs,
+    project_universal_credit_childcare_work_condition_inputs,
     project_universal_credit_housing_costs_inputs,
     project_universal_credit_income_deduction_inputs,
     project_universal_credit_tariff_income_inputs,
@@ -96,6 +100,10 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
 
 def decimal_output(value):
     return {"value": {"value": str(value)}}
+
+
+def judgment_output(holds):
+    return {"kind": "judgment", "outcome": "holds" if holds else "not_holds"}
 
 
 def test_national_insurance_class_1_request_projects_weekly_inputs(monkeypatch):
@@ -1308,6 +1316,129 @@ def test_universal_credit_childcare_element_request_projects_regulation_34_input
     }
 
 
+def test_universal_credit_childcare_work_condition_projection_uses_adult_work_flags():
+    assert project_universal_credit_childcare_work_condition_inputs(
+        {
+            "uc_childcare_adult_count": 2,
+            "uc_childcare_any_adult_in_work": True,
+            "uc_childcare_all_adults_in_work": False,
+        }
+    ) == {
+        "claimant_in_paid_work": True,
+        "claimant_ceased_paid_work_in_assessment_period": False,
+        "claimant_ceased_paid_work_in_previous_assessment_period": False,
+        "assessment_period_is_first_or_second_assessment_period_in_relation_to_award": False,
+        "claimant_ceased_paid_work_in_month_immediately_preceding_award_commencement": False,
+        "claimant_receiving_statutory_sick_pay": False,
+        "claimant_receiving_statutory_maternity_pay": False,
+        "claimant_receiving_statutory_paternity_pay": False,
+        "claimant_receiving_statutory_adoption_pay": False,
+        "claimant_receiving_statutory_shared_parental_pay": False,
+        "claimant_receiving_statutory_parental_bereavement_pay": False,
+        "claimant_receiving_statutory_neonatal_care_pay": False,
+        "claimant_receiving_maternity_allowance": False,
+        "claimant_has_offer_of_paid_work_due_to_start_before_end_of_next_assessment_period": False,
+        "claimant_is_member_of_couple": True,
+        "other_member_in_paid_work": False,
+        "other_member_has_limited_capability_for_work": False,
+        "other_member_has_regular_and_substantial_caring_responsibilities_for_severely_disabled_person": False,
+        "other_member_temporarily_absent_from_claimants_household": False,
+    }
+
+    single_projection = project_universal_credit_childcare_work_condition_inputs(
+        {
+            "uc_childcare_adult_count": 1,
+            "uc_childcare_any_adult_in_work": True,
+            "uc_childcare_all_adults_in_work": True,
+        }
+    )
+    assert single_projection["claimant_is_member_of_couple"] is False
+    assert single_projection["claimant_in_paid_work"] is True
+
+
+def test_universal_credit_childcare_work_condition_request_projects_regulation_32_inputs():
+    request = build_universal_credit_childcare_work_condition_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "uc_childcare_adult_count": 2,
+                    "uc_childcare_any_adult_in_work": True,
+                    "uc_childcare_all_adults_in_work": False,
+                    "uc_childcare_work_condition": False,
+                }
+            ],
+            "benunit_ids": [11],
+        },
+        year=2026,
+    )
+
+    assert request["mode"] == "explain"
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_11",
+            "period": {
+                "period_kind": "month",
+                "name": "benefit_month",
+                "start": "2026-04-01",
+                "end": "2026-04-30",
+            },
+            "outputs": list(
+                output["axiom"]
+                for output in UNIVERSAL_CREDIT_CHILDCARE_WORK_CONDITION_OUTPUTS.values()
+            ),
+        }
+    ]
+    inputs_by_name = {
+        record["name"]: record["value"] for record in request["dataset"]["inputs"]
+    }
+    assert inputs_by_name[
+        f"{UNIVERSAL_CREDIT_REGULATION_32_BASE}#input.claimant_in_paid_work"
+    ] == {
+        "kind": "bool",
+        "value": True,
+    }
+    assert inputs_by_name[
+        f"{UNIVERSAL_CREDIT_REGULATION_32_BASE}#input.claimant_is_member_of_couple"
+    ] == {
+        "kind": "bool",
+        "value": True,
+    }
+    assert inputs_by_name[
+        f"{UNIVERSAL_CREDIT_REGULATION_32_BASE}#input.other_member_in_paid_work"
+    ] == {
+        "kind": "bool",
+        "value": False,
+    }
+
+
+def test_adds_universal_credit_childcare_work_projection_columns():
+    pd = pytest.importorskip("pandas")
+    benunit = pd.DataFrame({"benunit_id": [10, 11, 12]})
+    person = pd.DataFrame(
+        {
+            "person_benunit_id": [10, 10, 11],
+            "is_adult": [True, True, True],
+            "in_work": [True, False, True],
+        }
+    )
+
+    projected = efrs_uk.add_universal_credit_childcare_work_projection_columns(
+        benunit,
+        person,
+    ).set_index("benunit_id")
+
+    assert projected.loc[10, "uc_childcare_adult_count"] == 2
+    assert bool(projected.loc[10, "uc_childcare_any_adult_in_work"]) is True
+    assert bool(projected.loc[10, "uc_childcare_all_adults_in_work"]) is False
+    assert projected.loc[11, "uc_childcare_adult_count"] == 1
+    assert bool(projected.loc[11, "uc_childcare_all_adults_in_work"]) is True
+    assert projected.loc[12, "uc_childcare_adult_count"] == 0
+    assert bool(projected.loc[12, "uc_childcare_any_adult_in_work"]) is False
+
+
 def test_universal_credit_housing_costs_projection_uses_monthly_amount():
     projected = project_universal_credit_housing_costs_inputs(
         {"uc_housing_costs_element": 360}
@@ -1909,6 +2040,15 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "uc_childcare_element",
         "uc_maximum_childcare_element_amount",
     )
+    assert policyengine_person_variables_for_surfaces(
+        ["universal-credit-childcare-work-condition"]
+    ) == (
+        "in_work",
+        "is_adult",
+    )
+    assert policyengine_benunit_variables_for_surfaces(
+        ["universal-credit-childcare-work-condition"]
+    ) == ("uc_childcare_work_condition",)
     assert policyengine_benunit_variables_for_surfaces(
         ["universal-credit-work-allowance"]
     ) == (
@@ -2099,7 +2239,7 @@ def test_policyengine_uk_version_guard_rejects_unpinned_version(monkeypatch):
 
     monkeypatch.setattr(efrs_uk, "version", fake_version)
 
-    with pytest.raises(SystemExit, match="policyengine-uk==2.88.42 required"):
+    with pytest.raises(SystemExit, match="policyengine-uk==2.88.43 required"):
         require_policyengine_uk_versions()
 
 
@@ -2513,6 +2653,50 @@ def test_compare_outputs_transforms_universal_credit_childcare_element_monthly()
     )
 
     assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_handles_universal_credit_childcare_work_condition():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "uc_childcare_work_condition": True,
+                },
+                {
+                    "benunit_id": 12,
+                    "uc_childcare_work_condition": False,
+                },
+            ],
+            "benunit_ids": [11, 12],
+        },
+        axiom_outputs_by_surface={
+            "universal-credit-childcare-work-condition": [
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_CHILDCARE_WORK_CONDITION_OUTPUTS[
+                            "work_condition_met_for_assessment_period"
+                        ]["axiom"]: judgment_output(True),
+                    }
+                },
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_CHILDCARE_WORK_CONDITION_OUTPUTS[
+                            "work_condition_met_for_assessment_period"
+                        ]["axiom"]: judgment_output(False),
+                    }
+                },
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 2
     assert report.mismatches == []
     assert report.oracle_divergences == []
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.574"
+version = "0.2.575"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.575"
+version = "0.2.576"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Add the UK Universal Credit Regulation 32 childcare work-condition EFRS oracle surface for `uc_childcare_work_condition`.
- Project person-level `is_adult` and `in_work` outputs to benefit-unit inputs instead of feeding the target PE output back into Axiom.
- Add an exact mapping for `uk:regulations/uksi/2013/376/32#work_condition_met_for_assessment_period` and keep remaining Regulation 32 helper predicates marked not comparable.
- Pin `policyengine-uk==2.88.43`, which includes PolicyEngine/policyengine-uk#1757.

## Validation
- `uv run ruff check src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py`
- `uv run ruff format --check src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py`
- `git diff --check`
- `uv run --python 3.13 --with pytest --with pytest-cov python -m pytest tests/test_policyengine_efrs_uk.py -q` -> 85 passed, 1 skipped
- `uv run --python 3.13 --with pytest --with pytest-cov python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q` -> 2 passed
- Full local EFRS compare against published `policyengine-uk==2.88.43`: 3,567,918 compared values, 0 mismatches, 0 oracle divergences.
- New Regulation 32 output alone: 61,858 compared benefit units, 0 mismatches, 0 oracle divergences.

## Related
- Depends on merged/released PolicyEngine/policyengine-uk#1757, which fixed the PE couple work-condition behavior found by this oracle comparison.