### PR TITLE
Add UK HBAI final oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.617"
+version = "0.2.618"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.618"
+version = "0.2.619"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.618"
+__version__ = "0.2.619"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.617"
+__version__ = "0.2.618"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -80,6 +80,8 @@ PENSION_CREDIT_SCHEDULE_IIA_PROGRAM_PATH = Path(
 PENSION_CREDIT_SCHEDULE_IIA_BASE = "uk:regulations/uksi/2002/1792/schedule/IIA"
 PENSION_CREDIT_REGULATION_15_PROGRAM_PATH = Path("regulations/uksi/2002/1792/15.yaml")
 PENSION_CREDIT_REGULATION_15_BASE = "uk:regulations/uksi/2002/1792/15"
+PENSION_CREDIT_FINAL_PROGRAM_PATH = Path("policies/govuk/pension-credit.yaml")
+PENSION_CREDIT_FINAL_BASE = "uk:policies/govuk/pension-credit"
 ESA_REGULATION_118_PROGRAM_PATH = Path("regulations/uksi/2008/794/118.yaml")
 ESA_REGULATION_118_BASE = "uk:regulations/uksi/2008/794/118"
 JSA_REGULATION_116_PROGRAM_PATH = Path("regulations/uksi/1996/207/116.yaml")
@@ -399,6 +401,14 @@ PENSION_CREDIT_DEEMED_INCOME_OUTPUTS = {
         "axiom": f"{PENSION_CREDIT_REGULATION_15_BASE}#capital_deemed_weekly_income",
         "pe": "pension_credit_deemed_income",
         "pe_transform": "annual_to_weekly",
+        "tolerance": 0.01,
+    },
+}
+
+PENSION_CREDIT_FINAL_OUTPUTS = {
+    "pension_credit_annual_amount": {
+        "axiom": f"{PENSION_CREDIT_FINAL_BASE}#pension_credit_annual_amount",
+        "pe": "pension_credit",
         "tolerance": 0.01,
     },
 }
@@ -941,6 +951,16 @@ SURFACE_SPECS = {
             "pension_credit_deemed_income",
         ),
     ),
+    "pension-credit-final": UKEFRSSurfaceSpec(
+        program=PENSION_CREDIT_FINAL_PROGRAM_PATH,
+        entity="benunit",
+        outputs=PENSION_CREDIT_FINAL_OUTPUTS,
+        pe_variables=(
+            "pension_credit",
+            "pension_credit_entitlement",
+            "would_claim_pc",
+        ),
+    ),
     "esa-income-tariff-income": UKEFRSSurfaceSpec(
         program=ESA_REGULATION_118_PROGRAM_PATH,
         entity="benunit",
@@ -1246,13 +1266,14 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom covers capital tariff income used inside income-based JSA, not the final JSA HBAI amount.",
     },
     "pension_credit": {
-        "status": "partial",
+        "status": "exact",
         "surfaces": (
             "state-pension-credit-guarantee-credit",
             "state-pension-credit-savings-credit",
             "pension-credit",
             "pension-credit-child-addition",
             "pension-credit-deemed-income",
+            "pension-credit-final",
         ),
         "covered_outputs": (
             "guarantee_credit",
@@ -1262,8 +1283,9 @@ HBAI_COMPONENT_COVERAGE = {
             "carer_minimum_guarantee_addition",
             "child_minimum_guarantee_addition",
             "pension_credit_deemed_income",
+            "pension_credit",
         ),
-        "rationale": "Axiom covers major Pension Credit rates, additions, and deemed-income components, not the final aggregate pension_credit variable.",
+        "rationale": "Axiom covers major Pension Credit rates, additions, deemed-income components, and the final annual PolicyEngine UK pension_credit wrapper after the would_claim_pc gate.",
     },
     "state_pension": {
         "status": "exact",
@@ -3626,6 +3648,8 @@ def build_axiom_request(
             pe_data=pe_data,
             year=year,
         )
+    if surface == "pension-credit-final":
+        return build_pension_credit_final_request(pe_data=pe_data, year=year)
     if surface == "esa-income-tariff-income":
         return build_esa_income_tariff_income_request(pe_data=pe_data, year=year)
     if surface == "jsa-income-tariff-income":
@@ -4415,6 +4439,40 @@ def build_legacy_weekly_tariff_income_request(
                 "entity_id": entity_id,
                 "period": interval,
                 "outputs": [spec["axiom"] for spec in outputs.values()],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_pension_credit_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "pension-credit-final"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_pension_credit_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{PENSION_CREDIT_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in PENSION_CREDIT_FINAL_OUTPUTS.values()
+                ],
             }
         )
 
@@ -5571,6 +5629,17 @@ def project_carers_allowance_final_inputs(row: Any, *, year: int) -> dict[str, A
     }
 
 
+def project_pension_credit_final_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "pension_credit_entitlement_for_year": money(
+            row_value(row, "pension_credit_entitlement", 0)
+        ),
+        "person_or_partner_would_claim_pension_credit": bool_row_value(
+            row, "would_claim_pc", False
+        ),
+    }
+
+
 def project_pension_credit_inputs(row: Any) -> dict[str, Any]:
     relation_type = str(row_value(row, "relation_type", "")).upper()
     is_couple = bool(row_value(row, "is_couple", False)) or relation_type == "COUPLE"
@@ -5731,6 +5800,13 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             if money(row_value(row, "carers_allowance", 0)) > 0
             or money(row_value(row, "carers_allowance_reported", 0)) > 0
             or money(row_value(row, "care_hours", 0)) >= 35
+        ]
+    if surface == "pension-credit-final":
+        return [
+            row
+            for row in benunits
+            if money(row_value(row, "pension_credit", 0)) > 0
+            or money(row_value(row, "pension_credit_entitlement", 0)) > 0
         ]
     if surface == "universal-credit-lcwra-element":
         return [
@@ -6363,6 +6439,28 @@ def row_value(row: Any, name: str, default: Any = None) -> Any:
     if hasattr(row, "get"):
         return row.get(name, default)
     return getattr(row, name, default)
+
+
+def bool_row_value(row: Any, name: str, default: bool = False) -> bool:
+    value = row_value(row, name, default)
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"", "nan", "none", "null"}:
+            return default
+        if normalized in {"true", "1", "yes", "y"}:
+            return True
+        if normalized in {"false", "0", "no", "n"}:
+            return False
+    try:
+        if math.isnan(value):
+            return default
+    except TypeError:
+        pass
+    return bool(value)
 
 
 def tax_year_interval(year: int) -> dict[str, str]:

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -122,6 +122,16 @@ STUDENT_LOAN_REPAYMENT_PROGRAM_PATH = Path(
 STUDENT_LOAN_REPAYMENT_BASE = "uk:policies/govuk/student-loan-repayments"
 CARERS_ALLOWANCE_FINAL_PROGRAM_PATH = Path("policies/govuk/carers-allowance.yaml")
 CARERS_ALLOWANCE_FINAL_BASE = "uk:policies/govuk/carers-allowance"
+CARER_SUPPORT_PAYMENT_FINAL_PROGRAM_PATH = Path(
+    "policies/govuk/carer-support-payment.yaml"
+)
+CARER_SUPPORT_PAYMENT_FINAL_BASE = "uk:policies/govuk/carer-support-payment"
+SCOTTISH_CHILD_PAYMENT_FINAL_PROGRAM_PATH = Path(
+    "policies/govuk/scottish-child-payment.yaml"
+)
+SCOTTISH_CHILD_PAYMENT_FINAL_BASE = "uk:policies/govuk/scottish-child-payment"
+SDA_FINAL_PROGRAM_PATH = Path("policies/govuk/severe-disablement-allowance.yaml")
+SDA_FINAL_BASE = "uk:policies/govuk/severe-disablement-allowance"
 
 PERSONAL_ALLOWANCE_OUTPUTS = {
     "personal_allowance": {
@@ -723,6 +733,31 @@ CARERS_ALLOWANCE_FINAL_OUTPUTS = {
     },
 }
 
+CARER_SUPPORT_PAYMENT_FINAL_OUTPUTS = {
+    "carer_support_payment_annual_amount": {
+        "axiom": (
+            f"{CARER_SUPPORT_PAYMENT_FINAL_BASE}#carer_support_payment_annual_amount"
+        ),
+        "pe": "carer_support_payment",
+    },
+}
+
+SCOTTISH_CHILD_PAYMENT_FINAL_OUTPUTS = {
+    "scottish_child_payment_annual_amount": {
+        "axiom": (
+            f"{SCOTTISH_CHILD_PAYMENT_FINAL_BASE}#scottish_child_payment_annual_amount"
+        ),
+        "pe": "scottish_child_payment",
+    },
+}
+
+SDA_FINAL_OUTPUTS = {
+    "severe_disablement_allowance_annual_amount": {
+        "axiom": (f"{SDA_FINAL_BASE}#severe_disablement_allowance_annual_amount"),
+        "pe": "sda",
+    },
+}
+
 
 @dataclass(frozen=True)
 class UKEFRSSurfaceSpec:
@@ -1211,6 +1246,36 @@ SURFACE_SPECS = {
             "country",
         ),
     ),
+    "carer-support-payment-final": UKEFRSSurfaceSpec(
+        program=CARER_SUPPORT_PAYMENT_FINAL_PROGRAM_PATH,
+        entity="person",
+        outputs=CARER_SUPPORT_PAYMENT_FINAL_OUTPUTS,
+        pe_variables=(
+            "care_hours",
+            "carer_support_payment",
+            "carers_allowance_reported",
+            "country",
+        ),
+    ),
+    "scottish-child-payment-final": UKEFRSSurfaceSpec(
+        program=SCOTTISH_CHILD_PAYMENT_FINAL_PROGRAM_PATH,
+        entity="person",
+        outputs=SCOTTISH_CHILD_PAYMENT_FINAL_OUTPUTS,
+        pe_variables=(
+            "is_scp_eligible",
+            "scottish_child_payment",
+            "would_claim_scp",
+        ),
+    ),
+    "severe-disablement-allowance-final": UKEFRSSurfaceSpec(
+        program=SDA_FINAL_PROGRAM_PATH,
+        entity="person",
+        outputs=SDA_FINAL_OUTPUTS,
+        pe_variables=(
+            "sda",
+            "sda_reported",
+        ),
+    ),
 }
 
 HBAI_FIXED_INPUT_COMPONENTS = frozenset(
@@ -1454,10 +1519,13 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom covers the weekly Carer's Allowance rate and the final annual PolicyEngine UK carers_allowance wrapper, including the care-hours or reported-receipt gate and the Scotland Carer Support Payment replacement gate.",
     },
     "sda": {
-        "status": "partial",
-        "surfaces": ("severe-disablement-allowance-rates",),
+        "status": "exact",
+        "surfaces": (
+            "severe-disablement-allowance-rates",
+            "severe-disablement-allowance-final",
+        ),
         "covered_outputs": ("sda",),
-        "rationale": "Axiom covers the Severe Disablement Allowance basic row and maximum weekly rate, not reported receipt or all age-related addition branches in the final SDA amount.",
+        "rationale": "Axiom covers the Severe Disablement Allowance maximum weekly rate and the final annual PolicyEngine UK sda wrapper over reported receipt.",
     },
     "ssmg": {
         "status": "partial",
@@ -1466,16 +1534,22 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom covers the Sure Start Maternity Grant amount, not the qualifying-benefit, pregnancy, child, prescribed-time, residence, or reported-receipt conditions feeding the final SSMG amount.",
     },
     "scottish_child_payment": {
-        "status": "partial",
-        "surfaces": ("scottish-child-payment-parameters",),
+        "status": "exact",
+        "surfaces": (
+            "scottish-child-payment-parameters",
+            "scottish-child-payment-final",
+        ),
         "covered_outputs": ("scottish_child_payment",),
-        "rationale": "Axiom covers the Scottish Child Payment weekly amount and child age threshold, not the qualifying benefits, residence, responsibility, application, take-up, or final annual amount.",
+        "rationale": "Axiom covers the Scottish Child Payment weekly amount, child age threshold, and final annual PolicyEngine UK scottish_child_payment wrapper after the eligibility and take-up gates.",
     },
     "carer_support_payment": {
-        "status": "partial",
-        "surfaces": ("carer-support-payment-parameters",),
+        "status": "exact",
+        "surfaces": (
+            "carer-support-payment-parameters",
+            "carer-support-payment-final",
+        ),
         "covered_outputs": ("carer_support_payment",),
-        "rationale": "Axiom covers the Carer Support Payment care-hours threshold, weekly rate, and Scottish Carer Supplement amount, not residence, cared-for-person, overlapping-benefit, or final annual amount rules.",
+        "rationale": "Axiom covers the Carer Support Payment care-hours threshold, weekly rate, Scottish Carer Supplement amount, and final annual PolicyEngine UK carer_support_payment wrapper after Scotland, effective-date, and care/reporting gates.",
     },
     "cost_of_living_support_payment": {
         "status": "partial",
@@ -3791,6 +3865,18 @@ def build_axiom_request(
         return build_student_loan_repayment_request(pe_data=pe_data, year=year)
     if surface == "carers-allowance-final":
         return build_carers_allowance_final_request(pe_data=pe_data, year=year)
+    if surface == "carer-support-payment-final":
+        return build_carer_support_payment_final_request(
+            pe_data=pe_data,
+            year=year,
+        )
+    if surface == "scottish-child-payment-final":
+        return build_scottish_child_payment_final_request(
+            pe_data=pe_data,
+            year=year,
+        )
+    if surface == "severe-disablement-allowance-final":
+        return build_sda_final_request(pe_data=pe_data, year=year)
     if surface in UNIVERSAL_CREDIT_REGULATION_36_SURFACES:
         return build_universal_credit_request(
             pe_data=pe_data,
@@ -5187,6 +5273,109 @@ def build_carers_allowance_final_request(
     }
 
 
+def build_carer_support_payment_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = uk_tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "carer-support-payment-final"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_carer_support_payment_final_inputs(
+            row,
+            year=year,
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{CARER_SUPPORT_PAYMENT_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in CARER_SUPPORT_PAYMENT_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_scottish_child_payment_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = uk_tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "scottish-child-payment-final"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_scottish_child_payment_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{SCOTTISH_CHILD_PAYMENT_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in SCOTTISH_CHILD_PAYMENT_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_sda_final_request(*, pe_data: dict[str, Any], year: int) -> dict[str, Any]:
+    interval = uk_tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "severe-disablement-allowance-final"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_sda_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{SDA_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [spec["axiom"] for spec in SDA_FINAL_OUTPUTS.values()],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def project_personal_allowance_inputs(row: Any) -> dict[str, Any]:
     adjusted_net_income = money(row_value(row, "adjusted_net_income"))
     gift_aid_grossed_up = money(row_value(row, "gift_aid_grossed_up", 0))
@@ -5788,6 +5977,45 @@ def project_carers_allowance_final_inputs(row: Any, *, year: int) -> dict[str, A
     }
 
 
+def project_carer_support_payment_final_inputs(
+    row: Any,
+    *,
+    year: int,
+) -> dict[str, Any]:
+    country = enum_name(row_value(row, "country", "")).upper()
+    return {
+        "person_is_in_scotland": country == "SCOTLAND",
+        "carer_support_payment_in_effect": year >= 2025,
+        "weekly_care_hours": money(row_value(row, "care_hours", 0)),
+        "reported_carers_allowance_for_year": money(
+            row_value(row, "carers_allowance_reported", 0)
+        ),
+    }
+
+
+def project_scottish_child_payment_final_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "is_scottish_child_payment_eligible": bool_row_value(
+            row,
+            "is_scp_eligible",
+            False,
+        ),
+        "would_claim_scottish_child_payment": bool_row_value(
+            row,
+            "would_claim_scp",
+            False,
+        ),
+    }
+
+
+def project_sda_final_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "reported_severe_disablement_allowance_for_year": money(
+            row_value(row, "sda_reported", 0)
+        ),
+    }
+
+
 def project_pension_credit_final_inputs(row: Any) -> dict[str, Any]:
     return {
         "pension_credit_entitlement_for_year": money(
@@ -5973,6 +6201,34 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             if money(row_value(row, "carers_allowance", 0)) > 0
             or money(row_value(row, "carers_allowance_reported", 0)) > 0
             or money(row_value(row, "care_hours", 0)) >= 35
+        ]
+    if surface == "carer-support-payment-final":
+        return [
+            row
+            for row in persons
+            if money(row_value(row, "carer_support_payment", 0)) > 0
+            or (
+                enum_name(row_value(row, "country", "")).upper() == "SCOTLAND"
+                and (
+                    money(row_value(row, "carers_allowance_reported", 0)) > 0
+                    or money(row_value(row, "care_hours", 0)) >= 35
+                )
+            )
+        ]
+    if surface == "scottish-child-payment-final":
+        return [
+            row
+            for row in persons
+            if money(row_value(row, "scottish_child_payment", 0)) > 0
+            or bool_row_value(row, "is_scp_eligible", False)
+            or bool_row_value(row, "would_claim_scp", False)
+        ]
+    if surface == "severe-disablement-allowance-final":
+        return [
+            row
+            for row in persons
+            if money(row_value(row, "sda", 0)) > 0
+            or money(row_value(row, "sda_reported", 0)) > 0
         ]
     if surface == "pension-credit-final":
         return [

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -84,6 +84,8 @@ PENSION_CREDIT_FINAL_PROGRAM_PATH = Path("policies/govuk/pension-credit.yaml")
 PENSION_CREDIT_FINAL_BASE = "uk:policies/govuk/pension-credit"
 ESA_REGULATION_118_PROGRAM_PATH = Path("regulations/uksi/2008/794/118.yaml")
 ESA_REGULATION_118_BASE = "uk:regulations/uksi/2008/794/118"
+ESA_FINAL_PROGRAM_PATH = Path("policies/govuk/esa-income.yaml")
+ESA_FINAL_BASE = "uk:policies/govuk/esa-income"
 JSA_REGULATION_116_PROGRAM_PATH = Path("regulations/uksi/1996/207/116.yaml")
 JSA_REGULATION_116_BASE = "uk:regulations/uksi/1996/207/116"
 INCOME_SUPPORT_REGULATION_53_PROGRAM_PATH = Path("regulations/uksi/1987/1967/53.yaml")
@@ -94,6 +96,8 @@ HOUSING_BENEFIT_PENSION_AGE_REGULATION_29_PROGRAM_PATH = Path(
     "regulations/uksi/2006/214/29.yaml"
 )
 HOUSING_BENEFIT_PENSION_AGE_REGULATION_29_BASE = "uk:regulations/uksi/2006/214/29"
+HOUSING_BENEFIT_FINAL_PROGRAM_PATH = Path("policies/govuk/housing-benefit.yaml")
+HOUSING_BENEFIT_FINAL_BASE = "uk:policies/govuk/housing-benefit"
 UNIVERSAL_CREDIT_PROGRAM_PATH = Path("regulations/uksi/2013/376/36.yaml")
 UNIVERSAL_CREDIT_BASE = "uk:regulations/uksi/2013/376/36"
 UNIVERSAL_CREDIT_REGULATION_18_PROGRAM_PATH = Path("regulations/uksi/2013/376/18.yaml")
@@ -423,6 +427,14 @@ ESA_TARIFF_INCOME_OUTPUTS = {
     },
 }
 
+ESA_FINAL_OUTPUTS = {
+    "income_related_esa_annual_amount": {
+        "axiom": f"{ESA_FINAL_BASE}#income_related_esa_annual_amount",
+        "pe": "esa_income",
+        "tolerance": 0.01,
+    },
+}
+
 JSA_TARIFF_INCOME_OUTPUTS = {
     "capital_tariff_weekly_income": {
         "axiom": f"{JSA_REGULATION_116_BASE}#capital_tariff_weekly_income",
@@ -462,6 +474,14 @@ HOUSING_BENEFIT_PENSION_AGE_TARIFF_INCOME_OUTPUTS = {
         "pe": "housing_benefit_tariff_income",
         "pe_transform": "annual_to_weekly",
         "applies": "housing_benefit_pension_age_tariff_income_defined",
+    },
+}
+
+HOUSING_BENEFIT_FINAL_OUTPUTS = {
+    "housing_benefit_annual_amount": {
+        "axiom": f"{HOUSING_BENEFIT_FINAL_BASE}#housing_benefit_annual_amount",
+        "pe": "housing_benefit",
+        "tolerance": 0.01,
     },
 }
 
@@ -970,6 +990,17 @@ SURFACE_SPECS = {
             "esa_income_tariff_income",
         ),
     ),
+    "esa-income-final": UKEFRSSurfaceSpec(
+        program=ESA_FINAL_PROGRAM_PATH,
+        entity="benunit",
+        outputs=ESA_FINAL_OUTPUTS,
+        pe_variables=(
+            "esa_income",
+            "esa_income_eligible",
+            "esa_income_tariff_income",
+        ),
+        projection_person_variables=("esa_income_reported",),
+    ),
     "jsa-income-tariff-income": UKEFRSSurfaceSpec(
         program=JSA_REGULATION_116_PROGRAM_PATH,
         entity="benunit",
@@ -1009,6 +1040,17 @@ SURFACE_SPECS = {
             "housing_benefit_tariff_income",
         ),
         projection_person_variables=("is_SP_age",),
+    ),
+    "housing-benefit-final": UKEFRSSurfaceSpec(
+        program=HOUSING_BENEFIT_FINAL_PROGRAM_PATH,
+        entity="benunit",
+        outputs=HOUSING_BENEFIT_FINAL_OUTPUTS,
+        pe_variables=(
+            "benefit_cap_reduction",
+            "housing_benefit",
+            "housing_benefit_pre_benefit_cap",
+            "would_claim_housing_benefit",
+        ),
     ),
     "universal-credit-standard-allowance": UKEFRSSurfaceSpec(
         program=UNIVERSAL_CREDIT_PROGRAM_PATH,
@@ -1239,19 +1281,23 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom covers per-child Child Benefit rates, section 141 weekly entitlement, and the final gross benefit-unit Child Benefit receipt after PolicyEngine UK's would_claim_child_benefit gate.",
     },
     "esa_income": {
-        "status": "partial",
-        "surfaces": ("esa-income-tariff-income",),
-        "covered_outputs": ("esa_income_tariff_income",),
-        "rationale": "Axiom covers capital tariff income used inside income-related ESA, not the final ESA HBAI amount.",
+        "status": "exact",
+        "surfaces": ("esa-income-tariff-income", "esa-income-final"),
+        "covered_outputs": ("esa_income_tariff_income", "esa_income"),
+        "rationale": "Axiom covers capital tariff income used inside income-related ESA and the final annual PolicyEngine UK esa_income wrapper over reported ESA, tariff income, and the eligibility gate.",
     },
     "housing_benefit": {
-        "status": "partial",
+        "status": "exact",
         "surfaces": (
             "housing-benefit-working-age-tariff-income",
             "housing-benefit-pension-age-tariff-income",
+            "housing-benefit-final",
         ),
-        "covered_outputs": ("housing_benefit_tariff_income",),
-        "rationale": "Axiom covers Housing Benefit capital tariff income branches, not the final Housing Benefit HBAI amount.",
+        "covered_outputs": (
+            "housing_benefit_tariff_income",
+            "housing_benefit",
+        ),
+        "rationale": "Axiom covers Housing Benefit capital tariff income branches and the final annual PolicyEngine UK housing_benefit wrapper after the claim gate and benefit-cap reduction.",
     },
     "income_support": {
         "status": "partial",
@@ -2167,6 +2213,10 @@ def load_local_policyengine_uk_data(
             merged_benunits,
             merged,
         )
+        merged_benunits = add_esa_income_reported_projection_columns(
+            merged_benunits,
+            merged,
+        )
         merged_benunits = add_housing_benefit_age_projection_columns(
             merged_benunits,
             merged,
@@ -2313,6 +2363,31 @@ def add_housing_benefit_age_projection_columns(
     merged["housing_benefit_any_over_sp_age"] = merged[
         "housing_benefit_any_over_sp_age"
     ].fillna(False)
+    return merged
+
+
+def add_esa_income_reported_projection_columns(
+    benunit: Any,
+    person: Any,
+) -> Any:
+    required = {"person_benunit_id", "esa_income_reported"}
+    if not required.issubset(set(person.columns)):
+        return benunit
+    projection = person[["person_benunit_id"]].copy()
+    projection["esa_income_reported_for_year"] = (
+        person["esa_income_reported"].fillna(0).astype(float)
+    )
+    by_benunit = projection.groupby("person_benunit_id", dropna=False).sum()
+    by_benunit = by_benunit[["esa_income_reported_for_year"]].reset_index()
+    merged = benunit.merge(
+        by_benunit,
+        left_on="benunit_id",
+        right_on="person_benunit_id",
+        how="left",
+    ).drop(columns=["person_benunit_id"], errors="ignore")
+    merged["esa_income_reported_for_year"] = merged[
+        "esa_income_reported_for_year"
+    ].fillna(0)
     return merged
 
 
@@ -3652,6 +3727,8 @@ def build_axiom_request(
         return build_pension_credit_final_request(pe_data=pe_data, year=year)
     if surface == "esa-income-tariff-income":
         return build_esa_income_tariff_income_request(pe_data=pe_data, year=year)
+    if surface == "esa-income-final":
+        return build_esa_income_final_request(pe_data=pe_data, year=year)
     if surface == "jsa-income-tariff-income":
         return build_jsa_income_tariff_income_request(pe_data=pe_data, year=year)
     if surface == "income-support-tariff-income":
@@ -3669,6 +3746,8 @@ def build_axiom_request(
             pe_data=pe_data,
             year=year,
         )
+    if surface == "housing-benefit-final":
+        return build_housing_benefit_final_request(pe_data=pe_data, year=year)
     if surface == "universal-credit-childcare-element":
         return build_universal_credit_childcare_element_request(
             pe_data=pe_data,
@@ -4496,6 +4575,38 @@ def build_esa_income_tariff_income_request(
     )
 
 
+def build_esa_income_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "esa-income-final"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_esa_income_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{ESA_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [spec["axiom"] for spec in ESA_FINAL_OUTPUTS.values()],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def build_jsa_income_tariff_income_request(
     *, pe_data: dict[str, Any], year: int
 ) -> dict[str, Any]:
@@ -4546,6 +4657,40 @@ def build_housing_benefit_pension_age_tariff_income_request(
         outputs=HOUSING_BENEFIT_PENSION_AGE_TARIFF_INCOME_OUTPUTS,
         project_inputs=project_housing_benefit_pension_age_tariff_income_inputs,
     )
+
+
+def build_housing_benefit_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "housing-benefit-final"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_housing_benefit_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{HOUSING_BENEFIT_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in HOUSING_BENEFIT_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
 
 
 def build_state_pension_credit_guarantee_credit_request(
@@ -5560,6 +5705,20 @@ def project_housing_benefit_pension_age_tariff_income_inputs(
     }
 
 
+def project_housing_benefit_final_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "housing_benefit_pre_benefit_cap_for_year": money(
+            row_value(row, "housing_benefit_pre_benefit_cap", 0)
+        ),
+        "benefit_cap_reduction_for_year": money(
+            row_value(row, "benefit_cap_reduction", 0)
+        ),
+        "would_claim_housing_benefit": bool_row_value(
+            row, "would_claim_housing_benefit", False
+        ),
+    }
+
+
 def project_universal_credit_assessable_capital_inputs(row: Any) -> dict[str, Any]:
     return {
         "claim_is_for_joint_claimants": False,
@@ -5636,6 +5795,20 @@ def project_pension_credit_final_inputs(row: Any) -> dict[str, Any]:
         ),
         "person_or_partner_would_claim_pension_credit": bool_row_value(
             row, "would_claim_pc", False
+        ),
+    }
+
+
+def project_esa_income_final_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "reported_income_related_esa_for_year": money(
+            row_value(row, "esa_income_reported_for_year", 0)
+        ),
+        "income_related_esa_tariff_income_for_year": money(
+            row_value(row, "esa_income_tariff_income", 0)
+        ),
+        "income_related_esa_eligible": bool_row_value(
+            row, "esa_income_eligible", False
         ),
     }
 
@@ -5807,6 +5980,22 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             for row in benunits
             if money(row_value(row, "pension_credit", 0)) > 0
             or money(row_value(row, "pension_credit_entitlement", 0)) > 0
+        ]
+    if surface == "esa-income-final":
+        return [
+            row
+            for row in benunits
+            if money(row_value(row, "esa_income", 0)) > 0
+            or money(row_value(row, "esa_income_reported_for_year", 0)) > 0
+            or money(row_value(row, "esa_income_tariff_income", 0)) > 0
+        ]
+    if surface == "housing-benefit-final":
+        return [
+            row
+            for row in benunits
+            if money(row_value(row, "housing_benefit", 0)) > 0
+            or money(row_value(row, "housing_benefit_pre_benefit_cap", 0)) > 0
+            or money(row_value(row, "benefit_cap_reduction", 0)) > 0
         ]
     if surface == "universal-credit-lcwra-element":
         return [

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1645,6 +1645,17 @@ mappings:
     comparison: money
     rationale: Same income-related ESA tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit esa_income_assessable_capital into the Regulation 118 claimant-capital leaf, sets the prescribed-accommodation branch false because PolicyEngine does not expose that legal predicate, limits comparison to capital at or below GBP 16,000, and converts PolicyEngine's annual output to a weekly amount.
 
+  - legal_id: uk:policies/govuk/esa-income#income_related_esa_annual_amount
+    country: uk
+    program: employment_and_support_allowance
+    mapping_type: direct_variable
+    policyengine_variable: esa_income
+    entity: benunit
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final annual income-related ESA amount after PolicyEngine UK's capital-test eligibility gate and tariff-income reduction over reported ESA.
+
   - legal_id: uk:regulations/uksi/1996/207/116#capital_tariff_weekly_income
     country: uk
     program: jobseekers_allowance
@@ -1688,6 +1699,17 @@ mappings:
     unit: GBP
     comparison: money
     rationale: Same pension-age Housing Benefit tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit housing_benefit_assessable_capital into the Regulation 29 claimant-capital leaf, projects the regulation 44(2) capital-disregard exception false because PolicyEngine applies capital exclusions upstream, limits comparison to pension-age rows without guarantee credit, and converts PolicyEngine's annual output to a weekly amount.
+
+  - legal_id: uk:policies/govuk/housing-benefit#housing_benefit_annual_amount
+    country: uk
+    program: housing_benefit
+    mapping_type: direct_variable
+    policyengine_variable: housing_benefit
+    entity: benunit
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final annual Housing Benefit amount after PolicyEngine UK's would-claim gate and benefit-cap reduction over pre-cap Housing Benefit.
 
   - legal_id: uk:statutes/ukpga/2002/16/1#qualifying_age
     country: uk

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1062,6 +1062,24 @@ mappings:
     comparison: number
     rationale: Regulation 18 requires the child to be under 16; PolicyEngine stores the same threshold as the maximum child age parameter.
 
+  - legal_id: uk:policies/govuk/scottish-child-payment#scottish_child_payment_weeks_in_year
+    country: uk
+    program: scottish_child_payment
+    mapping_type: not_comparable
+    comparable: false
+    candidate_priority: P4
+    rationale: Source-backed annualization helper for the policy-level final amount wrapper; PolicyEngine exposes the final annual Scottish Child Payment variable and the weekly amount parameter, not this multiplication factor as a separate oracle target.
+
+  - legal_id: uk:policies/govuk/scottish-child-payment#scottish_child_payment_annual_amount
+    country: uk
+    program: scottish_child_payment
+    mapping_type: direct_variable
+    policyengine_variable: scottish_child_payment
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Final annual Scottish Child Payment output is the same PolicyEngine UK variable after eligibility and take-up gates.
+
   - legal_id: uk:regulations/ssi/2023/302/5#carer_support_payment_minimum_weekly_care_hours
     country: uk
     program: carer_support_payment
@@ -1091,6 +1109,24 @@ mappings:
     unit: GBP
     comparison: money
     rationale: Same weekly Scottish Carer Supplement amount paid on top of Carer Support Payment.
+
+  - legal_id: uk:policies/govuk/carer-support-payment#carer_support_payment_weeks_in_year
+    country: uk
+    program: carer_support_payment
+    mapping_type: not_comparable
+    comparable: false
+    candidate_priority: P4
+    rationale: Source-backed annualization helper for the policy-level final amount wrapper; PolicyEngine exposes the final annual Carer Support Payment variable and the weekly rate parameters, not this multiplication factor as a separate oracle target.
+
+  - legal_id: uk:policies/govuk/carer-support-payment#carer_support_payment_annual_amount
+    country: uk
+    program: carer_support_payment
+    mapping_type: direct_variable
+    policyengine_variable: carer_support_payment
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Final annual Carer Support Payment output is the same PolicyEngine UK variable after Scotland, effective-date, and care/reporting gates.
 
   - legal_id: uk:statutes/ukpga/2022/38/1#means_tested_additional_payment_total
     country: uk
@@ -1497,6 +1533,24 @@ mappings:
     unit: GBP
     comparison: money
     rationale: Same weekly maximum Severe Disablement Allowance rate after deriving PolicyEngine's maximum-rate shape as the basic SDA row plus the highest age-related addition.
+
+  - legal_id: uk:policies/govuk/severe-disablement-allowance#severe_disablement_allowance_weeks_in_year
+    country: uk
+    program: sda
+    mapping_type: not_comparable
+    comparable: false
+    candidate_priority: P4
+    rationale: Source-backed annualization helper for the policy-level final amount wrapper; PolicyEngine exposes the final annual Severe Disablement Allowance variable and the weekly maximum rate parameter, not this multiplication factor as a separate oracle target.
+
+  - legal_id: uk:policies/govuk/severe-disablement-allowance#severe_disablement_allowance_annual_amount
+    country: uk
+    program: sda
+    mapping_type: direct_variable
+    policyengine_variable: sda
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Final annual Severe Disablement Allowance output is the same PolicyEngine UK variable over reported SDA receipt.
 
   - legal_id: uk:regulations/uksi/2026/148/schedule/1#carers_allowance_weekly_rate
     country: uk

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -709,6 +709,17 @@ mappings:
     comparison: money
     rationale: Same final annual Universal Credit receipt for the benefit unit after PolicyEngine UK's would_claim_uc gate and benefit-cap reduction.
 
+  - legal_id: uk:policies/govuk/pension-credit#pension_credit_annual_amount
+    country: uk
+    program: pension_credit
+    mapping_type: direct_variable
+    policyengine_variable: pension_credit
+    entity: benunit
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final annual Pension Credit receipt for the benefit unit after PolicyEngine UK's would_claim_pc gate over pension_credit_entitlement.
+
   - legal_id: uk:regulations/uksi/2002/1792/6#standard_minimum_guarantee_with_partner
     country: uk
     program: pension_credit

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3557,6 +3557,52 @@ rules:
     assert annual_amount["tested"] is True
 
 
+def test_policyengine_coverage_classifies_uk_pension_credit_final_output(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/pension-credit.yaml",
+        """format: rulespec/v1
+rules:
+  - name: pension_credit_annual_amount
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if person_or_partner_would_claim_pension_credit: pension_credit_entitlement_for_year else: 0
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/pension-credit.test.yaml",
+        """- name: pension credit final annual amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    uk:policies/govuk/pension-credit#input.pension_credit_entitlement_for_year: 3400.00
+    uk:policies/govuk/pension-credit#input.person_or_partner_would_claim_pension_credit: true
+  output:
+    uk:policies/govuk/pension-credit#pension_credit_annual_amount: 3400.00
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="pension_credit")
+
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    final_amount = items_by_id[
+        "uk:policies/govuk/pension-credit#pension_credit_annual_amount"
+    ]
+
+    assert final_amount["policyengine_variable"] == "pension_credit"
+    assert final_amount["mapping_type"] == "direct_variable"
+    assert final_amount["tested"] is True
+
+
 @pytest.mark.parametrize(
     (
         "path",

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3603,6 +3603,103 @@ rules:
     assert final_amount["tested"] is True
 
 
+def test_policyengine_coverage_classifies_uk_esa_income_final_output(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/esa-income.yaml",
+        """format: rulespec/v1
+rules:
+  - name: income_related_esa_annual_amount
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if income_related_esa_eligible: max(0, reported_income_related_esa_for_year - income_related_esa_tariff_income_for_year) else: 0
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/esa-income.test.yaml",
+        """- name: income related ESA final annual amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    uk:policies/govuk/esa-income#input.reported_income_related_esa_for_year: 2600.00
+    uk:policies/govuk/esa-income#input.income_related_esa_tariff_income_for_year: 520.00
+    uk:policies/govuk/esa-income#input.income_related_esa_eligible: true
+  output:
+    uk:policies/govuk/esa-income#income_related_esa_annual_amount: 2080.00
+""",
+    )
+
+    report = build_policyengine_coverage_report(
+        tmp_path,
+        program="employment_and_support_allowance",
+    )
+
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    final_amount = items_by_id[
+        "uk:policies/govuk/esa-income#income_related_esa_annual_amount"
+    ]
+
+    assert final_amount["policyengine_variable"] == "esa_income"
+    assert final_amount["mapping_type"] == "direct_variable"
+    assert final_amount["tested"] is True
+
+
+def test_policyengine_coverage_classifies_uk_housing_benefit_final_output(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/housing-benefit.yaml",
+        """format: rulespec/v1
+rules:
+  - name: housing_benefit_annual_amount
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if would_claim_housing_benefit: max(0, housing_benefit_pre_benefit_cap_for_year - benefit_cap_reduction_for_year) else: 0
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/housing-benefit.test.yaml",
+        """- name: housing benefit final annual amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    uk:policies/govuk/housing-benefit#input.housing_benefit_pre_benefit_cap_for_year: 5200.00
+    uk:policies/govuk/housing-benefit#input.benefit_cap_reduction_for_year: 1040.00
+    uk:policies/govuk/housing-benefit#input.would_claim_housing_benefit: true
+  output:
+    uk:policies/govuk/housing-benefit#housing_benefit_annual_amount: 4160.00
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="housing_benefit")
+
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    final_amount = items_by_id[
+        "uk:policies/govuk/housing-benefit#housing_benefit_annual_amount"
+    ]
+
+    assert final_amount["policyengine_variable"] == "housing_benefit"
+    assert final_amount["mapping_type"] == "direct_variable"
+    assert final_amount["tested"] is True
+
+
 @pytest.mark.parametrize(
     (
         "path",

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -3700,6 +3700,207 @@ rules:
     assert final_amount["tested"] is True
 
 
+def test_policyengine_coverage_classifies_uk_carer_support_payment_final_output(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/carer-support-payment.yaml",
+        """format: rulespec/v1
+rules:
+  - name: carer_support_payment_weeks_in_year
+    kind: parameter
+    entity: Person
+    dtype: Count
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 52
+  - name: carer_support_payment_annual_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if person_is_in_scotland and carer_support_payment_in_effect and (weekly_care_hours >= 35 or reported_carers_allowance_for_year > 0): 98.15 * carer_support_payment_weeks_in_year else: 0
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/carer-support-payment.test.yaml",
+        """- name: carer support payment final annual amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    uk:policies/govuk/carer-support-payment#input.person_is_in_scotland: true
+    uk:policies/govuk/carer-support-payment#input.carer_support_payment_in_effect: true
+    uk:policies/govuk/carer-support-payment#input.weekly_care_hours: 35
+    uk:policies/govuk/carer-support-payment#input.reported_carers_allowance_for_year: 0
+  output:
+    uk:policies/govuk/carer-support-payment#carer_support_payment_weeks_in_year: 52
+    uk:policies/govuk/carer-support-payment#carer_support_payment_annual_amount: 5103.80
+""",
+    )
+
+    report = build_policyengine_coverage_report(
+        tmp_path,
+        program="carer_support_payment",
+    )
+
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 1,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    weeks_in_year = items_by_id[
+        "uk:policies/govuk/carer-support-payment#carer_support_payment_weeks_in_year"
+    ]
+    final_amount = items_by_id[
+        "uk:policies/govuk/carer-support-payment#carer_support_payment_annual_amount"
+    ]
+
+    assert weeks_in_year["status"] == "known_not_comparable"
+    assert weeks_in_year["mapping_type"] == "not_comparable"
+    assert final_amount["policyengine_variable"] == "carer_support_payment"
+    assert final_amount["mapping_type"] == "direct_variable"
+    assert final_amount["tested"] is True
+
+
+def test_policyengine_coverage_classifies_uk_scottish_child_payment_final_output(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/scottish-child-payment.yaml",
+        """format: rulespec/v1
+rules:
+  - name: scottish_child_payment_weeks_in_year
+    kind: parameter
+    entity: Person
+    dtype: Count
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 52
+  - name: scottish_child_payment_annual_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if is_scottish_child_payment_eligible and would_claim_scottish_child_payment: 28.20 * scottish_child_payment_weeks_in_year else: 0
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/scottish-child-payment.test.yaml",
+        """- name: scottish child payment final annual amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    uk:policies/govuk/scottish-child-payment#input.is_scottish_child_payment_eligible: true
+    uk:policies/govuk/scottish-child-payment#input.would_claim_scottish_child_payment: true
+  output:
+    uk:policies/govuk/scottish-child-payment#scottish_child_payment_weeks_in_year: 52
+    uk:policies/govuk/scottish-child-payment#scottish_child_payment_annual_amount: 1466.40
+""",
+    )
+
+    report = build_policyengine_coverage_report(
+        tmp_path,
+        program="scottish_child_payment",
+    )
+
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 1,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    weeks_in_year = items_by_id[
+        "uk:policies/govuk/scottish-child-payment#scottish_child_payment_weeks_in_year"
+    ]
+    final_amount = items_by_id[
+        "uk:policies/govuk/scottish-child-payment#scottish_child_payment_annual_amount"
+    ]
+
+    assert weeks_in_year["status"] == "known_not_comparable"
+    assert weeks_in_year["mapping_type"] == "not_comparable"
+    assert final_amount["policyengine_variable"] == "scottish_child_payment"
+    assert final_amount["mapping_type"] == "direct_variable"
+    assert final_amount["tested"] is True
+
+
+def test_policyengine_coverage_classifies_uk_sda_final_output(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/severe-disablement-allowance.yaml",
+        """format: rulespec/v1
+rules:
+  - name: severe_disablement_allowance_weeks_in_year
+    kind: parameter
+    entity: Person
+    dtype: Count
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 52
+  - name: severe_disablement_allowance_annual_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: GBP
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if reported_severe_disablement_allowance_for_year > 0: 119.35 * severe_disablement_allowance_weeks_in_year else: 0
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-uk"
+        / "policies/govuk/severe-disablement-allowance.test.yaml",
+        """- name: severe disablement allowance final annual amount
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    uk:policies/govuk/severe-disablement-allowance#input.reported_severe_disablement_allowance_for_year: 6206.20
+  output:
+    uk:policies/govuk/severe-disablement-allowance#severe_disablement_allowance_weeks_in_year: 52
+    uk:policies/govuk/severe-disablement-allowance#severe_disablement_allowance_annual_amount: 6206.20
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="sda")
+
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 1,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    weeks_in_year = items_by_id[
+        "uk:policies/govuk/severe-disablement-allowance#severe_disablement_allowance_weeks_in_year"
+    ]
+    final_amount = items_by_id[
+        "uk:policies/govuk/severe-disablement-allowance#severe_disablement_allowance_annual_amount"
+    ]
+
+    assert weeks_in_year["status"] == "known_not_comparable"
+    assert weeks_in_year["mapping_type"] == "not_comparable"
+    assert final_amount["policyengine_variable"] == "sda"
+    assert final_amount["mapping_type"] == "direct_variable"
+    assert final_amount["tested"] is True
+
+
 @pytest.mark.parametrize(
     (
         "path",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -48,6 +48,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     PENSION_CREDIT_BASE,
     PENSION_CREDIT_CHILD_ADDITION_OUTPUTS,
     PENSION_CREDIT_DEEMED_INCOME_OUTPUTS,
+    PENSION_CREDIT_FINAL_BASE,
+    PENSION_CREDIT_FINAL_OUTPUTS,
     PENSION_CREDIT_OUTPUTS,
     PENSION_CREDIT_REGULATION_15_BASE,
     PENSION_CREDIT_SCHEDULE_IIA_BASE,
@@ -104,6 +106,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_national_insurance_final_request,
     build_pension_credit_child_addition_request,
     build_pension_credit_deemed_income_request,
+    build_pension_credit_final_request,
     build_pension_credit_request,
     build_personal_allowance_request,
     build_state_pension_credit_guarantee_credit_request,
@@ -146,6 +149,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_national_insurance_final_inputs,
     project_pension_credit_child_addition_inputs,
     project_pension_credit_deemed_income_inputs,
+    project_pension_credit_final_inputs,
     project_pension_credit_inputs,
     project_personal_allowance_inputs,
     project_state_pension_credit_guarantee_credit_inputs,
@@ -2284,6 +2288,73 @@ def test_carers_allowance_final_request_projects_final_inputs():
     ] == {"kind": "decimal", "value": "0.0"}
 
 
+def test_pension_credit_final_projection_uses_entitlement_components():
+    assert project_pension_credit_final_inputs(
+        {
+            "pension_credit_entitlement": 2_825,
+            "would_claim_pc": False,
+        }
+    ) == {
+        "pension_credit_entitlement_for_year": 2_825.0,
+        "person_or_partner_would_claim_pension_credit": False,
+    }
+    assert project_pension_credit_final_inputs(
+        {
+            "pension_credit_entitlement": 2_825,
+            "would_claim_pc": float("nan"),
+        }
+    )["person_or_partner_would_claim_pension_credit"] is False
+
+
+def test_pension_credit_final_request_projects_final_inputs():
+    request = build_pension_credit_final_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "pension_credit_entitlement": 3_400,
+                    "pension_credit": 3_400,
+                    "would_claim_pc": True,
+                },
+                {
+                    "benunit_id": 12,
+                    "pension_credit_entitlement": 0,
+                    "pension_credit": 0,
+                    "would_claim_pc": False,
+                },
+            ],
+            "benunit_ids": [11, 12],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_11",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": [
+                PENSION_CREDIT_FINAL_OUTPUTS["pension_credit_annual_amount"]["axiom"]
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{PENSION_CREDIT_FINAL_BASE}#input.pension_credit_entitlement_for_year:benunit_11"
+    ] == {"kind": "decimal", "value": "3400.0"}
+    assert inputs[
+        f"{PENSION_CREDIT_FINAL_BASE}#input.person_or_partner_would_claim_pension_credit:benunit_11"
+    ] == {"kind": "bool", "value": True}
+
+
 def test_universal_credit_childcare_element_projection_reverses_rate_and_cap():
     projected = project_universal_credit_childcare_element_inputs(
         {
@@ -3238,6 +3309,11 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "pension_credit_income",
         "standard_minimum_guarantee",
     )
+    assert policyengine_benunit_variables_for_surfaces(["pension-credit-final"]) == (
+        "pension_credit",
+        "pension_credit_entitlement",
+        "would_claim_pc",
+    )
     assert policyengine_benunit_variables_for_surfaces(["state-pension-final"]) == ()
     assert policyengine_benunit_variables_for_surfaces(
         ["benefit-cap-relevant-amount"]
@@ -3505,6 +3581,7 @@ class hbai_household_net_income(Variable):
         "child_benefit",
         "esa_contrib",
         "universal_credit",
+        "pension_credit",
         "working_tax_credit",
         "child_tax_credit",
         "tax_free_childcare",
@@ -3553,6 +3630,7 @@ class hbai_household_net_income(Variable):
         "child_benefit",
         "esa_contrib",
         "universal_credit",
+        "pension_credit",
         "working_tax_credit",
         "child_tax_credit",
         "tax_free_childcare",
@@ -3676,6 +3754,25 @@ class hbai_household_net_income(Variable):
         "uc_tariff_income",
         "universal_credit",
     )
+    assert by_name["pension_credit"].status == "exact"
+    assert by_name["pension_credit"].surfaces == (
+        "state-pension-credit-guarantee-credit",
+        "state-pension-credit-savings-credit",
+        "pension-credit",
+        "pension-credit-child-addition",
+        "pension-credit-deemed-income",
+        "pension-credit-final",
+    )
+    assert by_name["pension_credit"].covered_outputs == (
+        "guarantee_credit",
+        "savings_credit",
+        "standard_minimum_guarantee",
+        "severe_disability_minimum_guarantee_addition",
+        "carer_minimum_guarantee_addition",
+        "child_minimum_guarantee_addition",
+        "pension_credit_deemed_income",
+        "pension_credit",
+    )
     assert by_name["working_tax_credit"].status == "partial"
     assert by_name["child_tax_credit"].status == "partial"
     assert by_name["tax_free_childcare"].status == "partial"
@@ -3702,11 +3799,11 @@ class hbai_household_net_income(Variable):
     assert by_name["council_tax"].policy_component is False
     assert by_name["domestic_rates"].status == "fixed_input"
     assert by_name["domestic_rates"].policy_component is False
-    assert report.policy_component_count == 20
-    assert report.covered_policy_component_count == 20
-    assert report.exact_policy_component_count == 7
+    assert report.policy_component_count == 21
+    assert report.covered_policy_component_count == 21
+    assert report.exact_policy_component_count == 8
     assert report.covered_policy_component_share == 1
-    assert math.isclose(report.exact_policy_component_share, 7 / 20)
+    assert math.isclose(report.exact_policy_component_share, 8 / 21)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(
@@ -4261,6 +4358,39 @@ def test_compare_outputs_compares_carers_allowance_final_annual_amount():
                         CARERS_ALLOWANCE_FINAL_OUTPUTS[
                             "carers_allowance_annual_amount"
                         ]["axiom"]: decimal_output(4_495.40),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_pension_credit_final_annual_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "pension_credit": 3_400,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "pension-credit-final": [
+                {
+                    "outputs": {
+                        PENSION_CREDIT_FINAL_OUTPUTS[
+                            "pension_credit_annual_amount"
+                        ]["axiom"]: decimal_output(3_400),
                     }
                 }
             ]

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -16,8 +16,12 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     CHILD_BENEFIT_FINAL_OUTPUTS,
     CHILD_BENEFIT_OUTPUTS,
     CHILD_BENEFIT_SECTION_141_BASE,
+    ESA_FINAL_BASE,
+    ESA_FINAL_OUTPUTS,
     ESA_REGULATION_118_BASE,
     ESA_TARIFF_INCOME_OUTPUTS,
+    HOUSING_BENEFIT_FINAL_BASE,
+    HOUSING_BENEFIT_FINAL_OUTPUTS,
     HOUSING_BENEFIT_PENSION_AGE_REGULATION_29_BASE,
     HOUSING_BENEFIT_PENSION_AGE_TARIFF_INCOME_OUTPUTS,
     HOUSING_BENEFIT_REGULATION_52_BASE,
@@ -91,7 +95,9 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_carers_allowance_final_request,
     build_child_benefit_final_request,
     build_child_benefit_request,
+    build_esa_income_final_request,
     build_esa_income_tariff_income_request,
+    build_housing_benefit_final_request,
     build_housing_benefit_pension_age_tariff_income_request,
     build_housing_benefit_working_age_tariff_income_request,
     build_income_support_tariff_income_request,
@@ -134,7 +140,9 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_benefit_cap_relevant_amount_inputs,
     project_carers_allowance_final_inputs,
     project_child_benefit_inputs,
+    project_esa_income_final_inputs,
     project_esa_income_tariff_income_inputs,
+    project_housing_benefit_final_inputs,
     project_housing_benefit_pension_age_tariff_income_inputs,
     project_housing_benefit_working_age_tariff_income_inputs,
     project_income_support_tariff_income_inputs,
@@ -2355,6 +2363,158 @@ def test_pension_credit_final_request_projects_final_inputs():
     ] == {"kind": "bool", "value": True}
 
 
+def test_esa_income_final_projection_uses_reported_award_and_tariff_income():
+    assert project_esa_income_final_inputs(
+        {
+            "esa_income_reported_for_year": 2_600,
+            "esa_income_tariff_income": 520,
+            "esa_income_eligible": True,
+        }
+    ) == {
+        "reported_income_related_esa_for_year": 2_600.0,
+        "income_related_esa_tariff_income_for_year": 520.0,
+        "income_related_esa_eligible": True,
+    }
+    assert project_esa_income_final_inputs(
+        {
+            "esa_income_reported_for_year": 2_600,
+            "esa_income_tariff_income": 0,
+            "esa_income_eligible": float("nan"),
+        }
+    )["income_related_esa_eligible"] is False
+
+
+def test_esa_income_final_request_projects_final_inputs():
+    request = build_esa_income_final_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "esa_income_reported_for_year": 2_600,
+                    "esa_income_tariff_income": 520,
+                    "esa_income_eligible": True,
+                    "esa_income": 2_080,
+                },
+                {
+                    "benunit_id": 12,
+                    "esa_income_reported_for_year": 0,
+                    "esa_income_tariff_income": 0,
+                    "esa_income_eligible": False,
+                    "esa_income": 0,
+                },
+            ],
+            "benunit_ids": [11, 12],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_11",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": [
+                ESA_FINAL_OUTPUTS["income_related_esa_annual_amount"]["axiom"]
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{ESA_FINAL_BASE}#input.reported_income_related_esa_for_year:benunit_11"
+    ] == {"kind": "decimal", "value": "2600.0"}
+    assert inputs[
+        f"{ESA_FINAL_BASE}#input.income_related_esa_tariff_income_for_year:benunit_11"
+    ] == {"kind": "decimal", "value": "520.0"}
+    assert inputs[
+        f"{ESA_FINAL_BASE}#input.income_related_esa_eligible:benunit_11"
+    ] == {"kind": "bool", "value": True}
+
+
+def test_housing_benefit_final_projection_uses_pre_cap_and_cap_reduction():
+    assert project_housing_benefit_final_inputs(
+        {
+            "housing_benefit_pre_benefit_cap": 5_200,
+            "benefit_cap_reduction": 1_040,
+            "would_claim_housing_benefit": True,
+        }
+    ) == {
+        "housing_benefit_pre_benefit_cap_for_year": 5_200.0,
+        "benefit_cap_reduction_for_year": 1_040.0,
+        "would_claim_housing_benefit": True,
+    }
+    assert project_housing_benefit_final_inputs(
+        {
+            "housing_benefit_pre_benefit_cap": 5_200,
+            "benefit_cap_reduction": 0,
+            "would_claim_housing_benefit": float("nan"),
+        }
+    )["would_claim_housing_benefit"] is False
+
+
+def test_housing_benefit_final_request_projects_final_inputs():
+    request = build_housing_benefit_final_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "housing_benefit_pre_benefit_cap": 5_200,
+                    "benefit_cap_reduction": 1_040,
+                    "would_claim_housing_benefit": True,
+                    "housing_benefit": 4_160,
+                },
+                {
+                    "benunit_id": 12,
+                    "housing_benefit_pre_benefit_cap": 0,
+                    "benefit_cap_reduction": 0,
+                    "would_claim_housing_benefit": False,
+                    "housing_benefit": 0,
+                },
+            ],
+            "benunit_ids": [11, 12],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "benunit_11",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": [
+                HOUSING_BENEFIT_FINAL_OUTPUTS["housing_benefit_annual_amount"][
+                    "axiom"
+                ]
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{HOUSING_BENEFIT_FINAL_BASE}#input.housing_benefit_pre_benefit_cap_for_year:benunit_11"
+    ] == {"kind": "decimal", "value": "5200.0"}
+    assert inputs[
+        f"{HOUSING_BENEFIT_FINAL_BASE}#input.benefit_cap_reduction_for_year:benunit_11"
+    ] == {"kind": "decimal", "value": "1040.0"}
+    assert inputs[
+        f"{HOUSING_BENEFIT_FINAL_BASE}#input.would_claim_housing_benefit:benunit_11"
+    ] == {"kind": "bool", "value": True}
+
+
 def test_universal_credit_childcare_element_projection_reverses_rate_and_cap():
     projected = project_universal_credit_childcare_element_inputs(
         {
@@ -3274,6 +3434,9 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "state_pension_reported",
         "state_pension_type",
     )
+    assert policyengine_person_variables_for_surfaces(["esa-income-final"]) == (
+        "esa_income_reported",
+    )
     assert policyengine_person_variables_for_surfaces(["student-loan-repayment"]) == (
         "adjusted_net_income",
         "student_loan_plan",
@@ -3313,6 +3476,17 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "pension_credit",
         "pension_credit_entitlement",
         "would_claim_pc",
+    )
+    assert policyengine_benunit_variables_for_surfaces(["esa-income-final"]) == (
+        "esa_income",
+        "esa_income_eligible",
+        "esa_income_tariff_income",
+    )
+    assert policyengine_benunit_variables_for_surfaces(["housing-benefit-final"]) == (
+        "benefit_cap_reduction",
+        "housing_benefit",
+        "housing_benefit_pre_benefit_cap",
+        "would_claim_housing_benefit",
     )
     assert policyengine_benunit_variables_for_surfaces(["state-pension-final"]) == ()
     assert policyengine_benunit_variables_for_surfaces(
@@ -3579,7 +3753,9 @@ class hbai_household_net_income(Variable):
         "free_school_milk",
         "free_tv_licence_value",
         "child_benefit",
+        "esa_income",
         "esa_contrib",
+        "housing_benefit",
         "universal_credit",
         "pension_credit",
         "working_tax_credit",
@@ -3628,7 +3804,9 @@ class hbai_household_net_income(Variable):
         "free_school_milk",
         "free_tv_licence_value",
         "child_benefit",
+        "esa_income",
         "esa_contrib",
+        "housing_benefit",
         "universal_credit",
         "pension_credit",
         "working_tax_credit",
@@ -3773,6 +3951,25 @@ class hbai_household_net_income(Variable):
         "pension_credit_deemed_income",
         "pension_credit",
     )
+    assert by_name["esa_income"].status == "exact"
+    assert by_name["esa_income"].surfaces == (
+        "esa-income-tariff-income",
+        "esa-income-final",
+    )
+    assert by_name["esa_income"].covered_outputs == (
+        "esa_income_tariff_income",
+        "esa_income",
+    )
+    assert by_name["housing_benefit"].status == "exact"
+    assert by_name["housing_benefit"].surfaces == (
+        "housing-benefit-working-age-tariff-income",
+        "housing-benefit-pension-age-tariff-income",
+        "housing-benefit-final",
+    )
+    assert by_name["housing_benefit"].covered_outputs == (
+        "housing_benefit_tariff_income",
+        "housing_benefit",
+    )
     assert by_name["working_tax_credit"].status == "partial"
     assert by_name["child_tax_credit"].status == "partial"
     assert by_name["tax_free_childcare"].status == "partial"
@@ -3799,11 +3996,11 @@ class hbai_household_net_income(Variable):
     assert by_name["council_tax"].policy_component is False
     assert by_name["domestic_rates"].status == "fixed_input"
     assert by_name["domestic_rates"].policy_component is False
-    assert report.policy_component_count == 21
-    assert report.covered_policy_component_count == 21
-    assert report.exact_policy_component_count == 8
+    assert report.policy_component_count == 23
+    assert report.covered_policy_component_count == 23
+    assert report.exact_policy_component_count == 10
     assert report.covered_policy_component_share == 1
-    assert math.isclose(report.exact_policy_component_share, 8 / 21)
+    assert math.isclose(report.exact_policy_component_share, 10 / 23)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(
@@ -4391,6 +4588,72 @@ def test_compare_outputs_compares_pension_credit_final_annual_amount():
                         PENSION_CREDIT_FINAL_OUTPUTS[
                             "pension_credit_annual_amount"
                         ]["axiom"]: decimal_output(3_400),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_esa_income_final_annual_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "esa_income": 2_080,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "esa-income-final": [
+                {
+                    "outputs": {
+                        ESA_FINAL_OUTPUTS["income_related_esa_annual_amount"][
+                            "axiom"
+                        ]: decimal_output(2_080),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_housing_benefit_final_annual_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "housing_benefit": 4_160,
+                },
+            ],
+            "benunit_ids": [11],
+        },
+        axiom_outputs_by_surface={
+            "housing-benefit-final": [
+                {
+                    "outputs": {
+                        HOUSING_BENEFIT_FINAL_OUTPUTS[
+                            "housing_benefit_annual_amount"
+                        ]["axiom"]: decimal_output(4_160),
                     }
                 }
             ]

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -9,6 +9,8 @@ import axiom_encode.oracles.policyengine.efrs_uk as efrs_uk
 from axiom_encode.oracles.policyengine.efrs_uk import (
     BENEFIT_CAP_REGULATION_80A_BASE,
     BENEFIT_CAP_RELEVANT_AMOUNT_OUTPUTS,
+    CARER_SUPPORT_PAYMENT_FINAL_BASE,
+    CARER_SUPPORT_PAYMENT_FINAL_OUTPUTS,
     CARERS_ALLOWANCE_FINAL_BASE,
     CARERS_ALLOWANCE_FINAL_OUTPUTS,
     CHILD_BENEFIT_BASE,
@@ -60,6 +62,10 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     PERSONAL_ALLOWANCE_BASE,
     PERSONAL_ALLOWANCE_OUTPUTS,
     PERSONAL_ALLOWANCE_PROGRAM_PATH,
+    SCOTTISH_CHILD_PAYMENT_FINAL_BASE,
+    SCOTTISH_CHILD_PAYMENT_FINAL_OUTPUTS,
+    SDA_FINAL_BASE,
+    SDA_FINAL_OUTPUTS,
     STATE_PENSION_CREDIT_GUARANTEE_CREDIT_OUTPUTS,
     STATE_PENSION_CREDIT_QUALIFYING_AGE_OUTPUTS,
     STATE_PENSION_CREDIT_SAVINGS_CREDIT_OUTPUTS,
@@ -92,6 +98,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     WELFARE_REFORM_ACT_SECTION_8_BASE,
     WELFARE_REFORM_ACT_SECTION_11_BASE,
     build_benefit_cap_relevant_amount_request,
+    build_carer_support_payment_final_request,
     build_carers_allowance_final_request,
     build_child_benefit_final_request,
     build_child_benefit_request,
@@ -115,6 +122,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_pension_credit_final_request,
     build_pension_credit_request,
     build_personal_allowance_request,
+    build_scottish_child_payment_final_request,
+    build_sda_final_request,
     build_state_pension_credit_guarantee_credit_request,
     build_state_pension_credit_qualifying_age_request,
     build_state_pension_credit_savings_credit_request,
@@ -138,6 +147,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     policyengine_benunit_variables_for_surfaces,
     policyengine_person_variables_for_surfaces,
     project_benefit_cap_relevant_amount_inputs,
+    project_carer_support_payment_final_inputs,
     project_carers_allowance_final_inputs,
     project_child_benefit_inputs,
     project_esa_income_final_inputs,
@@ -160,6 +170,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_pension_credit_final_inputs,
     project_pension_credit_inputs,
     project_personal_allowance_inputs,
+    project_scottish_child_payment_final_inputs,
+    project_sda_final_inputs,
     project_state_pension_credit_guarantee_credit_inputs,
     project_state_pension_credit_qualifying_age_inputs,
     project_state_pension_credit_savings_credit_inputs,
@@ -2296,6 +2308,209 @@ def test_carers_allowance_final_request_projects_final_inputs():
     ] == {"kind": "decimal", "value": "0.0"}
 
 
+def test_carer_support_payment_final_projection_uses_pe_boundary_facts():
+    assert project_carer_support_payment_final_inputs(
+        {
+            "country": "SCOTLAND",
+            "care_hours": 40,
+            "carers_allowance_reported": 0,
+        },
+        year=2026,
+    ) == {
+        "person_is_in_scotland": True,
+        "carer_support_payment_in_effect": True,
+        "weekly_care_hours": 40.0,
+        "reported_carers_allowance_for_year": 0.0,
+    }
+
+
+def test_carer_support_payment_final_request_projects_final_inputs():
+    request = build_carer_support_payment_final_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 1,
+                    "country": "ENGLAND",
+                    "care_hours": 35,
+                    "carer_support_payment": 0,
+                    "carers_allowance_reported": 0,
+                },
+                {
+                    "person_id": 2,
+                    "country": "SCOTLAND",
+                    "care_hours": 35,
+                    "carer_support_payment": 5_103.80,
+                    "carers_allowance_reported": 0,
+                },
+            ],
+            "person_ids": [1, 2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_2",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-04-06",
+                "end": "2027-04-05",
+            },
+            "outputs": [
+                CARER_SUPPORT_PAYMENT_FINAL_OUTPUTS[
+                    "carer_support_payment_annual_amount"
+                ]["axiom"],
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{CARER_SUPPORT_PAYMENT_FINAL_BASE}#input.person_is_in_scotland:person_2"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{CARER_SUPPORT_PAYMENT_FINAL_BASE}#input.carer_support_payment_in_effect:person_2"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{CARER_SUPPORT_PAYMENT_FINAL_BASE}#input.weekly_care_hours:person_2"
+    ] == {"kind": "decimal", "value": "35.0"}
+    assert inputs[
+        f"{CARER_SUPPORT_PAYMENT_FINAL_BASE}#input.reported_carers_allowance_for_year:person_2"
+    ] == {"kind": "decimal", "value": "0.0"}
+
+
+def test_scottish_child_payment_final_projection_uses_pe_boundary_facts():
+    assert project_scottish_child_payment_final_inputs(
+        {
+            "is_scp_eligible": True,
+            "would_claim_scp": False,
+        }
+    ) == {
+        "is_scottish_child_payment_eligible": True,
+        "would_claim_scottish_child_payment": False,
+    }
+    assert (
+        project_scottish_child_payment_final_inputs(
+            {
+                "is_scp_eligible": float("nan"),
+                "would_claim_scp": True,
+            }
+        )["is_scottish_child_payment_eligible"]
+        is False
+    )
+
+
+def test_scottish_child_payment_final_request_projects_final_inputs():
+    request = build_scottish_child_payment_final_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 1,
+                    "is_scp_eligible": False,
+                    "would_claim_scp": False,
+                    "scottish_child_payment": 0,
+                },
+                {
+                    "person_id": 2,
+                    "is_scp_eligible": True,
+                    "would_claim_scp": True,
+                    "scottish_child_payment": 1_466.40,
+                },
+            ],
+            "person_ids": [1, 2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_2",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-04-06",
+                "end": "2027-04-05",
+            },
+            "outputs": [
+                SCOTTISH_CHILD_PAYMENT_FINAL_OUTPUTS[
+                    "scottish_child_payment_annual_amount"
+                ]["axiom"],
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{SCOTTISH_CHILD_PAYMENT_FINAL_BASE}#input.is_scottish_child_payment_eligible:person_2"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{SCOTTISH_CHILD_PAYMENT_FINAL_BASE}#input.would_claim_scottish_child_payment:person_2"
+    ] == {"kind": "bool", "value": True}
+
+
+def test_sda_final_projection_uses_reported_receipt():
+    assert project_sda_final_inputs(
+        {
+            "sda_reported": 6_206.20,
+        }
+    ) == {
+        "reported_severe_disablement_allowance_for_year": 6_206.20,
+    }
+
+
+def test_sda_final_request_projects_final_inputs():
+    request = build_sda_final_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 1,
+                    "sda": 0,
+                    "sda_reported": 0,
+                },
+                {
+                    "person_id": 2,
+                    "sda": 6_206.20,
+                    "sda_reported": 6_206.20,
+                },
+            ],
+            "person_ids": [1, 2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_2",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-04-06",
+                "end": "2027-04-05",
+            },
+            "outputs": [
+                SDA_FINAL_OUTPUTS["severe_disablement_allowance_annual_amount"][
+                    "axiom"
+                ],
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{SDA_FINAL_BASE}#input.reported_severe_disablement_allowance_for_year:person_2"
+    ] == {"kind": "decimal", "value": "6206.2"}
+
+
 def test_pension_credit_final_projection_uses_entitlement_components():
     assert project_pension_credit_final_inputs(
         {
@@ -2306,12 +2521,15 @@ def test_pension_credit_final_projection_uses_entitlement_components():
         "pension_credit_entitlement_for_year": 2_825.0,
         "person_or_partner_would_claim_pension_credit": False,
     }
-    assert project_pension_credit_final_inputs(
-        {
-            "pension_credit_entitlement": 2_825,
-            "would_claim_pc": float("nan"),
-        }
-    )["person_or_partner_would_claim_pension_credit"] is False
+    assert (
+        project_pension_credit_final_inputs(
+            {
+                "pension_credit_entitlement": 2_825,
+                "would_claim_pc": float("nan"),
+            }
+        )["person_or_partner_would_claim_pension_credit"]
+        is False
+    )
 
 
 def test_pension_credit_final_request_projects_final_inputs():
@@ -2375,13 +2593,16 @@ def test_esa_income_final_projection_uses_reported_award_and_tariff_income():
         "income_related_esa_tariff_income_for_year": 520.0,
         "income_related_esa_eligible": True,
     }
-    assert project_esa_income_final_inputs(
-        {
-            "esa_income_reported_for_year": 2_600,
-            "esa_income_tariff_income": 0,
-            "esa_income_eligible": float("nan"),
-        }
-    )["income_related_esa_eligible"] is False
+    assert (
+        project_esa_income_final_inputs(
+            {
+                "esa_income_reported_for_year": 2_600,
+                "esa_income_tariff_income": 0,
+                "esa_income_eligible": float("nan"),
+            }
+        )["income_related_esa_eligible"]
+        is False
+    )
 
 
 def test_esa_income_final_request_projects_final_inputs():
@@ -2418,9 +2639,7 @@ def test_esa_income_final_request_projects_final_inputs():
                 "start": "2026-01-01",
                 "end": "2026-12-31",
             },
-            "outputs": [
-                ESA_FINAL_OUTPUTS["income_related_esa_annual_amount"]["axiom"]
-            ],
+            "outputs": [ESA_FINAL_OUTPUTS["income_related_esa_annual_amount"]["axiom"]],
         }
     ]
     inputs = {
@@ -2433,9 +2652,10 @@ def test_esa_income_final_request_projects_final_inputs():
     assert inputs[
         f"{ESA_FINAL_BASE}#input.income_related_esa_tariff_income_for_year:benunit_11"
     ] == {"kind": "decimal", "value": "520.0"}
-    assert inputs[
-        f"{ESA_FINAL_BASE}#input.income_related_esa_eligible:benunit_11"
-    ] == {"kind": "bool", "value": True}
+    assert inputs[f"{ESA_FINAL_BASE}#input.income_related_esa_eligible:benunit_11"] == {
+        "kind": "bool",
+        "value": True,
+    }
 
 
 def test_housing_benefit_final_projection_uses_pre_cap_and_cap_reduction():
@@ -2450,13 +2670,16 @@ def test_housing_benefit_final_projection_uses_pre_cap_and_cap_reduction():
         "benefit_cap_reduction_for_year": 1_040.0,
         "would_claim_housing_benefit": True,
     }
-    assert project_housing_benefit_final_inputs(
-        {
-            "housing_benefit_pre_benefit_cap": 5_200,
-            "benefit_cap_reduction": 0,
-            "would_claim_housing_benefit": float("nan"),
-        }
-    )["would_claim_housing_benefit"] is False
+    assert (
+        project_housing_benefit_final_inputs(
+            {
+                "housing_benefit_pre_benefit_cap": 5_200,
+                "benefit_cap_reduction": 0,
+                "would_claim_housing_benefit": float("nan"),
+            }
+        )["would_claim_housing_benefit"]
+        is False
+    )
 
 
 def test_housing_benefit_final_request_projects_final_inputs():
@@ -2494,9 +2717,7 @@ def test_housing_benefit_final_request_projects_final_inputs():
                 "end": "2026-12-31",
             },
             "outputs": [
-                HOUSING_BENEFIT_FINAL_OUTPUTS["housing_benefit_annual_amount"][
-                    "axiom"
-                ]
+                HOUSING_BENEFIT_FINAL_OUTPUTS["housing_benefit_annual_amount"]["axiom"]
             ],
         }
     ]
@@ -3434,6 +3655,27 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "state_pension_reported",
         "state_pension_type",
     )
+    assert policyengine_person_variables_for_surfaces(
+        ["carer-support-payment-final"]
+    ) == (
+        "care_hours",
+        "carer_support_payment",
+        "carers_allowance_reported",
+        "country",
+    )
+    assert policyengine_person_variables_for_surfaces(
+        ["scottish-child-payment-final"]
+    ) == (
+        "is_scp_eligible",
+        "scottish_child_payment",
+        "would_claim_scp",
+    )
+    assert policyengine_person_variables_for_surfaces(
+        ["severe-disablement-allowance-final"]
+    ) == (
+        "sda",
+        "sda_reported",
+    )
     assert policyengine_person_variables_for_surfaces(["esa-income-final"]) == (
         "esa_income_reported",
     )
@@ -3981,10 +4223,29 @@ class hbai_household_net_income(Variable):
         "carers-allowance-rate",
         "carers-allowance-final",
     )
-    assert by_name["sda"].status == "partial"
+    assert by_name["sda"].status == "exact"
+    assert by_name["sda"].surfaces == (
+        "severe-disablement-allowance-rates",
+        "severe-disablement-allowance-final",
+    )
+    assert by_name["sda"].covered_outputs == ("sda",)
     assert by_name["ssmg"].status == "partial"
-    assert by_name["scottish_child_payment"].status == "partial"
-    assert by_name["carer_support_payment"].status == "partial"
+    assert by_name["scottish_child_payment"].status == "exact"
+    assert by_name["scottish_child_payment"].surfaces == (
+        "scottish-child-payment-parameters",
+        "scottish-child-payment-final",
+    )
+    assert by_name["scottish_child_payment"].covered_outputs == (
+        "scottish_child_payment",
+    )
+    assert by_name["carer_support_payment"].status == "exact"
+    assert by_name["carer_support_payment"].surfaces == (
+        "carer-support-payment-parameters",
+        "carer-support-payment-final",
+    )
+    assert by_name["carer_support_payment"].covered_outputs == (
+        "carer_support_payment",
+    )
     assert by_name["cost_of_living_support_payment"].status == "partial"
     assert by_name["state_pension"].status == "exact"
     assert by_name["state_pension"].surfaces == (
@@ -3998,9 +4259,9 @@ class hbai_household_net_income(Variable):
     assert by_name["domestic_rates"].policy_component is False
     assert report.policy_component_count == 23
     assert report.covered_policy_component_count == 23
-    assert report.exact_policy_component_count == 10
+    assert report.exact_policy_component_count == 13
     assert report.covered_policy_component_share == 1
-    assert math.isclose(report.exact_policy_component_share, 10 / 23)
+    assert math.isclose(report.exact_policy_component_share, 13 / 23)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(
@@ -4568,6 +4829,105 @@ def test_compare_outputs_compares_carers_allowance_final_annual_amount():
     assert report.oracle_divergences == []
 
 
+def test_compare_outputs_compares_carer_support_payment_final_annual_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 2,
+                    "carer_support_payment": 5_103.80,
+                },
+            ],
+            "person_ids": [2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        axiom_outputs_by_surface={
+            "carer-support-payment-final": [
+                {
+                    "outputs": {
+                        CARER_SUPPORT_PAYMENT_FINAL_OUTPUTS[
+                            "carer_support_payment_annual_amount"
+                        ]["axiom"]: decimal_output(5_103.80),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_scottish_child_payment_final_annual_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 2,
+                    "scottish_child_payment": 1_466.40,
+                },
+            ],
+            "person_ids": [2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        axiom_outputs_by_surface={
+            "scottish-child-payment-final": [
+                {
+                    "outputs": {
+                        SCOTTISH_CHILD_PAYMENT_FINAL_OUTPUTS[
+                            "scottish_child_payment_annual_amount"
+                        ]["axiom"]: decimal_output(1_466.40),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_sda_final_annual_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 2,
+                    "sda": 6_206.20,
+                },
+            ],
+            "person_ids": [2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        axiom_outputs_by_surface={
+            "severe-disablement-allowance-final": [
+                {
+                    "outputs": {
+                        SDA_FINAL_OUTPUTS["severe_disablement_allowance_annual_amount"][
+                            "axiom"
+                        ]: decimal_output(6_206.20),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
 def test_compare_outputs_compares_pension_credit_final_annual_amount():
     report = compare_outputs(
         pe_data={
@@ -4585,9 +4945,9 @@ def test_compare_outputs_compares_pension_credit_final_annual_amount():
             "pension-credit-final": [
                 {
                     "outputs": {
-                        PENSION_CREDIT_FINAL_OUTPUTS[
-                            "pension_credit_annual_amount"
-                        ]["axiom"]: decimal_output(3_400),
+                        PENSION_CREDIT_FINAL_OUTPUTS["pension_credit_annual_amount"][
+                            "axiom"
+                        ]: decimal_output(3_400),
                     }
                 }
             ]
@@ -4651,9 +5011,9 @@ def test_compare_outputs_compares_housing_benefit_final_annual_amount():
             "housing-benefit-final": [
                 {
                     "outputs": {
-                        HOUSING_BENEFIT_FINAL_OUTPUTS[
-                            "housing_benefit_annual_amount"
-                        ]["axiom"]: decimal_output(4_160),
+                        HOUSING_BENEFIT_FINAL_OUTPUTS["housing_benefit_annual_amount"][
+                            "axiom"
+                        ]: decimal_output(4_160),
                     }
                 }
             ]

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.618"
+version = "0.2.619"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.617"
+version = "0.2.618"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Adds final PolicyEngine UK EFRS oracle coverage for the remaining active HBAI wrapper components in this batch:

- Carer Support Payment final annual amount
- Scottish Child Payment final annual amount
- Severe Disablement Allowance final annual amount

This moves the local enhanced-FRS HBAI policy-weighted exact share to 99.582953659%, with 100% of active policy-weighted mass covered.

## Validation

- `ruff check src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py src/axiom_encode/__init__.py`
- `uv run --extra dev --python 3.13 python -m pytest tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py -q` - 433 passed, 2 skipped
- `uv run --extra dev --python 3.13 python -m pytest tests/test_cli.py -q -k "version_provenance or current_encoder_affecting_changes"` - 5 passed
- `axiom-encode uk-efrs-compare --surface carer-support-payment-final ... --sample-size 0 --fail-on-mismatch` - 142 compared values, 0 mismatches
- `axiom-encode uk-efrs-compare --surface scottish-child-payment-final ... --sample-size 0 --fail-on-mismatch` - 115,612 compared values, 0 mismatches
- `axiom-encode uk-efrs-compare --surface severe-disablement-allowance-final ... --sample-size 0 --fail-on-mismatch` - 20 compared values, 0 mismatches
- `axiom-encode uk-efrs-hbai-coverage --with-efrs-activity ... --json`
