### PR TITLE
Allow Medicaid MAGI person eligibility source scope

### DIFF
--- a/changelog.d/medicaid-magi-source-scope.fixed.md
+++ b/changelog.d/medicaid-magi-source-scope.fixed.md
@@ -1,0 +1,1 @@
+Allow final Medicaid MAGI person eligibility judgments to cite household-income source text for 42 CFR 435.110, .116, .118, and .119.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.601"
+version = "0.2.602"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.601"
+__version__ = "0.2.602"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -15910,6 +15910,34 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_medicaid_magi_income_helpers = (
+                    _try_repair_generated_medicaid_magi_income_helpers_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_medicaid_magi_income_helpers:
+                    outcome["auto_repaired_medicaid_magi_income_helpers"] = (
+                        repaired_medicaid_magi_income_helpers
+                    )
+                    print(
+                        "  apply=auto_repaired_medicaid_magi_income_helpers:"
+                        + ",".join(repaired_medicaid_magi_income_helpers)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_person_scoped_definitions = (
                     _try_repair_generated_person_scoped_definition_for_apply(
                         result,
@@ -16790,7 +16818,7 @@ def _try_repair_generated_source_relation_delegations_for_apply(
     policy_repo_path: Path | None = None,
     issues: list[str],
 ) -> list[str]:
-    """Fill missing delegation basis on generated implementation edges."""
+    """Fill or drop missing delegation basis on generated implementation edges."""
     if not any(
         _issue_mentions_missing_source_relation_delegation(issue) for issue in issues
     ):
@@ -16814,38 +16842,92 @@ def _try_repair_generated_source_relation_delegations_for_apply(
         return []
 
     repaired: list[str] = []
+    retained_rules: list[object] = []
+    changed = False
     for rule in rules:
         if not isinstance(rule, dict):
+            retained_rules.append(rule)
             continue
         if str(rule.get("kind") or "").strip().lower() != "source_relation":
+            retained_rules.append(rule)
             continue
         source_relation = rule.get("source_relation")
         if not isinstance(source_relation, dict):
+            retained_rules.append(rule)
             continue
         if str(source_relation.get("type") or "").strip().lower() != "implements":
+            retained_rules.append(rule)
             continue
         target = str(source_relation.get("target") or "").strip()
         if not target:
+            retained_rules.append(rule)
             continue
         delegation = _source_relation_delegation_basis_for_target(
             target,
             policy_repo_path=policy_repo_path,
         )
         if not delegation:
+            if _may_drop_generated_federal_regulation_implements_relation(
+                rule,
+                payload=payload,
+            ):
+                repaired.append(str(rule.get("name") or target))
+                changed = True
+                continue
+            retained_rules.append(rule)
             continue
         basis = source_relation.get("basis")
         if isinstance(basis, dict) and str(basis.get("delegation") or "").strip():
+            retained_rules.append(rule)
             continue
         if not isinstance(basis, dict):
             basis = {}
             source_relation["basis"] = basis
         basis["delegation"] = delegation
         repaired.append(str(rule.get("name") or target))
+        changed = True
+        retained_rules.append(rule)
 
     if not repaired:
         return []
-    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    if changed:
+        payload["rules"] = retained_rules
+        rules_file.write_text(
+            yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
+        )
     return repaired
+
+
+def _may_drop_generated_federal_regulation_implements_relation(
+    rule: dict[str, object],
+    *,
+    payload: dict[str, object],
+) -> bool:
+    """Return true for unsupported CFR-to-statute implementation provenance edges."""
+    source_relation = rule.get("source_relation")
+    if not isinstance(source_relation, dict):
+        return False
+    if source_relation.get("value"):
+        return False
+    basis = source_relation.get("basis")
+    if isinstance(basis, dict) and str(basis.get("delegation") or "").strip():
+        return False
+    target = str(source_relation.get("target") or "").strip()
+    if not target.startswith("us:statutes/"):
+        return False
+    module = payload.get("module")
+    if not isinstance(module, dict):
+        return False
+    source_verification = module.get("source_verification")
+    if not isinstance(source_verification, dict):
+        return False
+    if not any(
+        path.startswith("us/regulation/")
+        for path in _rulespec_module_source_paths(payload)
+    ):
+        return False
+    source = str(rule.get("source") or "").strip().lower()
+    return bool(re.search(r"\bc\.?\s*f\.?\s*r\.?\b", source, flags=re.IGNORECASE))
 
 
 def _source_relation_delegation_basis_for_target(
@@ -19663,6 +19745,10 @@ _SOURCE_SCOPE_PERSON_MISMATCH_ISSUE_PATTERN = re.compile(
     r"`(?:Household|SnapUnit|TaxUnit|Family|SPMUnit)`, but the embedded "
     r"source states an individual/person/member-scoped"
 )
+_SOURCE_SCOPE_UNIT_MISMATCH_PERSON_ISSUE_PATTERN = re.compile(
+    r"Source scope mismatch: `([^`]+)` is declared on `Person`, but the "
+    r"embedded source states a household/unit-scoped test\."
+)
 _EMPLOYER_SCOPE_ISSUE_PATTERN = re.compile(
     r"Employer-scoped rule at non-employer scope: `([^`]+)`"
 )
@@ -21191,6 +21277,260 @@ def _repair_person_scoped_rate_base_entities(
 
     rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
     return repaired
+
+
+def _try_repair_generated_medicaid_magi_income_helpers_for_apply(
+    result,
+    *,
+    output_root: Path,
+    issues: list[str],
+) -> list[str]:
+    """Inline invalid person-scoped Medicaid MAGI household-income helpers."""
+    target_names = _medicaid_magi_income_helper_issue_names(issues)
+    if not target_names:
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    test_file = _rulespec_test_path(rules_file)
+    return _inline_medicaid_magi_income_helpers(
+        rules_file=rules_file,
+        test_file=test_file,
+        target_names=target_names,
+    )
+
+
+def _medicaid_magi_income_helper_issue_names(issues: list[str]) -> list[str]:
+    names: list[str] = []
+    for issue in issues:
+        match = _SOURCE_SCOPE_UNIT_MISMATCH_PERSON_ISSUE_PATTERN.search(str(issue))
+        if match is not None:
+            names.append(match.group(1))
+    return names
+
+
+def _inline_medicaid_magi_income_helpers(
+    *,
+    rules_file: Path,
+    test_file: Path,
+    target_names: list[str],
+) -> list[str]:
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    if not _is_medicaid_magi_rulespec_payload(payload):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    by_name = {
+        str(rule.get("name")).strip(): rule
+        for rule in rules
+        if isinstance(rule, dict)
+        and isinstance(rule.get("name"), str)
+        and str(rule.get("name")).strip()
+    }
+    repaired: list[str] = []
+    removed: set[str] = set()
+    for target_name in dict.fromkeys(target_names):
+        helper = by_name.get(target_name)
+        if not isinstance(helper, dict):
+            continue
+        if not _is_medicaid_magi_income_helper_rule(helper):
+            continue
+        helper_formula = _medicaid_magi_single_formula(helper)
+        if not helper_formula or not _formula_mentions_income(helper_formula):
+            continue
+        formula_references = [
+            rule
+            for rule in rules
+            if isinstance(rule, dict)
+            and rule is not helper
+            and target_name in _formula_identifiers(_first_rule_formula(rule))
+        ]
+        if len(formula_references) != 1:
+            continue
+        dependents = [
+            rule
+            for rule in formula_references
+            if _is_medicaid_magi_final_eligibility_rule(rule)
+        ]
+        if len(dependents) != 1:
+            continue
+        dependent = dependents[0]
+        if _replace_formula_identifier_with_expression(
+            dependent,
+            identifier=target_name,
+            expression=helper_formula,
+        ):
+            repaired.append(target_name)
+            removed.add(target_name)
+
+    if not repaired:
+        return []
+
+    payload["rules"] = [
+        rule
+        for rule in rules
+        if not (
+            isinstance(rule, dict) and str(rule.get("name") or "").strip() in removed
+        )
+    ]
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    _remove_test_outputs_for_rule_names(test_file, removed)
+    return repaired
+
+
+def _is_medicaid_magi_rulespec_payload(payload: dict[str, object]) -> bool:
+    module = payload.get("module")
+    if not isinstance(module, dict):
+        return False
+    source_verification = module.get("source_verification")
+    if not isinstance(source_verification, dict):
+        return False
+    citation_paths = _medicaid_magi_source_verification_paths(source_verification)
+    return bool(
+        citation_paths
+        & {
+            "us/regulation/42/435/110",
+            "us/regulation/42/435/116",
+            "us/regulation/42/435/118",
+            "us/regulation/42/435/119",
+        }
+    )
+
+
+def _medicaid_magi_source_verification_paths(
+    source_verification: dict[str, object],
+) -> set[str]:
+    paths: set[str] = set()
+    singular = source_verification.get("corpus_citation_path")
+    if isinstance(singular, str) and singular.strip():
+        paths.add(singular.strip())
+    plural = source_verification.get("corpus_citation_paths")
+    if isinstance(plural, list):
+        paths.update(value.strip() for value in plural if isinstance(value, str))
+    elif isinstance(plural, str) and plural.strip():
+        paths.add(plural.strip())
+    return {path for path in paths if path}
+
+
+def _medicaid_magi_single_formula(rule: dict[str, object]) -> str:
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return ""
+    formulas = [
+        formula
+        for version in versions
+        if isinstance(version, dict)
+        and isinstance((formula := version.get("formula")), str)
+        and formula.strip()
+    ]
+    if len(formulas) != 1:
+        return ""
+    return formulas[0]
+
+
+def _is_medicaid_magi_income_helper_rule(rule: dict[str, object]) -> bool:
+    name = str(rule.get("name") or "").strip().lower()
+    return (
+        str(rule.get("kind") or "").strip().lower() == "derived"
+        and str(rule.get("entity") or "").strip().lower() == "person"
+        and str(rule.get("dtype") or "").strip().lower() == "judgment"
+        and any(token in name for token in ("income", "magi", "fpl"))
+    )
+
+
+def _is_medicaid_magi_final_eligibility_rule(rule: dict[str, object]) -> bool:
+    name = str(rule.get("name") or "").strip().lower()
+    return (
+        str(rule.get("kind") or "").strip().lower() == "derived"
+        and str(rule.get("entity") or "").strip().lower() == "person"
+        and str(rule.get("dtype") or "").strip().lower() == "judgment"
+        and any(token in name for token in ("eligible", "eligibility"))
+        and not any(token in name for token in ("income", "limit", "standard"))
+    )
+
+
+def _formula_mentions_income(formula: str) -> bool:
+    return any(
+        token in formula.lower() for token in ("income", "magi", "fpl", "poverty")
+    )
+
+
+def _replace_formula_identifier_with_expression(
+    rule: dict[str, object],
+    *,
+    identifier: str,
+    expression: str,
+) -> bool:
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return False
+    changed = False
+    replacement = f"({expression.strip()})"
+    for version in versions:
+        if not isinstance(version, dict):
+            continue
+        formula = version.get("formula")
+        if not isinstance(formula, str):
+            continue
+        updated = _replace_rulespec_identifier(
+            formula,
+            old=identifier,
+            new=replacement,
+        )
+        if updated != formula:
+            version["formula"] = updated
+            changed = True
+    return changed
+
+
+def _remove_test_outputs_for_rule_names(test_file: Path, rule_names: set[str]) -> None:
+    if not rule_names or not test_file.exists():
+        return
+    try:
+        test_cases = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, yaml.YAMLError, ValueError):
+        return
+    if not isinstance(test_cases, list):
+        return
+
+    changed = False
+    repaired_cases: list[object] = []
+    for case in test_cases:
+        if not isinstance(case, dict):
+            repaired_cases.append(case)
+            continue
+        outputs = case.get("output")
+        if not isinstance(outputs, dict):
+            repaired_cases.append(case)
+            continue
+        repaired_outputs = {
+            key: value
+            for key, value in outputs.items()
+            if str(key).rsplit("#", 1)[-1] not in rule_names
+        }
+        if len(repaired_outputs) != len(outputs):
+            changed = True
+        if repaired_outputs:
+            repaired_case = dict(case)
+            repaired_case["output"] = repaired_outputs
+            repaired_cases.append(repaired_case)
+
+    if changed:
+        test_file.write_text(
+            yaml.safe_dump(repaired_cases, sort_keys=False, allow_unicode=False)
+        )
 
 
 def _try_repair_generated_person_scoped_definition_for_apply(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -7191,6 +7191,43 @@ _FEDERAL_TAX_SOURCE_CONTEXT_PATTERN = re.compile(
     r"§\s*(?:\d+[A-Z]?|1\.\d+[A-Z]?)(?:\b|\()",
     flags=re.IGNORECASE,
 )
+_MEDICAID_MAGI_PERSON_ELIGIBILITY_CONTEXT_PATTERN = re.compile(
+    r"\b(?:individuals?|pregnant\s+(?:woman|women)|parents?|"
+    r"caretaker\s+relatives?|children|child|infants?)\b"
+    r"[\s\S]{0,600}\bhousehold\s+income\b"
+    r"|"
+    r"\bhousehold\s+income\b[\s\S]{0,600}\b"
+    r"(?:individuals?|pregnant\s+(?:woman|women)|parents?|"
+    r"caretaker\s+relatives?|children|child|infants?)\b",
+    flags=re.IGNORECASE,
+)
+_MEDICAID_MAGI_RULE_CITATION_PATTERN = re.compile(
+    r"\b42\s*(?:CFR|C\.?\s*F\.?\s*R\.?)\s*(?:§\s*)?"
+    r"435\.(?:110|116|118|119)\b"
+    r"|"
+    r"\bus/regulation/42/435/(?:110|116|118|119)\b",
+    flags=re.IGNORECASE,
+)
+_MEDICAID_MAGI_ELIGIBILITY_RULE_NAME_PATTERN = re.compile(
+    r"(?:^|_)(?:eligible|eligibility)(?:_|$)",
+    flags=re.IGNORECASE,
+)
+_MEDICAID_MAGI_INCOME_HELPER_RULE_NAME_PATTERN = re.compile(
+    r"(?:^|_)(?:income|resources?|assets?)(?:_|$)",
+    flags=re.IGNORECASE,
+)
+_MEDICAID_MAGI_INCOME_FORMULA_PATTERN = re.compile(
+    r"\b[A-Za-z_][A-Za-z0-9_]*(?:income|magi|fpl)[A-Za-z0-9_]*\b",
+    flags=re.IGNORECASE,
+)
+_MEDICAID_MAGI_SINGLE_INCOME_HELPER_FORMULA_PATTERN = re.compile(
+    r"^[A-Za-z_][A-Za-z0-9_]*(?:income|magi|fpl)[A-Za-z0-9_]*(?:\s*\([^()]*\))?$",
+    flags=re.IGNORECASE,
+)
+_FORMULA_BOOLEAN_CONNECTIVE_PATTERN = re.compile(
+    r"\b(?:and|or|not)\b",
+    flags=re.IGNORECASE,
+)
 _EMPLOYER_SCOPED_ENTITY_NAMES = {"business", "corporation", "taxunit"}
 _EMPLOYER_SCOPED_SOURCE_PATTERN = re.compile(
     r"\b(?:each|every|any|an?)\s+employer\b"
@@ -7369,7 +7406,101 @@ def _unit_entities_are_equivalent_for_source_rule(
     )
 
 
+def _person_rule_can_use_unit_scoped_medicaid_magi_source(
+    rule: dict[str, Any],
+    *,
+    fallback_source_text: str,
+) -> bool:
+    """Allow Medicaid MAGI individual eligibility to include household income.
+
+    The federal MAGI groups in 42 CFR 435.110, .116, .118, and .119 define
+    eligibility for individuals, while one condition is stated as household
+    income against FPL. The source-scope guard should continue rejecting generic
+    person rules proven only from household text, but these final Medicaid
+    eligibility judgments are legitimately person-scoped.
+    """
+    name = str(rule.get("name") or "")
+    if not _MEDICAID_MAGI_ELIGIBILITY_RULE_NAME_PATTERN.search(name):
+        return False
+    if _MEDICAID_MAGI_INCOME_HELPER_RULE_NAME_PATTERN.search(name):
+        return False
+    if str(rule.get("dtype") or "").strip().lower() != "judgment":
+        return False
+    if _medicaid_magi_rule_has_income_only_formula(rule):
+        return False
+    if not _medicaid_magi_rule_has_income_formula_reference(rule):
+        return False
+    proof_contexts = _rule_proof_source_contexts(rule)
+    citation_context = "\n".join(
+        [
+            str(rule.get("source") or ""),
+            *(text for _key, text in proof_contexts),
+        ]
+    )
+    if not _MEDICAID_MAGI_RULE_CITATION_PATTERN.search(citation_context):
+        return False
+    proof_excerpts = [text for key, text in proof_contexts if key == "excerpt"]
+    classified_texts = proof_excerpts or [fallback_source_text]
+    if not any(
+        re.search(r"\bhousehold\s+income\b", text, re.IGNORECASE)
+        for text in classified_texts
+    ):
+        return False
+    eligibility_context = "\n".join([*classified_texts, fallback_source_text])
+    return bool(
+        _MEDICAID_MAGI_PERSON_ELIGIBILITY_CONTEXT_PATTERN.search(eligibility_context)
+    )
+
+
+def _medicaid_magi_rule_has_income_only_formula(rule: dict[str, Any]) -> bool:
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return False
+    formulas = [
+        formula
+        for version in versions
+        if isinstance(version, dict)
+        and isinstance((formula := version.get("formula")), str)
+        and formula.strip()
+    ]
+    if not formulas:
+        return False
+    return all(
+        not _FORMULA_BOOLEAN_CONNECTIVE_PATTERN.search(formula)
+        and (
+            _MEDICAID_MAGI_INCOME_FORMULA_PATTERN.search(formula)
+            or _MEDICAID_MAGI_SINGLE_INCOME_HELPER_FORMULA_PATTERN.fullmatch(
+                formula.strip()
+            )
+        )
+        for formula in formulas
+    )
+
+
+def _medicaid_magi_rule_has_income_formula_reference(rule: dict[str, Any]) -> bool:
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return False
+    formulas = [
+        formula
+        for version in versions
+        if isinstance(version, dict)
+        and isinstance((formula := version.get("formula")), str)
+        and formula.strip()
+    ]
+    if not formulas:
+        return False
+    return all(
+        bool(_MEDICAID_MAGI_INCOME_FORMULA_PATTERN.search(formula))
+        for formula in formulas
+    )
+
+
 def _rule_proof_source_excerpts(rule: dict[str, Any]) -> list[str]:
+    return [text for key, text in _rule_proof_source_contexts(rule) if key == "excerpt"]
+
+
+def _rule_proof_source_contexts(rule: dict[str, Any]) -> list[tuple[str, str]]:
     metadata = rule.get("metadata")
     if not isinstance(metadata, dict):
         return []
@@ -7380,17 +7511,25 @@ def _rule_proof_source_excerpts(rule: dict[str, Any]) -> list[str]:
     if not isinstance(atoms, list):
         return []
 
-    excerpts: list[str] = []
+    contexts: list[tuple[str, str]] = []
     for atom in atoms:
         if not isinstance(atom, dict):
             continue
         source = atom.get("source")
         if not isinstance(source, dict):
             continue
-        excerpt = source.get("excerpt")
-        if isinstance(excerpt, str) and excerpt.strip():
-            excerpts.append(excerpt.strip())
-    return excerpts
+        for key in ("excerpt", "corpus_citation_path"):
+            value = source.get(key)
+            if isinstance(value, str) and value.strip():
+                contexts.append((key, value.strip()))
+        many_paths = source.get("corpus_citation_paths")
+        if isinstance(many_paths, list):
+            for value in many_paths:
+                if isinstance(value, str) and value.strip():
+                    contexts.append(("corpus_citation_paths", value.strip()))
+        elif isinstance(many_paths, str) and many_paths.strip():
+            contexts.append(("corpus_citation_paths", many_paths.strip()))
+    return contexts
 
 
 def _rule_source_scope(
@@ -7464,6 +7603,11 @@ def find_source_scope_consistency_issues(content: str) -> list[str]:
                 "or cite source text that states the unit-level test."
             )
         elif source_scope == _SOURCE_SCOPE_UNIT and normalized_entity == "person":
+            if _person_rule_can_use_unit_scoped_medicaid_magi_source(
+                rule,
+                fallback_source_text=source_text,
+            ):
+                continue
             issues.append(
                 "Source scope mismatch: "
                 f"`{name}` is declared on `Person`, but the embedded source "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,9 +42,11 @@ from axiom_encode.cli import (
     _has_zero_output_test,
     _hoist_nested_test_tables,
     _infer_missing_input_default,
+    _inline_medicaid_magi_income_helpers,
     _insert_false_input_default,
     _local_factual_input_names_from_rules_content,
     _looks_like_absolute_rulespec_output_target,
+    _medicaid_magi_income_helper_issue_names,
     _person_scoped_definition_issue_names,
     _promote_boolean_comparison_predicates_to_judgment,
     _qualify_deferred_output_subsection_paths,
@@ -4637,6 +4639,141 @@ rules:
         assert repaired == []
         assert rules_file.read_text() == original
 
+    def test_source_relation_delegation_repair_drops_unsupported_federal_cfr_implements(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = (
+            output_root / "runner" / "regulations" / "42-cfr" / "435" / "110.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/110
+rules:
+- name: implements_section_1931_b_and_d
+  kind: source_relation
+  source: 42 CFR 435.110(a)
+  source_relation:
+    type: implements
+    target: us:statutes/42/1396u-1
+- name: parent_or_caretaker_relative_medicaid_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.110(b)
+  versions:
+    - effective_from: '2014-01-01'
+      formula: person_is_parent
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_source_relation_delegations_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=tmp_path / "rulespec-us",
+            issues=[
+                "RuleSpec source relation `implements_section_1931_b_and_d` "
+                "with type `implements` must declare "
+                "source_relation.basis.delegation"
+            ],
+        )
+
+        assert repaired == ["implements_section_1931_b_and_d"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert [rule["name"] for rule in payload["rules"]] == [
+            "parent_or_caretaker_relative_medicaid_eligible"
+        ]
+
+    def test_source_relation_delegation_repair_drops_plural_cfr_implements(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = (
+            output_root / "runner" / "regulations" / "42-cfr" / "435" / "110.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_paths:
+      - us/regulation/42/435/110
+rules:
+- name: implements_section_1931_b_and_d
+  kind: source_relation
+  source: 42 C.F.R. § 435.110(a)
+  source_relation:
+    type: implements
+    target: us:statutes/42/1396u-1
+- name: parent_or_caretaker_relative_medicaid_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  source: 42 CFR 435.110(b)
+  versions:
+    - effective_from: '2014-01-01'
+      formula: person_is_parent
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_source_relation_delegations_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=tmp_path / "rulespec-us",
+            issues=[
+                "RuleSpec source relation `implements_section_1931_b_and_d` "
+                "with type `implements` must declare "
+                "source_relation.basis.delegation"
+            ],
+        )
+
+        assert repaired == ["implements_section_1931_b_and_d"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert [rule["name"] for rule in payload["rules"]] == [
+            "parent_or_caretaker_relative_medicaid_eligible"
+        ]
+
+    def test_source_relation_delegation_repair_keeps_non_cfr_implements_without_basis(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "state_rule.yaml"
+        rules_file.parent.mkdir(parents=True)
+        original = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ny/regulation/example
+rules:
+- name: implements_federal_option
+  kind: source_relation
+  source: State Rule
+  source_relation:
+    type: implements
+    target: us:statutes/42/1396u-1
+"""
+        rules_file.write_text(original)
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_source_relation_delegations_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=tmp_path / "rulespec-us",
+            issues=[
+                "RuleSpec source relation `implements_federal_option` with type "
+                "`implements` must declare source_relation.basis.delegation"
+            ],
+        )
+
+        assert repaired == []
+        assert rules_file.read_text() == original
+
     def test_source_relation_delegation_repair_prefers_single_delegate_rule(
         self, tmp_path
     ):
@@ -6050,6 +6187,311 @@ rules:
         ]
 
         assert _person_scoped_definition_issue_names(issues) == []
+
+    def test_medicaid_magi_income_helper_issue_names(self):
+        issues = [
+            "Source scope mismatch: "
+            "`household_income_at_or_below_state_section_1931_income_standard` "
+            "is declared on `Person`, but the embedded source states a "
+            "household/unit-scoped test. Encode the rule at the source-stated "
+            "unit scope or cite source text that states the person-level test."
+        ]
+
+        assert _medicaid_magi_income_helper_issue_names(issues) == [
+            "household_income_at_or_below_state_section_1931_income_standard"
+        ]
+
+    def test_inline_medicaid_magi_income_helpers_removes_one_use_income_helper(
+        self, tmp_path
+    ):
+        rules_file = tmp_path / "regulations/42-cfr/435/110.yaml"
+        test_file = tmp_path / "regulations/42-cfr/435/110.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/110
+rules:
+- name: person_is_parent_or_caretaker_relative_or_living_spouse
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '2014-01-01'
+    formula: person_is_parent
+- name: household_income_at_or_below_state_section_1931_income_standard
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '2014-01-01'
+    formula: household_magi_income <= state_established_section_1931_income_standard
+- name: parent_or_caretaker_relative_medicaid_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '2014-01-01'
+    formula: |-
+      person_is_parent_or_caretaker_relative_or_living_spouse
+      and household_income_at_or_below_state_section_1931_income_standard
+"""
+        )
+        test_file.write_text(
+            """- name: eligible_parent
+  output:
+    us:regulations/42-cfr/435/110#household_income_at_or_below_state_section_1931_income_standard: holds
+    us:regulations/42-cfr/435/110#parent_or_caretaker_relative_medicaid_eligible: holds
+"""
+        )
+
+        repaired = _inline_medicaid_magi_income_helpers(
+            rules_file=rules_file,
+            test_file=test_file,
+            target_names=[
+                "household_income_at_or_below_state_section_1931_income_standard"
+            ],
+        )
+
+        assert repaired == [
+            "household_income_at_or_below_state_section_1931_income_standard"
+        ]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert [rule["name"] for rule in payload["rules"]] == [
+            "person_is_parent_or_caretaker_relative_or_living_spouse",
+            "parent_or_caretaker_relative_medicaid_eligible",
+        ]
+        final_formula = payload["rules"][1]["versions"][0]["formula"]
+        assert (
+            "household_income_at_or_below_state_section_1931_income_standard"
+            not in (final_formula)
+        )
+        assert (
+            "(household_magi_income <= state_established_section_1931_income_standard)"
+            in final_formula
+        )
+        test_cases = yaml.safe_load(test_file.read_text())
+        assert list(test_cases[0]["output"]) == [
+            "us:regulations/42-cfr/435/110#parent_or_caretaker_relative_medicaid_eligible"
+        ]
+
+    def test_inline_medicaid_magi_income_helpers_ignores_non_medicaid_module(
+        self, tmp_path
+    ):
+        rules_file = tmp_path / "statutes/26/1.yaml"
+        test_file = tmp_path / "statutes/26/1.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        original = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/1
+rules:
+- name: household_income_at_or_below_threshold
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  versions:
+  - effective_from: '2026-01-01'
+    formula: household_income <= threshold
+"""
+        rules_file.write_text(original)
+
+        repaired = _inline_medicaid_magi_income_helpers(
+            rules_file=rules_file,
+            test_file=test_file,
+            target_names=["household_income_at_or_below_threshold"],
+        )
+
+        assert repaired == []
+        assert rules_file.read_text() == original
+
+    def test_inline_medicaid_magi_income_helpers_accepts_plural_source_paths(
+        self, tmp_path
+    ):
+        rules_file = tmp_path / "regulations/42-cfr/435/110.yaml"
+        test_file = tmp_path / "regulations/42-cfr/435/110.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_paths:
+      - us/regulation/42/435/110
+      - us/regulation/42/435/603
+rules:
+- name: household_income_at_or_below_state_section_1931_income_standard
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '2014-01-01'
+    formula: household_magi_income <= state_established_section_1931_income_standard
+- name: parent_or_caretaker_relative_medicaid_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '2014-01-01'
+    formula: household_income_at_or_below_state_section_1931_income_standard and person_is_parent
+"""
+        )
+
+        repaired = _inline_medicaid_magi_income_helpers(
+            rules_file=rules_file,
+            test_file=test_file,
+            target_names=[
+                "household_income_at_or_below_state_section_1931_income_standard"
+            ],
+        )
+
+        assert repaired == [
+            "household_income_at_or_below_state_section_1931_income_standard"
+        ]
+
+    def test_inline_medicaid_magi_income_helpers_skips_multi_version_helper(
+        self, tmp_path
+    ):
+        rules_file = tmp_path / "regulations/42-cfr/435/110.yaml"
+        test_file = tmp_path / "regulations/42-cfr/435/110.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        original = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/110
+rules:
+- name: household_income_at_or_below_state_section_1931_income_standard
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '2014-01-01'
+    formula: household_magi_income <= old_standard
+  - effective_from: '2026-01-01'
+    formula: household_magi_income <= new_standard
+- name: parent_or_caretaker_relative_medicaid_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '2014-01-01'
+    formula: household_income_at_or_below_state_section_1931_income_standard and person_is_parent
+"""
+        rules_file.write_text(original)
+
+        repaired = _inline_medicaid_magi_income_helpers(
+            rules_file=rules_file,
+            test_file=test_file,
+            target_names=[
+                "household_income_at_or_below_state_section_1931_income_standard"
+            ],
+        )
+
+        assert repaired == []
+        assert rules_file.read_text() == original
+
+    def test_inline_medicaid_magi_income_helpers_skips_shared_helper(self, tmp_path):
+        rules_file = tmp_path / "regulations/42-cfr/435/110.yaml"
+        test_file = tmp_path / "regulations/42-cfr/435/110.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        original = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/110
+rules:
+- name: household_income_at_or_below_state_section_1931_income_standard
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '2014-01-01'
+    formula: household_magi_income <= state_established_section_1931_income_standard
+- name: parent_income_screen_result
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '2014-01-01'
+    formula: household_income_at_or_below_state_section_1931_income_standard
+- name: parent_or_caretaker_relative_medicaid_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '2014-01-01'
+    formula: household_income_at_or_below_state_section_1931_income_standard and person_is_parent
+"""
+        rules_file.write_text(original)
+
+        repaired = _inline_medicaid_magi_income_helpers(
+            rules_file=rules_file,
+            test_file=test_file,
+            target_names=[
+                "household_income_at_or_below_state_section_1931_income_standard"
+            ],
+        )
+
+        assert repaired == []
+        assert rules_file.read_text() == original
+
+    def test_inline_medicaid_magi_income_helpers_allows_magi_named_final_rule(
+        self, tmp_path
+    ):
+        rules_file = tmp_path / "regulations/42-cfr/435/110.yaml"
+        test_file = tmp_path / "regulations/42-cfr/435/110.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/110
+rules:
+- name: household_income_at_or_below_state_section_1931_income_standard
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '2014-01-01'
+    formula: household_magi_income <= state_established_section_1931_income_standard
+- name: magi_medicaid_eligible
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '2014-01-01'
+    formula: household_income_at_or_below_state_section_1931_income_standard and person_is_parent
+"""
+        )
+
+        repaired = _inline_medicaid_magi_income_helpers(
+            rules_file=rules_file,
+            test_file=test_file,
+            target_names=[
+                "household_income_at_or_below_state_section_1931_income_standard"
+            ],
+        )
+
+        assert repaired == [
+            "household_income_at_or_below_state_section_1931_income_standard"
+        ]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["rules"][0]["name"] == "magi_medicaid_eligible"
+        assert (
+            "household_magi_income <= state_established_section_1931_income_standard"
+            in (payload["rules"][0]["versions"][0]["formula"])
+        )
 
     def test_remove_cross_module_dependent_test_outputs_drops_imported_output(
         self, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -12811,6 +12811,684 @@ rules:
     ]
 
 
+def test_source_scope_consistency_allows_medicaid_magi_person_eligibility_with_household_income():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/119
+  summary: |-
+    Effective January 1, 2014, the agency must provide Medicaid to
+    individuals who are age 19 or older and under age 65 and have household
+    income that is at or below 133 percent FPL for the applicable family size.
+rules:
+  - name: adult_group_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.119(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "the agency must provide Medicaid to individuals who have household income that is at or below 133 percent FPL for the applicable family size."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          age >= 19
+          and age < 65
+          and household_income_as_fraction_of_fpl <= 1.33
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_allows_medicaid_magi_full_adult_group_excerpt():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/119
+  summary: |-
+    Effective January 1, 2014, the agency must provide Medicaid to
+    individuals who meet the adult group conditions and have household income
+    at or below 133 percent FPL for the applicable family size.
+rules:
+  - name: adult_group_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.119(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "The agency must provide Medicaid to individuals who meet all of the following: (1) Are age 19 or older and under age 65. (2) Are not pregnant. (3) Are not entitled to or enrolled for Medicare benefits under part A or B of title XVIII of the Act. (4) Are not otherwise eligible for and enrolled for mandatory coverage under a State's Medicaid State plan in accordance with subpart B of this part. (5) Have household income that is at or below 133 percent FPL for the applicable family size."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          age >= 19
+          and age < 65
+          and not is_pregnant
+          and not enrolled_in_medicare_part_a_or_b
+          and not otherwise_eligible_for_mandatory_medicaid
+          and household_income_as_fraction_of_fpl <= 1.33
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_allows_medicaid_magi_corpus_only_proof():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/119
+  summary: |-
+    Effective January 1, 2014, the agency must provide Medicaid to
+    individuals who are age 19 or older and under age 65 and have household
+    income that is at or below 133 percent FPL for the applicable family size.
+rules:
+  - name: adult_group_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.119(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          age >= 19
+          and age < 65
+          and household_income_as_fraction_of_fpl <= 1.33
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_allows_medicaid_magi_summary_only_source():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Effective January 1, 2014, the agency must provide Medicaid to
+    individuals who are age 19 or older and under age 65 and have household
+    income that is at or below 133 percent FPL for the applicable family size.
+rules:
+  - name: adult_group_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.119(b)
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          age >= 19
+          and age < 65
+          and household_income_as_fraction_of_fpl <= 1.33
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_allows_medicaid_magi_plural_corpus_paths():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_paths:
+      - us/regulation/42/435/119
+      - us/regulation/42/435/603
+  summary: |-
+    Effective January 1, 2014, the agency must provide Medicaid to
+    individuals who are age 19 or older and under age 65 and have household
+    income that is at or below 133 percent FPL for the applicable family size.
+rules:
+  - name: adult_group_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.119(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_paths:
+                - us/regulation/42/435/119
+                - us/regulation/42/435/603
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          age >= 19
+          and age < 65
+          and magi_income_as_fraction_of_fpl <= 1.33
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_allows_medicaid_magi_cfr_section_symbol_citation():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/119
+  summary: |-
+    Effective January 1, 2014, the agency must provide Medicaid to
+    individuals who are age 19 or older and under age 65 and have household
+    income that is at or below 133 percent FPL for the applicable family size.
+rules:
+  - name: adult_group_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 C.F.R. § 435.119(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              excerpt: "the agency must provide Medicaid to individuals who have household income that is at or below 133 percent FPL for the applicable family size."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          age >= 19
+          and age < 65
+          and household_income_as_fraction_of_fpl <= 1.33
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_allows_medicaid_magi_infant_eligibility():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/118
+  summary: |-
+    The agency must provide Medicaid to infants under age 1 who have
+    household income at or below the applicable income standard.
+rules:
+  - name: infant_group_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.118
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/118
+              excerpt: "Infants under age 1 with household income at or below 194 percent of the Federal poverty level."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          age < 1
+          and household_income_as_fraction_of_fpl <= 1.94
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_allows_medicaid_magi_pregnant_woman_eligibility():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/116
+  summary: |-
+    The agency must provide Medicaid to a pregnant woman whose household
+    income is at or below the applicable income standard.
+rules:
+  - name: pregnant_woman_group_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.116
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/116
+              excerpt: "A pregnant woman whose household income is at or below 200 percent FPL."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          is_pregnant
+          and household_income_as_fraction_of_fpl <= 2.00
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_allows_medicaid_magi_child_eligibility():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/118
+  summary: |-
+    The agency must provide Medicaid to a child whose household income is at
+    or below the applicable income standard.
+rules:
+  - name: child_group_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.118
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/118
+              excerpt: "A child age 1 through 5 whose household income is at or below 150 percent FPL."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          age >= 1
+          and age <= 5
+          and household_income_as_fraction_of_fpl <= 1.50
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_still_rejects_medicaid_magi_income_helper_as_person_rule():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/119
+  summary: Medicaid adult group household income test.
+rules:
+  - name: adult_group_income_requirement
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.119(b)(5)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "Have household income that is at or below 133 percent FPL for the applicable family size."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          household_income_as_fraction_of_fpl <= 1.33
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `adult_group_income_requirement` is declared "
+        "on `Person`, but the embedded source states a household/unit-scoped "
+        "test. Encode the rule at the source-stated unit scope or cite source "
+        "text that states the person-level test."
+    ]
+
+
+def test_source_scope_consistency_rejects_medicaid_magi_income_eligible_helper():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/119
+  summary: |-
+    Effective January 1, 2014, the agency must provide Medicaid to
+    individuals who are age 19 or older and under age 65 and have household
+    income that is at or below 133 percent FPL for the applicable family size.
+rules:
+  - name: adult_group_income_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.119(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "the agency must provide Medicaid to individuals who have household income that is at or below 133 percent FPL for the applicable family size."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          household_income_as_fraction_of_fpl <= 1.33
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `adult_group_income_eligible` is declared "
+        "on `Person`, but the embedded source states a household/unit-scoped "
+        "test. Encode the rule at the source-stated unit scope or cite source "
+        "text that states the person-level test."
+    ]
+
+
+def test_source_scope_consistency_rejects_medicaid_magi_income_only_eligible_rule():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/119
+  summary: |-
+    The agency must provide Medicaid to individuals who have household income
+    at or below 133 percent FPL.
+rules:
+  - name: adult_group_fpl_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.119(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "The agency must provide Medicaid to individuals who have household income that is at or below 133 percent FPL for the applicable family size."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: household_income_as_fraction_of_fpl <= 1.33
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `adult_group_fpl_eligible` is declared "
+        "on `Person`, but the embedded source states a household/unit-scoped "
+        "test. Encode the rule at the source-stated unit scope or cite source "
+        "text that states the person-level test."
+    ]
+
+
+def test_source_scope_consistency_rejects_medicaid_magi_single_income_helper_formula():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/119
+  summary: |-
+    The agency must provide Medicaid to individuals who have household income
+    at or below 133 percent FPL.
+rules:
+  - name: adult_group_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.119(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "The agency must provide Medicaid to individuals who have household income that is at or below 133 percent FPL for the applicable family size."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: adult_group_income_requirement
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `adult_group_eligible` is declared "
+        "on `Person`, but the embedded source states a household/unit-scoped "
+        "test. Encode the rule at the source-stated unit scope or cite source "
+        "text that states the person-level test."
+    ]
+
+
+def test_source_scope_consistency_rejects_medicaid_magi_income_only_magi_formula():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/119
+  summary: |-
+    The agency must provide Medicaid to individuals who have household income
+    at or below 133 percent FPL.
+rules:
+  - name: adult_group_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.119(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "The agency must provide Medicaid to individuals who have household income that is at or below 133 percent FPL for the applicable family size."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: magi_income_as_fraction_of_fpl <= 1.33
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `adult_group_eligible` is declared "
+        "on `Person`, but the embedded source states a household/unit-scoped "
+        "test. Encode the rule at the source-stated unit scope or cite source "
+        "text that states the person-level test."
+    ]
+
+
+def test_source_scope_consistency_rejects_medicaid_magi_numeric_limit_helper():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/119
+  summary: |-
+    The agency must provide Medicaid to individuals who have household income
+    at or below 133 percent FPL.
+rules:
+  - name: adult_group_eligible_fpl_limit
+    kind: derived
+    entity: Person
+    dtype: Float
+    period: Year
+    source: 42 CFR 435.119
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: literal
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "Have household income that is at or below 133 percent FPL for the applicable family size."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: '1.33'
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `adult_group_eligible_fpl_limit` is declared "
+        "on `Person`, but the embedded source states a household/unit-scoped "
+        "test. Encode the rule at the source-stated unit scope or cite source "
+        "text that states the person-level test."
+    ]
+
+
+def test_source_scope_consistency_rejects_medicaid_prefixed_magi_income_helper():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/119
+  summary: |-
+    Effective January 1, 2014, the agency must provide Medicaid to
+    individuals who are age 19 or older and under age 65 and have household
+    income that is at or below 133 percent FPL for the applicable family size.
+rules:
+  - name: medicaid_adult_group_income_requirement
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.119(b)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "the agency must provide Medicaid to individuals who have household income that is at or below 133 percent FPL for the applicable family size."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          household_income_as_fraction_of_fpl <= 1.33
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `medicaid_adult_group_income_requirement` is "
+        "declared on `Person`, but the embedded source states a "
+        "household/unit-scoped test. Encode the rule at the source-stated "
+        "unit scope or cite source text that states the person-level test."
+    ]
+
+
+def test_source_scope_consistency_still_rejects_non_income_rule_in_medicaid_magi_module():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/119
+  summary: |-
+    Effective January 1, 2014, the agency must provide Medicaid to
+    individuals who are age 19 or older and under age 65 and have household
+    income that is at or below 133 percent FPL for the applicable family size.
+rules:
+  - name: adult_group_resource_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.119
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us/regulation/42/435/119
+              excerpt: "Household resources are tested against the applicable resource limit for household eligibility."
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          household_resources <= resource_limit
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `adult_group_resource_eligible` is declared "
+        "on `Person`, but the embedded source states a household/unit-scoped "
+        "test. Encode the rule at the source-stated unit scope or cite source "
+        "text that states the person-level test."
+    ]
+
+
+def test_source_scope_consistency_rejects_medicaid_magi_without_rule_proof_excerpt():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/119
+  summary: |-
+    Effective January 1, 2014, the agency must provide Medicaid to
+    individuals who are age 19 or older and under age 65 and have household
+    income that is at or below 133 percent FPL for the applicable family size.
+rules:
+  - name: adult_group_resource_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.119
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          household_resources <= resource_limit
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `adult_group_resource_eligible` is declared "
+        "on `Person`, but the embedded source states a household/unit-scoped "
+        "test. Encode the rule at the source-stated unit scope or cite source "
+        "text that states the person-level test."
+    ]
+
+
+def test_source_scope_consistency_rejects_medicaid_magi_generic_final_non_income_formula():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/119
+  summary: |-
+    Effective January 1, 2014, the agency must provide Medicaid to
+    individuals who are age 19 or older and under age 65 and have household
+    income that is at or below 133 percent FPL for the applicable family size.
+rules:
+  - name: adult_group_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: 42 CFR 435.119
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          age >= 19
+          and household_resources <= resource_limit
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: `adult_group_eligible` is declared on `Person`, "
+        "but the embedded source states a household/unit-scoped test. Encode "
+        "the rule at the source-stated unit scope or cite source text that "
+        "states the person-level test."
+    ]
+
+
 def test_source_scope_consistency_allows_household_source_as_snapunit_rule():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.601"
+version = "0.2.602"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- allow final Medicaid MAGI person eligibility judgments for 42 CFR 435.110, .116, .118, and .119 to cite household-income source text
- keep rejecting income/resource helper rules and income-only formulas, including MAGI/FPL-named helpers
- support corpus-only and plural corpus proof path shapes for this source-scope exception

## Checks
- UV_PYTHON=3.13 uv run pytest tests/test_rulespec_validation.py -q -k 'source_scope_consistency' (38 passed)
- UV_PYTHON=3.13 uv run ruff check pyproject.toml src/axiom_encode scripts tests
- python -m compileall -q src/axiom_encode scripts
- UV_PYTHON=3.13 uv run pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- Review cycle: codex exec review --commit HEAD found no actionable issues after fixes
