### PR TITLE
Classify Medicaid MAGI PolicyEngine coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.602"
+version = "0.2.603"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.602"
+__version__ = "0.2.603"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -15602,6 +15602,30 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 1396a(xx) Medicaid community-engagement outputs implement the H.R.1 work-requirement mandate and source-specific exceptions; PolicyEngine US does not expose this federal Medicaid work-requirement workflow as one-to-one oracle variables.
 
+  - legal_id_prefix: us:regulations/42-cfr/435/110#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.110 parent/caretaker-relative MAGI eligibility outputs are federal source-level eligibility predicates and income-limit applications; PolicyEngine US exposes broader Medicaid eligibility variables, but not this CFR section's one-to-one output surface.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/116#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.116 pregnant-woman MAGI eligibility, coverage-scope, and income-standard predicates are federal source-level Medicaid rules that PolicyEngine US does not expose as one-to-one oracle variables or parameters.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/118#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.118 infant and child MAGI eligibility, age-band, and income-standard predicates are source-specific federal Medicaid outputs; PolicyEngine US does not expose the same CFR-level helper and final-decision surface as one-to-one oracle variables.
+
+  - legal_id_prefix: us:regulations/42-cfr/435/119#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 435.119 adult-group MAGI eligibility outputs include source-level age, income-limit, parent/caretaker, and dependent-child conditions; PolicyEngine US has broader Medicaid parameters, but not this exact CFR-level output surface.
+
   - legal_id_prefix: us:regulations/42-cfr/435/550#
     country: us
     program: medicaid

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -692,6 +692,69 @@ rules:
     assert "community-engagement" in str(disenrollment_output["rationale"])
 
 
+def test_policyengine_coverage_classifies_medicaid_magi_prefixes(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "regulations/42-cfr/435/110.yaml",
+        """format: rulespec/v1
+rules:
+  - name: parent_or_caretaker_relative_eligible
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: parent_or_caretaker_relative and household_income_within_limit
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "regulations/42-cfr/435/116.yaml",
+        """format: rulespec/v1
+rules:
+  - name: pregnant_woman_eligible
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: is_pregnant and income_within_standard
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "regulations/42-cfr/435/118.yaml",
+        """format: rulespec/v1
+rules:
+  - name: infants_and_children_eligible
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: child_under_age_19 and income_within_standard
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "regulations/42-cfr/435/119.yaml",
+        """format: rulespec/v1
+rules:
+  - name: adult_group_eligible
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: adult_group_age_eligible and income_within_limit
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="medicaid")
+
+    assert report["total_outputs"] == 4
+    assert report["status_counts"] == {"known_not_comparable": 4}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    expected_legal_ids = [
+        "us:regulations/42-cfr/435/110#parent_or_caretaker_relative_eligible",
+        "us:regulations/42-cfr/435/116#pregnant_woman_eligible",
+        "us:regulations/42-cfr/435/118#infants_and_children_eligible",
+        "us:regulations/42-cfr/435/119#adult_group_eligible",
+    ]
+    for legal_id in expected_legal_ids:
+        output = items_by_id[legal_id]
+        assert output["mapping_type"] == "not_comparable"
+        assert "MAGI" in str(output["rationale"])
+
+
 def test_policyengine_coverage_classifies_nc_and_sc_snap_manual_prefixes(tmp_path):
     _write_rulespec_file(
         tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.602"
+version = "0.2.603"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 42 CFR 435.110/.116/.118/.119 Medicaid MAGI RuleSpec outputs as known not comparable for PolicyEngine oracle coverage
- add a focused coverage test for those four federal MAGI prefixes
- bump axiom-encode to 0.2.603 because the registry change is encoder-affecting

## Review cycle
- pass 1: `codex exec review --commit HEAD` -> no introduced correctness issues
- CI then failed the version-provenance guard; fixed by adding the 0.2.603 version bump
- pass 2 after substantive change: `codex exec review --commit HEAD` -> no actionable bugs

## Checks
- `UV_PYTHON=3.13 uv run pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py -q -k 'medicaid or current_encoder'`
- `UV_PYTHON=3.13 uv run python - <<'PY' ... load_policyengine_registry() ... PY`
- `UV_PYTHON=3.13 uv run ruff check pyproject.toml src/axiom_encode/__init__.py tests/test_policyengine_coverage.py`
- `UV_PYTHON=3.13 uv run ruff format --check src/axiom_encode/__init__.py tests/test_policyengine_coverage.py`
- `python -m compileall -q src/axiom_encode/oracles/policyengine src/axiom_encode/__init__.py tests/test_policyengine_coverage.py`
- RuleSpec PR #391 isolated coverage gate with this encoder: `axiom-encode oracle-coverage --program medicaid --fail-on-unmapped` -> 142 outputs, all known_not_comparable