### PR TITLE
Classify UK DLA annualization helper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.620"
+version = "0.2.621"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.620"
+__version__ = "0.2.621"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1421,6 +1421,14 @@ mappings:
     comparison: money
     rationale: Same Disability Living Allowance mobility component after selecting the higher, lower, or nil category; the UK oracle converts PolicyEngine UK's annual value to a weekly amount for comparison.
 
+  - legal_id: uk:policies/govuk/disability-living-allowance#disability_living_allowance_weeks_in_year
+    country: uk
+    program: dla
+    mapping_type: not_comparable
+    comparable: false
+    candidate_priority: P4
+    rationale: Source-backed annualization helper for the policy-level final amount wrapper; PolicyEngine exposes the final annual Disability Living Allowance variable and weekly component rates, not this multiplication factor as a separate oracle target.
+
   - legal_id: uk:policies/govuk/disability-living-allowance#disability_living_allowance_annual_amount
     country: uk
     program: dla

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.620"
+version = "0.2.621"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Mark the DLA final wrapper's `disability_living_allowance_weeks_in_year` helper as not comparable in PolicyEngine oracle coverage.
- Bump axiom-encode to 0.2.621.

This fixes the rulespec-uk DLA PR repository check, which otherwise reports the helper output as unmapped even though the DLA weekly component and annual amount outputs are mapped and tested.

## Validation
- `uv run ruff check src/axiom_encode/__init__.py src/axiom_encode/oracles/policyengine/coverage.py tests/test_policyengine_coverage.py tests/test_cli.py`
- `uv run ruff format --check src/axiom_encode/__init__.py src/axiom_encode/oracles/policyengine/coverage.py tests/test_policyengine_coverage.py tests/test_cli.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::test_package_version_metadata_matches_pyproject -q` (coverage suite passed before commit; version gate passed after commit)
- CI-like rulespec gate: `uv run axiom-encode oracle-coverage --root <temp parent containing rulespec-uk PR #39> --fail-on-unmapped --fail-on-untested-comparable --limit 50`

Oracle coverage after fix: 534 rulespec-uk outputs, comparable=158, known_not_comparable=376, unmapped=0, untested comparable=0.
