### PR TITLE
Add UK student loan and Class 4 NI EFRS oracles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.608"
+version = "0.2.609"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.608"
+__version__ = "0.2.609"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -38,6 +38,8 @@ POLICYENGINE_UK_VERSION = "2.88.43"
 
 NATIONAL_INSURANCE_SECTION_8_PROGRAM_PATH = Path("statutes/ukpga/1992/4/8.yaml")
 NATIONAL_INSURANCE_SECTION_8_BASE = "uk:statutes/ukpga/1992/4/8"
+NATIONAL_INSURANCE_SECTION_15_PROGRAM_PATH = Path("statutes/ukpga/1992/4/15.yaml")
+NATIONAL_INSURANCE_SECTION_15_BASE = "uk:statutes/ukpga/1992/4/15"
 PERSONAL_ALLOWANCE_PROGRAM_PATH = Path("statutes/ukpga/2007/3/35.yaml")
 PERSONAL_ALLOWANCE_BASE = "uk:statutes/ukpga/2007/3/35"
 INCOME_TAX_SECTION_10_PROGRAM_PATH = Path("statutes/ukpga/2007/3/10.yaml")
@@ -166,6 +168,13 @@ INCOME_TAX_INCOME_BASE_OUTPUTS = {
     "income_tax_liability": {
         "axiom": f"{INCOME_TAX_SECTION_23_BASE}#income_tax_liability",
         "pe": "income_tax",
+    },
+}
+
+NATIONAL_INSURANCE_CLASS_4_OUTPUTS = {
+    "main_class_4_contribution": {
+        "axiom": f"{NATIONAL_INSURANCE_SECTION_15_BASE}#main_class_4_contribution",
+        "pe": "ni_class_4_main",
     },
 }
 
@@ -638,6 +647,17 @@ SURFACE_SPECS = {
             "ni_liable",
         ),
     ),
+    "national-insurance-class-4": UKEFRSSurfaceSpec(
+        program=NATIONAL_INSURANCE_SECTION_15_PROGRAM_PATH,
+        entity="person",
+        outputs=NATIONAL_INSURANCE_CLASS_4_OUTPUTS,
+        pe_variables=(
+            "ni_class_1_employee",
+            "ni_class_4_main",
+            "ni_liable",
+            "self_employment_income",
+        ),
+    ),
     "personal-allowance": UKEFRSSurfaceSpec(
         program=PERSONAL_ALLOWANCE_PROGRAM_PATH,
         entity="person",
@@ -1032,9 +1052,9 @@ HBAI_COMPONENT_COVERAGE = {
     },
     "national_insurance": {
         "status": "partial",
-        "surfaces": ("national-insurance-class-1",),
-        "covered_outputs": ("ni_employee",),
-        "rationale": "Axiom covers employee Class 1 National Insurance; HBAI national_insurance also includes non-Class-1 components.",
+        "surfaces": ("national-insurance-class-1", "national-insurance-class-4"),
+        "covered_outputs": ("ni_employee", "ni_class_4_main"),
+        "rationale": "Axiom covers employee Class 1 National Insurance and the main-rate Class 4 self-employed contribution; HBAI national_insurance also includes the Class 4 annual maximum/final amount and any other non-Class-1 components.",
     },
     "child_benefit": {
         "status": "partial",
@@ -3380,6 +3400,8 @@ def build_axiom_request(
 ) -> dict[str, Any]:
     if surface == "national-insurance-class-1":
         return build_national_insurance_class_1_request(pe_data=pe_data, year=year)
+    if surface == "national-insurance-class-4":
+        return build_national_insurance_class_4_request(pe_data=pe_data, year=year)
     if surface == "personal-allowance":
         return build_personal_allowance_request(pe_data=pe_data, year=year)
     if surface == "income-tax-income-base":
@@ -3530,6 +3552,41 @@ def build_national_insurance_class_1_request(
                 "outputs": [
                     spec["axiom"]
                     for spec in NATIONAL_INSURANCE_CLASS_1_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_national_insurance_class_4_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = uk_tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "national-insurance-class-4"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_national_insurance_class_4_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{NATIONAL_INSURANCE_SECTION_15_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in NATIONAL_INSURANCE_CLASS_4_OUTPUTS.values()
                 ],
             }
         )
@@ -4641,6 +4698,18 @@ def project_child_benefit_inputs(row: Any) -> dict[str, Any]:
     }
 
 
+def project_national_insurance_class_4_inputs(row: Any) -> dict[str, Any]:
+    profits = money(row_value(row, "self_employment_income", 0)) - money(
+        row_value(row, "ni_class_1_employee", 0)
+    )
+    return {
+        "class_4_contributions_payable_under_section_15": bool(
+            row_value(row, "ni_liable", True)
+        ),
+        "profits_chargeable_to_class_4_contributions": profits,
+    }
+
+
 def project_benefit_cap_relevant_amount_inputs(row: Any) -> dict[str, Any]:
     num_adults = int(money(row_value(row, "num_adults", 0)))
     num_children = int(money(row_value(row, "num_children", 0)))
@@ -5033,6 +5102,13 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             row
             for row in persons
             if money(row_value(row, "child_benefit_respective_amount", 0)) > 0
+        ]
+    if surface == "national-insurance-class-4":
+        return [
+            row
+            for row in persons
+            if money(row_value(row, "self_employment_income", 0)) > 0
+            or money(row_value(row, "ni_class_4_main", 0)) > 0
         ]
     benunits = pe_data.get("benunits", [])
     if surface == "benefit-cap-relevant-amount":

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -94,6 +94,10 @@ WELFARE_REFORM_ACT_SECTION_8_PROGRAM_PATH = Path("statutes/ukpga/2012/5/8.yaml")
 WELFARE_REFORM_ACT_SECTION_8_BASE = "uk:statutes/ukpga/2012/5/8"
 WELFARE_REFORM_ACT_SECTION_11_PROGRAM_PATH = Path("statutes/ukpga/2012/5/11.yaml")
 WELFARE_REFORM_ACT_SECTION_11_BASE = "uk:statutes/ukpga/2012/5/11"
+STUDENT_LOAN_REPAYMENT_PROGRAM_PATH = Path(
+    "policies/govuk/student-loan-repayments.yaml"
+)
+STUDENT_LOAN_REPAYMENT_BASE = "uk:policies/govuk/student-loan-repayments"
 
 PERSONAL_ALLOWANCE_OUTPUTS = {
     "personal_allowance": {
@@ -603,6 +607,13 @@ UNIVERSAL_CREDIT_2026_RULESPEC_RATES = {
     "earned_income_taper_rate": 0.55,
 }
 
+STUDENT_LOAN_REPAYMENT_OUTPUTS = {
+    "student_loan_repayment": {
+        "axiom": f"{STUDENT_LOAN_REPAYMENT_BASE}#student_loan_repayment",
+        "pe": "student_loan_repayment",
+    },
+}
+
 
 @dataclass(frozen=True)
 class UKEFRSSurfaceSpec:
@@ -966,6 +977,16 @@ SURFACE_SPECS = {
             "uc_tariff_income",
         ),
     ),
+    "student-loan-repayment": UKEFRSSurfaceSpec(
+        program=STUDENT_LOAN_REPAYMENT_PROGRAM_PATH,
+        entity="person",
+        outputs=STUDENT_LOAN_REPAYMENT_OUTPUTS,
+        pe_variables=(
+            "adjusted_net_income",
+            "student_loan_plan",
+            "student_loan_repayment",
+        ),
+    ),
 }
 
 HBAI_FIXED_INPUT_COMPONENTS = frozenset(
@@ -1111,6 +1132,12 @@ HBAI_COMPONENT_COVERAGE = {
             "uc_tariff_income",
         ),
         "rationale": "Axiom covers many Universal Credit legal elements and the award-before-take-up expression, not the final HBAI universal_credit aggregate.",
+    },
+    "student_loan_repayments": {
+        "status": "partial",
+        "surfaces": ("student-loan-repayment",),
+        "covered_outputs": ("student_loan_repayment",),
+        "rationale": "Axiom covers PolicyEngine UK's modelled student_loan_repayment formula by plan-specific threshold and repayment rate. The HBAI student_loan_repayments component remains partial because local EFRS supplies it as reported input data even when student_loan_plan is NONE, overriding PolicyEngine UK's wrapper formula.",
     },
     "working_tax_credit": {
         "status": "partial",
@@ -3339,6 +3366,9 @@ def rule_base_from_program(program: Path) -> str:
     if "statutes" in parts:
         index = parts.index("statutes")
         return "uk:" + "/".join(parts[index:])
+    if "policies" in parts:
+        index = parts.index("policies")
+        return "uk:" + "/".join(parts[index:])
     raise ValueError(f"cannot infer UK RuleSpec base from {program}")
 
 
@@ -3447,6 +3477,8 @@ def build_axiom_request(
             pe_data=pe_data,
             year=year,
         )
+    if surface == "student-loan-repayment":
+        return build_student_loan_repayment_request(pe_data=pe_data, year=year)
     if surface in UNIVERSAL_CREDIT_REGULATION_36_SURFACES:
         return build_universal_credit_request(
             pe_data=pe_data,
@@ -4419,6 +4451,40 @@ def build_universal_credit_work_allowance_request(
     }
 
 
+def build_student_loan_repayment_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = uk_tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "student-loan-repayment"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_student_loan_repayment_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{STUDENT_LOAN_REPAYMENT_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in STUDENT_LOAN_REPAYMENT_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def project_personal_allowance_inputs(row: Any) -> dict[str, Any]:
     adjusted_net_income = money(row_value(row, "adjusted_net_income"))
     gift_aid_grossed_up = money(row_value(row, "gift_aid_grossed_up", 0))
@@ -4855,6 +4921,25 @@ def project_universal_credit_work_allowance_inputs(row: Any) -> dict[str, Any]:
             row_value(row, "uc_housing_costs_element", 0)
         )
         > 0,
+    }
+
+
+def project_student_loan_repayment_inputs(row: Any) -> dict[str, Any]:
+    plan = enum_name(row_value(row, "student_loan_plan", "NONE")).upper()
+    return {
+        "loan_plan_is_plan_1": plan == "PLAN_1",
+        "loan_plan_is_plan_2": plan == "PLAN_2",
+        "loan_plan_is_plan_4": plan == "PLAN_4",
+        "loan_plan_is_plan_5": plan == "PLAN_5",
+        "loan_plan_is_postgraduate": plan
+        in {
+            "POSTGRADUATE",
+            "POSTGRADUATE_LOAN",
+            "PLAN_3",
+        },
+        "annual_income_before_tax_and_other_deductions": money(
+            row_value(row, "adjusted_net_income", 0)
+        ),
     }
 
 
@@ -5594,6 +5679,14 @@ def tax_year_interval(year: int) -> dict[str, str]:
         "period_kind": "tax_year",
         "start": f"{year:04d}-01-01",
         "end": f"{year:04d}-12-31",
+    }
+
+
+def uk_tax_year_interval(year: int) -> dict[str, str]:
+    return {
+        "period_kind": "tax_year",
+        "start": f"{year:04d}-04-06",
+        "end": f"{year + 1:04d}-04-05",
     }
 
 

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -349,6 +349,67 @@ mappings:
     comparison: money
     rationale: Same additional-band employee Class 1 NI component after the UK EFRS adapter projects weekly section 8 inputs and compares on PolicyEngine ni_liable rows.
 
+  - legal_id: uk:statutes/ukpga/1992/4/15#lower_profits_limit
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.national_insurance.class_4.thresholds.lower_profits_limit
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same Class 4 lower profits limit for self-employed profits.
+
+  - legal_id: uk:statutes/ukpga/1992/4/15#upper_profits_limit
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.national_insurance.class_4.thresholds.upper_profits_limit
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same Class 4 upper profits limit for self-employed profits.
+
+  - legal_id: uk:statutes/ukpga/1992/4/15#main_class_4_percentage
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.national_insurance.class_4.rates.main
+    period: year
+    comparison: rate
+    rationale: Same Class 4 main contribution percentage.
+
+  - legal_id: uk:statutes/ukpga/1992/4/15#additional_class_4_percentage
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.national_insurance.class_4.rates.additional
+    period: year
+    comparison: rate
+    rationale: Same Class 4 additional contribution percentage.
+
+  - legal_id: uk:statutes/ukpga/1992/4/15#main_class_4_contribution
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ni_class_4_main
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same main-band Class 4 NI component after the UK EFRS adapter projects annual section 15 profits and compares on PolicyEngine ni_liable rows.
+
+  - legal_id: uk:statutes/ukpga/1992/4/15#additional_class_4_contribution
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 15 additional-band Class 4 contribution before the annual maximum; PolicyEngine UK exposes ni_class_4_main and final ni_class_4, but not a separate additional-band component.
+
+  - legal_id: uk:statutes/ukpga/1992/4/15#class_4_contribution_before_annual_maximum
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 15 aggregate Class 4 contribution before Regulation 100's annual maximum; PolicyEngine UK exposes final ni_class_4 after the annual maximum rather than this pre-maximum subtotal.
+
   - legal_id: uk:regulations/uksi/2006/965/2#child_benefit_enhanced_weekly_rate
     country: uk
     program: child_benefit

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -410,6 +410,118 @@ mappings:
     mapping_type: not_comparable
     rationale: Section 15 aggregate Class 4 contribution before Regulation 100's annual maximum; PolicyEngine UK exposes final ni_class_4 after the annual maximum rather than this pre-maximum subtotal.
 
+  - legal_id: uk:policies/govuk/student-loan-repayments#plan_1_annual_income_threshold
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.student_loans.thresholds.plan_1
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same Plan 1 annual student-loan repayment threshold.
+
+  - legal_id: uk:policies/govuk/student-loan-repayments#plan_2_annual_income_threshold
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.student_loans.thresholds.plan_2
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same Plan 2 annual student-loan repayment threshold.
+
+  - legal_id: uk:policies/govuk/student-loan-repayments#plan_4_annual_income_threshold
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.student_loans.thresholds.plan_4
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same Plan 4 annual student-loan repayment threshold.
+
+  - legal_id: uk:policies/govuk/student-loan-repayments#plan_5_annual_income_threshold
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.student_loans.thresholds.plan_5
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same Plan 5 annual student-loan repayment threshold.
+
+  - legal_id: uk:policies/govuk/student-loan-repayments#postgraduate_loan_annual_income_threshold
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.student_loans.thresholds.postgraduate
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same Postgraduate Loan annual repayment threshold.
+
+  - legal_id: uk:policies/govuk/student-loan-repayments#undergraduate_plan_repayment_rate
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.student_loans.repayment_rate
+    period: year
+    comparison: rate
+    rationale: Same student-loan repayment rate for undergraduate Plans 1, 2, 4, and 5.
+
+  - legal_id: uk:policies/govuk/student-loan-repayments#postgraduate_loan_repayment_rate
+    country: uk
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.student_loans.postgraduate_repayment_rate
+    period: year
+    comparison: rate
+    rationale: Same Postgraduate Loan repayment rate.
+
+  - legal_id: uk:policies/govuk/student-loan-repayments#student_loan_repayment_rate
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: student_loan_repayment_rate
+    entity: person
+    period: year
+    comparison: rate
+    rationale: Same person-level student-loan repayment rate selected from the person's loan plan.
+
+  - legal_id: uk:policies/govuk/student-loan-repayments#student_loan_repayment
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: student_loan_repayment
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same modelled annual student-loan repayment from adjusted net income, loan plan, threshold, and rate.
+
+  - legal_id: uk:policies/govuk/student-loan-repayments#student_loan_repayments
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: student_loan_repayments
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same wrapper variable for annual student-loan repayments; in local EFRS this may be supplied as reported input data, but the PolicyEngine formula delegates to student_loan_repayment.
+
+  - legal_id: uk:policies/govuk/student-loan-repayments#listed_student_loan_plan_applies
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Axiom helper indicating whether a statutory repayment-plan branch applies; PolicyEngine UK exposes the student_loan_plan enum input rather than this boolean predicate.
+
+  - legal_id: uk:policies/govuk/student-loan-repayments#student_loan_annual_income_threshold
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Axiom helper selecting the applicable repayment threshold from the person's loan plan; PolicyEngine UK applies the same parameter selection inside student_loan_repayment rather than exposing this selected threshold as a variable.
+
   - legal_id: uk:regulations/uksi/2006/965/2#child_benefit_enhanced_weekly_rate
     country: uk
     program: child_benefit

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -33,7 +33,9 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     JSA_REGULATION_116_BASE,
     JSA_TARIFF_INCOME_OUTPUTS,
     NATIONAL_INSURANCE_CLASS_1_OUTPUTS,
+    NATIONAL_INSURANCE_CLASS_4_OUTPUTS,
     NATIONAL_INSURANCE_SECTION_8_BASE,
+    NATIONAL_INSURANCE_SECTION_15_BASE,
     PENSION_CREDIT_BASE,
     PENSION_CREDIT_CHILD_ADDITION_OUTPUTS,
     PENSION_CREDIT_DEEMED_INCOME_OUTPUTS,
@@ -82,6 +84,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_income_tax_section_13_request,
     build_jsa_income_tariff_income_request,
     build_national_insurance_class_1_request,
+    build_national_insurance_class_4_request,
     build_pension_credit_child_addition_request,
     build_pension_credit_deemed_income_request,
     build_pension_credit_request,
@@ -118,6 +121,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_income_tax_section_13_inputs,
     project_income_tax_section_23_inputs,
     project_jsa_income_tariff_income_inputs,
+    project_national_insurance_class_4_inputs,
     project_pension_credit_child_addition_inputs,
     project_pension_credit_deemed_income_inputs,
     project_pension_credit_inputs,
@@ -203,6 +207,69 @@ def test_national_insurance_class_1_request_projects_weekly_inputs(monkeypatch):
     assert inputs[
         f"{NATIONAL_INSURANCE_SECTION_8_BASE}#input.current_upper_earnings_limit_or_prescribed_equivalent:person_7"
     ] == {"kind": "decimal", "value": "966.73"}
+
+
+def test_national_insurance_class_4_projection_uses_pe_profit_base():
+    assert project_national_insurance_class_4_inputs(
+        {
+            "self_employment_income": 60_000,
+            "ni_class_1_employee": 3_000,
+            "ni_liable": True,
+        }
+    ) == {
+        "class_4_contributions_payable_under_section_15": True,
+        "profits_chargeable_to_class_4_contributions": 57_000,
+    }
+
+
+def test_national_insurance_class_4_request_projects_annual_inputs():
+    request = build_national_insurance_class_4_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 7,
+                    "self_employment_income": 0,
+                    "ni_class_1_employee": 0,
+                    "ni_class_4_main": 0,
+                    "ni_liable": True,
+                },
+                {
+                    "person_id": 8,
+                    "self_employment_income": 60_000,
+                    "ni_class_1_employee": 3_000,
+                    "ni_class_4_main": 2_262,
+                    "ni_liable": True,
+                },
+            ],
+            "person_ids": [7, 8],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_8",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-04-06",
+                "end": "2027-04-05",
+            },
+            "outputs": [
+                output["axiom"]
+                for output in NATIONAL_INSURANCE_CLASS_4_OUTPUTS.values()
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{NATIONAL_INSURANCE_SECTION_15_BASE}#input.class_4_contributions_payable_under_section_15:person_8"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{NATIONAL_INSURANCE_SECTION_15_BASE}#input.profits_chargeable_to_class_4_contributions:person_8"
+    ] == {"kind": "decimal", "value": "57000.0"}
 
 
 class FakePolicyEngineVariable:
@@ -2561,6 +2628,14 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "ni_liable",
     )
     assert policyengine_person_variables_for_surfaces(
+        ["national-insurance-class-4"]
+    ) == (
+        "ni_class_1_employee",
+        "ni_class_4_main",
+        "ni_liable",
+        "self_employment_income",
+    )
+    assert policyengine_person_variables_for_surfaces(
         ["state-pension-credit-qualifying-age"]
     ) == (
         "age",
@@ -2977,6 +3052,15 @@ class hbai_household_net_income(Variable):
     assert by_name["healthy_start_vouchers"].policy_component is False
     assert by_name["income_tax"].status == "exact"
     assert by_name["income_tax"].policy_component is True
+    assert by_name["national_insurance"].status == "partial"
+    assert by_name["national_insurance"].surfaces == (
+        "national-insurance-class-1",
+        "national-insurance-class-4",
+    )
+    assert by_name["national_insurance"].covered_outputs == (
+        "ni_employee",
+        "ni_class_4_main",
+    )
     assert by_name["student_loan_repayments"].status == "partial"
     assert by_name["universal_credit"].status == "partial"
     assert by_name["working_tax_credit"].status == "partial"

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -49,6 +49,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     STATE_PENSION_CREDIT_SECTION_1_BASE,
     STATE_PENSION_CREDIT_SECTION_2_BASE,
     STATE_PENSION_CREDIT_SECTION_3_BASE,
+    STUDENT_LOAN_REPAYMENT_BASE,
+    STUDENT_LOAN_REPAYMENT_OUTPUTS,
     UNIVERSAL_CREDIT_ASSESSABLE_CAPITAL_OUTPUTS,
     UNIVERSAL_CREDIT_AWARD_OUTPUTS,
     UNIVERSAL_CREDIT_CHILD_ELEMENT_OUTPUTS,
@@ -87,6 +89,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_state_pension_credit_guarantee_credit_request,
     build_state_pension_credit_qualifying_age_request,
     build_state_pension_credit_savings_credit_request,
+    build_student_loan_repayment_request,
     build_uk_efrs_coverage_report,
     build_uk_hbai_policy_coverage_report,
     build_universal_credit_assessable_capital_request,
@@ -122,6 +125,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_state_pension_credit_guarantee_credit_inputs,
     project_state_pension_credit_qualifying_age_inputs,
     project_state_pension_credit_savings_credit_inputs,
+    project_student_loan_repayment_inputs,
     project_universal_credit_assessable_capital_inputs,
     project_universal_credit_award_inputs,
     project_universal_credit_childcare_element_inputs,
@@ -275,6 +279,120 @@ def test_personal_allowance_request_projects_efrs_people():
             "kind": "decimal",
             "value": "20000.0",
         },
+    }
+
+
+def test_student_loan_repayment_projection_uses_policyengine_plan_enum():
+    assert project_student_loan_repayment_inputs(
+        {
+            "student_loan_plan": "StudentLoanPlan.PLAN_4",
+            "adjusted_net_income": 40_000,
+        }
+    ) == {
+        "loan_plan_is_plan_1": False,
+        "loan_plan_is_plan_2": False,
+        "loan_plan_is_plan_4": True,
+        "loan_plan_is_plan_5": False,
+        "loan_plan_is_postgraduate": False,
+        "annual_income_before_tax_and_other_deductions": 40_000,
+    }
+
+    assert project_student_loan_repayment_inputs(
+        {
+            "student_loan_plan": "StudentLoanPlan.POSTGRADUATE",
+            "adjusted_net_income": 35_000,
+        }
+    ) == {
+        "loan_plan_is_plan_1": False,
+        "loan_plan_is_plan_2": False,
+        "loan_plan_is_plan_4": False,
+        "loan_plan_is_plan_5": False,
+        "loan_plan_is_postgraduate": True,
+        "annual_income_before_tax_and_other_deductions": 35_000,
+    }
+
+    assert project_student_loan_repayment_inputs(
+        {
+            "student_loan_plan": "StudentLoanPlan.NONE",
+            "adjusted_net_income": 100_000,
+        }
+    ) == {
+        "loan_plan_is_plan_1": False,
+        "loan_plan_is_plan_2": False,
+        "loan_plan_is_plan_4": False,
+        "loan_plan_is_plan_5": False,
+        "loan_plan_is_postgraduate": False,
+        "annual_income_before_tax_and_other_deductions": 100_000,
+    }
+
+
+def test_student_loan_repayment_request_projects_plan_inputs():
+    request = build_student_loan_repayment_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 7,
+                    "student_loan_plan": "StudentLoanPlan.PLAN_1",
+                    "adjusted_net_income": 40_000,
+                    "student_loan_repayment": 1_179,
+                    "student_loan_repayments": 1_179,
+                }
+            ],
+            "person_ids": [7],
+        },
+        year=2026,
+    )
+
+    period = {
+        "period_kind": "tax_year",
+        "start": "2026-04-06",
+        "end": "2027-04-05",
+    }
+    assert request["mode"] == "explain"
+    assert request["queries"] == [
+        {
+            "entity_id": "person_7",
+            "period": period,
+            "outputs": [
+                output["axiom"]
+                for output in STUDENT_LOAN_REPAYMENT_OUTPUTS.values()
+            ],
+        }
+    ]
+    assert {
+        record["name"]: (record["entity_id"], record["interval"], record["value"])
+        for record in request["dataset"]["inputs"]
+    } == {
+        f"{STUDENT_LOAN_REPAYMENT_BASE}#input.loan_plan_is_plan_1": (
+            "person_7",
+            period,
+            {"kind": "bool", "value": True},
+        ),
+        f"{STUDENT_LOAN_REPAYMENT_BASE}#input.loan_plan_is_plan_2": (
+            "person_7",
+            period,
+            {"kind": "bool", "value": False},
+        ),
+        f"{STUDENT_LOAN_REPAYMENT_BASE}#input.loan_plan_is_plan_4": (
+            "person_7",
+            period,
+            {"kind": "bool", "value": False},
+        ),
+        f"{STUDENT_LOAN_REPAYMENT_BASE}#input.loan_plan_is_plan_5": (
+            "person_7",
+            period,
+            {"kind": "bool", "value": False},
+        ),
+        f"{STUDENT_LOAN_REPAYMENT_BASE}#input.loan_plan_is_postgraduate": (
+            "person_7",
+            period,
+            {"kind": "bool", "value": False},
+        ),
+        f"{STUDENT_LOAN_REPAYMENT_BASE}#input.annual_income_before_tax_and_other_deductions": (
+            "person_7",
+            period,
+            {"kind": "decimal", "value": "40000.0"},
+        ),
     }
 
 
@@ -2451,6 +2569,13 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "is_SP_age",
         "state_pension_age",
     )
+    assert policyengine_person_variables_for_surfaces(
+        ["student-loan-repayment"]
+    ) == (
+        "adjusted_net_income",
+        "student_loan_plan",
+        "student_loan_repayment",
+    )
     assert policyengine_benunit_variables_for_surfaces(
         ["personal-allowance", "pension-credit"]
     ) == (
@@ -2569,6 +2694,9 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "uc_assessable_capital",
         "uc_tariff_income",
     )
+    assert policyengine_benunit_variables_for_surfaces(
+        ["student-loan-repayment"]
+    ) == ()
     assert policyengine_person_variables_for_surfaces(
         ["income-tax-section-11d-savings-income"]
     ) == (
@@ -2767,6 +2895,7 @@ class hbai_household_net_income(Variable):
     subtracts = [
         "income_tax",
         "national_insurance",
+        "student_loan_repayments",
         "council_tax",
         "domestic_rates",
         "maintenance_expenses",
@@ -2814,6 +2943,7 @@ class hbai_household_net_income(Variable):
     assert report.subtracts == (
         "income_tax",
         "national_insurance",
+        "student_loan_repayments",
         "council_tax",
         "domestic_rates",
         "maintenance_expenses",
@@ -2852,6 +2982,7 @@ class hbai_household_net_income(Variable):
     assert by_name["healthy_start_vouchers"].policy_component is False
     assert by_name["income_tax"].status == "exact"
     assert by_name["income_tax"].policy_component is True
+    assert by_name["student_loan_repayments"].status == "partial"
     assert by_name["universal_credit"].status == "partial"
     assert by_name["working_tax_credit"].status == "partial"
     assert by_name["child_tax_credit"].status == "partial"
@@ -2871,11 +3002,11 @@ class hbai_household_net_income(Variable):
     assert by_name["council_tax"].policy_component is False
     assert by_name["domestic_rates"].status == "fixed_input"
     assert by_name["domestic_rates"].policy_component is False
-    assert report.policy_component_count == 19
-    assert report.covered_policy_component_count == 19
+    assert report.policy_component_count == 20
+    assert report.covered_policy_component_count == 20
     assert report.exact_policy_component_count == 2
     assert report.covered_policy_component_share == 1
-    assert math.isclose(report.exact_policy_component_share, 2 / 19)
+    assert math.isclose(report.exact_policy_component_share, 2 / 20)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -354,8 +354,7 @@ def test_student_loan_repayment_request_projects_plan_inputs():
             "entity_id": "person_7",
             "period": period,
             "outputs": [
-                output["axiom"]
-                for output in STUDENT_LOAN_REPAYMENT_OUTPUTS.values()
+                output["axiom"] for output in STUDENT_LOAN_REPAYMENT_OUTPUTS.values()
             ],
         }
     ]
@@ -2569,9 +2568,7 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "is_SP_age",
         "state_pension_age",
     )
-    assert policyengine_person_variables_for_surfaces(
-        ["student-loan-repayment"]
-    ) == (
+    assert policyengine_person_variables_for_surfaces(["student-loan-repayment"]) == (
         "adjusted_net_income",
         "student_loan_plan",
         "student_loan_repayment",
@@ -2694,9 +2691,7 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "uc_assessable_capital",
         "uc_tariff_income",
     )
-    assert policyengine_benunit_variables_for_surfaces(
-        ["student-loan-repayment"]
-    ) == ()
+    assert policyengine_benunit_variables_for_surfaces(["student-loan-repayment"]) == ()
     assert policyengine_person_variables_for_surfaces(
         ["income-tax-section-11d-savings-income"]
     ) == (

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.608"
+version = "0.2.609"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Adds UK EFRS oracle coverage for GOV.UK student loan repayments.
- Adds UK EFRS oracle coverage for main-rate Class 4 National Insurance contributions.
- Adds PolicyEngine oracle-coverage registry mappings for both surfaces so dependent rulespec-uk PRs have zero unmapped outputs.
- Updates HBAI coverage metadata for student loan repayments and National Insurance.
- Bumps axiom-encode to 0.2.602 for encoder-affecting oracle changes.

## Validation
- uv run --extra dev --python 3.13 python -m pytest tests/test_policyengine_efrs_uk.py -q
- uv run --extra dev --python 3.13 python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- uv run --extra dev --python 3.13 ruff check src tests
- uv run --extra dev --python 3.13 ruff format --check src tests
- CI-shaped oracle coverage for rulespec-uk student loan PR: zero unmapped, zero untested comparable outputs.
- CI-shaped oracle coverage for rulespec-uk Class 4 PR: zero unmapped, zero untested comparable outputs.
- Local PE EFRS oracle comparison, student-loan-repayment: 115,612 compared values, 0 mismatches.
- Local PE EFRS oracle comparison, national-insurance-class-4: 10,894 compared values, 0 mismatches.