### PR TITLE
Add UK Scottish Child Payment PE oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.593"
+version = "0.2.594"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.593"
+__version__ = "0.2.594"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -1168,6 +1168,12 @@ HBAI_COMPONENT_COVERAGE = {
         "covered_outputs": ("ssmg",),
         "rationale": "Axiom covers the Sure Start Maternity Grant amount, not the qualifying-benefit, pregnancy, child, prescribed-time, residence, or reported-receipt conditions feeding the final SSMG amount.",
     },
+    "scottish_child_payment": {
+        "status": "partial",
+        "surfaces": ("scottish-child-payment-parameters",),
+        "covered_outputs": ("scottish_child_payment",),
+        "rationale": "Axiom covers the Scottish Child Payment weekly amount and child age threshold, not the qualifying benefits, residence, responsibility, application, take-up, or final annual amount.",
+    },
     "winter_fuel_allowance": {
         "status": "partial",
         "surfaces": ("winter-fuel-payment-rates",),

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -696,6 +696,26 @@ mappings:
     comparison: money
     rationale: Same Sure Start Maternity Grant amount payable when the regulation's entitlement conditions are satisfied.
 
+  - legal_id: uk:regulations/ssi/2020/351/20#scottish_child_payment_weekly_amount
+    country: uk
+    program: scottish_child_payment
+    mapping_type: parameter_value
+    policyengine_parameter: gov.social_security_scotland.scottish_child_payment.amount
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Scottish Child Payment amount payable in respect of an eligible child.
+
+  - legal_id: uk:regulations/ssi/2020/351/18#scottish_child_payment_maximum_child_age
+    country: uk
+    program: scottish_child_payment
+    mapping_type: parameter_value
+    policyengine_parameter: gov.social_security_scotland.scottish_child_payment.max_age
+    period: year
+    unit: year
+    comparison: number
+    rationale: Regulation 18 requires the child to be under 16; PolicyEngine stores the same threshold as the maximum child age parameter.
+
   - legal_id: uk:regulations/uksi/2013/377/24#pip_daily_living_standard_weekly_rate
     country: uk
     program: pip

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2018,6 +2018,81 @@ rules:
     assert item["tested"] is True
 
 
+def test_policyengine_coverage_classifies_uk_scottish_child_payment_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/ssi/2020/351/20.yaml",
+        """format: rulespec/v1
+rules:
+  - name: scottish_child_payment_weekly_amount
+    kind: parameter
+    dtype: Money
+    period: Week
+    unit: GBP
+    versions:
+      - effective_from: '2026-04-01'
+        formula: 28.20
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/ssi/2020/351/18.yaml",
+        """format: rulespec/v1
+rules:
+  - name: scottish_child_payment_maximum_child_age
+    kind: parameter
+    dtype: Integer
+    period: Year
+    unit: year
+    versions:
+      - effective_from: '2022-11-14'
+        formula: 16
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/ssi/2020/351/20.test.yaml",
+        """- name: scottish_child_payment_2026_weekly_amount
+  output:
+    uk:regulations/ssi/2020/351/20#scottish_child_payment_weekly_amount: 28.20
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/ssi/2020/351/18.test.yaml",
+        """- name: scottish_child_payment_maximum_child_age
+  output:
+    uk:regulations/ssi/2020/351/18#scottish_child_payment_maximum_child_age: 16
+""",
+    )
+
+    report = build_policyengine_coverage_report(
+        tmp_path,
+        program="scottish_child_payment",
+    )
+
+    assert report["status_counts"] == {"comparable": 2}
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    weekly_amount = items_by_id[
+        "uk:regulations/ssi/2020/351/20#scottish_child_payment_weekly_amount"
+    ]
+    maximum_age = items_by_id[
+        "uk:regulations/ssi/2020/351/18#scottish_child_payment_maximum_child_age"
+    ]
+
+    assert (
+        weekly_amount["policyengine_parameter"]
+        == "gov.social_security_scotland.scottish_child_payment.amount"
+    )
+    assert (
+        maximum_age["policyengine_parameter"]
+        == "gov.social_security_scotland.scottish_child_payment.max_age"
+    )
+    assert weekly_amount["mapping_type"] == "parameter_value"
+    assert maximum_age["mapping_type"] == "parameter_value"
+    assert weekly_amount["tested"] is True
+    assert maximum_age["tested"] is True
+
+
 def test_policyengine_coverage_classifies_uk_schedule_1_benefit_rate_outputs(
     tmp_path,
 ):

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -2743,6 +2743,7 @@ class hbai_household_net_income(Variable):
         "carers_allowance",
         "sda",
         "ssmg",
+        "scottish_child_payment",
         "state_pension",
         "winter_fuel_allowance",
     ]
@@ -2771,6 +2772,7 @@ class hbai_household_net_income(Variable):
         "carers_allowance",
         "sda",
         "ssmg",
+        "scottish_child_payment",
         "state_pension",
         "winter_fuel_allowance",
     )
@@ -2794,14 +2796,15 @@ class hbai_household_net_income(Variable):
     assert by_name["carers_allowance"].status == "partial"
     assert by_name["sda"].status == "partial"
     assert by_name["ssmg"].status == "partial"
+    assert by_name["scottish_child_payment"].status == "partial"
     assert by_name["state_pension"].status == "partial"
     assert by_name["winter_fuel_allowance"].status == "partial"
     assert by_name["council_tax"].status == "missing"
-    assert report.policy_component_count == 16
-    assert report.covered_policy_component_count == 15
+    assert report.policy_component_count == 17
+    assert report.covered_policy_component_count == 16
     assert report.exact_policy_component_count == 1
-    assert math.isclose(report.covered_policy_component_share, 15 / 16)
-    assert math.isclose(report.exact_policy_component_share, 1 / 16)
+    assert math.isclose(report.covered_policy_component_share, 16 / 17)
+    assert math.isclose(report.exact_policy_component_share, 1 / 17)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.593"
+version = "0.2.594"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map Scottish Child Payment weekly amount and max child age RuleSpec leaves to PE-UK parameters
- classify Scottish Child Payment as partial HBAI policy coverage
- add focused oracle/HBAI tests and bump axiom-encode to 0.2.593

## Tests
- uv run --extra dev ruff format src/ tests/
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_scottish_child_payment_outputs tests/test_policyengine_efrs_uk.py::test_uk_hbai_policy_coverage_report_classifies_policy_components -q
- uv run --extra dev pytest tests/test_policyengine_coverage.py tests/test_policyengine_efrs_uk.py -q
- uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- uv run --extra dev pytest -q