### PR TITLE
Add UK Child Benefit final oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.611"
+version = "0.2.612"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.611"
+__version__ = "0.2.612"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -588,6 +588,8 @@ def _infer_program_from_legal_id(legal_id: str, *, rule_name: str = "") -> str:
         return "tax"
     if lowered.startswith("uk:regulations/uksi/2006/965/2"):
         return "child_benefit"
+    if lowered.startswith("uk:policies/govuk/child-benefit"):
+        return "child_benefit"
     if lowered.startswith("uk:regulations/uksi/2002/1792/6"):
         return "pension_credit"
     if lowered.startswith("uk:regulations/uksi/2013/376/36"):

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -56,6 +56,10 @@ INCOME_TAX_SECTION_23_PROGRAM_PATH = Path("statutes/ukpga/2007/3/23.yaml")
 INCOME_TAX_SECTION_23_BASE = "uk:statutes/ukpga/2007/3/23"
 CHILD_BENEFIT_PROGRAM_PATH = Path("regulations/uksi/2006/965/2.yaml")
 CHILD_BENEFIT_BASE = "uk:regulations/uksi/2006/965/2"
+CHILD_BENEFIT_SECTION_141_PROGRAM_PATH = Path("statutes/ukpga/1992/4/141.yaml")
+CHILD_BENEFIT_SECTION_141_BASE = "uk:statutes/ukpga/1992/4/141"
+CHILD_BENEFIT_FINAL_PROGRAM_PATH = Path("policies/govuk/child-benefit.yaml")
+CHILD_BENEFIT_FINAL_BASE = "uk:policies/govuk/child-benefit"
 BENEFIT_CAP_REGULATION_80A_PROGRAM_PATH = Path("regulations/uksi/2013/376/80A.yaml")
 BENEFIT_CAP_REGULATION_80A_BASE = "uk:regulations/uksi/2013/376/80A"
 STATE_PENSION_CREDIT_SECTION_1_PROGRAM_PATH = Path("statutes/ukpga/2002/16/1.yaml")
@@ -281,6 +285,14 @@ CHILD_BENEFIT_OUTPUTS = {
     "child_benefit_weekly_rate": {
         "axiom": f"{CHILD_BENEFIT_BASE}#child_benefit_weekly_rate",
         "pe": "child_benefit_respective_amount",
+        "pe_transform": "annual_to_weekly",
+    },
+}
+
+CHILD_BENEFIT_FINAL_OUTPUTS = {
+    "child_benefit_weekly_amount": {
+        "axiom": f"{CHILD_BENEFIT_FINAL_BASE}#child_benefit_weekly_amount",
+        "pe": "child_benefit",
         "pe_transform": "annual_to_weekly",
     },
 }
@@ -769,6 +781,20 @@ SURFACE_SPECS = {
             "child_benefit_respective_amount",
         ),
     ),
+    "child-benefit-final": UKEFRSSurfaceSpec(
+        program=CHILD_BENEFIT_FINAL_PROGRAM_PATH,
+        entity="benunit",
+        outputs=CHILD_BENEFIT_FINAL_OUTPUTS,
+        pe_variables=(
+            "child_benefit",
+            "child_benefit_entitlement",
+            "would_claim_child_benefit",
+        ),
+        projection_person_variables=(
+            "child_benefit_child_index",
+            "child_benefit_respective_amount",
+        ),
+    ),
     "benefit-cap-relevant-amount": UKEFRSSurfaceSpec(
         program=BENEFIT_CAP_REGULATION_80A_PROGRAM_PATH,
         entity="benunit",
@@ -1093,10 +1119,14 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom covers employee Class 1 National Insurance, the main-rate Class 4 self-employed contribution, and final Class 4 after Regulation 100's annual maximum; HBAI national_insurance also includes Class 2 and Class 3 components that are not encoded here.",
     },
     "child_benefit": {
-        "status": "partial",
-        "surfaces": ("child-benefit",),
-        "covered_outputs": ("child_benefit_respective_amount",),
-        "rationale": "Axiom covers the per-child weekly rates feeding Child Benefit, not the household aggregate HBAI component.",
+        "status": "exact",
+        "surfaces": ("child-benefit", "child-benefit-final"),
+        "covered_outputs": (
+            "child_benefit_respective_amount",
+            "child_benefit_entitlement",
+            "child_benefit",
+        ),
+        "rationale": "Axiom covers per-child Child Benefit rates, section 141 weekly entitlement, and the final gross benefit-unit Child Benefit receipt after PolicyEngine UK's would_claim_child_benefit gate.",
     },
     "esa_income": {
         "status": "partial",
@@ -2038,6 +2068,7 @@ def load_local_policyengine_uk_data(
             benunit_records[index] for index in selected_benunit_indices
         ]
     return {
+        "all_persons": records,
         "persons": selected,
         "person_ids": [int(row_value(row, "person_id")) for row in selected],
         "benunits": selected_benunits,
@@ -3455,6 +3486,8 @@ def build_axiom_request(
         return build_income_tax_section_13_request(pe_data=pe_data, year=year)
     if surface == "child-benefit":
         return build_child_benefit_request(pe_data=pe_data, year=year)
+    if surface == "child-benefit-final":
+        return build_child_benefit_final_request(pe_data=pe_data, year=year)
     if surface == "benefit-cap-relevant-amount":
         return build_benefit_cap_relevant_amount_request(
             pe_data=pe_data,
@@ -3919,6 +3952,75 @@ def build_child_benefit_request(
     return {
         "mode": "explain",
         "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_child_benefit_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = benefit_week_interval(year)
+    inputs: list[dict[str, Any]] = []
+    relations: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    child_rows_by_benunit = child_benefit_person_rows_by_benunit(pe_data)
+    for row in rows_for_surface(pe_data, "child-benefit-final"):
+        benunit_id = int(row_value(row, "benunit_id"))
+        entity_id = benunit_entity_id(benunit_id)
+        inputs.append(
+            input_record(
+                f"{CHILD_BENEFIT_FINAL_BASE}#input.would_claim_child_benefit",
+                entity_id,
+                interval,
+                bool(row_value(row, "would_claim_child_benefit", True)),
+            )
+        )
+        for child_row in child_rows_by_benunit.get(benunit_id, []):
+            person_id = int(row_value(child_row, "person_id"))
+            person_id_text = person_entity_id(person_id)
+            relations.append(
+                {
+                    "name": (
+                        f"{CHILD_BENEFIT_SECTION_141_BASE}#relation."
+                        "child_benefit_children_or_qualifying_young_persons_for_whom_person_responsible"
+                    ),
+                    "tuple": [person_id_text, entity_id],
+                    "interval": interval,
+                }
+            )
+            inputs.append(
+                input_record(
+                    (
+                        f"{CHILD_BENEFIT_SECTION_141_BASE}"
+                        "#input.is_child_or_qualifying_young_person_for_child_benefit"
+                    ),
+                    person_id_text,
+                    interval,
+                    True,
+                )
+            )
+            for name, value in project_child_benefit_inputs(child_row).items():
+                inputs.append(
+                    input_record(
+                        f"{CHILD_BENEFIT_BASE}#input.{name}",
+                        person_id_text,
+                        interval,
+                        value,
+                    )
+                )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in CHILD_BENEFIT_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": relations},
         "queries": queries,
     }
 
@@ -4779,6 +4881,27 @@ def project_child_benefit_inputs(row: Any) -> dict[str, Any]:
     }
 
 
+def child_benefit_person_rows_by_benunit(
+    pe_data: dict[str, Any],
+) -> dict[int, list[dict[str, Any]]]:
+    grouped: dict[int, list[dict[str, Any]]] = {}
+    for row in pe_data.get("all_persons") or pe_data["persons"]:
+        if money(row_value(row, "child_benefit_respective_amount", 0)) <= 0:
+            continue
+        benunit_id = row_value(row, "person_benunit_id")
+        if benunit_id is None:
+            continue
+        grouped.setdefault(int(benunit_id), []).append(row)
+    for rows in grouped.values():
+        rows.sort(
+            key=lambda item: (
+                int(row_value(item, "child_benefit_child_index", 999_999)),
+                int(row_value(item, "person_id")),
+            )
+        )
+    return grouped
+
+
 def project_national_insurance_class_4_inputs(row: Any) -> dict[str, Any]:
     profits = money(row_value(row, "self_employment_income", 0)) - money(
         row_value(row, "ni_class_1_employee", 0)
@@ -5215,6 +5338,13 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             for row in persons
             if money(row_value(row, "child_benefit_respective_amount", 0)) > 0
         ]
+    if surface == "child-benefit-final":
+        return [
+            row
+            for row in pe_data.get("benunits", [])
+            if money(row_value(row, "child_benefit_entitlement", 0)) > 0
+            or money(row_value(row, "child_benefit", 0)) > 0
+        ]
     if surface in {"national-insurance-class-4", "national-insurance-class-4-final"}:
         return [
             row
@@ -5384,6 +5514,11 @@ def compare_outputs(
             "specified-benefit, and polygamous-marriage branches are projected "
             "false because PolicyEngine UK's child_benefit_respective_amount "
             "does not expose those legal predicates separately.",
+            "Final Child Benefit comparison builds the section 141 family-to-child "
+            "relation from positive PolicyEngine child_benefit_respective_amount "
+            "person rows, projects PolicyEngine UK's would_claim_child_benefit "
+            "receipt gate as an explicit input leaf, and compares the resulting "
+            "weekly amount with PolicyEngine's annual child_benefit divided by 52.",
             "Universal Credit Regulation 80A benefit-cap relevant-amount "
             "comparison filters to finite PolicyEngine benefit_cap rows, "
             "divides the annual PE cap by 12, and projects the annual-limit "

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -675,6 +675,18 @@ mappings:
     result_multiplier: 0.019230769230769232
     rationale: Same per-child Child Benefit weekly rate for a responsible child or qualifying young person, with PolicyEngine's annual child_benefit_respective_amount converted to a weekly amount.
 
+  - legal_id: uk:policies/govuk/child-benefit#child_benefit_weekly_amount
+    country: uk
+    program: child_benefit
+    mapping_type: direct_variable
+    policyengine_variable: child_benefit
+    entity: benunit
+    period: week
+    unit: GBP
+    comparison: money
+    result_multiplier: 0.019230769230769232
+    rationale: Same final gross Child Benefit receipt for the benefit unit, with PolicyEngine UK's annual child_benefit converted to a weekly amount after the would_claim_child_benefit gate.
+
   - legal_id: uk:regulations/uksi/2002/1792/6#standard_minimum_guarantee_with_partner
     country: uk
     program: pension_credit
@@ -1880,6 +1892,12 @@ prefixes:
     program: child_benefit
     mapping_type: not_comparable
     rationale: Child Benefit section 141 helper outputs not listed above are responsibility, child-counting, or weekly entitlement predicates that PolicyEngine UK does not expose as one-to-one oracle variables or parameters.
+
+  - legal_id_prefix: uk:policies/govuk/child-benefit#
+    country: uk
+    program: child_benefit
+    mapping_type: not_comparable
+    rationale: Child Benefit final receipt helper outputs not listed above are Axiom-side period conversion and projected receipt-gate helpers rather than separate PolicyEngine UK oracle variables.
 
   - legal_id_prefix: uk:regulations/uksi/2002/1792/6#
     country: uk

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3561,6 +3561,69 @@ rules:
     assert entitled["status"] == "known_not_comparable"
 
 
+def test_policyengine_coverage_classifies_uk_child_benefit_final_output(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/child-benefit.yaml",
+        """format: rulespec/v1
+rules:
+  - name: child_benefit_weekly_payment_periods_in_year
+    kind: parameter
+    dtype: Number
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 52
+  - name: child_benefit_weekly_amount
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Week
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if would_claim_child_benefit: child_benefit_weekly_entitlement else: 0
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/child-benefit.test.yaml",
+        """- name: child benefit final amount
+  period:
+    period_kind: custom
+    name: benefit_week
+    start: '2026-01-05'
+    end: '2026-01-11'
+  input:
+    uk:policies/govuk/child-benefit#input.would_claim_child_benefit: true
+  output:
+    uk:policies/govuk/child-benefit#child_benefit_weekly_payment_periods_in_year: 52
+    uk:policies/govuk/child-benefit#child_benefit_weekly_amount: 44.95
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="child_benefit")
+
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 1,
+    }
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    final_amount = items_by_id[
+        "uk:policies/govuk/child-benefit#child_benefit_weekly_amount"
+    ]
+    periods = items_by_id[
+        "uk:policies/govuk/child-benefit#child_benefit_weekly_payment_periods_in_year"
+    ]
+
+    assert final_amount["status"] == "comparable"
+    assert final_amount["policyengine_variable"] == "child_benefit"
+    assert final_amount["mapping_type"] == "direct_variable"
+    assert final_amount["tested"] is True
+    assert periods["status"] == "known_not_comparable"
+
+
 def test_policyengine_coverage_classifies_arizona_snap_medical_and_child_support(
     tmp_path,
 ):

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -10,7 +10,10 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     BENEFIT_CAP_REGULATION_80A_BASE,
     BENEFIT_CAP_RELEVANT_AMOUNT_OUTPUTS,
     CHILD_BENEFIT_BASE,
+    CHILD_BENEFIT_FINAL_BASE,
+    CHILD_BENEFIT_FINAL_OUTPUTS,
     CHILD_BENEFIT_OUTPUTS,
+    CHILD_BENEFIT_SECTION_141_BASE,
     ESA_REGULATION_118_BASE,
     ESA_TARIFF_INCOME_OUTPUTS,
     HOUSING_BENEFIT_PENSION_AGE_REGULATION_29_BASE,
@@ -75,6 +78,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     WELFARE_REFORM_ACT_SECTION_8_BASE,
     WELFARE_REFORM_ACT_SECTION_11_BASE,
     build_benefit_cap_relevant_amount_request,
+    build_child_benefit_final_request,
     build_child_benefit_request,
     build_esa_income_tariff_income_request,
     build_housing_benefit_pension_age_tariff_income_request,
@@ -1122,6 +1126,104 @@ def test_child_benefit_request_filters_to_positive_respective_amount_rows():
     ]
     assert {record["name"]: record["value"] for record in request["dataset"]["inputs"]}[
         f"{CHILD_BENEFIT_BASE}#input.child_or_qualifying_young_person_is_only_elder_or_eldest_for_payee"
+    ] == {
+        "kind": "bool",
+        "value": True,
+    }
+
+
+def test_child_benefit_final_request_projects_family_relation_and_claim_gate():
+    request = build_child_benefit_final_request(
+        pe_data={
+            "all_persons": [
+                {
+                    "person_id": 7,
+                    "person_benunit_id": 3,
+                    "child_benefit_child_index": -1,
+                    "child_benefit_respective_amount": 0,
+                },
+                {
+                    "person_id": 8,
+                    "person_benunit_id": 3,
+                    "child_benefit_child_index": 1,
+                    "child_benefit_respective_amount": 27.05 * WEEKS_IN_YEAR,
+                },
+                {
+                    "person_id": 9,
+                    "person_benunit_id": 3,
+                    "child_benefit_child_index": 2,
+                    "child_benefit_respective_amount": 17.90 * WEEKS_IN_YEAR,
+                },
+            ],
+            "persons": [],
+            "benunits": [
+                {
+                    "benunit_id": 3,
+                    "child_benefit": 0,
+                    "child_benefit_entitlement": 44.95 * WEEKS_IN_YEAR,
+                    "would_claim_child_benefit": False,
+                }
+            ],
+            "person_ids": [],
+            "benunit_ids": [3],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_3",
+            "period": {
+                "period_kind": "custom",
+                "name": "benefit_week",
+                "start": "2026-04-06",
+                "end": "2026-04-12",
+            },
+            "outputs": [
+                CHILD_BENEFIT_FINAL_OUTPUTS["child_benefit_weekly_amount"]["axiom"]
+            ],
+        }
+    ]
+    assert request["dataset"]["relations"] == [
+        {
+            "name": (
+                f"{CHILD_BENEFIT_SECTION_141_BASE}#relation."
+                "child_benefit_children_or_qualifying_young_persons_for_whom_person_responsible"
+            ),
+            "tuple": ["person_8", "benunit_3"],
+            "interval": {
+                "period_kind": "custom",
+                "name": "benefit_week",
+                "start": "2026-04-06",
+                "end": "2026-04-12",
+            },
+        },
+        {
+            "name": (
+                f"{CHILD_BENEFIT_SECTION_141_BASE}#relation."
+                "child_benefit_children_or_qualifying_young_persons_for_whom_person_responsible"
+            ),
+            "tuple": ["person_9", "benunit_3"],
+            "interval": {
+                "period_kind": "custom",
+                "name": "benefit_week",
+                "start": "2026-04-06",
+                "end": "2026-04-12",
+            },
+        },
+    ]
+    inputs = {
+        f"{record['name']}:{record['entity_id']}": record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{CHILD_BENEFIT_FINAL_BASE}#input.would_claim_child_benefit:benunit_3"
+    ] == {
+        "kind": "bool",
+        "value": False,
+    }
+    assert inputs[
+        f"{CHILD_BENEFIT_SECTION_141_BASE}#input.is_child_or_qualifying_young_person_for_child_benefit:person_8"
     ] == {
         "kind": "bool",
         "value": True,
@@ -3135,6 +3237,16 @@ class hbai_household_net_income(Variable):
     assert by_name["free_school_milk"].policy_component is False
     assert by_name["free_tv_licence_value"].status == "partial"
     assert by_name["free_tv_licence_value"].policy_component is True
+    assert by_name["child_benefit"].status == "exact"
+    assert by_name["child_benefit"].surfaces == (
+        "child-benefit",
+        "child-benefit-final",
+    )
+    assert by_name["child_benefit"].covered_outputs == (
+        "child_benefit_respective_amount",
+        "child_benefit_entitlement",
+        "child_benefit",
+    )
     assert by_name["esa_contrib"].status == "fixed_input"
     assert by_name["esa_contrib"].policy_component is False
     assert by_name["afcs"].status == "fixed_input"
@@ -3190,9 +3302,9 @@ class hbai_household_net_income(Variable):
     assert by_name["domestic_rates"].policy_component is False
     assert report.policy_component_count == 20
     assert report.covered_policy_component_count == 20
-    assert report.exact_policy_component_count == 2
+    assert report.exact_policy_component_count == 3
     assert report.covered_policy_component_share == 1
-    assert math.isclose(report.exact_policy_component_share, 2 / 20)
+    assert math.isclose(report.exact_policy_component_share, 3 / 20)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(
@@ -3256,11 +3368,10 @@ class hbai_household_net_income(Variable):
 
     assert payload["policy_component_count"] == 2
     assert payload["covered_policy_component_count"] == 2
-    assert payload["exact_policy_component_count"] == 1
+    assert payload["exact_policy_component_count"] == 2
     assert payload["status_counts"] == {
-        "exact": 1,
+        "exact": 2,
         "fixed_input": 1,
-        "partial": 1,
     }
     assert payload["activity_totals"] is None
     assert payload["components"][0]["name"] == "employment_income"
@@ -3422,6 +3533,43 @@ def test_compare_outputs_compares_child_benefit_weekly_rate():
     )
 
     assert report.compared_persons == 2
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+    assert report.output_summary[0]["compared"] == 1
+
+
+def test_compare_outputs_compares_child_benefit_final_weekly_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 3,
+                    "child_benefit": 0,
+                    "child_benefit_entitlement": 44.95 * WEEKS_IN_YEAR,
+                    "would_claim_child_benefit": False,
+                }
+            ],
+            "benunit_ids": [3],
+        },
+        axiom_outputs_by_surface={
+            "child-benefit-final": [
+                {
+                    "outputs": {
+                        CHILD_BENEFIT_FINAL_OUTPUTS["child_benefit_weekly_amount"][
+                            "axiom"
+                        ]: decimal_output(0)
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_benunits == 1
     assert report.compared_values == 1
     assert report.mismatches == []
     assert report.oracle_divergences == []

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.611"
+version = "0.2.612"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add the `child-benefit-final` UK EFRS comparison surface
- map final weekly Child Benefit receipt to PolicyEngine UK `child_benefit / 52`
- project `would_claim_child_benefit` as an explicit leaf and build the SSCBA 1992 s.141 family-child relation from PE person-level rates
- mark HBAI `child_benefit` as exact with covered final outputs

## Validation
- `uv run --extra dev --python 3.13 pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py -q`
- `uv run --extra dev --python 3.13 ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/oracles/policyengine/efrs_uk.py src/axiom_encode/oracles/policyengine/coverage.py tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py`
- local full EFRS compare, `child-benefit-final`, PE-UK 2.88.56: 61,858 benunits, 13,636 compared values, 0 mismatches