### PR TITLE
Map UK winter fuel payment coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.589"
+version = "0.2.590"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.589"
+__version__ = "0.2.590"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -1156,6 +1156,12 @@ HBAI_COMPONENT_COVERAGE = {
         "covered_outputs": ("sda",),
         "rationale": "Axiom covers the Severe Disablement Allowance basic row and maximum weekly rate, not reported receipt or all age-related addition branches in the final SDA amount.",
     },
+    "winter_fuel_allowance": {
+        "status": "partial",
+        "surfaces": ("winter-fuel-payment-rates",),
+        "covered_outputs": ("winter_fuel_allowance",),
+        "rationale": "Axiom covers ordinary Winter Fuel Payment lower and higher annual amounts and the age-80 threshold, not the final household-level entitlement, shared-household branches, residential-care branches, Scotland replacement, or tax recovery mechanics.",
+    },
 }
 
 UNIVERSAL_CREDIT_REGULATION_36_SURFACES = frozenset(

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -914,6 +914,92 @@ mappings:
     comparison: money
     rationale: Same weekly Carer's Allowance rate in Schedule 1 Part III of the 2026 up-rating order.
 
+  - legal_id: uk:regulations/uksi/2025/969/3#winter_fuel_payment_under_80_standard_amount
+    country: uk
+    program: winter_fuel_allowance
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.winter_fuel_payment.amount.lower
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same ordinary annual Winter Fuel Payment amount for a person below age 80 in Regulation 3(1).
+
+  - legal_id: uk:regulations/uksi/2025/969/3#winter_fuel_payment_under_80_shared_or_residential_care_amount
+    country: uk
+    program: winter_fuel_allowance
+    mapping_type: not_comparable
+    policyengine_parameter: gov.dwp.winter_fuel_payment.amount.lower
+    candidate_priority: P2
+    rationale: Regulation 3(2) states a GBP 100 shared-household or residential-care branch for a person below age 80, while PolicyEngine stores only ordinary lower and higher Winter Fuel Payment amounts.
+
+  - legal_id: uk:regulations/uksi/2025/969/3#winter_fuel_payment_under_80_partner_80_relevant_benefit_amount
+    country: uk
+    program: winter_fuel_allowance
+    mapping_type: not_comparable
+    policyengine_parameter: gov.dwp.winter_fuel_payment.amount.higher
+    candidate_priority: P2
+    rationale: Regulation 3(3) states a GBP 300 partner-age-80 branch for a person below age 80 with a relevant benefit, while PolicyEngine's higher amount parameter is not branch-specific.
+
+  - legal_id: uk:regulations/uksi/2025/969/3#winter_fuel_payment_age_80_standard_amount
+    country: uk
+    program: winter_fuel_allowance
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.winter_fuel_payment.amount.higher
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same ordinary annual Winter Fuel Payment amount for a person aged 80 or over in Regulation 3(4).
+
+  - legal_id: uk:regulations/uksi/2025/969/3#winter_fuel_payment_age_80_shared_under_80_amount
+    country: uk
+    program: winter_fuel_allowance
+    mapping_type: not_comparable
+    policyengine_parameter: gov.dwp.winter_fuel_payment.amount.lower
+    candidate_priority: P2
+    rationale: Regulation 3(5) states a GBP 200 shared-household branch for a person aged 80 or over, while PolicyEngine stores only ordinary lower and higher Winter Fuel Payment amounts.
+
+  - legal_id: uk:regulations/uksi/2025/969/3#winter_fuel_payment_age_80_shared_80_or_residential_care_amount
+    country: uk
+    program: winter_fuel_allowance
+    mapping_type: not_comparable
+    policyengine_parameter: gov.dwp.winter_fuel_payment.amount.higher
+    candidate_priority: P2
+    rationale: Regulation 3(6) states a GBP 150 shared-household or residential-care branch for a person aged 80 or over, while PolicyEngine stores only ordinary lower and higher Winter Fuel Payment amounts.
+
+  - legal_id: uk:regulations/uksi/2025/969/3#winter_fuel_payment_higher_age_requirement
+    country: uk
+    program: winter_fuel_allowance
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.winter_fuel_payment.eligibility.higher_age_requirement
+    period: year
+    unit: year
+    comparison: count
+    rationale: Same age-80 threshold used by Regulation 3 to select the ordinary higher Winter Fuel Payment amount.
+
+  - legal_id: uk:regulations/uksi/2025/969/3#winter_fuel_payment_lower_amount
+    country: uk
+    program: winter_fuel_allowance
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.winter_fuel_payment.amount.lower
+    related_legal_ids:
+      - uk:regulations/uksi/2025/969/3#winter_fuel_payment_under_80_standard_amount
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same PE-shaped ordinary lower Winter Fuel Payment amount derived from Regulation 3(1).
+
+  - legal_id: uk:regulations/uksi/2025/969/3#winter_fuel_payment_higher_amount
+    country: uk
+    program: winter_fuel_allowance
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.winter_fuel_payment.amount.higher
+    related_legal_ids:
+      - uk:regulations/uksi/2025/969/3#winter_fuel_payment_age_80_standard_amount
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same PE-shaped ordinary higher Winter Fuel Payment amount derived from Regulation 3(4).
+
   - legal_id: uk:regulations/uksi/2002/1792/15#capital_deemed_weekly_income
     country: uk
     program: pension_credit

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2012,6 +2012,134 @@ rules:
     assert carers_allowance["tested"] is True
 
 
+def test_policyengine_coverage_classifies_uk_winter_fuel_payment_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2025/969/3.yaml",
+        """format: rulespec/v1
+rules:
+  - name: winter_fuel_payment_under_80_standard_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2025-09-15'
+        formula: 200
+  - name: winter_fuel_payment_under_80_shared_or_residential_care_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2025-09-15'
+        formula: 100
+  - name: winter_fuel_payment_under_80_partner_80_relevant_benefit_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2025-09-15'
+        formula: 300
+  - name: winter_fuel_payment_age_80_standard_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2025-09-15'
+        formula: 300
+  - name: winter_fuel_payment_age_80_shared_under_80_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2025-09-15'
+        formula: 200
+  - name: winter_fuel_payment_age_80_shared_80_or_residential_care_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2025-09-15'
+        formula: 150
+  - name: winter_fuel_payment_higher_age_requirement
+    kind: parameter
+    dtype: Count
+    period: Year
+    versions:
+      - effective_from: '2025-09-15'
+        formula: 80
+  - name: winter_fuel_payment_lower_amount
+    kind: derived
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2025-09-15'
+        formula: winter_fuel_payment_under_80_standard_amount
+  - name: winter_fuel_payment_higher_amount
+    kind: derived
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2025-09-15'
+        formula: winter_fuel_payment_age_80_standard_amount
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2025/969/3.test.yaml",
+        """- name: winter fuel payment amounts
+  period:
+    period_kind: custom
+    name: calendar_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input: {}
+  output:
+    uk:regulations/uksi/2025/969/3#winter_fuel_payment_under_80_standard_amount: 200
+    uk:regulations/uksi/2025/969/3#winter_fuel_payment_under_80_shared_or_residential_care_amount: 100
+    uk:regulations/uksi/2025/969/3#winter_fuel_payment_under_80_partner_80_relevant_benefit_amount: 300
+    uk:regulations/uksi/2025/969/3#winter_fuel_payment_age_80_standard_amount: 300
+    uk:regulations/uksi/2025/969/3#winter_fuel_payment_age_80_shared_under_80_amount: 200
+    uk:regulations/uksi/2025/969/3#winter_fuel_payment_age_80_shared_80_or_residential_care_amount: 150
+    uk:regulations/uksi/2025/969/3#winter_fuel_payment_higher_age_requirement: 80
+    uk:regulations/uksi/2025/969/3#winter_fuel_payment_lower_amount: 200
+    uk:regulations/uksi/2025/969/3#winter_fuel_payment_higher_amount: 300
+""",
+    )
+
+    report = build_policyengine_coverage_report(
+        tmp_path, program="winter_fuel_allowance"
+    )
+
+    assert report["status_counts"] == {
+        "comparable": 5,
+        "known_not_comparable": 4,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    lower = items_by_id[
+        "uk:regulations/uksi/2025/969/3#winter_fuel_payment_lower_amount"
+    ]
+    higher = items_by_id[
+        "uk:regulations/uksi/2025/969/3#winter_fuel_payment_higher_amount"
+    ]
+    age = items_by_id[
+        "uk:regulations/uksi/2025/969/3#winter_fuel_payment_higher_age_requirement"
+    ]
+    shared = items_by_id[
+        "uk:regulations/uksi/2025/969/3#winter_fuel_payment_under_80_shared_or_residential_care_amount"
+    ]
+
+    assert lower["policyengine_parameter"] == "gov.dwp.winter_fuel_payment.amount.lower"
+    assert (
+        higher["policyengine_parameter"] == "gov.dwp.winter_fuel_payment.amount.higher"
+    )
+    assert (
+        age["policyengine_parameter"]
+        == "gov.dwp.winter_fuel_payment.eligibility.higher_age_requirement"
+    )
+    assert shared["status"] == "known_not_comparable"
+    assert lower["tested"] is True
+    assert higher["tested"] is True
+    assert age["tested"] is True
+
+
 def test_policyengine_coverage_classifies_uk_dla_rate_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-uk" / "regulations/uksi/2026/148/article/14.yaml",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -2742,6 +2742,7 @@ class hbai_household_net_income(Variable):
         "carers_allowance",
         "sda",
         "state_pension",
+        "winter_fuel_allowance",
     ]
     subtracts = [
         "income_tax",
@@ -2767,6 +2768,7 @@ class hbai_household_net_income(Variable):
         "carers_allowance",
         "sda",
         "state_pension",
+        "winter_fuel_allowance",
     )
     assert report.subtracts == (
         "income_tax",
@@ -2787,12 +2789,13 @@ class hbai_household_net_income(Variable):
     assert by_name["carers_allowance"].status == "partial"
     assert by_name["sda"].status == "partial"
     assert by_name["state_pension"].status == "partial"
+    assert by_name["winter_fuel_allowance"].status == "partial"
     assert by_name["council_tax"].status == "missing"
-    assert report.policy_component_count == 13
-    assert report.covered_policy_component_count == 12
+    assert report.policy_component_count == 14
+    assert report.covered_policy_component_count == 13
     assert report.exact_policy_component_count == 1
-    assert math.isclose(report.covered_policy_component_share, 12 / 13)
-    assert math.isclose(report.exact_policy_component_share, 1 / 13)
+    assert math.isclose(report.covered_policy_component_share, 13 / 14)
+    assert math.isclose(report.exact_policy_component_share, 1 / 14)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.589"
+version = "0.2.590"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map UK Winter Fuel Payment lower/higher annual amounts and age-80 threshold to PolicyEngine parameters
- classify shared-household/residential-care WFA branches as known not comparable to current PE parameters
- add WFA to the UK HBAI policy coverage report as partial coverage

## Validation
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_winter_fuel_payment_outputs tests/test_policyengine_efrs_uk.py::test_uk_hbai_policy_coverage_report_classifies_policy_components tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
- `uv run --extra dev axiom-encode oracle-coverage --root <tmp copy of rulespec-uk WFA branch> --oracle policyengine --program winter_fuel_allowance --fail-on-unmapped --fail-on-untested-comparable`
- `uv run --extra dev pytest tests/ -q`

## Notes
- PE-UK appears to model the 2025 high-income recovery by zeroing entitlement rather than as a separate recovery/tax mechanism; tracked in PolicyEngine/policyengine-uk#1760.
