### PR TITLE
Add UK cost-of-living support PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.596"
+version = "0.2.597"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.596"
+__version__ = "0.2.597"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -1180,6 +1180,12 @@ HBAI_COMPONENT_COVERAGE = {
         "covered_outputs": ("carer_support_payment",),
         "rationale": "Axiom covers the Carer Support Payment care-hours threshold, weekly rate, and Scottish Carer Supplement amount, not residence, cared-for-person, overlapping-benefit, or final annual amount rules.",
     },
+    "cost_of_living_support_payment": {
+        "status": "partial",
+        "surfaces": ("cost-of-living-support-payment-parameters",),
+        "covered_outputs": ("cost_of_living_support_payment",),
+        "rationale": "Axiom covers the statutory means-tested and disability Cost-of-Living Payment amounts, not the qualifying-period, benefit-receipt, tax-credit, pensioner-top-up, fraud, or final household aggregation rules.",
+    },
     "winter_fuel_allowance": {
         "status": "partial",
         "surfaces": ("winter-fuel-payment-rates",),

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -746,6 +746,76 @@ mappings:
     comparison: money
     rationale: Same weekly Scottish Carer Supplement amount paid on top of Carer Support Payment.
 
+  - legal_id: uk:statutes/ukpga/2022/38/1#means_tested_additional_payment_total
+    country: uk
+    program: cost_of_living_support_payment
+    mapping_type: parameter_value
+    policyengine_parameter: gov.treasury.cost_of_living_support.means_tested_households.amount
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same 2022-23 total means-tested Cost-of-Living Payments, aggregating the GBP 326 and GBP 324 single payments stated in section 1.
+
+  - legal_id: uk:statutes/ukpga/2022/38/1#first_means_tested_additional_payment_amount
+    country: uk
+    program: cost_of_living_support_payment
+    mapping_type: not_comparable
+    rationale: Section 1 states this first 2022-23 instalment separately, while PolicyEngine UK stores the annual aggregate means-tested Cost-of-Living Payment amount rather than individual instalments.
+
+  - legal_id: uk:statutes/ukpga/2022/38/1#second_means_tested_additional_payment_amount
+    country: uk
+    program: cost_of_living_support_payment
+    mapping_type: not_comparable
+    rationale: Section 1 states this second 2022-23 instalment separately, while PolicyEngine UK stores the annual aggregate means-tested Cost-of-Living Payment amount rather than individual instalments.
+
+  - legal_id: uk:statutes/ukpga/2022/38/5#disability_additional_payment_amount
+    country: uk
+    program: cost_of_living_support_payment
+    mapping_type: parameter_value
+    policyengine_parameter: gov.treasury.cost_of_living_support.disabled.amount
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same one-off Disability Cost-of-Living Payment amount for 2022-23.
+
+  - legal_id: uk:statutes/ukpga/2023/7/1#means_tested_additional_payment_total
+    country: uk
+    program: cost_of_living_support_payment
+    mapping_type: parameter_value
+    policyengine_parameter: gov.treasury.cost_of_living_support.means_tested_households.amount
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same 2023-24 total means-tested Cost-of-Living Payments, aggregating the GBP 301, GBP 300, and GBP 299 single payments stated in section 1.
+
+  - legal_id: uk:statutes/ukpga/2023/7/1#first_means_tested_additional_payment_amount
+    country: uk
+    program: cost_of_living_support_payment
+    mapping_type: not_comparable
+    rationale: Section 1 states this first 2023-24 instalment separately, while PolicyEngine UK stores the annual aggregate means-tested Cost-of-Living Payment amount rather than individual instalments.
+
+  - legal_id: uk:statutes/ukpga/2023/7/1#second_means_tested_additional_payment_amount
+    country: uk
+    program: cost_of_living_support_payment
+    mapping_type: not_comparable
+    rationale: Section 1 states this second 2023-24 instalment separately, while PolicyEngine UK stores the annual aggregate means-tested Cost-of-Living Payment amount rather than individual instalments.
+
+  - legal_id: uk:statutes/ukpga/2023/7/1#third_means_tested_additional_payment_amount
+    country: uk
+    program: cost_of_living_support_payment
+    mapping_type: not_comparable
+    rationale: Section 1 states this third 2023-24 instalment separately, while PolicyEngine UK stores the annual aggregate means-tested Cost-of-Living Payment amount rather than individual instalments.
+
+  - legal_id: uk:statutes/ukpga/2023/7/5#disability_additional_payment_amount
+    country: uk
+    program: cost_of_living_support_payment
+    mapping_type: parameter_value
+    policyengine_parameter: gov.treasury.cost_of_living_support.disabled.amount
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same one-off Disability Cost-of-Living Payment amount for 2023-24.
+
   - legal_id: uk:regulations/uksi/2013/377/24#pip_daily_living_standard_weekly_rate
     country: uk
     program: pip

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2243,6 +2243,188 @@ rules:
     assert supplement["tested"] is True
 
 
+def test_policyengine_coverage_classifies_uk_cost_of_living_support_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2022/38/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: first_means_tested_additional_payment_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2022-06-28'
+        formula: 326
+  - name: second_means_tested_additional_payment_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2022-06-28'
+        formula: 324
+  - name: means_tested_additional_payment_total
+    kind: derived
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2022-06-28'
+        formula: first_means_tested_additional_payment_amount + second_means_tested_additional_payment_amount
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2022/38/5.yaml",
+        """format: rulespec/v1
+rules:
+  - name: disability_additional_payment_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2022-06-28'
+        formula: 150
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2023/7/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: first_means_tested_additional_payment_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2023-03-23'
+        formula: 301
+  - name: second_means_tested_additional_payment_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2023-03-23'
+        formula: 300
+  - name: third_means_tested_additional_payment_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2023-03-23'
+        formula: 299
+  - name: means_tested_additional_payment_total
+    kind: derived
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2023-03-23'
+        formula: first_means_tested_additional_payment_amount + second_means_tested_additional_payment_amount + third_means_tested_additional_payment_amount
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2023/7/5.yaml",
+        """format: rulespec/v1
+rules:
+  - name: disability_additional_payment_amount
+    kind: parameter
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2023-03-23'
+        formula: 150
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2022/38/1.test.yaml",
+        """- name: means_tested_additional_payment_total_2022
+  output:
+    uk:statutes/ukpga/2022/38/1#first_means_tested_additional_payment_amount: 326
+    uk:statutes/ukpga/2022/38/1#second_means_tested_additional_payment_amount: 324
+    uk:statutes/ukpga/2022/38/1#means_tested_additional_payment_total: 650
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2022/38/5.test.yaml",
+        """- name: disability_additional_payment_amount_2022
+  output:
+    uk:statutes/ukpga/2022/38/5#disability_additional_payment_amount: 150
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2023/7/1.test.yaml",
+        """- name: means_tested_additional_payment_total_2023
+  output:
+    uk:statutes/ukpga/2023/7/1#first_means_tested_additional_payment_amount: 301
+    uk:statutes/ukpga/2023/7/1#second_means_tested_additional_payment_amount: 300
+    uk:statutes/ukpga/2023/7/1#third_means_tested_additional_payment_amount: 299
+    uk:statutes/ukpga/2023/7/1#means_tested_additional_payment_total: 900
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2023/7/5.test.yaml",
+        """- name: disability_additional_payment_amount_2023
+  output:
+    uk:statutes/ukpga/2023/7/5#disability_additional_payment_amount: 150
+""",
+    )
+
+    report = build_policyengine_coverage_report(
+        tmp_path,
+        program="cost_of_living_support_payment",
+    )
+
+    assert report["status_counts"] == {
+        "comparable": 4,
+        "known_not_comparable": 5,
+    }
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2022/38/1#means_tested_additional_payment_total"
+        ]["policyengine_parameter"]
+        == "gov.treasury.cost_of_living_support.means_tested_households.amount"
+    )
+    assert (
+        items_by_id["uk:statutes/ukpga/2023/7/1#means_tested_additional_payment_total"][
+            "policyengine_parameter"
+        ]
+        == "gov.treasury.cost_of_living_support.means_tested_households.amount"
+    )
+    assert (
+        items_by_id["uk:statutes/ukpga/2022/38/5#disability_additional_payment_amount"][
+            "policyengine_parameter"
+        ]
+        == "gov.treasury.cost_of_living_support.disabled.amount"
+    )
+    assert (
+        items_by_id["uk:statutes/ukpga/2023/7/5#disability_additional_payment_amount"][
+            "policyengine_parameter"
+        ]
+        == "gov.treasury.cost_of_living_support.disabled.amount"
+    )
+    comparable_items = [
+        item for item in items_by_id.values() if item["status"] == "comparable"
+    ]
+    helper_items = [
+        item
+        for item in items_by_id.values()
+        if item["status"] == "known_not_comparable"
+    ]
+    assert {item["mapping_type"] for item in comparable_items} == {"parameter_value"}
+    assert {item["mapping_type"] for item in helper_items} == {"not_comparable"}
+    assert all(item["tested"] is True for item in comparable_items)
+
+
 def test_policyengine_coverage_classifies_uk_schedule_1_benefit_rate_outputs(
     tmp_path,
 ):

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -2745,6 +2745,7 @@ class hbai_household_net_income(Variable):
         "ssmg",
         "scottish_child_payment",
         "carer_support_payment",
+        "cost_of_living_support_payment",
         "state_pension",
         "winter_fuel_allowance",
     ]
@@ -2775,6 +2776,7 @@ class hbai_household_net_income(Variable):
         "ssmg",
         "scottish_child_payment",
         "carer_support_payment",
+        "cost_of_living_support_payment",
         "state_pension",
         "winter_fuel_allowance",
     )
@@ -2800,14 +2802,15 @@ class hbai_household_net_income(Variable):
     assert by_name["ssmg"].status == "partial"
     assert by_name["scottish_child_payment"].status == "partial"
     assert by_name["carer_support_payment"].status == "partial"
+    assert by_name["cost_of_living_support_payment"].status == "partial"
     assert by_name["state_pension"].status == "partial"
     assert by_name["winter_fuel_allowance"].status == "partial"
     assert by_name["council_tax"].status == "missing"
-    assert report.policy_component_count == 18
-    assert report.covered_policy_component_count == 17
+    assert report.policy_component_count == 19
+    assert report.covered_policy_component_count == 18
     assert report.exact_policy_component_count == 1
-    assert math.isclose(report.covered_policy_component_share, 17 / 18)
-    assert math.isclose(report.exact_policy_component_share, 1 / 18)
+    assert math.isclose(report.covered_policy_component_share, 18 / 19)
+    assert math.isclose(report.exact_policy_component_share, 1 / 19)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.596"
+version = "0.2.597"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Adds UK PolicyEngine oracle coverage for cost-of-living support payment amount surfaces:

- maps the 2022 and 2023 means-tested annual totals to `gov.treasury.cost_of_living_support.means_tested_households.amount`
- maps the 2022 and 2023 disability amounts to `gov.treasury.cost_of_living_support.disabled.amount`
- classifies individual instalment helper amounts as known not comparable because PE stores annual aggregates
- marks `cost_of_living_support_payment` as a partial HBAI net-income component

## Validation

- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_cost_of_living_support_outputs tests/test_policyengine_efrs_uk.py::test_uk_hbai_policy_coverage_report_classifies_policy_components tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
- RuleSpec oracle coverage dry run against the paired rulespec-uk branch: 4 comparable, 5 known not comparable, 0 untested comparable outputs
