### PR TITLE
Repair generated source relation delegations

### DIFF
--- a/changelog.d/source-relation-delegation-repair.fixed.md
+++ b/changelog.d/source-relation-delegation-repair.fixed.md
@@ -1,0 +1,1 @@
+Repair generated implementation source relations that omit required delegation basis metadata during signed apply.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.595"
+version = "0.2.596"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.595"
+__version__ = "0.2.596"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -15238,6 +15238,35 @@ def cmd_encode(args):
             )
             outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_source_relations = (
+                    _try_repair_generated_source_relation_delegations_for_apply(
+                        result,
+                        output_root=args.output,
+                        policy_repo_path=policy_repo_path,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_source_relations:
+                    outcome["auto_repaired_source_relation_delegations"] = (
+                        repaired_source_relations
+                    )
+                    print(
+                        "  apply=auto_repaired_source_relation_delegations:"
+                        + ",".join(repaired_source_relations)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_same_section_imports = _try_repair_generated_missing_same_section_subsection_imports_for_apply(
                     result,
                     output_root=args.output,
@@ -16754,6 +16783,203 @@ def _try_repair_generated_boolean_parameter_inputs_for_apply(
     )
 
 
+def _try_repair_generated_source_relation_delegations_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path | None = None,
+    issues: list[str],
+) -> list[str]:
+    """Fill missing delegation basis on generated implementation edges."""
+    if not any(
+        _issue_mentions_missing_source_relation_delegation(issue) for issue in issues
+    ):
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    repaired: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "source_relation":
+            continue
+        source_relation = rule.get("source_relation")
+        if not isinstance(source_relation, dict):
+            continue
+        if str(source_relation.get("type") or "").strip().lower() != "implements":
+            continue
+        target = str(source_relation.get("target") or "").strip()
+        if not target:
+            continue
+        delegation = _source_relation_delegation_basis_for_target(
+            target,
+            policy_repo_path=policy_repo_path,
+        )
+        if not delegation:
+            continue
+        basis = source_relation.get("basis")
+        if isinstance(basis, dict) and str(basis.get("delegation") or "").strip():
+            continue
+        if not isinstance(basis, dict):
+            basis = {}
+            source_relation["basis"] = basis
+        basis["delegation"] = delegation
+        repaired.append(str(rule.get("name") or target))
+
+    if not repaired:
+        return []
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repaired
+
+
+def _source_relation_delegation_basis_for_target(
+    target: str,
+    *,
+    policy_repo_path: Path | None,
+) -> str | None:
+    """Return a concrete delegation slot for a source-relation target."""
+    normalized_target = _normalize_source_relation_target_ref(target)
+    if not normalized_target:
+        return None
+    if policy_repo_path is None:
+        return None
+    module_target, _, target_symbol = normalized_target.partition("#")
+
+    target_file = _rulespec_file_for_absolute_module_ref(
+        normalized_target,
+        policy_repo_path=policy_repo_path,
+    )
+    if target_file is None or not target_file.exists():
+        return None
+    try:
+        payload = yaml.safe_load(target_file.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    rule_delegations: set[str] = set()
+    deferred_delegations: set[str] = set()
+    rules = payload.get("rules")
+    if isinstance(rules, list):
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            source_relation = rule.get("source_relation")
+            if not isinstance(source_relation, dict):
+                continue
+            if str(source_relation.get("type") or "").strip().lower() != "delegates":
+                continue
+            name = str(rule.get("name") or "").strip()
+            if name:
+                candidate = f"{module_target}#{name}"
+                delegate_target = _normalize_source_relation_target_ref(
+                    source_relation.get("target")
+                )
+                if name == target_symbol or delegate_target == normalized_target:
+                    return candidate
+                if not target_symbol:
+                    rule_delegations.add(candidate)
+
+    module = payload.get("module")
+    deferred_outputs = (
+        module.get("deferred_outputs") if isinstance(module, dict) else None
+    )
+    if isinstance(deferred_outputs, list):
+        prefix = module_target + "#"
+        for output in deferred_outputs:
+            if not isinstance(output, dict):
+                continue
+            output_ref = _normalize_source_relation_target_ref(output.get("output"))
+            if not output_ref:
+                continue
+            if output_ref == normalized_target:
+                deferred_delegations.add(output_ref)
+            elif not target_symbol and output_ref.startswith(prefix):
+                deferred_delegations.add(output_ref)
+
+    if len(rule_delegations) == 1:
+        return next(iter(rule_delegations))
+    if len(rule_delegations) > 1:
+        return None
+    if len(deferred_delegations) == 1:
+        return next(iter(deferred_delegations))
+    return None
+
+
+def _normalize_source_relation_target_ref(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    base, separator, symbol = normalized.partition("#")
+    if base.endswith((".yaml", ".yml")):
+        base = str(Path(base).with_suffix(""))
+    return f"{base}{separator}{symbol}" if separator else base
+
+
+def _rulespec_file_for_absolute_module_ref(
+    target: str,
+    *,
+    policy_repo_path: Path,
+) -> Path | None:
+    module_ref = str(target or "").strip().split("#", 1)[0]
+    if not module_ref or ":" not in module_ref:
+        return None
+    prefix, relative = module_ref.split(":", 1)
+    prefix = prefix.strip()
+    relative = relative.strip("/")
+    if not prefix or not relative:
+        return None
+    relative_file = Path(relative)
+    if relative_file.suffix not in {".yaml", ".yml"}:
+        relative_file = Path(f"{relative}.yaml")
+    repo_name = f"rulespec-{prefix}"
+    current_repo = Path(policy_repo_path).expanduser()
+
+    candidates: list[Path] = []
+    candidate_roots = [
+        current_repo,
+        current_repo.parent,
+        current_repo / "_axiom",
+        current_repo.parent / "_axiom",
+    ]
+    env_roots = os.environ.get("AXIOM_RULESPEC_REPO_ROOTS", "")
+    candidate_roots.extend(
+        Path(root).expanduser() for root in env_roots.split(os.pathsep) if root
+    )
+    for root in candidate_roots:
+        if root.name == repo_name or canonical_rulespec_repo_name(root) == repo_name:
+            candidates.append(root / relative_file)
+        candidates.append(root / repo_name / relative_file)
+
+    seen_candidates: set[Path] = set()
+    for candidate in candidates:
+        if candidate in seen_candidates:
+            continue
+        seen_candidates.add(candidate)
+        if candidate.exists():
+            return candidate
+    return candidates[0] if candidates else None
+
+
 def _missing_input_names_from_issues(issues: list[str]) -> set[str]:
     names: set[str] = set()
     for issue in issues:
@@ -16763,6 +16989,15 @@ def _missing_input_names_from_issues(issues: list[str]) -> set[str]:
         for match in re.finditer(r"missing input `([A-Za-z_][A-Za-z0-9_]*)`", text):
             names.add(match.group(1))
     return names
+
+
+def _issue_mentions_missing_source_relation_delegation(issue: str) -> bool:
+    text = str(issue)
+    unquoted = text.replace("`", "")
+    return (
+        "must declare source_relation.basis.delegation" in unquoted
+        and "source relation" in unquoted.lower()
+    )
 
 
 def _issue_mentions_versioned_derived_formula(issue: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,6 +102,7 @@ from axiom_encode.cli import (
     _try_repair_generated_nonoperative_source_coverage_for_apply,
     _try_repair_generated_policyengine_oracle_inputs_for_apply,
     _try_repair_generated_section_1401_b_1_self_employment_income_for_apply,
+    _try_repair_generated_source_relation_delegations_for_apply,
     _try_repair_generated_source_table_band_scalars_for_apply,
     _try_repair_generated_unresolved_local_test_outputs_for_apply,
     _try_repair_generated_unsafe_formula_outputs_for_apply,
@@ -4549,6 +4550,486 @@ rules:
                 "us-co:statutes/39/39-22-123.5#credit_excluded_from_income"
             ]
             == "holds"
+        )
+
+    def test_source_relation_delegation_repair_fills_implementation_basis(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us"
+        target_file = policy_repo / "statutes" / "42" / "1396a" / "xx.yaml"
+        target_file.parent.mkdir(parents=True)
+        target_file.write_text(
+            """format: rulespec/v1
+module:
+  deferred_outputs:
+    - output: us:statutes/42/1396a/xx#state_must_apply_community_engagement_requirement
+      reason: Requires implementing regulations.
+rules: []
+"""
+        )
+        rules_file = (
+            output_root / "runner" / "regulations" / "42-cfr" / "435" / "550.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: sections_435_550_through_435_563_implement_section_1902_xx
+  kind: source_relation
+  source: 42 CFR 435.550
+  source_relation:
+    type: implements
+    target: us:statutes/42/1396a/xx
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_source_relation_delegations_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "RuleSpec source relation "
+                "`sections_435_550_through_435_563_implement_section_1902_xx` "
+                "with type `implements` must declare "
+                "source_relation.basis.delegation"
+            ],
+        )
+
+        assert repaired == [
+            "sections_435_550_through_435_563_implement_section_1902_xx"
+        ]
+        payload = yaml.safe_load(rules_file.read_text())
+        source_relation = payload["rules"][0]["source_relation"]
+        assert (
+            source_relation["basis"]["delegation"]
+            == "us:statutes/42/1396a/xx#state_must_apply_community_engagement_requirement"
+        )
+
+    def test_source_relation_delegation_repair_skips_sets_without_basis(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "state_rule.yaml"
+        rules_file.parent.mkdir(parents=True)
+        original = """format: rulespec/v1
+rules:
+- name: sets_state_allowance
+  kind: source_relation
+  source: State Rule
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#state_option
+    value: us-ny:regulations/18-nycrr/387/12/f/3/v/c#allowance
+"""
+        rules_file.write_text(original)
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_source_relation_delegations_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=tmp_path / "rulespec-us",
+            issues=[
+                "RuleSpec source relation `sets_state_allowance` with type "
+                "`sets` must declare source_relation.basis.delegation"
+            ],
+        )
+
+        assert repaired == []
+        assert rules_file.read_text() == original
+
+    def test_source_relation_delegation_repair_prefers_single_delegate_rule(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us"
+        target_file = policy_repo / "regulations" / "7-cfr" / "273" / "9.yaml"
+        target_file.parent.mkdir(parents=True)
+        target_file.write_text(
+            """format: rulespec/v1
+module:
+  deferred_outputs:
+    - output: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+      reason: Implemented by state policy.
+rules:
+- name: snap_state_standard_utility_allowance_delegation
+  kind: source_relation
+  source_relation:
+    type: delegates
+    target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+"""
+        )
+        rules_file = output_root / "runner" / "state_rule.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: implements_federal_snap_option
+  kind: source_relation
+  source_relation:
+    type: implements
+    target: us:regulations/7-cfr/273/9
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_source_relation_delegations_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "RuleSpec source relation `implements_federal_snap_option` "
+                "with type `implements` must declare "
+                "`source_relation.basis.delegation`"
+            ],
+        )
+
+        assert repaired == ["implements_federal_snap_option"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert (
+            payload["rules"][0]["source_relation"]["basis"]["delegation"]
+            == "us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation"
+        )
+
+    def test_source_relation_delegation_repair_resolves_sibling_target_repo(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        state_repo = tmp_path / "rulespec-us-ny"
+        federal_repo = tmp_path / "rulespec-us"
+        target_file = federal_repo / "regulations" / "7-cfr" / "273" / "9.yaml"
+        target_file.parent.mkdir(parents=True)
+        target_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: snap_state_standard_utility_allowance_delegation
+  kind: source_relation
+  source_relation:
+    type: delegates
+    target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+"""
+        )
+        rules_file = output_root / "runner" / "state_rule.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: implements_federal_snap_option
+  kind: source_relation
+  source_relation:
+    type: implements
+    target: us:regulations/7-cfr/273/9
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_source_relation_delegations_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=state_repo,
+            issues=[
+                "RuleSpec source relation `implements_federal_snap_option` "
+                "with type `implements` must declare "
+                "source_relation.basis.delegation"
+            ],
+        )
+
+        assert repaired == ["implements_federal_snap_option"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert (
+            payload["rules"][0]["source_relation"]["basis"]["delegation"]
+            == "us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation"
+        )
+
+    def test_source_relation_delegation_repair_resolves_configured_repo_root(
+        self, tmp_path, monkeypatch
+    ):
+        output_root = tmp_path / "out"
+        state_repo = tmp_path / "worktrees" / "rulespec-us-ny"
+        configured_parent = tmp_path / "configured"
+        federal_repo = configured_parent / "rulespec-us"
+        target_file = federal_repo / "regulations" / "7-cfr" / "273" / "9.yaml"
+        target_file.parent.mkdir(parents=True)
+        target_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: snap_state_standard_utility_allowance_delegation
+  kind: source_relation
+  source_relation:
+    type: delegates
+    target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+"""
+        )
+        monkeypatch.setenv("AXIOM_RULESPEC_REPO_ROOTS", str(configured_parent))
+        rules_file = output_root / "runner" / "state_rule.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: implements_federal_snap_option
+  kind: source_relation
+  source_relation:
+    type: implements
+    target: us:regulations/7-cfr/273/9
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_source_relation_delegations_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=state_repo,
+            issues=[
+                "RuleSpec source relation `implements_federal_snap_option` "
+                "with type `implements` must declare "
+                "source_relation.basis.delegation"
+            ],
+        )
+
+        assert repaired == ["implements_federal_snap_option"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert (
+            payload["rules"][0]["source_relation"]["basis"]["delegation"]
+            == "us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation"
+        )
+
+    def test_source_relation_delegation_repair_resolves_symbol_target_to_delegation(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us"
+        target_file = policy_repo / "regulations" / "7-cfr" / "273" / "9.yaml"
+        target_file.parent.mkdir(parents=True)
+        target_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: snap_state_standard_utility_allowance_delegation
+  kind: source_relation
+  source_relation:
+    type: delegates
+    target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+"""
+        )
+        rules_file = output_root / "runner" / "state_rule.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: implements_federal_snap_option
+  kind: source_relation
+  source_relation:
+    type: implements
+    target: us:regulations/7-cfr/273/9.yaml#snap_individual_utility_allowance_state_option
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_source_relation_delegations_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "RuleSpec source relation `implements_federal_snap_option` "
+                "with type `implements` must declare "
+                "source_relation.basis.delegation"
+            ],
+        )
+
+        assert repaired == ["implements_federal_snap_option"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert (
+            payload["rules"][0]["source_relation"]["basis"]["delegation"]
+            == "us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation"
+        )
+
+    def test_source_relation_delegation_repair_normalizes_delegate_yaml_target(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us"
+        target_file = policy_repo / "regulations" / "7-cfr" / "273" / "9.yaml"
+        target_file.parent.mkdir(parents=True)
+        target_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: snap_state_standard_utility_allowance_delegation
+  kind: source_relation
+  source_relation:
+    type: delegates
+    target: us:regulations/7-cfr/273/9.yaml#snap_individual_utility_allowance_state_option
+"""
+        )
+        rules_file = output_root / "runner" / "state_rule.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: implements_federal_snap_option
+  kind: source_relation
+  source_relation:
+    type: implements
+    target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_source_relation_delegations_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "RuleSpec source relation `implements_federal_snap_option` "
+                "with type `implements` must declare "
+                "source_relation.basis.delegation"
+            ],
+        )
+
+        assert repaired == ["implements_federal_snap_option"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert (
+            payload["rules"][0]["source_relation"]["basis"]["delegation"]
+            == "us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation"
+        )
+
+    def test_source_relation_delegation_repair_skips_ambiguous_delegations(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us"
+        target_file = policy_repo / "regulations" / "7-cfr" / "273" / "9.yaml"
+        target_file.parent.mkdir(parents=True)
+        target_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: snap_first_state_option_delegation
+  kind: source_relation
+  source_relation:
+    type: delegates
+    target: us:regulations/7-cfr/273/9#snap_first_state_option
+- name: snap_second_state_option_delegation
+  kind: source_relation
+  source_relation:
+    type: delegates
+    target: us:regulations/7-cfr/273/9#snap_second_state_option
+"""
+        )
+        rules_file = output_root / "runner" / "state_rule.yaml"
+        rules_file.parent.mkdir(parents=True)
+        original = """format: rulespec/v1
+rules:
+- name: implements_federal_snap_option
+  kind: source_relation
+  source_relation:
+    type: implements
+    target: us:regulations/7-cfr/273/9
+"""
+        rules_file.write_text(original)
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_source_relation_delegations_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "RuleSpec source relation `implements_federal_snap_option` "
+                "with type `implements` must declare "
+                "source_relation.basis.delegation"
+            ],
+        )
+
+        assert repaired == []
+        assert rules_file.read_text() == original
+
+    def test_source_relation_delegation_repair_skips_symbol_target_mismatch(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us"
+        target_file = policy_repo / "regulations" / "7-cfr" / "273" / "9.yaml"
+        target_file.parent.mkdir(parents=True)
+        target_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: snap_other_state_option_delegation
+  kind: source_relation
+  source_relation:
+    type: delegates
+    target: us:regulations/7-cfr/273/9#snap_other_state_option
+"""
+        )
+        rules_file = output_root / "runner" / "state_rule.yaml"
+        rules_file.parent.mkdir(parents=True)
+        original = """format: rulespec/v1
+rules:
+- name: implements_federal_snap_option
+  kind: source_relation
+  source_relation:
+    type: implements
+    target: us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option
+"""
+        rules_file.write_text(original)
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_source_relation_delegations_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "RuleSpec source relation `implements_federal_snap_option` "
+                "with type `implements` must declare "
+                "source_relation.basis.delegation"
+            ],
+        )
+
+        assert repaired == []
+        assert rules_file.read_text() == original
+
+    def test_source_relation_delegation_repair_resolves_explicit_yaml_target(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us"
+        target_file = policy_repo / "statutes" / "42" / "1396a" / "xx.yaml"
+        target_file.parent.mkdir(parents=True)
+        target_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: medicaid_community_engagement_delegation
+  kind: source_relation
+  source_relation:
+    type: delegates
+    target: us:statutes/42/1396a/xx#community_engagement_requirement
+"""
+        )
+        rules_file = output_root / "runner" / "regulation.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: implements_medicaid_community_engagement
+  kind: source_relation
+  source_relation:
+    type: implements
+    target: us:statutes/42/1396a/xx.yaml
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_source_relation_delegations_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "RuleSpec source relation `implements_medicaid_community_engagement` "
+                "with type `implements` must declare "
+                "source_relation.basis.delegation"
+            ],
+        )
+
+        assert repaired == ["implements_medicaid_community_engagement"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert (
+            payload["rules"][0]["source_relation"]["basis"]["delegation"]
+            == "us:statutes/42/1396a/xx#medicaid_community_engagement_delegation"
         )
 
     def test_boolean_comparison_repair_skips_ambiguous_unnamed_error(self, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.595"
+version = "0.2.596"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Repairs generated implementation source relations during signed apply when the model omits required `source_relation.basis.delegation` metadata.

The repair is intentionally narrow:
- only runs after overlay validation reports missing source-relation delegation metadata;
- only repairs generated `kind: source_relation` / `type: implements` records;
- resolves the delegation basis from an existing target module slot, preferring `type: delegates` records and then deferred outputs;
- normalizes `.yaml` / `.yml` target spellings before comparison;
- skips unsafe cases such as `sets` relations without a concrete upstream slot.

## Checks

- `UV_PYTHON=3.13 uv run pytest tests/test_cli.py -k 'source_relation_delegation'` - passed, 10 selected
- `UV_PYTHON=3.13 uv run ruff check pyproject.toml src/axiom_encode scripts tests` - passed
- `UV_PYTHON=3.13 uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py` - passed
- `python -m compileall -q src/axiom_encode scripts` - passed
- `UV_PYTHON=3.13 uv run pytest` - 1812 passed, 61 skipped, 1 unrelated local corpus failure in `tests/test_repo_cross_statute_imports.py` scanning adjacent `rulespec-us/statutes` Title 26 files

## Review cycle

- Independent review after first round found target-normalization and diagnostic-matching issues; both fixed with regressions.
- Final independent review on `a76724775768f3f4e37f2d6b4a70f56ba7a458ff`: no actionable correctness issues.

## CI

- GitHub lint: passed
- GitHub test (3.13): passed