### PR TITLE
Add UK Carer's Allowance final oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.615"
+version = "0.2.616"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.615"
+__version__ = "0.2.616"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -114,6 +114,8 @@ STUDENT_LOAN_REPAYMENT_PROGRAM_PATH = Path(
     "policies/govuk/student-loan-repayments.yaml"
 )
 STUDENT_LOAN_REPAYMENT_BASE = "uk:policies/govuk/student-loan-repayments"
+CARERS_ALLOWANCE_FINAL_PROGRAM_PATH = Path("policies/govuk/carers-allowance.yaml")
+CARERS_ALLOWANCE_FINAL_BASE = "uk:policies/govuk/carers-allowance"
 
 PERSONAL_ALLOWANCE_OUTPUTS = {
     "personal_allowance": {
@@ -684,6 +686,13 @@ STUDENT_LOAN_REPAYMENT_OUTPUTS = {
     },
 }
 
+CARERS_ALLOWANCE_FINAL_OUTPUTS = {
+    "carers_allowance_annual_amount": {
+        "axiom": f"{CARERS_ALLOWANCE_FINAL_BASE}#carers_allowance_annual_amount",
+        "pe": "carers_allowance",
+    },
+}
+
 
 @dataclass(frozen=True)
 class UKEFRSSurfaceSpec:
@@ -1129,6 +1138,17 @@ SURFACE_SPECS = {
             "student_loan_repayment",
         ),
     ),
+    "carers-allowance-final": UKEFRSSurfaceSpec(
+        program=CARERS_ALLOWANCE_FINAL_PROGRAM_PATH,
+        entity="person",
+        outputs=CARERS_ALLOWANCE_FINAL_OUTPUTS,
+        pe_variables=(
+            "care_hours",
+            "carers_allowance",
+            "carers_allowance_reported",
+            "country",
+        ),
+    ),
 }
 
 HBAI_FIXED_INPUT_COMPONENTS = frozenset(
@@ -1360,10 +1380,10 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom covers Attendance Allowance weekly higher and lower rates, not the category assignment or final aggregate Attendance Allowance amount.",
     },
     "carers_allowance": {
-        "status": "partial",
-        "surfaces": ("carers-allowance-rate",),
+        "status": "exact",
+        "surfaces": ("carers-allowance-rate", "carers-allowance-final"),
         "covered_outputs": ("carers_allowance",),
-        "rationale": "Axiom covers the weekly Carer's Allowance rate, not the care-hours, Scotland replacement, or final aggregate Carer's Allowance calculation.",
+        "rationale": "Axiom covers the weekly Carer's Allowance rate and the final annual PolicyEngine UK carers_allowance wrapper, including the care-hours or reported-receipt gate and the Scotland Carer Support Payment replacement gate.",
     },
     "sda": {
         "status": "partial",
@@ -3666,6 +3686,8 @@ def build_axiom_request(
         )
     if surface == "student-loan-repayment":
         return build_student_loan_repayment_request(pe_data=pe_data, year=year)
+    if surface == "carers-allowance-final":
+        return build_carers_allowance_final_request(pe_data=pe_data, year=year)
     if surface in UNIVERSAL_CREDIT_REGULATION_36_SURFACES:
         return build_universal_credit_request(
             pe_data=pe_data,
@@ -4925,6 +4947,43 @@ def build_student_loan_repayment_request(
     }
 
 
+def build_carers_allowance_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = uk_tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "carers-allowance-final"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_carers_allowance_final_inputs(
+            row,
+            year=year,
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{CARERS_ALLOWANCE_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in CARERS_ALLOWANCE_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def project_personal_allowance_inputs(row: Any) -> dict[str, Any]:
     adjusted_net_income = money(row_value(row, "adjusted_net_income"))
     gift_aid_grossed_up = money(row_value(row, "gift_aid_grossed_up", 0))
@@ -5500,6 +5559,18 @@ def project_student_loan_repayment_inputs(row: Any) -> dict[str, Any]:
     }
 
 
+def project_carers_allowance_final_inputs(row: Any, *, year: int) -> dict[str, Any]:
+    country = enum_name(row_value(row, "country", "")).upper()
+    return {
+        "person_is_in_scotland": country == "SCOTLAND",
+        "carer_support_payment_replaces_carers_allowance": year >= 2025,
+        "weekly_care_hours": money(row_value(row, "care_hours", 0)),
+        "reported_carers_allowance_for_year": money(
+            row_value(row, "carers_allowance_reported", 0)
+        ),
+    }
+
+
 def project_pension_credit_inputs(row: Any) -> dict[str, Any]:
     relation_type = str(row_value(row, "relation_type", "")).upper()
     is_couple = bool(row_value(row, "is_couple", False)) or relation_type == "COUPLE"
@@ -5652,6 +5723,14 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             if money(row_value(row, "universal_credit", 0)) > 0
             or money(row_value(row, "universal_credit_pre_benefit_cap", 0)) > 0
             or money(row_value(row, "benefit_cap_reduction", 0)) > 0
+        ]
+    if surface == "carers-allowance-final":
+        return [
+            row
+            for row in persons
+            if money(row_value(row, "carers_allowance", 0)) > 0
+            or money(row_value(row, "carers_allowance_reported", 0)) > 0
+            or money(row_value(row, "care_hours", 0)) >= 35
         ]
     if surface == "universal-credit-lcwra-element":
         return [
@@ -5859,6 +5938,11 @@ def compare_outputs(
             "benefit_cap_reduction into a final annual wrapper matching "
             "PolicyEngine UK's universal_credit amount after the would_claim_uc "
             "gate and benefit-cap reduction.",
+            "PolicyEngine-aligned Carer's Allowance final comparison projects "
+            "PolicyEngine UK's person-level care hours, country, reported "
+            "Carer's Allowance receipt, and Scotland replacement gate into a "
+            "final annual wrapper that uses the RuleSpec weekly rate and "
+            "35-hour care threshold.",
             "Welfare Reform Act 2012 section 11 Universal Credit housing-costs "
             "comparison projects PolicyEngine's annual uc_housing_costs_element "
             "into the monthly amount determined or calculated by regulations, "

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1497,6 +1497,27 @@ mappings:
     comparison: money
     rationale: Same weekly Carer's Allowance rate in Schedule 1 Part III of the 2026 up-rating order.
 
+  - legal_id: uk:policies/govuk/carers-allowance#carers_allowance_minimum_weekly_care_hours
+    country: uk
+    program: carers_allowance
+    mapping_type: parameter_value
+    policyengine_parameter: gov.dwp.carers_allowance.min_hours
+    period: week
+    unit: hour
+    comparison: count
+    rationale: Same minimum weekly care-hours threshold for Carer's Allowance.
+
+  - legal_id: uk:policies/govuk/carers-allowance#carers_allowance_annual_amount
+    country: uk
+    program: carers_allowance
+    mapping_type: direct_variable
+    policyengine_variable: carers_allowance
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final annual Carer's Allowance amount after PolicyEngine UK's care-hours or reported-receipt gate and Scotland Carer Support Payment replacement gate.
+
   - legal_id: uk:regulations/uksi/2025/969/3#winter_fuel_payment_under_80_standard_amount
     country: uk
     program: winter_fuel_allowance

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3475,6 +3475,72 @@ rules:
     assert item["tested"] is True
 
 
+def test_policyengine_coverage_classifies_uk_carers_allowance_final_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/carers-allowance.yaml",
+        """format: rulespec/v1
+rules:
+  - name: carers_allowance_minimum_weekly_care_hours
+    kind: parameter
+    entity: Person
+    dtype: Count
+    period: Week
+    unit: hour
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 35
+  - name: carers_allowance_annual_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if not (person_is_in_scotland and carer_support_payment_replaces_carers_allowance) and (weekly_care_hours >= carers_allowance_minimum_weekly_care_hours or reported_carers_allowance_for_year > 0): carers_allowance_weekly_rate * 52 else: 0
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/carers-allowance.test.yaml",
+        """- name: carers allowance final annual amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    uk:policies/govuk/carers-allowance#input.person_is_in_scotland: false
+    uk:policies/govuk/carers-allowance#input.carer_support_payment_replaces_carers_allowance: true
+    uk:policies/govuk/carers-allowance#input.weekly_care_hours: 35
+    uk:policies/govuk/carers-allowance#input.reported_carers_allowance_for_year: 0
+  output:
+    uk:policies/govuk/carers-allowance#carers_allowance_minimum_weekly_care_hours: 35
+    uk:policies/govuk/carers-allowance#carers_allowance_annual_amount: 4495.40
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="carers_allowance")
+
+    assert report["status_counts"] == {"comparable": 2}
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    min_hours = items_by_id[
+        "uk:policies/govuk/carers-allowance#carers_allowance_minimum_weekly_care_hours"
+    ]
+    annual_amount = items_by_id[
+        "uk:policies/govuk/carers-allowance#carers_allowance_annual_amount"
+    ]
+
+    assert min_hours["policyengine_parameter"] == "gov.dwp.carers_allowance.min_hours"
+    assert min_hours["mapping_type"] == "parameter_value"
+    assert min_hours["tested"] is True
+    assert annual_amount["policyengine_variable"] == "carers_allowance"
+    assert annual_amount["mapping_type"] == "direct_variable"
+    assert annual_amount["tested"] is True
+
+
 @pytest.mark.parametrize(
     (
         "path",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -9,6 +9,8 @@ import axiom_encode.oracles.policyengine.efrs_uk as efrs_uk
 from axiom_encode.oracles.policyengine.efrs_uk import (
     BENEFIT_CAP_REGULATION_80A_BASE,
     BENEFIT_CAP_RELEVANT_AMOUNT_OUTPUTS,
+    CARERS_ALLOWANCE_FINAL_BASE,
+    CARERS_ALLOWANCE_FINAL_OUTPUTS,
     CHILD_BENEFIT_BASE,
     CHILD_BENEFIT_FINAL_BASE,
     CHILD_BENEFIT_FINAL_OUTPUTS,
@@ -84,6 +86,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     WELFARE_REFORM_ACT_SECTION_8_BASE,
     WELFARE_REFORM_ACT_SECTION_11_BASE,
     build_benefit_cap_relevant_amount_request,
+    build_carers_allowance_final_request,
     build_child_benefit_final_request,
     build_child_benefit_request,
     build_esa_income_tariff_income_request,
@@ -126,6 +129,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     policyengine_benunit_variables_for_surfaces,
     policyengine_person_variables_for_surfaces,
     project_benefit_cap_relevant_amount_inputs,
+    project_carers_allowance_final_inputs,
     project_child_benefit_inputs,
     project_esa_income_tariff_income_inputs,
     project_housing_benefit_pension_age_tariff_income_inputs,
@@ -2205,6 +2209,81 @@ def test_universal_credit_final_request_projects_final_inputs():
     ] == {"kind": "decimal", "value": "1250.0"}
 
 
+def test_carers_allowance_final_projection_uses_pe_boundary_facts():
+    assert project_carers_allowance_final_inputs(
+        {
+            "country": "SCOTLAND",
+            "care_hours": 40,
+            "carers_allowance_reported": 0,
+        },
+        year=2026,
+    ) == {
+        "person_is_in_scotland": True,
+        "carer_support_payment_replaces_carers_allowance": True,
+        "weekly_care_hours": 40.0,
+        "reported_carers_allowance_for_year": 0.0,
+    }
+
+
+def test_carers_allowance_final_request_projects_final_inputs():
+    request = build_carers_allowance_final_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 1,
+                    "country": "ENGLAND",
+                    "care_hours": 0,
+                    "carers_allowance": 0,
+                    "carers_allowance_reported": 0,
+                },
+                {
+                    "person_id": 2,
+                    "country": "ENGLAND",
+                    "care_hours": 35,
+                    "carers_allowance": 4_495.40,
+                    "carers_allowance_reported": 0,
+                },
+            ],
+            "person_ids": [1, 2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_2",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-04-06",
+                "end": "2027-04-05",
+            },
+            "outputs": [
+                CARERS_ALLOWANCE_FINAL_OUTPUTS["carers_allowance_annual_amount"][
+                    "axiom"
+                ],
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{CARERS_ALLOWANCE_FINAL_BASE}#input.person_is_in_scotland:person_2"
+    ] == {"kind": "bool", "value": False}
+    assert inputs[
+        f"{CARERS_ALLOWANCE_FINAL_BASE}#input.carer_support_payment_replaces_carers_allowance:person_2"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{CARERS_ALLOWANCE_FINAL_BASE}#input.weekly_care_hours:person_2"
+    ] == {"kind": "decimal", "value": "35.0"}
+    assert inputs[
+        f"{CARERS_ALLOWANCE_FINAL_BASE}#input.reported_carers_allowance_for_year:person_2"
+    ] == {"kind": "decimal", "value": "0.0"}
+
+
 def test_universal_credit_childcare_element_projection_reverses_rate_and_cap():
     projected = project_universal_credit_childcare_element_inputs(
         {
@@ -3603,7 +3682,11 @@ class hbai_household_net_income(Variable):
     assert by_name["pip"].status == "exact"
     assert by_name["dla"].status == "partial"
     assert by_name["attendance_allowance"].status == "partial"
-    assert by_name["carers_allowance"].status == "partial"
+    assert by_name["carers_allowance"].status == "exact"
+    assert by_name["carers_allowance"].surfaces == (
+        "carers-allowance-rate",
+        "carers-allowance-final",
+    )
     assert by_name["sda"].status == "partial"
     assert by_name["ssmg"].status == "partial"
     assert by_name["scottish_child_payment"].status == "partial"
@@ -3621,9 +3704,9 @@ class hbai_household_net_income(Variable):
     assert by_name["domestic_rates"].policy_component is False
     assert report.policy_component_count == 20
     assert report.covered_policy_component_count == 20
-    assert report.exact_policy_component_count == 6
+    assert report.exact_policy_component_count == 7
     assert report.covered_policy_component_share == 1
-    assert math.isclose(report.exact_policy_component_share, 6 / 20)
+    assert math.isclose(report.exact_policy_component_share, 7 / 20)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(
@@ -4145,6 +4228,39 @@ def test_compare_outputs_compares_universal_credit_final_annual_amount():
                         UNIVERSAL_CREDIT_FINAL_OUTPUTS[
                             "universal_credit_annual_amount"
                         ]["axiom"]: decimal_output(10_750),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_carers_allowance_final_annual_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 2,
+                    "carers_allowance": 4_495.40,
+                },
+            ],
+            "person_ids": [2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        axiom_outputs_by_surface={
+            "carers-allowance-final": [
+                {
+                    "outputs": {
+                        CARERS_ALLOWANCE_FINAL_OUTPUTS[
+                            "carers_allowance_annual_amount"
+                        ]["axiom"]: decimal_output(4_495.40),
                     }
                 }
             ]

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.615"
+version = "0.2.616"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a UK EFRS oracle surface for the final annual Carer's Allowance wrapper
- map the final annual output and minimum care-hours threshold to PolicyEngine UK
- classify the HBAI carers_allowance component as exact once the matching rulespec lands

## Tests
- uv run --python 3.13 ruff check src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py
- uv run --extra dev --python 3.13 python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- uv run --extra dev --python 3.13 python -m pytest tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_carers_allowance_final_outputs tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_universal_credit_final_output -q