### PR TITLE
Map UK Child Tax Credit element coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.584"
+version = "0.2.585"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.584"
+__version__ = "0.2.585"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -1098,6 +1098,17 @@ HBAI_COMPONENT_COVERAGE = {
         ),
         "rationale": "Axiom covers Schedule 2 element rates after the WTC encoding; it does not yet compute final Working Tax Credit entitlement.",
     },
+    "child_tax_credit": {
+        "status": "partial",
+        "surfaces": ("child-tax-credit-elements",),
+        "covered_outputs": (
+            "CTC_family_element",
+            "CTC_child_element",
+            "CTC_disabled_child_element",
+            "CTC_severely_disabled_child_element",
+        ),
+        "rationale": "Axiom covers Child Tax Credit family, child, disabled-child, and severe-disabled-child element rates; it does not yet compute final Child Tax Credit entitlement.",
+    },
 }
 
 UNIVERSAL_CREDIT_REGULATION_36_SURFACES = frozenset(

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -583,6 +583,82 @@ mappings:
     comparison: money
     rationale: Same annual Working Tax Credit severe disability element maximum rate in Schedule 2.
 
+  - legal_id: uk:regulations/uksi/2002/2007/7#ctc_family_element_amount
+    country: uk
+    program: child_tax_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.tax_credits.child_tax_credit.elements.family_element
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual Child Tax Credit family element amount in Regulation 7.
+
+  - legal_id: uk:regulations/uksi/2024/247/3#ctc_individual_element_substituted_amount
+    country: uk
+    program: child_tax_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.tax_credits.child_tax_credit.elements.child_element
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual Child Tax Credit individual child or qualifying young person element amount substituted into Regulation 7 by the 2024 up-rating regulations.
+
+  - legal_id: uk:regulations/uksi/2024/247/3#ctc_individual_element_amount
+    country: uk
+    program: child_tax_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.tax_credits.child_tax_credit.elements.child_element
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual Child Tax Credit individual child or qualifying young person element amount after applying the 2024 up-rating substitution.
+
+  - legal_id: uk:regulations/uksi/2024/247/3#ctc_disabled_child_element_substituted_amount
+    country: uk
+    program: child_tax_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.tax_credits.child_tax_credit.elements.dis_child_element
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual Child Tax Credit disabled-child element amount substituted into Regulation 7 by the 2024 up-rating regulations.
+
+  - legal_id: uk:regulations/uksi/2024/247/3#ctc_disabled_child_element_amount
+    country: uk
+    program: child_tax_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.tax_credits.child_tax_credit.elements.dis_child_element
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual Child Tax Credit disabled-child element amount after applying the 2024 up-rating substitution.
+
+  - legal_id: uk:regulations/uksi/2024/247/3#ctc_severely_disabled_child_rate_substituted_amount
+    country: uk
+    program: child_tax_credit
+    mapping_type: not_comparable
+    policyengine_parameter: gov.dwp.tax_credits.child_tax_credit.elements.severe_dis_child_element
+    candidate_priority: P2
+    rationale: Regulation 7 states a total severe-disabled-child rate, while PolicyEngine stores only the additional severe-disabled layer paid on top of the disabled-child element.
+
+  - legal_id: uk:regulations/uksi/2024/247/3#ctc_severely_disabled_child_rate_amount
+    country: uk
+    program: child_tax_credit
+    mapping_type: not_comparable
+    policyengine_parameter: gov.dwp.tax_credits.child_tax_credit.elements.severe_dis_child_element
+    candidate_priority: P2
+    rationale: Regulation 7 states a total severe-disabled-child rate, while PolicyEngine stores only the additional severe-disabled layer paid on top of the disabled-child element.
+
+  - legal_id: uk:regulations/uksi/2024/247/3#ctc_severely_disabled_child_additional_amount
+    country: uk
+    program: child_tax_credit
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.tax_credits.child_tax_credit.elements.severe_dis_child_element
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual additional Child Tax Credit severe-disabled-child layer after deriving the PolicyEngine-shape value as the severe-disabled total rate minus the disabled-child element.
+
   - legal_id: uk:regulations/uksi/2002/1792/15#capital_deemed_weekly_income
     country: uk
     program: pension_credit

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1669,6 +1669,141 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_uk_child_tax_credit_element_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2002/2007/7.yaml",
+        """format: rulespec/v1
+rules:
+  - name: ctc_family_element_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-04-06'
+        formula: 545
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2002/2007/7.test.yaml",
+        """- name: ctc family element
+  period:
+    period_kind: tax_year
+    start: '2024-04-06'
+    end: '2025-04-05'
+  input: {}
+  output:
+    uk:regulations/uksi/2002/2007/7#ctc_family_element_amount: 545
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2024/247/3.yaml",
+        """format: rulespec/v1
+rules:
+  - name: ctc_individual_element_substituted_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-04-06'
+        formula: 3455
+  - name: ctc_disabled_child_element_substituted_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-04-06'
+        formula: 4170
+  - name: ctc_severely_disabled_child_rate_substituted_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-04-06'
+        formula: 5850
+  - name: ctc_individual_element_amount
+    kind: derived
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-04-06'
+        formula: ctc_individual_element_substituted_amount
+  - name: ctc_disabled_child_element_amount
+    kind: derived
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-04-06'
+        formula: ctc_disabled_child_element_substituted_amount
+  - name: ctc_severely_disabled_child_rate_amount
+    kind: derived
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-04-06'
+        formula: ctc_severely_disabled_child_rate_substituted_amount
+  - name: ctc_severely_disabled_child_additional_amount
+    kind: derived
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-04-06'
+        formula: ctc_severely_disabled_child_rate_amount - ctc_disabled_child_element_amount
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2024/247/3.test.yaml",
+        """- name: ctc uprating
+  period:
+    period_kind: tax_year
+    start: '2024-04-06'
+    end: '2025-04-05'
+  input: {}
+  output:
+    uk:regulations/uksi/2024/247/3#ctc_individual_element_substituted_amount: 3455
+    uk:regulations/uksi/2024/247/3#ctc_disabled_child_element_substituted_amount: 4170
+    uk:regulations/uksi/2024/247/3#ctc_severely_disabled_child_rate_substituted_amount: 5850
+    uk:regulations/uksi/2024/247/3#ctc_individual_element_amount: 3455
+    uk:regulations/uksi/2024/247/3#ctc_disabled_child_element_amount: 4170
+    uk:regulations/uksi/2024/247/3#ctc_severely_disabled_child_rate_amount: 5850
+    uk:regulations/uksi/2024/247/3#ctc_severely_disabled_child_additional_amount: 1680
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="child_tax_credit")
+
+    assert report["status_counts"] == {
+        "comparable": 6,
+        "known_not_comparable": 2,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    family = items_by_id["uk:regulations/uksi/2002/2007/7#ctc_family_element_amount"]
+    child = items_by_id["uk:regulations/uksi/2024/247/3#ctc_individual_element_amount"]
+    severe_rate = items_by_id[
+        "uk:regulations/uksi/2024/247/3#ctc_severely_disabled_child_rate_amount"
+    ]
+    severe_additional = items_by_id[
+        "uk:regulations/uksi/2024/247/3#ctc_severely_disabled_child_additional_amount"
+    ]
+
+    assert (
+        family["policyengine_parameter"]
+        == "gov.dwp.tax_credits.child_tax_credit.elements.family_element"
+    )
+    assert (
+        child["policyengine_parameter"]
+        == "gov.dwp.tax_credits.child_tax_credit.elements.child_element"
+    )
+    assert severe_rate["status"] == "known_not_comparable"
+    assert (
+        severe_additional["policyengine_parameter"]
+        == "gov.dwp.tax_credits.child_tax_credit.elements.severe_dis_child_element"
+    )
+    assert severe_additional["mapping_type"] == "parameter_value"
+    assert severe_additional["tested"] is True
+
+
 @pytest.mark.parametrize(
     (
         "path",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -2768,12 +2768,12 @@ class hbai_household_net_income(Variable):
     assert by_name["income_tax"].policy_component is True
     assert by_name["universal_credit"].status == "partial"
     assert by_name["working_tax_credit"].status == "partial"
-    assert by_name["child_tax_credit"].status == "missing"
+    assert by_name["child_tax_credit"].status == "partial"
     assert by_name["council_tax"].status == "missing"
     assert report.policy_component_count == 7
-    assert report.covered_policy_component_count == 5
+    assert report.covered_policy_component_count == 6
     assert report.exact_policy_component_count == 1
-    assert math.isclose(report.covered_policy_component_share, 5 / 7)
+    assert math.isclose(report.covered_policy_component_share, 6 / 7)
     assert math.isclose(report.exact_policy_component_share, 1 / 7)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.584"
+version = "0.2.585"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Add PolicyEngine UK oracle mappings for the new Child Tax Credit element RuleSpec outputs from TheAxiomFoundation/rulespec-uk#16.
- Classify Child Tax Credit as partial HBAI household net-income coverage, with family, child, disabled-child, and severe-disabled-child element rates covered.
- Bump axiom-encode version metadata to `0.2.585` for generated-rulespec provenance.

## HBAI coverage impact
- Covered HBAI policy components move from `10/41` to `11/41` (`26.8%`).
- Exact components remain `1/41`; Child Tax Credit moves from missing to partial.

## Validation
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_child_tax_credit_element_outputs -q`
- `uv run --extra dev pytest tests/test_policyengine_efrs_uk.py::test_uk_hbai_policy_coverage_report_classifies_policy_components -q`
- `uv run --extra dev pytest tests/test_policyengine_coverage.py tests/test_policyengine_efrs_uk.py -q`
- `uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
- `uv run --extra dev axiom-encode uk-efrs-hbai-coverage --source-root /Users/maxghenis/policyengine-uk/policyengine_uk/variables --json`