### PR TITLE
Support policy subparagraph source coverage

### DIFF
--- a/changelog.d/policy-corpus-subparagraph-coverage.fixed.md
+++ b/changelog.d/policy-corpus-subparagraph-coverage.fixed.md
@@ -1,0 +1,1 @@
+Allow state policy, manual, guidance, and form corpus citations to satisfy source subparagraph coverage checks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.592"
+version = "0.2.593"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.592"
+__version__ = "0.2.593"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -8865,7 +8865,28 @@ def _source_subparagraph_citation_pattern(citation_path: str) -> re.Pattern[str]
             r"(?P<suffix>(?:\([A-Za-z0-9]+\))+)",
             flags=re.IGNORECASE,
         )
+    if (
+        len(parts) >= 3
+        and parts[0].startswith("us-")
+        and parts[1] in _RULESPEC_DOCUMENT_CLASS_DIRS
+    ):
+        return re.compile(
+            rf"(?<![\w.-]){exact_corpus_path}"
+            r"(?P<suffix>(?:\([A-Za-z0-9]+\))+)",
+            flags=re.IGNORECASE,
+        )
     return None
+
+
+_RULESPEC_DOCUMENT_CLASS_DIRS = {
+    "form": "forms",
+    "forms": "forms",
+    "guidance": "guidance",
+    "manual": "manuals",
+    "manuals": "manuals",
+    "policies": "policies",
+    "policy": "policies",
+}
 
 
 def _rulespec_base_parts_for_corpus_path(citation_path: str) -> tuple[str, ...]:
@@ -8880,6 +8901,12 @@ def _rulespec_base_parts_for_corpus_path(citation_path: str) -> tuple[str, ...]:
         return ("regulations", f"{parts[2]}-cfr", parts[3], parts[4])
     if len(parts) >= 3 and parts[0].startswith("us-") and parts[1] == "regulation":
         return ("regulations", *parts[2:])
+    if (
+        len(parts) >= 3
+        and parts[0].startswith("us-")
+        and parts[1] in _RULESPEC_DOCUMENT_CLASS_DIRS
+    ):
+        return (_RULESPEC_DOCUMENT_CLASS_DIRS[parts[1]], *parts[2:])
     return ()
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -14657,6 +14657,64 @@ rules: []
     )
 
 
+def test_source_subparagraph_coverage_accepts_state_policy_corpus_source():
+    source_text = """Standard of need
+(g) Regular recurring monthly needs are set by the statewide schedule.
+"""
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ny/policy/otda/tanf-state-plan-2024-2026/standard-of-need-and-monthly-grant
+  summary: New York TANF standard of need.
+rules:
+  - name: regular_recurring_monthly_need
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    source: us-ny/policy/otda/tanf-state-plan-2024-2026/standard-of-need-and-monthly-grant(g)
+    versions:
+      - effective_from: '2012-10-01'
+        formula: monthly_need_schedule_amount
+"""
+
+    assert (
+        find_source_subparagraph_coverage_issues(
+            content,
+            source_texts={
+                "us-ny/policy/otda/tanf-state-plan-2024-2026/standard-of-need-and-monthly-grant": source_text
+            },
+        )
+        == []
+    )
+
+
+def test_source_subparagraph_coverage_accepts_state_policy_deferred_output():
+    source_text = """Standard of need
+(g) Regular recurring monthly needs are set by the statewide schedule.
+"""
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ny/policy/otda/tanf-state-plan-2024-2026/standard-of-need-and-monthly-grant
+  summary: New York TANF standard of need.
+  deferred_outputs:
+    - output: us-ny:policies/otda/tanf-state-plan-2024-2026/standard-of-need-and-monthly-grant/g#regular_recurring_monthly_need
+      reason: Deferred until the statewide schedule is split into a reusable table.
+rules: []
+"""
+
+    assert (
+        find_source_subparagraph_coverage_issues(
+            content,
+            source_texts={
+                "us-ny/policy/otda/tanf-state-plan-2024-2026/standard-of-need-and-monthly-grant": source_text
+            },
+        )
+        == []
+    )
+
+
 def test_source_subparagraph_coverage_allows_repealed_empty_slice(tmp_path):
     source_text = """Wages
 (a) Wages means all remuneration for employment.

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.592"
+version = "0.2.593"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- allow policy/manual/guidance corpus paths to satisfy source subparagraph coverage via exact corpus-path parenthetical citations
- map those document classes to their RuleSpec output directories for deferred-output coverage
- add state policy regression coverage for rule and deferred-output citations

## Checks
- uv run --python 3.13 --extra dev ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- python -m compileall -q src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- uv run --python 3.13 --extra dev pytest tests/test_rulespec_validation.py -k 'source_subparagraph_coverage'

Draft pending review cycle per AGENTS.md.