### PR TITLE
Add UK Class 4 NI final oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.610"
+version = "0.2.611"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.610"
+__version__ = "0.2.611"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -34,12 +34,16 @@ from .ecps_tax import (
 DEFAULT_DATASET = "enhanced_frs_2023_24"
 WEEKS_IN_YEAR = 52
 MONTHS_IN_YEAR = 12
-POLICYENGINE_UK_VERSION = "2.88.43"
+POLICYENGINE_UK_VERSION = "2.88.56"
 
 NATIONAL_INSURANCE_SECTION_8_PROGRAM_PATH = Path("statutes/ukpga/1992/4/8.yaml")
 NATIONAL_INSURANCE_SECTION_8_BASE = "uk:statutes/ukpga/1992/4/8"
 NATIONAL_INSURANCE_SECTION_15_PROGRAM_PATH = Path("statutes/ukpga/1992/4/15.yaml")
 NATIONAL_INSURANCE_SECTION_15_BASE = "uk:statutes/ukpga/1992/4/15"
+NATIONAL_INSURANCE_REGULATION_100_PROGRAM_PATH = Path(
+    "regulations/uksi/2001/1004/100.yaml"
+)
+NATIONAL_INSURANCE_REGULATION_100_BASE = "uk:regulations/uksi/2001/1004/100"
 PERSONAL_ALLOWANCE_PROGRAM_PATH = Path("statutes/ukpga/2007/3/35.yaml")
 PERSONAL_ALLOWANCE_BASE = "uk:statutes/ukpga/2007/3/35"
 INCOME_TAX_SECTION_10_PROGRAM_PATH = Path("statutes/ukpga/2007/3/10.yaml")
@@ -175,6 +179,20 @@ NATIONAL_INSURANCE_CLASS_4_OUTPUTS = {
     "main_class_4_contribution": {
         "axiom": f"{NATIONAL_INSURANCE_SECTION_15_BASE}#main_class_4_contribution",
         "pe": "ni_class_4_main",
+    },
+}
+
+NATIONAL_INSURANCE_REGULATION_100_OUTPUTS = {
+    "class_4_annual_maximum": {
+        "axiom": f"{NATIONAL_INSURANCE_REGULATION_100_BASE}#class_4_annual_maximum",
+        "pe": "ni_class_4_maximum",
+    },
+    "class_4_contribution_after_annual_maximum": {
+        "axiom": (
+            f"{NATIONAL_INSURANCE_REGULATION_100_BASE}"
+            "#class_4_contribution_after_annual_maximum"
+        ),
+        "pe": "ni_class_4",
     },
 }
 
@@ -658,6 +676,20 @@ SURFACE_SPECS = {
             "self_employment_income",
         ),
     ),
+    "national-insurance-class-4-final": UKEFRSSurfaceSpec(
+        program=NATIONAL_INSURANCE_REGULATION_100_PROGRAM_PATH,
+        entity="person",
+        outputs=NATIONAL_INSURANCE_REGULATION_100_OUTPUTS,
+        pe_variables=(
+            "ni_class_1_employee",
+            "ni_class_1_employee_primary",
+            "ni_class_4",
+            "ni_class_4_main",
+            "ni_class_4_maximum",
+            "ni_liable",
+            "self_employment_income",
+        ),
+    ),
     "personal-allowance": UKEFRSSurfaceSpec(
         program=PERSONAL_ALLOWANCE_PROGRAM_PATH,
         entity="person",
@@ -1052,9 +1084,13 @@ HBAI_COMPONENT_COVERAGE = {
     },
     "national_insurance": {
         "status": "partial",
-        "surfaces": ("national-insurance-class-1", "national-insurance-class-4"),
-        "covered_outputs": ("ni_employee", "ni_class_4_main"),
-        "rationale": "Axiom covers employee Class 1 National Insurance and the main-rate Class 4 self-employed contribution; HBAI national_insurance also includes the Class 4 annual maximum/final amount and any other non-Class-1 components.",
+        "surfaces": (
+            "national-insurance-class-1",
+            "national-insurance-class-4",
+            "national-insurance-class-4-final",
+        ),
+        "covered_outputs": ("ni_employee", "ni_class_4_main", "ni_class_4"),
+        "rationale": "Axiom covers employee Class 1 National Insurance, the main-rate Class 4 self-employed contribution, and final Class 4 after Regulation 100's annual maximum; HBAI national_insurance also includes Class 2 and Class 3 components that are not encoded here.",
     },
     "child_benefit": {
         "status": "partial",
@@ -3402,6 +3438,11 @@ def build_axiom_request(
         return build_national_insurance_class_1_request(pe_data=pe_data, year=year)
     if surface == "national-insurance-class-4":
         return build_national_insurance_class_4_request(pe_data=pe_data, year=year)
+    if surface == "national-insurance-class-4-final":
+        return build_national_insurance_class_4_final_request(
+            pe_data=pe_data,
+            year=year,
+        )
     if surface == "personal-allowance":
         return build_personal_allowance_request(pe_data=pe_data, year=year)
     if surface == "income-tax-income-base":
@@ -3587,6 +3628,46 @@ def build_national_insurance_class_4_request(
                 "outputs": [
                     spec["axiom"]
                     for spec in NATIONAL_INSURANCE_CLASS_4_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_national_insurance_class_4_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = uk_tax_year_interval(year)
+    parameters = policyengine_uk_class_4_parameters(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "national-insurance-class-4-final"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        projected = project_national_insurance_class_4_final_inputs(
+            row,
+            parameters=parameters,
+        )
+        for name, value in projected.items():
+            inputs.append(
+                input_record(
+                    f"{NATIONAL_INSURANCE_REGULATION_100_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in NATIONAL_INSURANCE_REGULATION_100_OUTPUTS.values()
                 ],
             }
         )
@@ -4710,6 +4791,37 @@ def project_national_insurance_class_4_inputs(row: Any) -> dict[str, Any]:
     }
 
 
+def project_national_insurance_class_4_final_inputs(
+    row: Any,
+    *,
+    parameters: dict[str, float],
+) -> dict[str, Any]:
+    self_employment_income = money(row_value(row, "self_employment_income", 0))
+    employee_ni = money(row_value(row, "ni_class_1_employee", 0))
+    profits = self_employment_income - employee_ni
+    additional_band_profits = max(0, profits - parameters["upper_profits_limit"])
+    pre_maximum_amount = money(row_value(row, "ni_class_4_main", 0)) + (
+        additional_band_profits * parameters["additional_class_4_percentage"]
+    )
+    primary_class_1 = money(row_value(row, "ni_class_1_employee_primary", 0))
+    return {
+        "primary_class_1_contributions_paid_at_main_primary_percentage": primary_class_1,
+        "primary_class_1_contributions_payable_at_main_primary_percentage": primary_class_1,
+        "class_4_contributions_payable_at_main_class_4_percentage": money(
+            row_value(row, "ni_class_4_main", 0)
+        ),
+        "class_4_contribution_before_annual_maximum": pre_maximum_amount,
+        "class_4_contributions_payable_under_section_15_for_year": bool(
+            row_value(row, "ni_liable", True)
+        ),
+        "profits_and_gains_for_year": self_employment_income,
+        "lower_profits_limit": parameters["lower_profits_limit"],
+        "upper_profits_limit": parameters["upper_profits_limit"],
+        "main_class_4_percentage": parameters["main_class_4_percentage"],
+        "additional_class_4_percentage": parameters["additional_class_4_percentage"],
+    }
+
+
 def project_benefit_cap_relevant_amount_inputs(row: Any) -> dict[str, Any]:
     num_adults = int(money(row_value(row, "num_adults", 0)))
     num_children = int(money(row_value(row, "num_children", 0)))
@@ -5103,12 +5215,13 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             for row in persons
             if money(row_value(row, "child_benefit_respective_amount", 0)) > 0
         ]
-    if surface == "national-insurance-class-4":
+    if surface in {"national-insurance-class-4", "national-insurance-class-4-final"}:
         return [
             row
             for row in persons
             if money(row_value(row, "self_employment_income", 0)) > 0
             or money(row_value(row, "ni_class_4_main", 0)) > 0
+            or money(row_value(row, "ni_class_4", 0)) > 0
         ]
     benunits = pe_data.get("benunits", [])
     if surface == "benefit-cap-relevant-amount":
@@ -5859,6 +5972,26 @@ def policyengine_uk_class_1_weekly_parameters(year: int) -> dict[str, float]:
     return {
         "primary_threshold": money(class_1.thresholds.primary_threshold),
         "upper_earnings_limit": money(class_1.thresholds.upper_earnings_limit),
+    }
+
+
+def policyengine_uk_class_4_parameters(year: int) -> dict[str, float]:
+    require_policyengine_uk_versions()
+    try:
+        from policyengine_uk import CountryTaxBenefitSystem
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(policyengine_uk_install_message()) from exc
+
+    class_4 = (
+        CountryTaxBenefitSystem()
+        .parameters(f"{year:04d}-04-06")
+        .gov.hmrc.national_insurance.class_4
+    )
+    return {
+        "lower_profits_limit": money(class_4.thresholds.lower_profits_limit),
+        "upper_profits_limit": money(class_4.thresholds.upper_profits_limit),
+        "main_class_4_percentage": float(class_4.rates.main),
+        "additional_class_4_percentage": float(class_4.rates.additional),
     }
 
 

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -410,6 +410,78 @@ mappings:
     mapping_type: not_comparable
     rationale: Section 15 aggregate Class 4 contribution before Regulation 100's annual maximum; PolicyEngine UK exposes final ni_class_4 after the annual maximum rather than this pre-maximum subtotal.
 
+  - legal_id: uk:regulations/uksi/2001/1004/100#class_4_annual_maximum_step_one
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Regulation 100 Step One is a statutory intermediate for calculating the Class 4 annual maximum; PolicyEngine UK exposes the final annual maximum, not this step output.
+
+  - legal_id: uk:regulations/uksi/2001/1004/100#class_4_annual_maximum_step_two
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Regulation 100 Step Two is a statutory intermediate for calculating the Class 4 annual maximum; PolicyEngine UK exposes the final annual maximum, not this step output.
+
+  - legal_id: uk:regulations/uksi/2001/1004/100#class_4_annual_maximum_step_four_value
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Regulation 100 Step Four's raw value is a statutory intermediate for calculating the Class 4 annual maximum; PolicyEngine UK exposes the final annual maximum, not this step output.
+
+  - legal_id: uk:regulations/uksi/2001/1004/100#class_4_annual_maximum_step_four_amount
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Regulation 100 Step Four's nonnegative amount is a statutory intermediate for calculating the Class 4 annual maximum; PolicyEngine UK exposes the final annual maximum, not this step output.
+
+  - legal_id: uk:regulations/uksi/2001/1004/100#class_4_annual_maximum_case_1_applies
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Regulation 100 Case 1 is a statutory branch predicate for calculating the Class 4 annual maximum; PolicyEngine UK exposes the final annual maximum, not this legal judgment output.
+
+  - legal_id: uk:regulations/uksi/2001/1004/100#class_4_annual_maximum_case_2_applies
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Regulation 100 Case 2 is a statutory branch predicate for calculating the Class 4 annual maximum; PolicyEngine UK exposes the final annual maximum, not this legal judgment output.
+
+  - legal_id: uk:regulations/uksi/2001/1004/100#class_4_annual_maximum_case_3_applies
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Regulation 100 Case 3 is a statutory branch predicate for calculating the Class 4 annual maximum; PolicyEngine UK exposes the final annual maximum, not this legal judgment output.
+
+  - legal_id: uk:regulations/uksi/2001/1004/100#class_4_annual_maximum_step_five
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Regulation 100 Step Five is a statutory intermediate for calculating the Class 4 annual maximum; PolicyEngine UK exposes the final annual maximum, not this step output.
+
+  - legal_id: uk:regulations/uksi/2001/1004/100#class_4_annual_maximum_step_six
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Regulation 100 Step Six is a statutory intermediate for calculating the Class 4 annual maximum; PolicyEngine UK exposes the final annual maximum, not this step output.
+
+  - legal_id: uk:regulations/uksi/2001/1004/100#class_4_annual_maximum_step_seven
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Regulation 100 Step Seven is a statutory intermediate for calculating the Class 4 annual maximum; PolicyEngine UK exposes the final annual maximum, not this step output.
+
+  - legal_id: uk:regulations/uksi/2001/1004/100#class_4_annual_maximum_step_eight
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Regulation 100 Step Eight is a statutory intermediate for calculating the Class 4 annual maximum; PolicyEngine UK exposes the final annual maximum, not this step output.
+
+  - legal_id: uk:regulations/uksi/2001/1004/100#class_4_annual_maximum_step_nine
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Regulation 100 Step Nine is a statutory intermediate for calculating the Class 4 annual maximum; PolicyEngine UK exposes the final annual maximum, not this step output.
+
   - legal_id: uk:regulations/uksi/2001/1004/100#class_4_annual_maximum
     country: uk
     program: tax

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -410,6 +410,28 @@ mappings:
     mapping_type: not_comparable
     rationale: Section 15 aggregate Class 4 contribution before Regulation 100's annual maximum; PolicyEngine UK exposes final ni_class_4 after the annual maximum rather than this pre-maximum subtotal.
 
+  - legal_id: uk:regulations/uksi/2001/1004/100#class_4_annual_maximum
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ni_class_4_maximum
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same Regulation 100 Class 4 annual maximum after the UK EFRS adapter projects annual primary Class 1, Class 4 main-rate, and profits inputs.
+
+  - legal_id: uk:regulations/uksi/2001/1004/100#class_4_contribution_after_annual_maximum
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: ni_class_4
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final Class 4 NI contribution after applying Regulation 100's annual maximum.
+
   - legal_id: uk:policies/govuk/student-loan-repayments#plan_1_annual_income_threshold
     country: uk
     program: tax

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -34,6 +34,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     JSA_TARIFF_INCOME_OUTPUTS,
     NATIONAL_INSURANCE_CLASS_1_OUTPUTS,
     NATIONAL_INSURANCE_CLASS_4_OUTPUTS,
+    NATIONAL_INSURANCE_REGULATION_100_BASE,
+    NATIONAL_INSURANCE_REGULATION_100_OUTPUTS,
     NATIONAL_INSURANCE_SECTION_8_BASE,
     NATIONAL_INSURANCE_SECTION_15_BASE,
     PENSION_CREDIT_BASE,
@@ -84,6 +86,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_income_tax_section_13_request,
     build_jsa_income_tariff_income_request,
     build_national_insurance_class_1_request,
+    build_national_insurance_class_4_final_request,
     build_national_insurance_class_4_request,
     build_pension_credit_child_addition_request,
     build_pension_credit_deemed_income_request,
@@ -121,6 +124,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_income_tax_section_13_inputs,
     project_income_tax_section_23_inputs,
     project_jsa_income_tariff_income_inputs,
+    project_national_insurance_class_4_final_inputs,
     project_national_insurance_class_4_inputs,
     project_pension_credit_child_addition_inputs,
     project_pension_credit_deemed_income_inputs,
@@ -270,6 +274,107 @@ def test_national_insurance_class_4_request_projects_annual_inputs():
     assert inputs[
         f"{NATIONAL_INSURANCE_SECTION_15_BASE}#input.profits_chargeable_to_class_4_contributions:person_8"
     ] == {"kind": "decimal", "value": "57000.0"}
+
+
+def test_national_insurance_class_4_final_projection_uses_regulation_100_inputs():
+    assert project_national_insurance_class_4_final_inputs(
+        {
+            "self_employment_income": 100_000,
+            "ni_class_1_employee": 3_000,
+            "ni_class_1_employee_primary": 6_000,
+            "ni_class_4_main": 2_262,
+            "ni_liable": True,
+        },
+        parameters={
+            "lower_profits_limit": 12_570,
+            "upper_profits_limit": 50_270,
+            "main_class_4_percentage": 0.06,
+            "additional_class_4_percentage": 0.02,
+        },
+    ) == {
+        "primary_class_1_contributions_paid_at_main_primary_percentage": 6_000,
+        "primary_class_1_contributions_payable_at_main_primary_percentage": 6_000,
+        "class_4_contributions_payable_at_main_class_4_percentage": 2_262,
+        "class_4_contribution_before_annual_maximum": 3_196.6,
+        "class_4_contributions_payable_under_section_15_for_year": True,
+        "profits_and_gains_for_year": 100_000,
+        "lower_profits_limit": 12_570,
+        "upper_profits_limit": 50_270,
+        "main_class_4_percentage": 0.06,
+        "additional_class_4_percentage": 0.02,
+    }
+
+
+def test_national_insurance_class_4_final_request_projects_annual_inputs(monkeypatch):
+    monkeypatch.setattr(
+        efrs_uk,
+        "policyengine_uk_class_4_parameters",
+        lambda year: {
+            "lower_profits_limit": 12_570,
+            "upper_profits_limit": 50_270,
+            "main_class_4_percentage": 0.06,
+            "additional_class_4_percentage": 0.02,
+        },
+    )
+    request = build_national_insurance_class_4_final_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 7,
+                    "self_employment_income": 0,
+                    "ni_class_1_employee": 0,
+                    "ni_class_1_employee_primary": 0,
+                    "ni_class_4": 0,
+                    "ni_class_4_main": 0,
+                    "ni_class_4_maximum": 0,
+                    "ni_liable": True,
+                },
+                {
+                    "person_id": 8,
+                    "self_employment_income": 100_000,
+                    "ni_class_1_employee": 3_000,
+                    "ni_class_1_employee_primary": 6_000,
+                    "ni_class_4": 1_748.6,
+                    "ni_class_4_main": 2_262,
+                    "ni_class_4_maximum": 1_748.6,
+                    "ni_liable": True,
+                },
+            ],
+            "person_ids": [7, 8],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_8",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-04-06",
+                "end": "2027-04-05",
+            },
+            "outputs": [
+                output["axiom"]
+                for output in NATIONAL_INSURANCE_REGULATION_100_OUTPUTS.values()
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{NATIONAL_INSURANCE_REGULATION_100_BASE}#input.primary_class_1_contributions_paid_at_main_primary_percentage:person_8"
+    ] == {"kind": "decimal", "value": "6000.0"}
+    assert inputs[
+        f"{NATIONAL_INSURANCE_REGULATION_100_BASE}#input.class_4_contribution_before_annual_maximum:person_8"
+    ] == {"kind": "decimal", "value": "3196.6"}
+    assert inputs[
+        f"{NATIONAL_INSURANCE_REGULATION_100_BASE}#input.class_4_contributions_payable_under_section_15_for_year:person_8"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{NATIONAL_INSURANCE_REGULATION_100_BASE}#input.profits_and_gains_for_year:person_8"
+    ] == {"kind": "decimal", "value": "100000.0"}
 
 
 class FakePolicyEngineVariable:
@@ -3056,10 +3161,12 @@ class hbai_household_net_income(Variable):
     assert by_name["national_insurance"].surfaces == (
         "national-insurance-class-1",
         "national-insurance-class-4",
+        "national-insurance-class-4-final",
     )
     assert by_name["national_insurance"].covered_outputs == (
         "ni_employee",
         "ni_class_4_main",
+        "ni_class_4",
     )
     assert by_name["student_loan_repayments"].status == "partial"
     assert by_name["universal_credit"].status == "partial"
@@ -3169,7 +3276,7 @@ def test_policyengine_uk_version_guard_rejects_unpinned_version(monkeypatch):
 
     monkeypatch.setattr(efrs_uk, "version", fake_version)
 
-    with pytest.raises(SystemExit, match="policyengine-uk==2.88.43 required"):
+    with pytest.raises(SystemExit, match="policyengine-uk==2.88.56 required"):
         require_policyengine_uk_versions()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.610"
+version = "0.2.611"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- pin the UK EFRS oracle to policyengine-uk 2.88.56, which includes the Class 4 annual-maximum PE fix
- add a Regulation 100 `national-insurance-class-4-final` EFRS surface for `ni_class_4_maximum` and final `ni_class_4`
- map the Regulation 100 outputs to PolicyEngine UK and include them in HBAI national insurance coverage

## Validation
- `uv run --extra dev --python 3.13 pytest tests/test_policyengine_efrs_uk.py -q`
- `uv run --extra dev --python 3.13 ruff check src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py`
- `uv run --extra dev --python 3.13 python - <<'PY' ... yaml.safe_load(...) ... PY`
- `uv run --extra dev --python 3.13 pytest tests/test_policyengine_coverage.py -q`
- full EFRS compare for `national-insurance-class-4-final`: 21,788 compared values, 0 mismatches, 0 oracle divergences
