### PR TITLE
Classify UK Carer's Allowance annualization helper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.616"
+version = "0.2.617"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.616"
+__version__ = "0.2.617"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1507,6 +1507,14 @@ mappings:
     comparison: count
     rationale: Same minimum weekly care-hours threshold for Carer's Allowance.
 
+  - legal_id: uk:policies/govuk/carers-allowance#carers_allowance_weeks_in_year
+    country: uk
+    program: carers_allowance
+    mapping_type: not_comparable
+    comparable: false
+    candidate_priority: P4
+    rationale: Source-backed annualization helper for the policy-level final amount wrapper; PolicyEngine exposes the final annual Carer's Allowance variable and the weekly rate parameter, not this multiplication factor as a separate oracle target.
+
   - legal_id: uk:policies/govuk/carers-allowance#carers_allowance_annual_amount
     country: uk
     program: carers_allowance

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3491,6 +3491,14 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: 35
+  - name: carers_allowance_weeks_in_year
+    kind: parameter
+    entity: Person
+    dtype: Count
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 52
   - name: carers_allowance_annual_amount
     kind: derived
     entity: Person
@@ -3500,7 +3508,7 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: |-
-          if not (person_is_in_scotland and carer_support_payment_replaces_carers_allowance) and (weekly_care_hours >= carers_allowance_minimum_weekly_care_hours or reported_carers_allowance_for_year > 0): carers_allowance_weekly_rate * 52 else: 0
+          if not (person_is_in_scotland and carer_support_payment_replaces_carers_allowance) and (weekly_care_hours >= carers_allowance_minimum_weekly_care_hours or reported_carers_allowance_for_year > 0): carers_allowance_weekly_rate * carers_allowance_weeks_in_year else: 0
 """,
     )
     _write_rulespec_file(
@@ -3523,11 +3531,17 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path, program="carers_allowance")
 
-    assert report["status_counts"] == {"comparable": 2}
+    assert report["status_counts"] == {
+        "comparable": 2,
+        "known_not_comparable": 1,
+    }
     assert report["untested_comparable"] == 0
     items_by_id = {item["legal_id"]: item for item in report["items"]}
     min_hours = items_by_id[
         "uk:policies/govuk/carers-allowance#carers_allowance_minimum_weekly_care_hours"
+    ]
+    weeks_in_year = items_by_id[
+        "uk:policies/govuk/carers-allowance#carers_allowance_weeks_in_year"
     ]
     annual_amount = items_by_id[
         "uk:policies/govuk/carers-allowance#carers_allowance_annual_amount"
@@ -3536,6 +3550,8 @@ rules:
     assert min_hours["policyengine_parameter"] == "gov.dwp.carers_allowance.min_hours"
     assert min_hours["mapping_type"] == "parameter_value"
     assert min_hours["tested"] is True
+    assert weeks_in_year["status"] == "known_not_comparable"
+    assert weeks_in_year["mapping_type"] == "not_comparable"
     assert annual_amount["policyengine_variable"] == "carers_allowance"
     assert annual_amount["mapping_type"] == "direct_variable"
     assert annual_amount["tested"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.616"
+version = "0.2.617"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- marks the policy-level Carer's Allowance weeks-in-year helper as known-not-comparable
- keeps final annual Carer's Allowance coverage mapped to the PolicyEngine variable
- bumps axiom-encode to 0.2.617

## Tests
- uv run --extra dev --python 3.13 python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- uv run --extra dev --python 3.13 python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_carers_allowance_final_outputs -q