### PR TITLE
Add UK Carer Support Payment PE oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.594"
+version = "0.2.595"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.594"
+__version__ = "0.2.595"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -1174,6 +1174,12 @@ HBAI_COMPONENT_COVERAGE = {
         "covered_outputs": ("scottish_child_payment",),
         "rationale": "Axiom covers the Scottish Child Payment weekly amount and child age threshold, not the qualifying benefits, residence, responsibility, application, take-up, or final annual amount.",
     },
+    "carer_support_payment": {
+        "status": "partial",
+        "surfaces": ("carer-support-payment-parameters",),
+        "covered_outputs": ("carer_support_payment",),
+        "rationale": "Axiom covers the Carer Support Payment care-hours threshold, weekly rate, and Scottish Carer Supplement amount, not residence, cared-for-person, overlapping-benefit, or final annual amount rules.",
+    },
     "winter_fuel_allowance": {
         "status": "partial",
         "surfaces": ("winter-fuel-payment-rates",),

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -716,6 +716,36 @@ mappings:
     comparison: number
     rationale: Regulation 18 requires the child to be under 16; PolicyEngine stores the same threshold as the maximum child age parameter.
 
+  - legal_id: uk:regulations/ssi/2023/302/5#carer_support_payment_minimum_weekly_care_hours
+    country: uk
+    program: carer_support_payment
+    mapping_type: parameter_value
+    policyengine_parameter: gov.social_security_scotland.carer_support_payment.min_hours
+    period: week
+    unit: hour
+    comparison: number
+    rationale: Regulation 5(2) treats regular and substantial care as at least 35 hours in an award week; PolicyEngine stores the same weekly care-hours threshold.
+
+  - legal_id: uk:regulations/ssi/2023/302/16#carer_support_payment_weekly_rate
+    country: uk
+    program: carer_support_payment
+    mapping_type: parameter_value
+    policyengine_parameter: gov.social_security_scotland.carer_support_payment.rate
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Carer Support Payment rate payable before any overlapping-benefit reduction.
+
+  - legal_id: uk:regulations/ssi/2023/302/16#scottish_carer_supplement_weekly_rate
+    country: uk
+    program: carer_support_payment
+    mapping_type: parameter_value
+    policyengine_parameter: gov.social_security_scotland.carer_support_payment.supplement
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same weekly Scottish Carer Supplement amount paid on top of Carer Support Payment.
+
   - legal_id: uk:regulations/uksi/2013/377/24#pip_daily_living_standard_weekly_rate
     country: uk
     program: pip

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2093,6 +2093,99 @@ rules:
     assert maximum_age["tested"] is True
 
 
+def test_policyengine_coverage_classifies_uk_carer_support_payment_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/ssi/2023/302/5.yaml",
+        """format: rulespec/v1
+rules:
+  - name: carer_support_payment_minimum_weekly_care_hours
+    kind: parameter
+    dtype: Count
+    period: Week
+    unit: hour
+    versions:
+      - effective_from: '2024-11-01'
+        formula: 35
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/ssi/2023/302/16.yaml",
+        """format: rulespec/v1
+rules:
+  - name: carer_support_payment_weekly_rate
+    kind: parameter
+    dtype: Money
+    period: Week
+    unit: GBP
+    versions:
+      - effective_from: '2026-04-05'
+        formula: 86.45
+  - name: scottish_carer_supplement_weekly_rate
+    kind: parameter
+    dtype: Money
+    period: Week
+    unit: GBP
+    versions:
+      - effective_from: '2026-04-05'
+        formula: 11.70
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/ssi/2023/302/5.test.yaml",
+        """- name: carer_support_payment_minimum_weekly_care_hours
+  output:
+    uk:regulations/ssi/2023/302/5#carer_support_payment_minimum_weekly_care_hours: 35
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/ssi/2023/302/16.test.yaml",
+        """- name: carer_support_payment_2026_weekly_rates
+  output:
+    uk:regulations/ssi/2023/302/16#carer_support_payment_weekly_rate: 86.45
+    uk:regulations/ssi/2023/302/16#scottish_carer_supplement_weekly_rate: 11.70
+""",
+    )
+
+    report = build_policyengine_coverage_report(
+        tmp_path,
+        program="carer_support_payment",
+    )
+
+    assert report["status_counts"] == {"comparable": 3}
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    min_hours = items_by_id[
+        "uk:regulations/ssi/2023/302/5#carer_support_payment_minimum_weekly_care_hours"
+    ]
+    rate = items_by_id[
+        "uk:regulations/ssi/2023/302/16#carer_support_payment_weekly_rate"
+    ]
+    supplement = items_by_id[
+        "uk:regulations/ssi/2023/302/16#scottish_carer_supplement_weekly_rate"
+    ]
+
+    assert (
+        min_hours["policyengine_parameter"]
+        == "gov.social_security_scotland.carer_support_payment.min_hours"
+    )
+    assert (
+        rate["policyengine_parameter"]
+        == "gov.social_security_scotland.carer_support_payment.rate"
+    )
+    assert (
+        supplement["policyengine_parameter"]
+        == "gov.social_security_scotland.carer_support_payment.supplement"
+    )
+    assert min_hours["mapping_type"] == "parameter_value"
+    assert rate["mapping_type"] == "parameter_value"
+    assert supplement["mapping_type"] == "parameter_value"
+    assert min_hours["tested"] is True
+    assert rate["tested"] is True
+    assert supplement["tested"] is True
+
+
 def test_policyengine_coverage_classifies_uk_schedule_1_benefit_rate_outputs(
     tmp_path,
 ):

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -2744,6 +2744,7 @@ class hbai_household_net_income(Variable):
         "sda",
         "ssmg",
         "scottish_child_payment",
+        "carer_support_payment",
         "state_pension",
         "winter_fuel_allowance",
     ]
@@ -2773,6 +2774,7 @@ class hbai_household_net_income(Variable):
         "sda",
         "ssmg",
         "scottish_child_payment",
+        "carer_support_payment",
         "state_pension",
         "winter_fuel_allowance",
     )
@@ -2797,14 +2799,15 @@ class hbai_household_net_income(Variable):
     assert by_name["sda"].status == "partial"
     assert by_name["ssmg"].status == "partial"
     assert by_name["scottish_child_payment"].status == "partial"
+    assert by_name["carer_support_payment"].status == "partial"
     assert by_name["state_pension"].status == "partial"
     assert by_name["winter_fuel_allowance"].status == "partial"
     assert by_name["council_tax"].status == "missing"
-    assert report.policy_component_count == 17
-    assert report.covered_policy_component_count == 16
+    assert report.policy_component_count == 18
+    assert report.covered_policy_component_count == 17
     assert report.exact_policy_component_count == 1
-    assert math.isclose(report.covered_policy_component_share, 16 / 17)
-    assert math.isclose(report.exact_policy_component_share, 1 / 17)
+    assert math.isclose(report.covered_policy_component_share, 17 / 18)
+    assert math.isclose(report.exact_policy_component_share, 1 / 18)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.594"
+version = "0.2.595"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map Carer Support Payment care-hours threshold, weekly rate, and Scottish Carer Supplement weekly rate to PE-UK parameters
- classify the HBAI `carer_support_payment` component as partially covered
- add policyengine coverage and UK HBAI coverage tests

## Tests
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_carer_support_payment_outputs tests/test_policyengine_efrs_uk.py::test_uk_hbai_policy_coverage_report_classifies_policy_components -q`
- `uv run --extra dev pytest -q`
