### PR TITLE
Map UK state pension rate coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.588"
+version = "0.2.589"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.588"
+__version__ = "0.2.589"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -1052,6 +1052,16 @@ HBAI_COMPONENT_COVERAGE = {
         ),
         "rationale": "Axiom covers major Pension Credit rates, additions, and deemed-income components, not the final aggregate pension_credit variable.",
     },
+    "state_pension": {
+        "status": "partial",
+        "surfaces": ("state-pension-rates",),
+        "covered_outputs": (
+            "basic_state_pension",
+            "new_state_pension",
+            "state_pension",
+        ),
+        "rationale": "Axiom covers the basic and full new State Pension weekly rates, not person-specific entitlement, deferral, inherited, or transitional amount rules feeding the final state_pension variable.",
+    },
     "universal_credit": {
         "status": "partial",
         "surfaces": (

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -799,6 +799,46 @@ mappings:
     comparison: money
     rationale: Same weekly Disability Living Allowance lower-rate mobility component amount after applying the Article 14 substitution.
 
+  - legal_id: uk:regulations/uksi/2026/148/article/4#category_a_basic_retirement_pension_substituted_amount
+    country: uk
+    program: state_pension
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.state_pension.basic_state_pension.amount
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Category A basic retirement pension amount substituted into section 44(4) by Article 4 of the 2026 up-rating order.
+
+  - legal_id: uk:regulations/uksi/2026/148/article/4#category_a_basic_retirement_pension_weekly_rate
+    country: uk
+    program: state_pension
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.state_pension.basic_state_pension.amount
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Category A basic retirement pension amount after applying the Article 4 substitution.
+
+  - legal_id: uk:regulations/uksi/2026/148/article/6#full_new_state_pension_substituted_amount
+    country: uk
+    program: state_pension
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.state_pension.new_state_pension.amount
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly full new State Pension amount substituted into regulation 1A of the State Pension Regulations 2015 by Article 6 of the 2026 up-rating order.
+
+  - legal_id: uk:regulations/uksi/2026/148/article/6#full_new_state_pension_weekly_rate
+    country: uk
+    program: state_pension
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.state_pension.new_state_pension.amount
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly full new State Pension amount after applying the Article 6 substitution.
+
   - legal_id: uk:regulations/uksi/2026/148/schedule/1#attendance_allowance_higher_weekly_rate
     country: uk
     program: attendance_allowance

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2150,6 +2150,99 @@ rules:
     assert all(item["tested"] is True for item in report["items"])
 
 
+def test_policyengine_coverage_classifies_uk_state_pension_rate_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2026/148/article/4.yaml",
+        """format: rulespec/v1
+rules:
+  - name: category_a_basic_retirement_pension_substituted_amount
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 184.90
+  - name: category_a_basic_retirement_pension_weekly_rate
+    kind: derived
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: category_a_basic_retirement_pension_substituted_amount
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2026/148/article/4.test.yaml",
+        """- name: article 4 basic state pension rate
+  period:
+    period_kind: week
+    start: '2026-04-06'
+    end: '2026-04-12'
+  input: {}
+  output:
+    uk:regulations/uksi/2026/148/article/4#category_a_basic_retirement_pension_substituted_amount: 184.90
+    uk:regulations/uksi/2026/148/article/4#category_a_basic_retirement_pension_weekly_rate: 184.90
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2026/148/article/6.yaml",
+        """format: rulespec/v1
+rules:
+  - name: full_new_state_pension_substituted_amount
+    kind: parameter
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 241.30
+  - name: full_new_state_pension_weekly_rate
+    kind: derived
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: full_new_state_pension_substituted_amount
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2026/148/article/6.test.yaml",
+        """- name: article 6 new state pension rate
+  period:
+    period_kind: week
+    start: '2026-04-06'
+    end: '2026-04-12'
+  input: {}
+  output:
+    uk:regulations/uksi/2026/148/article/6#full_new_state_pension_substituted_amount: 241.30
+    uk:regulations/uksi/2026/148/article/6#full_new_state_pension_weekly_rate: 241.30
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="state_pension")
+
+    assert report["status_counts"] == {"comparable": 4}
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    basic_rate = items_by_id[
+        "uk:regulations/uksi/2026/148/article/4#category_a_basic_retirement_pension_weekly_rate"
+    ]
+    new_rate = items_by_id[
+        "uk:regulations/uksi/2026/148/article/6#full_new_state_pension_weekly_rate"
+    ]
+    assert (
+        basic_rate["policyengine_parameter"]
+        == "gov.dwp.state_pension.basic_state_pension.amount"
+    )
+    assert (
+        new_rate["policyengine_parameter"]
+        == "gov.dwp.state_pension.new_state_pension.amount"
+    )
+    assert all(item["mapping_type"] == "parameter_value" for item in report["items"])
+    assert all(item["tested"] is True for item in report["items"])
+
+
 @pytest.mark.parametrize(
     (
         "path",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -2741,6 +2741,7 @@ class hbai_household_net_income(Variable):
         "attendance_allowance",
         "carers_allowance",
         "sda",
+        "state_pension",
     ]
     subtracts = [
         "income_tax",
@@ -2765,6 +2766,7 @@ class hbai_household_net_income(Variable):
         "attendance_allowance",
         "carers_allowance",
         "sda",
+        "state_pension",
     )
     assert report.subtracts == (
         "income_tax",
@@ -2784,12 +2786,13 @@ class hbai_household_net_income(Variable):
     assert by_name["attendance_allowance"].status == "partial"
     assert by_name["carers_allowance"].status == "partial"
     assert by_name["sda"].status == "partial"
+    assert by_name["state_pension"].status == "partial"
     assert by_name["council_tax"].status == "missing"
-    assert report.policy_component_count == 12
-    assert report.covered_policy_component_count == 11
+    assert report.policy_component_count == 13
+    assert report.covered_policy_component_count == 12
     assert report.exact_policy_component_count == 1
-    assert math.isclose(report.covered_policy_component_share, 11 / 12)
-    assert math.isclose(report.exact_policy_component_share, 1 / 12)
+    assert math.isclose(report.covered_policy_component_share, 12 / 13)
+    assert math.isclose(report.exact_policy_component_share, 1 / 13)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.588"
+version = "0.2.589"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map UKSI 2026/148 Article 4 and Article 6 State Pension rate outputs to PolicyEngine UK state pension parameters
- classify the HBAI `state_pension` component as partial coverage through the basic and full new State Pension rate surfaces
- add coverage and HBAI tests, and bump axiom-encode to 0.2.589

## Validation
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_state_pension_rate_outputs tests/test_policyengine_efrs_uk.py::test_uk_hbai_policy_coverage_report_classifies_policy_components tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
- `uv run --extra dev pytest tests/ -q` (1834 passed, 22 skipped)
- `uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/oracle-coverage-state-pension-20260605 --oracle policyengine --program state_pension --fail-on-unmapped --fail-on-untested-comparable`