### PR TITLE
Map UK PIP rate coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.585"
+version = "0.2.586"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.585"
+__version__ = "0.2.586"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -1109,6 +1109,15 @@ HBAI_COMPONENT_COVERAGE = {
         ),
         "rationale": "Axiom covers Child Tax Credit family, child, disabled-child, and severe-disabled-child element rates; it does not yet compute final Child Tax Credit entitlement.",
     },
+    "pip": {
+        "status": "partial",
+        "surfaces": ("personal-independence-payment-rates",),
+        "covered_outputs": (
+            "pip_dl",
+            "pip_m",
+        ),
+        "rationale": "Axiom covers Personal Independence Payment daily-living and mobility weekly rates, not the category assignment or final aggregate PIP amount.",
+    },
 }
 
 UNIVERSAL_CREDIT_REGULATION_36_SURFACES = frozenset(

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -659,6 +659,46 @@ mappings:
     comparison: money
     rationale: Same annual additional Child Tax Credit severe-disabled-child layer after deriving the PolicyEngine-shape value as the severe-disabled total rate minus the disabled-child element.
 
+  - legal_id: uk:regulations/uksi/2013/377/24#pip_daily_living_standard_weekly_rate
+    country: uk
+    program: pip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.pip.daily_living.standard
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Personal Independence Payment daily-living standard rate in Regulation 24.
+
+  - legal_id: uk:regulations/uksi/2013/377/24#pip_daily_living_enhanced_weekly_rate
+    country: uk
+    program: pip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.pip.daily_living.enhanced
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Personal Independence Payment daily-living enhanced rate in Regulation 24.
+
+  - legal_id: uk:regulations/uksi/2013/377/24#pip_mobility_standard_weekly_rate
+    country: uk
+    program: pip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.pip.mobility.standard
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Personal Independence Payment mobility standard rate in Regulation 24.
+
+  - legal_id: uk:regulations/uksi/2013/377/24#pip_mobility_enhanced_weekly_rate
+    country: uk
+    program: pip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.pip.mobility.enhanced
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Personal Independence Payment mobility enhanced rate in Regulation 24.
+
   - legal_id: uk:regulations/uksi/2002/1792/15#capital_deemed_weekly_income
     country: uk
     program: pension_credit

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1804,6 +1804,90 @@ rules:
     assert severe_additional["tested"] is True
 
 
+def test_policyengine_coverage_classifies_uk_pip_rate_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2013/377/24.yaml",
+        """format: rulespec/v1
+rules:
+  - name: pip_daily_living_standard_weekly_rate
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 76.70
+  - name: pip_daily_living_enhanced_weekly_rate
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 114.60
+  - name: pip_mobility_standard_weekly_rate
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 30.30
+  - name: pip_mobility_enhanced_weekly_rate
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 80.00
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2013/377/24.test.yaml",
+        """- name: pip rates
+  period:
+    period_kind: week
+    start: '2026-04-06'
+    end: '2026-04-12'
+  input: {}
+  output:
+    uk:regulations/uksi/2013/377/24#pip_daily_living_standard_weekly_rate: 76.70
+    uk:regulations/uksi/2013/377/24#pip_daily_living_enhanced_weekly_rate: 114.60
+    uk:regulations/uksi/2013/377/24#pip_mobility_standard_weekly_rate: 30.30
+    uk:regulations/uksi/2013/377/24#pip_mobility_enhanced_weekly_rate: 80.00
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="pip")
+
+    assert report["status_counts"] == {"comparable": 4}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    daily_standard = items_by_id[
+        "uk:regulations/uksi/2013/377/24#pip_daily_living_standard_weekly_rate"
+    ]
+    daily_enhanced = items_by_id[
+        "uk:regulations/uksi/2013/377/24#pip_daily_living_enhanced_weekly_rate"
+    ]
+    mobility_standard = items_by_id[
+        "uk:regulations/uksi/2013/377/24#pip_mobility_standard_weekly_rate"
+    ]
+    mobility_enhanced = items_by_id[
+        "uk:regulations/uksi/2013/377/24#pip_mobility_enhanced_weekly_rate"
+    ]
+
+    assert (
+        daily_standard["policyengine_parameter"] == "gov.dwp.pip.daily_living.standard"
+    )
+    assert (
+        daily_enhanced["policyengine_parameter"] == "gov.dwp.pip.daily_living.enhanced"
+    )
+    assert (
+        mobility_standard["policyengine_parameter"] == "gov.dwp.pip.mobility.standard"
+    )
+    assert (
+        mobility_enhanced["policyengine_parameter"] == "gov.dwp.pip.mobility.enhanced"
+    )
+    assert daily_standard["mapping_type"] == "parameter_value"
+    assert daily_standard["tested"] is True
+
+
 @pytest.mark.parametrize(
     (
         "path",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -2736,6 +2736,7 @@ class hbai_household_net_income(Variable):
         "universal_credit",
         "working_tax_credit",
         "child_tax_credit",
+        "pip",
     ]
     subtracts = [
         "income_tax",
@@ -2755,6 +2756,7 @@ class hbai_household_net_income(Variable):
         "universal_credit",
         "working_tax_credit",
         "child_tax_credit",
+        "pip",
     )
     assert report.subtracts == (
         "income_tax",
@@ -2769,12 +2771,13 @@ class hbai_household_net_income(Variable):
     assert by_name["universal_credit"].status == "partial"
     assert by_name["working_tax_credit"].status == "partial"
     assert by_name["child_tax_credit"].status == "partial"
+    assert by_name["pip"].status == "partial"
     assert by_name["council_tax"].status == "missing"
-    assert report.policy_component_count == 7
-    assert report.covered_policy_component_count == 6
+    assert report.policy_component_count == 8
+    assert report.covered_policy_component_count == 7
     assert report.exact_policy_component_count == 1
-    assert math.isclose(report.covered_policy_component_share, 6 / 7)
-    assert math.isclose(report.exact_policy_component_share, 1 / 7)
+    assert math.isclose(report.covered_policy_component_share, 7 / 8)
+    assert math.isclose(report.exact_policy_component_share, 1 / 8)
 
 
 def test_uk_hbai_policy_coverage_report_serializes_json(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.585"
+version = "0.2.586"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map UK Personal Independence Payment Regulation 24 weekly rates to PolicyEngine-UK PIP parameters
- classify PIP as partial coverage in the UK HBAI household net income policy coverage report
- bump axiom-encode to 0.2.586

## HBAI policy coverage
- `hbai_household_net_income` policy components covered: 12 / 41 (29.3%)
- PIP is partial: covers `pip_dl` and `pip_m` rate surfaces, not assessment category assignment or final aggregate `pip`

## Tests
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_pip_rate_outputs tests/test_policyengine_efrs_uk.py::test_uk_hbai_policy_coverage_report_classifies_policy_components tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
- `uv run --extra dev axiom-encode uk-efrs-hbai-coverage --source-root /Users/maxghenis/policyengine-uk/policyengine_uk/variables --json`