### PR TITLE
Add UK Universal Credit final oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.614"
+version = "0.2.615"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.614"
+__version__ = "0.2.615"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -104,6 +104,8 @@ UNIVERSAL_CREDIT_REGULATION_34_PROGRAM_PATH = Path("regulations/uksi/2013/376/34
 UNIVERSAL_CREDIT_REGULATION_34_BASE = "uk:regulations/uksi/2013/376/34"
 UNIVERSAL_CREDIT_REGULATION_72_PROGRAM_PATH = Path("regulations/uksi/2013/376/72.yaml")
 UNIVERSAL_CREDIT_REGULATION_72_BASE = "uk:regulations/uksi/2013/376/72"
+UNIVERSAL_CREDIT_FINAL_PROGRAM_PATH = Path("policies/govuk/universal-credit.yaml")
+UNIVERSAL_CREDIT_FINAL_BASE = "uk:policies/govuk/universal-credit"
 WELFARE_REFORM_ACT_SECTION_8_PROGRAM_PATH = Path("statutes/ukpga/2012/5/8.yaml")
 WELFARE_REFORM_ACT_SECTION_8_BASE = "uk:statutes/ukpga/2012/5/8"
 WELFARE_REFORM_ACT_SECTION_11_PROGRAM_PATH = Path("statutes/ukpga/2012/5/11.yaml")
@@ -583,6 +585,14 @@ UNIVERSAL_CREDIT_AWARD_OUTPUTS = {
     },
 }
 
+UNIVERSAL_CREDIT_FINAL_OUTPUTS = {
+    "universal_credit_annual_amount": {
+        "axiom": f"{UNIVERSAL_CREDIT_FINAL_BASE}#universal_credit_annual_amount",
+        "pe": "universal_credit",
+        "tolerance": 0.01,
+    },
+}
+
 UNIVERSAL_CREDIT_HOUSING_COSTS_OUTPUTS = {
     "section_11_amount_for_accommodation_payments": {
         "axiom": (
@@ -1048,6 +1058,17 @@ SURFACE_SPECS = {
             "uc_standard_allowance",
         ),
     ),
+    "universal-credit-final": UKEFRSSurfaceSpec(
+        program=UNIVERSAL_CREDIT_FINAL_PROGRAM_PATH,
+        entity="benunit",
+        outputs=UNIVERSAL_CREDIT_FINAL_OUTPUTS,
+        pe_variables=(
+            "benefit_cap_reduction",
+            "universal_credit",
+            "universal_credit_pre_benefit_cap",
+            "would_claim_uc",
+        ),
+    ),
     "universal-credit-housing-costs": UKEFRSSurfaceSpec(
         program=WELFARE_REFORM_ACT_SECTION_11_PROGRAM_PATH,
         entity="benunit",
@@ -1235,7 +1256,7 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom covers the basic and full new State Pension weekly rates plus the final PolicyEngine UK state_pension receipt wrapper, which prorates reported dataset-year State Pension by current and data-year basic or new State Pension flat-rate ceilings.",
     },
     "universal_credit": {
-        "status": "partial",
+        "status": "exact",
         "surfaces": (
             "universal-credit-standard-allowance",
             "universal-credit-child-element",
@@ -1250,6 +1271,7 @@ HBAI_COMPONENT_COVERAGE = {
             "universal-credit-income-deduction",
             "universal-credit-assessable-capital",
             "universal-credit-tariff-income",
+            "universal-credit-final",
         ),
         "covered_outputs": (
             "uc_standard_allowance",
@@ -1265,8 +1287,9 @@ HBAI_COMPONENT_COVERAGE = {
             "uc_work_allowance",
             "uc_assessable_capital",
             "uc_tariff_income",
+            "universal_credit",
         ),
-        "rationale": "Axiom covers many Universal Credit legal elements and the award-before-take-up expression, not the final HBAI universal_credit aggregate.",
+        "rationale": "Axiom covers many Universal Credit legal elements, the award-before-take-up expression, and the final annual PolicyEngine UK universal_credit wrapper after the would_claim_uc gate and benefit-cap reduction.",
     },
     "student_loan_repayments": {
         "status": "partial",
@@ -3614,6 +3637,8 @@ def build_axiom_request(
         )
     if surface == "universal-credit-award":
         return build_universal_credit_award_request(pe_data=pe_data, year=year)
+    if surface == "universal-credit-final":
+        return build_universal_credit_final_request(pe_data=pe_data, year=year)
     if surface == "universal-credit-housing-costs":
         return build_universal_credit_housing_costs_request(
             pe_data=pe_data,
@@ -4653,6 +4678,40 @@ def build_universal_credit_award_request(
     }
 
 
+def build_universal_credit_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "universal-credit-final"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_universal_credit_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{UNIVERSAL_CREDIT_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in UNIVERSAL_CREDIT_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def build_universal_credit_housing_costs_request(
     *, pe_data: dict[str, Any], year: int
 ) -> dict[str, Any]:
@@ -5186,6 +5245,17 @@ def project_universal_credit_award_inputs(row: Any) -> dict[str, Any]:
     }
 
 
+def project_universal_credit_final_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "universal_credit_pre_benefit_cap_for_year": money(
+            row_value(row, "universal_credit_pre_benefit_cap", 0)
+        ),
+        "benefit_cap_reduction_for_year": money(
+            row_value(row, "benefit_cap_reduction", 0)
+        ),
+    }
+
+
 def project_universal_credit_childcare_element_inputs(row: Any) -> dict[str, Any]:
     monthly_childcare_element = money(row_value(row, "uc_childcare_element", 0)) / (
         MONTHS_IN_YEAR
@@ -5575,6 +5645,14 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             for row in benunits
             if money(row_value(row, "uc_standard_allowance", 0)) > 0
         ]
+    if surface == "universal-credit-final":
+        return [
+            row
+            for row in benunits
+            if money(row_value(row, "universal_credit", 0)) > 0
+            or money(row_value(row, "universal_credit_pre_benefit_cap", 0)) > 0
+            or money(row_value(row, "benefit_cap_reduction", 0)) > 0
+        ]
     if surface == "universal-credit-lcwra-element":
         return [
             row for row in benunits if money(row_value(row, "uc_LCWRA_element", 0)) > 0
@@ -5776,6 +5854,11 @@ def compare_outputs(
             "The final section 8 award amount is compared against "
             "max(uc_maximum_amount - uc_income_reduction, 0), before "
             "PolicyEngine's would_claim_uc take-up gate.",
+            "PolicyEngine-aligned Universal Credit final comparison projects "
+            "annual universal_credit_pre_benefit_cap and annual "
+            "benefit_cap_reduction into a final annual wrapper matching "
+            "PolicyEngine UK's universal_credit amount after the would_claim_uc "
+            "gate and benefit-cap reduction.",
             "Welfare Reform Act 2012 section 11 Universal Credit housing-costs "
             "comparison projects PolicyEngine's annual uc_housing_costs_element "
             "into the monthly amount determined or calculated by regulations, "

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -698,6 +698,17 @@ mappings:
     result_multiplier: 0.019230769230769232
     rationale: Same final gross Child Benefit receipt for the benefit unit, with PolicyEngine UK's annual child_benefit converted to a weekly amount after the would_claim_child_benefit gate.
 
+  - legal_id: uk:policies/govuk/universal-credit#universal_credit_annual_amount
+    country: uk
+    program: universal_credit
+    mapping_type: direct_variable
+    policyengine_variable: universal_credit
+    entity: benunit
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final annual Universal Credit receipt for the benefit unit after PolicyEngine UK's would_claim_uc gate and benefit-cap reduction.
+
   - legal_id: uk:regulations/uksi/2002/1792/6#standard_minimum_guarantee_with_partner
     country: uk
     program: pension_credit

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3429,6 +3429,52 @@ rules:
     assert item["tested"] is True
 
 
+def test_policyengine_coverage_classifies_uk_universal_credit_final_output(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/universal-credit.yaml",
+        """format: rulespec/v1
+rules:
+  - name: universal_credit_annual_amount
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(0, universal_credit_pre_benefit_cap_for_year - benefit_cap_reduction_for_year)
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/universal-credit.test.yaml",
+        """- name: universal credit final annual amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    uk:policies/govuk/universal-credit#input.universal_credit_pre_benefit_cap_for_year: 12000.00
+    uk:policies/govuk/universal-credit#input.benefit_cap_reduction_for_year: 1250.00
+  output:
+    uk:policies/govuk/universal-credit#universal_credit_annual_amount: 10750.00
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="universal_credit")
+
+    assert report["status_counts"] == {"comparable": 1}
+    assert report["untested_comparable"] == 0
+    item = report["items"][0]
+    assert item["legal_id"] == (
+        "uk:policies/govuk/universal-credit#universal_credit_annual_amount"
+    )
+    assert item["policyengine_variable"] == "universal_credit"
+    assert item["mapping_type"] == "direct_variable"
+    assert item["tested"] is True
+
+
 @pytest.mark.parametrize(
     (
         "path",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -67,6 +67,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     UNIVERSAL_CREDIT_CHILD_ELEMENT_OUTPUTS,
     UNIVERSAL_CREDIT_CHILDCARE_ELEMENT_OUTPUTS,
     UNIVERSAL_CREDIT_CHILDCARE_WORK_CONDITION_OUTPUTS,
+    UNIVERSAL_CREDIT_FINAL_BASE,
+    UNIVERSAL_CREDIT_FINAL_OUTPUTS,
     UNIVERSAL_CREDIT_HOUSING_COSTS_OUTPUTS,
     UNIVERSAL_CREDIT_INCOME_DEDUCTION_OUTPUTS,
     UNIVERSAL_CREDIT_LCWRA_OUTPUTS,
@@ -112,6 +114,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_universal_credit_award_request,
     build_universal_credit_childcare_element_request,
     build_universal_credit_childcare_work_condition_request,
+    build_universal_credit_final_request,
     build_universal_credit_housing_costs_request,
     build_universal_credit_income_deduction_request,
     build_universal_credit_request,
@@ -150,6 +153,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_universal_credit_award_inputs,
     project_universal_credit_childcare_element_inputs,
     project_universal_credit_childcare_work_condition_inputs,
+    project_universal_credit_final_inputs,
     project_universal_credit_housing_costs_inputs,
     project_universal_credit_income_deduction_inputs,
     project_universal_credit_tariff_income_inputs,
@@ -2138,6 +2142,69 @@ def test_universal_credit_award_request_projects_section_8_inputs():
     }
 
 
+def test_universal_credit_final_projection_uses_annual_pre_cap_and_cap_reduction():
+    assert project_universal_credit_final_inputs(
+        {
+            "universal_credit_pre_benefit_cap": 12_000,
+            "benefit_cap_reduction": 1_250,
+        }
+    ) == {
+        "universal_credit_pre_benefit_cap_for_year": 12_000.0,
+        "benefit_cap_reduction_for_year": 1_250.0,
+    }
+
+
+def test_universal_credit_final_request_projects_final_inputs():
+    request = build_universal_credit_final_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 10,
+                    "universal_credit": 0,
+                    "universal_credit_pre_benefit_cap": 0,
+                    "benefit_cap_reduction": 0,
+                },
+                {
+                    "benunit_id": 11,
+                    "universal_credit": 10_750,
+                    "universal_credit_pre_benefit_cap": 12_000,
+                    "benefit_cap_reduction": 1_250,
+                },
+            ],
+            "benunit_ids": [10, 11],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_11",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": [
+                UNIVERSAL_CREDIT_FINAL_OUTPUTS["universal_credit_annual_amount"][
+                    "axiom"
+                ],
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{UNIVERSAL_CREDIT_FINAL_BASE}#input.universal_credit_pre_benefit_cap_for_year:benunit_11"
+    ] == {"kind": "decimal", "value": "12000.0"}
+    assert inputs[
+        f"{UNIVERSAL_CREDIT_FINAL_BASE}#input.benefit_cap_reduction_for_year:benunit_11"
+    ] == {"kind": "decimal", "value": "1250.0"}
+
+
 def test_universal_credit_childcare_element_projection_reverses_rate_and_cap():
     projected = project_universal_credit_childcare_element_inputs(
         {
@@ -3131,6 +3198,12 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "uc_maximum_amount",
         "uc_standard_allowance",
     )
+    assert policyengine_benunit_variables_for_surfaces(["universal-credit-final"]) == (
+        "benefit_cap_reduction",
+        "universal_credit",
+        "universal_credit_pre_benefit_cap",
+        "would_claim_uc",
+    )
     assert policyengine_benunit_variables_for_surfaces(
         ["universal-credit-housing-costs"]
     ) == ("uc_housing_costs_element",)
@@ -3303,8 +3376,8 @@ class hbai_household_net_income(Variable):
 
     assert report.variables_total == 1
     assert report.computed_variables_total == 1
-    assert report.missing_variables_total == 1
-    assert report.missing_variables[0].name == "universal_credit"
+    assert report.missing_variables_total == 0
+    assert report.missing_variables == []
 
 
 def test_uk_efrs_coverage_report_serializes_json(tmp_path):
@@ -3491,7 +3564,39 @@ class hbai_household_net_income(Variable):
         "national_insurance",
     )
     assert by_name["student_loan_repayments"].status == "partial"
-    assert by_name["universal_credit"].status == "partial"
+    assert by_name["universal_credit"].status == "exact"
+    assert by_name["universal_credit"].surfaces == (
+        "universal-credit-standard-allowance",
+        "universal-credit-child-element",
+        "universal-credit-lcwra-element",
+        "universal-credit-carer-element",
+        "universal-credit-childcare-cap",
+        "universal-credit-childcare-work-condition",
+        "universal-credit-childcare-element",
+        "universal-credit-award",
+        "universal-credit-housing-costs",
+        "universal-credit-work-allowance",
+        "universal-credit-income-deduction",
+        "universal-credit-assessable-capital",
+        "universal-credit-tariff-income",
+        "universal-credit-final",
+    )
+    assert by_name["universal_credit"].covered_outputs == (
+        "uc_standard_allowance",
+        "uc_individual_child_element",
+        "uc_individual_disabled_child_element",
+        "uc_individual_severely_disabled_child_element",
+        "uc_LCWRA_element",
+        "uc_carer_element",
+        "uc_childcare_element",
+        "uc_maximum_amount",
+        "uc_income_reduction",
+        "uc_housing_costs_element",
+        "uc_work_allowance",
+        "uc_assessable_capital",
+        "uc_tariff_income",
+        "universal_credit",
+    )
     assert by_name["working_tax_credit"].status == "partial"
     assert by_name["child_tax_credit"].status == "partial"
     assert by_name["tax_free_childcare"].status == "partial"
@@ -3516,9 +3621,9 @@ class hbai_household_net_income(Variable):
     assert by_name["domestic_rates"].policy_component is False
     assert report.policy_component_count == 20
     assert report.covered_policy_component_count == 20
-    assert report.exact_policy_component_count == 5
+    assert report.exact_policy_component_count == 6
     assert report.covered_policy_component_share == 1
-    assert math.isclose(report.exact_policy_component_share, 5 / 20)
+    assert math.isclose(report.exact_policy_component_share, 6 / 20)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(
@@ -4018,6 +4123,39 @@ def test_compare_outputs_transforms_universal_credit_award_outputs_monthly():
 
     assert report.compared_values == 3
     assert report.mismatches == []
+
+
+def test_compare_outputs_compares_universal_credit_final_annual_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "universal_credit": 10_750,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "universal-credit-final": [
+                {
+                    "outputs": {
+                        UNIVERSAL_CREDIT_FINAL_OUTPUTS[
+                            "universal_credit_annual_amount"
+                        ]["axiom"]: decimal_output(10_750),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
 
 
 def test_compare_outputs_floors_universal_credit_award_expression():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.614"
+version = "0.2.615"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Adds a PolicyEngine-aligned Universal Credit final annual wrapper for HBAI coverage.

What changed:
- Adds a universal-credit-final EFRS surface targeting policies/govuk/universal-credit.yaml.
- Maps uk:policies/govuk/universal-credit#universal_credit_annual_amount to PolicyEngine UK's universal_credit benunit variable.
- Projects annual universal_credit_pre_benefit_cap and benefit_cap_reduction inputs, with final comparison matching the PolicyEngine UK universal_credit amount after the would_claim_uc gate and benefit-cap reduction.
- Marks the HBAI universal_credit component exact and bumps axiom-encode to 0.2.615.

Local gates passed:
- ruff check on touched Python test/oracle files
- pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
- pytest tests/test_policyengine_efrs_uk.py plus UC/NI coverage classifier tests

Follow-up:
- Companion rulespec-uk surface will add policies/govuk/universal-credit.yaml and its tests.