### PR TITLE
Map UK Child Benefit entitlement oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.609"
+version = "0.2.610"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.609"
+__version__ = "0.2.610"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -557,6 +557,30 @@ mappings:
     comparison: money
     rationale: Same branch-selected statutory child benefit weekly amount for a child or qualifying young person.
 
+  - legal_id: uk:statutes/ukpga/1992/4/141#child_benefit_weekly_entitlement
+    country: uk
+    program: child_benefit
+    mapping_type: direct_variable
+    policyengine_variable: child_benefit_entitlement
+    entity: benunit
+    period: week
+    unit: GBP
+    comparison: money
+    result_multiplier: 0.019230769230769232
+    rationale: Same Child Benefit entitlement amount before PolicyEngine UK's would_claim_child_benefit take-up gate, with PolicyEngine's annual entitlement converted to a weekly amount.
+
+  - legal_id: uk:statutes/ukpga/1992/4/141#child_benefit_weekly_rate_for_responsible_child_or_qualifying_young_person
+    country: uk
+    program: child_benefit
+    mapping_type: direct_variable
+    policyengine_variable: child_benefit_respective_amount
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    result_multiplier: 0.019230769230769232
+    rationale: Same per-child Child Benefit weekly rate for a responsible child or qualifying young person, with PolicyEngine's annual child_benefit_respective_amount converted to a weekly amount.
+
   - legal_id: uk:regulations/uksi/2002/1792/6#standard_minimum_guarantee_with_partner
     country: uk
     program: pension_credit
@@ -1756,6 +1780,12 @@ prefixes:
     program: child_benefit
     mapping_type: not_comparable
     rationale: Child Benefit helper outputs not listed above are payability, relationship-coordination, or specified-benefit predicates that PolicyEngine UK does not expose as one-to-one oracle variables or parameters.
+
+  - legal_id_prefix: uk:statutes/ukpga/1992/4/141#
+    country: uk
+    program: child_benefit
+    mapping_type: not_comparable
+    rationale: Child Benefit section 141 helper outputs not listed above are responsibility, child-counting, or weekly entitlement predicates that PolicyEngine UK does not expose as one-to-one oracle variables or parameters.
 
   - legal_id_prefix: uk:regulations/uksi/2002/1792/6#
     country: uk

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3474,6 +3474,93 @@ rules:
     assert enhanced_rate["test_output_count"] == 1
 
 
+def test_policyengine_coverage_classifies_uk_child_benefit_entitlement_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/1992/4/141.yaml",
+        """format: rulespec/v1
+rules:
+  - name: entitled_to_child_benefit_for_week
+    kind: derived
+    entity: Family
+    dtype: Judgment
+    period: Week
+    versions:
+      - effective_from: '2026-01-01'
+        formula: child_count > 0
+  - name: child_benefit_weekly_rate_for_responsible_child_or_qualifying_young_person
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Week
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: child_benefit_weekly_rate
+  - name: child_or_qualifying_young_person_counts_for_child_benefit_weekly_entitlement
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Week
+    versions:
+      - effective_from: '2026-01-01'
+        formula: is_child_or_qualifying_young_person
+  - name: child_benefit_weekly_entitlement
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Week
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: weekly_rate_sum
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/1992/4/141.test.yaml",
+        """- name: child benefit entitlement
+  period:
+    period_kind: custom
+    name: benefit_week
+    start: '2026-01-05'
+    end: '2026-01-11'
+  input: {}
+  output:
+    uk:statutes/ukpga/1992/4/141#entitled_to_child_benefit_for_week: holds
+    uk:statutes/ukpga/1992/4/141#child_benefit_weekly_rate_for_responsible_child_or_qualifying_young_person: 27.05
+    uk:statutes/ukpga/1992/4/141#child_or_qualifying_young_person_counts_for_child_benefit_weekly_entitlement: holds
+    uk:statutes/ukpga/1992/4/141#child_benefit_weekly_entitlement: 44.95
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="child_benefit")
+
+    assert report["status_counts"] == {
+        "comparable": 2,
+        "known_not_comparable": 2,
+    }
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    entitlement = items_by_id[
+        "uk:statutes/ukpga/1992/4/141#child_benefit_weekly_entitlement"
+    ]
+    rate = items_by_id[
+        "uk:statutes/ukpga/1992/4/141#child_benefit_weekly_rate_for_responsible_child_or_qualifying_young_person"
+    ]
+    entitled = items_by_id[
+        "uk:statutes/ukpga/1992/4/141#entitled_to_child_benefit_for_week"
+    ]
+
+    assert entitlement["status"] == "comparable"
+    assert entitlement["policyengine_variable"] == "child_benefit_entitlement"
+    assert entitlement["mapping_type"] == "direct_variable"
+    assert entitlement["tested"] is True
+    assert rate["status"] == "comparable"
+    assert rate["policyengine_variable"] == "child_benefit_respective_amount"
+    assert entitled["status"] == "known_not_comparable"
+
+
 def test_policyengine_coverage_classifies_arizona_snap_medical_and_child_support(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.609"
+version = "0.2.610"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map UK Child Benefit section 141 weekly entitlement outputs to PolicyEngine UK child benefit variables
- classify remaining section 141 helper outputs as known not comparable
- bump axiom-encode to 0.2.606 for the encoder-affecting registry change

## Validation
- uv run --extra dev --python 3.13 python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_child_benefit_entitlement_outputs tests/test_policyengine_coverage.py::test_policyengine_coverage_counts_uk_aliases_as_tested -q
- uv run --extra dev --python 3.13 python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::test_package_version_metadata_matches_pyproject -q
- uv run --extra dev --python 3.13 ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run --extra dev --python 3.13 axiom-encode oracle-coverage --root /tmp/axiom-pr30-coverage-root --program child_benefit --fail-on-unmapped --fail-on-untested-comparable