### PR TITLE
Map UK Sure Start Maternity Grant coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.591"
+version = "0.2.592"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.591"
+__version__ = "0.2.592"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -1162,6 +1162,12 @@ HBAI_COMPONENT_COVERAGE = {
         "covered_outputs": ("sda",),
         "rationale": "Axiom covers the Severe Disablement Allowance basic row and maximum weekly rate, not reported receipt or all age-related addition branches in the final SDA amount.",
     },
+    "ssmg": {
+        "status": "partial",
+        "surfaces": ("sure-start-maternity-grant-rate",),
+        "covered_outputs": ("ssmg",),
+        "rationale": "Axiom covers the Sure Start Maternity Grant amount, not the qualifying-benefit, pregnancy, child, prescribed-time, residence, or reported-receipt conditions feeding the final SSMG amount.",
+    },
     "winter_fuel_allowance": {
         "status": "partial",
         "surfaces": ("winter-fuel-payment-rates",),

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -686,6 +686,16 @@ mappings:
     comparison: money
     rationale: Same annual individual adjusted-net-income limit for Tax-Free Childcare eligibility.
 
+  - legal_id: uk:regulations/uksi/2005/3061/5#sure_start_maternity_grant_amount
+    country: uk
+    program: ssmg
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.ssmg.rate
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same Sure Start Maternity Grant amount payable when the regulation's entitlement conditions are satisfied.
+
   - legal_id: uk:regulations/uksi/2013/377/24#pip_daily_living_standard_weekly_rate
     country: uk
     program: pip

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1984,6 +1984,40 @@ rules:
     assert income_limit["tested"] is True
 
 
+def test_policyengine_coverage_classifies_uk_sure_start_maternity_grant_output(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2005/3061/5.yaml",
+        """format: rulespec/v1
+rules:
+  - name: sure_start_maternity_grant_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2005-12-05'
+        formula: 500
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2005/3061/5.test.yaml",
+        """- name: sure_start_maternity_grant_2026_amount
+  output:
+    uk:regulations/uksi/2005/3061/5#sure_start_maternity_grant_amount: 500
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="ssmg")
+
+    assert report["status_counts"] == {"comparable": 1}
+    assert report["untested_comparable"] == 0
+    item = report["items"][0]
+    assert item["policyengine_parameter"] == "gov.dwp.ssmg.rate"
+    assert item["mapping_type"] == "parameter_value"
+    assert item["tested"] is True
+
+
 def test_policyengine_coverage_classifies_uk_schedule_1_benefit_rate_outputs(
     tmp_path,
 ):

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -2742,6 +2742,7 @@ class hbai_household_net_income(Variable):
         "attendance_allowance",
         "carers_allowance",
         "sda",
+        "ssmg",
         "state_pension",
         "winter_fuel_allowance",
     ]
@@ -2769,6 +2770,7 @@ class hbai_household_net_income(Variable):
         "attendance_allowance",
         "carers_allowance",
         "sda",
+        "ssmg",
         "state_pension",
         "winter_fuel_allowance",
     )
@@ -2791,14 +2793,15 @@ class hbai_household_net_income(Variable):
     assert by_name["attendance_allowance"].status == "partial"
     assert by_name["carers_allowance"].status == "partial"
     assert by_name["sda"].status == "partial"
+    assert by_name["ssmg"].status == "partial"
     assert by_name["state_pension"].status == "partial"
     assert by_name["winter_fuel_allowance"].status == "partial"
     assert by_name["council_tax"].status == "missing"
-    assert report.policy_component_count == 15
-    assert report.covered_policy_component_count == 14
+    assert report.policy_component_count == 16
+    assert report.covered_policy_component_count == 15
     assert report.exact_policy_component_count == 1
-    assert math.isclose(report.covered_policy_component_share, 14 / 15)
-    assert math.isclose(report.exact_policy_component_share, 1 / 15)
+    assert math.isclose(report.covered_policy_component_share, 15 / 16)
+    assert math.isclose(report.exact_policy_component_share, 1 / 16)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.591"
+version = "0.2.592"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map the UK Sure Start Maternity Grant rate output to PolicyEngine parameter `gov.dwp.ssmg.rate`
- classify HBAI `ssmg` coverage as partial because this covers the statutory rate, not eligibility or final entitlement logic
- add focused oracle and HBAI coverage tests

## Validation
- `uv run --extra dev ruff format src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- focused PolicyEngine oracle/HBAI tests
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/_axiom-worktrees/coverage-ssmg-20260605 --oracle policyengine --program ssmg --fail-on-unmapped --fail-on-untested-comparable --json` (1 comparable output, 0 untested comparable)

Dependent RuleSpec branch is local and validated; I will open it after this oracle mapping lands.