### PR TITLE
Add UK capital and legacy tariff oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.578"
+version = "0.2.579"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.576"
+version = "0.2.577"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.579"
+version = "0.2.580"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.577"
+version = "0.2.578"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.576"
+__version__ = "0.2.577"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.578"
+__version__ = "0.2.579"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.577"
+__version__ = "0.2.578"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.579"
+__version__ = "0.2.580"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -17,7 +17,7 @@ from collections import Counter, defaultdict
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 import yaml
 
@@ -62,6 +62,18 @@ PENSION_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2002/1792/6.yaml")
 PENSION_CREDIT_BASE = "uk:regulations/uksi/2002/1792/6"
 PENSION_CREDIT_REGULATION_15_PROGRAM_PATH = Path("regulations/uksi/2002/1792/15.yaml")
 PENSION_CREDIT_REGULATION_15_BASE = "uk:regulations/uksi/2002/1792/15"
+ESA_REGULATION_118_PROGRAM_PATH = Path("regulations/uksi/2008/794/118.yaml")
+ESA_REGULATION_118_BASE = "uk:regulations/uksi/2008/794/118"
+JSA_REGULATION_116_PROGRAM_PATH = Path("regulations/uksi/1996/207/116.yaml")
+JSA_REGULATION_116_BASE = "uk:regulations/uksi/1996/207/116"
+INCOME_SUPPORT_REGULATION_53_PROGRAM_PATH = Path("regulations/uksi/1987/1967/53.yaml")
+INCOME_SUPPORT_REGULATION_53_BASE = "uk:regulations/uksi/1987/1967/53"
+HOUSING_BENEFIT_REGULATION_52_PROGRAM_PATH = Path("regulations/uksi/2006/213/52.yaml")
+HOUSING_BENEFIT_REGULATION_52_BASE = "uk:regulations/uksi/2006/213/52"
+HOUSING_BENEFIT_PENSION_AGE_REGULATION_29_PROGRAM_PATH = Path(
+    "regulations/uksi/2006/214/29.yaml"
+)
+HOUSING_BENEFIT_PENSION_AGE_REGULATION_29_BASE = "uk:regulations/uksi/2006/214/29"
 UNIVERSAL_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2013/376/36.yaml")
 UNIVERSAL_CREDIT_BASE = "uk:regulations/uksi/2013/376/36"
 UNIVERSAL_CREDIT_REGULATION_18_PROGRAM_PATH = Path("regulations/uksi/2013/376/18.yaml")
@@ -307,6 +319,58 @@ PENSION_CREDIT_DEEMED_INCOME_OUTPUTS = {
         "pe": "pension_credit_deemed_income",
         "pe_transform": "annual_to_weekly",
         "tolerance": 0.01,
+    },
+}
+
+ESA_TARIFF_INCOME_OUTPUTS = {
+    "capital_tariff_weekly_income": {
+        "axiom": f"{ESA_REGULATION_118_BASE}#capital_tariff_weekly_income",
+        "pe": "esa_income_tariff_income",
+        "pe_transform": "annual_to_weekly",
+        "capital_pe": "esa_income_assessable_capital",
+        "applies": "legacy_capital_tariff_income_defined",
+    },
+}
+
+JSA_TARIFF_INCOME_OUTPUTS = {
+    "capital_tariff_weekly_income": {
+        "axiom": f"{JSA_REGULATION_116_BASE}#capital_tariff_weekly_income",
+        "pe": "jsa_income_tariff_income",
+        "pe_transform": "annual_to_weekly",
+        "capital_pe": "jsa_income_assessable_capital",
+        "applies": "legacy_capital_tariff_income_defined",
+    },
+}
+
+INCOME_SUPPORT_TARIFF_INCOME_OUTPUTS = {
+    "capital_tariff_weekly_income": {
+        "axiom": f"{INCOME_SUPPORT_REGULATION_53_BASE}#capital_tariff_weekly_income",
+        "pe": "income_support_tariff_income",
+        "pe_transform": "annual_to_weekly",
+        "capital_pe": "income_support_assessable_capital",
+        "applies": "legacy_capital_tariff_income_defined",
+    },
+}
+
+HOUSING_BENEFIT_WORKING_AGE_TARIFF_INCOME_OUTPUTS = {
+    "capital_tariff_weekly_income": {
+        "axiom": f"{HOUSING_BENEFIT_REGULATION_52_BASE}#capital_tariff_weekly_income",
+        "pe": "housing_benefit_tariff_income",
+        "pe_transform": "annual_to_weekly",
+        "capital_pe": "housing_benefit_assessable_capital",
+        "applies": "housing_benefit_working_age_tariff_income_defined",
+    },
+}
+
+HOUSING_BENEFIT_PENSION_AGE_TARIFF_INCOME_OUTPUTS = {
+    "capital_tariff_weekly_income": {
+        "axiom": (
+            f"{HOUSING_BENEFIT_PENSION_AGE_REGULATION_29_BASE}"
+            "#capital_tariff_weekly_income"
+        ),
+        "pe": "housing_benefit_tariff_income",
+        "pe_transform": "annual_to_weekly",
+        "applies": "housing_benefit_pension_age_tariff_income_defined",
     },
 }
 
@@ -698,6 +762,55 @@ SURFACE_SPECS = {
             "pension_credit_assessable_capital",
             "pension_credit_deemed_income",
         ),
+    ),
+    "esa-income-tariff-income": UKEFRSSurfaceSpec(
+        program=ESA_REGULATION_118_PROGRAM_PATH,
+        entity="benunit",
+        outputs=ESA_TARIFF_INCOME_OUTPUTS,
+        pe_variables=(
+            "esa_income_assessable_capital",
+            "esa_income_tariff_income",
+        ),
+    ),
+    "jsa-income-tariff-income": UKEFRSSurfaceSpec(
+        program=JSA_REGULATION_116_PROGRAM_PATH,
+        entity="benunit",
+        outputs=JSA_TARIFF_INCOME_OUTPUTS,
+        pe_variables=(
+            "jsa_income_assessable_capital",
+            "jsa_income_tariff_income",
+        ),
+    ),
+    "income-support-tariff-income": UKEFRSSurfaceSpec(
+        program=INCOME_SUPPORT_REGULATION_53_PROGRAM_PATH,
+        entity="benunit",
+        outputs=INCOME_SUPPORT_TARIFF_INCOME_OUTPUTS,
+        pe_variables=(
+            "income_support_assessable_capital",
+            "income_support_tariff_income",
+        ),
+    ),
+    "housing-benefit-working-age-tariff-income": UKEFRSSurfaceSpec(
+        program=HOUSING_BENEFIT_REGULATION_52_PROGRAM_PATH,
+        entity="benunit",
+        outputs=HOUSING_BENEFIT_WORKING_AGE_TARIFF_INCOME_OUTPUTS,
+        pe_variables=(
+            "guarantee_credit",
+            "housing_benefit_assessable_capital",
+            "housing_benefit_tariff_income",
+        ),
+        projection_person_variables=("is_SP_age",),
+    ),
+    "housing-benefit-pension-age-tariff-income": UKEFRSSurfaceSpec(
+        program=HOUSING_BENEFIT_PENSION_AGE_REGULATION_29_PROGRAM_PATH,
+        entity="benunit",
+        outputs=HOUSING_BENEFIT_PENSION_AGE_TARIFF_INCOME_OUTPUTS,
+        pe_variables=(
+            "guarantee_credit",
+            "housing_benefit_assessable_capital",
+            "housing_benefit_tariff_income",
+        ),
+        projection_person_variables=("is_SP_age",),
     ),
     "universal-credit-standard-allowance": UKEFRSSurfaceSpec(
         program=UNIVERSAL_CREDIT_PROGRAM_PATH,
@@ -1333,6 +1446,10 @@ def load_local_policyengine_uk_data(
             merged_benunits,
             merged,
         )
+        merged_benunits = add_housing_benefit_age_projection_columns(
+            merged_benunits,
+            merged,
+        )
         benunit_records = table_records(merged_benunits)
         selected_benunit_ids = ()
         if person_ids:
@@ -1443,6 +1560,32 @@ def add_universal_credit_childcare_work_projection_columns(
     merged["uc_childcare_all_adults_in_work"] = merged[
         "uc_childcare_all_adults_in_work"
     ].fillna(True)
+    return merged
+
+
+def add_housing_benefit_age_projection_columns(
+    benunit: Any,
+    person: Any,
+) -> Any:
+    required = {"person_benunit_id", "is_SP_age"}
+    if not required.issubset(set(person.columns)):
+        return benunit
+    projection = person[["person_benunit_id"]].copy()
+    projection["housing_benefit_sp_age_count"] = person["is_SP_age"].astype(int)
+    by_benunit = projection.groupby("person_benunit_id", dropna=False).sum()
+    by_benunit["housing_benefit_any_over_sp_age"] = (
+        by_benunit["housing_benefit_sp_age_count"] > 0
+    )
+    by_benunit = by_benunit[["housing_benefit_any_over_sp_age"]].reset_index()
+    merged = benunit.merge(
+        by_benunit,
+        left_on="benunit_id",
+        right_on="person_benunit_id",
+        how="left",
+    ).drop(columns=["person_benunit_id"], errors="ignore")
+    merged["housing_benefit_any_over_sp_age"] = merged[
+        "housing_benefit_any_over_sp_age"
+    ].fillna(False)
     return merged
 
 
@@ -2359,6 +2502,25 @@ def build_axiom_request(
             pe_data=pe_data,
             year=year,
         )
+    if surface == "esa-income-tariff-income":
+        return build_esa_income_tariff_income_request(pe_data=pe_data, year=year)
+    if surface == "jsa-income-tariff-income":
+        return build_jsa_income_tariff_income_request(pe_data=pe_data, year=year)
+    if surface == "income-support-tariff-income":
+        return build_income_support_tariff_income_request(
+            pe_data=pe_data,
+            year=year,
+        )
+    if surface == "housing-benefit-working-age-tariff-income":
+        return build_housing_benefit_working_age_tariff_income_request(
+            pe_data=pe_data,
+            year=year,
+        )
+    if surface == "housing-benefit-pension-age-tariff-income":
+        return build_housing_benefit_pension_age_tariff_income_request(
+            pe_data=pe_data,
+            year=year,
+        )
     if surface == "universal-credit-childcare-element":
         return build_universal_credit_childcare_element_request(
             pe_data=pe_data,
@@ -2839,6 +3001,109 @@ def build_pension_credit_deemed_income_request(
         "dataset": {"inputs": inputs, "relations": []},
         "queries": queries,
     }
+
+
+def build_legacy_weekly_tariff_income_request(
+    *,
+    pe_data: dict[str, Any],
+    year: int,
+    surface: str,
+    base: str,
+    outputs: dict[str, dict[str, Any]],
+    project_inputs: Callable[[Any], dict[str, Any]],
+) -> dict[str, Any]:
+    interval = benefit_week_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, surface):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{base}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [spec["axiom"] for spec in outputs.values()],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_esa_income_tariff_income_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    return build_legacy_weekly_tariff_income_request(
+        pe_data=pe_data,
+        year=year,
+        surface="esa-income-tariff-income",
+        base=ESA_REGULATION_118_BASE,
+        outputs=ESA_TARIFF_INCOME_OUTPUTS,
+        project_inputs=project_esa_income_tariff_income_inputs,
+    )
+
+
+def build_jsa_income_tariff_income_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    return build_legacy_weekly_tariff_income_request(
+        pe_data=pe_data,
+        year=year,
+        surface="jsa-income-tariff-income",
+        base=JSA_REGULATION_116_BASE,
+        outputs=JSA_TARIFF_INCOME_OUTPUTS,
+        project_inputs=project_jsa_income_tariff_income_inputs,
+    )
+
+
+def build_income_support_tariff_income_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    return build_legacy_weekly_tariff_income_request(
+        pe_data=pe_data,
+        year=year,
+        surface="income-support-tariff-income",
+        base=INCOME_SUPPORT_REGULATION_53_BASE,
+        outputs=INCOME_SUPPORT_TARIFF_INCOME_OUTPUTS,
+        project_inputs=project_income_support_tariff_income_inputs,
+    )
+
+
+def build_housing_benefit_working_age_tariff_income_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    return build_legacy_weekly_tariff_income_request(
+        pe_data=pe_data,
+        year=year,
+        surface="housing-benefit-working-age-tariff-income",
+        base=HOUSING_BENEFIT_REGULATION_52_BASE,
+        outputs=HOUSING_BENEFIT_WORKING_AGE_TARIFF_INCOME_OUTPUTS,
+        project_inputs=project_housing_benefit_working_age_tariff_income_inputs,
+    )
+
+
+def build_housing_benefit_pension_age_tariff_income_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    return build_legacy_weekly_tariff_income_request(
+        pe_data=pe_data,
+        year=year,
+        surface="housing-benefit-pension-age-tariff-income",
+        base=HOUSING_BENEFIT_PENSION_AGE_REGULATION_29_BASE,
+        outputs=HOUSING_BENEFIT_PENSION_AGE_TARIFF_INCOME_OUTPUTS,
+        project_inputs=project_housing_benefit_pension_age_tariff_income_inputs,
+    )
 
 
 def build_state_pension_credit_guarantee_credit_request(
@@ -3586,6 +3851,51 @@ def project_pension_credit_deemed_income_inputs(row: Any) -> dict[str, Any]:
     }
 
 
+def project_esa_income_tariff_income_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "claimant_capital": money(row_value(row, "esa_income_assessable_capital", 0)),
+        "claimant_in_prescribed_accommodation_under_regulation_118_3": False,
+    }
+
+
+def project_jsa_income_tariff_income_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "claimant_capital": money(row_value(row, "jsa_income_assessable_capital", 0)),
+        "claimant_in_prescribed_accommodation_under_regulation_116_1B": False,
+    }
+
+
+def project_income_support_tariff_income_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "claimant_capital": money(
+            row_value(row, "income_support_assessable_capital", 0)
+        ),
+        "claimant_in_prescribed_accommodation_under_regulation_53_1B": False,
+    }
+
+
+def project_housing_benefit_working_age_tariff_income_inputs(
+    row: Any,
+) -> dict[str, Any]:
+    return {
+        "claimant_capital": money(
+            row_value(row, "housing_benefit_assessable_capital", 0)
+        ),
+        "claimant_in_prescribed_circumstances_under_regulation_52_4": False,
+    }
+
+
+def project_housing_benefit_pension_age_tariff_income_inputs(
+    row: Any,
+) -> dict[str, Any]:
+    return {
+        "claimant_capital": money(
+            row_value(row, "housing_benefit_assessable_capital", 0)
+        ),
+        "capital_disregarded_under_regulation_44_2": False,
+    }
+
+
 def project_universal_credit_assessable_capital_inputs(row: Any) -> dict[str, Any]:
     return {
         "claim_is_for_joint_claimants": False,
@@ -3953,6 +4263,22 @@ def compare_outputs(
             "exclusions upstream, and compares weekly RuleSpec deemed income "
             "against PolicyEngine's annual pension_credit_deemed_income "
             "divided by 52.",
+            "ESA, JSA, Income Support, and working-age Housing Benefit "
+            "tariff-income comparisons project PolicyEngine's corresponding "
+            "assessable-capital stock into the claimant-capital leaf, project "
+            "the prescribed-accommodation or prescribed-circumstances branch "
+            "false because PE does not expose those legal predicates, and "
+            "compare only rows at or below the GBP 16,000 statutory capital "
+            "limit. PolicyEngine computes its internal tariff variable beyond "
+            "that limit, but those rows are outside the direct tariff-income "
+            "oracle surface.",
+            "Pension-age Housing Benefit tariff-income comparison projects "
+            "PolicyEngine's housing_benefit_assessable_capital into the "
+            "claimant-capital leaf, projects the regulation 44(2) "
+            "capital-disregard exception false because PE applies capital "
+            "exclusions upstream, and compares non-guarantee-credit "
+            "pension-age rows against PolicyEngine's annual "
+            "housing_benefit_tariff_income divided by 52.",
             "Universal Credit Regulation 34 childcare-costs element comparison "
             "projects PolicyEngine's annual uc_childcare_element into monthly "
             "relevant childcare charges by reversing the statutory 85 percent "
@@ -4087,6 +4413,16 @@ def output_applies(spec: dict[str, Any], row: Any) -> bool:
         )
     if applies == "uc_tariff_income_defined":
         return bool(row_value(row, "is_uc_eligible", False))
+    if applies == "legacy_capital_tariff_income_defined":
+        return money(row_value(row, spec["capital_pe"], 0)) <= 16_000
+    if applies == "housing_benefit_working_age_tariff_income_defined":
+        return not bool(row_value(row, "housing_benefit_any_over_sp_age", False)) and (
+            money(row_value(row, spec["capital_pe"], 0)) <= 16_000
+        )
+    if applies == "housing_benefit_pension_age_tariff_income_defined":
+        return bool(row_value(row, "housing_benefit_any_over_sp_age", False)) and (
+            money(row_value(row, "guarantee_credit", 0)) <= 0
+        )
     if isinstance(applies, tuple) and len(applies) == 2:
         name, expected = applies
         value = row_value(row, name)

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -54,6 +54,8 @@ BENEFIT_CAP_REGULATION_80A_PROGRAM_PATH = Path("regulations/uksi/2013/376/80A.ya
 BENEFIT_CAP_REGULATION_80A_BASE = "uk:regulations/uksi/2013/376/80A"
 STATE_PENSION_CREDIT_SECTION_1_PROGRAM_PATH = Path("statutes/ukpga/2002/16/1.yaml")
 STATE_PENSION_CREDIT_SECTION_1_BASE = "uk:statutes/ukpga/2002/16/1"
+STATE_PENSION_CREDIT_SECTION_2_PROGRAM_PATH = Path("statutes/ukpga/2002/16/2.yaml")
+STATE_PENSION_CREDIT_SECTION_2_BASE = "uk:statutes/ukpga/2002/16/2"
 STATE_PENSION_CREDIT_SECTION_3_PROGRAM_PATH = Path("statutes/ukpga/2002/16/3.yaml")
 STATE_PENSION_CREDIT_SECTION_3_BASE = "uk:statutes/ukpga/2002/16/3"
 PENSION_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2002/1792/6.yaml")
@@ -251,6 +253,21 @@ STATE_PENSION_CREDIT_QUALIFYING_AGE_OUTPUTS = {
             "#claimant_has_attained_qualifying_age"
         ),
         "pe": "is_SP_age",
+    },
+}
+
+STATE_PENSION_CREDIT_GUARANTEE_CREDIT_OUTPUTS = {
+    "appropriate_minimum_guarantee": {
+        "axiom": (
+            f"{STATE_PENSION_CREDIT_SECTION_2_BASE}#appropriate_minimum_guarantee"
+        ),
+        "pe": "minimum_guarantee",
+        "tolerance": 0.1,
+    },
+    "guarantee_credit": {
+        "axiom": f"{STATE_PENSION_CREDIT_SECTION_2_BASE}#guarantee_credit",
+        "pe": "guarantee_credit",
+        "tolerance": 0.1,
     },
 }
 
@@ -608,6 +625,18 @@ SURFACE_SPECS = {
             "gender",
             "is_SP_age",
             "state_pension_age",
+        ),
+    ),
+    "state-pension-credit-guarantee-credit": UKEFRSSurfaceSpec(
+        program=STATE_PENSION_CREDIT_SECTION_2_PROGRAM_PATH,
+        entity="benunit",
+        outputs=STATE_PENSION_CREDIT_GUARANTEE_CREDIT_OUTPUTS,
+        pe_variables=(
+            "guarantee_credit",
+            "is_guarantee_credit_eligible",
+            "minimum_guarantee",
+            "pension_credit_income",
+            "standard_minimum_guarantee",
         ),
     ),
     "state-pension-credit-savings-credit": UKEFRSSurfaceSpec(
@@ -2274,6 +2303,11 @@ def build_axiom_request(
             pe_data=pe_data,
             year=year,
         )
+    if surface == "state-pension-credit-guarantee-credit":
+        return build_state_pension_credit_guarantee_credit_request(
+            pe_data=pe_data,
+            year=year,
+        )
     if surface == "state-pension-credit-savings-credit":
         return build_state_pension_credit_savings_credit_request(
             pe_data=pe_data,
@@ -2713,6 +2747,43 @@ def build_pension_credit_request(
                 "entity_id": entity_id,
                 "period": interval,
                 "outputs": [spec["axiom"] for spec in PENSION_CREDIT_OUTPUTS.values()],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_state_pension_credit_guarantee_credit_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "state-pension-credit-guarantee-credit"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_state_pension_credit_guarantee_credit_inputs(
+            row
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{STATE_PENSION_CREDIT_SECTION_2_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in STATE_PENSION_CREDIT_GUARANTEE_CREDIT_OUTPUTS.values()
+                ],
             }
         )
 
@@ -3434,6 +3505,24 @@ def project_pension_credit_inputs(row: Any) -> dict[str, Any]:
     }
 
 
+def project_state_pension_credit_guarantee_credit_inputs(
+    row: Any,
+) -> dict[str, Any]:
+    standard_minimum_guarantee = money(row_value(row, "standard_minimum_guarantee", 0))
+    minimum_guarantee = money(row_value(row, "minimum_guarantee", 0))
+    return {
+        "claimant_income": money(row_value(row, "pension_credit_income", 0)),
+        "standard_minimum_guarantee": standard_minimum_guarantee,
+        "prescribed_additional_amounts_applicable": max(
+            0.0,
+            minimum_guarantee - standard_minimum_guarantee,
+        ),
+        "claimant_is_entitled_to_guarantee_credit": bool(
+            row_value(row, "is_guarantee_credit_eligible", False)
+        ),
+    }
+
+
 def project_state_pension_credit_savings_credit_inputs(
     row: Any,
     *,
@@ -3655,6 +3744,12 @@ def compare_outputs(
             "PolicyEngine's is_SP_age boolean. Current PolicyEngine UK EFRS "
             "data exposes the modern equalized-age surface rather than "
             "historical sex-specific age transitions.",
+            "State Pension Credit Act section 2 guarantee-credit comparison "
+            "projects PolicyEngine's annual minimum_guarantee into the "
+            "statutory appropriate minimum guarantee by supplying "
+            "standard_minimum_guarantee and the remaining positive prescribed "
+            "additional amount, and gates the amount with PolicyEngine's "
+            "is_guarantee_credit_eligible predicate.",
             "State Pension Credit Act section 3 savings-credit comparison "
             "projects PolicyEngine's annual savings_credit_income as qualifying "
             "income, pension_credit_income as claimant income, "

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -62,6 +62,8 @@ PENSION_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2002/1792/6.yaml")
 PENSION_CREDIT_BASE = "uk:regulations/uksi/2002/1792/6"
 UNIVERSAL_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2013/376/36.yaml")
 UNIVERSAL_CREDIT_BASE = "uk:regulations/uksi/2013/376/36"
+UNIVERSAL_CREDIT_REGULATION_18_PROGRAM_PATH = Path("regulations/uksi/2013/376/18.yaml")
+UNIVERSAL_CREDIT_REGULATION_18_BASE = "uk:regulations/uksi/2013/376/18"
 UNIVERSAL_CREDIT_REGULATION_22_PROGRAM_PATH = Path("regulations/uksi/2013/376/22.yaml")
 UNIVERSAL_CREDIT_REGULATION_22_BASE = "uk:regulations/uksi/2013/376/22"
 UNIVERSAL_CREDIT_REGULATION_32_PROGRAM_PATH = Path("regulations/uksi/2013/376/32.yaml")
@@ -475,6 +477,17 @@ UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS = {
     },
 }
 
+UNIVERSAL_CREDIT_ASSESSABLE_CAPITAL_OUTPUTS = {
+    "claimant_capital_for_prescribed_capital_limit": {
+        "axiom": (
+            f"{UNIVERSAL_CREDIT_REGULATION_18_BASE}"
+            "#claimant_capital_for_prescribed_capital_limit"
+        ),
+        "pe": "uc_assessable_capital",
+        "tolerance": 0.1,
+    },
+}
+
 UNIVERSAL_CREDIT_TARIFF_INCOME_OUTPUTS = {
     "capital_tariff_monthly_income": {
         "axiom": f"{UNIVERSAL_CREDIT_REGULATION_72_BASE}#capital_tariff_monthly_income",
@@ -776,6 +789,12 @@ SURFACE_SPECS = {
             "uc_unearned_income",
             "uc_work_allowance",
         ),
+    ),
+    "universal-credit-assessable-capital": UKEFRSSurfaceSpec(
+        program=UNIVERSAL_CREDIT_REGULATION_18_PROGRAM_PATH,
+        entity="benunit",
+        outputs=UNIVERSAL_CREDIT_ASSESSABLE_CAPITAL_OUTPUTS,
+        pe_variables=("uc_assessable_capital",),
     ),
     "universal-credit-tariff-income": UKEFRSSurfaceSpec(
         program=UNIVERSAL_CREDIT_REGULATION_72_PROGRAM_PATH,
@@ -2337,6 +2356,11 @@ def build_axiom_request(
             pe_data=pe_data,
             year=year,
         )
+    if surface == "universal-credit-assessable-capital":
+        return build_universal_credit_assessable_capital_request(
+            pe_data=pe_data,
+            year=year,
+        )
     if surface == "universal-credit-tariff-income":
         return build_universal_credit_tariff_income_request(
             pe_data=pe_data,
@@ -3039,6 +3063,43 @@ def build_universal_credit_income_deduction_request(
     }
 
 
+def build_universal_credit_assessable_capital_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = day_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "universal-credit-assessable-capital"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_universal_credit_assessable_capital_inputs(
+            row
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{UNIVERSAL_CREDIT_REGULATION_18_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in UNIVERSAL_CREDIT_ASSESSABLE_CAPITAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def build_universal_credit_tariff_income_request(
     *, pe_data: dict[str, Any], year: int
 ) -> dict[str, Any]:
@@ -3456,6 +3517,16 @@ def project_universal_credit_tariff_income_inputs(row: Any) -> dict[str, Any]:
     }
 
 
+def project_universal_credit_assessable_capital_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "claim_is_for_joint_claimants": False,
+        "claimant_is_member_of_couple": False,
+        "claimant_makes_claim_as_single_person": False,
+        "claimant_capital": money(row_value(row, "uc_assessable_capital", 0)),
+        "other_member_of_couple_capital": 0.0,
+    }
+
+
 def project_universal_credit_work_allowance_inputs(row: Any) -> dict[str, Any]:
     num_adults = int(money(row_value(row, "num_adults", 0)))
     num_children = int(money(row_value(row, "num_children", 0)))
@@ -3792,6 +3863,12 @@ def compare_outputs(
             "and PolicyEngine's negative-unearned-income treatment does not "
             "differ from Regulation 22's non-negative unearned-income "
             "deduction.",
+            "Universal Credit Regulation 18 assessable-capital comparison "
+            "projects PolicyEngine's benefit-unit uc_assessable_capital stock "
+            "into the claimant capital leaf, with other-member inclusion "
+            "projected to zero because PolicyEngine already resolves household "
+            "capital allocation, reported-capital overrides, and exclusions "
+            "upstream.",
             "Universal Credit Regulation 72 tariff-income comparison projects "
             "PolicyEngine's annual uc_assessable_capital stock into the "
             "RuleSpec person_capital leaf, projects capital disregards and "

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -60,6 +60,8 @@ STATE_PENSION_CREDIT_SECTION_3_PROGRAM_PATH = Path("statutes/ukpga/2002/16/3.yam
 STATE_PENSION_CREDIT_SECTION_3_BASE = "uk:statutes/ukpga/2002/16/3"
 PENSION_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2002/1792/6.yaml")
 PENSION_CREDIT_BASE = "uk:regulations/uksi/2002/1792/6"
+PENSION_CREDIT_REGULATION_15_PROGRAM_PATH = Path("regulations/uksi/2002/1792/15.yaml")
+PENSION_CREDIT_REGULATION_15_BASE = "uk:regulations/uksi/2002/1792/15"
 UNIVERSAL_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2013/376/36.yaml")
 UNIVERSAL_CREDIT_BASE = "uk:regulations/uksi/2013/376/36"
 UNIVERSAL_CREDIT_REGULATION_18_PROGRAM_PATH = Path("regulations/uksi/2013/376/18.yaml")
@@ -296,6 +298,15 @@ PENSION_CREDIT_OUTPUTS = {
         "axiom": f"{PENSION_CREDIT_BASE}#carer_additional_amount",
         "pe": "carer_minimum_guarantee_addition",
         "pe_transform": "annual_to_weekly_per_carer",
+    },
+}
+
+PENSION_CREDIT_DEEMED_INCOME_OUTPUTS = {
+    "capital_deemed_weekly_income": {
+        "axiom": f"{PENSION_CREDIT_REGULATION_15_BASE}#capital_deemed_weekly_income",
+        "pe": "pension_credit_deemed_income",
+        "pe_transform": "annual_to_weekly",
+        "tolerance": 0.01,
     },
 }
 
@@ -677,6 +688,15 @@ SURFACE_SPECS = {
             "relation_type",
             "severe_disability_minimum_guarantee_addition",
             "standard_minimum_guarantee",
+        ),
+    ),
+    "pension-credit-deemed-income": UKEFRSSurfaceSpec(
+        program=PENSION_CREDIT_REGULATION_15_PROGRAM_PATH,
+        entity="benunit",
+        outputs=PENSION_CREDIT_DEEMED_INCOME_OUTPUTS,
+        pe_variables=(
+            "pension_credit_assessable_capital",
+            "pension_credit_deemed_income",
         ),
     ),
     "universal-credit-standard-allowance": UKEFRSSurfaceSpec(
@@ -2334,6 +2354,11 @@ def build_axiom_request(
         )
     if surface == "pension-credit":
         return build_pension_credit_request(pe_data=pe_data, year=year)
+    if surface == "pension-credit-deemed-income":
+        return build_pension_credit_deemed_income_request(
+            pe_data=pe_data,
+            year=year,
+        )
     if surface == "universal-credit-childcare-element":
         return build_universal_credit_childcare_element_request(
             pe_data=pe_data,
@@ -2771,6 +2796,41 @@ def build_pension_credit_request(
                 "entity_id": entity_id,
                 "period": interval,
                 "outputs": [spec["axiom"] for spec in PENSION_CREDIT_OUTPUTS.values()],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_pension_credit_deemed_income_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = benefit_week_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "pension-credit-deemed-income"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_pension_credit_deemed_income_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{PENSION_CREDIT_REGULATION_15_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in PENSION_CREDIT_DEEMED_INCOME_OUTPUTS.values()
+                ],
             }
         )
 
@@ -3517,6 +3577,15 @@ def project_universal_credit_tariff_income_inputs(row: Any) -> dict[str, Any]:
     }
 
 
+def project_pension_credit_deemed_income_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "claimant_capital": money(
+            row_value(row, "pension_credit_assessable_capital", 0)
+        ),
+        "capital_disregarded_under_regulation_17_8": False,
+    }
+
+
 def project_universal_credit_assessable_capital_inputs(row: Any) -> dict[str, Any]:
     return {
         "claim_is_for_joint_claimants": False,
@@ -3876,6 +3945,14 @@ def compare_outputs(
             "RuleSpec tariff income against PolicyEngine's annual "
             "uc_tariff_income divided by 12, and only counts rows where "
             "PolicyEngine defines UC eligibility.",
+            "State Pension Credit Regulations 2002 Regulation 15 deemed-income "
+            "comparison projects PolicyEngine's benefit-unit "
+            "pension_credit_assessable_capital stock into the claimant capital "
+            "leaf, projects the Regulation 17(8) capital-disregard exception "
+            "false because PolicyEngine already applies capital-source "
+            "exclusions upstream, and compares weekly RuleSpec deemed income "
+            "against PolicyEngine's annual pension_credit_deemed_income "
+            "divided by 52.",
             "Universal Credit Regulation 34 childcare-costs element comparison "
             "projects PolicyEngine's annual uc_childcare_element into monthly "
             "relevant childcare charges by reversing the statutory 85 percent "

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -720,6 +720,17 @@ mappings:
     comparison: money
     rationale: Same Universal Credit tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit assessed capital to the Regulation 72 capital leaf and converts PolicyEngine's annual output to a monthly amount.
 
+  - legal_id: uk:regulations/uksi/2013/376/18#claimant_capital_for_prescribed_capital_limit
+    country: uk
+    program: universal_credit
+    mapping_type: direct_variable
+    policyengine_variable: uc_assessable_capital
+    entity: benunit
+    period: day
+    unit: GBP
+    comparison: money
+    rationale: Same Universal Credit assessable capital stock after the UK EFRS adapter projects PolicyEngine's benefit-unit uc_assessable_capital into the Regulation 18 claimant-capital leaf, with other-member inclusion set to zero because PolicyEngine already resolves household capital allocation, reported-capital overrides, and exclusions upstream.
+
   - legal_id: uk:regulations/uksi/2013/376/32#work_condition_met_for_assessment_period
     country: uk
     program: universal_credit

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -488,6 +488,36 @@ mappings:
     candidate_priority: P3
     rationale: State Pension Credit Act section 1 tests whether the claimant has attained the statutory qualifying age at day granularity. The UK EFRS oracle compares RuleSpec's judgment output to PolicyEngine UK's annual is_SP_age predicate after supplying the same age and state_pension_age projection used for qualifying_age.
 
+  - legal_id: uk:statutes/ukpga/2002/16/2#guarantee_credit
+    country: uk
+    program: pension_credit
+    mapping_type: direct_variable
+    policyengine_variable: guarantee_credit
+    entity: benunit
+    period: year
+    unit: GBP
+    comparison: money
+    candidate_priority: P2
+    rationale: Same annual State Pension Credit guarantee credit amount. The EFRS oracle projects claimant income from PolicyEngine's pension_credit_income, appropriate minimum guarantee from minimum_guarantee, and entitlement from is_guarantee_credit_eligible.
+
+  - legal_id: uk:statutes/ukpga/2002/16/2#appropriate_minimum_guarantee
+    country: uk
+    program: pension_credit
+    mapping_type: direct_variable
+    policyengine_variable: minimum_guarantee
+    entity: benunit
+    period: year
+    unit: GBP
+    comparison: money
+    candidate_priority: P3
+    rationale: Same annual State Pension Credit appropriate minimum guarantee, after the EFRS oracle projects PolicyEngine's standard_minimum_guarantee and positive additional amount decomposition into the section 2 formula.
+
+  - legal_id: uk:statutes/ukpga/2002/16/2#guarantee_credit_condition_satisfied
+    country: uk
+    program: pension_credit
+    mapping_type: not_comparable
+    rationale: Source-law income condition for State Pension Credit Act section 2. PolicyEngine UK exposes is_guarantee_credit_eligible, but that combines this income condition with section 1 entitlement predicates and is not a one-to-one match.
+
   - legal_id: uk:statutes/ukpga/2002/16/3#savings_credit
     country: uk
     program: pension_credit

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -476,6 +476,61 @@ mappings:
     comparison: money
     rationale: Same Pension Credit deemed income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit pension_credit_assessable_capital into the Regulation 15 claimant-capital leaf and converts PolicyEngine's annual output to a weekly amount.
 
+  - legal_id: uk:regulations/uksi/2008/794/118#capital_tariff_weekly_income
+    country: uk
+    program: employment_and_support_allowance
+    mapping_type: direct_variable
+    policyengine_variable: esa_income_tariff_income
+    entity: benunit
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same income-related ESA tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit esa_income_assessable_capital into the Regulation 118 claimant-capital leaf, sets the prescribed-accommodation branch false because PolicyEngine does not expose that legal predicate, limits comparison to capital at or below GBP 16,000, and converts PolicyEngine's annual output to a weekly amount.
+
+  - legal_id: uk:regulations/uksi/1996/207/116#capital_tariff_weekly_income
+    country: uk
+    program: jobseekers_allowance
+    mapping_type: direct_variable
+    policyengine_variable: jsa_income_tariff_income
+    entity: benunit
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same income-based JSA tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit jsa_income_assessable_capital into the Regulation 116 claimant-capital leaf, sets the prescribed-accommodation branch false because PolicyEngine does not expose that legal predicate, limits comparison to capital at or below GBP 16,000, and converts PolicyEngine's annual output to a weekly amount.
+
+  - legal_id: uk:regulations/uksi/1987/1967/53#capital_tariff_weekly_income
+    country: uk
+    program: income_support
+    mapping_type: direct_variable
+    policyengine_variable: income_support_tariff_income
+    entity: benunit
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Income Support tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit income_support_assessable_capital into the Regulation 53 claimant-capital leaf, sets the prescribed-accommodation branch false because PolicyEngine does not expose that legal predicate, limits comparison to capital at or below GBP 16,000, and converts PolicyEngine's annual output to a weekly amount.
+
+  - legal_id: uk:regulations/uksi/2006/213/52#capital_tariff_weekly_income
+    country: uk
+    program: housing_benefit
+    mapping_type: direct_variable
+    policyengine_variable: housing_benefit_tariff_income
+    entity: benunit
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same working-age Housing Benefit tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit housing_benefit_assessable_capital into the Regulation 52 claimant-capital leaf, sets the prescribed-circumstances branch false because PolicyEngine does not expose that legal predicate, limits comparison to non-pension-age rows with capital at or below GBP 16,000, and converts PolicyEngine's annual output to a weekly amount.
+
+  - legal_id: uk:regulations/uksi/2006/214/29#capital_tariff_weekly_income
+    country: uk
+    program: housing_benefit
+    mapping_type: direct_variable
+    policyengine_variable: housing_benefit_tariff_income
+    entity: benunit
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same pension-age Housing Benefit tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit housing_benefit_assessable_capital into the Regulation 29 claimant-capital leaf, projects the regulation 44(2) capital-disregard exception false because PolicyEngine applies capital exclusions upstream, limits comparison to pension-age rows without guarantee credit, and converts PolicyEngine's annual output to a weekly amount.
+
   - legal_id: uk:statutes/ukpga/2002/16/1#qualifying_age
     country: uk
     program: pension_credit
@@ -777,6 +832,36 @@ prefixes:
     program: pension_credit
     mapping_type: not_comparable
     rationale: Pension Credit Regulation 15 helper outputs not listed above are capital-to-deemed-income parameters or branch-control predicates that PolicyEngine UK does not expose as one-to-one oracle variables.
+
+  - legal_id_prefix: uk:regulations/uksi/2008/794/118#
+    country: uk
+    program: employment_and_support_allowance
+    mapping_type: not_comparable
+    rationale: ESA Regulation 118 helper outputs not listed above are capital-to-tariff-income parameters, upper-limit predicates, or prescribed-accommodation branch controls that PolicyEngine UK does not expose as one-to-one oracle variables.
+
+  - legal_id_prefix: uk:regulations/uksi/1996/207/116#
+    country: uk
+    program: jobseekers_allowance
+    mapping_type: not_comparable
+    rationale: JSA Regulation 116 helper outputs not listed above are capital-to-tariff-income parameters, upper-limit predicates, or prescribed-accommodation branch controls that PolicyEngine UK does not expose as one-to-one oracle variables.
+
+  - legal_id_prefix: uk:regulations/uksi/1987/1967/53#
+    country: uk
+    program: income_support
+    mapping_type: not_comparable
+    rationale: Income Support Regulation 53 helper outputs not listed above are capital-to-tariff-income parameters, upper-limit predicates, or prescribed-accommodation branch controls that PolicyEngine UK does not expose as one-to-one oracle variables.
+
+  - legal_id_prefix: uk:regulations/uksi/2006/213/52#
+    country: uk
+    program: housing_benefit
+    mapping_type: not_comparable
+    rationale: Housing Benefit Regulation 52 helper outputs not listed above are working-age capital-to-tariff-income parameters, upper-limit predicates, or prescribed-circumstances branch controls that PolicyEngine UK does not expose as one-to-one oracle variables.
+
+  - legal_id_prefix: uk:regulations/uksi/2006/214/29#
+    country: uk
+    program: housing_benefit
+    mapping_type: not_comparable
+    rationale: Pension-age Housing Benefit Regulation 29 helper outputs not listed above are capital-to-tariff-income parameters or capital-disregard predicates that PolicyEngine UK does not expose as one-to-one oracle variables.
 
   - legal_id_prefix: uk:regulations/uksi/2013/376/36#
     country: uk

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -465,6 +465,17 @@ mappings:
     comparison: money
     rationale: Same Pension Credit carer addition output after applying claimant circumstances.
 
+  - legal_id: uk:regulations/uksi/2002/1792/15#capital_deemed_weekly_income
+    country: uk
+    program: pension_credit
+    mapping_type: direct_variable
+    policyengine_variable: pension_credit_deemed_income
+    entity: benunit
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Pension Credit deemed income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit pension_credit_assessable_capital into the Regulation 15 claimant-capital leaf and converts PolicyEngine's annual output to a weekly amount.
+
   - legal_id: uk:statutes/ukpga/2002/16/1#qualifying_age
     country: uk
     program: pension_credit
@@ -760,6 +771,12 @@ prefixes:
     program: pension_credit
     mapping_type: not_comparable
     rationale: Pension Credit helper outputs not listed above are remand-prisoner, tax-credit cessation, nil substitution, or branch-control intermediates that PolicyEngine UK does not expose as one-to-one oracle variables or parameters.
+
+  - legal_id_prefix: uk:regulations/uksi/2002/1792/15#
+    country: uk
+    program: pension_credit
+    mapping_type: not_comparable
+    rationale: Pension Credit Regulation 15 helper outputs not listed above are capital-to-deemed-income parameters or branch-control predicates that PolicyEngine UK does not expose as one-to-one oracle variables.
 
   - legal_id_prefix: uk:regulations/uksi/2013/376/36#
     country: uk

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -663,6 +663,66 @@ rules:
     assert rounding_multiple["status"] == "known_not_comparable"
 
 
+def test_policyengine_coverage_classifies_uk_uc_regulation_18_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2013/376/18.yaml",
+        """format: rulespec/v1
+rules:
+  - name: claimant_capital_for_prescribed_capital_limit
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Day
+    unit: GBP
+    versions:
+      - effective_from: '2013-04-29'
+        formula: claimant_capital
+  - name: prescribed_capital_limit_for_claim
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Day
+    unit: GBP
+    versions:
+      - effective_from: '2013-04-29'
+        formula: prescribed_capital_limit_for_single_claimant
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2013/376/18.test.yaml",
+        """- name: capital
+  period:
+    period_kind: custom
+    name: day
+    start: '2026-04-06'
+    end: '2026-04-06'
+  input: {}
+  output:
+    uk:regulations/uksi/2013/376/18#claimant_capital_for_prescribed_capital_limit: 12000
+    uk:regulations/uksi/2013/376/18#prescribed_capital_limit_for_claim: 16000
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="universal_credit")
+
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 1,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    claimant_capital = items_by_id[
+        "uk:regulations/uksi/2013/376/18#claimant_capital_for_prescribed_capital_limit"
+    ]
+    prescribed_limit = items_by_id[
+        "uk:regulations/uksi/2013/376/18#prescribed_capital_limit_for_claim"
+    ]
+    assert claimant_capital["policyengine_variable"] == "uc_assessable_capital"
+    assert claimant_capital["status"] == "comparable"
+    assert claimant_capital["mapping_type"] == "direct_variable"
+    assert claimant_capital["tested"] is True
+    assert prescribed_limit["status"] == "known_not_comparable"
+
+
 def test_policyengine_coverage_classifies_uk_income_tax_section_23_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-uk" / "statutes/ukpga/2007/3/23.yaml",

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1334,6 +1334,68 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_uk_pension_credit_regulation_15_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2002/1792/15.yaml",
+        """format: rulespec/v1
+rules:
+  - name: capital_treated_as_yielding_weekly_income
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Week
+    versions:
+      - effective_from: '2009-11-02'
+        formula: claimant_capital > capital_deemed_income_lower_threshold
+  - name: capital_deemed_weekly_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Week
+    unit: GBP
+    versions:
+      - effective_from: '2009-11-02'
+        formula: capital_deemed_income_weekly_amount_per_band
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2002/1792/15.test.yaml",
+        """- name: deemed income
+  period:
+    period_kind: custom
+    name: benefit_week
+    start: '2026-04-06'
+    end: '2026-04-12'
+  input: {}
+  output:
+    uk:regulations/uksi/2002/1792/15#capital_treated_as_yielding_weekly_income: holds
+    uk:regulations/uksi/2002/1792/15#capital_deemed_weekly_income: 2
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="pension_credit")
+
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 1,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    deemed_income = items_by_id[
+        "uk:regulations/uksi/2002/1792/15#capital_deemed_weekly_income"
+    ]
+    helper = items_by_id[
+        "uk:regulations/uksi/2002/1792/15#capital_treated_as_yielding_weekly_income"
+    ]
+
+    assert deemed_income["policyengine_variable"] == "pension_credit_deemed_income"
+    assert deemed_income["status"] == "comparable"
+    assert deemed_income["mapping_type"] == "direct_variable"
+    assert deemed_income["tested"] is True
+    assert helper["status"] == "known_not_comparable"
+
+
 def test_policyengine_coverage_counts_uk_aliases_as_tested(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-uk" / "regulations/uksi/2006/965/2.yaml",

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1396,6 +1396,115 @@ rules:
     assert helper["status"] == "known_not_comparable"
 
 
+@pytest.mark.parametrize(
+    (
+        "path",
+        "legal_base",
+        "program",
+        "policyengine_variable",
+        "helper_name",
+    ),
+    [
+        (
+            "regulations/uksi/2008/794/118",
+            "uk:regulations/uksi/2008/794/118",
+            "employment_and_support_allowance",
+            "esa_income_tariff_income",
+            "capital_treated_as_yielding_weekly_income",
+        ),
+        (
+            "regulations/uksi/1996/207/116",
+            "uk:regulations/uksi/1996/207/116",
+            "jobseekers_allowance",
+            "jsa_income_tariff_income",
+            "capital_treated_as_yielding_weekly_income",
+        ),
+        (
+            "regulations/uksi/1987/1967/53",
+            "uk:regulations/uksi/1987/1967/53",
+            "income_support",
+            "income_support_tariff_income",
+            "capital_treated_as_yielding_weekly_income",
+        ),
+        (
+            "regulations/uksi/2006/213/52",
+            "uk:regulations/uksi/2006/213/52",
+            "housing_benefit",
+            "housing_benefit_tariff_income",
+            "capital_treated_as_yielding_weekly_tariff_income",
+        ),
+        (
+            "regulations/uksi/2006/214/29",
+            "uk:regulations/uksi/2006/214/29",
+            "housing_benefit",
+            "housing_benefit_tariff_income",
+            "capital_treated_as_yielding_weekly_income",
+        ),
+    ],
+)
+def test_policyengine_coverage_classifies_uk_legacy_tariff_income_outputs(
+    tmp_path,
+    path,
+    legal_base,
+    program,
+    policyengine_variable,
+    helper_name,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / f"{path}.yaml",
+        f"""format: rulespec/v1
+rules:
+  - name: {helper_name}
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Week
+    versions:
+      - effective_from: '2026-01-01'
+        formula: claimant_capital > capital_tariff_income_lower_threshold
+  - name: capital_tariff_weekly_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Week
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: capital_tariff_income_weekly_amount_per_band
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / f"{path}.test.yaml",
+        f"""- name: tariff income
+  period:
+    period_kind: custom
+    name: benefit_week
+    start: '2026-04-06'
+    end: '2026-04-12'
+  input: {{}}
+  output:
+    {legal_base}#{helper_name}: holds
+    {legal_base}#capital_tariff_weekly_income: 2
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program=program)
+
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 1,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    tariff_income = items_by_id[f"{legal_base}#capital_tariff_weekly_income"]
+    helper = items_by_id[f"{legal_base}#{helper_name}"]
+
+    assert tariff_income["policyengine_variable"] == policyengine_variable
+    assert tariff_income["status"] == "comparable"
+    assert tariff_income["mapping_type"] == "direct_variable"
+    assert tariff_income["tested"] is True
+    assert helper["status"] == "known_not_comparable"
+
+
 def test_policyengine_coverage_counts_uk_aliases_as_tested(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-uk" / "regulations/uksi/2006/965/2.yaml",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -29,9 +29,11 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     PERSONAL_ALLOWANCE_BASE,
     PERSONAL_ALLOWANCE_OUTPUTS,
     PERSONAL_ALLOWANCE_PROGRAM_PATH,
+    STATE_PENSION_CREDIT_GUARANTEE_CREDIT_OUTPUTS,
     STATE_PENSION_CREDIT_QUALIFYING_AGE_OUTPUTS,
     STATE_PENSION_CREDIT_SAVINGS_CREDIT_OUTPUTS,
     STATE_PENSION_CREDIT_SECTION_1_BASE,
+    STATE_PENSION_CREDIT_SECTION_2_BASE,
     STATE_PENSION_CREDIT_SECTION_3_BASE,
     UNIVERSAL_CREDIT_AWARD_OUTPUTS,
     UNIVERSAL_CREDIT_CHILD_ELEMENT_OUTPUTS,
@@ -59,6 +61,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_national_insurance_class_1_request,
     build_pension_credit_request,
     build_personal_allowance_request,
+    build_state_pension_credit_guarantee_credit_request,
     build_state_pension_credit_qualifying_age_request,
     build_state_pension_credit_savings_credit_request,
     build_uk_efrs_coverage_report,
@@ -84,6 +87,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_income_tax_section_23_inputs,
     project_pension_credit_inputs,
     project_personal_allowance_inputs,
+    project_state_pension_credit_guarantee_credit_inputs,
     project_state_pension_credit_qualifying_age_inputs,
     project_state_pension_credit_savings_credit_inputs,
     project_universal_credit_award_inputs,
@@ -1012,6 +1016,76 @@ def test_pension_credit_request_projects_benefit_units():
     ] == {
         "kind": "bool",
         "value": False,
+    }
+
+
+def test_state_pension_credit_guarantee_credit_projection_uses_section_2_inputs():
+    projected = project_state_pension_credit_guarantee_credit_inputs(
+        {
+            "is_guarantee_credit_eligible": True,
+            "pension_credit_income": 11_000,
+            "standard_minimum_guarantee": 238.00 * WEEKS_IN_YEAR,
+            "minimum_guarantee": 280.00 * WEEKS_IN_YEAR,
+        }
+    )
+
+    assert projected == {
+        "claimant_income": 11_000,
+        "standard_minimum_guarantee": 238.00 * WEEKS_IN_YEAR,
+        "prescribed_additional_amounts_applicable": 42.00 * WEEKS_IN_YEAR,
+        "claimant_is_entitled_to_guarantee_credit": True,
+    }
+
+
+def test_state_pension_credit_guarantee_credit_request_projects_benefit_units():
+    request = build_state_pension_credit_guarantee_credit_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 12,
+                    "benunit_weight": 1,
+                    "is_guarantee_credit_eligible": True,
+                    "guarantee_credit": 2_000,
+                    "pension_credit_income": 11_000,
+                    "standard_minimum_guarantee": 238.00 * WEEKS_IN_YEAR,
+                    "minimum_guarantee": 280.00 * WEEKS_IN_YEAR,
+                }
+            ],
+            "benunit_ids": [12],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_12",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": list(
+                output["axiom"]
+                for output in STATE_PENSION_CREDIT_GUARANTEE_CREDIT_OUTPUTS.values()
+            ),
+        }
+    ]
+    inputs = {
+        record["name"]: record["value"] for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{STATE_PENSION_CREDIT_SECTION_2_BASE}#input.claimant_is_entitled_to_guarantee_credit"
+    ] == {
+        "kind": "bool",
+        "value": True,
+    }
+    assert inputs[
+        f"{STATE_PENSION_CREDIT_SECTION_2_BASE}#input.prescribed_additional_amounts_applicable"
+    ] == {
+        "kind": "decimal",
+        "value": str(42.00 * WEEKS_IN_YEAR),
     }
 
 
@@ -1991,6 +2065,15 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "relation_type",
         "savings_credit",
         "savings_credit_income",
+        "standard_minimum_guarantee",
+    )
+    assert policyengine_benunit_variables_for_surfaces(
+        ["state-pension-credit-guarantee-credit"]
+    ) == (
+        "guarantee_credit",
+        "is_guarantee_credit_eligible",
+        "minimum_guarantee",
+        "pension_credit_income",
         "standard_minimum_guarantee",
     )
     assert policyengine_benunit_variables_for_surfaces(
@@ -3300,6 +3383,43 @@ def test_compare_outputs_no_longer_classifies_policyengine_savings_credit_bug():
 
     assert len(report.mismatches) == 1
     assert report.mismatches[0].entity_id == "benunit_79791"
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_handles_state_pension_credit_guarantee_credit():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 12,
+                    "minimum_guarantee": 14_560,
+                    "guarantee_credit": 3_560,
+                }
+            ],
+            "benunit_ids": [12],
+        },
+        axiom_outputs_by_surface={
+            "state-pension-credit-guarantee-credit": [
+                {
+                    "outputs": {
+                        STATE_PENSION_CREDIT_GUARANTEE_CREDIT_OUTPUTS[
+                            "appropriate_minimum_guarantee"
+                        ]["axiom"]: decimal_output(14_560),
+                        STATE_PENSION_CREDIT_GUARANTEE_CREDIT_OUTPUTS[
+                            "guarantee_credit"
+                        ]["axiom"]: decimal_output(3_560),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=0,
+    )
+
+    assert report.compared_values == 2
+    assert report.mismatches == []
     assert report.oracle_divergences == []
 
 

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -11,6 +11,14 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     BENEFIT_CAP_RELEVANT_AMOUNT_OUTPUTS,
     CHILD_BENEFIT_BASE,
     CHILD_BENEFIT_OUTPUTS,
+    ESA_REGULATION_118_BASE,
+    ESA_TARIFF_INCOME_OUTPUTS,
+    HOUSING_BENEFIT_PENSION_AGE_REGULATION_29_BASE,
+    HOUSING_BENEFIT_PENSION_AGE_TARIFF_INCOME_OUTPUTS,
+    HOUSING_BENEFIT_REGULATION_52_BASE,
+    HOUSING_BENEFIT_WORKING_AGE_TARIFF_INCOME_OUTPUTS,
+    INCOME_SUPPORT_REGULATION_53_BASE,
+    INCOME_SUPPORT_TARIFF_INCOME_OUTPUTS,
     INCOME_TAX_INCOME_BASE_COMPONENTS,
     INCOME_TAX_INCOME_BASE_OUTPUTS,
     INCOME_TAX_SECTION_10_BASE,
@@ -22,6 +30,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     INCOME_TAX_SECTION_23_ADDITION_COMPONENTS,
     INCOME_TAX_SECTION_23_BASE,
     INCOME_TAX_SECTION_23_REDUCTION_COMPONENTS,
+    JSA_REGULATION_116_BASE,
+    JSA_TARIFF_INCOME_OUTPUTS,
     NATIONAL_INSURANCE_CLASS_1_OUTPUTS,
     NATIONAL_INSURANCE_SECTION_8_BASE,
     PENSION_CREDIT_BASE,
@@ -58,10 +68,15 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     WELFARE_REFORM_ACT_SECTION_11_BASE,
     build_benefit_cap_relevant_amount_request,
     build_child_benefit_request,
+    build_esa_income_tariff_income_request,
+    build_housing_benefit_pension_age_tariff_income_request,
+    build_housing_benefit_working_age_tariff_income_request,
+    build_income_support_tariff_income_request,
     build_income_tax_income_base_request,
     build_income_tax_section_10_request,
     build_income_tax_section_11d_request,
     build_income_tax_section_13_request,
+    build_jsa_income_tariff_income_request,
     build_national_insurance_class_1_request,
     build_pension_credit_deemed_income_request,
     build_pension_credit_request,
@@ -86,11 +101,16 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     policyengine_person_variables_for_surfaces,
     project_benefit_cap_relevant_amount_inputs,
     project_child_benefit_inputs,
+    project_esa_income_tariff_income_inputs,
+    project_housing_benefit_pension_age_tariff_income_inputs,
+    project_housing_benefit_working_age_tariff_income_inputs,
+    project_income_support_tariff_income_inputs,
     project_income_tax_income_base_components,
     project_income_tax_section_10_inputs,
     project_income_tax_section_11d_inputs,
     project_income_tax_section_13_inputs,
     project_income_tax_section_23_inputs,
+    project_jsa_income_tariff_income_inputs,
     project_pension_credit_deemed_income_inputs,
     project_pension_credit_inputs,
     project_personal_allowance_inputs,
@@ -1084,6 +1104,156 @@ def test_pension_credit_deemed_income_request_projects_regulation_15_inputs():
         f"{PENSION_CREDIT_REGULATION_15_BASE}"
         "#input.capital_disregarded_under_regulation_17_8"
     ] == {
+        "kind": "bool",
+        "value": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("project", "row", "expected"),
+    [
+        (
+            project_esa_income_tariff_income_inputs,
+            {"esa_income_assessable_capital": 6_251},
+            {
+                "claimant_capital": 6_251,
+                "claimant_in_prescribed_accommodation_under_regulation_118_3": False,
+            },
+        ),
+        (
+            project_jsa_income_tariff_income_inputs,
+            {"jsa_income_assessable_capital": 6_251},
+            {
+                "claimant_capital": 6_251,
+                "claimant_in_prescribed_accommodation_under_regulation_116_1B": False,
+            },
+        ),
+        (
+            project_income_support_tariff_income_inputs,
+            {"income_support_assessable_capital": 6_251},
+            {
+                "claimant_capital": 6_251,
+                "claimant_in_prescribed_accommodation_under_regulation_53_1B": False,
+            },
+        ),
+        (
+            project_housing_benefit_working_age_tariff_income_inputs,
+            {"housing_benefit_assessable_capital": 6_251},
+            {
+                "claimant_capital": 6_251,
+                "claimant_in_prescribed_circumstances_under_regulation_52_4": False,
+            },
+        ),
+        (
+            project_housing_benefit_pension_age_tariff_income_inputs,
+            {"housing_benefit_assessable_capital": 10_501},
+            {
+                "claimant_capital": 10_501,
+                "capital_disregarded_under_regulation_44_2": False,
+            },
+        ),
+    ],
+)
+def test_legacy_tariff_income_projections_use_assessable_capital(
+    project,
+    row,
+    expected,
+):
+    assert project(row) == expected
+
+
+@pytest.mark.parametrize(
+    ("build", "base", "outputs", "row", "branch_leaf"),
+    [
+        (
+            build_esa_income_tariff_income_request,
+            ESA_REGULATION_118_BASE,
+            ESA_TARIFF_INCOME_OUTPUTS,
+            {
+                "esa_income_assessable_capital": 6_251,
+                "esa_income_tariff_income": 2 * WEEKS_IN_YEAR,
+            },
+            "claimant_in_prescribed_accommodation_under_regulation_118_3",
+        ),
+        (
+            build_jsa_income_tariff_income_request,
+            JSA_REGULATION_116_BASE,
+            JSA_TARIFF_INCOME_OUTPUTS,
+            {
+                "jsa_income_assessable_capital": 6_251,
+                "jsa_income_tariff_income": 2 * WEEKS_IN_YEAR,
+            },
+            "claimant_in_prescribed_accommodation_under_regulation_116_1B",
+        ),
+        (
+            build_income_support_tariff_income_request,
+            INCOME_SUPPORT_REGULATION_53_BASE,
+            INCOME_SUPPORT_TARIFF_INCOME_OUTPUTS,
+            {
+                "income_support_assessable_capital": 6_251,
+                "income_support_tariff_income": 2 * WEEKS_IN_YEAR,
+            },
+            "claimant_in_prescribed_accommodation_under_regulation_53_1B",
+        ),
+        (
+            build_housing_benefit_working_age_tariff_income_request,
+            HOUSING_BENEFIT_REGULATION_52_BASE,
+            HOUSING_BENEFIT_WORKING_AGE_TARIFF_INCOME_OUTPUTS,
+            {
+                "housing_benefit_assessable_capital": 6_251,
+                "housing_benefit_tariff_income": 2 * WEEKS_IN_YEAR,
+            },
+            "claimant_in_prescribed_circumstances_under_regulation_52_4",
+        ),
+        (
+            build_housing_benefit_pension_age_tariff_income_request,
+            HOUSING_BENEFIT_PENSION_AGE_REGULATION_29_BASE,
+            HOUSING_BENEFIT_PENSION_AGE_TARIFF_INCOME_OUTPUTS,
+            {
+                "housing_benefit_assessable_capital": 10_501,
+                "housing_benefit_tariff_income": 2 * WEEKS_IN_YEAR,
+            },
+            "capital_disregarded_under_regulation_44_2",
+        ),
+    ],
+)
+def test_legacy_tariff_income_requests_project_benefit_week_inputs(
+    build,
+    base,
+    outputs,
+    row,
+    branch_leaf,
+):
+    request = build(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [{"benunit_id": 11, **row}],
+            "benunit_ids": [11],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_11",
+            "period": {
+                "period_kind": "custom",
+                "name": "benefit_week",
+                "start": "2026-04-06",
+                "end": "2026-04-12",
+            },
+            "outputs": [output["axiom"] for output in outputs.values()],
+        }
+    ]
+    inputs_by_name = {
+        record["name"]: record["value"] for record in request["dataset"]["inputs"]
+    }
+    assert inputs_by_name[f"{base}#input.claimant_capital"] == {
+        "kind": "decimal",
+        "value": str(float(row[next(key for key in row if key.endswith("_capital"))])),
+    }
+    assert inputs_by_name[f"{base}#input.{branch_leaf}"] == {
         "kind": "bool",
         "value": False,
     }
@@ -3367,6 +3537,190 @@ def test_compare_outputs_transforms_pension_credit_deemed_income_weekly():
     assert report.compared_values == 1
     assert report.mismatches == []
     assert report.oracle_divergences == []
+
+
+@pytest.mark.parametrize(
+    ("surface", "outputs", "output_name", "row", "axiom_value"),
+    [
+        (
+            "esa-income-tariff-income",
+            ESA_TARIFF_INCOME_OUTPUTS,
+            "capital_tariff_weekly_income",
+            {
+                "benunit_id": 11,
+                "esa_income_assessable_capital": 6_251,
+                "esa_income_tariff_income": 2 * WEEKS_IN_YEAR,
+            },
+            2,
+        ),
+        (
+            "jsa-income-tariff-income",
+            JSA_TARIFF_INCOME_OUTPUTS,
+            "capital_tariff_weekly_income",
+            {
+                "benunit_id": 11,
+                "jsa_income_assessable_capital": 6_251,
+                "jsa_income_tariff_income": 2 * WEEKS_IN_YEAR,
+            },
+            2,
+        ),
+        (
+            "income-support-tariff-income",
+            INCOME_SUPPORT_TARIFF_INCOME_OUTPUTS,
+            "capital_tariff_weekly_income",
+            {
+                "benunit_id": 11,
+                "income_support_assessable_capital": 6_251,
+                "income_support_tariff_income": 2 * WEEKS_IN_YEAR,
+            },
+            2,
+        ),
+        (
+            "housing-benefit-working-age-tariff-income",
+            HOUSING_BENEFIT_WORKING_AGE_TARIFF_INCOME_OUTPUTS,
+            "capital_tariff_weekly_income",
+            {
+                "benunit_id": 11,
+                "guarantee_credit": 0,
+                "housing_benefit_any_over_sp_age": False,
+                "housing_benefit_assessable_capital": 6_251,
+                "housing_benefit_tariff_income": 2 * WEEKS_IN_YEAR,
+            },
+            2,
+        ),
+        (
+            "housing-benefit-pension-age-tariff-income",
+            HOUSING_BENEFIT_PENSION_AGE_TARIFF_INCOME_OUTPUTS,
+            "capital_tariff_weekly_income",
+            {
+                "benunit_id": 11,
+                "guarantee_credit": 0,
+                "housing_benefit_any_over_sp_age": True,
+                "housing_benefit_assessable_capital": 10_501,
+                "housing_benefit_tariff_income": 2 * WEEKS_IN_YEAR,
+            },
+            2,
+        ),
+    ],
+)
+def test_compare_outputs_transforms_legacy_tariff_income_weekly(
+    surface,
+    outputs,
+    output_name,
+    row,
+    axiom_value,
+):
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [row],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            surface: [
+                {
+                    "outputs": {
+                        outputs[output_name]["axiom"]: decimal_output(axiom_value),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_skips_legacy_tariff_income_above_capital_limit():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "esa_income_assessable_capital": 16_001,
+                    "esa_income_tariff_income": 29 * WEEKS_IN_YEAR,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "esa-income-tariff-income": [
+                {
+                    "outputs": {
+                        ESA_TARIFF_INCOME_OUTPUTS["capital_tariff_weekly_income"][
+                            "axiom"
+                        ]: decimal_output(0),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 0
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_splits_housing_benefit_tariff_income_age_surfaces():
+    pe_data = {
+        "persons": [],
+        "person_ids": [],
+        "benunits": [
+            {
+                "benunit_id": 11,
+                "guarantee_credit": 0,
+                "housing_benefit_any_over_sp_age": True,
+                "housing_benefit_assessable_capital": 10_501,
+                "housing_benefit_tariff_income": 2 * WEEKS_IN_YEAR,
+            },
+        ],
+        "benunit_ids": [11],
+    }
+
+    working_age_report = compare_outputs(
+        pe_data=pe_data,
+        axiom_outputs_by_surface={
+            "housing-benefit-working-age-tariff-income": [
+                {
+                    "outputs": {
+                        HOUSING_BENEFIT_WORKING_AGE_TARIFF_INCOME_OUTPUTS[
+                            "capital_tariff_weekly_income"
+                        ]["axiom"]: decimal_output(0),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+    pension_age_report = compare_outputs(
+        pe_data=pe_data,
+        axiom_outputs_by_surface={
+            "housing-benefit-pension-age-tariff-income": [
+                {
+                    "outputs": {
+                        HOUSING_BENEFIT_PENSION_AGE_TARIFF_INCOME_OUTPUTS[
+                            "capital_tariff_weekly_income"
+                        ]["axiom"]: decimal_output(2),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert working_age_report.compared_values == 0
+    assert pension_age_report.compared_values == 1
+    assert pension_age_report.mismatches == []
 
 
 def test_compare_outputs_skips_undefined_universal_credit_tariff_income():

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -35,6 +35,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     STATE_PENSION_CREDIT_SECTION_1_BASE,
     STATE_PENSION_CREDIT_SECTION_2_BASE,
     STATE_PENSION_CREDIT_SECTION_3_BASE,
+    UNIVERSAL_CREDIT_ASSESSABLE_CAPITAL_OUTPUTS,
     UNIVERSAL_CREDIT_AWARD_OUTPUTS,
     UNIVERSAL_CREDIT_CHILD_ELEMENT_OUTPUTS,
     UNIVERSAL_CREDIT_CHILDCARE_ELEMENT_OUTPUTS,
@@ -42,6 +43,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     UNIVERSAL_CREDIT_HOUSING_COSTS_OUTPUTS,
     UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS,
     UNIVERSAL_CREDIT_LCWRA_OUTPUTS,
+    UNIVERSAL_CREDIT_REGULATION_18_BASE,
     UNIVERSAL_CREDIT_REGULATION_22_BASE,
     UNIVERSAL_CREDIT_REGULATION_32_BASE,
     UNIVERSAL_CREDIT_REGULATION_34_BASE,
@@ -65,6 +67,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_state_pension_credit_qualifying_age_request,
     build_state_pension_credit_savings_credit_request,
     build_uk_efrs_coverage_report,
+    build_universal_credit_assessable_capital_request,
     build_universal_credit_award_request,
     build_universal_credit_childcare_element_request,
     build_universal_credit_childcare_work_condition_request,
@@ -90,6 +93,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_state_pension_credit_guarantee_credit_inputs,
     project_state_pension_credit_qualifying_age_inputs,
     project_state_pension_credit_savings_credit_inputs,
+    project_universal_credit_assessable_capital_inputs,
     project_universal_credit_award_inputs,
     project_universal_credit_childcare_element_inputs,
     project_universal_credit_childcare_work_condition_inputs,
@@ -1783,6 +1787,69 @@ def test_universal_credit_tariff_income_projection_uses_regulation_72_inputs():
     }
 
 
+def test_universal_credit_assessable_capital_projection_uses_regulation_18_inputs():
+    assert project_universal_credit_assessable_capital_inputs(
+        {
+            "uc_assessable_capital": 12_345,
+        }
+    ) == {
+        "claim_is_for_joint_claimants": False,
+        "claimant_is_member_of_couple": False,
+        "claimant_makes_claim_as_single_person": False,
+        "claimant_capital": 12_345,
+        "other_member_of_couple_capital": 0.0,
+    }
+
+
+def test_universal_credit_assessable_capital_request_projects_regulation_18_inputs():
+    request = build_universal_credit_assessable_capital_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "uc_assessable_capital": 12_345,
+                }
+            ],
+            "benunit_ids": [11],
+        },
+        year=2026,
+    )
+
+    assert request["mode"] == "explain"
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_11",
+            "period": {
+                "period_kind": "custom",
+                "name": "day",
+                "start": "2026-04-06",
+                "end": "2026-04-06",
+            },
+            "outputs": list(
+                output["axiom"]
+                for output in UNIVERSAL_CREDIT_ASSESSABLE_CAPITAL_OUTPUTS.values()
+            ),
+        }
+    ]
+    inputs_by_name = {
+        record["name"]: record["value"] for record in request["dataset"]["inputs"]
+    }
+    assert inputs_by_name[
+        f"{UNIVERSAL_CREDIT_REGULATION_18_BASE}#input.claimant_capital"
+    ] == {
+        "kind": "decimal",
+        "value": "12345.0",
+    }
+    assert inputs_by_name[
+        f"{UNIVERSAL_CREDIT_REGULATION_18_BASE}#input.other_member_of_couple_capital"
+    ] == {
+        "kind": "decimal",
+        "value": "0.0",
+    }
+
+
 def test_universal_credit_tariff_income_request_projects_regulation_72_inputs():
     request = build_universal_credit_tariff_income_request(
         pe_data={
@@ -2154,6 +2221,9 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "uc_unearned_income",
         "uc_work_allowance",
     )
+    assert policyengine_benunit_variables_for_surfaces(
+        ["universal-credit-assessable-capital"]
+    ) == ("uc_assessable_capital",)
     assert policyengine_benunit_variables_for_surfaces(
         ["universal-credit-tariff-income"]
     ) == (
@@ -3127,6 +3197,39 @@ def test_compare_outputs_skips_negative_unearned_income_deduction_final():
     )
 
     assert report.compared_values == 2
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_handles_universal_credit_assessable_capital():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "uc_assessable_capital": 12_345,
+                }
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "universal-credit-assessable-capital": [
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_ASSESSABLE_CAPITAL_OUTPUTS[
+                            "claimant_capital_for_prescribed_capital_limit"
+                        ]["axiom"]: decimal_output(12_345),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=0,
+    )
+
+    assert report.compared_values == 1
     assert report.mismatches == []
     assert report.oracle_divergences == []
 

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -25,7 +25,9 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     NATIONAL_INSURANCE_CLASS_1_OUTPUTS,
     NATIONAL_INSURANCE_SECTION_8_BASE,
     PENSION_CREDIT_BASE,
+    PENSION_CREDIT_DEEMED_INCOME_OUTPUTS,
     PENSION_CREDIT_OUTPUTS,
+    PENSION_CREDIT_REGULATION_15_BASE,
     PERSONAL_ALLOWANCE_BASE,
     PERSONAL_ALLOWANCE_OUTPUTS,
     PERSONAL_ALLOWANCE_PROGRAM_PATH,
@@ -61,6 +63,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_income_tax_section_11d_request,
     build_income_tax_section_13_request,
     build_national_insurance_class_1_request,
+    build_pension_credit_deemed_income_request,
     build_pension_credit_request,
     build_personal_allowance_request,
     build_state_pension_credit_guarantee_credit_request,
@@ -88,6 +91,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_income_tax_section_11d_inputs,
     project_income_tax_section_13_inputs,
     project_income_tax_section_23_inputs,
+    project_pension_credit_deemed_income_inputs,
     project_pension_credit_inputs,
     project_personal_allowance_inputs,
     project_state_pension_credit_guarantee_credit_inputs,
@@ -1017,6 +1021,68 @@ def test_pension_credit_request_projects_benefit_units():
     ]
     assert {record["name"]: record["value"] for record in request["dataset"]["inputs"]}[
         f"{PENSION_CREDIT_BASE}#input.claimant_has_partner"
+    ] == {
+        "kind": "bool",
+        "value": False,
+    }
+
+
+def test_pension_credit_deemed_income_projection_uses_regulation_15_inputs():
+    assert project_pension_credit_deemed_income_inputs(
+        {
+            "pension_credit_assessable_capital": 10_501,
+        }
+    ) == {
+        "claimant_capital": 10_501,
+        "capital_disregarded_under_regulation_17_8": False,
+    }
+
+
+def test_pension_credit_deemed_income_request_projects_regulation_15_inputs():
+    request = build_pension_credit_deemed_income_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "pension_credit_assessable_capital": 10_501,
+                    "pension_credit_deemed_income": 2 * WEEKS_IN_YEAR,
+                }
+            ],
+            "benunit_ids": [11],
+        },
+        year=2026,
+    )
+
+    assert request["mode"] == "explain"
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_11",
+            "period": {
+                "period_kind": "custom",
+                "name": "benefit_week",
+                "start": "2026-04-06",
+                "end": "2026-04-12",
+            },
+            "outputs": list(
+                output["axiom"]
+                for output in PENSION_CREDIT_DEEMED_INCOME_OUTPUTS.values()
+            ),
+        }
+    ]
+    inputs_by_name = {
+        record["name"]: record["value"] for record in request["dataset"]["inputs"]
+    }
+    assert inputs_by_name[
+        f"{PENSION_CREDIT_REGULATION_15_BASE}#input.claimant_capital"
+    ] == {
+        "kind": "decimal",
+        "value": "10501.0",
+    }
+    assert inputs_by_name[
+        f"{PENSION_CREDIT_REGULATION_15_BASE}"
+        "#input.capital_disregarded_under_regulation_17_8"
     ] == {
         "kind": "bool",
         "value": False,
@@ -3256,6 +3322,40 @@ def test_compare_outputs_transforms_universal_credit_tariff_income_monthly():
                         UNIVERSAL_CREDIT_TARIFF_INCOME_OUTPUTS[
                             "capital_tariff_monthly_income"
                         ]["axiom"]: decimal_output(4.35),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_transforms_pension_credit_deemed_income_weekly():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "pension_credit_assessable_capital": 10_501,
+                    "pension_credit_deemed_income": 2 * WEEKS_IN_YEAR,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "pension-credit-deemed-income": [
+                {
+                    "outputs": {
+                        PENSION_CREDIT_DEEMED_INCOME_OUTPUTS[
+                            "capital_deemed_weekly_income"
+                        ]["axiom"]: decimal_output(2),
                     }
                 }
             ]

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.576"
+version = "0.2.577"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.579"
+version = "0.2.580"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.578"
+version = "0.2.579"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.577"
+version = "0.2.578"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Adds UK EFRS oracle coverage and mappings for State Pension Credit guarantee credit, Pension Credit Regulation 15 deemed income, UC Regulation 18 assessable capital, and legacy capital tariff income.
- New legacy tariff surfaces cover ESA Regulation 118, JSA Regulation 116, Income Support Regulation 53, Housing Benefit Regulation 52, and pension-age Housing Benefit Regulation 29.
- Projects PolicyEngine assessable-capital outputs into the source-level claimant-capital leaves, with explicit guards for branches PE does not currently expose, and bumps `axiom-encode` to `0.2.580`.

## Local validation
- `pytest tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_pension_credit_regulation_15_outputs tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_legacy_tariff_income_outputs tests/test_cli.py::test_package_version_metadata_matches_pyproject` -> 118 passed, 1 skipped
- `ruff check` and `ruff format --check` on changed files -> passed
- `python -m compileall -q src/axiom_encode scripts` -> passed
- `git diff --check` -> passed

## Local EFRS oracle validation
Using local enhanced FRS 2023/24, PolicyEngine Core 3.26.11, PolicyEngine UK 2.88.43, and rulespec-uk branch `codex/uk-next-pe-coverage-20260605`:

- Full `--surface all`: 115,612 persons, 61,858 benunits, 3,911,140 compared values, 63 outputs, 0 mismatches, 0 oracle divergences, 0 skipped surfaces
- ESA tariff income: 20,410 values, 0 mismatches
- JSA tariff income: 20,288 values, 0 mismatches
- Income Support tariff income: 20,342 values, 0 mismatches
- Housing Benefit working-age tariff income: 16,272 values, 0 mismatches
- Housing Benefit pension-age tariff income: 18,478 values, 0 mismatches
