### PR TITLE
Add UK State Pension final oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.612"
+version = "0.2.613"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.612"
+__version__ = "0.2.613"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -590,6 +590,8 @@ def _infer_program_from_legal_id(legal_id: str, *, rule_name: str = "") -> str:
         return "child_benefit"
     if lowered.startswith("uk:policies/govuk/child-benefit"):
         return "child_benefit"
+    if lowered.startswith("uk:policies/govuk/state-pension"):
+        return "state_pension"
     if lowered.startswith("uk:regulations/uksi/2002/1792/6"):
         return "pension_credit"
     if lowered.startswith("uk:regulations/uksi/2013/376/36"):

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -68,6 +68,8 @@ STATE_PENSION_CREDIT_SECTION_2_PROGRAM_PATH = Path("statutes/ukpga/2002/16/2.yam
 STATE_PENSION_CREDIT_SECTION_2_BASE = "uk:statutes/ukpga/2002/16/2"
 STATE_PENSION_CREDIT_SECTION_3_PROGRAM_PATH = Path("statutes/ukpga/2002/16/3.yaml")
 STATE_PENSION_CREDIT_SECTION_3_BASE = "uk:statutes/ukpga/2002/16/3"
+STATE_PENSION_FINAL_PROGRAM_PATH = Path("policies/govuk/state-pension.yaml")
+STATE_PENSION_FINAL_BASE = "uk:policies/govuk/state-pension"
 PENSION_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2002/1792/6.yaml")
 PENSION_CREDIT_BASE = "uk:regulations/uksi/2002/1792/6"
 PENSION_CREDIT_SCHEDULE_IIA_PROGRAM_PATH = Path(
@@ -339,6 +341,15 @@ STATE_PENSION_CREDIT_SAVINGS_CREDIT_OUTPUTS = {
         "axiom": f"{STATE_PENSION_CREDIT_SECTION_3_BASE}#savings_credit",
         "pe": "savings_credit",
         "tolerance": 0.1,
+    },
+}
+
+STATE_PENSION_FINAL_OUTPUTS = {
+    "state_pension_weekly_amount": {
+        "axiom": f"{STATE_PENSION_FINAL_BASE}#state_pension_weekly_amount",
+        "pe": "state_pension",
+        "pe_transform": "annual_to_weekly",
+        "tolerance": 0.01,
     },
 }
 
@@ -843,6 +854,16 @@ SURFACE_SPECS = {
             "standard_minimum_guarantee",
         ),
     ),
+    "state-pension-final": UKEFRSSurfaceSpec(
+        program=STATE_PENSION_FINAL_PROGRAM_PATH,
+        entity="person",
+        outputs=STATE_PENSION_FINAL_OUTPUTS,
+        pe_variables=(
+            "state_pension",
+            "state_pension_reported",
+            "state_pension_type",
+        ),
+    ),
     "pension-credit": UKEFRSSurfaceSpec(
         program=PENSION_CREDIT_PROGRAM_PATH,
         entity="benunit",
@@ -1176,14 +1197,14 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom covers major Pension Credit rates, additions, and deemed-income components, not the final aggregate pension_credit variable.",
     },
     "state_pension": {
-        "status": "partial",
-        "surfaces": ("state-pension-rates",),
+        "status": "exact",
+        "surfaces": ("state-pension-rates", "state-pension-final"),
         "covered_outputs": (
             "basic_state_pension",
             "new_state_pension",
             "state_pension",
         ),
-        "rationale": "Axiom covers the basic and full new State Pension weekly rates, not person-specific entitlement, deferral, inherited, or transitional amount rules feeding the final state_pension variable.",
+        "rationale": "Axiom covers the basic and full new State Pension weekly rates plus the final PolicyEngine UK state_pension receipt wrapper, which prorates reported dataset-year State Pension by current and data-year basic or new State Pension flat-rate ceilings.",
     },
     "universal_credit": {
         "status": "partial",
@@ -1997,6 +2018,7 @@ def load_local_policyengine_uk_data(
     log("Loading local PolicyEngine UK EFRS...")
     pe_dataset = UKSingleYearDataset(file_path=str(local_path))
     sim = Microsimulation(dataset=pe_dataset)
+    data_year = min(sim.dataset.years)
 
     with pd.HDFStore(local_path, mode="r") as store:
         raw_person = store["person"].copy()
@@ -2013,6 +2035,17 @@ def load_local_policyengine_uk_data(
         merged[variable] = sim.calculate(
             variable,
             period=year,
+            map_to="person",
+        ).values
+    if {"state_pension_reported", "state_pension_type"} & set(person_variables):
+        merged["state_pension_reported_data_year"] = sim.calculate(
+            "state_pension_reported",
+            period=data_year,
+            map_to="person",
+        ).values
+        merged["state_pension_type_data_year"] = sim.calculate(
+            "state_pension_type",
+            period=data_year,
             map_to="person",
         ).values
     records = table_records(merged)
@@ -2068,6 +2101,7 @@ def load_local_policyengine_uk_data(
             benunit_records[index] for index in selected_benunit_indices
         ]
     return {
+        "data_year": data_year,
         "all_persons": records,
         "persons": selected,
         "person_ids": [int(row_value(row, "person_id")) for row in selected],
@@ -3508,6 +3542,8 @@ def build_axiom_request(
             pe_data=pe_data,
             year=year,
         )
+    if surface == "state-pension-final":
+        return build_state_pension_final_request(pe_data=pe_data, year=year)
     if surface == "pension-credit":
         return build_pension_credit_request(pe_data=pe_data, year=year)
     if surface == "pension-credit-child-addition":
@@ -4086,6 +4122,47 @@ def build_state_pension_credit_qualifying_age_request(
                 "outputs": [
                     spec["axiom"]
                     for spec in STATE_PENSION_CREDIT_QUALIFYING_AGE_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_state_pension_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = benefit_week_interval(year)
+    parameters = policyengine_uk_state_pension_parameters(
+        year=year,
+        data_year=int(pe_data.get("data_year") or year),
+    )
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "state-pension-final"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_state_pension_final_inputs(
+            row,
+            parameters=parameters,
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{STATE_PENSION_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in STATE_PENSION_FINAL_OUTPUTS.values()
                 ],
             }
         )
@@ -4972,6 +5049,37 @@ def project_state_pension_credit_qualifying_age_inputs(row: Any) -> dict[str, An
     }
 
 
+def project_state_pension_final_inputs(
+    row: Any,
+    *,
+    parameters: dict[str, float],
+) -> dict[str, Any]:
+    current_type = enum_name(row_value(row, "state_pension_type", "")).upper()
+    data_year_type = enum_name(
+        row_value(row, "state_pension_type_data_year", "")
+    ).upper()
+    return {
+        "current_state_pension_type_is_basic": current_type == "BASIC",
+        "current_state_pension_type_is_new": current_type == "NEW",
+        "data_year_state_pension_type_is_basic": data_year_type == "BASIC",
+        "data_year_state_pension_type_is_new": data_year_type == "NEW",
+        "reported_state_pension_weekly_amount_in_data_year": money(
+            row_value(row, "state_pension_reported_data_year", 0)
+        )
+        / WEEKS_IN_YEAR,
+        "data_year_basic_state_pension_weekly_rate": parameters[
+            "data_year_basic_state_pension_weekly_rate"
+        ],
+        "data_year_full_new_state_pension_weekly_rate": parameters[
+            "data_year_full_new_state_pension_weekly_rate"
+        ],
+        "state_pension_abolished_by_policy": False,
+        "state_pension_policy_uprating_factor": parameters[
+            "state_pension_policy_uprating_factor"
+        ],
+    }
+
+
 def project_universal_credit_award_inputs(row: Any) -> dict[str, Any]:
     is_uc_eligible = bool(row_value(row, "is_uc_eligible", False))
 
@@ -5344,6 +5452,13 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             for row in pe_data.get("benunits", [])
             if money(row_value(row, "child_benefit_entitlement", 0)) > 0
             or money(row_value(row, "child_benefit", 0)) > 0
+        ]
+    if surface == "state-pension-final":
+        return [
+            row
+            for row in persons
+            if money(row_value(row, "state_pension", 0)) > 0
+            or money(row_value(row, "state_pension_reported_data_year", 0)) > 0
         ]
     if surface in {"national-insurance-class-4", "national-insurance-class-4-final"}:
         return [
@@ -6127,6 +6242,27 @@ def policyengine_uk_class_4_parameters(year: int) -> dict[str, float]:
         "upper_profits_limit": money(class_4.thresholds.upper_profits_limit),
         "main_class_4_percentage": float(class_4.rates.main),
         "additional_class_4_percentage": float(class_4.rates.additional),
+    }
+
+
+def policyengine_uk_state_pension_parameters(
+    *, year: int, data_year: int
+) -> dict[str, float]:
+    require_policyengine_uk_versions()
+    try:
+        from policyengine_uk import CountryTaxBenefitSystem
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(policyengine_uk_install_message()) from exc
+
+    state_pension = CountryTaxBenefitSystem().parameters.gov.dwp.state_pension
+    return {
+        "data_year_basic_state_pension_weekly_rate": money(
+            state_pension.basic_state_pension.amount(data_year)
+        ),
+        "data_year_full_new_state_pension_weekly_rate": money(
+            state_pension.new_state_pension.amount(data_year)
+        ),
+        "state_pension_policy_uprating_factor": 1.0,
     }
 
 

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1370,6 +1370,36 @@ mappings:
     comparison: money
     rationale: Same weekly full new State Pension amount after applying the Article 6 substitution.
 
+  - legal_id: uk:policies/govuk/state-pension#current_state_pension_flat_weekly_amount
+    country: uk
+    program: state_pension
+    mapping_type: not_comparable
+    rationale: PolicyEngine UK exposes basic_state_pension and new_state_pension separately; this policy wrapper output selects the current flat component for either current State Pension type and has no one-to-one PolicyEngine variable.
+
+  - legal_id: uk:policies/govuk/state-pension#additional_state_pension_weekly_amount
+    country: uk
+    program: state_pension
+    mapping_type: direct_variable
+    policyengine_variable: additional_state_pension
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    result_multiplier: 0.019230769230769232
+    rationale: Same additional or protected State Pension amount above the dataset-year basic or new State Pension ceiling, with PolicyEngine UK's annual additional_state_pension converted to a weekly amount.
+
+  - legal_id: uk:policies/govuk/state-pension#state_pension_weekly_amount
+    country: uk
+    program: state_pension
+    mapping_type: direct_variable
+    policyengine_variable: state_pension
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    result_multiplier: 0.019230769230769232
+    rationale: Same final gross State Pension receipt for the person, with PolicyEngine UK's annual state_pension converted to a weekly amount after the reported dataset-year pension and current-rate proration wrapper.
+
   - legal_id: uk:regulations/uksi/2026/148/schedule/1#attendance_allowance_higher_weekly_rate
     country: uk
     program: attendance_allowance
@@ -1898,6 +1928,12 @@ prefixes:
     program: child_benefit
     mapping_type: not_comparable
     rationale: Child Benefit final receipt helper outputs not listed above are Axiom-side period conversion and projected receipt-gate helpers rather than separate PolicyEngine UK oracle variables.
+
+  - legal_id_prefix: uk:policies/govuk/state-pension#
+    country: uk
+    program: state_pension
+    mapping_type: not_comparable
+    rationale: State Pension final receipt helper outputs not listed above are Axiom-side type-selection and dataset-year proration helpers rather than separate PolicyEngine UK oracle variables.
 
   - legal_id_prefix: uk:regulations/uksi/2002/1792/6#
     country: uk

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3312,6 +3312,81 @@ rules:
     assert all(item["tested"] is True for item in report["items"])
 
 
+def test_policyengine_coverage_classifies_uk_state_pension_final_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/state-pension.yaml",
+        """format: rulespec/v1
+rules:
+  - name: current_state_pension_flat_weekly_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 184.90
+  - name: additional_state_pension_weekly_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: 15.10
+  - name: state_pension_weekly_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Week
+    versions:
+      - effective_from: '2026-04-06'
+        formula: current_state_pension_flat_weekly_amount + additional_state_pension_weekly_amount
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/state-pension.test.yaml",
+        """- name: state pension final wrapper
+  period:
+    period_kind: week
+    start: '2026-04-06'
+    end: '2026-04-12'
+  input: {}
+  output:
+    uk:policies/govuk/state-pension#additional_state_pension_weekly_amount: 15.10
+    uk:policies/govuk/state-pension#state_pension_weekly_amount: 200.00
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="state_pension")
+
+    assert report["status_counts"] == {
+        "comparable": 2,
+        "known_not_comparable": 1,
+    }
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id[
+            "uk:policies/govuk/state-pension#additional_state_pension_weekly_amount"
+        ]["policyengine_variable"]
+        == "additional_state_pension"
+    )
+    assert (
+        items_by_id["uk:policies/govuk/state-pension#state_pension_weekly_amount"][
+            "policyengine_variable"
+        ]
+        == "state_pension"
+    )
+    assert (
+        items_by_id[
+            "uk:policies/govuk/state-pension#current_state_pension_flat_weekly_amount"
+        ]["status"]
+        == "known_not_comparable"
+    )
+
+
 @pytest.mark.parametrize(
     (
         "path",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -56,6 +56,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     STATE_PENSION_CREDIT_SECTION_1_BASE,
     STATE_PENSION_CREDIT_SECTION_2_BASE,
     STATE_PENSION_CREDIT_SECTION_3_BASE,
+    STATE_PENSION_FINAL_BASE,
+    STATE_PENSION_FINAL_OUTPUTS,
     STUDENT_LOAN_REPAYMENT_BASE,
     STUDENT_LOAN_REPAYMENT_OUTPUTS,
     UNIVERSAL_CREDIT_ASSESSABLE_CAPITAL_OUTPUTS,
@@ -99,6 +101,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_state_pension_credit_guarantee_credit_request,
     build_state_pension_credit_qualifying_age_request,
     build_state_pension_credit_savings_credit_request,
+    build_state_pension_final_request,
     build_student_loan_repayment_request,
     build_uk_efrs_coverage_report,
     build_uk_hbai_policy_coverage_report,
@@ -137,6 +140,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_state_pension_credit_guarantee_credit_inputs,
     project_state_pension_credit_qualifying_age_inputs,
     project_state_pension_credit_savings_credit_inputs,
+    project_state_pension_final_inputs,
     project_student_loan_repayment_inputs,
     project_universal_credit_assessable_capital_inputs,
     project_universal_credit_award_inputs,
@@ -1396,6 +1400,120 @@ def test_state_pension_credit_qualifying_age_request_projects_people():
     ] == {
         "kind": "bool",
         "value": True,
+    }
+
+
+def test_state_pension_final_projection_uses_current_and_data_year_types():
+    projected = project_state_pension_final_inputs(
+        {
+            "state_pension_type": "NEW",
+            "state_pension_type_data_year": "BASIC",
+            "state_pension_reported_data_year": 10_400,
+        },
+        parameters={
+            "data_year_basic_state_pension_weekly_rate": 184.90,
+            "data_year_full_new_state_pension_weekly_rate": 241.30,
+            "state_pension_policy_uprating_factor": 1.0,
+        },
+    )
+
+    assert projected == {
+        "current_state_pension_type_is_basic": False,
+        "current_state_pension_type_is_new": True,
+        "data_year_state_pension_type_is_basic": True,
+        "data_year_state_pension_type_is_new": False,
+        "reported_state_pension_weekly_amount_in_data_year": 200,
+        "data_year_basic_state_pension_weekly_rate": 184.90,
+        "data_year_full_new_state_pension_weekly_rate": 241.30,
+        "state_pension_abolished_by_policy": False,
+        "state_pension_policy_uprating_factor": 1.0,
+    }
+
+
+def test_state_pension_final_request_projects_people(monkeypatch):
+    monkeypatch.setattr(
+        efrs_uk,
+        "policyengine_uk_state_pension_parameters",
+        lambda *, year, data_year: {
+            "data_year_basic_state_pension_weekly_rate": 184.90,
+            "data_year_full_new_state_pension_weekly_rate": 241.30,
+            "state_pension_policy_uprating_factor": 1.0,
+        },
+    )
+
+    request = build_state_pension_final_request(
+        pe_data={
+            "data_year": 2023,
+            "persons": [
+                {
+                    "person_id": 7,
+                    "state_pension": 10_400,
+                    "state_pension_type": "BASIC",
+                    "state_pension_type_data_year": "BASIC",
+                    "state_pension_reported_data_year": 10_400,
+                }
+            ],
+            "person_ids": [7],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_7",
+            "period": {
+                "period_kind": "custom",
+                "name": "benefit_week",
+                "start": "2026-04-06",
+                "end": "2026-04-12",
+            },
+            "outputs": [
+                f"{STATE_PENSION_FINAL_BASE}#state_pension_weekly_amount",
+            ],
+        }
+    ]
+    values_by_name = {
+        item["name"]: item["value"] for item in request["dataset"]["inputs"]
+    }
+    assert values_by_name == {
+        f"{STATE_PENSION_FINAL_BASE}#input.current_state_pension_type_is_basic": {
+            "kind": "bool",
+            "value": True,
+        },
+        f"{STATE_PENSION_FINAL_BASE}#input.current_state_pension_type_is_new": {
+            "kind": "bool",
+            "value": False,
+        },
+        f"{STATE_PENSION_FINAL_BASE}#input.data_year_state_pension_type_is_basic": {
+            "kind": "bool",
+            "value": True,
+        },
+        f"{STATE_PENSION_FINAL_BASE}#input.data_year_state_pension_type_is_new": {
+            "kind": "bool",
+            "value": False,
+        },
+        f"{STATE_PENSION_FINAL_BASE}#input.reported_state_pension_weekly_amount_in_data_year": {
+            "kind": "decimal",
+            "value": "200.0",
+        },
+        f"{STATE_PENSION_FINAL_BASE}#input.data_year_basic_state_pension_weekly_rate": {
+            "kind": "decimal",
+            "value": "184.9",
+        },
+        f"{STATE_PENSION_FINAL_BASE}#input.data_year_full_new_state_pension_weekly_rate": {
+            "kind": "decimal",
+            "value": "241.3",
+        },
+        f"{STATE_PENSION_FINAL_BASE}#input.state_pension_abolished_by_policy": {
+            "kind": "bool",
+            "value": False,
+        },
+        f"{STATE_PENSION_FINAL_BASE}#input.state_pension_policy_uprating_factor": {
+            "kind": "decimal",
+            "value": "1.0",
+        },
     }
 
 
@@ -2850,6 +2968,11 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "is_SP_age",
         "state_pension_age",
     )
+    assert policyengine_person_variables_for_surfaces(["state-pension-final"]) == (
+        "state_pension",
+        "state_pension_reported",
+        "state_pension_type",
+    )
     assert policyengine_person_variables_for_surfaces(["student-loan-repayment"]) == (
         "adjusted_net_income",
         "student_loan_plan",
@@ -2885,6 +3008,7 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "pension_credit_income",
         "standard_minimum_guarantee",
     )
+    assert policyengine_benunit_variables_for_surfaces(["state-pension-final"]) == ()
     assert policyengine_benunit_variables_for_surfaces(
         ["benefit-cap-relevant-amount"]
     ) == (
@@ -3294,7 +3418,11 @@ class hbai_household_net_income(Variable):
     assert by_name["scottish_child_payment"].status == "partial"
     assert by_name["carer_support_payment"].status == "partial"
     assert by_name["cost_of_living_support_payment"].status == "partial"
-    assert by_name["state_pension"].status == "partial"
+    assert by_name["state_pension"].status == "exact"
+    assert by_name["state_pension"].surfaces == (
+        "state-pension-rates",
+        "state-pension-final",
+    )
     assert by_name["winter_fuel_allowance"].status == "partial"
     assert by_name["council_tax"].status == "fixed_input"
     assert by_name["council_tax"].policy_component is False
@@ -3302,9 +3430,9 @@ class hbai_household_net_income(Variable):
     assert by_name["domestic_rates"].policy_component is False
     assert report.policy_component_count == 20
     assert report.covered_policy_component_count == 20
-    assert report.exact_policy_component_count == 3
+    assert report.exact_policy_component_count == 4
     assert report.covered_policy_component_share == 1
-    assert math.isclose(report.exact_policy_component_share, 3 / 20)
+    assert math.isclose(report.exact_policy_component_share, 4 / 20)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(
@@ -3570,6 +3698,41 @@ def test_compare_outputs_compares_child_benefit_final_weekly_amount():
     )
 
     assert report.compared_benunits == 1
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+    assert report.output_summary[0]["compared"] == 1
+
+
+def test_compare_outputs_compares_state_pension_final_weekly_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 3,
+                    "state_pension": 200 * WEEKS_IN_YEAR,
+                }
+            ],
+            "person_ids": [3],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        axiom_outputs_by_surface={
+            "state-pension-final": [
+                {
+                    "outputs": {
+                        STATE_PENSION_FINAL_OUTPUTS["state_pension_weekly_amount"][
+                            "axiom"
+                        ]: decimal_output(200)
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_persons == 1
     assert report.compared_values == 1
     assert report.mismatches == []
     assert report.oracle_divergences == []

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.612"
+version = "0.2.613"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a UK EFRS oracle surface for the final PolicyEngine UK State Pension receipt wrapper
- project current/data-year State Pension type and dataset-year reported State Pension into the Axiom request
- classify the HBAI `state_pension` component as exact when paired with the new RuleSpec surface

## Validation
- `uv run --extra dev --python 3.13 pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py -q` (398 passed, 2 skipped)
- `uv run --extra dev --python 3.13 ruff check src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_coverage.py tests/test_policyengine_efrs_uk.py`
- full local EFRS compare for `state-pension-final`: 27,182 compared values, 0 mismatches, max abs weekly diff 0.000049
