### PR TITLE
Add UK Pension Credit child addition oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.580"
+version = "0.2.581"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.580"
+__version__ = "0.2.581"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -60,6 +60,10 @@ STATE_PENSION_CREDIT_SECTION_3_PROGRAM_PATH = Path("statutes/ukpga/2002/16/3.yam
 STATE_PENSION_CREDIT_SECTION_3_BASE = "uk:statutes/ukpga/2002/16/3"
 PENSION_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2002/1792/6.yaml")
 PENSION_CREDIT_BASE = "uk:regulations/uksi/2002/1792/6"
+PENSION_CREDIT_SCHEDULE_IIA_PROGRAM_PATH = Path(
+    "regulations/uksi/2002/1792/schedule/IIA.yaml"
+)
+PENSION_CREDIT_SCHEDULE_IIA_BASE = "uk:regulations/uksi/2002/1792/schedule/IIA"
 PENSION_CREDIT_REGULATION_15_PROGRAM_PATH = Path("regulations/uksi/2002/1792/15.yaml")
 PENSION_CREDIT_REGULATION_15_BASE = "uk:regulations/uksi/2002/1792/15"
 ESA_REGULATION_118_PROGRAM_PATH = Path("regulations/uksi/2008/794/118.yaml")
@@ -310,6 +314,15 @@ PENSION_CREDIT_OUTPUTS = {
         "axiom": f"{PENSION_CREDIT_BASE}#carer_additional_amount",
         "pe": "carer_minimum_guarantee_addition",
         "pe_transform": "annual_to_weekly_per_carer",
+    },
+}
+
+PENSION_CREDIT_CHILD_ADDITION_OUTPUTS = {
+    "additional_amount_applicable": {
+        "axiom": f"{PENSION_CREDIT_SCHEDULE_IIA_BASE}#additional_amount_applicable",
+        "pe": "child_minimum_guarantee_addition",
+        "pe_transform": "annual_to_weekly",
+        "tolerance": 0.01,
     },
 }
 
@@ -752,6 +765,20 @@ SURFACE_SPECS = {
             "relation_type",
             "severe_disability_minimum_guarantee_addition",
             "standard_minimum_guarantee",
+        ),
+    ),
+    "pension-credit-child-addition": UKEFRSSurfaceSpec(
+        program=PENSION_CREDIT_SCHEDULE_IIA_PROGRAM_PATH,
+        entity="benunit",
+        outputs=PENSION_CREDIT_CHILD_ADDITION_OUTPUTS,
+        pe_variables=("child_minimum_guarantee_addition",),
+        projection_person_variables=(
+            "birth_year",
+            "dla",
+            "is_child_or_qualifying_young_person_for_pension_credit",
+            "pip",
+            "receives_enhanced_pip_dl",
+            "receives_highest_dla_sc",
         ),
     ),
     "pension-credit-deemed-income": UKEFRSSurfaceSpec(
@@ -1450,6 +1477,10 @@ def load_local_policyengine_uk_data(
             merged_benunits,
             merged,
         )
+        merged_benunits = add_pension_credit_child_addition_projection_columns(
+            merged_benunits,
+            merged,
+        )
         benunit_records = table_records(merged_benunits)
         selected_benunit_ids = ()
         if person_ids:
@@ -1586,6 +1617,69 @@ def add_housing_benefit_age_projection_columns(
     merged["housing_benefit_any_over_sp_age"] = merged[
         "housing_benefit_any_over_sp_age"
     ].fillna(False)
+    return merged
+
+
+def add_pension_credit_child_addition_projection_columns(
+    benunit: Any,
+    person: Any,
+) -> Any:
+    required = {
+        "person_benunit_id",
+        "birth_year",
+        "dla",
+        "is_child_or_qualifying_young_person_for_pension_credit",
+        "pip",
+        "receives_enhanced_pip_dl",
+        "receives_highest_dla_sc",
+    }
+    if not required.issubset(set(person.columns)):
+        return benunit
+    projection = person[["person_benunit_id"]].copy()
+    is_child = (
+        person["is_child_or_qualifying_young_person_for_pension_credit"]
+        .fillna(False)
+        .astype(bool)
+    )
+    standard_disability = (
+        person["dla"].fillna(0).astype(float) + person["pip"].fillna(0).astype(float)
+    ) > 0
+    severe_disability = person["receives_highest_dla_sc"].fillna(False).astype(
+        bool
+    ) | person["receives_enhanced_pip_dl"].fillna(False).astype(bool)
+    birth_year = person["birth_year"].fillna(9999).astype(float)
+    projection["pc_child_addition_child_count"] = is_child.astype(int)
+    projection["pc_child_addition_standard_disabled_child_count"] = (
+        is_child & standard_disability & ~severe_disability
+    ).astype(int)
+    projection["pc_child_addition_severely_disabled_child_count"] = (
+        is_child & severe_disability
+    ).astype(int)
+    projection["pc_child_addition_any_pre_2017_child"] = (
+        is_child & (birth_year < 2017)
+    ).astype(int)
+    by_benunit = projection.groupby("person_benunit_id", dropna=False).sum()
+    by_benunit["pc_child_addition_any_pre_2017_child"] = (
+        by_benunit["pc_child_addition_any_pre_2017_child"] > 0
+    )
+    output_columns = [
+        "pc_child_addition_child_count",
+        "pc_child_addition_standard_disabled_child_count",
+        "pc_child_addition_severely_disabled_child_count",
+        "pc_child_addition_any_pre_2017_child",
+    ]
+    by_benunit = by_benunit[output_columns].reset_index()
+    merged = benunit.merge(
+        by_benunit,
+        left_on="benunit_id",
+        right_on="person_benunit_id",
+        how="left",
+    ).drop(columns=["person_benunit_id"], errors="ignore")
+    for column in output_columns:
+        if column == "pc_child_addition_any_pre_2017_child":
+            merged[column] = merged[column].fillna(False)
+        else:
+            merged[column] = merged[column].fillna(0).astype(int)
     return merged
 
 
@@ -2497,6 +2591,8 @@ def build_axiom_request(
         )
     if surface == "pension-credit":
         return build_pension_credit_request(pe_data=pe_data, year=year)
+    if surface == "pension-credit-child-addition":
+        return build_pension_credit_child_addition_request(pe_data=pe_data, year=year)
     if surface == "pension-credit-deemed-income":
         return build_pension_credit_deemed_income_request(
             pe_data=pe_data,
@@ -2958,6 +3054,41 @@ def build_pension_credit_request(
                 "entity_id": entity_id,
                 "period": interval,
                 "outputs": [spec["axiom"] for spec in PENSION_CREDIT_OUTPUTS.values()],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_pension_credit_child_addition_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = benefit_week_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "pension-credit-child-addition"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_pension_credit_child_addition_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{PENSION_CREDIT_SCHEDULE_IIA_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in PENSION_CREDIT_CHILD_ADDITION_OUTPUTS.values()
+                ],
             }
         )
 
@@ -3955,6 +4086,23 @@ def project_pension_credit_inputs(row: Any) -> dict[str, Any]:
     }
 
 
+def project_pension_credit_child_addition_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "claimant_responsible_child_or_qualifying_young_person_count": int(
+            money(row_value(row, "pc_child_addition_child_count", 0))
+        ),
+        "claimant_responsible_disabled_not_severely_disabled_child_or_qualifying_young_person_count": int(
+            money(row_value(row, "pc_child_addition_standard_disabled_child_count", 0))
+        ),
+        "claimant_responsible_severely_disabled_child_or_qualifying_young_person_count": int(
+            money(row_value(row, "pc_child_addition_severely_disabled_child_count", 0))
+        ),
+        "eldest_child_or_qualifying_young_person_born_before_6_april_2017": bool(
+            row_value(row, "pc_child_addition_any_pre_2017_child", False)
+        ),
+    }
+
+
 def project_state_pension_credit_guarantee_credit_inputs(
     row: Any,
 ) -> dict[str, Any]:
@@ -4186,6 +4334,12 @@ def compare_outputs(
             "divided by num_carers and 52. The EFRS oracle has no positive "
             "severe-disability addition rows, so that branch is currently a "
             "zero-row guard rather than a positive-eligibility validation.",
+            "Pension Credit Schedule IIA child-addition comparison projects "
+            "PolicyEngine person-level child-or-qualifying-young-person, "
+            "birth-year, and disability-benefit outputs into benefit-unit "
+            "counts and the eldest-child-before-6-April-2017 flag, then "
+            "compares the weekly RuleSpec aggregate against PolicyEngine's "
+            "annual child_minimum_guarantee_addition divided by 52.",
             "State Pension Credit Act section 1 qualifying-age comparison "
             "queries RuleSpec's day-level qualifying_age on a representative "
             "day and supplies PolicyEngine's annual state_pension_age for both "

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -465,6 +465,66 @@ mappings:
     comparison: money
     rationale: Same Pension Credit carer addition output after applying claimant circumstances.
 
+  - legal_id: uk:regulations/uksi/2002/1792/schedule/IIA#child_or_qualifying_young_person_weekly_amount
+    country: uk
+    program: pension_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.pension_credit.guarantee_credit.child.addition
+    aliases:
+      - uk:regulations/uksi/2002/1792/schedule/IIA#additional_amount_applicable
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same standard weekly Pension Credit child or qualifying-young-person addition. Companion tests exercise it through the aggregate Schedule IIA amount.
+
+  - legal_id: uk:regulations/uksi/2002/1792/schedule/IIA#first_child_or_qualifying_young_person_born_before_6_april_2017_weekly_amount
+    country: uk
+    program: pension_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.pension_credit.guarantee_credit.child.first.addition
+    aliases:
+      - uk:regulations/uksi/2002/1792/schedule/IIA#additional_amount_applicable
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Pension Credit amount for the eldest responsible child or qualifying young person born before 6 April 2017. Companion tests exercise it through the aggregate Schedule IIA amount.
+
+  - legal_id: uk:regulations/uksi/2002/1792/schedule/IIA#disabled_child_or_qualifying_young_person_further_weekly_amount
+    country: uk
+    program: pension_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.pension_credit.guarantee_credit.child.disability.addition
+    aliases:
+      - uk:regulations/uksi/2002/1792/schedule/IIA#additional_amount_applicable
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same further weekly Pension Credit amount for a disabled child or qualifying young person. Companion tests exercise it through the aggregate Schedule IIA amount.
+
+  - legal_id: uk:regulations/uksi/2002/1792/schedule/IIA#severely_disabled_child_or_qualifying_young_person_further_weekly_amount
+    country: uk
+    program: pension_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.pension_credit.guarantee_credit.child.disability.severe.addition
+    aliases:
+      - uk:regulations/uksi/2002/1792/schedule/IIA#additional_amount_applicable
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same further weekly Pension Credit amount for a severely disabled child or qualifying young person. Companion tests exercise it through the aggregate Schedule IIA amount.
+
+  - legal_id: uk:regulations/uksi/2002/1792/schedule/IIA#additional_amount_applicable
+    country: uk
+    program: pension_credit
+    mapping_type: direct_variable
+    policyengine_variable: child_minimum_guarantee_addition
+    entity: benunit
+    period: week
+    unit: GBP
+    comparison: money
+    candidate_priority: P2
+    rationale: Same Pension Credit child-related addition after the UK EFRS adapter projects PolicyEngine's child count, pre-2017 eldest-child flag, and disability buckets into Schedule IIA inputs and converts PolicyEngine's annual output to a weekly amount.
+
   - legal_id: uk:regulations/uksi/2002/1792/15#capital_deemed_weekly_income
     country: uk
     program: pension_credit
@@ -826,6 +886,12 @@ prefixes:
     program: pension_credit
     mapping_type: not_comparable
     rationale: Pension Credit helper outputs not listed above are remand-prisoner, tax-credit cessation, nil substitution, or branch-control intermediates that PolicyEngine UK does not expose as one-to-one oracle variables or parameters.
+
+  - legal_id_prefix: uk:regulations/uksi/2002/1792/schedule/IIA#
+    country: uk
+    program: pension_credit
+    mapping_type: not_comparable
+    rationale: Pension Credit Schedule IIA helper outputs not listed above are responsibility, absence, disability, or aggregation intermediates that PolicyEngine UK does not expose as one-to-one oracle variables or parameters.
 
   - legal_id_prefix: uk:regulations/uksi/2002/1792/15#
     country: uk

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1396,6 +1396,112 @@ rules:
     assert helper["status"] == "known_not_comparable"
 
 
+def test_policyengine_coverage_classifies_uk_pension_credit_schedule_iia_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2002/1792/schedule/IIA.yaml",
+        """format: rulespec/v1
+rules:
+  - name: child_or_qualifying_young_person_weekly_amount
+    kind: parameter
+    entity: Person
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 69.98
+  - name: first_child_or_qualifying_young_person_born_before_6_april_2017_weekly_amount
+    kind: parameter
+    entity: Person
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 81.07
+  - name: disabled_child_or_qualifying_young_person_further_weekly_amount
+    kind: parameter
+    entity: Person
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 37.93
+  - name: severely_disabled_child_or_qualifying_young_person_further_weekly_amount
+    kind: parameter
+    entity: Person
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 118.46
+  - name: schedule_applies_to_claimant
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: claimant_responsible_child_or_qualifying_young_person_count > 0
+  - name: additional_amount_applicable
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: child_or_qualifying_young_person_weekly_amount
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2002/1792/schedule/IIA.test.yaml",
+        """- name: child addition
+  period:
+    period_kind: custom
+    name: benefit_week
+    start: '2026-04-06'
+    end: '2026-04-12'
+  input: {}
+  output:
+    uk:regulations/uksi/2002/1792/schedule/IIA#child_or_qualifying_young_person_weekly_amount: 69.98
+    uk:regulations/uksi/2002/1792/schedule/IIA#first_child_or_qualifying_young_person_born_before_6_april_2017_weekly_amount: 81.07
+    uk:regulations/uksi/2002/1792/schedule/IIA#disabled_child_or_qualifying_young_person_further_weekly_amount: 37.93
+    uk:regulations/uksi/2002/1792/schedule/IIA#severely_disabled_child_or_qualifying_young_person_further_weekly_amount: 118.46
+    uk:regulations/uksi/2002/1792/schedule/IIA#additional_amount_applicable: 69.98
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="pension_credit")
+
+    assert report["status_counts"] == {
+        "comparable": 5,
+        "known_not_comparable": 1,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    additional_amount = items_by_id[
+        "uk:regulations/uksi/2002/1792/schedule/IIA#additional_amount_applicable"
+    ]
+    child_amount = items_by_id[
+        "uk:regulations/uksi/2002/1792/schedule/IIA#child_or_qualifying_young_person_weekly_amount"
+    ]
+    helper = items_by_id[
+        "uk:regulations/uksi/2002/1792/schedule/IIA#schedule_applies_to_claimant"
+    ]
+
+    assert (
+        additional_amount["policyengine_variable"] == "child_minimum_guarantee_addition"
+    )
+    assert additional_amount["status"] == "comparable"
+    assert additional_amount["mapping_type"] == "direct_variable"
+    assert additional_amount["tested"] is True
+    assert (
+        child_amount["policyengine_parameter"]
+        == "gov.dwp.pension_credit.guarantee_credit.child.addition"
+    )
+    assert child_amount["mapping_type"] == "parameter_value"
+    assert helper["status"] == "known_not_comparable"
+
+
 @pytest.mark.parametrize(
     (
         "path",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -35,9 +35,11 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     NATIONAL_INSURANCE_CLASS_1_OUTPUTS,
     NATIONAL_INSURANCE_SECTION_8_BASE,
     PENSION_CREDIT_BASE,
+    PENSION_CREDIT_CHILD_ADDITION_OUTPUTS,
     PENSION_CREDIT_DEEMED_INCOME_OUTPUTS,
     PENSION_CREDIT_OUTPUTS,
     PENSION_CREDIT_REGULATION_15_BASE,
+    PENSION_CREDIT_SCHEDULE_IIA_BASE,
     PERSONAL_ALLOWANCE_BASE,
     PERSONAL_ALLOWANCE_OUTPUTS,
     PERSONAL_ALLOWANCE_PROGRAM_PATH,
@@ -78,6 +80,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_income_tax_section_13_request,
     build_jsa_income_tariff_income_request,
     build_national_insurance_class_1_request,
+    build_pension_credit_child_addition_request,
     build_pension_credit_deemed_income_request,
     build_pension_credit_request,
     build_personal_allowance_request,
@@ -111,6 +114,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_income_tax_section_13_inputs,
     project_income_tax_section_23_inputs,
     project_jsa_income_tariff_income_inputs,
+    project_pension_credit_child_addition_inputs,
     project_pension_credit_deemed_income_inputs,
     project_pension_credit_inputs,
     project_personal_allowance_inputs,
@@ -1751,6 +1755,103 @@ def test_adds_universal_credit_childcare_work_projection_columns():
     assert bool(projected.loc[11, "uc_childcare_all_adults_in_work"]) is True
     assert projected.loc[12, "uc_childcare_adult_count"] == 0
     assert bool(projected.loc[12, "uc_childcare_any_adult_in_work"]) is False
+
+
+def test_adds_pension_credit_child_addition_projection_columns():
+    pd = pytest.importorskip("pandas")
+    benunit = pd.DataFrame({"benunit_id": [10, 11, 12]})
+    person = pd.DataFrame(
+        {
+            "person_benunit_id": [10, 10, 10, 11],
+            "birth_year": [2010, 2018, 1980, 2019],
+            "is_child_or_qualifying_young_person_for_pension_credit": [
+                True,
+                True,
+                False,
+                True,
+            ],
+            "dla": [0, 1, 0, 0],
+            "pip": [0, 0, 0, 0],
+            "receives_highest_dla_sc": [True, False, False, False],
+            "receives_enhanced_pip_dl": [False, False, False, False],
+        }
+    )
+
+    projected = efrs_uk.add_pension_credit_child_addition_projection_columns(
+        benunit,
+        person,
+    ).set_index("benunit_id")
+
+    assert projected.loc[10, "pc_child_addition_child_count"] == 2
+    assert projected.loc[10, "pc_child_addition_standard_disabled_child_count"] == 1
+    assert projected.loc[10, "pc_child_addition_severely_disabled_child_count"] == 1
+    assert bool(projected.loc[10, "pc_child_addition_any_pre_2017_child"]) is True
+    assert projected.loc[11, "pc_child_addition_child_count"] == 1
+    assert bool(projected.loc[11, "pc_child_addition_any_pre_2017_child"]) is False
+    assert projected.loc[12, "pc_child_addition_child_count"] == 0
+
+
+def test_pension_credit_child_addition_request_projects_schedule_iia_inputs():
+    request = build_pension_credit_child_addition_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 22,
+                    "pc_child_addition_child_count": 2,
+                    "pc_child_addition_standard_disabled_child_count": 1,
+                    "pc_child_addition_severely_disabled_child_count": 1,
+                    "pc_child_addition_any_pre_2017_child": True,
+                }
+            ],
+            "benunit_ids": [22],
+        },
+        year=2026,
+    )
+
+    inputs_by_name = {
+        item["name"]: item["value"] for item in request["dataset"]["inputs"]
+    }
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_22",
+            "period": {
+                "period_kind": "custom",
+                "name": "benefit_week",
+                "start": "2026-04-06",
+                "end": "2026-04-12",
+            },
+            "outputs": [
+                PENSION_CREDIT_CHILD_ADDITION_OUTPUTS["additional_amount_applicable"][
+                    "axiom"
+                ]
+            ],
+        }
+    ]
+    assert inputs_by_name[
+        f"{PENSION_CREDIT_SCHEDULE_IIA_BASE}#input.claimant_responsible_child_or_qualifying_young_person_count"
+    ] == {"kind": "integer", "value": 2}
+    assert inputs_by_name[
+        f"{PENSION_CREDIT_SCHEDULE_IIA_BASE}#input.claimant_responsible_disabled_not_severely_disabled_child_or_qualifying_young_person_count"
+    ] == {"kind": "integer", "value": 1}
+    assert inputs_by_name[
+        f"{PENSION_CREDIT_SCHEDULE_IIA_BASE}#input.claimant_responsible_severely_disabled_child_or_qualifying_young_person_count"
+    ] == {"kind": "integer", "value": 1}
+    assert inputs_by_name[
+        f"{PENSION_CREDIT_SCHEDULE_IIA_BASE}#input.eldest_child_or_qualifying_young_person_born_before_6_april_2017"
+    ] == {"kind": "bool", "value": True}
+
+
+def test_project_pension_credit_child_addition_inputs_defaults_to_zero():
+    projected = project_pension_credit_child_addition_inputs({})
+
+    assert projected == {
+        "claimant_responsible_child_or_qualifying_young_person_count": 0,
+        "claimant_responsible_disabled_not_severely_disabled_child_or_qualifying_young_person_count": 0,
+        "claimant_responsible_severely_disabled_child_or_qualifying_young_person_count": 0,
+        "eldest_child_or_qualifying_young_person_born_before_6_april_2017": False,
+    }
 
 
 def test_universal_credit_housing_costs_projection_uses_monthly_amount():
@@ -3976,6 +4077,39 @@ def test_compare_outputs_handles_state_pension_credit_guarantee_credit():
     )
 
     assert report.compared_values == 2
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_handles_pension_credit_child_addition():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 22,
+                    "child_minimum_guarantee_addition": 307.44 * WEEKS_IN_YEAR,
+                }
+            ],
+            "benunit_ids": [22],
+        },
+        axiom_outputs_by_surface={
+            "pension-credit-child-addition": [
+                {
+                    "outputs": {
+                        PENSION_CREDIT_CHILD_ADDITION_OUTPUTS[
+                            "additional_amount_applicable"
+                        ]["axiom"]: decimal_output(307.44),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=0,
+    )
+
+    assert report.compared_values == 1
     assert report.mismatches == []
     assert report.oracle_divergences == []
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.580"
+version = "0.2.581"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add PolicyEngine UK EFRS oracle coverage for Pension Credit Schedule IIA child-related additions
- map Schedule IIA child, first-child, disabled-child, severe-disabled-child parameters and aggregate output to PE UK
- project PE person-level child/QYP, birth-year, DLA/PIP, and severe-disability outputs into vectorized benefit-unit Schedule IIA inputs

## Validation
- `uv run ruff check src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py -q` (361 passed, 2 skipped)
- `axiom-encode uk-efrs-compare --surface pension-credit-child-addition --sample-size 0 --fail-on-mismatch` (61,858 values, 0 mismatches)
- `axiom-encode uk-efrs-compare --surface all --sample-size 0 --fail-on-mismatch` (3,972,998 values across 64 outputs, 0 mismatches, 0 oracle divergences)
