### PR TITLE
Map UK tax-free childcare coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.590"
+version = "0.2.591"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.590"
+__version__ = "0.2.591"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -1119,6 +1119,12 @@ HBAI_COMPONENT_COVERAGE = {
         ),
         "rationale": "Axiom covers Child Tax Credit family, child, disabled-child, and severe-disabled-child element rates; it does not yet compute final Child Tax Credit entitlement.",
     },
+    "tax_free_childcare": {
+        "status": "partial",
+        "surfaces": ("tax-free-childcare-parameters",),
+        "covered_outputs": ("tax_free_childcare",),
+        "rationale": "Axiom covers the Tax-Free Childcare contribution rate and income cap, not the child/provider eligibility tests, expenses, annual caps, or final aggregate amount.",
+    },
     "pip": {
         "status": "partial",
         "surfaces": ("personal-independence-payment-rates",),

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -659,6 +659,33 @@ mappings:
     comparison: money
     rationale: Same annual additional Child Tax Credit severe-disabled-child layer after deriving the PolicyEngine-shape value as the severe-disabled total rate minus the disabled-child element.
 
+  - legal_id: uk:statutes/ukpga/2014/28/1#tax_free_childcare_top_up_payment_rate
+    country: uk
+    program: tax_free_childcare
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hmrc.tax_free_childcare.contribution.rate
+    candidate_priority: P2
+    rationale: Section 1 states the top-up payment as 25 percent of a qualifying payment, while PolicyEngine stores the government's 20 percent share of total household plus government contributions.
+
+  - legal_id: uk:statutes/ukpga/2014/28/21#tax_free_childcare_top_up_element_rate
+    country: uk
+    program: tax_free_childcare
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.tax_free_childcare.contribution.rate
+    period: year
+    comparison: rate
+    rationale: Same Tax-Free Childcare government contribution share after deriving the PolicyEngine-shape top-up element from Section 21.
+
+  - legal_id: uk:regulations/uksi/2015/448/15#tax_free_childcare_maximum_adjusted_net_income
+    country: uk
+    program: tax_free_childcare
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.tax_free_childcare.income.income_limit
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual individual adjusted-net-income limit for Tax-Free Childcare eligibility.
+
   - legal_id: uk:regulations/uksi/2013/377/24#pip_daily_living_standard_weekly_rate
     country: uk
     program: pip

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1888,6 +1888,102 @@ rules:
     assert daily_standard["tested"] is True
 
 
+def test_policyengine_coverage_classifies_uk_tax_free_childcare_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2014/28/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: tax_free_childcare_top_up_payment_rate
+    kind: parameter
+    dtype: Decimal
+    period: Year
+    versions:
+      - effective_from: '2017-04-21'
+        formula: '0.25'
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2014/28/21.yaml",
+        """format: rulespec/v1
+rules:
+  - name: tax_free_childcare_top_up_element_rate
+    kind: derived
+    dtype: Decimal
+    period: Year
+    versions:
+      - effective_from: '2017-04-21'
+        formula: '0.2'
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2015/448/15.yaml",
+        """format: rulespec/v1
+rules:
+  - name: tax_free_childcare_maximum_adjusted_net_income
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2015-01-01'
+        formula: 100000
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2014/28/1.test.yaml",
+        """- name: section_1_top_up_payment_rate
+  output:
+    uk:statutes/ukpga/2014/28/1#tax_free_childcare_top_up_payment_rate: 0.25
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2014/28/21.test.yaml",
+        """- name: section_21_top_up_element_rate
+  output:
+    uk:statutes/ukpga/2014/28/21#tax_free_childcare_top_up_element_rate: 0.2
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2015/448/15.test.yaml",
+        """- name: regulation_15_maximum_adjusted_net_income
+  output:
+    uk:regulations/uksi/2015/448/15#tax_free_childcare_maximum_adjusted_net_income: 100000
+""",
+    )
+
+    report = build_policyengine_coverage_report(
+        tmp_path,
+        program="tax_free_childcare",
+    )
+
+    assert report["status_counts"] == {
+        "comparable": 2,
+        "known_not_comparable": 1,
+    }
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    payment_rate = items_by_id[
+        "uk:statutes/ukpga/2014/28/1#tax_free_childcare_top_up_payment_rate"
+    ]
+    element_rate = items_by_id[
+        "uk:statutes/ukpga/2014/28/21#tax_free_childcare_top_up_element_rate"
+    ]
+    income_limit = items_by_id[
+        "uk:regulations/uksi/2015/448/15#tax_free_childcare_maximum_adjusted_net_income"
+    ]
+
+    assert payment_rate["status"] == "known_not_comparable"
+    assert (
+        element_rate["policyengine_parameter"]
+        == "gov.hmrc.tax_free_childcare.contribution.rate"
+    )
+    assert (
+        income_limit["policyengine_parameter"]
+        == "gov.hmrc.tax_free_childcare.income.income_limit"
+    )
+    assert element_rate["mapping_type"] == "parameter_value"
+    assert income_limit["tested"] is True
+
+
 def test_policyengine_coverage_classifies_uk_schedule_1_benefit_rate_outputs(
     tmp_path,
 ):

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -2736,6 +2736,7 @@ class hbai_household_net_income(Variable):
         "universal_credit",
         "working_tax_credit",
         "child_tax_credit",
+        "tax_free_childcare",
         "pip",
         "dla",
         "attendance_allowance",
@@ -2762,6 +2763,7 @@ class hbai_household_net_income(Variable):
         "universal_credit",
         "working_tax_credit",
         "child_tax_credit",
+        "tax_free_childcare",
         "pip",
         "dla",
         "attendance_allowance",
@@ -2783,6 +2785,7 @@ class hbai_household_net_income(Variable):
     assert by_name["universal_credit"].status == "partial"
     assert by_name["working_tax_credit"].status == "partial"
     assert by_name["child_tax_credit"].status == "partial"
+    assert by_name["tax_free_childcare"].status == "partial"
     assert by_name["pip"].status == "partial"
     assert by_name["dla"].status == "partial"
     assert by_name["attendance_allowance"].status == "partial"
@@ -2791,11 +2794,11 @@ class hbai_household_net_income(Variable):
     assert by_name["state_pension"].status == "partial"
     assert by_name["winter_fuel_allowance"].status == "partial"
     assert by_name["council_tax"].status == "missing"
-    assert report.policy_component_count == 14
-    assert report.covered_policy_component_count == 13
+    assert report.policy_component_count == 15
+    assert report.covered_policy_component_count == 14
     assert report.exact_policy_component_count == 1
-    assert math.isclose(report.covered_policy_component_share, 13 / 14)
-    assert math.isclose(report.exact_policy_component_share, 1 / 14)
+    assert math.isclose(report.covered_policy_component_share, 14 / 15)
+    assert math.isclose(report.exact_policy_component_share, 1 / 15)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.590"
+version = "0.2.591"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Maps UK Tax-Free Childcare RuleSpec outputs to PolicyEngine-UK oracle parameters.
- Treats the Section 21 20% top-up element rate and Regulation 15 GBP 100k income cap as comparable PE parameter values.
- Classifies the Section 1 25% top-up-on-payment rate as known-not-comparable because PE stores the government share of total contributions instead.
- Marks HBAI `tax_free_childcare` coverage as partial.

## Validation
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_tax_free_childcare_outputs tests/test_policyengine_efrs_uk.py::test_uk_hbai_policy_coverage_report_classifies_policy_components`
- `uv run --extra dev pytest tests/test_policyengine_coverage.py tests/test_policyengine_efrs_uk.py` (373 passed, 2 skipped)
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/coverage-tfc-20260605 --oracle policyengine --program tax_free_childcare --fail-on-unmapped --fail-on-untested-comparable --json`

Dependent RuleSpec branch is local at `codex/uk-tax-free-childcare-parameters-20260605` and will be opened after this oracle mapping lands.