### PR TITLE
Classify UK WTC Schedule 2 oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.582"
+version = "0.2.583"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.582"
+__version__ = "0.2.583"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -525,6 +525,64 @@ mappings:
     candidate_priority: P2
     rationale: Same Pension Credit child-related addition after the UK EFRS adapter projects PolicyEngine's child count, pre-2017 eldest-child flag, and disability buckets into Schedule IIA inputs and converts PolicyEngine's annual output to a weekly amount.
 
+  - legal_id: uk:regulations/uksi/2002/2005/schedule/2#wtc_basic_element_amount
+    country: uk
+    program: working_tax_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.tax_credits.working_tax_credit.elements.basic
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual Working Tax Credit basic element maximum rate in Schedule 2.
+
+  - legal_id: uk:regulations/uksi/2002/2005/schedule/2#wtc_disabled_element_amount
+    country: uk
+    program: working_tax_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.tax_credits.working_tax_credit.elements.disabled
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual Working Tax Credit disability element maximum rate in Schedule 2.
+
+  - legal_id: uk:regulations/uksi/2002/2005/schedule/2#schedule_2_row_3_maximum_annual_rate
+    country: uk
+    program: working_tax_credit
+    mapping_type: not_comparable
+    policyengine_parameter: gov.dwp.tax_credits.working_tax_credit.elements.worker
+    candidate_priority: P2
+    rationale: Official Schedule 2 states GBP 1,015 for the 30 hour element, but current PE-UK derives GBP 1,010.22 for 2024 from a stale uprated worker-element parameter instead of the direct Schedule 2 amount.
+
+  - legal_id: uk:regulations/uksi/2002/2005/schedule/2#wtc_second_adult_element_amount
+    country: uk
+    program: working_tax_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.tax_credits.working_tax_credit.elements.couple
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual Working Tax Credit second-adult/couple element maximum rate in Schedule 2.
+
+  - legal_id: uk:regulations/uksi/2002/2005/schedule/2#wtc_lone_parent_element_amount
+    country: uk
+    program: working_tax_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.tax_credits.working_tax_credit.elements.lone_parent
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual Working Tax Credit lone-parent element maximum rate in Schedule 2.
+
+  - legal_id: uk:regulations/uksi/2002/2005/schedule/2#wtc_severely_disabled_element_amount
+    country: uk
+    program: working_tax_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.tax_credits.working_tax_credit.elements.severely_disabled
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual Working Tax Credit severe disability element maximum rate in Schedule 2.
+
   - legal_id: uk:regulations/uksi/2002/1792/15#capital_deemed_weekly_income
     country: uk
     program: pension_credit

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1568,6 +1568,107 @@ rules:
     assert helper["status"] == "known_not_comparable"
 
 
+def test_policyengine_coverage_classifies_uk_wtc_schedule_2_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2002/2005/schedule/2.yaml",
+        """format: rulespec/v1
+rules:
+  - name: wtc_basic_element_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-04-06'
+        formula: 2435
+  - name: wtc_disabled_element_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-04-06'
+        formula: 3935
+  - name: schedule_2_row_3_maximum_annual_rate
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-04-06'
+        formula: 1015
+  - name: wtc_second_adult_element_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-04-06'
+        formula: 2500
+  - name: wtc_lone_parent_element_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-04-06'
+        formula: 2500
+  - name: wtc_severely_disabled_element_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-04-06'
+        formula: 1705
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2002/2005/schedule/2.test.yaml",
+        """- name: wtc schedule 2
+  period:
+    period_kind: tax_year
+    start: '2024-04-06'
+    end: '2025-04-05'
+  input: {}
+  output:
+    uk:regulations/uksi/2002/2005/schedule/2#wtc_basic_element_amount: 2435
+    uk:regulations/uksi/2002/2005/schedule/2#wtc_disabled_element_amount: 3935
+    uk:regulations/uksi/2002/2005/schedule/2#schedule_2_row_3_maximum_annual_rate: 1015
+    uk:regulations/uksi/2002/2005/schedule/2#wtc_second_adult_element_amount: 2500
+    uk:regulations/uksi/2002/2005/schedule/2#wtc_lone_parent_element_amount: 2500
+    uk:regulations/uksi/2002/2005/schedule/2#wtc_severely_disabled_element_amount: 1705
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="working_tax_credit")
+
+    assert report["status_counts"] == {
+        "comparable": 5,
+        "known_not_comparable": 1,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    basic = items_by_id[
+        "uk:regulations/uksi/2002/2005/schedule/2#wtc_basic_element_amount"
+    ]
+    second_adult = items_by_id[
+        "uk:regulations/uksi/2002/2005/schedule/2#wtc_second_adult_element_amount"
+    ]
+    row_3 = items_by_id[
+        "uk:regulations/uksi/2002/2005/schedule/2#schedule_2_row_3_maximum_annual_rate"
+    ]
+
+    assert (
+        basic["policyengine_parameter"]
+        == "gov.dwp.tax_credits.working_tax_credit.elements.basic"
+    )
+    assert basic["mapping_type"] == "parameter_value"
+    assert basic["tested"] is True
+    assert (
+        second_adult["policyengine_parameter"]
+        == "gov.dwp.tax_credits.working_tax_credit.elements.couple"
+    )
+    assert row_3["status"] == "known_not_comparable"
+    assert (
+        row_3["policyengine_parameter"]
+        == "gov.dwp.tax_credits.working_tax_credit.elements.worker"
+    )
+
+
 @pytest.mark.parametrize(
     (
         "path",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.582"
+version = "0.2.583"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map five official UK Working Tax Credit Schedule 2 element-rate outputs to PolicyEngine parameter values
- classify the Schedule 2 30-hour row as known-not-comparable because PE-UK currently returns GBP 1,010.22 for 2024 while official Schedule 2 states GBP 1,015
- add coverage-registry regression coverage for the new WTC Schedule 2 outputs

## Checks
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev ruff check tests/test_policyengine_coverage.py
- uv run --extra dev python - <<PY ... load_policyengine_registry() ... PY
- uv run --extra dev axiom-encode oracle-coverage --root /tmp/axiom-rulespec-uk-wtc-oracle-root-20260605 --oracle policyengine --fail-on-unmapped --fail-on-untested-comparable --json

This unblocks the dependent rulespec-uk Schedule 2 encoding while preserving the PE-UK worker-element mismatch as an explicit known gap.