### PR TITLE
Map UK Schedule 1 benefit rate coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.586"
+version = "0.2.587"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.586"
+__version__ = "0.2.587"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -1118,6 +1118,24 @@ HBAI_COMPONENT_COVERAGE = {
         ),
         "rationale": "Axiom covers Personal Independence Payment daily-living and mobility weekly rates, not the category assignment or final aggregate PIP amount.",
     },
+    "attendance_allowance": {
+        "status": "partial",
+        "surfaces": ("attendance-allowance-rates",),
+        "covered_outputs": ("attendance_allowance",),
+        "rationale": "Axiom covers Attendance Allowance weekly higher and lower rates, not the category assignment or final aggregate Attendance Allowance amount.",
+    },
+    "carers_allowance": {
+        "status": "partial",
+        "surfaces": ("carers-allowance-rate",),
+        "covered_outputs": ("carers_allowance",),
+        "rationale": "Axiom covers the weekly Carer's Allowance rate, not the care-hours, Scotland replacement, or final aggregate Carer's Allowance calculation.",
+    },
+    "sda": {
+        "status": "partial",
+        "surfaces": ("severe-disablement-allowance-rates",),
+        "covered_outputs": ("sda",),
+        "rationale": "Axiom covers the Severe Disablement Allowance basic row and maximum weekly rate, not reported receipt or all age-related addition branches in the final SDA amount.",
+    },
 }
 
 UNIVERSAL_CREDIT_REGULATION_36_SURFACES = frozenset(

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -699,6 +699,81 @@ mappings:
     comparison: money
     rationale: Same weekly Personal Independence Payment mobility enhanced rate in Regulation 24.
 
+  - legal_id: uk:regulations/uksi/2026/148/schedule/1#attendance_allowance_higher_weekly_rate
+    country: uk
+    program: attendance_allowance
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.attendance_allowance.higher
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly higher Attendance Allowance rate in Schedule 1 Part III of the 2026 up-rating order.
+
+  - legal_id: uk:regulations/uksi/2026/148/schedule/1#attendance_allowance_lower_weekly_rate
+    country: uk
+    program: attendance_allowance
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.attendance_allowance.lower
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly lower Attendance Allowance rate in Schedule 1 Part III of the 2026 up-rating order.
+
+  - legal_id: uk:regulations/uksi/2026/148/schedule/1#severe_disablement_allowance_basic_weekly_rate
+    country: uk
+    program: sda
+    mapping_type: not_comparable
+    policyengine_parameter: gov.dwp.sda.maximum
+    candidate_priority: P2
+    rationale: Schedule 1 Part III states the basic Severe Disablement Allowance row separately, while PolicyEngine stores a maximum SDA rate including the highest age-related addition.
+
+  - legal_id: uk:regulations/uksi/2026/148/schedule/1#sda_age_related_addition_higher_weekly_rate
+    country: uk
+    program: sda
+    mapping_type: not_comparable
+    policyengine_parameter: gov.dwp.sda.maximum
+    candidate_priority: P2
+    rationale: Schedule 1 Part III states the highest SDA age-related addition separately, while PolicyEngine stores a combined maximum SDA rate.
+
+  - legal_id: uk:regulations/uksi/2026/148/schedule/1#sda_age_related_addition_middle_weekly_rate
+    country: uk
+    program: sda
+    mapping_type: not_comparable
+    policyengine_parameter: gov.dwp.sda.maximum
+    candidate_priority: P2
+    rationale: Schedule 1 Part III states the middle SDA age-related addition separately, while PolicyEngine stores a combined maximum SDA rate and does not expose this branch as a separate parameter.
+
+  - legal_id: uk:regulations/uksi/2026/148/schedule/1#sda_age_related_addition_lower_weekly_rate
+    country: uk
+    program: sda
+    mapping_type: not_comparable
+    policyengine_parameter: gov.dwp.sda.maximum
+    candidate_priority: P2
+    rationale: Schedule 1 Part III states the lower SDA age-related addition separately, while PolicyEngine stores a combined maximum SDA rate and does not expose this branch as a separate parameter.
+
+  - legal_id: uk:regulations/uksi/2026/148/schedule/1#severe_disablement_allowance_maximum_weekly_rate
+    country: uk
+    program: sda
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.sda.maximum
+    related_legal_ids:
+      - uk:regulations/uksi/2026/148/schedule/1#severe_disablement_allowance_basic_weekly_rate
+      - uk:regulations/uksi/2026/148/schedule/1#sda_age_related_addition_higher_weekly_rate
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly maximum Severe Disablement Allowance rate after deriving PolicyEngine's maximum-rate shape as the basic SDA row plus the highest age-related addition.
+
+  - legal_id: uk:regulations/uksi/2026/148/schedule/1#carers_allowance_weekly_rate
+    country: uk
+    program: carers_allowance
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.carers_allowance.rate
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Carer's Allowance rate in Schedule 1 Part III of the 2026 up-rating order.
+
   - legal_id: uk:regulations/uksi/2002/1792/15#capital_deemed_weekly_income
     country: uk
     program: pension_credit

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1888,6 +1888,130 @@ rules:
     assert daily_standard["tested"] is True
 
 
+def test_policyengine_coverage_classifies_uk_schedule_1_benefit_rate_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2026/148/schedule/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: attendance_allowance_higher_weekly_rate
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 114.60
+  - name: attendance_allowance_lower_weekly_rate
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 76.70
+  - name: severe_disablement_allowance_basic_weekly_rate
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 103.85
+  - name: sda_age_related_addition_higher_weekly_rate
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 15.50
+  - name: sda_age_related_addition_middle_weekly_rate
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 8.60
+  - name: sda_age_related_addition_lower_weekly_rate
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 8.60
+  - name: severe_disablement_allowance_maximum_weekly_rate
+    kind: derived
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: severe_disablement_allowance_basic_weekly_rate + sda_age_related_addition_higher_weekly_rate
+  - name: carers_allowance_weekly_rate
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 86.45
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2026/148/schedule/1.test.yaml",
+        """- name: schedule 1 benefit rates
+  period:
+    period_kind: week
+    start: '2026-04-06'
+    end: '2026-04-12'
+  input: {}
+  output:
+    uk:regulations/uksi/2026/148/schedule/1#attendance_allowance_higher_weekly_rate: 114.60
+    uk:regulations/uksi/2026/148/schedule/1#attendance_allowance_lower_weekly_rate: 76.70
+    uk:regulations/uksi/2026/148/schedule/1#severe_disablement_allowance_basic_weekly_rate: 103.85
+    uk:regulations/uksi/2026/148/schedule/1#sda_age_related_addition_higher_weekly_rate: 15.50
+    uk:regulations/uksi/2026/148/schedule/1#sda_age_related_addition_middle_weekly_rate: 8.60
+    uk:regulations/uksi/2026/148/schedule/1#sda_age_related_addition_lower_weekly_rate: 8.60
+    uk:regulations/uksi/2026/148/schedule/1#severe_disablement_allowance_maximum_weekly_rate: 119.35
+    uk:regulations/uksi/2026/148/schedule/1#carers_allowance_weekly_rate: 86.45
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path)
+
+    assert report["status_counts"] == {
+        "comparable": 4,
+        "known_not_comparable": 4,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    attendance_higher = items_by_id[
+        "uk:regulations/uksi/2026/148/schedule/1#attendance_allowance_higher_weekly_rate"
+    ]
+    attendance_lower = items_by_id[
+        "uk:regulations/uksi/2026/148/schedule/1#attendance_allowance_lower_weekly_rate"
+    ]
+    sda_basic = items_by_id[
+        "uk:regulations/uksi/2026/148/schedule/1#severe_disablement_allowance_basic_weekly_rate"
+    ]
+    sda_maximum = items_by_id[
+        "uk:regulations/uksi/2026/148/schedule/1#severe_disablement_allowance_maximum_weekly_rate"
+    ]
+    carers_allowance = items_by_id[
+        "uk:regulations/uksi/2026/148/schedule/1#carers_allowance_weekly_rate"
+    ]
+
+    assert (
+        attendance_higher["policyengine_parameter"]
+        == "gov.dwp.attendance_allowance.higher"
+    )
+    assert (
+        attendance_lower["policyengine_parameter"]
+        == "gov.dwp.attendance_allowance.lower"
+    )
+    assert sda_basic["status"] == "known_not_comparable"
+    assert sda_maximum["policyengine_parameter"] == "gov.dwp.sda.maximum"
+    assert carers_allowance["policyengine_parameter"] == "gov.dwp.carers_allowance.rate"
+    assert attendance_higher["tested"] is True
+    assert sda_maximum["tested"] is True
+    assert carers_allowance["tested"] is True
+
+
 @pytest.mark.parametrize(
     (
         "path",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -2737,6 +2737,9 @@ class hbai_household_net_income(Variable):
         "working_tax_credit",
         "child_tax_credit",
         "pip",
+        "attendance_allowance",
+        "carers_allowance",
+        "sda",
     ]
     subtracts = [
         "income_tax",
@@ -2757,6 +2760,9 @@ class hbai_household_net_income(Variable):
         "working_tax_credit",
         "child_tax_credit",
         "pip",
+        "attendance_allowance",
+        "carers_allowance",
+        "sda",
     )
     assert report.subtracts == (
         "income_tax",
@@ -2772,12 +2778,15 @@ class hbai_household_net_income(Variable):
     assert by_name["working_tax_credit"].status == "partial"
     assert by_name["child_tax_credit"].status == "partial"
     assert by_name["pip"].status == "partial"
+    assert by_name["attendance_allowance"].status == "partial"
+    assert by_name["carers_allowance"].status == "partial"
+    assert by_name["sda"].status == "partial"
     assert by_name["council_tax"].status == "missing"
-    assert report.policy_component_count == 8
-    assert report.covered_policy_component_count == 7
+    assert report.policy_component_count == 11
+    assert report.covered_policy_component_count == 10
     assert report.exact_policy_component_count == 1
-    assert math.isclose(report.covered_policy_component_share, 7 / 8)
-    assert math.isclose(report.exact_policy_component_share, 1 / 8)
+    assert math.isclose(report.covered_policy_component_share, 10 / 11)
+    assert math.isclose(report.exact_policy_component_share, 1 / 11)
 
 
 def test_uk_hbai_policy_coverage_report_serializes_json(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.586"
+version = "0.2.587"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map UKSI 2026/148 Schedule 1 Part III benefit-rate outputs to PolicyEngine UK parameters
- classify Attendance Allowance, Carer's Allowance, and Severe Disablement Allowance in the HBAI component coverage report
- add oracle coverage tests for comparable and known-not-comparable Schedule 1 rows

## HBAI alignment
- projected HBAI component coverage: 15/41 (36.6%)
- status counts: exact 1, partial 14, fixed_input 13, missing 26

## Tests
- uv run --extra dev ruff format src/ tests/
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_schedule_1_benefit_rate_outputs tests/test_policyengine_efrs_uk.py::test_uk_hbai_policy_coverage_report_classifies_policy_components tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q