### PR TITLE
Add UK National Insurance final oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.613"
+version = "0.2.614"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.613"
+__version__ = "0.2.614"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -36,6 +36,8 @@ WEEKS_IN_YEAR = 52
 MONTHS_IN_YEAR = 12
 POLICYENGINE_UK_VERSION = "2.88.56"
 
+NATIONAL_INSURANCE_SECTION_1_PROGRAM_PATH = Path("statutes/ukpga/1992/4/1.yaml")
+NATIONAL_INSURANCE_SECTION_1_BASE = "uk:statutes/ukpga/1992/4/1"
 NATIONAL_INSURANCE_SECTION_8_PROGRAM_PATH = Path("statutes/ukpga/1992/4/8.yaml")
 NATIONAL_INSURANCE_SECTION_8_BASE = "uk:statutes/ukpga/1992/4/8"
 NATIONAL_INSURANCE_SECTION_15_PROGRAM_PATH = Path("statutes/ukpga/1992/4/15.yaml")
@@ -199,6 +201,14 @@ NATIONAL_INSURANCE_REGULATION_100_OUTPUTS = {
             "#class_4_contribution_after_annual_maximum"
         ),
         "pe": "ni_class_4",
+    },
+}
+
+NATIONAL_INSURANCE_FINAL_OUTPUTS = {
+    "national_insurance_contribution": {
+        "axiom": f"{NATIONAL_INSURANCE_SECTION_1_BASE}#national_insurance_contribution",
+        "pe": "national_insurance",
+        "tolerance": 0.01,
     },
 }
 
@@ -713,6 +723,18 @@ SURFACE_SPECS = {
             "self_employment_income",
         ),
     ),
+    "national-insurance-final": UKEFRSSurfaceSpec(
+        program=NATIONAL_INSURANCE_SECTION_1_PROGRAM_PATH,
+        entity="person",
+        outputs=NATIONAL_INSURANCE_FINAL_OUTPUTS,
+        pe_variables=(
+            "national_insurance",
+            "ni_class_1_employee",
+            "ni_class_2",
+            "ni_class_3",
+            "ni_class_4",
+        ),
+    ),
     "personal-allowance": UKEFRSSurfaceSpec(
         program=PERSONAL_ALLOWANCE_PROGRAM_PATH,
         entity="person",
@@ -1130,14 +1152,20 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom compares the Section 23 income tax liability output directly to PolicyEngine UK's income_tax variable.",
     },
     "national_insurance": {
-        "status": "partial",
+        "status": "exact",
         "surfaces": (
             "national-insurance-class-1",
             "national-insurance-class-4",
             "national-insurance-class-4-final",
+            "national-insurance-final",
         ),
-        "covered_outputs": ("ni_employee", "ni_class_4_main", "ni_class_4"),
-        "rationale": "Axiom covers employee Class 1 National Insurance, the main-rate Class 4 self-employed contribution, and final Class 4 after Regulation 100's annual maximum; HBAI national_insurance also includes Class 2 and Class 3 components that are not encoded here.",
+        "covered_outputs": (
+            "ni_employee",
+            "ni_class_4_main",
+            "ni_class_4",
+            "national_insurance",
+        ),
+        "rationale": "Axiom covers employee Class 1 National Insurance, the main-rate Class 4 self-employed contribution, final Class 4 after Regulation 100's annual maximum, and the final annual PolicyEngine UK national_insurance aggregate of Class 1, Class 2, Class 3, and Class 4 contributions.",
     },
     "child_benefit": {
         "status": "exact",
@@ -3508,6 +3536,8 @@ def build_axiom_request(
             pe_data=pe_data,
             year=year,
         )
+    if surface == "national-insurance-final":
+        return build_national_insurance_final_request(pe_data=pe_data, year=year)
     if surface == "personal-allowance":
         return build_personal_allowance_request(pe_data=pe_data, year=year)
     if surface == "income-tax-income-base":
@@ -3737,6 +3767,40 @@ def build_national_insurance_class_4_final_request(
                 "outputs": [
                     spec["axiom"]
                     for spec in NATIONAL_INSURANCE_REGULATION_100_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_national_insurance_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = uk_tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "national-insurance-final"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_national_insurance_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{NATIONAL_INSURANCE_SECTION_1_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in NATIONAL_INSURANCE_FINAL_OUTPUTS.values()
                 ],
             }
         )
@@ -5080,6 +5144,17 @@ def project_state_pension_final_inputs(
     }
 
 
+def project_national_insurance_final_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "primary_class_1_contribution_for_year": money(
+            row_value(row, "ni_class_1_employee", 0)
+        ),
+        "class_2_contribution_for_year": money(row_value(row, "ni_class_2", 0)),
+        "class_3_contribution_for_year": money(row_value(row, "ni_class_3", 0)),
+        "class_4_contribution_for_year": money(row_value(row, "ni_class_4", 0)),
+    }
+
+
 def project_universal_credit_award_inputs(row: Any) -> dict[str, Any]:
     is_uc_eligible = bool(row_value(row, "is_uc_eligible", False))
 
@@ -5466,6 +5541,16 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             for row in persons
             if money(row_value(row, "self_employment_income", 0)) > 0
             or money(row_value(row, "ni_class_4_main", 0)) > 0
+            or money(row_value(row, "ni_class_4", 0)) > 0
+        ]
+    if surface == "national-insurance-final":
+        return [
+            row
+            for row in persons
+            if money(row_value(row, "national_insurance", 0)) > 0
+            or money(row_value(row, "ni_class_1_employee", 0)) > 0
+            or money(row_value(row, "ni_class_2", 0)) > 0
+            or money(row_value(row, "ni_class_3", 0)) > 0
             or money(row_value(row, "ni_class_4", 0)) > 0
         ]
     benunits = pe_data.get("benunits", [])

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -316,6 +316,17 @@ mappings:
     comparison: rate
     rationale: Same Class 1 employee additional primary contribution percentage.
 
+  - legal_id: uk:statutes/ukpga/1992/4/1#national_insurance_contribution
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: national_insurance
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final annual person-level National Insurance contribution aggregate after the UK EFRS adapter supplies PolicyEngine UK's Class 1, Class 2, Class 3, and final Class 4 contribution amounts.
+
   - legal_id: uk:statutes/ukpga/1992/4/8#primary_class_1_contribution
     country: uk
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3387,6 +3387,48 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_uk_national_insurance_final_output(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/1992/4/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: national_insurance_contribution
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-04-06'
+        formula: primary_class_1_contribution_for_year + class_4_contribution_for_year
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "statutes/ukpga/1992/4/1.test.yaml",
+        """- name: national insurance final aggregate
+  period:
+    period_kind: tax_year
+    start: '2026-04-06'
+    end: '2027-04-05'
+  input: {}
+  output:
+    uk:statutes/ukpga/1992/4/1#national_insurance_contribution: 2900.00
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["status_counts"] == {"comparable": 1}
+    assert report["untested_comparable"] == 0
+    item = report["items"][0]
+    assert item["legal_id"] == (
+        "uk:statutes/ukpga/1992/4/1#national_insurance_contribution"
+    )
+    assert item["policyengine_variable"] == "national_insurance"
+    assert item["tested"] is True
+
+
 @pytest.mark.parametrize(
     (
         "path",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -37,8 +37,10 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     JSA_TARIFF_INCOME_OUTPUTS,
     NATIONAL_INSURANCE_CLASS_1_OUTPUTS,
     NATIONAL_INSURANCE_CLASS_4_OUTPUTS,
+    NATIONAL_INSURANCE_FINAL_OUTPUTS,
     NATIONAL_INSURANCE_REGULATION_100_BASE,
     NATIONAL_INSURANCE_REGULATION_100_OUTPUTS,
+    NATIONAL_INSURANCE_SECTION_1_BASE,
     NATIONAL_INSURANCE_SECTION_8_BASE,
     NATIONAL_INSURANCE_SECTION_15_BASE,
     PENSION_CREDIT_BASE,
@@ -94,6 +96,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_national_insurance_class_1_request,
     build_national_insurance_class_4_final_request,
     build_national_insurance_class_4_request,
+    build_national_insurance_final_request,
     build_pension_credit_child_addition_request,
     build_pension_credit_deemed_income_request,
     build_pension_credit_request,
@@ -133,6 +136,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_jsa_income_tariff_income_inputs,
     project_national_insurance_class_4_final_inputs,
     project_national_insurance_class_4_inputs,
+    project_national_insurance_final_inputs,
     project_pension_credit_child_addition_inputs,
     project_pension_credit_deemed_income_inputs,
     project_pension_credit_inputs,
@@ -383,6 +387,79 @@ def test_national_insurance_class_4_final_request_projects_annual_inputs(monkeyp
     assert inputs[
         f"{NATIONAL_INSURANCE_REGULATION_100_BASE}#input.profits_and_gains_for_year:person_8"
     ] == {"kind": "decimal", "value": "100000.0"}
+
+
+def test_national_insurance_final_projection_uses_contribution_classes():
+    assert project_national_insurance_final_inputs(
+        {
+            "ni_class_1_employee": 2_400,
+            "ni_class_2": 100,
+            "ni_class_3": 50,
+            "ni_class_4": 350,
+        }
+    ) == {
+        "primary_class_1_contribution_for_year": 2_400,
+        "class_2_contribution_for_year": 100,
+        "class_3_contribution_for_year": 50,
+        "class_4_contribution_for_year": 350,
+    }
+
+
+def test_national_insurance_final_request_projects_annual_inputs():
+    request = build_national_insurance_final_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 7,
+                    "national_insurance": 0,
+                    "ni_class_1_employee": 0,
+                    "ni_class_2": 0,
+                    "ni_class_3": 0,
+                    "ni_class_4": 0,
+                },
+                {
+                    "person_id": 8,
+                    "national_insurance": 2_900,
+                    "ni_class_1_employee": 2_400,
+                    "ni_class_2": 100,
+                    "ni_class_3": 50,
+                    "ni_class_4": 350,
+                },
+            ],
+            "person_ids": [7, 8],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_8",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-04-06",
+                "end": "2027-04-05",
+            },
+            "outputs": [
+                f"{NATIONAL_INSURANCE_SECTION_1_BASE}#national_insurance_contribution",
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{NATIONAL_INSURANCE_SECTION_1_BASE}#input.primary_class_1_contribution_for_year:person_8"
+    ] == {"kind": "decimal", "value": "2400.0"}
+    assert inputs[
+        f"{NATIONAL_INSURANCE_SECTION_1_BASE}#input.class_2_contribution_for_year:person_8"
+    ] == {"kind": "decimal", "value": "100.0"}
+    assert inputs[
+        f"{NATIONAL_INSURANCE_SECTION_1_BASE}#input.class_3_contribution_for_year:person_8"
+    ] == {"kind": "decimal", "value": "50.0"}
+    assert inputs[
+        f"{NATIONAL_INSURANCE_SECTION_1_BASE}#input.class_4_contribution_for_year:person_8"
+    ] == {"kind": "decimal", "value": "350.0"}
 
 
 class FakePolicyEngineVariable:
@@ -2960,6 +3037,13 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "ni_liable",
         "self_employment_income",
     )
+    assert policyengine_person_variables_for_surfaces(["national-insurance-final"]) == (
+        "national_insurance",
+        "ni_class_1_employee",
+        "ni_class_2",
+        "ni_class_3",
+        "ni_class_4",
+    )
     assert policyengine_person_variables_for_surfaces(
         ["state-pension-credit-qualifying-age"]
     ) == (
@@ -3393,16 +3477,18 @@ class hbai_household_net_income(Variable):
     assert by_name["healthy_start_vouchers"].policy_component is False
     assert by_name["income_tax"].status == "exact"
     assert by_name["income_tax"].policy_component is True
-    assert by_name["national_insurance"].status == "partial"
+    assert by_name["national_insurance"].status == "exact"
     assert by_name["national_insurance"].surfaces == (
         "national-insurance-class-1",
         "national-insurance-class-4",
         "national-insurance-class-4-final",
+        "national-insurance-final",
     )
     assert by_name["national_insurance"].covered_outputs == (
         "ni_employee",
         "ni_class_4_main",
         "ni_class_4",
+        "national_insurance",
     )
     assert by_name["student_loan_repayments"].status == "partial"
     assert by_name["universal_credit"].status == "partial"
@@ -3430,9 +3516,9 @@ class hbai_household_net_income(Variable):
     assert by_name["domestic_rates"].policy_component is False
     assert report.policy_component_count == 20
     assert report.covered_policy_component_count == 20
-    assert report.exact_policy_component_count == 4
+    assert report.exact_policy_component_count == 5
     assert report.covered_policy_component_share == 1
-    assert math.isclose(report.exact_policy_component_share, 4 / 20)
+    assert math.isclose(report.exact_policy_component_share, 5 / 20)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(
@@ -3724,6 +3810,41 @@ def test_compare_outputs_compares_state_pension_final_weekly_amount():
                         STATE_PENSION_FINAL_OUTPUTS["state_pension_weekly_amount"][
                             "axiom"
                         ]: decimal_output(200)
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_persons == 1
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+    assert report.output_summary[0]["compared"] == 1
+
+
+def test_compare_outputs_compares_national_insurance_final_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 3,
+                    "national_insurance": 2_900,
+                }
+            ],
+            "person_ids": [3],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        axiom_outputs_by_surface={
+            "national-insurance-final": [
+                {
+                    "outputs": {
+                        NATIONAL_INSURANCE_FINAL_OUTPUTS[
+                            "national_insurance_contribution"
+                        ]["axiom"]: decimal_output(2_900)
                     }
                 }
             ]

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.613"
+version = "0.2.614"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a UK National Insurance final oracle surface mapping Section 1's aggregate contribution to PolicyEngine UK's `national_insurance`
- include Class 1, Class 2, Class 3, and final Class 4 inputs so EFRS/HBAI can compare the final PE aggregate directly
- mark the HBAI `national_insurance` component exact once the final aggregate is covered

## Validation
- `uv run --extra dev --python 3.13 pytest tests/test_policyengine_efrs_uk.py -q`
- `uv run --extra dev --python 3.13 pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev --python 3.13 ruff check src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_coverage.py tests/test_policyengine_efrs_uk.py`
- `uv run --extra dev --python 3.13 pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
- local EFRS compare for `national-insurance-final`: 41,494 compared values, 0 mismatches, max absolute annual diff 0.000244140625
- HBAI exact policy weighted abs share after NI: 0.975530228558382
