### PR TITLE
Map UK TV licence fee coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.605"
+version = "0.2.607"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.607"
+version = "0.2.608"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.607"
+__version__ = "0.2.608"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.605"
+__version__ = "0.2.607"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -16525,6 +16525,11 @@ def _uk_legislation_gov_source_path_aliases(citation_path: str) -> tuple[str, ..
 
 def _local_corpus_provisions_roots() -> tuple[Path, ...]:
     roots: list[Path] = []
+    cwd: Path | None = None
+    with contextlib.suppress(OSError):
+        cwd = Path.cwd().resolve()
+        roots.append(cwd)
+
     for env_name in (
         "AXIOM_CORPUS_ARTIFACT_ROOT",
         "AXIOM_CORPUS_LOCAL_ROOT",
@@ -16534,12 +16539,10 @@ def _local_corpus_provisions_roots() -> tuple[Path, ...]:
         if raw_root:
             roots.append(Path(raw_root).expanduser())
 
-    with contextlib.suppress(OSError):
-        cwd = Path.cwd().resolve()
+    if cwd is not None:
         for base in (cwd, *cwd.parents):
             roots.extend(
                 (
-                    base,
                     base / "axiom-corpus",
                     base / "TheAxiomFoundation" / "axiom-corpus",
                     base.parent / "axiom-corpus",

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -1141,6 +1141,12 @@ HBAI_COMPONENT_COVERAGE = {
         "covered_outputs": ("tax_free_childcare",),
         "rationale": "Axiom covers the Tax-Free Childcare contribution rate and income cap, not the child/provider eligibility tests, expenses, annual caps, or final aggregate amount.",
     },
+    "free_tv_licence_value": {
+        "status": "partial",
+        "surfaces": ("tv-licence-fee",),
+        "covered_outputs": ("colour_tv_licence_general_form_issue_fee",),
+        "rationale": "Axiom covers the statutory colour TV licence fee feeding PolicyEngine UK's free_tv_licence_value; TV ownership, evasion, and aged or blind discount eligibility remain outside this fee surface.",
+    },
     "pip": {
         "status": "exact",
         "surfaces": ("personal-independence-payment-rates",),

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -696,6 +696,16 @@ mappings:
     comparison: money
     rationale: Same Sure Start Maternity Grant amount payable when the regulation's entitlement conditions are satisfied.
 
+  - legal_id: uk:regulations/uksi/2004/692/schedule/1#colour_tv_licence_general_form_issue_fee
+    country: uk
+    program: tv_licence
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dcms.bbc.tv_licence.colour
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual colour TV licence General Form issue fee used by PolicyEngine UK's TV licence and free-TV-licence-value formulas.
+
   - legal_id: uk:regulations/ssi/2020/351/20#scottish_child_payment_weekly_amount
     country: uk
     program: scottish_child_payment

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3178,6 +3178,47 @@ rules:
     assert all(item["tested"] is True for item in report["items"])
 
 
+def test_policyengine_coverage_classifies_uk_tv_licence_fee_output(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2004/692/schedule/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: colour_tv_licence_general_form_issue_fee
+    kind: parameter
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-04-01'
+        formula: 180.00
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "regulations/uksi/2004/692/schedule/1.test.yaml",
+        """- name: tv licence fee
+  period:
+    period_kind: custom
+    name: licence_year
+    start: '2026-04-01'
+    end: '2027-03-31'
+  input: {}
+  output:
+    uk:regulations/uksi/2004/692/schedule/1#colour_tv_licence_general_form_issue_fee: 180.00
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tv_licence")
+
+    assert report["status_counts"] == {"comparable": 1}
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "uk:regulations/uksi/2004/692/schedule/1#colour_tv_licence_general_form_issue_fee"
+    )
+    assert item["policyengine_parameter"] == "gov.dcms.bbc.tv_licence.colour"
+    assert item["mapping_type"] == "parameter_value"
+    assert item["tested"] is True
+
+
 def test_policyengine_coverage_classifies_uk_state_pension_rate_outputs(
     tmp_path,
 ):

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -2736,6 +2736,7 @@ class hbai_household_net_income(Variable):
         "free_school_meals",
         "free_school_fruit_veg",
         "free_school_milk",
+        "free_tv_licence_value",
         "child_benefit",
         "esa_contrib",
         "universal_credit",
@@ -2782,6 +2783,7 @@ class hbai_household_net_income(Variable):
         "free_school_meals",
         "free_school_fruit_veg",
         "free_school_milk",
+        "free_tv_licence_value",
         "child_benefit",
         "esa_contrib",
         "universal_credit",
@@ -2826,6 +2828,8 @@ class hbai_household_net_income(Variable):
     assert by_name["free_school_fruit_veg"].policy_component is False
     assert by_name["free_school_milk"].status == "fixed_input"
     assert by_name["free_school_milk"].policy_component is False
+    assert by_name["free_tv_licence_value"].status == "partial"
+    assert by_name["free_tv_licence_value"].policy_component is True
     assert by_name["esa_contrib"].status == "fixed_input"
     assert by_name["esa_contrib"].policy_component is False
     assert by_name["afcs"].status == "fixed_input"
@@ -2867,11 +2871,11 @@ class hbai_household_net_income(Variable):
     assert by_name["council_tax"].policy_component is False
     assert by_name["domestic_rates"].status == "fixed_input"
     assert by_name["domestic_rates"].policy_component is False
-    assert report.policy_component_count == 18
-    assert report.covered_policy_component_count == 18
+    assert report.policy_component_count == 19
+    assert report.covered_policy_component_count == 19
     assert report.exact_policy_component_count == 2
     assert report.covered_policy_component_share == 1
-    assert math.isclose(report.exact_policy_component_share, 2 / 18)
+    assert math.isclose(report.exact_policy_component_share, 2 / 19)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -12274,6 +12274,57 @@ rules:
     assert find_ungrounded_numeric_issues(content) == []
 
 
+def test_source_verification_prefers_current_repo_corpus_artifact(
+    tmp_path,
+    monkeypatch,
+):
+    workspace = tmp_path / "rulespec-uk"
+    workspace_provisions = (
+        workspace / "data" / "corpus" / "provisions" / "uk" / "regulation"
+    )
+    workspace_provisions.mkdir(parents=True)
+    (workspace_provisions / "local.jsonl").write_text(
+        json.dumps(
+            {
+                "citation_path": "uk/regulation/example/schedule/1",
+                "body": "Local source states the issue fee is GBP 180.00.",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    external_corpus = tmp_path / "axiom-corpus"
+    external_provisions = (
+        external_corpus / "data" / "corpus" / "provisions" / "uk" / "regulation"
+    )
+    external_provisions.mkdir(parents=True)
+    (external_provisions / "external.jsonl").write_text(
+        json.dumps(
+            {
+                "citation_path": "uk/regulation/example/schedule/1",
+                "body": "External source states the issue fee is GBP 999.00.",
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(workspace)
+    monkeypatch.setenv("AXIOM_CORPUS_REPO", str(external_corpus))
+    validator_pipeline._fetch_corpus_source_text.cache_clear()
+    validator_pipeline._fetch_local_corpus_source_text.cache_clear()
+
+    assert (
+        validator_pipeline._fetch_local_corpus_source_text(
+            "uk/regulation/example/schedule/1"
+        )
+        == "Local source states the issue fee is GBP 180.00."
+    )
+
+
 def test_source_verification_resolves_compact_uk_statute_corpus_path(
     tmp_path,
     monkeypatch,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.605"
+version = "0.2.607"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.607"
+version = "0.2.608"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map the UK TV licence colour fee rulespec output to PolicyEngine UK tv licence colour parameter
- count `free_tv_licence_value` as partially covered in the UK HBAI/net-income oracle report
- prefer the current rulespec checkout local `data/corpus` artifacts before external corpus checkouts during source verification
- bump axiom-encode to 0.2.608

## Checks
- `uv run --extra dev --python 3.13 python -m ruff check src/axiom_encode/__init__.py src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_rulespec_validation.py tests/test_policyengine_coverage.py tests/test_policyengine_efrs_uk.py`
- parsed `src/axiom_encode/oracles/policyengine/mappings/uk.yaml` with PyYAML
- `uv run --extra dev --python 3.13 python -m pytest tests/test_rulespec_validation.py::test_source_verification_reads_local_corpus_artifact tests/test_rulespec_validation.py::test_source_verification_prefers_current_repo_corpus_artifact tests/test_rulespec_validation.py::test_source_verification_resolves_compact_uk_statute_corpus_path tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_tv_licence_fee_output tests/test_policyengine_efrs_uk.py::test_uk_hbai_policy_coverage_report_classifies_policy_components -q`
- `git diff --check origin/main..HEAD`