### PR TITLE
Add UK DLA final oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.619"
+version = "0.2.620"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.619"
+__version__ = "0.2.620"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -35,6 +35,7 @@ DEFAULT_DATASET = "enhanced_frs_2023_24"
 WEEKS_IN_YEAR = 52
 MONTHS_IN_YEAR = 12
 POLICYENGINE_UK_VERSION = "2.88.56"
+CATEGORY_THRESHOLD_WEEKLY_TOLERANCE = 1.0
 
 NATIONAL_INSURANCE_SECTION_1_PROGRAM_PATH = Path("statutes/ukpga/1992/4/1.yaml")
 NATIONAL_INSURANCE_SECTION_1_BASE = "uk:statutes/ukpga/1992/4/1"
@@ -132,6 +133,8 @@ SCOTTISH_CHILD_PAYMENT_FINAL_PROGRAM_PATH = Path(
 SCOTTISH_CHILD_PAYMENT_FINAL_BASE = "uk:policies/govuk/scottish-child-payment"
 SDA_FINAL_PROGRAM_PATH = Path("policies/govuk/severe-disablement-allowance.yaml")
 SDA_FINAL_BASE = "uk:policies/govuk/severe-disablement-allowance"
+DLA_FINAL_PROGRAM_PATH = Path("policies/govuk/disability-living-allowance.yaml")
+DLA_FINAL_BASE = "uk:policies/govuk/disability-living-allowance"
 
 PERSONAL_ALLOWANCE_OUTPUTS = {
     "personal_allowance": {
@@ -758,6 +761,30 @@ SDA_FINAL_OUTPUTS = {
     },
 }
 
+DLA_FINAL_OUTPUTS = {
+    "disability_living_allowance_self_care_weekly_amount": {
+        "axiom": (
+            f"{DLA_FINAL_BASE}#disability_living_allowance_self_care_weekly_amount"
+        ),
+        "pe": "dla_sc",
+        "pe_transform": "annual_to_weekly",
+        "tolerance": 0.01,
+    },
+    "disability_living_allowance_mobility_weekly_amount": {
+        "axiom": (
+            f"{DLA_FINAL_BASE}#disability_living_allowance_mobility_weekly_amount"
+        ),
+        "pe": "dla_m",
+        "pe_transform": "annual_to_weekly",
+        "tolerance": 0.01,
+    },
+    "disability_living_allowance_annual_amount": {
+        "axiom": f"{DLA_FINAL_BASE}#disability_living_allowance_annual_amount",
+        "pe": "dla",
+        "tolerance": 0.01,
+    },
+}
+
 
 @dataclass(frozen=True)
 class UKEFRSSurfaceSpec:
@@ -1276,6 +1303,18 @@ SURFACE_SPECS = {
             "sda_reported",
         ),
     ),
+    "disability-living-allowance-final": UKEFRSSurfaceSpec(
+        program=DLA_FINAL_PROGRAM_PATH,
+        entity="person",
+        outputs=DLA_FINAL_OUTPUTS,
+        pe_variables=(
+            "dla",
+            "dla_m",
+            "dla_m_category",
+            "dla_sc",
+            "dla_sc_category",
+        ),
+    ),
 }
 
 HBAI_FIXED_INPUT_COMPONENTS = frozenset(
@@ -1311,6 +1350,14 @@ HBAI_FIXED_INPUT_COMPONENTS = frozenset(
         "statutory_sick_pay",
     }
 )
+
+HBAI_OUT_OF_SCOPE_COMPONENTS = {
+    "LVT": (
+        "PolicyEngine UK's LVT placeholder is outside the current Axiom UK "
+        "tax-benefit law encoding scope, so it is excluded from policy "
+        "alignment coverage."
+    ),
+}
 
 HBAI_COMPONENT_COVERAGE = {
     "income_tax": {
@@ -1497,14 +1544,17 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom covers PolicyEngine UK's category-input Personal Independence Payment mechanics, including daily-living, mobility, enhanced daily-living receipt, and the final aggregate PIP amount; descriptor scoring and residence, age, care-home, and hospital exclusions remain held as inputs or outside PolicyEngine's current PIP formula.",
     },
     "dla": {
-        "status": "partial",
-        "surfaces": ("disability-living-allowance-rates",),
+        "status": "exact",
+        "surfaces": (
+            "disability-living-allowance-rates",
+            "disability-living-allowance-final",
+        ),
         "covered_outputs": (
             "dla_sc",
             "dla_m",
             "dla",
         ),
-        "rationale": "Axiom covers Disability Living Allowance care and mobility weekly rates, not the category assignment or final aggregate DLA amount.",
+        "rationale": "Axiom covers Disability Living Allowance weekly self-care and mobility rates plus the final annual PolicyEngine UK DLA wrapper using PE's category inputs.",
     },
     "attendance_allowance": {
         "status": "partial",
@@ -2182,6 +2232,121 @@ def compare_uk_efrs(
     )
 
 
+def disability_category_from_reported_amounts(
+    reported_amounts: Any,
+    thresholds: tuple[tuple[str, float], ...],
+) -> list[str]:
+    """Map annual reported disability amounts to PE-UK category inputs."""
+
+    categories: list[str] = []
+    for raw_value in reported_amounts:
+        try:
+            annual_amount = float(raw_value)
+        except (TypeError, ValueError):
+            annual_amount = 0.0
+        if not math.isfinite(annual_amount):
+            annual_amount = 0.0
+        weekly_amount = annual_amount / WEEKS_IN_YEAR
+        category = "NONE"
+        for category_name, weekly_rate in thresholds:
+            threshold = max(
+                0.0,
+                float(weekly_rate) - CATEGORY_THRESHOLD_WEEKLY_TOLERANCE,
+            )
+            if weekly_amount >= threshold:
+                category = category_name
+        categories.append(category)
+    return categories
+
+
+def policyengine_uk_disability_category_thresholds(
+    year: int,
+) -> tuple[tuple[str, str, tuple[tuple[str, float], ...]], ...]:
+    try:
+        from policyengine_uk import CountryTaxBenefitSystem
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(policyengine_uk_install_message()) from exc
+
+    dwp = CountryTaxBenefitSystem().parameters(year).baseline.gov.dwp
+    return (
+        (
+            "attendance_allowance_reported",
+            "aa_category",
+            (
+                ("LOWER", dwp.attendance_allowance.lower),
+                ("HIGHER", dwp.attendance_allowance.higher),
+            ),
+        ),
+        (
+            "dla_sc_reported",
+            "dla_sc_category",
+            (
+                ("LOWER", dwp.dla.self_care.lower),
+                ("MIDDLE", dwp.dla.self_care.middle),
+                ("HIGHER", dwp.dla.self_care.higher),
+            ),
+        ),
+        (
+            "dla_m_reported",
+            "dla_m_category",
+            (
+                ("LOWER", dwp.dla.mobility.lower),
+                ("HIGHER", dwp.dla.mobility.higher),
+            ),
+        ),
+        (
+            "pip_m_reported",
+            "pip_m_category",
+            (
+                ("STANDARD", dwp.pip.mobility.standard),
+                ("ENHANCED", dwp.pip.mobility.enhanced),
+            ),
+        ),
+        (
+            "pip_dl_reported",
+            "pip_dl_category",
+            (
+                ("STANDARD", dwp.pip.daily_living.standard),
+                ("ENHANCED", dwp.pip.daily_living.enhanced),
+            ),
+        ),
+    )
+
+
+def add_policyengine_uk_disability_categories_from_reported_amounts(
+    dataset: Any,
+    *,
+    year: int,
+) -> tuple[str, ...]:
+    """Backfill post-migration disability category inputs for stale local H5s."""
+
+    person = getattr(dataset, "person", None)
+    if person is None:
+        return ()
+
+    columns = set(person.columns)
+    missing_category_mappings = [
+        (reported_column, category_column, thresholds)
+        for reported_column, category_column, thresholds in (
+            policyengine_uk_disability_category_thresholds(year)
+        )
+        if reported_column in columns and category_column not in columns
+    ]
+    if not missing_category_mappings:
+        return ()
+
+    person = person.copy()
+    added_columns: list[str] = []
+    for reported_column, category_column, thresholds in missing_category_mappings:
+        person[category_column] = disability_category_from_reported_amounts(
+            person[reported_column],
+            thresholds,
+        )
+        added_columns.append(category_column)
+    dataset.person = person
+    return tuple(added_columns)
+
+
 def load_policyengine_uk_data(
     *,
     year: int,
@@ -2230,6 +2395,17 @@ def load_local_policyengine_uk_data(
 
     log("Loading local PolicyEngine UK EFRS...")
     pe_dataset = UKSingleYearDataset(file_path=str(local_path))
+    added_disability_categories = (
+        add_policyengine_uk_disability_categories_from_reported_amounts(
+            pe_dataset,
+            year=year,
+        )
+    )
+    if added_disability_categories:
+        log(
+            "Derived local EFRS disability category inputs from reported amounts: "
+            + ", ".join(added_disability_categories)
+        )
     sim = Microsimulation(dataset=pe_dataset)
     data_year = min(sim.dataset.years)
 
@@ -2840,6 +3016,17 @@ def classify_hbai_component(
             ),
             activity=activity,
         )
+    if name in HBAI_OUT_OF_SCOPE_COMPONENTS:
+        return UKEFRSHBAIComponentCoverage(
+            name=name,
+            direction=direction,
+            status="out_of_scope",
+            policy_component=False,
+            surfaces=(),
+            covered_outputs=(),
+            rationale=HBAI_OUT_OF_SCOPE_COMPONENTS[name],
+            activity=activity,
+        )
     coverage = HBAI_COMPONENT_COVERAGE.get(name)
     if coverage is not None:
         return UKEFRSHBAIComponentCoverage(
@@ -2894,6 +3081,17 @@ def policyengine_uk_hbai_activity(
 
     log("Loading local PolicyEngine UK EFRS for HBAI activity...")
     pe_dataset = UKSingleYearDataset(file_path=str(local_dataset))
+    added_disability_categories = (
+        add_policyengine_uk_disability_categories_from_reported_amounts(
+            pe_dataset,
+            year=year,
+        )
+    )
+    if added_disability_categories:
+        log(
+            "Derived local EFRS disability category inputs from reported amounts: "
+            + ", ".join(added_disability_categories)
+        )
     sim = Microsimulation(dataset=pe_dataset)
 
     activity: dict[str, UKEFRSHBAIComponentActivity] = {}
@@ -3246,6 +3444,17 @@ def policyengine_uk_efrs_activity(
 
     log("Loading local PolicyEngine UK EFRS for coverage activity...")
     pe_dataset = UKSingleYearDataset(file_path=str(local_dataset))
+    added_disability_categories = (
+        add_policyengine_uk_disability_categories_from_reported_amounts(
+            pe_dataset,
+            year=year,
+        )
+    )
+    if added_disability_categories:
+        log(
+            "Derived local EFRS disability category inputs from reported amounts: "
+            + ", ".join(added_disability_categories)
+        )
     sim = Microsimulation(dataset=pe_dataset)
     with pd.HDFStore(local_dataset, mode="r") as store:
         raw_person = store["person"].copy()
@@ -3877,6 +4086,8 @@ def build_axiom_request(
         )
     if surface == "severe-disablement-allowance-final":
         return build_sda_final_request(pe_data=pe_data, year=year)
+    if surface == "disability-living-allowance-final":
+        return build_dla_final_request(pe_data=pe_data, year=year)
     if surface in UNIVERSAL_CREDIT_REGULATION_36_SURFACES:
         return build_universal_credit_request(
             pe_data=pe_data,
@@ -5376,6 +5587,36 @@ def build_sda_final_request(*, pe_data: dict[str, Any], year: int) -> dict[str, 
     }
 
 
+def build_dla_final_request(*, pe_data: dict[str, Any], year: int) -> dict[str, Any]:
+    interval = uk_tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "disability-living-allowance-final"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_dla_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{DLA_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [spec["axiom"] for spec in DLA_FINAL_OUTPUTS.values()],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def project_personal_allowance_inputs(row: Any) -> dict[str, Any]:
     adjusted_net_income = money(row_value(row, "adjusted_net_income"))
     gift_aid_grossed_up = money(row_value(row, "gift_aid_grossed_up", 0))
@@ -6016,6 +6257,18 @@ def project_sda_final_inputs(row: Any) -> dict[str, Any]:
     }
 
 
+def project_dla_final_inputs(row: Any) -> dict[str, Any]:
+    self_care_category = enum_name(row_value(row, "dla_sc_category", "NONE")).upper()
+    mobility_category = enum_name(row_value(row, "dla_m_category", "NONE")).upper()
+    return {
+        "person_has_higher_rate_dla_self_care_category": self_care_category == "HIGHER",
+        "person_has_middle_rate_dla_self_care_category": self_care_category == "MIDDLE",
+        "person_has_lower_rate_dla_self_care_category": self_care_category == "LOWER",
+        "person_has_higher_rate_dla_mobility_category": mobility_category == "HIGHER",
+        "person_has_lower_rate_dla_mobility_category": mobility_category == "LOWER",
+    }
+
+
 def project_pension_credit_final_inputs(row: Any) -> dict[str, Any]:
     return {
         "pension_credit_entitlement_for_year": money(
@@ -6229,6 +6482,16 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             for row in persons
             if money(row_value(row, "sda", 0)) > 0
             or money(row_value(row, "sda_reported", 0)) > 0
+        ]
+    if surface == "disability-living-allowance-final":
+        return [
+            row
+            for row in persons
+            if money(row_value(row, "dla", 0)) > 0
+            or money(row_value(row, "dla_sc", 0)) > 0
+            or money(row_value(row, "dla_m", 0)) > 0
+            or enum_name(row_value(row, "dla_sc_category", "NONE")).upper() != "NONE"
+            or enum_name(row_value(row, "dla_m_category", "NONE")).upper() != "NONE"
         ]
     if surface == "pension-credit-final":
         return [
@@ -6464,6 +6727,15 @@ def compare_outputs(
             "Carer's Allowance receipt, and Scotland replacement gate into a "
             "final annual wrapper that uses the RuleSpec weekly rate and "
             "35-hour care threshold.",
+            "PolicyEngine-aligned Disability Living Allowance final comparison "
+            "projects PolicyEngine UK's DLA self-care and mobility category "
+            "enums into boolean category leaves, then compares selected weekly "
+            "components and the final annual aggregate.",
+            "When a local EFRS .h5 predates the PolicyEngine UK disability "
+            "category-input migration, the oracle derives PIP, DLA, and "
+            "Attendance Allowance category inputs in memory from reported "
+            "amount columns using the policyengine-uk-data category threshold "
+            "rule; it does not rewrite the local dataset.",
             "Welfare Reform Act 2012 section 11 Universal Credit housing-costs "
             "comparison projects PolicyEngine's annual uc_housing_costs_element "
             "into the monthly amount determined or calculated by regulations, "

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1399,6 +1399,39 @@ mappings:
     comparison: money
     rationale: Same weekly Disability Living Allowance lower-rate mobility component amount after applying the Article 14 substitution.
 
+  - legal_id: uk:policies/govuk/disability-living-allowance#disability_living_allowance_self_care_weekly_amount
+    country: uk
+    program: dla
+    mapping_type: direct_variable
+    policyengine_variable: dla_sc
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Disability Living Allowance self-care component after selecting the higher, middle, lower, or nil category; the UK oracle converts PolicyEngine UK's annual value to a weekly amount for comparison.
+
+  - legal_id: uk:policies/govuk/disability-living-allowance#disability_living_allowance_mobility_weekly_amount
+    country: uk
+    program: dla
+    mapping_type: direct_variable
+    policyengine_variable: dla_m
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    rationale: Same Disability Living Allowance mobility component after selecting the higher, lower, or nil category; the UK oracle converts PolicyEngine UK's annual value to a weekly amount for comparison.
+
+  - legal_id: uk:policies/govuk/disability-living-allowance#disability_living_allowance_annual_amount
+    country: uk
+    program: dla
+    mapping_type: direct_variable
+    policyengine_variable: dla
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual Disability Living Allowance total as the sum of annual self-care and mobility components.
+
   - legal_id: uk:regulations/uksi/2026/148/article/4#category_a_basic_retirement_pension_substituted_amount
     country: uk
     program: state_pension

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -2,6 +2,7 @@ import argparse
 import math
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -18,6 +19,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     CHILD_BENEFIT_FINAL_OUTPUTS,
     CHILD_BENEFIT_OUTPUTS,
     CHILD_BENEFIT_SECTION_141_BASE,
+    DLA_FINAL_BASE,
+    DLA_FINAL_OUTPUTS,
     ESA_FINAL_BASE,
     ESA_FINAL_OUTPUTS,
     ESA_REGULATION_118_BASE,
@@ -97,11 +100,13 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     WEEKS_IN_YEAR,
     WELFARE_REFORM_ACT_SECTION_8_BASE,
     WELFARE_REFORM_ACT_SECTION_11_BASE,
+    add_policyengine_uk_disability_categories_from_reported_amounts,
     build_benefit_cap_relevant_amount_request,
     build_carer_support_payment_final_request,
     build_carers_allowance_final_request,
     build_child_benefit_final_request,
     build_child_benefit_request,
+    build_dla_final_request,
     build_esa_income_final_request,
     build_esa_income_tariff_income_request,
     build_housing_benefit_final_request,
@@ -143,6 +148,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_universal_credit_work_allowance_request,
     compare_outputs,
     compare_uk_efrs,
+    disability_category_from_reported_amounts,
     normalize_policyengine_entity,
     policyengine_benunit_variables_for_surfaces,
     policyengine_person_variables_for_surfaces,
@@ -150,6 +156,7 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_carer_support_payment_final_inputs,
     project_carers_allowance_final_inputs,
     project_child_benefit_inputs,
+    project_dla_final_inputs,
     project_esa_income_final_inputs,
     project_esa_income_tariff_income_inputs,
     project_housing_benefit_final_inputs,
@@ -197,6 +204,96 @@ def decimal_output(value):
 
 def judgment_output(holds):
     return {"kind": "judgment", "outcome": "holds" if holds else "not_holds"}
+
+
+class FakePersonFrame:
+    def __init__(self, data):
+        self.data = {key: list(value) for key, value in data.items()}
+
+    @property
+    def columns(self):
+        return self.data.keys()
+
+    def copy(self):
+        return FakePersonFrame(self.data)
+
+    def __getitem__(self, key):
+        return self.data[key]
+
+    def __setitem__(self, key, value):
+        self.data[key] = list(value)
+
+
+def test_disability_category_from_reported_amounts_uses_weekly_thresholds():
+    assert disability_category_from_reported_amounts(
+        [
+            0,
+            29.0 * WEEKS_IN_YEAR,
+            29.5 * WEEKS_IN_YEAR,
+            75.8 * WEEKS_IN_YEAR,
+            114.0 * WEEKS_IN_YEAR,
+            float("nan"),
+        ],
+        (
+            ("LOWER", 30.30),
+            ("MIDDLE", 76.70),
+            ("HIGHER", 114.60),
+        ),
+    ) == [
+        "NONE",
+        "NONE",
+        "LOWER",
+        "MIDDLE",
+        "HIGHER",
+        "NONE",
+    ]
+
+
+def test_add_policyengine_uk_disability_categories_backfills_stale_local_h5(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        efrs_uk,
+        "policyengine_uk_disability_category_thresholds",
+        lambda year: (
+            (
+                "dla_sc_reported",
+                "dla_sc_category",
+                (
+                    ("LOWER", 30.30),
+                    ("MIDDLE", 76.70),
+                    ("HIGHER", 114.60),
+                ),
+            ),
+            (
+                "pip_dl_reported",
+                "pip_dl_category",
+                (
+                    ("STANDARD", 73.90),
+                    ("ENHANCED", 110.40),
+                ),
+            ),
+        ),
+    )
+    original_person = FakePersonFrame(
+        {
+            "person_id": [1, 2],
+            "dla_sc_reported": [0, 76.7 * WEEKS_IN_YEAR],
+            "pip_dl_reported": [110.4 * WEEKS_IN_YEAR, 0],
+        }
+    )
+    dataset = SimpleNamespace(person=original_person)
+
+    added = add_policyengine_uk_disability_categories_from_reported_amounts(
+        dataset,
+        year=2026,
+    )
+
+    assert added == ("dla_sc_category", "pip_dl_category")
+    assert dataset.person is not original_person
+    assert dataset.person.data["dla_sc_category"] == ["NONE", "MIDDLE"]
+    assert dataset.person.data["pip_dl_category"] == ["ENHANCED", "NONE"]
+    assert "dla_sc_category" not in original_person.data
 
 
 def test_national_insurance_class_1_request_projects_weekly_inputs(monkeypatch):
@@ -2511,6 +2608,80 @@ def test_sda_final_request_projects_final_inputs():
     ] == {"kind": "decimal", "value": "6206.2"}
 
 
+def test_dla_final_projection_uses_category_inputs():
+    assert project_dla_final_inputs(
+        {
+            "dla_sc_category": "MIDDLE",
+            "dla_m_category": "HIGHER",
+        }
+    ) == {
+        "person_has_higher_rate_dla_self_care_category": False,
+        "person_has_middle_rate_dla_self_care_category": True,
+        "person_has_lower_rate_dla_self_care_category": False,
+        "person_has_higher_rate_dla_mobility_category": True,
+        "person_has_lower_rate_dla_mobility_category": False,
+    }
+
+
+def test_dla_final_request_projects_final_inputs():
+    request = build_dla_final_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 1,
+                    "dla": 0,
+                    "dla_sc": 0,
+                    "dla_m": 0,
+                    "dla_sc_category": "NONE",
+                    "dla_m_category": "NONE",
+                },
+                {
+                    "person_id": 2,
+                    "dla": 8_148.40,
+                    "dla_sc": 3_988.40,
+                    "dla_m": 4_160.00,
+                    "dla_sc_category": "MIDDLE",
+                    "dla_m_category": "HIGHER",
+                },
+            ],
+            "person_ids": [1, 2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_2",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-04-06",
+                "end": "2027-04-05",
+            },
+            "outputs": [
+                DLA_FINAL_OUTPUTS[
+                    "disability_living_allowance_self_care_weekly_amount"
+                ]["axiom"],
+                DLA_FINAL_OUTPUTS["disability_living_allowance_mobility_weekly_amount"][
+                    "axiom"
+                ],
+                DLA_FINAL_OUTPUTS["disability_living_allowance_annual_amount"]["axiom"],
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{DLA_FINAL_BASE}#input.person_has_middle_rate_dla_self_care_category:person_2"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{DLA_FINAL_BASE}#input.person_has_higher_rate_dla_mobility_category:person_2"
+    ] == {"kind": "bool", "value": True}
+
+
 def test_pension_credit_final_projection_uses_entitlement_components():
     assert project_pension_credit_final_inputs(
         {
@@ -4031,6 +4202,7 @@ class hbai_household_net_income(Variable):
         "council_tax",
         "domestic_rates",
         "maintenance_expenses",
+        "LVT",
     ]
 """.strip()
     )
@@ -4082,6 +4254,7 @@ class hbai_household_net_income(Variable):
         "council_tax",
         "domestic_rates",
         "maintenance_expenses",
+        "LVT",
     )
     assert by_name["employment_income"].status == "fixed_input"
     assert by_name["employment_income"].policy_component is False
@@ -4216,7 +4389,16 @@ class hbai_household_net_income(Variable):
     assert by_name["child_tax_credit"].status == "partial"
     assert by_name["tax_free_childcare"].status == "partial"
     assert by_name["pip"].status == "exact"
-    assert by_name["dla"].status == "partial"
+    assert by_name["dla"].status == "exact"
+    assert by_name["dla"].surfaces == (
+        "disability-living-allowance-rates",
+        "disability-living-allowance-final",
+    )
+    assert by_name["dla"].covered_outputs == (
+        "dla_sc",
+        "dla_m",
+        "dla",
+    )
     assert by_name["attendance_allowance"].status == "partial"
     assert by_name["carers_allowance"].status == "exact"
     assert by_name["carers_allowance"].surfaces == (
@@ -4257,11 +4439,13 @@ class hbai_household_net_income(Variable):
     assert by_name["council_tax"].policy_component is False
     assert by_name["domestic_rates"].status == "fixed_input"
     assert by_name["domestic_rates"].policy_component is False
+    assert by_name["LVT"].status == "out_of_scope"
+    assert by_name["LVT"].policy_component is False
     assert report.policy_component_count == 23
     assert report.covered_policy_component_count == 23
-    assert report.exact_policy_component_count == 13
+    assert report.exact_policy_component_count == 14
     assert report.covered_policy_component_share == 1
-    assert math.isclose(report.exact_policy_component_share, 13 / 23)
+    assert math.isclose(report.exact_policy_component_share, 14 / 23)
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(
@@ -4297,13 +4481,12 @@ class hbai_household_net_income(Variable):
     assert report.adds == ("employment_income", "dla")
     assert report.subtracts == ("income_tax",)
     assert report.status_counts == {
-        "exact": 1,
+        "exact": 2,
         "fixed_input": 1,
-        "partial": 1,
     }
     assert report.policy_component_count == 2
     assert report.covered_policy_component_count == 2
-    assert report.exact_policy_component_count == 1
+    assert report.exact_policy_component_count == 2
 
 
 def test_uk_hbai_policy_coverage_report_serializes_json(tmp_path):
@@ -4924,6 +5107,49 @@ def test_compare_outputs_compares_sda_final_annual_amount():
     )
 
     assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_dla_final_components_and_annual_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 2,
+                    "dla": 8_148.40,
+                    "dla_sc": 3_988.40,
+                    "dla_m": 4_160.00,
+                    "dla_sc_category": "MIDDLE",
+                    "dla_m_category": "HIGHER",
+                },
+            ],
+            "person_ids": [2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        axiom_outputs_by_surface={
+            "disability-living-allowance-final": [
+                {
+                    "outputs": {
+                        DLA_FINAL_OUTPUTS[
+                            "disability_living_allowance_self_care_weekly_amount"
+                        ]["axiom"]: decimal_output(76.70),
+                        DLA_FINAL_OUTPUTS[
+                            "disability_living_allowance_mobility_weekly_amount"
+                        ]["axiom"]: decimal_output(80.00),
+                        DLA_FINAL_OUTPUTS["disability_living_allowance_annual_amount"][
+                            "axiom"
+                        ]: decimal_output(8_148.40),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 3
     assert report.mismatches == []
     assert report.oracle_divergences == []
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.619"
+version = "0.2.620"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a UK EFRS disability-living-allowance-final surface comparing weekly self-care, weekly mobility, and annual DLA outputs
- derive local pre-migration disability category inputs in memory from reported EFRS amounts so stale local H5s exercise PIP/DLA/AA rows without rewriting data
- mark PE-UK LVT as out of scope for Axiom HBAI coverage and map the new DLA final RuleSpec IDs to PE-UK variables

## Validation
- `uv run ruff check src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_efrs_uk.py tests/test_policyengine_coverage.py`
- `uv run --with policyengine-core==3.26.11 --with policyengine-uk==2.88.56 axiom-encode uk-efrs-compare --rulespec-root /Users/maxghenis/_axiom-worktrees/rulespec-uk-pip-policy-20260606 --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine --surface disability-living-allowance-final --dataset /Users/maxghenis/CosilicoAI/microplex-uk/artifacts/live_uk_local_direct_20260328/enhanced_frs_with_geography.h5 --sample-size 0 --fail-on-mismatch --json`

DLA local EFRS result: 1,428 rows per output, 4,284 compared values, 0 mismatches.