### PR TITLE
Classify Medicaid work requirement oracle coverage

### DIFF
--- a/changelog.d/medicaid-workreq-oracle-coverage.fixed.md
+++ b/changelog.d/medicaid-workreq-oracle-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify Medicaid community engagement RuleSpec outputs in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.598"
+version = "0.2.599"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.598"
+__version__ = "0.2.599"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -15589,3 +15589,93 @@ prefixes:
     program: snap
     mapping_type: not_comparable
     rationale: Section 2014(g) resource-test intermediates (vehicle countable amount, fair-market-value threshold, indexed base-amount components, rounding increments) are internal pieces of PolicyEngine's asset-limit aggregation; PE exposes the final snap_assets and snap_asset_limit but not these per-vehicle and base-amount computation steps.
+
+  - legal_id_prefix: us:statutes/42/1396a/xx#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: Section 1396a(xx) Medicaid community-engagement outputs implement the H.R.1 work-requirement mandate and source-specific exceptions; PolicyEngine US does not expose this federal Medicaid work-requirement workflow as one-to-one oracle variables.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/550#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.550 is a scope/definitions rule for Medicaid community engagement; PolicyEngine US does not expose this CMS work-requirement workflow as one-to-one oracle variables.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/551#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.551 applicable-individual predicates are source-specific Medicaid community-engagement eligibility gates that PolicyEngine US does not expose as one-to-one oracle variables.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/552#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.552 community-engagement hour and income pathways are CMS Medicaid work-requirement calculations not represented as one-to-one PolicyEngine US variables or parameters.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/553#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.553 mandatory-exception predicates are source-specific Medicaid work-requirement exemptions that PolicyEngine US does not expose as one-to-one oracle variables.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/554#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.554 excluded-individual predicates cover CMS Medicaid work-requirement exclusions that PolicyEngine US does not expose as one-to-one oracle variables.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/555#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.555 short-term-hardship categories and deeming rules are CMS Medicaid work-requirement exceptions not represented as one-to-one PolicyEngine US variables.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/556#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.556 assessment timing, lookback, notice, and verification predicates are Medicaid community-engagement administration rules outside PolicyEngine US's one-to-one oracle surface.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/557#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.557 renewal-period assessment and notice predicates are CMS Medicaid work-requirement administration rules that PolicyEngine US does not expose as one-to-one variables.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/558#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.558 enrollment-period month counting, grace periods, and disenrollment predicates are Medicaid community-engagement workflow rules outside PolicyEngine US's one-to-one oracle surface.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/559#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.559 beneficiary-notice predicates are source-specific Medicaid work-requirement notice rules not represented as one-to-one PolicyEngine US variables.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/560#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.560 reactivation scope is part of the CMS Medicaid community-engagement workflow, which PolicyEngine US does not expose as one-to-one oracle variables.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/561#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.561 waiver-state eligibility and enrollment conditions are Medicaid demonstration-specific work-requirement rules outside PolicyEngine US's one-to-one oracle surface.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/562#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.562 state-plan-amendment implementation scope is administrative Medicaid work-requirement material not represented as one-to-one PolicyEngine US variables.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/563#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.563 reporting obligations are CMS Medicaid work-requirement administration rules outside PolicyEngine US's one-to-one oracle surface.

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -636,6 +636,62 @@ rules:
     assert "state income bridge" in str(exact_output["rationale"])
 
 
+def test_policyengine_coverage_classifies_medicaid_work_requirement_prefixes(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/42/1396a/xx.yaml",
+        """format: rulespec/v1
+rules:
+  - name: medicaid_community_engagement_condition_applies
+    kind: derived
+    versions:
+      - effective_from: '2026-12-31'
+        formula: applicable_individual and not exempt
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "regulations/42-cfr/435/552.yaml",
+        """format: rulespec/v1
+rules:
+  - name: monthly_community_engagement_hours_requirement
+    kind: parameter
+    versions:
+      - effective_from: '2026-12-31'
+        value: 80
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "regulations/42-cfr/435/558.yaml",
+        """format: rulespec/v1
+rules:
+  - name: disenrollment_after_noncompliance_period
+    kind: derived
+    versions:
+      - effective_from: '2026-12-31'
+        formula: noncompliance_months >= 3
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="medicaid")
+
+    assert report["total_outputs"] == 3
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    statute_output = items_by_id[
+        "us:statutes/42/1396a/xx#medicaid_community_engagement_condition_applies"
+    ]
+    hours_output = items_by_id[
+        "us:regulations/42-cfr/435/552#monthly_community_engagement_hours_requirement"
+    ]
+    disenrollment_output = items_by_id[
+        "us:regulations/42-cfr/435/558#disenrollment_after_noncompliance_period"
+    ]
+    assert statute_output["mapping_type"] == "not_comparable"
+    assert hours_output["mapping_type"] == "not_comparable"
+    assert disenrollment_output["mapping_type"] == "not_comparable"
+    assert "work-requirement" in str(statute_output["rationale"])
+    assert "community-engagement" in str(disenrollment_output["rationale"])
+
+
 def test_policyengine_coverage_classifies_nc_and_sc_snap_manual_prefixes(tmp_path):
     _write_rulespec_file(
         tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.598"
+version = "0.2.599"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 42 USC 1396a(xx) and 42 CFR 435.550-563 Medicaid community-engagement/work-requirement outputs as known not-comparable to PolicyEngine US
- add a PolicyEngine coverage regression for the statute/regulation prefixes that blocked rulespec-us PR #390 CI
- bump axiom-encode to 0.2.597 because PolicyEngine mappings are encoder-affecting

## Review cycle
- Independent review via `codex exec review --commit HEAD` before version-bump amend: no actionable correctness issues found
- Post-CI fix was version metadata/changelog only; reran focused guard and coverage checks

## Checks
- `UV_PYTHON=3.13 uv run pytest tests/test_policyengine_coverage.py -q` (261 passed)
- `UV_PYTHON=3.13 uv run pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_medicaid_work_requirement_prefixes -q` (2 passed)
- `UV_PYTHON=3.13 uv run pytest tests/test_policyengine_classifier.py tests/test_policyengine_ecps_tax.py -q` (91 passed, 19 skipped)
- `UV_PYTHON=3.13 uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `UV_PYTHON=3.13 uv run ruff format --check tests/test_policyengine_coverage.py`
- `python -m compileall -q src/axiom_encode scripts`
- CI-layout coverage sanity for rulespec-us Medicaid files: 109 known_not_comparable, 0 bad