### PR TITLE
Classify US conclusive determinations for PE coverage

### DIFF
--- a/changelog.d/us-conclusive-determination-coverage.fixed.md
+++ b/changelog.d/us-conclusive-determination-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify federal conclusive agency and secretary determination RuleSpec outputs as known not comparable for PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.581"
+version = "0.2.582"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.581"
+__version__ = "0.2.582"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -14094,6 +14094,18 @@ mappings:
     rationale: "Source-specific intermediate output (rule `timely_application_for_recertification`, grounded against `Ala. Admin. Code 660-4-7-.08`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
 prefixes:
+  - legal_id_prefix: us:statutes/5/5566#
+    country: us
+    program: unknown
+    mapping_type: not_comparable
+    rationale: Section 5566 conclusive-agency-determination outputs are adjudicative predicates about official findings of death, dependency, and related status; PolicyEngine has no one-to-one microsimulation variables for those agency determinations.
+
+  - legal_id_prefix: us:statutes/37/556#
+    country: us
+    program: unknown
+    mapping_type: not_comparable
+    rationale: Section 556 secretary-determination outputs are final administrative determinations for death gratuity administration; PolicyEngine has no one-to-one microsimulation variables for those legal adjudication predicates.
+
   - legal_id_prefix: us:_compose/ca-snap#
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -91,6 +91,72 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_conclusive_agency_determinations(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/5/5566.yaml",
+        """format: rulespec/v1
+rules:
+  - name: agency_determination_conclusive_as_to_death
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: agency_determination_made
+  - name: agency_determination_conclusive_as_to_dependency
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: agency_determination_made
+  - name: agency_determination_conclusive_as_to_essential_date
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: agency_determination_made
+  - name: agency_determination_conclusive_as_to_official_report_of_death
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: agency_determination_made
+  - name: agency_determination_conclusive_as_to_other_covered_status
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: agency_determination_made
+  - name: agency_determination_conclusive_under_subchapter
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: agency_determination_made
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/37/556.yaml",
+        """format: rulespec/v1
+rules:
+  - name: secretary_determination_conclusive
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: secretary_determination_made
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path)
+
+    assert report["status_counts"] == {"known_not_comparable": 7}
+    assert {item["program"] for item in report["items"]} == {"unknown"}
+    assert {item["status"] for item in report["items"]} == {"known_not_comparable"}
+    assert {item["mapping_type"] for item in report["items"]} == {"not_comparable"}
+
+
 def test_policyengine_coverage_classifies_colorado_tanf_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us-co" / "regulations/9-ccr-2503-6/3.606.1/F.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.581"
+version = "0.2.582"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 5 USC 5566 and 37 USC 556 conclusive agency/secretary determination outputs as PolicyEngine known-not-comparable
- add a regression test for the seven outputs that blocked global oracle coverage
- bump axiom-encode to 0.2.582 and add a towncrier fragment

## Tests
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine/registry.py src/axiom_encode/oracles/policyengine/coverage.py
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_conclusive_agency_determinations -q
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev axiom-encode oracle-coverage --root /tmp/axiom-rulespec-coverage-20260605 --fail-on-unmapped --fail-on-untested-comparable