### PR TITLE
Add UK PIP PolicyEngine coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.598"
+version = "0.2.599"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.598"
+__version__ = "0.2.599"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -24776,6 +24776,10 @@ print(f'RESULT:{{val}}')
         rule_name_lower = (rule_name or "").lower()
         lowered = {str(key).lower(): value for key, value in inputs.items()}
 
+        pip_script = self._build_pe_uk_pip_scenario_script(pe_var, inputs, year)
+        if pip_script is not None:
+            return pip_script
+
         if pe_var == "uc_standard_allowance" and self._is_uk_uc_standard_allowance_var(
             rule_name_lower
         ):
@@ -25942,6 +25946,139 @@ monthly = sim.calculate('{pe_var}', '{month_period}')
 eldest = sim.calculate('is_eldest_child', '{month_period}')
 target_index = {target_index}
 {result_logic.rstrip()}
+print(f'RESULT:{{val}}')
+"""
+
+    def _build_pe_uk_pip_scenario_script(
+        self, pe_var: str, inputs: dict, year: str
+    ) -> str | None:
+        """Build a UK PIP scenario from RuleSpec entitlement-category facts."""
+        if pe_var not in {"pip_dl", "pip_m", "pip", "receives_enhanced_pip_dl"}:
+            return None
+
+        def fact(*names: str) -> Any | None:
+            for name in names:
+                value = self._rulespec_test_input_value(inputs, name)
+                if value is not None:
+                    return value
+            return None
+
+        def bool_or_none(value: Any | None) -> bool | None:
+            if value is None:
+                return None
+            if isinstance(value, str):
+                normalized = value.strip().lower()
+                if normalized in {"holds", "true", "yes", "1"}:
+                    return True
+                if normalized in {"not_holds", "false", "no", "0"}:
+                    return False
+            return bool(value)
+
+        dl_required = bool_or_none(
+            fact("required_period_condition_met_for_daily_living_component")
+        )
+        dl_standard = bool_or_none(
+            fact(
+                "pip_daily_living_standard_rate_entitlement",
+                "daily_living_component_standard_rate_entitlement",
+            )
+        )
+        if dl_standard is None and dl_required is not None:
+            limited = bool_or_none(
+                fact(
+                    "ability_to_carry_out_daily_living_activities_is_limited_by_physical_or_mental_condition"
+                )
+            )
+            if limited is not None:
+                dl_standard = limited and dl_required
+
+        dl_enhanced = bool_or_none(
+            fact(
+                "pip_daily_living_enhanced_rate_entitlement",
+                "daily_living_component_enhanced_rate_entitlement",
+            )
+        )
+        if dl_enhanced is None and dl_required is not None:
+            severely_limited = bool_or_none(
+                fact(
+                    "ability_to_carry_out_daily_living_activities_is_severely_limited_by_physical_or_mental_condition"
+                )
+            )
+            if severely_limited is not None:
+                dl_enhanced = severely_limited and dl_required
+
+        mobility_age = bool_or_none(
+            fact("person_is_of_or_over_age_prescribed_for_mobility_component")
+        )
+        mobility_required = bool_or_none(
+            fact("required_period_condition_met_for_mobility_component")
+        )
+        mobility_standard = bool_or_none(
+            fact(
+                "pip_mobility_standard_rate_entitlement",
+                "mobility_component_standard_rate_entitlement",
+            )
+        )
+        if (
+            mobility_standard is None
+            and mobility_age is not None
+            and mobility_required is not None
+        ):
+            mobility_limited = bool_or_none(
+                fact(
+                    "ability_to_carry_out_mobility_activities_is_limited_by_physical_or_mental_condition"
+                )
+            )
+            if mobility_limited is not None:
+                mobility_standard = (
+                    mobility_age and mobility_limited and mobility_required
+                )
+
+        mobility_enhanced = bool_or_none(
+            fact(
+                "pip_mobility_enhanced_rate_entitlement",
+                "mobility_component_enhanced_rate_entitlement",
+            )
+        )
+        if (
+            mobility_enhanced is None
+            and mobility_age is not None
+            and mobility_required is not None
+        ):
+            mobility_severely_limited = bool_or_none(
+                fact(
+                    "ability_to_carry_out_mobility_activities_is_severely_limited_by_physical_or_mental_condition"
+                )
+            )
+            if mobility_severely_limited is not None:
+                mobility_enhanced = (
+                    mobility_age and mobility_severely_limited and mobility_required
+                )
+
+        def category(standard: bool | None, enhanced: bool | None) -> str:
+            if enhanced:
+                return "ENHANCED"
+            if standard:
+                return "STANDARD"
+            return "NONE"
+
+        dl_category = category(dl_standard, dl_enhanced)
+        mobility_category = category(mobility_standard, mobility_enhanced)
+        year_key = repr(str(year))
+        scale = "1" if pe_var == "receives_enhanced_pip_dl" else "52"
+
+        return f"""
+from policyengine_uk import Simulation
+
+situation = {{
+    'people': {{'adult': {{'age': {{{year_key}: 30}}, 'pip_dl_category': {{{year_key}: '{dl_category}'}}, 'pip_m_category': {{{year_key}: '{mobility_category}'}}}}}},
+    'benunits': {{'benunit': {{'members': ['adult']}}}},
+    'households': {{'household': {{'members': ['adult']}}}},
+}}
+
+sim = Simulation(situation=situation)
+annual = sim.calculate('{pe_var}', int('{year}'))
+val = float(annual[0]) / {scale}
 print(f'RESULT:{{val}}')
 """
 

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -1126,13 +1126,15 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom covers the Tax-Free Childcare contribution rate and income cap, not the child/provider eligibility tests, expenses, annual caps, or final aggregate amount.",
     },
     "pip": {
-        "status": "partial",
+        "status": "exact",
         "surfaces": ("personal-independence-payment-rates",),
         "covered_outputs": (
             "pip_dl",
             "pip_m",
+            "pip",
+            "receives_enhanced_pip_dl",
         ),
-        "rationale": "Axiom covers Personal Independence Payment daily-living and mobility weekly rates, not the category assignment or final aggregate PIP amount.",
+        "rationale": "Axiom covers PolicyEngine UK's category-input Personal Independence Payment mechanics, including daily-living, mobility, enhanced daily-living receipt, and the final aggregate PIP amount; descriptor scoring and residence, age, care-home, and hospital exclusions remain held as inputs or outside PolicyEngine's current PIP formula.",
     },
     "dla": {
         "status": "partial",

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -856,6 +856,67 @@ mappings:
     comparison: money
     rationale: Same weekly Personal Independence Payment mobility enhanced rate in Regulation 24.
 
+  - legal_id: uk:statutes/ukpga/2012/5/78#pip_daily_living_enhanced_rate_entitlement
+    country: uk
+    program: pip
+    mapping_type: direct_variable
+    policyengine_variable: receives_enhanced_pip_dl
+    entity: person
+    period: week
+    comparison: boolean
+    rationale: Same enhanced daily-living PIP category indicator, with PolicyEngine UK treating the PIP daily-living category as a person input.
+
+  - legal_id: uk:statutes/ukpga/2012/5/78#pip_daily_living_standard_rate_entitlement
+    country: uk
+    program: pip
+    mapping_type: not_comparable
+    rationale: PolicyEngine UK accepts the PIP daily-living category as an input and exposes enhanced daily-living receipt, but it does not expose a separate standard-rate daily-living entitlement output.
+
+  - legal_id: uk:statutes/ukpga/2012/5/78#pip_daily_living_component_weekly_amount
+    country: uk
+    program: pip
+    mapping_type: direct_variable
+    policyengine_variable: pip_dl
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same PIP daily-living component amount after selecting the standard, enhanced, or nil rate; the UK oracle converts PolicyEngine UK's annual value to a weekly amount for comparison.
+
+  - legal_id: uk:statutes/ukpga/2012/5/79#pip_mobility_standard_rate_entitlement
+    country: uk
+    program: pip
+    mapping_type: not_comparable
+    rationale: PolicyEngine UK accepts the PIP mobility category as an input, but it does not expose a separate standard-rate mobility entitlement output.
+
+  - legal_id: uk:statutes/ukpga/2012/5/79#pip_mobility_enhanced_rate_entitlement
+    country: uk
+    program: pip
+    mapping_type: not_comparable
+    rationale: PolicyEngine UK accepts the PIP mobility category as an input, but it does not expose a separate enhanced-rate mobility entitlement output.
+
+  - legal_id: uk:statutes/ukpga/2012/5/79#pip_mobility_component_weekly_amount
+    country: uk
+    program: pip
+    mapping_type: direct_variable
+    policyengine_variable: pip_m
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same PIP mobility component amount after selecting the standard, enhanced, or nil rate; the UK oracle converts PolicyEngine UK's annual value to a weekly amount for comparison.
+
+  - legal_id: uk:statutes/ukpga/2012/5/77#personal_independence_payment_weekly_amount
+    country: uk
+    program: pip
+    mapping_type: direct_variable
+    policyengine_variable: pip
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Personal Independence Payment total as the sum of daily-living and mobility components; the UK oracle converts PolicyEngine UK's annual value to a weekly amount for comparison.
+
   - legal_id: uk:regulations/uksi/2026/148/article/14#dla_self_care_higher_substituted_amount
     country: uk
     program: dla

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1945,6 +1945,172 @@ rules:
     assert daily_standard["tested"] is True
 
 
+def test_policyengine_coverage_classifies_uk_pip_component_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2012/5/78.yaml",
+        """format: rulespec/v1
+rules:
+  - name: pip_daily_living_enhanced_rate_entitlement
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: enhanced_condition
+  - name: pip_daily_living_standard_rate_entitlement
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: standard_condition
+  - name: pip_daily_living_component_weekly_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 114.60
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2012/5/79.yaml",
+        """format: rulespec/v1
+rules:
+  - name: pip_mobility_standard_rate_entitlement
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: standard_condition
+  - name: pip_mobility_enhanced_rate_entitlement
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: enhanced_condition
+  - name: pip_mobility_component_weekly_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 30.30
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2012/5/77.yaml",
+        """format: rulespec/v1
+rules:
+  - name: personal_independence_payment_weekly_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 144.90
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2012/5/78.test.yaml",
+        """- name: daily living amount
+  period:
+    period_kind: week
+    start: '2026-04-06'
+    end: '2026-04-12'
+  input:
+    enhanced_condition: true
+  output:
+    uk:statutes/ukpga/2012/5/78#pip_daily_living_enhanced_rate_entitlement: holds
+    uk:statutes/ukpga/2012/5/78#pip_daily_living_component_weekly_amount: 114.60
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2012/5/79.test.yaml",
+        """- name: mobility amount
+  period:
+    period_kind: week
+    start: '2026-04-06'
+    end: '2026-04-12'
+  input: {}
+  output:
+    uk:statutes/ukpga/2012/5/79#pip_mobility_component_weekly_amount: 30.30
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/2012/5/77.test.yaml",
+        """- name: total amount
+  period:
+    period_kind: week
+    start: '2026-04-06'
+    end: '2026-04-12'
+  input: {}
+  output:
+    uk:statutes/ukpga/2012/5/77#personal_independence_payment_weekly_amount: 144.90
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="pip")
+
+    assert report["status_counts"] == {
+        "comparable": 4,
+        "known_not_comparable": 3,
+    }
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2012/5/78#pip_daily_living_enhanced_rate_entitlement"
+        ]["policyengine_variable"]
+        == "receives_enhanced_pip_dl"
+    )
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2012/5/78#pip_daily_living_component_weekly_amount"
+        ]["policyengine_variable"]
+        == "pip_dl"
+    )
+    assert (
+        items_by_id["uk:statutes/ukpga/2012/5/79#pip_mobility_component_weekly_amount"][
+            "policyengine_variable"
+        ]
+        == "pip_m"
+    )
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2012/5/77#personal_independence_payment_weekly_amount"
+        ]["policyengine_variable"]
+        == "pip"
+    )
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2012/5/78#pip_daily_living_standard_rate_entitlement"
+        ]["status"]
+        == "known_not_comparable"
+    )
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2012/5/79#pip_mobility_standard_rate_entitlement"
+        ]["status"]
+        == "known_not_comparable"
+    )
+    assert (
+        items_by_id[
+            "uk:statutes/ukpga/2012/5/79#pip_mobility_enhanced_rate_entitlement"
+        ]["status"]
+        == "known_not_comparable"
+    )
+
+
 def test_policyengine_coverage_classifies_uk_tax_free_childcare_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-uk" / "statutes/ukpga/2014/28/1.yaml",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -2794,7 +2794,7 @@ class hbai_household_net_income(Variable):
     assert by_name["working_tax_credit"].status == "partial"
     assert by_name["child_tax_credit"].status == "partial"
     assert by_name["tax_free_childcare"].status == "partial"
-    assert by_name["pip"].status == "partial"
+    assert by_name["pip"].status == "exact"
     assert by_name["dla"].status == "partial"
     assert by_name["attendance_allowance"].status == "partial"
     assert by_name["carers_allowance"].status == "partial"
@@ -2808,9 +2808,9 @@ class hbai_household_net_income(Variable):
     assert by_name["council_tax"].status == "missing"
     assert report.policy_component_count == 19
     assert report.covered_policy_component_count == 18
-    assert report.exact_policy_component_count == 1
+    assert report.exact_policy_component_count == 2
     assert math.isclose(report.covered_policy_component_share, 18 / 19)
-    assert math.isclose(report.exact_policy_component_share, 1 / 19)
+    assert math.isclose(report.exact_policy_component_share, 2 / 19)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -3251,6 +3251,30 @@ def test_policyengine_oracle_applies_result_multiplier(tmp_path):
     assert "snap_fpg" in scripts[0]
 
 
+def test_policyengine_uk_pip_adapter_sets_category_inputs(tmp_path):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=True,
+        oracle_validators=("policyengine",),
+    )
+
+    script = pipeline._build_pe_uk_scenario_script(
+        "pip",
+        {
+            "pip_daily_living_enhanced_rate_entitlement": True,
+            "pip_mobility_standard_rate_entitlement": True,
+        },
+        "2026",
+        "personal_independence_payment_weekly_amount",
+    )
+
+    assert "'pip_dl_category': {'2026': 'ENHANCED'}" in script
+    assert "'pip_m_category': {'2026': 'STANDARD'}" in script
+    assert "sim.calculate('pip', int('2026'))" in script
+    assert "val = float(annual[0]) / 52" in script
+
+
 def test_policyengine_resolver_rejects_friendly_us_names(tmp_path):
     pipeline = ValidatorPipeline(
         policy_repo_path=tmp_path,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.598"
+version = "0.2.599"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map UK PIP daily-living, mobility, enhanced daily-living receipt, and total PIP outputs to PolicyEngine UK
- add a UK PIP scenario adapter that projects RuleSpec entitlement/category facts into PE-UK PIP category inputs
- classify PE-UK HBAI PIP coverage as exact and bump axiom-encode to 0.2.599

## Validation
- uv run --extra dev ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_coverage.py tests/test_policyengine_efrs_uk.py tests/test_rulespec_validation.py
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_coverage.py tests/test_policyengine_efrs_uk.py tests/test_rulespec_validation.py
- uv run --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_pip_rate_outputs tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_pip_component_outputs tests/test_rulespec_validation.py::test_policyengine_uk_pip_adapter_sets_category_inputs tests/test_policyengine_efrs_uk.py::test_uk_hbai_policy_coverage_report_classifies_policy_components
- uv lock --check
- uv run --extra dev axiom-encode uk-efrs-hbai-coverage --source-root /Users/maxghenis/_axiom-worktrees/pe-uk-main-hbai-scan-20260605/policyengine_uk/variables --json

HBAI coverage: PIP moves from partial to exact; exact policy components are 2/42 and covered policy components remain 23/42.