### PR TITLE
Classify UK HBAI reported tax inputs as fixed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.603"
+version = "0.2.605"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.603"
+__version__ = "0.2.605"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -970,12 +970,26 @@ SURFACE_SPECS = {
 
 HBAI_FIXED_INPUT_COMPONENTS = frozenset(
     {
+        "afcs",
+        "bsp",
+        "council_tax",
+        "council_tax_benefit",
         "dividend_income",
+        "domestic_rates",
         "employee_pension_contributions",
         "employment_income",
+        "esa_contrib",
         "external_child_payments",
+        "free_school_fruit_veg",
+        "free_school_meals",
+        "free_school_milk",
+        "healthy_start_vouchers",
+        "iidb",
+        "incapacity_benefit",
+        "jsa_contrib",
         "maintenance_expenses",
         "maintenance_income",
+        "maternity_allowance",
         "miscellaneous_income",
         "personal_pension_contributions",
         "private_pension_income",
@@ -983,6 +997,8 @@ HBAI_FIXED_INPUT_COMPONENTS = frozenset(
         "property_income",
         "savings_interest_income",
         "self_employment_income",
+        "statutory_maternity_pay",
+        "statutory_sick_pay",
     }
 )
 
@@ -2423,8 +2439,8 @@ def classify_hbai_component(
             surfaces=(),
             covered_outputs=(),
             rationale=(
-                "Private, market, maintenance, or pension-contribution input held "
-                "fixed when measuring policy alignment."
+                "Private, market, reported, or PolicyEngine input-only component "
+                "held fixed when measuring policy alignment."
             ),
             activity=activity,
         )

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -2732,27 +2732,42 @@ class hbai_household_net_income(Variable):
     entity = Household
     adds = [
         "employment_income",
+        "council_tax_benefit",
+        "free_school_meals",
+        "free_school_fruit_veg",
+        "free_school_milk",
         "child_benefit",
+        "esa_contrib",
         "universal_credit",
         "working_tax_credit",
         "child_tax_credit",
         "tax_free_childcare",
+        "afcs",
+        "bsp",
         "pip",
         "dla",
+        "iidb",
+        "incapacity_benefit",
         "attendance_allowance",
         "carers_allowance",
+        "jsa_contrib",
+        "maternity_allowance",
         "sda",
         "ssmg",
         "scottish_child_payment",
         "carer_support_payment",
         "cost_of_living_support_payment",
         "state_pension",
+        "statutory_sick_pay",
+        "statutory_maternity_pay",
+        "healthy_start_vouchers",
         "winter_fuel_allowance",
     ]
     subtracts = [
         "income_tax",
         "national_insurance",
         "council_tax",
+        "domestic_rates",
         "maintenance_expenses",
     ]
 """.strip()
@@ -2763,31 +2778,74 @@ class hbai_household_net_income(Variable):
 
     assert report.adds == (
         "employment_income",
+        "council_tax_benefit",
+        "free_school_meals",
+        "free_school_fruit_veg",
+        "free_school_milk",
         "child_benefit",
+        "esa_contrib",
         "universal_credit",
         "working_tax_credit",
         "child_tax_credit",
         "tax_free_childcare",
+        "afcs",
+        "bsp",
         "pip",
         "dla",
+        "iidb",
+        "incapacity_benefit",
         "attendance_allowance",
         "carers_allowance",
+        "jsa_contrib",
+        "maternity_allowance",
         "sda",
         "ssmg",
         "scottish_child_payment",
         "carer_support_payment",
         "cost_of_living_support_payment",
         "state_pension",
+        "statutory_sick_pay",
+        "statutory_maternity_pay",
+        "healthy_start_vouchers",
         "winter_fuel_allowance",
     )
     assert report.subtracts == (
         "income_tax",
         "national_insurance",
         "council_tax",
+        "domestic_rates",
         "maintenance_expenses",
     )
     assert by_name["employment_income"].status == "fixed_input"
     assert by_name["employment_income"].policy_component is False
+    assert by_name["council_tax_benefit"].status == "fixed_input"
+    assert by_name["council_tax_benefit"].policy_component is False
+    assert by_name["free_school_meals"].status == "fixed_input"
+    assert by_name["free_school_meals"].policy_component is False
+    assert by_name["free_school_fruit_veg"].status == "fixed_input"
+    assert by_name["free_school_fruit_veg"].policy_component is False
+    assert by_name["free_school_milk"].status == "fixed_input"
+    assert by_name["free_school_milk"].policy_component is False
+    assert by_name["esa_contrib"].status == "fixed_input"
+    assert by_name["esa_contrib"].policy_component is False
+    assert by_name["afcs"].status == "fixed_input"
+    assert by_name["afcs"].policy_component is False
+    assert by_name["bsp"].status == "fixed_input"
+    assert by_name["bsp"].policy_component is False
+    assert by_name["iidb"].status == "fixed_input"
+    assert by_name["iidb"].policy_component is False
+    assert by_name["incapacity_benefit"].status == "fixed_input"
+    assert by_name["incapacity_benefit"].policy_component is False
+    assert by_name["jsa_contrib"].status == "fixed_input"
+    assert by_name["jsa_contrib"].policy_component is False
+    assert by_name["maternity_allowance"].status == "fixed_input"
+    assert by_name["maternity_allowance"].policy_component is False
+    assert by_name["statutory_sick_pay"].status == "fixed_input"
+    assert by_name["statutory_sick_pay"].policy_component is False
+    assert by_name["statutory_maternity_pay"].status == "fixed_input"
+    assert by_name["statutory_maternity_pay"].policy_component is False
+    assert by_name["healthy_start_vouchers"].status == "fixed_input"
+    assert by_name["healthy_start_vouchers"].policy_component is False
     assert by_name["income_tax"].status == "exact"
     assert by_name["income_tax"].policy_component is True
     assert by_name["universal_credit"].status == "partial"
@@ -2805,12 +2863,15 @@ class hbai_household_net_income(Variable):
     assert by_name["cost_of_living_support_payment"].status == "partial"
     assert by_name["state_pension"].status == "partial"
     assert by_name["winter_fuel_allowance"].status == "partial"
-    assert by_name["council_tax"].status == "missing"
-    assert report.policy_component_count == 19
+    assert by_name["council_tax"].status == "fixed_input"
+    assert by_name["council_tax"].policy_component is False
+    assert by_name["domestic_rates"].status == "fixed_input"
+    assert by_name["domestic_rates"].policy_component is False
+    assert report.policy_component_count == 18
     assert report.covered_policy_component_count == 18
     assert report.exact_policy_component_count == 2
-    assert math.isclose(report.covered_policy_component_share, 18 / 19)
-    assert math.isclose(report.exact_policy_component_share, 2 / 19)
+    assert report.covered_policy_component_share == 1
+    assert math.isclose(report.exact_policy_component_share, 2 / 18)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.603"
+version = "0.2.605"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify UK HBAI council_tax, council_tax_benefit, and domestic_rates as fixed/input-only components
- update the HBAI coverage test so reported PE inputs do not inflate missing policy-surface counts
- clarify the fixed-input rationale to include reported and PolicyEngine input-only components

## Validation
- uv run --extra dev --python 3.13 ruff check src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py
- uv run --extra dev --python 3.13 ruff format --check src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py
- uv run --extra dev --python 3.13 python -m pytest tests/test_policyengine_efrs_uk.py -q
- uv run --extra dev --python 3.13 python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::test_package_version_metadata_matches_pyproject -q
- uv run --with policyengine-core==3.26.11 --with policyengine-uk==2.88.43 --python 3.13 axiom-encode uk-efrs-hbai-coverage --year 2026 --dataset /Users/maxghenis/PolicyEngine/policyengine-uk-data/policyengine_uk_data/storage/enhanced_frs_2023_24.h5 --with-efrs-activity --json