### PR TITLE
Map UK DLA rate coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.587"
+version = "0.2.588"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.587"
+__version__ = "0.2.588"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -1118,6 +1118,16 @@ HBAI_COMPONENT_COVERAGE = {
         ),
         "rationale": "Axiom covers Personal Independence Payment daily-living and mobility weekly rates, not the category assignment or final aggregate PIP amount.",
     },
+    "dla": {
+        "status": "partial",
+        "surfaces": ("disability-living-allowance-rates",),
+        "covered_outputs": (
+            "dla_sc",
+            "dla_m",
+            "dla",
+        ),
+        "rationale": "Axiom covers Disability Living Allowance care and mobility weekly rates, not the category assignment or final aggregate DLA amount.",
+    },
     "attendance_allowance": {
         "status": "partial",
         "surfaces": ("attendance-allowance-rates",),
@@ -2532,6 +2542,7 @@ def parse_policyengine_uk_variable_sources(
             tree = ast.parse(source_file.read_text())
         except SyntaxError:
             continue
+        module_string_sequences = module_level_string_sequences(tree)
         for node in tree.body:
             if not isinstance(node, ast.ClassDef):
                 continue
@@ -2562,11 +2573,23 @@ def parse_policyengine_uk_variable_sources(
                         entity = normalize_policyengine_entity(ast_value_name(value))
                     if target.id in {"adds", "subtracts"}:
                         has_aggregate = True
-                        components = ast_string_sequence(value)
+                        components = ast_string_sequence(
+                            value,
+                            module_string_sequences,
+                        )
                         if target.id == "adds":
                             adds = components
                         else:
                             subtracts = components
+            if node.name == "hbai_household_net_income" and (not adds or not subtracts):
+                formula_adds, formula_subtracts = formula_add_subtract_components(
+                    node,
+                    module_string_sequences,
+                )
+                adds = adds or formula_adds
+                subtracts = subtracts or formula_subtracts
+                if adds or subtracts:
+                    has_aggregate = True
             sources[node.name] = UKEFRSVariableSource(
                 name=node.name,
                 entity=entity,
@@ -2578,6 +2601,57 @@ def parse_policyengine_uk_variable_sources(
                 subtracts=subtracts,
             )
     return sources
+
+
+def module_level_string_sequences(tree: ast.Module) -> dict[str, tuple[str, ...]]:
+    sequences: dict[str, tuple[str, ...]] = {}
+    for item in tree.body:
+        targets: list[ast.expr] = []
+        value: ast.expr | None = None
+        if isinstance(item, ast.Assign):
+            targets = list(item.targets)
+            value = item.value
+        elif isinstance(item, ast.AnnAssign):
+            targets = [item.target]
+            value = item.value
+        if value is None:
+            continue
+        components = ast_string_sequence(value)
+        if not components:
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name):
+                sequences[target.id] = components
+    return sequences
+
+
+def formula_add_subtract_components(
+    node: ast.ClassDef,
+    module_string_sequences: dict[str, tuple[str, ...]],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    adds: list[str] = []
+    subtracts: list[str] = []
+    for item in node.body:
+        if not isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not item.name.startswith("formula"):
+            continue
+        for child in ast.walk(item):
+            if not isinstance(child, ast.Call):
+                continue
+            if ast_value_name(child.func) != "add":
+                continue
+            if len(child.args) < 3:
+                continue
+            components = ast_string_sequence(child.args[2], module_string_sequences)
+            if not components:
+                continue
+            source_name = ast_value_name(child.args[2]).upper()
+            if "SUBTRACT" in source_name:
+                subtracts.extend(components)
+            elif "ADD" in source_name:
+                adds.extend(components)
+    return tuple(dict.fromkeys(adds)), tuple(dict.fromkeys(subtracts))
 
 
 def class_extends_variable(node: ast.ClassDef) -> bool:
@@ -2596,7 +2670,12 @@ def ast_value_name(node: ast.AST) -> str:
     return ""
 
 
-def ast_string_sequence(node: ast.AST | None) -> tuple[str, ...]:
+def ast_string_sequence(
+    node: ast.AST | None,
+    named_sequences: dict[str, tuple[str, ...]] | None = None,
+) -> tuple[str, ...]:
+    if isinstance(node, ast.Name) and named_sequences is not None:
+        return named_sequences.get(node.id, ())
     if isinstance(node, (ast.List, ast.Tuple)):
         values: list[str] = []
         for item in node.elts:

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -699,6 +699,106 @@ mappings:
     comparison: money
     rationale: Same weekly Personal Independence Payment mobility enhanced rate in Regulation 24.
 
+  - legal_id: uk:regulations/uksi/2026/148/article/14#dla_self_care_higher_substituted_amount
+    country: uk
+    program: dla
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.dla.self_care.higher
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Disability Living Allowance highest-rate care component amount substituted by Article 14 of the 2026 up-rating order.
+
+  - legal_id: uk:regulations/uksi/2026/148/article/14#dla_self_care_middle_substituted_amount
+    country: uk
+    program: dla
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.dla.self_care.middle
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Disability Living Allowance middle-rate care component amount substituted by Article 14 of the 2026 up-rating order.
+
+  - legal_id: uk:regulations/uksi/2026/148/article/14#dla_self_care_lower_substituted_amount
+    country: uk
+    program: dla
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.dla.self_care.lower
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Disability Living Allowance lowest-rate care component amount substituted by Article 14 of the 2026 up-rating order.
+
+  - legal_id: uk:regulations/uksi/2026/148/article/14#dla_mobility_higher_substituted_amount
+    country: uk
+    program: dla
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.dla.mobility.higher
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Disability Living Allowance higher-rate mobility component amount substituted by Article 14 of the 2026 up-rating order.
+
+  - legal_id: uk:regulations/uksi/2026/148/article/14#dla_mobility_lower_substituted_amount
+    country: uk
+    program: dla
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.dla.mobility.lower
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Disability Living Allowance lower-rate mobility component amount substituted by Article 14 of the 2026 up-rating order.
+
+  - legal_id: uk:regulations/uksi/2026/148/article/14#dla_self_care_higher_weekly_rate
+    country: uk
+    program: dla
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.dla.self_care.higher
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Disability Living Allowance highest-rate care component amount after applying the Article 14 substitution.
+
+  - legal_id: uk:regulations/uksi/2026/148/article/14#dla_self_care_middle_weekly_rate
+    country: uk
+    program: dla
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.dla.self_care.middle
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Disability Living Allowance middle-rate care component amount after applying the Article 14 substitution.
+
+  - legal_id: uk:regulations/uksi/2026/148/article/14#dla_self_care_lower_weekly_rate
+    country: uk
+    program: dla
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.dla.self_care.lower
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Disability Living Allowance lowest-rate care component amount after applying the Article 14 substitution.
+
+  - legal_id: uk:regulations/uksi/2026/148/article/14#dla_mobility_higher_weekly_rate
+    country: uk
+    program: dla
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.dla.mobility.higher
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Disability Living Allowance higher-rate mobility component amount after applying the Article 14 substitution.
+
+  - legal_id: uk:regulations/uksi/2026/148/article/14#dla_mobility_lower_weekly_rate
+    country: uk
+    program: dla
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.dla.mobility.lower
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Disability Living Allowance lower-rate mobility component amount after applying the Article 14 substitution.
+
   - legal_id: uk:regulations/uksi/2026/148/schedule/1#attendance_allowance_higher_weekly_rate
     country: uk
     program: attendance_allowance

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2012,6 +2012,144 @@ rules:
     assert carers_allowance["tested"] is True
 
 
+def test_policyengine_coverage_classifies_uk_dla_rate_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2026/148/article/14.yaml",
+        """format: rulespec/v1
+rules:
+  - name: dla_self_care_higher_substituted_amount
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 114.60
+  - name: dla_self_care_middle_substituted_amount
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 76.70
+  - name: dla_self_care_lower_substituted_amount
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 30.30
+  - name: dla_mobility_higher_substituted_amount
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 80.00
+  - name: dla_mobility_lower_substituted_amount
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 30.30
+  - name: dla_self_care_higher_weekly_rate
+    kind: derived
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: dla_self_care_higher_substituted_amount
+  - name: dla_self_care_middle_weekly_rate
+    kind: derived
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: dla_self_care_middle_substituted_amount
+  - name: dla_self_care_lower_weekly_rate
+    kind: derived
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: dla_self_care_lower_substituted_amount
+  - name: dla_mobility_higher_weekly_rate
+    kind: derived
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: dla_mobility_higher_substituted_amount
+  - name: dla_mobility_lower_weekly_rate
+    kind: derived
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: dla_mobility_lower_substituted_amount
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2026/148/article/14.test.yaml",
+        """- name: article 14 dla rates
+  period:
+    period_kind: week
+    start: '2026-04-06'
+    end: '2026-04-12'
+  input: {}
+  output:
+    uk:regulations/uksi/2026/148/article/14#dla_self_care_higher_substituted_amount: 114.60
+    uk:regulations/uksi/2026/148/article/14#dla_self_care_middle_substituted_amount: 76.70
+    uk:regulations/uksi/2026/148/article/14#dla_self_care_lower_substituted_amount: 30.30
+    uk:regulations/uksi/2026/148/article/14#dla_mobility_higher_substituted_amount: 80.00
+    uk:regulations/uksi/2026/148/article/14#dla_mobility_lower_substituted_amount: 30.30
+    uk:regulations/uksi/2026/148/article/14#dla_self_care_higher_weekly_rate: 114.60
+    uk:regulations/uksi/2026/148/article/14#dla_self_care_middle_weekly_rate: 76.70
+    uk:regulations/uksi/2026/148/article/14#dla_self_care_lower_weekly_rate: 30.30
+    uk:regulations/uksi/2026/148/article/14#dla_mobility_higher_weekly_rate: 80.00
+    uk:regulations/uksi/2026/148/article/14#dla_mobility_lower_weekly_rate: 30.30
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="dla")
+
+    assert report["status_counts"] == {"comparable": 10}
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id[
+            "uk:regulations/uksi/2026/148/article/14#dla_self_care_higher_weekly_rate"
+        ]["policyengine_parameter"]
+        == "gov.dwp.dla.self_care.higher"
+    )
+    assert (
+        items_by_id[
+            "uk:regulations/uksi/2026/148/article/14#dla_self_care_middle_weekly_rate"
+        ]["policyengine_parameter"]
+        == "gov.dwp.dla.self_care.middle"
+    )
+    assert (
+        items_by_id[
+            "uk:regulations/uksi/2026/148/article/14#dla_self_care_lower_weekly_rate"
+        ]["policyengine_parameter"]
+        == "gov.dwp.dla.self_care.lower"
+    )
+    assert (
+        items_by_id[
+            "uk:regulations/uksi/2026/148/article/14#dla_mobility_higher_weekly_rate"
+        ]["policyengine_parameter"]
+        == "gov.dwp.dla.mobility.higher"
+    )
+    assert (
+        items_by_id[
+            "uk:regulations/uksi/2026/148/article/14#dla_mobility_lower_weekly_rate"
+        ]["policyengine_parameter"]
+        == "gov.dwp.dla.mobility.lower"
+    )
+    assert all(item["mapping_type"] == "parameter_value" for item in report["items"])
+    assert all(item["tested"] is True for item in report["items"])
+
+
 @pytest.mark.parametrize(
     (
         "path",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -2737,6 +2737,7 @@ class hbai_household_net_income(Variable):
         "working_tax_credit",
         "child_tax_credit",
         "pip",
+        "dla",
         "attendance_allowance",
         "carers_allowance",
         "sda",
@@ -2760,6 +2761,7 @@ class hbai_household_net_income(Variable):
         "working_tax_credit",
         "child_tax_credit",
         "pip",
+        "dla",
         "attendance_allowance",
         "carers_allowance",
         "sda",
@@ -2778,15 +2780,58 @@ class hbai_household_net_income(Variable):
     assert by_name["working_tax_credit"].status == "partial"
     assert by_name["child_tax_credit"].status == "partial"
     assert by_name["pip"].status == "partial"
+    assert by_name["dla"].status == "partial"
     assert by_name["attendance_allowance"].status == "partial"
     assert by_name["carers_allowance"].status == "partial"
     assert by_name["sda"].status == "partial"
     assert by_name["council_tax"].status == "missing"
-    assert report.policy_component_count == 11
-    assert report.covered_policy_component_count == 10
+    assert report.policy_component_count == 12
+    assert report.covered_policy_component_count == 11
     assert report.exact_policy_component_count == 1
-    assert math.isclose(report.covered_policy_component_share, 10 / 11)
-    assert math.isclose(report.exact_policy_component_share, 1 / 11)
+    assert math.isclose(report.covered_policy_component_share, 11 / 12)
+    assert math.isclose(report.exact_policy_component_share, 1 / 12)
+
+
+def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(
+    tmp_path,
+):
+    source_root = tmp_path / "variables"
+    hbai_path = source_root / "household" / "income"
+    hbai_path.mkdir(parents=True)
+    (hbai_path / "hbai_household_net_income.py").write_text(
+        """
+from policyengine_uk.model_api import *
+
+HBAI_HOUSEHOLD_NET_INCOME_ADDS = [
+    "employment_income",
+    "dla",
+]
+HBAI_HOUSEHOLD_NET_INCOME_SUBTRACTS = [
+    "income_tax",
+]
+
+class hbai_household_net_income(Variable):
+    entity = Household
+
+    def formula(household, period, parameters):
+        return add(household, period, HBAI_HOUSEHOLD_NET_INCOME_ADDS) - add(
+            household, period, HBAI_HOUSEHOLD_NET_INCOME_SUBTRACTS
+        )
+""".strip()
+    )
+
+    report = build_uk_hbai_policy_coverage_report(source_root=source_root)
+
+    assert report.adds == ("employment_income", "dla")
+    assert report.subtracts == ("income_tax",)
+    assert report.status_counts == {
+        "exact": 1,
+        "fixed_input": 1,
+        "partial": 1,
+    }
+    assert report.policy_component_count == 2
+    assert report.covered_policy_component_count == 2
+    assert report.exact_policy_component_count == 1
 
 
 def test_uk_hbai_policy_coverage_report_serializes_json(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.587"
+version = "0.2.588"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map UKSI 2026/148 Article 14 DLA care and mobility rates to PolicyEngine UK parameters
- classify DLA as partial HBAI policy-component coverage
- teach HBAI coverage parsing to read PE-UK's module-level HBAI adds/subtracts constants
- bump axiom-encode to 0.2.588

## Validation
- uv run --extra dev ruff format src/ tests/
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_schedule_1_benefit_rate_outputs tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_dla_rate_outputs tests/test_policyengine_efrs_uk.py::test_uk_hbai_policy_coverage_report_classifies_policy_components tests/test_policyengine_efrs_uk.py::test_uk_hbai_policy_coverage_report_reads_module_level_component_constants tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- uv run --extra dev pytest tests/ -q
- uv run --extra dev axiom-encode uk-efrs-hbai-coverage --source-root /Users/maxghenis/_axiom-worktrees/pe-uk-dla-rate-verify-20260605/policyengine_uk/variables --json