### PR TITLE
Classify NY TANF oracle coverage

### DIFF
--- a/changelog.d/ny-tanf-oracle-coverage.fixed.md
+++ b/changelog.d/ny-tanf-oracle-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify New York TANF State Plan RuleSpec outputs in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.594"
+version = "0.2.595"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.594"
+__version__ = "0.2.595"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -14406,6 +14406,13 @@ prefixes:
     mapping_type: not_comparable
     rationale: New York SNAP composition outputs assemble federal SNAP rules and New York utility choices; exact oracle comparisons should target imported provision-level outputs unless a specific composition output is mapped separately.
 
+  - legal_id_prefix: us-ny:policies/otda/tanf-state-plan-2024-2026/
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: New York TANF State Plan outputs are source-specific OTDA cash-assistance eligibility, income-disregard, standard-of-need, grant, home-energy, and shelter schedule mechanics. PolicyEngine-US does not expose these State Plan provision boundaries as one-to-one TANF oracle outputs; direct comparison should wait for a New York TANF adapter that targets the same state source slices.
+
   - legal_id_prefix: us:policies/usda/snap/fy-2026-cola/
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -201,6 +201,63 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_new_york_tanf_state_plan_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-ny"
+        / "policies/otda/tanf-state-plan-2024-2026"
+        / "financial-eligibility-and-income-disregards.yaml",
+        """format: rulespec/v1
+rules:
+  - name: application_resource_limit
+    kind: parameter
+    versions:
+      - effective_from: '2024-01-01'
+        value: 2000
+  - name: earned_income_disregard_rate
+    kind: parameter
+    versions:
+      - effective_from: '2024-01-01'
+        value: 0.5
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-ny"
+        / "policies/otda/tanf-state-plan-2024-2026"
+        / "standard-of-need-and-monthly-grant.yaml",
+        """format: rulespec/v1
+rules:
+  - name: regular_recurring_monthly_need
+    kind: derived
+    versions:
+      - effective_from: '2024-01-01'
+        formula: need_schedule_amount
+  - name: monthly_grant_and_allowance_with_home_energy
+    kind: derived
+    versions:
+      - effective_from: '2024-01-01'
+        formula: grant_and_allowance_amount
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tanf")
+
+    assert report["total_outputs"] == 4
+    assert report["status_counts"] == {"known_not_comparable": 4}
+    assert report["untested_comparable"] == 0
+    assert {item["program"] for item in report["items"]} == {"tanf"}
+    assert {item["mapping_type"] for item in report["items"]} == {"not_comparable"}
+    assert {item["candidate_priority"] for item in report["items"]} == {"P4"}
+    assert all(
+        "New York TANF State Plan outputs are source-specific OTDA"
+        in str(item["rationale"])
+        for item in report["items"]
+    )
+
+
 def test_policyengine_coverage_infers_health_programs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us-co" / "regulations/hcpf/health-coverage.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.594"
+version = "0.2.595"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify NY TANF State Plan RuleSpec outputs as known not comparable in PolicyEngine oracle coverage
- add a focused coverage regression test for representative NY TANF financial and standard-of-need outputs
- add changelog entry

## Checks
- PASS: uv run ruff check pyproject.toml src/axiom_encode scripts tests
- PASS: python -m compileall -q src/axiom_encode scripts
- PASS: uv run pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_new_york_tanf_state_plan_outputs tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_colorado_tanf_outputs -q
- PASS: uv run --python 3.13 --extra dev axiom-encode oracle-coverage --root /Users/pavelmakarchuk --program tanf --fail-on-unmapped --json (NY TANF: 44 known_not_comparable, 0 unmapped)
- LOCAL ONLY: uv run pytest completed with 1800 passed, 61 skipped, 1 failed in tests/test_repo_cross_statute_imports.py due existing sibling rulespec-us cross-statute import failures unrelated to this registry patch

## Cycle
- Pending /cycle review.