### PR TITLE
Add UK national EFRS parity coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.622"
+version = "0.2.623"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.621"
+version = "0.2.622"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.622"
+__version__ = "0.2.623"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.621"
+__version__ = "0.2.622"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -122,6 +122,9 @@ from .oracles.policyengine.efrs_uk import (
     configure_hbai_coverage_parser as configure_uk_efrs_hbai_coverage_parser,
 )
 from .oracles.policyengine.efrs_uk import (
+    configure_national_coverage_parser as configure_uk_efrs_national_coverage_parser,
+)
+from .oracles.policyengine.efrs_uk import (
     configure_parser as configure_uk_efrs_compare_parser,
 )
 from .oracles.policyengine.efrs_uk import (
@@ -132,6 +135,9 @@ from .oracles.policyengine.efrs_uk import (
 )
 from .oracles.policyengine.efrs_uk import (
     main_hbai_coverage as run_uk_efrs_hbai_coverage,
+)
+from .oracles.policyengine.efrs_uk import (
+    main_national_coverage as run_uk_efrs_national_coverage,
 )
 from .oracles.policyengine.registry import load_policyengine_registry
 from .oracles.policyengine.snap_readiness import build_snap_readiness_report
@@ -745,6 +751,12 @@ def main():
         help="Report HBAI net-income policy-component coverage",
     )
     configure_uk_efrs_hbai_coverage_parser(uk_efrs_hbai_coverage_parser)
+
+    uk_efrs_national_coverage_parser = subparsers.add_parser(
+        "uk-efrs-national-coverage",
+        help="Report non-CTR national PE-UK policy-component coverage",
+    )
+    configure_uk_efrs_national_coverage_parser(uk_efrs_national_coverage_parser)
 
     snap_readiness_parser = subparsers.add_parser(
         "snap-readiness",
@@ -1829,6 +1841,8 @@ def main():
         sys.exit(run_uk_efrs_coverage(args))
     elif args.command == "uk-efrs-hbai-coverage":
         sys.exit(run_uk_efrs_hbai_coverage(args))
+    elif args.command == "uk-efrs-national-coverage":
+        sys.exit(run_uk_efrs_national_coverage(args))
     elif args.command == "snap-readiness":
         cmd_snap_readiness(args)
     elif args.command == "calibration":

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -185,6 +185,14 @@ DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_PROGRAM_PATH = Path(
 DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_BASE = (
     "uk:policies/govuk/dfe-extended-childcare-entitlement"
 )
+BUSINESS_RATES_FINAL_PROGRAM_PATH = Path("policies/govuk/business-rates.yaml")
+BUSINESS_RATES_FINAL_BASE = "uk:policies/govuk/business-rates"
+NATIONAL_MINIMUM_WAGE_FINAL_PROGRAM_PATH = Path(
+    "policies/govuk/national-minimum-wage.yaml"
+)
+NATIONAL_MINIMUM_WAGE_FINAL_BASE = "uk:policies/govuk/national-minimum-wage"
+MATERNITY_ALLOWANCE_FINAL_PROGRAM_PATH = Path("policies/govuk/maternity-allowance.yaml")
+MATERNITY_ALLOWANCE_FINAL_BASE = "uk:policies/govuk/maternity-allowance"
 
 PERSONAL_ALLOWANCE_OUTPUTS = {
     "personal_allowance": {
@@ -1094,6 +1102,34 @@ DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_OUTPUTS = {
     },
 }
 
+BUSINESS_RATES_FINAL_OUTPUTS = {
+    "business_rates_annual_amount": {
+        "axiom": f"{BUSINESS_RATES_FINAL_BASE}#business_rates_annual_amount",
+        "pe": "business_rates",
+        "tolerance": 0.01,
+    },
+}
+
+NATIONAL_MINIMUM_WAGE_FINAL_OUTPUTS = {
+    "national_minimum_wage_hourly_rate": {
+        "axiom": (
+            f"{NATIONAL_MINIMUM_WAGE_FINAL_BASE}#national_minimum_wage_hourly_rate"
+        ),
+        "pe": "minimum_wage",
+        "tolerance": 0.001,
+    },
+}
+
+MATERNITY_ALLOWANCE_FINAL_OUTPUTS = {
+    "maternity_allowance_annual_amount": {
+        "axiom": (
+            f"{MATERNITY_ALLOWANCE_FINAL_BASE}#maternity_allowance_annual_amount"
+        ),
+        "pe": "maternity_allowance",
+        "tolerance": 0.01,
+    },
+}
+
 
 @dataclass(frozen=True)
 class UKEFRSSurfaceSpec:
@@ -1872,6 +1908,34 @@ SURFACE_SPECS = {
             "ssmg_reported",
         ),
     ),
+    "business-rates-final": UKEFRSSurfaceSpec(
+        program=BUSINESS_RATES_FINAL_PROGRAM_PATH,
+        entity="household",
+        outputs=BUSINESS_RATES_FINAL_OUTPUTS,
+        pe_variables=(
+            "business_rates",
+            "shareholding",
+        ),
+    ),
+    "national-minimum-wage-final": UKEFRSSurfaceSpec(
+        program=NATIONAL_MINIMUM_WAGE_FINAL_PROGRAM_PATH,
+        entity="person",
+        outputs=NATIONAL_MINIMUM_WAGE_FINAL_OUTPUTS,
+        pe_variables=(
+            "age",
+            "is_apprentice",
+            "minimum_wage",
+        ),
+    ),
+    "maternity-allowance-final": UKEFRSSurfaceSpec(
+        program=MATERNITY_ALLOWANCE_FINAL_PROGRAM_PATH,
+        entity="person",
+        outputs=MATERNITY_ALLOWANCE_FINAL_OUTPUTS,
+        pe_variables=(
+            "maternity_allowance",
+            "maternity_allowance_reported",
+        ),
+    ),
 }
 
 HBAI_FIXED_INPUT_COMPONENTS = frozenset(
@@ -1895,7 +1959,6 @@ HBAI_FIXED_INPUT_COMPONENTS = frozenset(
         "jsa_contrib",
         "maintenance_expenses",
         "maintenance_income",
-        "maternity_allowance",
         "miscellaneous_income",
         "personal_pension_contributions",
         "private_pension_income",
@@ -2175,6 +2238,12 @@ HBAI_COMPONENT_COVERAGE = {
         ),
         "rationale": "Axiom covers PolicyEngine UK's Sure Start Maternity Grant final person amount: the statutory grant rate and the reported-receipt gate used by PolicyEngine. Upstream qualifying-benefit, pregnancy or child, claim-time, and residence conditions remain projected into the reported-receipt leaf input.",
     },
+    "maternity_allowance": {
+        "status": "exact",
+        "surfaces": ("maternity-allowance-final",),
+        "covered_outputs": ("maternity_allowance",),
+        "rationale": "Axiom covers PolicyEngine UK's Maternity Allowance wrapper exactly as PE models it: the annual amount is the reported maternity_allowance_reported input held in the EFRS dataset.",
+    },
     "scottish_child_payment": {
         "status": "exact",
         "surfaces": (
@@ -2297,7 +2366,7 @@ NATIONAL_POLICY_COMPONENTS = (
     {
         "program_id": "minimum_wage",
         "name": "National Minimum Wage",
-        "variable": None,
+        "variable": "minimum_wage",
         "category": "Other",
         "agency": "HMRC",
         "coverage": "UK",
@@ -2631,10 +2700,16 @@ NATIONAL_POLICY_COMPONENT_COVERAGE = {
     "student_loan_repayment": HBAI_COMPONENT_COVERAGE["student_loan_repayments"],
     "tax_free_childcare": HBAI_COMPONENT_COVERAGE["tax_free_childcare"],
     "business_rates": {
-        "status": "out_of_scope",
-        "surfaces": (),
-        "covered_outputs": (),
-        "rationale": "PolicyEngine UK's business-rates program is marked partial with parameters needing updates beyond 2021, and it is outside the current household EFRS national tax-benefit validation scope.",
+        "status": "exact",
+        "surfaces": ("business-rates-final",),
+        "covered_outputs": ("business_rates",),
+        "rationale": "Axiom covers PolicyEngine UK's business_rates incidence surface exactly as PE models it: household shareholding multiplied by the active aggregate business-rates revenue parameter.",
+    },
+    "minimum_wage": {
+        "status": "exact",
+        "surfaces": ("national-minimum-wage-final",),
+        "covered_outputs": ("minimum_wage",),
+        "rationale": "Axiom covers PolicyEngine UK's National Minimum Wage hourly-rate surface from the apprentice override and non-apprentice age bands.",
     },
     "universal_credit": HBAI_COMPONENT_COVERAGE["universal_credit"],
     "pension_credit": HBAI_COMPONENT_COVERAGE["pension_credit"],
@@ -2688,10 +2763,10 @@ NATIONAL_POLICY_COMPONENT_COVERAGE = {
     "winter_fuel_allowance": HBAI_COMPONENT_COVERAGE["winter_fuel_allowance"],
     "ssmg": HBAI_COMPONENT_COVERAGE["ssmg"],
     "maternity_allowance": {
-        "status": "fixed_input",
-        "surfaces": (),
-        "covered_outputs": (),
-        "rationale": "PolicyEngine UK's maternity_allowance variable delegates to reported survey receipt in EFRS; it is held fixed rather than treated as a remaining policy-rule gap.",
+        "status": "exact",
+        "surfaces": ("maternity-allowance-final",),
+        "covered_outputs": ("maternity_allowance",),
+        "rationale": "Axiom covers PolicyEngine UK's Maternity Allowance wrapper exactly as PE models it: the final amount delegates to reported maternity_allowance_reported survey receipt.",
     },
     "universal_childcare_entitlement": {
         "status": "exact",
@@ -2810,13 +2885,7 @@ NATIONAL_POLICY_COMPONENT_COVERAGE = {
     },
 }
 
-NATIONAL_POLICY_PARAMETER_ONLY_COMPONENTS = {
-    "minimum_wage": (
-        "National Minimum Wage has PE parameters but no primary household EFRS "
-        "cash-output variable in programs.yaml, so it is tracked separately from "
-        "the current EFRS output-alignment queue."
-    ),
-}
+NATIONAL_POLICY_PARAMETER_ONLY_COMPONENTS: dict[str, str] = {}
 
 UNIVERSAL_CREDIT_REGULATION_36_SURFACES = frozenset(
     surface
@@ -5942,6 +6011,12 @@ def build_axiom_request(
         )
     if surface == "sure-start-maternity-grant-final":
         return build_ssmg_final_request(pe_data=pe_data, year=year)
+    if surface == "business-rates-final":
+        return build_business_rates_final_request(pe_data=pe_data, year=year)
+    if surface == "national-minimum-wage-final":
+        return build_national_minimum_wage_final_request(pe_data=pe_data, year=year)
+    if surface == "maternity-allowance-final":
+        return build_maternity_allowance_final_request(pe_data=pe_data, year=year)
     if surface in UNIVERSAL_CREDIT_REGULATION_36_SURFACES:
         return build_universal_credit_request(
             pe_data=pe_data,
@@ -7732,6 +7807,111 @@ def build_ltt_final_request(*, pe_data: dict[str, Any], year: int) -> dict[str, 
                 "entity_id": entity_id,
                 "period": interval,
                 "outputs": [spec["axiom"] for spec in LTT_FINAL_OUTPUTS.values()],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_business_rates_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "business-rates-final"):
+        entity_id = household_entity_id(int(row_value(row, "household_id")))
+        inputs.append(
+            input_record(
+                f"{BUSINESS_RATES_FINAL_BASE}#input.business_rates_shareholding",
+                entity_id,
+                interval,
+                money(row_value(row, "shareholding", 0)),
+            )
+        )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in BUSINESS_RATES_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_national_minimum_wage_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "national-minimum-wage-final"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in {
+            "minimum_wage_age": money(row_value(row, "age", 0)),
+            "minimum_wage_is_apprentice": bool(row_value(row, "is_apprentice", False)),
+        }.items():
+            inputs.append(
+                input_record(
+                    f"{NATIONAL_MINIMUM_WAGE_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in NATIONAL_MINIMUM_WAGE_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_maternity_allowance_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "maternity-allowance-final"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        inputs.append(
+            input_record(
+                f"{MATERNITY_ALLOWANCE_FINAL_BASE}"
+                "#input.reported_maternity_allowance_for_year",
+                entity_id,
+                interval,
+                money(row_value(row, "maternity_allowance_reported", 0)),
+            )
+        )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in MATERNITY_ALLOWANCE_FINAL_OUTPUTS.values()
+                ],
             }
         )
 

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -121,6 +121,22 @@ STUDENT_LOAN_REPAYMENT_PROGRAM_PATH = Path(
     "policies/govuk/student-loan-repayments.yaml"
 )
 STUDENT_LOAN_REPAYMENT_BASE = "uk:policies/govuk/student-loan-repayments"
+CAPITAL_GAINS_TAX_FINAL_PROGRAM_PATH = Path(
+    "policies/govuk/capital-gains-tax.yaml"
+)
+CAPITAL_GAINS_TAX_FINAL_BASE = "uk:policies/govuk/capital-gains-tax"
+STAMP_DUTY_LAND_TAX_FINAL_PROGRAM_PATH = Path(
+    "policies/govuk/stamp-duty-land-tax.yaml"
+)
+STAMP_DUTY_LAND_TAX_FINAL_BASE = "uk:policies/govuk/stamp-duty-land-tax"
+LBTT_FINAL_PROGRAM_PATH = Path("policies/govuk/land-and-buildings-transaction-tax.yaml")
+LBTT_FINAL_BASE = "uk:policies/govuk/land-and-buildings-transaction-tax"
+LTT_FINAL_PROGRAM_PATH = Path("policies/govuk/land-transaction-tax.yaml")
+LTT_FINAL_BASE = "uk:policies/govuk/land-transaction-tax"
+CLOSED_LEGACY_BENEFITS_FINAL_PROGRAM_PATH = Path(
+    "policies/govuk/closed-legacy-benefits.yaml"
+)
+CLOSED_LEGACY_BENEFITS_FINAL_BASE = "uk:policies/govuk/closed-legacy-benefits"
 CARERS_ALLOWANCE_FINAL_PROGRAM_PATH = Path("policies/govuk/carers-allowance.yaml")
 CARERS_ALLOWANCE_FINAL_BASE = "uk:policies/govuk/carers-allowance"
 CARER_SUPPORT_PAYMENT_FINAL_PROGRAM_PATH = Path(
@@ -135,6 +151,46 @@ SDA_FINAL_PROGRAM_PATH = Path("policies/govuk/severe-disablement-allowance.yaml"
 SDA_FINAL_BASE = "uk:policies/govuk/severe-disablement-allowance"
 DLA_FINAL_PROGRAM_PATH = Path("policies/govuk/disability-living-allowance.yaml")
 DLA_FINAL_BASE = "uk:policies/govuk/disability-living-allowance"
+ATTENDANCE_ALLOWANCE_FINAL_PROGRAM_PATH = Path(
+    "policies/govuk/attendance-allowance.yaml"
+)
+ATTENDANCE_ALLOWANCE_FINAL_BASE = "uk:policies/govuk/attendance-allowance"
+WINTER_FUEL_ALLOWANCE_FINAL_PROGRAM_PATH = Path(
+    "policies/govuk/winter-fuel-allowance.yaml"
+)
+WINTER_FUEL_ALLOWANCE_FINAL_BASE = "uk:policies/govuk/winter-fuel-allowance"
+TAX_FREE_CHILDCARE_FINAL_PROGRAM_PATH = Path("policies/govuk/tax-free-childcare.yaml")
+TAX_FREE_CHILDCARE_FINAL_BASE = "uk:policies/govuk/tax-free-childcare"
+VAT_FINAL_PROGRAM_PATH = Path("policies/govuk/vat.yaml")
+VAT_FINAL_BASE = "uk:policies/govuk/vat"
+FUEL_DUTY_FINAL_PROGRAM_PATH = Path("policies/govuk/fuel-duty.yaml")
+FUEL_DUTY_FINAL_BASE = "uk:policies/govuk/fuel-duty"
+TV_LICENCE_FINAL_PROGRAM_PATH = Path("policies/govuk/tv-licence.yaml")
+TV_LICENCE_FINAL_BASE = "uk:policies/govuk/tv-licence"
+SSMG_FINAL_PROGRAM_PATH = Path("policies/govuk/sure-start-maternity-grant.yaml")
+SSMG_FINAL_BASE = "uk:policies/govuk/sure-start-maternity-grant"
+COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_PROGRAM_PATH = Path(
+    "policies/govuk/cost-of-living-support-payment.yaml"
+)
+COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_BASE = (
+    "uk:policies/govuk/cost-of-living-support-payment"
+)
+ENERGY_BILLS_REBATE_FINAL_PROGRAM_PATH = Path(
+    "policies/govuk/energy-bills-rebate.yaml"
+)
+ENERGY_BILLS_REBATE_FINAL_BASE = "uk:policies/govuk/energy-bills-rebate"
+ENERGY_PRICE_GUARANTEE_FINAL_PROGRAM_PATH = Path(
+    "policies/govuk/energy-price-guarantee.yaml"
+)
+ENERGY_PRICE_GUARANTEE_FINAL_BASE = "uk:policies/govuk/energy-price-guarantee"
+DFE_PERSON_PROGRAMS_FINAL_PROGRAM_PATH = Path("policies/govuk/dfe-person-programs.yaml")
+DFE_PERSON_PROGRAMS_FINAL_BASE = "uk:policies/govuk/dfe-person-programs"
+DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_PROGRAM_PATH = Path(
+    "policies/govuk/dfe-extended-childcare-entitlement.yaml"
+)
+DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_BASE = (
+    "uk:policies/govuk/dfe-extended-childcare-entitlement"
+)
 
 PERSONAL_ALLOWANCE_OUTPUTS = {
     "personal_allowance": {
@@ -729,6 +785,37 @@ STUDENT_LOAN_REPAYMENT_OUTPUTS = {
     },
 }
 
+CLOSED_LEGACY_BENEFITS_FINAL_OUTPUTS = {
+    "income_support": {
+        "axiom": f"{CLOSED_LEGACY_BENEFITS_FINAL_BASE}#income_support",
+        "pe": "income_support",
+    },
+    "jsa_income": {
+        "axiom": f"{CLOSED_LEGACY_BENEFITS_FINAL_BASE}#jsa_income",
+        "pe": "jsa_income",
+    },
+    "working_tax_credit": {
+        "axiom": f"{CLOSED_LEGACY_BENEFITS_FINAL_BASE}#working_tax_credit",
+        "pe": "working_tax_credit",
+    },
+    "child_tax_credit": {
+        "axiom": f"{CLOSED_LEGACY_BENEFITS_FINAL_BASE}#child_tax_credit",
+        "pe": "child_tax_credit",
+    },
+    "tax_credits": {
+        "axiom": f"{CLOSED_LEGACY_BENEFITS_FINAL_BASE}#tax_credits",
+        "pe": "tax_credits",
+    },
+    "jsa": {
+        "axiom": f"{CLOSED_LEGACY_BENEFITS_FINAL_BASE}#jsa",
+        "pe": "jsa",
+    },
+    "esa": {
+        "axiom": f"{CLOSED_LEGACY_BENEFITS_FINAL_BASE}#esa",
+        "pe": "esa",
+    },
+}
+
 CARERS_ALLOWANCE_FINAL_OUTPUTS = {
     "carers_allowance_annual_amount": {
         "axiom": f"{CARERS_ALLOWANCE_FINAL_BASE}#carers_allowance_annual_amount",
@@ -781,6 +868,243 @@ DLA_FINAL_OUTPUTS = {
     "disability_living_allowance_annual_amount": {
         "axiom": f"{DLA_FINAL_BASE}#disability_living_allowance_annual_amount",
         "pe": "dla",
+        "tolerance": 0.01,
+    },
+}
+
+ATTENDANCE_ALLOWANCE_FINAL_OUTPUTS = {
+    "attendance_allowance_weekly_amount": {
+        "axiom": f"{ATTENDANCE_ALLOWANCE_FINAL_BASE}#attendance_allowance_weekly_amount",
+        "pe": "attendance_allowance",
+        "pe_transform": "annual_to_weekly",
+        "tolerance": 0.01,
+    },
+    "attendance_allowance_annual_amount": {
+        "axiom": f"{ATTENDANCE_ALLOWANCE_FINAL_BASE}#attendance_allowance_annual_amount",
+        "pe": "attendance_allowance",
+        "tolerance": 0.01,
+    },
+}
+
+WINTER_FUEL_ALLOWANCE_FINAL_OUTPUTS = {
+    "winter_fuel_allowance_annual_amount": {
+        "axiom": (
+            f"{WINTER_FUEL_ALLOWANCE_FINAL_BASE}#winter_fuel_allowance_annual_amount"
+        ),
+        "pe": "winter_fuel_allowance",
+        "tolerance": 0.01,
+    },
+}
+
+TAX_FREE_CHILDCARE_FINAL_OUTPUTS = {
+    "tax_free_childcare_annual_amount": {
+        "axiom": f"{TAX_FREE_CHILDCARE_FINAL_BASE}#tax_free_childcare_annual_amount",
+        "pe": "tax_free_childcare",
+        "tolerance": 0.01,
+    },
+}
+
+CAPITAL_GAINS_TAX_FINAL_OUTPUTS = {
+    "capital_gains_tax_annual_amount": {
+        "axiom": (
+            f"{CAPITAL_GAINS_TAX_FINAL_BASE}#capital_gains_tax_annual_amount"
+        ),
+        "pe": "capital_gains_tax",
+        "tolerance": 0.01,
+    },
+}
+
+STAMP_DUTY_LAND_TAX_FINAL_OUTPUTS = {
+    "stamp_duty_land_tax_annual_amount": {
+        "axiom": (
+            f"{STAMP_DUTY_LAND_TAX_FINAL_BASE}"
+            "#stamp_duty_land_tax_annual_amount"
+        ),
+        "pe": "stamp_duty_land_tax",
+        "tolerance": 0.01,
+    },
+}
+
+LBTT_FINAL_OUTPUTS = {
+    "land_and_buildings_transaction_tax_annual_amount": {
+        "axiom": (
+            f"{LBTT_FINAL_BASE}"
+            "#land_and_buildings_transaction_tax_annual_amount"
+        ),
+        "pe": "land_and_buildings_transaction_tax",
+        "tolerance": 0.01,
+    },
+}
+
+LTT_FINAL_OUTPUTS = {
+    "land_transaction_tax_annual_amount": {
+        "axiom": f"{LTT_FINAL_BASE}#land_transaction_tax_annual_amount",
+        "pe": "land_transaction_tax",
+        "tolerance": 0.01,
+    },
+}
+
+VAT_FINAL_OUTPUTS = {
+    "vat_annual_amount": {
+        "axiom": f"{VAT_FINAL_BASE}#vat_annual_amount",
+        "pe": "vat",
+        "tolerance": 0.01,
+    },
+}
+
+FUEL_DUTY_FINAL_OUTPUTS = {
+    "fuel_duty_annual_amount": {
+        "axiom": f"{FUEL_DUTY_FINAL_BASE}#fuel_duty_annual_amount",
+        "pe": "fuel_duty",
+        "tolerance": 0.01,
+    },
+}
+
+TV_LICENCE_FINAL_OUTPUTS = {
+    "free_tv_licence_value": {
+        "axiom": f"{TV_LICENCE_FINAL_BASE}#free_tv_licence_value",
+        "pe": "free_tv_licence_value",
+        "tolerance": 0.01,
+    },
+    "tv_licence_annual_amount": {
+        "axiom": f"{TV_LICENCE_FINAL_BASE}#tv_licence_annual_amount",
+        "pe": "tv_licence",
+        "tolerance": 0.01,
+    },
+}
+
+SSMG_FINAL_OUTPUTS = {
+    "sure_start_maternity_grant_annual_amount": {
+        "axiom": (f"{SSMG_FINAL_BASE}#sure_start_maternity_grant_annual_amount"),
+        "pe": "ssmg",
+        "tolerance": 0.01,
+    },
+}
+
+COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_OUTPUTS = {
+    "cost_of_living_support_payment_annual_amount": {
+        "axiom": (
+            f"{COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_BASE}"
+            "#cost_of_living_support_payment_annual_amount"
+        ),
+        "pe": "cost_of_living_support_payment",
+        "tolerance": 0.01,
+    },
+}
+
+ENERGY_BILLS_REBATE_FINAL_OUTPUTS = {
+    "energy_bills_rebate_council_tax_rebate": {
+        "axiom": (
+            f"{ENERGY_BILLS_REBATE_FINAL_BASE}"
+            "#energy_bills_rebate_council_tax_rebate"
+        ),
+        "pe": "ebr_council_tax_rebate",
+        "tolerance": 0.01,
+    },
+    "energy_bills_rebate_energy_bills_credit": {
+        "axiom": (
+            f"{ENERGY_BILLS_REBATE_FINAL_BASE}"
+            "#energy_bills_rebate_energy_bills_credit"
+        ),
+        "pe": "ebr_energy_bills_credit",
+        "tolerance": 0.01,
+    },
+    "energy_bills_rebate_annual_amount": {
+        "axiom": f"{ENERGY_BILLS_REBATE_FINAL_BASE}#energy_bills_rebate_annual_amount",
+        "pe": "energy_bills_rebate",
+        "tolerance": 0.01,
+    },
+}
+
+ENERGY_PRICE_GUARANTEE_FINAL_OUTPUTS = {
+    "energy_price_guarantee_subsidy_annual_amount": {
+        "axiom": (
+            f"{ENERGY_PRICE_GUARANTEE_FINAL_BASE}"
+            "#energy_price_guarantee_subsidy_annual_amount"
+        ),
+        "pe": "epg_subsidy",
+        "tolerance": 0.01,
+    },
+}
+
+DFE_PERSON_PROGRAMS_FINAL_OUTPUTS = {
+    "universal_childcare_entitlement_annual_amount": {
+        "axiom": (
+            f"{DFE_PERSON_PROGRAMS_FINAL_BASE}"
+            "#universal_childcare_entitlement_annual_amount"
+        ),
+        "pe": "universal_childcare_entitlement",
+        "tolerance": 0.01,
+    },
+    "targeted_childcare_entitlement_annual_amount": {
+        "axiom": (
+            f"{DFE_PERSON_PROGRAMS_FINAL_BASE}"
+            "#targeted_childcare_entitlement_annual_amount"
+        ),
+        "pe": "targeted_childcare_entitlement",
+        "tolerance": 0.01,
+    },
+    "childcare_grant_annual_amount": {
+        "axiom": f"{DFE_PERSON_PROGRAMS_FINAL_BASE}#childcare_grant_annual_amount",
+        "pe": "childcare_grant",
+        "tolerance": 0.01,
+    },
+    "parents_learning_allowance_annual_amount": {
+        "axiom": (
+            f"{DFE_PERSON_PROGRAMS_FINAL_BASE}"
+            "#parents_learning_allowance_annual_amount"
+        ),
+        "pe": "parents_learning_allowance",
+        "tolerance": 0.01,
+    },
+    "adult_dependants_grant_annual_amount": {
+        "axiom": (
+            f"{DFE_PERSON_PROGRAMS_FINAL_BASE}"
+            "#adult_dependants_grant_annual_amount"
+        ),
+        "pe": "adult_dependants_grant",
+        "tolerance": 0.01,
+    },
+    "travel_grant_annual_amount": {
+        "axiom": f"{DFE_PERSON_PROGRAMS_FINAL_BASE}#travel_grant_annual_amount",
+        "pe": "travel_grant",
+        "tolerance": 0.01,
+    },
+    "disabled_students_allowance_annual_amount": {
+        "axiom": (
+            f"{DFE_PERSON_PROGRAMS_FINAL_BASE}"
+            "#disabled_students_allowance_annual_amount"
+        ),
+        "pe": "disabled_students_allowance",
+        "tolerance": 0.01,
+    },
+    "care_to_learn_annual_amount": {
+        "axiom": f"{DFE_PERSON_PROGRAMS_FINAL_BASE}#care_to_learn_annual_amount",
+        "pe": "care_to_learn",
+        "tolerance": 0.01,
+    },
+    "maintenance_loan_annual_amount": {
+        "axiom": f"{DFE_PERSON_PROGRAMS_FINAL_BASE}#maintenance_loan_annual_amount",
+        "pe": "maintenance_loan",
+        "tolerance": 0.01,
+    },
+    "bursary_fund_16_to_19_annual_amount": {
+        "axiom": (
+            f"{DFE_PERSON_PROGRAMS_FINAL_BASE}"
+            "#bursary_fund_16_to_19_annual_amount"
+        ),
+        "pe": "bursary_fund_16_to_19",
+        "tolerance": 0.01,
+    },
+}
+
+DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_OUTPUTS = {
+    "extended_childcare_entitlement_annual_amount": {
+        "axiom": (
+            f"{DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_BASE}"
+            "#extended_childcare_entitlement_annual_amount"
+        ),
+        "pe": "extended_childcare_entitlement",
         "tolerance": 0.01,
     },
 }
@@ -1258,8 +1582,26 @@ SURFACE_SPECS = {
         outputs=STUDENT_LOAN_REPAYMENT_OUTPUTS,
         pe_variables=(
             "adjusted_net_income",
+            "student_loan_balance",
             "student_loan_plan",
             "student_loan_repayment",
+        ),
+    ),
+    "closed-legacy-benefits-final": UKEFRSSurfaceSpec(
+        program=CLOSED_LEGACY_BENEFITS_FINAL_PROGRAM_PATH,
+        entity="benunit",
+        outputs=CLOSED_LEGACY_BENEFITS_FINAL_OUTPUTS,
+        pe_variables=(
+            "child_tax_credit",
+            "esa",
+            "esa_contrib",
+            "esa_income",
+            "income_support",
+            "jsa",
+            "jsa_contrib",
+            "jsa_income",
+            "tax_credits",
+            "working_tax_credit",
         ),
     ),
     "carers-allowance-final": UKEFRSSurfaceSpec(
@@ -1313,6 +1655,236 @@ SURFACE_SPECS = {
             "dla_m_category",
             "dla_sc",
             "dla_sc_category",
+        ),
+    ),
+    "attendance-allowance-final": UKEFRSSurfaceSpec(
+        program=ATTENDANCE_ALLOWANCE_FINAL_PROGRAM_PATH,
+        entity="person",
+        outputs=ATTENDANCE_ALLOWANCE_FINAL_OUTPUTS,
+        pe_variables=(
+            "aa_category",
+            "attendance_allowance",
+        ),
+    ),
+    "winter-fuel-allowance-final": UKEFRSSurfaceSpec(
+        program=WINTER_FUEL_ALLOWANCE_FINAL_PROGRAM_PATH,
+        entity="household",
+        outputs=WINTER_FUEL_ALLOWANCE_FINAL_OUTPUTS,
+        pe_variables=(
+            "country",
+            "esa_income",
+            "income_support",
+            "jsa_income",
+            "pension_credit",
+            "winter_fuel_allowance",
+        ),
+        projection_person_variables=(
+            "age",
+            "is_SP_age",
+            "total_income",
+        ),
+    ),
+    "tax-free-childcare-final": UKEFRSSurfaceSpec(
+        program=TAX_FREE_CHILDCARE_FINAL_PROGRAM_PATH,
+        entity="person",
+        outputs=TAX_FREE_CHILDCARE_FINAL_OUTPUTS,
+        pe_variables=(
+            "childcare_expenses",
+            "is_blind",
+            "is_disabled_for_benefits",
+            "tax_free_childcare",
+            "tax_free_childcare_eligible",
+            "tax_free_childcare_eligible_declaration_periods",
+            "tax_free_childcare_qualifying_child",
+            "tax_free_childcare_uses_qualifying_provider",
+        ),
+    ),
+    "capital-gains-tax-final": UKEFRSSurfaceSpec(
+        program=CAPITAL_GAINS_TAX_FINAL_PROGRAM_PATH,
+        entity="person",
+        outputs=CAPITAL_GAINS_TAX_FINAL_OUTPUTS,
+        pe_variables=(
+            "adjusted_net_income",
+            "allowances",
+            "capital_gains",
+            "capital_gains_tax",
+            "gift_aid",
+            "gift_aid_grossed_up",
+            "pension_contributions_relief",
+            "personal_pension_contributions",
+        ),
+    ),
+    "stamp-duty-land-tax-final": UKEFRSSurfaceSpec(
+        program=STAMP_DUTY_LAND_TAX_FINAL_PROGRAM_PATH,
+        entity="household",
+        outputs=STAMP_DUTY_LAND_TAX_FINAL_OUTPUTS,
+        pe_variables=(
+            "additional_residential_property_purchased",
+            "country",
+            "cumulative_non_residential_rent",
+            "cumulative_residential_rent",
+            "main_residential_property_purchased",
+            "main_residential_property_purchased_is_first_home",
+            "non_residential_property_purchased",
+            "non_residential_rent",
+            "rent",
+            "sdlt_liable",
+            "stamp_duty_land_tax",
+        ),
+    ),
+    "land-and-buildings-transaction-tax-final": UKEFRSSurfaceSpec(
+        program=LBTT_FINAL_PROGRAM_PATH,
+        entity="household",
+        outputs=LBTT_FINAL_OUTPUTS,
+        pe_variables=(
+            "land_and_buildings_transaction_tax",
+            "lbtt_liable",
+            "lbtt_on_rent",
+            "lbtt_on_transactions",
+        ),
+    ),
+    "land-transaction-tax-final": UKEFRSSurfaceSpec(
+        program=LTT_FINAL_PROGRAM_PATH,
+        entity="household",
+        outputs=LTT_FINAL_OUTPUTS,
+        pe_variables=(
+            "land_transaction_tax",
+            "ltt_liable",
+            "ltt_on_rent",
+            "ltt_on_transactions",
+        ),
+    ),
+    "vat-final": UKEFRSSurfaceSpec(
+        program=VAT_FINAL_PROGRAM_PATH,
+        entity="household",
+        outputs=VAT_FINAL_OUTPUTS,
+        pe_variables=(
+            "full_rate_vat_consumption",
+            "reduced_rate_vat_consumption",
+            "vat",
+        ),
+    ),
+    "fuel-duty-final": UKEFRSSurfaceSpec(
+        program=FUEL_DUTY_FINAL_PROGRAM_PATH,
+        entity="household",
+        outputs=FUEL_DUTY_FINAL_OUTPUTS,
+        pe_variables=(
+            "diesel_litres",
+            "fuel_duty",
+            "in_rural_fuel_duty_relief_area",
+            "petrol_litres",
+        ),
+    ),
+    "free-tv-licence-value": UKEFRSSurfaceSpec(
+        program=TV_LICENCE_FINAL_PROGRAM_PATH,
+        entity="household",
+        outputs=TV_LICENCE_FINAL_OUTPUTS,
+        pe_variables=(
+            "free_tv_licence_value",
+            "household_owns_tv",
+            "tv_licence",
+            "tv_licence_discount",
+            "would_evade_tv_licence_fee",
+        ),
+    ),
+    "cost-of-living-support-payment-final": UKEFRSSurfaceSpec(
+        program=COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_PROGRAM_PATH,
+        entity="household",
+        outputs=COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_OUTPUTS,
+        pe_variables=(
+            "armed_forces_independence_payment",
+            "attendance_allowance",
+            "cost_of_living_support_payment",
+            "dla",
+            "esa_income",
+            "housing_benefit",
+            "income_support",
+            "jsa_income",
+            "pension_credit",
+            "pip",
+            "universal_credit",
+            "winter_fuel_allowance",
+        ),
+    ),
+    "energy-bills-rebate-final": UKEFRSSurfaceSpec(
+        program=ENERGY_BILLS_REBATE_FINAL_PROGRAM_PATH,
+        entity="household",
+        outputs=ENERGY_BILLS_REBATE_FINAL_OUTPUTS,
+        pe_variables=(
+            "ebr_council_tax_rebate",
+            "ebr_energy_bills_credit",
+            "energy_bills_rebate",
+        ),
+    ),
+    "energy-price-guarantee-final": UKEFRSSurfaceSpec(
+        program=ENERGY_PRICE_GUARANTEE_FINAL_PROGRAM_PATH,
+        entity="household",
+        outputs=ENERGY_PRICE_GUARANTEE_FINAL_OUTPUTS,
+        pe_variables=(
+            "domestic_energy_consumption",
+            "epg_subsidy",
+        ),
+    ),
+    "dfe-person-programs-final": UKEFRSSurfaceSpec(
+        program=DFE_PERSON_PROGRAMS_FINAL_PROGRAM_PATH,
+        entity="person",
+        outputs=DFE_PERSON_PROGRAMS_FINAL_OUTPUTS,
+        pe_variables=(
+            "adult_dependants_grant",
+            "adult_dependants_grant_eligible",
+            "age",
+            "bursary_fund_16_to_19",
+            "bursary_fund_16_to_19_participation_costs",
+            "bursary_fund_16_to_19_vulnerable_group_eligible",
+            "care_to_learn",
+            "care_to_learn_eligible",
+            "childcare_expenses",
+            "childcare_grant",
+            "childcare_grant_eligible",
+            "childcare_grant_eligible_children",
+            "disabled_students_allowance",
+            "disabled_students_allowance_eligible",
+            "disabled_students_allowance_eligible_expenses",
+            "maintenance_loan",
+            "maintenance_loan_eligible",
+            "maintenance_loan_entitled_to_benefits",
+            "maintenance_loan_household_income",
+            "maintenance_loan_living_arrangement",
+            "max_free_entitlement_hours_used",
+            "parents_learning_allowance",
+            "parents_learning_allowance_eligible",
+            "region",
+            "targeted_childcare_entitlement",
+            "targeted_childcare_entitlement_eligible",
+            "travel_grant",
+            "travel_grant_eligible",
+            "travel_grant_eligible_expenses",
+            "travel_grant_household_income",
+            "universal_childcare_entitlement",
+            "universal_childcare_entitlement_eligible",
+        ),
+    ),
+    "dfe-extended-childcare-entitlement-final": UKEFRSSurfaceSpec(
+        program=DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_PROGRAM_PATH,
+        entity="benunit",
+        outputs=DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_OUTPUTS,
+        pe_variables=(
+            "extended_childcare_entitlement",
+            "extended_childcare_entitlement_eligible",
+            "maximum_extended_childcare_hours_usage",
+        ),
+        projection_person_variables=(
+            "age",
+            "max_free_entitlement_hours_used",
+        ),
+    ),
+    "sure-start-maternity-grant-final": UKEFRSSurfaceSpec(
+        program=SSMG_FINAL_PROGRAM_PATH,
+        entity="person",
+        outputs=SSMG_FINAL_OUTPUTS,
+        pe_variables=(
+            "ssmg",
+            "ssmg_reported",
         ),
     ),
 }
@@ -1412,16 +1984,22 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom covers Housing Benefit capital tariff income branches and the final annual PolicyEngine UK housing_benefit wrapper after the claim gate and benefit-cap reduction.",
     },
     "income_support": {
-        "status": "partial",
-        "surfaces": ("income-support-tariff-income",),
-        "covered_outputs": ("income_support_tariff_income",),
-        "rationale": "Axiom covers Income Support capital tariff income, not the final Income Support HBAI amount.",
+        "status": "exact",
+        "surfaces": (
+            "income-support-tariff-income",
+            "closed-legacy-benefits-final",
+        ),
+        "covered_outputs": ("income_support_tariff_income", "income_support"),
+        "rationale": "Axiom covers Income Support capital tariff income and the current-law final nil amount after DWP closed the remaining Income Support legacy caseload through managed migration.",
     },
     "jsa_income": {
-        "status": "partial",
-        "surfaces": ("jsa-income-tariff-income",),
-        "covered_outputs": ("jsa_income_tariff_income",),
-        "rationale": "Axiom covers capital tariff income used inside income-based JSA, not the final JSA HBAI amount.",
+        "status": "exact",
+        "surfaces": (
+            "jsa-income-tariff-income",
+            "closed-legacy-benefits-final",
+        ),
+        "covered_outputs": ("jsa_income_tariff_income", "jsa_income"),
+        "rationale": "Axiom covers capital tariff income used inside income-based JSA and the current-law final nil amount after DWP closed the remaining income-related Jobseeker's Allowance legacy caseload through managed migration.",
     },
     "pension_credit": {
         "status": "exact",
@@ -1492,45 +2070,65 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom covers many Universal Credit legal elements, the award-before-take-up expression, and the final annual PolicyEngine UK universal_credit wrapper after the would_claim_uc gate and benefit-cap reduction.",
     },
     "student_loan_repayments": {
-        "status": "partial",
+        "status": "exact",
         "surfaces": ("student-loan-repayment",),
-        "covered_outputs": ("student_loan_repayment",),
-        "rationale": "Axiom covers PolicyEngine UK's modelled student_loan_repayment formula by plan-specific threshold and repayment rate. The HBAI student_loan_repayments component remains partial because local EFRS supplies it as reported input data even when student_loan_plan is NONE, overriding PolicyEngine UK's wrapper formula.",
+        "covered_outputs": (
+            "student_loan_repayment",
+            "student_loan_repayments",
+        ),
+        "rationale": "Axiom covers PolicyEngine UK's modeled student-loan repayment formula by plan-specific threshold, repayment rate, and outstanding-balance cap. PolicyEngine UK's HBAI student_loan_repayments wrapper delegates to that modeled formula, while the local EFRS may override the wrapper with reported survey repayments; that override is fixed data input rather than a remaining policy-rule gap.",
     },
     "working_tax_credit": {
-        "status": "partial",
-        "surfaces": ("working-tax-credit-elements",),
+        "status": "exact",
+        "surfaces": (
+            "working-tax-credit-elements",
+            "closed-legacy-benefits-final",
+        ),
         "covered_outputs": (
             "wtc_basic_element",
             "wtc_couple_element",
             "wtc_lone_parent_element",
             "wtc_disabled_worker_element",
             "wtc_severely_disabled_worker_element",
+            "working_tax_credit",
         ),
-        "rationale": "Axiom covers Schedule 2 element rates after the WTC encoding; it does not yet compute final Working Tax Credit entitlement.",
+        "rationale": "Axiom covers Schedule 2 element rates and the current-law final nil Working Tax Credit amount after tax credits ended on 5 April 2025.",
     },
     "child_tax_credit": {
-        "status": "partial",
-        "surfaces": ("child-tax-credit-elements",),
+        "status": "exact",
+        "surfaces": (
+            "child-tax-credit-elements",
+            "closed-legacy-benefits-final",
+        ),
         "covered_outputs": (
             "CTC_family_element",
             "CTC_child_element",
             "CTC_disabled_child_element",
             "CTC_severely_disabled_child_element",
+            "child_tax_credit",
         ),
-        "rationale": "Axiom covers Child Tax Credit family, child, disabled-child, and severe-disabled-child element rates; it does not yet compute final Child Tax Credit entitlement.",
+        "rationale": "Axiom covers Child Tax Credit family, child, disabled-child, and severe-disabled-child element rates plus the current-law final nil Child Tax Credit amount after tax credits ended on 5 April 2025.",
     },
     "tax_free_childcare": {
-        "status": "partial",
-        "surfaces": ("tax-free-childcare-parameters",),
+        "status": "exact",
+        "surfaces": (
+            "tax-free-childcare-parameters",
+            "tax-free-childcare-final",
+        ),
         "covered_outputs": ("tax_free_childcare",),
-        "rationale": "Axiom covers the Tax-Free Childcare contribution rate and income cap, not the child/provider eligibility tests, expenses, annual caps, or final aggregate amount.",
+        "rationale": "Axiom covers PolicyEngine UK's Tax-Free Childcare final person amount: the statutory top-up rate, standard and disabled-child annual caps, provider and child eligibility predicates, eligible declaration periods, and final aggregate amount. Upstream factual predicates such as valid declarations, work, income, UK connection, and qualifying provider status remain projected leaf inputs.",
     },
     "free_tv_licence_value": {
-        "status": "partial",
-        "surfaces": ("tv-licence-fee",),
-        "covered_outputs": ("colour_tv_licence_general_form_issue_fee",),
-        "rationale": "Axiom covers the statutory colour TV licence fee feeding PolicyEngine UK's free_tv_licence_value; TV ownership, evasion, and aged or blind discount eligibility remain outside this fee surface.",
+        "status": "exact",
+        "surfaces": (
+            "tv-licence-fee",
+            "free-tv-licence-value",
+        ),
+        "covered_outputs": (
+            "colour_tv_licence_general_form_issue_fee",
+            "free_tv_licence_value",
+        ),
+        "rationale": "Axiom covers PolicyEngine UK's free_tv_licence_value HBAI component: the statutory colour TV licence fee, household TV ownership, evasion, and the aged or blind discount fraction projected as leaf inputs.",
     },
     "pip": {
         "status": "exact",
@@ -1557,10 +2155,13 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom covers Disability Living Allowance weekly self-care and mobility rates plus the final annual PolicyEngine UK DLA wrapper using PE's category inputs.",
     },
     "attendance_allowance": {
-        "status": "partial",
-        "surfaces": ("attendance-allowance-rates",),
+        "status": "exact",
+        "surfaces": (
+            "attendance-allowance-rates",
+            "attendance-allowance-final",
+        ),
         "covered_outputs": ("attendance_allowance",),
-        "rationale": "Axiom covers Attendance Allowance weekly higher and lower rates, not the category assignment or final aggregate Attendance Allowance amount.",
+        "rationale": "Axiom covers Attendance Allowance weekly higher and lower rates plus the final annual PolicyEngine UK Attendance Allowance wrapper using PE's category input.",
     },
     "carers_allowance": {
         "status": "exact",
@@ -1578,10 +2179,16 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom covers the Severe Disablement Allowance maximum weekly rate and the final annual PolicyEngine UK sda wrapper over reported receipt.",
     },
     "ssmg": {
-        "status": "partial",
-        "surfaces": ("sure-start-maternity-grant-rate",),
-        "covered_outputs": ("ssmg",),
-        "rationale": "Axiom covers the Sure Start Maternity Grant amount, not the qualifying-benefit, pregnancy, child, prescribed-time, residence, or reported-receipt conditions feeding the final SSMG amount.",
+        "status": "exact",
+        "surfaces": (
+            "sure-start-maternity-grant-rate",
+            "sure-start-maternity-grant-final",
+        ),
+        "covered_outputs": (
+            "sure_start_maternity_grant_amount",
+            "ssmg",
+        ),
+        "rationale": "Axiom covers PolicyEngine UK's Sure Start Maternity Grant final person amount: the statutory grant rate and the reported-receipt gate used by PolicyEngine. Upstream qualifying-benefit, pregnancy or child, claim-time, and residence conditions remain projected into the reported-receipt leaf input.",
     },
     "scottish_child_payment": {
         "status": "exact",
@@ -1602,17 +2209,628 @@ HBAI_COMPONENT_COVERAGE = {
         "rationale": "Axiom covers the Carer Support Payment care-hours threshold, weekly rate, Scottish Carer Supplement amount, and final annual PolicyEngine UK carer_support_payment wrapper after Scotland, effective-date, and care/reporting gates.",
     },
     "cost_of_living_support_payment": {
-        "status": "partial",
-        "surfaces": ("cost-of-living-support-payment-parameters",),
+        "status": "exact",
+        "surfaces": (
+            "cost-of-living-support-payment-parameters",
+            "cost-of-living-support-payment-final",
+        ),
         "covered_outputs": ("cost_of_living_support_payment",),
-        "rationale": "Axiom covers the statutory means-tested and disability Cost-of-Living Payment amounts, not the qualifying-period, benefit-receipt, tax-credit, pensioner-top-up, fraud, or final household aggregation rules.",
+        "rationale": "Axiom covers PolicyEngine UK's final annual household Cost-of-Living Support Payment: source-backed 2022 and 2023 payment amounts, the current no-further-payments zero amounts, and final means-tested, pensioner, and disability benefit receipt aggregation using PE's qualifying-benefit variables as projected leaf inputs.",
     },
     "winter_fuel_allowance": {
-        "status": "partial",
-        "surfaces": ("winter-fuel-payment-rates",),
+        "status": "exact",
+        "surfaces": (
+            "winter-fuel-payment-rates",
+            "winter-fuel-allowance-final",
+        ),
         "covered_outputs": ("winter_fuel_allowance",),
-        "rationale": "Axiom covers ordinary Winter Fuel Payment lower and higher annual amounts and the age-80 threshold, not the final household-level entitlement, shared-household branches, residential-care branches, Scotland replacement, or tax recovery mechanics.",
+        "rationale": "Axiom covers ordinary Winter Fuel Payment lower and higher annual amounts, the age-80 threshold, and the final PolicyEngine UK household-level Winter Fuel Allowance wrapper using PE's eligibility inputs.",
     },
+}
+
+NATIONAL_POLICY_COMPONENTS = (
+    {
+        "program_id": "income_tax",
+        "name": "Income tax",
+        "variable": "income_tax",
+        "category": "Taxes",
+        "agency": "HMRC",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "national_insurance",
+        "name": "National Insurance",
+        "variable": "national_insurance",
+        "category": "Taxes",
+        "agency": "HMRC",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "capital_gains_tax",
+        "name": "Capital gains tax",
+        "variable": "capital_gains_tax",
+        "category": "Taxes",
+        "agency": "HMRC",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "child_benefit",
+        "name": "Child Benefit",
+        "variable": "child_benefit",
+        "category": "Benefits",
+        "agency": "HMRC",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "stamp_duty_land_tax",
+        "name": "Stamp Duty Land Tax",
+        "variable": "stamp_duty_land_tax",
+        "category": "Taxes",
+        "agency": "HMRC",
+        "coverage": "England and Northern Ireland",
+    },
+    {
+        "program_id": "vat",
+        "name": "VAT",
+        "variable": "vat",
+        "category": "Taxes",
+        "agency": "HMRC",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "fuel_duty",
+        "name": "Fuel duty",
+        "variable": "fuel_duty",
+        "category": "Taxes",
+        "agency": "HMRC",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "student_loans",
+        "name": "Student loan repayments",
+        "variable": "student_loan_repayment",
+        "category": "Taxes",
+        "agency": "HMRC",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "tax_free_childcare",
+        "name": "Tax-Free Childcare",
+        "variable": "tax_free_childcare",
+        "category": "Benefits",
+        "agency": "HMRC",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "business_rates",
+        "name": "Business rates",
+        "variable": "business_rates",
+        "category": "Taxes",
+        "agency": "HMRC",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "minimum_wage",
+        "name": "National Minimum Wage",
+        "variable": None,
+        "category": "Other",
+        "agency": "HMRC",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "universal_credit",
+        "name": "Universal Credit",
+        "variable": "universal_credit",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "pension_credit",
+        "name": "Pension Credit",
+        "variable": "pension_credit",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "state_pension",
+        "name": "State Pension",
+        "variable": "state_pension",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "housing_benefit",
+        "name": "Housing Benefit",
+        "variable": "housing_benefit",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "income_support",
+        "name": "Income Support",
+        "variable": "income_support",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "jsa",
+        "name": "Jobseeker's Allowance",
+        "variable": "jsa",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "esa",
+        "name": "Employment and Support Allowance",
+        "variable": "esa",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "attendance_allowance",
+        "name": "Attendance Allowance",
+        "variable": "attendance_allowance",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "carers_allowance",
+        "name": "Carer's Allowance",
+        "variable": "carers_allowance",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "dla",
+        "name": "Disability Living Allowance",
+        "variable": "dla",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "pip",
+        "name": "Personal Independence Payment",
+        "variable": "pip",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "benefit_cap",
+        "name": "Benefit cap",
+        "variable": "benefit_cap",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "tax_credits",
+        "name": "Tax credits",
+        "variable": "tax_credits",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "sda",
+        "name": "Severe Disablement Allowance",
+        "variable": "sda",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "winter_fuel_payment",
+        "name": "Winter Fuel Payment",
+        "variable": "winter_fuel_allowance",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "ssmg",
+        "name": "Sure Start Maternity Grant",
+        "variable": "ssmg",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "maternity_allowance",
+        "name": "Maternity Allowance",
+        "variable": "maternity_allowance",
+        "category": "Benefits",
+        "agency": "DWP",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "universal_childcare_entitlement",
+        "name": "Universal childcare entitlement",
+        "variable": "universal_childcare_entitlement",
+        "category": "Education",
+        "agency": "DfE",
+        "coverage": "England",
+    },
+    {
+        "program_id": "extended_childcare_entitlement",
+        "name": "Extended childcare entitlement",
+        "variable": "extended_childcare_entitlement",
+        "category": "Education",
+        "agency": "DfE",
+        "coverage": "England",
+    },
+    {
+        "program_id": "targeted_childcare_entitlement",
+        "name": "Targeted childcare entitlement",
+        "variable": "targeted_childcare_entitlement",
+        "category": "Education",
+        "agency": "DfE",
+        "coverage": "England",
+    },
+    {
+        "program_id": "childcare_grant",
+        "name": "Childcare Grant",
+        "variable": "childcare_grant",
+        "category": "Benefits",
+        "agency": "DfE",
+        "coverage": "England",
+    },
+    {
+        "program_id": "parents_learning_allowance",
+        "name": "Parents' Learning Allowance",
+        "variable": "parents_learning_allowance",
+        "category": "Benefits",
+        "agency": "DfE",
+        "coverage": "England",
+    },
+    {
+        "program_id": "adult_dependants_grant",
+        "name": "Adult Dependants' Grant",
+        "variable": "adult_dependants_grant",
+        "category": "Benefits",
+        "agency": "DfE",
+        "coverage": "England",
+    },
+    {
+        "program_id": "travel_grant",
+        "name": "Travel Grant",
+        "variable": "travel_grant",
+        "category": "Benefits",
+        "agency": "DfE",
+        "coverage": "England",
+    },
+    {
+        "program_id": "disabled_students_allowance",
+        "name": "Disabled Students' Allowance",
+        "variable": "disabled_students_allowance",
+        "category": "Benefits",
+        "agency": "DfE",
+        "coverage": "England",
+    },
+    {
+        "program_id": "care_to_learn",
+        "name": "Care to Learn",
+        "variable": "care_to_learn",
+        "category": "Benefits",
+        "agency": "DfE",
+        "coverage": "England",
+    },
+    {
+        "program_id": "maintenance_loan",
+        "name": "Maintenance Loan",
+        "variable": "maintenance_loan",
+        "category": "Benefits",
+        "agency": "DfE",
+        "coverage": "England",
+    },
+    {
+        "program_id": "bursary_fund_16_to_19",
+        "name": "16 to 19 Bursary Fund",
+        "variable": "bursary_fund_16_to_19",
+        "category": "Benefits",
+        "agency": "DfE",
+        "coverage": "England",
+    },
+    {
+        "program_id": "tv_licence",
+        "name": "TV Licence",
+        "variable": "tv_licence",
+        "category": "Taxes",
+        "agency": "DCMS",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "cost_of_living_support",
+        "name": "Cost of Living Support Payments",
+        "variable": "cost_of_living_support_payment",
+        "category": "Benefits",
+        "agency": "Treasury",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "energy_price_guarantee",
+        "name": "Energy Price Guarantee",
+        "variable": "epg_subsidy",
+        "category": "Benefits",
+        "agency": "Ofgem",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "energy_bills_rebate",
+        "name": "Energy Bills Rebate",
+        "variable": "energy_bills_rebate",
+        "category": "Benefits",
+        "agency": "Treasury",
+        "coverage": "UK",
+    },
+    {
+        "program_id": "land_and_buildings_transaction_tax",
+        "name": "Land and Buildings Transaction Tax",
+        "variable": "land_and_buildings_transaction_tax",
+        "category": "Taxes",
+        "agency": "Revenue Scotland",
+        "coverage": "Scotland",
+    },
+    {
+        "program_id": "land_transaction_tax",
+        "name": "Land Transaction Tax",
+        "variable": "land_transaction_tax",
+        "category": "Taxes",
+        "agency": "Welsh Revenue Authority",
+        "coverage": "Wales",
+    },
+    {
+        "program_id": "scottish_child_payment",
+        "name": "Scottish Child Payment",
+        "variable": "scottish_child_payment",
+        "category": "Benefits",
+        "agency": "Social Security Scotland",
+        "coverage": "Scotland",
+    },
+    {
+        "program_id": "carer_support_payment",
+        "name": "Carer Support Payment",
+        "variable": "carer_support_payment",
+        "category": "Benefits",
+        "agency": "Social Security Scotland",
+        "coverage": "Scotland",
+    },
+    {
+        "program_id": "council_tax",
+        "name": "Council Tax",
+        "variable": "council_tax",
+        "category": "Taxes",
+        "agency": "Local",
+        "coverage": "Local government",
+    },
+)
+
+NATIONAL_POLICY_COMPONENT_COVERAGE = {
+    "income_tax": HBAI_COMPONENT_COVERAGE["income_tax"],
+    "national_insurance": HBAI_COMPONENT_COVERAGE["national_insurance"],
+    "capital_gains_tax": {
+        "status": "exact",
+        "surfaces": ("capital-gains-tax-final",),
+        "covered_outputs": ("capital_gains_tax",),
+        "rationale": "Axiom covers PolicyEngine UK's person-level Capital Gains Tax surface from positive capital gains, the annual exempt amount, Gift Aid and pension basic-rate-band extensions, income-tax thresholds, and main CGT rates.",
+    },
+    "child_benefit": HBAI_COMPONENT_COVERAGE["child_benefit"],
+    "stamp_duty_land_tax": {
+        "status": "exact",
+        "surfaces": ("stamp-duty-land-tax-final",),
+        "covered_outputs": ("stamp_duty_land_tax",),
+        "rationale": "Axiom covers PolicyEngine UK's household Stamp Duty Land Tax surface over main residential purchases, first-time buyer relief, additional residential purchases, non-residential purchases, residential and non-residential rent, and the SDLT-liability gate.",
+    },
+    "vat": {
+        "status": "exact",
+        "surfaces": ("vat-final",),
+        "covered_outputs": ("vat",),
+        "rationale": "Axiom covers PolicyEngine UK's household VAT surface from full-rate and reduced-rate consumption, statutory VAT rates, and PE's microdata-coverage calibration scalar.",
+    },
+    "fuel_duty": {
+        "status": "exact",
+        "surfaces": ("fuel-duty-final",),
+        "covered_outputs": ("fuel_duty",),
+        "rationale": "Axiom covers PolicyEngine UK's household fuel_duty surface from petrol and diesel litres, the PE per-litre petrol/diesel duty rate, and rural fuel duty relief.",
+    },
+    "student_loan_repayment": HBAI_COMPONENT_COVERAGE["student_loan_repayments"],
+    "tax_free_childcare": HBAI_COMPONENT_COVERAGE["tax_free_childcare"],
+    "business_rates": {
+        "status": "out_of_scope",
+        "surfaces": (),
+        "covered_outputs": (),
+        "rationale": "PolicyEngine UK's business-rates program is marked partial with parameters needing updates beyond 2021, and it is outside the current household EFRS national tax-benefit validation scope.",
+    },
+    "universal_credit": HBAI_COMPONENT_COVERAGE["universal_credit"],
+    "pension_credit": HBAI_COMPONENT_COVERAGE["pension_credit"],
+    "state_pension": HBAI_COMPONENT_COVERAGE["state_pension"],
+    "housing_benefit": HBAI_COMPONENT_COVERAGE["housing_benefit"],
+    "income_support": HBAI_COMPONENT_COVERAGE["income_support"],
+    "jsa": {
+        "status": "exact",
+        "surfaces": (
+            "jsa-income-tariff-income",
+            "closed-legacy-benefits-final",
+        ),
+        "covered_outputs": ("jsa_income_tariff_income", "jsa_income", "jsa"),
+        "rationale": "Axiom covers PolicyEngine UK's Jobseeker's Allowance aggregate as current-law nil income-based JSA plus contribution-based JSA reported as a fixed leaf input.",
+    },
+    "esa": {
+        "status": "exact",
+        "surfaces": (
+            "esa-income-tariff-income",
+            "esa-income-final",
+            "closed-legacy-benefits-final",
+        ),
+        "covered_outputs": ("esa_income_tariff_income", "esa_income", "esa"),
+        "rationale": "Axiom covers PolicyEngine UK's Employment and Support Allowance aggregate as the separately compared income-related ESA amount plus contribution-based ESA reported as a fixed leaf input.",
+    },
+    "attendance_allowance": HBAI_COMPONENT_COVERAGE["attendance_allowance"],
+    "carers_allowance": HBAI_COMPONENT_COVERAGE["carers_allowance"],
+    "dla": HBAI_COMPONENT_COVERAGE["dla"],
+    "pip": HBAI_COMPONENT_COVERAGE["pip"],
+    "benefit_cap": {
+        "status": "exact",
+        "surfaces": ("benefit-cap-relevant-amount",),
+        "covered_outputs": ("benefit_cap",),
+        "rationale": "Axiom covers PolicyEngine UK's finite benefit_cap relevant-amount surface through Universal Credit Regulations 2013 regulation 80A.",
+    },
+    "tax_credits": {
+        "status": "exact",
+        "surfaces": (
+            "working-tax-credit-elements",
+            "child-tax-credit-elements",
+            "closed-legacy-benefits-final",
+        ),
+        "covered_outputs": (
+            "working_tax_credit",
+            "child_tax_credit",
+            "tax_credits",
+        ),
+        "rationale": "Axiom covers PolicyEngine UK's current-law final nil Tax Credits aggregate after Working Tax Credit and Child Tax Credit ended, alongside the historical WTC and CTC element parameters.",
+    },
+    "sda": HBAI_COMPONENT_COVERAGE["sda"],
+    "winter_fuel_allowance": HBAI_COMPONENT_COVERAGE["winter_fuel_allowance"],
+    "ssmg": HBAI_COMPONENT_COVERAGE["ssmg"],
+    "maternity_allowance": {
+        "status": "fixed_input",
+        "surfaces": (),
+        "covered_outputs": (),
+        "rationale": "PolicyEngine UK's maternity_allowance variable delegates to reported survey receipt in EFRS; it is held fixed rather than treated as a remaining policy-rule gap.",
+    },
+    "universal_childcare_entitlement": {
+        "status": "exact",
+        "surfaces": ("dfe-person-programs-final",),
+        "covered_outputs": ("universal_childcare_entitlement",),
+        "rationale": "Axiom covers PolicyEngine UK's person-level universal childcare entitlement from the PE eligibility leaf, free-hours usage, child age, childcare weeks, annual hours cap, and DfE childcare funding-rate schedule.",
+    },
+    "extended_childcare_entitlement": {
+        "status": "exact",
+        "surfaces": ("dfe-extended-childcare-entitlement-final",),
+        "covered_outputs": ("extended_childcare_entitlement",),
+        "rationale": "Axiom covers PolicyEngine UK's benefit-unit extended childcare entitlement from the PE eligibility leaf, child age/free-hours relation rows, maximum extended-hours usage, childcare weeks, and DfE childcare funding-rate schedule.",
+    },
+    "targeted_childcare_entitlement": {
+        "status": "exact",
+        "surfaces": ("dfe-person-programs-final",),
+        "covered_outputs": ("targeted_childcare_entitlement",),
+        "rationale": "Axiom covers PolicyEngine UK's person-level targeted childcare entitlement from the PE eligibility leaf, free-hours usage, child age, targeted age band, childcare weeks, annual hours cap, and DfE childcare funding-rate schedule.",
+    },
+    "childcare_grant": {
+        "status": "exact",
+        "surfaces": ("dfe-person-programs-final",),
+        "covered_outputs": ("childcare_grant",),
+        "rationale": "Axiom covers PolicyEngine UK's Childcare Grant from the PE eligibility leaf, eligible-child count, annual childcare expenses, 85% coverage rate, and one-child/two-or-more weekly caps.",
+    },
+    "parents_learning_allowance": {
+        "status": "exact",
+        "surfaces": ("dfe-person-programs-final",),
+        "covered_outputs": ("parents_learning_allowance",),
+        "rationale": "Axiom covers PolicyEngine UK's Parents' Learning Allowance as the PE eligibility leaf multiplied by the 2026 maximum award.",
+    },
+    "adult_dependants_grant": {
+        "status": "exact",
+        "surfaces": ("dfe-person-programs-final",),
+        "covered_outputs": ("adult_dependants_grant",),
+        "rationale": "Axiom covers PolicyEngine UK's Adult Dependants' Grant as the PE eligibility leaf multiplied by the 2026 maximum award.",
+    },
+    "travel_grant": {
+        "status": "exact",
+        "surfaces": ("dfe-person-programs-final",),
+        "covered_outputs": ("travel_grant",),
+        "rationale": "Axiom covers PolicyEngine UK's Travel Grant from the PE eligibility leaf, eligible expenses, initial contribution, and income-reduction threshold and rate.",
+    },
+    "disabled_students_allowance": {
+        "status": "exact",
+        "surfaces": ("dfe-person-programs-final",),
+        "covered_outputs": ("disabled_students_allowance",),
+        "rationale": "Axiom covers PolicyEngine UK's Disabled Students' Allowance from the PE eligibility leaf, eligible expenses, and maximum award cap.",
+    },
+    "care_to_learn": {
+        "status": "exact",
+        "surfaces": ("dfe-person-programs-final",),
+        "covered_outputs": ("care_to_learn",),
+        "rationale": "Axiom covers PolicyEngine UK's Care to Learn amount from the PE eligibility leaf, London region flag, weekly London/non-London maxima, and annual week multiplier.",
+    },
+    "maintenance_loan": {
+        "status": "exact",
+        "surfaces": ("dfe-person-programs-final",),
+        "covered_outputs": ("maintenance_loan",),
+        "rationale": "Axiom covers PolicyEngine UK's maintenance loan from PE eligibility, household income, living arrangement, benefits entitlement, age, standard/benefits/over-60 schedules, tapers, floors, and nearest-pound rounding.",
+    },
+    "bursary_fund_16_to_19": {
+        "status": "exact",
+        "surfaces": ("dfe-person-programs-final",),
+        "covered_outputs": ("bursary_fund_16_to_19",),
+        "rationale": "Axiom covers PolicyEngine UK's 16 to 19 Bursary Fund from the PE vulnerable-group eligibility leaf, participation costs, and vulnerable-group maximum cap.",
+    },
+    "tv_licence": {
+        "status": "exact",
+        "surfaces": ("tv-licence-fee", "free-tv-licence-value"),
+        "covered_outputs": (
+            "colour_tv_licence_general_form_issue_fee",
+            "free_tv_licence_value",
+            "tv_licence",
+        ),
+        "rationale": "Axiom covers PolicyEngine UK's household TV licence tax and free-TV-licence value from the statutory colour licence fee, household TV ownership, evasion, and TV licence discount fraction.",
+    },
+    "cost_of_living_support_payment": HBAI_COMPONENT_COVERAGE[
+        "cost_of_living_support_payment"
+    ],
+    "epg_subsidy": {
+        "status": "exact",
+        "surfaces": ("energy-price-guarantee-final",),
+        "covered_outputs": ("epg_subsidy",),
+        "rationale": "Axiom covers PolicyEngine UK's 2026 Energy Price Guarantee subsidy from annual domestic energy consumption and the active PolicyEngine UK Ofgem price-cap and price-guarantee parameters; the subsidy floors to zero because the guarantee level is not below the cap.",
+    },
+    "energy_bills_rebate": {
+        "status": "exact",
+        "surfaces": ("energy-bills-rebate-final",),
+        "covered_outputs": (
+            "ebr_council_tax_rebate",
+            "ebr_energy_bills_credit",
+            "energy_bills_rebate",
+        ),
+        "rationale": "Axiom covers PolicyEngine UK's 2026 Energy Bills Rebate aggregate as the sum of the council-tax-rebate and energy-bills-credit components, both zeroed by the active PolicyEngine UK temporary energy-support parameters.",
+    },
+    "land_and_buildings_transaction_tax": {
+        "status": "exact",
+        "surfaces": ("land-and-buildings-transaction-tax-final",),
+        "covered_outputs": ("land_and_buildings_transaction_tax",),
+        "rationale": "Axiom covers PolicyEngine UK's final Scotland LBTT aggregate by summing the PE transaction and rent component amounts and applying the PE LBTT-liability gate.",
+    },
+    "land_transaction_tax": {
+        "status": "exact",
+        "surfaces": ("land-transaction-tax-final",),
+        "covered_outputs": ("land_transaction_tax",),
+        "rationale": "Axiom covers PolicyEngine UK's final Wales LTT aggregate by summing the PE transaction and rent component amounts and applying the PE LTT-liability gate.",
+    },
+    "scottish_child_payment": HBAI_COMPONENT_COVERAGE["scottish_child_payment"],
+    "carer_support_payment": HBAI_COMPONENT_COVERAGE["carer_support_payment"],
+    "council_tax": {
+        "status": "out_of_scope",
+        "surfaces": (),
+        "covered_outputs": (),
+        "rationale": "Council Tax and Council Tax Reduction are local-government surfaces. They are intentionally excluded from the national-program manifest until separate jurisdictional rulespec repos are introduced.",
+    },
+}
+
+NATIONAL_POLICY_PARAMETER_ONLY_COMPONENTS = {
+    "minimum_wage": (
+        "National Minimum Wage has PE parameters but no primary household EFRS "
+        "cash-output variable in programs.yaml, so it is tracked separately from "
+        "the current EFRS output-alignment queue."
+    ),
 }
 
 UNIVERSAL_CREDIT_REGULATION_36_SURFACES = frozenset(
@@ -1888,6 +3106,149 @@ class UKEFRSHBAICoverageReport:
 
 
 @dataclass(frozen=True)
+class UKEFRSNationalPolicyComponentCoverage:
+    program_id: str
+    name: str
+    variable: str | None
+    category: str
+    agency: str
+    coverage: str
+    status: str
+    policy_component: bool
+    surfaces: tuple[str, ...]
+    covered_outputs: tuple[str, ...]
+    rationale: str
+    entity: str | None = None
+    path: str | None = None
+    computed: bool | None = None
+    activity: UKEFRSVariableActivity | None = None
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "program_id": self.program_id,
+            "name": self.name,
+            "variable": self.variable,
+            "category": self.category,
+            "agency": self.agency,
+            "coverage": self.coverage,
+            "status": self.status,
+            "policy_component": self.policy_component,
+            "surfaces": list(self.surfaces),
+            "covered_outputs": list(self.covered_outputs),
+            "rationale": self.rationale,
+            "entity": self.entity,
+            "path": self.path,
+            "computed": self.computed,
+            "activity": self.activity.to_json() if self.activity else None,
+        }
+
+
+@dataclass(frozen=True)
+class UKEFRSNationalPolicyCoverageReport:
+    policyengine_versions: dict[str, str]
+    source_root: str | None
+    year: int
+    dataset: str
+    components: list[UKEFRSNationalPolicyComponentCoverage]
+    activity_errors: list[dict[str, str]]
+
+    @property
+    def status_counts(self) -> dict[str, int]:
+        return dict(
+            sorted(Counter(component.status for component in self.components).items())
+        )
+
+    @property
+    def policy_component_count(self) -> int:
+        return sum(1 for component in self.components if component.policy_component)
+
+    @property
+    def covered_policy_component_count(self) -> int:
+        return sum(
+            1
+            for component in self.components
+            if component.policy_component and component.status in {"exact", "partial"}
+        )
+
+    @property
+    def exact_policy_component_count(self) -> int:
+        return sum(
+            1
+            for component in self.components
+            if component.policy_component and component.status == "exact"
+        )
+
+    @property
+    def covered_policy_component_share(self) -> float:
+        if self.policy_component_count == 0:
+            return 0.0
+        return self.covered_policy_component_count / self.policy_component_count
+
+    @property
+    def exact_policy_component_share(self) -> float:
+        if self.policy_component_count == 0:
+            return 0.0
+        return self.exact_policy_component_count / self.policy_component_count
+
+    @property
+    def activity_totals(self) -> dict[str, float] | None:
+        components_with_activity = [
+            component
+            for component in self.components
+            if component.policy_component and component.activity is not None
+        ]
+        if not components_with_activity:
+            return None
+        total = sum(
+            component.activity.weighted_abs_total
+            for component in components_with_activity
+            if component.activity is not None
+        )
+        covered = sum(
+            component.activity.weighted_abs_total
+            for component in components_with_activity
+            if component.activity is not None
+            and component.status in {"exact", "partial"}
+        )
+        exact = sum(
+            component.activity.weighted_abs_total
+            for component in components_with_activity
+            if component.activity is not None and component.status == "exact"
+        )
+        missing = sum(
+            component.activity.weighted_abs_total
+            for component in components_with_activity
+            if component.activity is not None and component.status == "missing"
+        )
+        return {
+            "policy_weighted_abs_total": total,
+            "covered_policy_weighted_abs_total": covered,
+            "exact_policy_weighted_abs_total": exact,
+            "missing_policy_weighted_abs_total": missing,
+            "covered_policy_weighted_abs_share": covered / total if total else 0.0,
+            "exact_policy_weighted_abs_share": exact / total if total else 0.0,
+            "missing_policy_weighted_abs_share": missing / total if total else 0.0,
+        }
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "policyengine_versions": self.policyengine_versions,
+            "source_root": self.source_root,
+            "year": self.year,
+            "dataset": self.dataset,
+            "status_counts": self.status_counts,
+            "policy_component_count": self.policy_component_count,
+            "covered_policy_component_count": self.covered_policy_component_count,
+            "exact_policy_component_count": self.exact_policy_component_count,
+            "covered_policy_component_share": self.covered_policy_component_share,
+            "exact_policy_component_share": self.exact_policy_component_share,
+            "activity_totals": self.activity_totals,
+            "components": [component.to_json() for component in self.components],
+            "activity_errors": self.activity_errors,
+        }
+
+
+@dataclass(frozen=True)
 class UKEFRSComparisonRow:
     surface: str
     entity_id: str
@@ -1907,6 +3268,7 @@ class UKEFRSOracleDivergence(UKEFRSComparisonRow):
 class UKEFRSComparisonReport:
     compared_persons: int
     compared_benunits: int
+    compared_households: int
     compared_values: int
     mismatches: list[UKEFRSComparisonRow]
     oracle_divergences: list[UKEFRSOracleDivergence]
@@ -1918,6 +3280,7 @@ class UKEFRSComparisonReport:
         return {
             "compared_persons": self.compared_persons,
             "compared_benunits": self.compared_benunits,
+            "compared_households": self.compared_households,
             "compared_values": self.compared_values,
             "mismatch_count": len(self.mismatches),
             "mismatches": [row.__dict__ for row in self.mismatches],
@@ -2140,6 +3503,48 @@ def configure_hbai_coverage_parser(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--json", action="store_true", help="Output as JSON")
 
 
+def configure_national_coverage_parser(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--year", type=int, default=2026)
+    parser.add_argument(
+        "--dataset",
+        default=DEFAULT_DATASET,
+        help=(
+            "PolicyEngine UK dataset logical name, HuggingFace URI, or local .h5 "
+            "path for --with-efrs-activity"
+        ),
+    )
+    parser.add_argument(
+        "--data-folder",
+        type=Path,
+        default=Path(".axiom") / "policyengine-data",
+        help="PolicyEngine dataset cache folder",
+    )
+    parser.add_argument(
+        "--source-root",
+        type=Path,
+        default=None,
+        help=(
+            "PolicyEngine UK variables source root; defaults to the installed "
+            "policyengine_uk package"
+        ),
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=50,
+        help="Maximum components to print in text mode",
+    )
+    parser.add_argument(
+        "--with-efrs-activity",
+        action="store_true",
+        help=(
+            "Run PolicyEngine over EFRS and rank national law components by "
+            "observed activity"
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+
 def main_coverage(args: argparse.Namespace) -> int:
     report = build_uk_efrs_coverage_report(
         year=args.year,
@@ -2171,6 +3576,21 @@ def main_hbai_coverage(args: argparse.Namespace) -> int:
     return 0
 
 
+def main_national_coverage(args: argparse.Namespace) -> int:
+    report = build_uk_national_policy_coverage_report(
+        year=args.year,
+        dataset=args.dataset,
+        data_folder=args.data_folder,
+        include_efrs_activity=args.with_efrs_activity,
+        source_root=args.source_root,
+    )
+    if args.json:
+        print(json.dumps(report.to_json(), indent=2, sort_keys=True))
+    else:
+        print_uk_national_policy_coverage_report(report, top=args.top)
+    return 0
+
+
 def compare_uk_efrs(
     *,
     workspace_root: Path,
@@ -2199,6 +3619,7 @@ def compare_uk_efrs(
         person_ids=person_ids,
         person_variables=policyengine_person_variables_for_surfaces(surfaces),
         benunit_variables=policyengine_benunit_variables_for_surfaces(surfaces),
+        household_variables=policyengine_household_variables_for_surfaces(surfaces),
     )
     surface_results: dict[str, list[dict[str, Any]]] = {}
     for selected_surface in surfaces:
@@ -2358,6 +3779,7 @@ def load_policyengine_uk_data(
         "personal-allowance"
     ].pe_variables,
     benunit_variables: tuple[str, ...] = (),
+    household_variables: tuple[str, ...] = (),
 ) -> dict[str, Any]:
     local_dataset = local_policyengine_uk_dataset_path(dataset)
     if local_dataset is not None:
@@ -2368,6 +3790,7 @@ def load_policyengine_uk_data(
             person_ids=person_ids,
             person_variables=person_variables,
             benunit_variables=benunit_variables,
+            household_variables=household_variables,
         )
 
     raise SystemExit(
@@ -2384,6 +3807,7 @@ def load_local_policyengine_uk_data(
     person_ids: tuple[int, ...],
     person_variables: tuple[str, ...],
     benunit_variables: tuple[str, ...],
+    household_variables: tuple[str, ...],
 ) -> dict[str, Any]:
     require_policyengine_uk_versions()
     try:
@@ -2418,6 +3842,8 @@ def load_local_policyengine_uk_data(
     person_columns = ["person_id", "person_weight"]
     if "person_benunit_id" in person.columns:
         person_columns.append("person_benunit_id")
+    if "person_household_id" in person.columns:
+        person_columns.append("person_household_id")
     merged = person[person_columns].copy()
     log("Running PolicyEngine UK person outputs...")
     for variable in person_variables:
@@ -2445,6 +3871,7 @@ def load_local_policyengine_uk_data(
     )
     selected = [records[index] for index in selected_indices]
     selected_benunits: list[dict[str, Any]] = []
+    selected_households: list[dict[str, Any]] = []
     if benunit_variables:
         benunit = add_policyengine_uk_benunit_weights(
             raw_benunit,
@@ -2493,6 +3920,38 @@ def load_local_policyengine_uk_data(
         selected_benunits = [
             benunit_records[index] for index in selected_benunit_indices
         ]
+    if household_variables:
+        merged_households = household[["household_id", "household_weight"]].copy()
+        log("Running PolicyEngine UK household outputs...")
+        for variable in household_variables:
+            merged_households[variable] = sim.calculate(
+                variable,
+                period=year,
+                map_to="household",
+            ).values
+        merged_households = add_winter_fuel_allowance_projection_columns(
+            merged_households,
+            merged,
+            year=year,
+        )
+        household_records = table_records(merged_households)
+        selected_household_ids = ()
+        if person_ids:
+            selected_household_ids = tuple(
+                dict.fromkeys(
+                    int(row_value(row, "person_household_id"))
+                    for row in selected
+                    if row_value(row, "person_household_id") is not None
+                )
+            )
+        selected_household_indices = select_household_indices(
+            household_records,
+            sample_size=sample_size,
+            household_ids=selected_household_ids,
+        )
+        selected_households = [
+            household_records[index] for index in selected_household_indices
+        ]
     return {
         "data_year": data_year,
         "all_persons": records,
@@ -2500,6 +3959,10 @@ def load_local_policyengine_uk_data(
         "person_ids": [int(row_value(row, "person_id")) for row in selected],
         "benunits": selected_benunits,
         "benunit_ids": [int(row_value(row, "benunit_id")) for row in selected_benunits],
+        "households": selected_households,
+        "household_ids": [
+            int(row_value(row, "household_id")) for row in selected_households
+        ],
     }
 
 
@@ -2704,6 +4167,144 @@ def add_pension_credit_child_addition_projection_columns(
     return merged
 
 
+def policyengine_uk_winter_fuel_payment_parameters(year: int) -> dict[str, Any]:
+    try:
+        from policyengine_uk import CountryTaxBenefitSystem
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(policyengine_uk_install_message()) from exc
+
+    wfp = (
+        CountryTaxBenefitSystem().parameters(year).baseline.gov.dwp.winter_fuel_payment
+    )
+    return {
+        "maximum_taxable_income": float(
+            wfp.eligibility.taxable_income_test.maximum_taxable_income
+        ),
+        "require_benefits": bool(wfp.eligibility.require_benefits),
+        "state_pension_age_requirement": bool(
+            wfp.eligibility.state_pension_age_requirement
+        ),
+        "use_maximum_taxable_income": bool(
+            wfp.eligibility.taxable_income_test.use_maximum_taxable_income
+        ),
+    }
+
+
+def policyengine_uk_fuel_duty_parameters(year: int) -> dict[str, Any]:
+    try:
+        from policyengine_uk import CountryTaxBenefitSystem
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(policyengine_uk_install_message()) from exc
+
+    fuel_duty = CountryTaxBenefitSystem().parameters(
+        year
+    ).baseline.gov.hmrc.fuel_duty
+    return {
+        "petrol_and_diesel": float(fuel_duty.petrol_and_diesel),
+    }
+
+
+def policyengine_uk_vat_parameters(year: int) -> dict[str, Any]:
+    try:
+        from policyengine_uk import CountryTaxBenefitSystem
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(policyengine_uk_install_message()) from exc
+
+    parameters = CountryTaxBenefitSystem().parameters(year).baseline.gov
+    return {
+        "microdata_vat_coverage": float(parameters.simulation.microdata_vat_coverage),
+    }
+
+
+def policyengine_uk_capital_gains_tax_parameters(year: int) -> dict[str, Any]:
+    try:
+        from policyengine_uk import CountryTaxBenefitSystem
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(policyengine_uk_install_message()) from exc
+
+    parameters = CountryTaxBenefitSystem().parameters(year).baseline.gov.hmrc
+    thresholds = parameters.income_tax.rates.uk.thresholds
+    return {
+        "annual_exempt_amount": float(parameters.cgt.annual_exempt_amount),
+        "basic_rate": float(parameters.cgt.basic_rate),
+        "higher_rate": float(parameters.cgt.higher_rate),
+        "additional_rate": float(parameters.cgt.additional_rate),
+        "income_tax_basic_rate_limit": float(thresholds[1]),
+        "income_tax_higher_rate_limit": float(thresholds[2]),
+    }
+
+
+def add_winter_fuel_allowance_projection_columns(
+    household: Any,
+    person: Any,
+    *,
+    year: int,
+) -> Any:
+    required = {"person_household_id", "age", "is_SP_age", "total_income"}
+    if not required.issubset(set(person.columns)):
+        return household
+
+    parameters = policyengine_uk_winter_fuel_payment_parameters(year)
+    projection = person[["person_household_id"]].copy()
+    age = person["age"].fillna(0).astype(float)
+    is_sp_age = person["is_SP_age"].fillna(False).astype(bool)
+    total_income = person["total_income"].fillna(0).astype(float)
+    projection["oldest_household_member_age"] = age
+    projection["household_has_state_pension_age_person"] = is_sp_age.astype(int)
+    projection["household_has_pensioner_below_wfp_income_limit"] = (
+        is_sp_age & (total_income < parameters["maximum_taxable_income"])
+    ).astype(int)
+    by_household = projection.groupby("person_household_id", dropna=False).agg(
+        {
+            "oldest_household_member_age": "max",
+            "household_has_state_pension_age_person": "max",
+            "household_has_pensioner_below_wfp_income_limit": "max",
+        }
+    )
+    by_household["household_has_state_pension_age_person"] = by_household[
+        "household_has_state_pension_age_person"
+    ].astype(bool)
+    by_household["household_has_pensioner_below_wfp_income_limit"] = by_household[
+        "household_has_pensioner_below_wfp_income_limit"
+    ].astype(bool)
+    by_household = by_household.reset_index()
+    merged = household.merge(
+        by_household,
+        left_on="household_id",
+        right_on="person_household_id",
+        how="left",
+    ).drop(columns=["person_household_id"], errors="ignore")
+    merged["oldest_household_member_age"] = merged[
+        "oldest_household_member_age"
+    ].fillna(0)
+    merged["household_has_state_pension_age_person"] = merged[
+        "household_has_state_pension_age_person"
+    ].fillna(False)
+    pensioner_below_income_limit = merged[
+        "household_has_pensioner_below_wfp_income_limit"
+    ].fillna(False)
+    if "country" in merged.columns:
+        country = merged["country"].astype(str).str.split(".").str[-1].str.upper()
+        country_is_england_or_wales = country.isin(["ENGLAND", "WALES"])
+    else:
+        country_is_england_or_wales = False
+    merged["household_meets_winter_fuel_payment_income_passport"] = (
+        parameters["use_maximum_taxable_income"]
+        & pensioner_below_income_limit
+        & country_is_england_or_wales
+    )
+    merged["winter_fuel_payment_means_tested_benefits_required"] = parameters[
+        "require_benefits"
+    ]
+    merged["winter_fuel_payment_state_pension_age_required"] = parameters[
+        "state_pension_age_requirement"
+    ]
+    return merged.drop(
+        columns=["household_has_pensioner_below_wfp_income_limit"],
+        errors="ignore",
+    )
+
+
 def resolve_policyengine_uk_dataset_reference(dataset: str) -> str:
     if "://" in dataset:
         return dataset
@@ -2820,6 +4421,12 @@ def policyengine_benunit_variables_for_surfaces(
     surfaces: list[str],
 ) -> tuple[str, ...]:
     return policyengine_variables_for_surfaces(surfaces, entity="benunit")
+
+
+def policyengine_household_variables_for_surfaces(
+    surfaces: list[str],
+) -> tuple[str, ...]:
+    return policyengine_variables_for_surfaces(surfaces, entity="household")
 
 
 def policyengine_variables_for_surfaces(
@@ -3047,6 +4654,128 @@ def classify_hbai_component(
         surfaces=(),
         covered_outputs=(),
         rationale="No current Axiom UK RuleSpec surface is classified as covering this HBAI policy component.",
+        activity=activity,
+    )
+
+
+def build_uk_national_policy_coverage_report(
+    *,
+    year: int = 2026,
+    dataset: str = DEFAULT_DATASET,
+    data_folder: Path = Path(".axiom") / "policyengine-data",
+    include_efrs_activity: bool = False,
+    source_root: Path | None = None,
+) -> UKEFRSNationalPolicyCoverageReport:
+    versions = policyengine_uk_versions()
+    resolved_source_root = source_root or policyengine_uk_variables_source_root()
+    variables = discover_policyengine_uk_variables(source_root=resolved_source_root)
+    variables_by_name = {variable.name: variable for variable in variables}
+
+    manifest_variables = [
+        variables_by_name[str(component["variable"])]
+        for component in NATIONAL_POLICY_COMPONENTS
+        if component.get("variable") in variables_by_name
+    ]
+    activity_by_name: dict[str, UKEFRSVariableActivity] = {}
+    activity_errors: list[dict[str, str]] = []
+    if include_efrs_activity and manifest_variables:
+        raw_activity, activity_errors = policyengine_uk_efrs_activity(
+            manifest_variables,
+            year=year,
+            dataset=dataset,
+            data_folder=data_folder,
+        )
+        activity_by_name = {item.name: item for item in raw_activity}
+
+    components = [
+        classify_national_policy_component(
+            component,
+            variable=variables_by_name.get(str(component.get("variable"))),
+            activity=activity_by_name.get(str(component.get("variable"))),
+        )
+        for component in NATIONAL_POLICY_COMPONENTS
+    ]
+
+    return UKEFRSNationalPolicyCoverageReport(
+        policyengine_versions=versions,
+        source_root=str(resolved_source_root.resolve()),
+        year=year,
+        dataset=dataset,
+        components=components,
+        activity_errors=activity_errors,
+    )
+
+
+def classify_national_policy_component(
+    component: dict[str, Any],
+    *,
+    variable: UKEFRSVariableMetadata | None,
+    activity: UKEFRSVariableActivity | None,
+) -> UKEFRSNationalPolicyComponentCoverage:
+    variable_name = component.get("variable")
+    if variable_name is None:
+        rationale = NATIONAL_POLICY_PARAMETER_ONLY_COMPONENTS.get(
+            str(component["program_id"]),
+            "This PolicyEngine UK program has no primary EFRS cash-output variable.",
+        )
+        return UKEFRSNationalPolicyComponentCoverage(
+            program_id=str(component["program_id"]),
+            name=str(component["name"]),
+            variable=None,
+            category=str(component["category"]),
+            agency=str(component["agency"]),
+            coverage=str(component["coverage"]),
+            status="parameter_only",
+            policy_component=False,
+            surfaces=(),
+            covered_outputs=(),
+            rationale=rationale,
+        )
+
+    coverage = NATIONAL_POLICY_COMPONENT_COVERAGE.get(str(variable_name))
+    if coverage is None:
+        coverage = {
+            "status": "missing",
+            "surfaces": (),
+            "covered_outputs": (),
+            "rationale": (
+                "No current Axiom UK RuleSpec surface is classified as covering "
+                f"the PolicyEngine UK {variable_name} national policy component."
+            ),
+        }
+
+    status = str(coverage["status"])
+    if variable is None and status not in {"out_of_scope", "parameter_only"}:
+        status = "unavailable"
+        rationale = (
+            f"PolicyEngine UK variable {variable_name} was listed in the national "
+            "policy manifest but was not found in the installed PE-UK variable set."
+        )
+        policy_component = False
+    else:
+        rationale = str(coverage["rationale"])
+        policy_component = status not in {
+            "fixed_input",
+            "out_of_scope",
+            "parameter_only",
+            "unavailable",
+        }
+
+    return UKEFRSNationalPolicyComponentCoverage(
+        program_id=str(component["program_id"]),
+        name=str(component["name"]),
+        variable=str(variable_name),
+        category=str(component["category"]),
+        agency=str(component["agency"]),
+        coverage=str(component["coverage"]),
+        status=status,
+        policy_component=policy_component,
+        surfaces=tuple(str(item) for item in coverage["surfaces"]),
+        covered_outputs=tuple(str(item) for item in coverage["covered_outputs"]),
+        rationale=rationale,
+        entity=variable.entity if variable else None,
+        path=variable.path if variable else None,
+        computed=variable.computed if variable else None,
         activity=activity,
     )
 
@@ -3718,6 +5447,89 @@ def print_uk_hbai_policy_coverage_report(
             print(f"  - {error.get('variable', '?')}: {error.get('error', '')}")
 
 
+def print_uk_national_policy_coverage_report(
+    report: UKEFRSNationalPolicyCoverageReport,
+    *,
+    top: int,
+) -> None:
+    print("PolicyEngine UK national policy coverage")
+    print(
+        "PolicyEngine versions: "
+        + ", ".join(
+            f"{package}=={version}"
+            for package, version in report.policyengine_versions.items()
+        )
+    )
+    if report.source_root:
+        print(f"Variable source root: {report.source_root}")
+    print(f"Year: {report.year}")
+    print(f"Dataset: {report.dataset}")
+    print(f"Manifest components: {len(report.components):,}")
+    print(
+        "Policy components covered exactly or partially: "
+        f"{report.covered_policy_component_count:,}/"
+        f"{report.policy_component_count:,} "
+        f"({report.covered_policy_component_share:.1%})"
+    )
+    print(
+        "Policy components covered exactly: "
+        f"{report.exact_policy_component_count:,}/"
+        f"{report.policy_component_count:,} "
+        f"({report.exact_policy_component_share:.1%})"
+    )
+    print("Status counts:")
+    for status, count in report.status_counts.items():
+        print(f"  - {status}: {count:,}")
+    if report.activity_totals:
+        totals = report.activity_totals
+        print()
+        print(
+            "Policy component weighted abs activity covered exactly or partially: "
+            f"{totals['covered_policy_weighted_abs_share']:.1%}"
+        )
+        print(
+            "Policy component weighted abs activity covered exactly: "
+            f"{totals['exact_policy_weighted_abs_share']:.1%}"
+        )
+        print(
+            "Policy component weighted abs activity still missing: "
+            f"{totals['missing_policy_weighted_abs_share']:.1%}"
+        )
+    print()
+    print(f"National policy components (first {top:,}):")
+    components = report.components
+    if any(component.activity for component in components):
+        components = sorted(
+            components,
+            key=lambda component: (
+                component.activity.weighted_abs_total if component.activity else -1,
+                component.name,
+            ),
+            reverse=True,
+        )
+    for component in components[:top]:
+        activity = ""
+        if component.activity:
+            activity = (
+                f", nonzero={component.activity.nonzero_count:,}, "
+                f"weighted_abs_total={component.activity.weighted_abs_total:.2f}"
+            )
+        surfaces = ", ".join(component.surfaces) if component.surfaces else "none"
+        print(
+            f"  - {component.name} [{component.variable or component.program_id}] "
+            f"({component.agency}, {component.coverage}): "
+            f"{component.status}, surfaces={surfaces}{activity}"
+        )
+    if report.activity_errors:
+        print()
+        print("Activity errors:")
+        for error in report.activity_errors[:top]:
+            print(
+                f"  - {error.get('entity', '?')}:{error.get('variable', '?')}: "
+                f"{error.get('error', '')}"
+            )
+
+
 def select_person_indices(
     rows: list[dict[str, Any]],
     *,
@@ -3747,6 +5559,22 @@ def select_benunit_indices(
         id_column="benunit_id",
         weight_column="benunit_weight",
         entity_label="EFRS benunit_id",
+    )
+
+
+def select_household_indices(
+    rows: list[dict[str, Any]],
+    *,
+    sample_size: int,
+    household_ids: tuple[int, ...] = (),
+) -> list[int]:
+    return select_entity_indices(
+        rows,
+        sample_size=sample_size,
+        requested_ids=household_ids,
+        id_column="household_id",
+        weight_column="household_weight",
+        entity_label="EFRS household_id",
     )
 
 
@@ -4019,6 +5847,8 @@ def build_axiom_request(
             pe_data=pe_data,
             year=year,
         )
+    if surface == "closed-legacy-benefits-final":
+        return build_closed_legacy_benefits_final_request(pe_data=pe_data, year=year)
     if surface == "housing-benefit-working-age-tariff-income":
         return build_housing_benefit_working_age_tariff_income_request(
             pe_data=pe_data,
@@ -4088,6 +5918,47 @@ def build_axiom_request(
         return build_sda_final_request(pe_data=pe_data, year=year)
     if surface == "disability-living-allowance-final":
         return build_dla_final_request(pe_data=pe_data, year=year)
+    if surface == "attendance-allowance-final":
+        return build_attendance_allowance_final_request(pe_data=pe_data, year=year)
+    if surface == "winter-fuel-allowance-final":
+        return build_winter_fuel_allowance_final_request(pe_data=pe_data, year=year)
+    if surface == "tax-free-childcare-final":
+        return build_tax_free_childcare_final_request(pe_data=pe_data, year=year)
+    if surface == "capital-gains-tax-final":
+        return build_capital_gains_tax_final_request(pe_data=pe_data, year=year)
+    if surface == "stamp-duty-land-tax-final":
+        return build_stamp_duty_land_tax_final_request(pe_data=pe_data, year=year)
+    if surface == "land-and-buildings-transaction-tax-final":
+        return build_lbtt_final_request(pe_data=pe_data, year=year)
+    if surface == "land-transaction-tax-final":
+        return build_ltt_final_request(pe_data=pe_data, year=year)
+    if surface == "vat-final":
+        return build_vat_final_request(pe_data=pe_data, year=year)
+    if surface == "fuel-duty-final":
+        return build_fuel_duty_final_request(pe_data=pe_data, year=year)
+    if surface == "free-tv-licence-value":
+        return build_free_tv_licence_value_request(pe_data=pe_data, year=year)
+    if surface == "cost-of-living-support-payment-final":
+        return build_cost_of_living_support_payment_final_request(
+            pe_data=pe_data,
+            year=year,
+        )
+    if surface == "energy-bills-rebate-final":
+        return build_energy_bills_rebate_final_request(pe_data=pe_data, year=year)
+    if surface == "energy-price-guarantee-final":
+        return build_energy_price_guarantee_final_request(
+            pe_data=pe_data,
+            year=year,
+        )
+    if surface == "dfe-person-programs-final":
+        return build_dfe_person_programs_final_request(pe_data=pe_data, year=year)
+    if surface == "dfe-extended-childcare-entitlement-final":
+        return build_dfe_extended_childcare_entitlement_final_request(
+            pe_data=pe_data,
+            year=year,
+        )
+    if surface == "sure-start-maternity-grant-final":
+        return build_ssmg_final_request(pe_data=pe_data, year=year)
     if surface in UNIVERSAL_CREDIT_REGULATION_36_SURFACES:
         return build_universal_credit_request(
             pe_data=pe_data,
@@ -4930,6 +6801,41 @@ def build_income_support_tariff_income_request(
     )
 
 
+def build_closed_legacy_benefits_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "closed-legacy-benefits-final"):
+        entity_id = benunit_entity_id(int(row_value(row, "benunit_id")))
+        for name, value in project_closed_legacy_benefits_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{CLOSED_LEGACY_BENEFITS_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in CLOSED_LEGACY_BENEFITS_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def build_housing_benefit_working_age_tariff_income_request(
     *, pe_data: dict[str, Any], year: int
 ) -> dict[str, Any]:
@@ -5617,6 +7523,581 @@ def build_dla_final_request(*, pe_data: dict[str, Any], year: int) -> dict[str, 
     }
 
 
+def build_attendance_allowance_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = uk_tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "attendance-allowance-final"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_attendance_allowance_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{ATTENDANCE_ALLOWANCE_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in ATTENDANCE_ALLOWANCE_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_winter_fuel_allowance_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "winter-fuel-allowance-final"):
+        entity_id = household_entity_id(int(row_value(row, "household_id")))
+        for name, value in project_winter_fuel_allowance_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{WINTER_FUEL_ALLOWANCE_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in WINTER_FUEL_ALLOWANCE_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_tax_free_childcare_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = uk_tax_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "tax-free-childcare-final"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_tax_free_childcare_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{TAX_FREE_CHILDCARE_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in TAX_FREE_CHILDCARE_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_capital_gains_tax_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    parameters = policyengine_uk_capital_gains_tax_parameters(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "capital-gains-tax-final"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_capital_gains_tax_final_inputs(
+            row,
+            parameters=parameters,
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{CAPITAL_GAINS_TAX_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in CAPITAL_GAINS_TAX_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_stamp_duty_land_tax_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "stamp-duty-land-tax-final"):
+        entity_id = household_entity_id(int(row_value(row, "household_id")))
+        for name, value in project_stamp_duty_land_tax_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{STAMP_DUTY_LAND_TAX_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in STAMP_DUTY_LAND_TAX_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_lbtt_final_request(*, pe_data: dict[str, Any], year: int) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "land-and-buildings-transaction-tax-final"):
+        entity_id = household_entity_id(int(row_value(row, "household_id")))
+        for name, value in project_lbtt_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{LBTT_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [spec["axiom"] for spec in LBTT_FINAL_OUTPUTS.values()],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_ltt_final_request(*, pe_data: dict[str, Any], year: int) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "land-transaction-tax-final"):
+        entity_id = household_entity_id(int(row_value(row, "household_id")))
+        for name, value in project_ltt_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{LTT_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [spec["axiom"] for spec in LTT_FINAL_OUTPUTS.values()],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_vat_final_request(*, pe_data: dict[str, Any], year: int) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    parameters = policyengine_uk_vat_parameters(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "vat-final"):
+        entity_id = household_entity_id(int(row_value(row, "household_id")))
+        for name, value in project_vat_final_inputs(
+            row,
+            parameters=parameters,
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{VAT_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [spec["axiom"] for spec in VAT_FINAL_OUTPUTS.values()],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_fuel_duty_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    parameters = policyengine_uk_fuel_duty_parameters(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "fuel-duty-final"):
+        entity_id = household_entity_id(int(row_value(row, "household_id")))
+        for name, value in project_fuel_duty_final_inputs(
+            row,
+            parameters=parameters,
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{FUEL_DUTY_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in FUEL_DUTY_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_free_tv_licence_value_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = licence_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "free-tv-licence-value"):
+        entity_id = household_entity_id(int(row_value(row, "household_id")))
+        for name, value in project_free_tv_licence_value_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{TV_LICENCE_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"] for spec in TV_LICENCE_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_cost_of_living_support_payment_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "cost-of-living-support-payment-final"):
+        entity_id = household_entity_id(int(row_value(row, "household_id")))
+        for name, value in project_cost_of_living_support_payment_final_inputs(
+            row
+        ).items():
+            inputs.append(
+                input_record(
+                    f"{COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_energy_bills_rebate_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "energy-bills-rebate-final"):
+        queries.append(
+            {
+                "entity_id": household_entity_id(int(row_value(row, "household_id"))),
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in ENERGY_BILLS_REBATE_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": [], "relations": []},
+        "queries": queries,
+    }
+
+
+def build_energy_price_guarantee_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "energy-price-guarantee-final"):
+        entity_id = household_entity_id(int(row_value(row, "household_id")))
+        for name, value in project_energy_price_guarantee_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{ENERGY_PRICE_GUARANTEE_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in ENERGY_PRICE_GUARANTEE_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_dfe_person_programs_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "dfe-person-programs-final"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_dfe_person_programs_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{DFE_PERSON_PROGRAMS_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in DFE_PERSON_PROGRAMS_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
+def build_dfe_extended_childcare_entitlement_final_request(
+    *, pe_data: dict[str, Any], year: int
+) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    relations: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    child_rows_by_benunit = person_rows_by_benunit(pe_data)
+    for row in rows_for_surface(pe_data, "dfe-extended-childcare-entitlement-final"):
+        benunit_id = int(row_value(row, "benunit_id"))
+        entity_id = benunit_entity_id(benunit_id)
+        inputs.append(
+            input_record(
+                (
+                    f"{DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_BASE}"
+                    "#input.extended_childcare_entitlement_is_eligible"
+                ),
+                entity_id,
+                interval,
+                bool_row_value(row, "extended_childcare_entitlement_eligible", False),
+            )
+        )
+        maximum_hours_usage = money(
+            row_value(row, "maximum_extended_childcare_hours_usage", 0)
+        )
+        for child_row in child_rows_by_benunit.get(benunit_id, []):
+            person_id_text = person_entity_id(int(row_value(child_row, "person_id")))
+            relations.append(
+                {
+                    "name": (
+                        f"{DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_BASE}"
+                        "#relation.extended_childcare_entitlement_children"
+                    ),
+                    "tuple": [person_id_text, entity_id],
+                    "interval": interval,
+                }
+            )
+            for name, value in project_dfe_extended_childcare_child_inputs(
+                child_row,
+                maximum_hours_usage=maximum_hours_usage,
+            ).items():
+                inputs.append(
+                    input_record(
+                        (
+                            f"{DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_BASE}"
+                            f"#input.{name}"
+                        ),
+                        person_id_text,
+                        interval,
+                        value,
+                    )
+                )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [
+                    spec["axiom"]
+                    for spec in DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_OUTPUTS.values()
+                ],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": relations},
+        "queries": queries,
+    }
+
+
+def build_ssmg_final_request(*, pe_data: dict[str, Any], year: int) -> dict[str, Any]:
+    interval = calendar_year_interval(year)
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for row in rows_for_surface(pe_data, "sure-start-maternity-grant-final"):
+        entity_id = person_entity_id(int(row_value(row, "person_id")))
+        for name, value in project_ssmg_final_inputs(row).items():
+            inputs.append(
+                input_record(
+                    f"{SSMG_FINAL_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": interval,
+                "outputs": [spec["axiom"] for spec in SSMG_FINAL_OUTPUTS.values()],
+            }
+        )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+
+
 def project_personal_allowance_inputs(row: Any) -> dict[str, Any]:
     adjusted_net_income = money(row_value(row, "adjusted_net_income"))
     gift_aid_grossed_up = money(row_value(row, "gift_aid_grossed_up", 0))
@@ -6203,6 +8684,23 @@ def project_student_loan_repayment_inputs(row: Any) -> dict[str, Any]:
         "annual_income_before_tax_and_other_deductions": money(
             row_value(row, "adjusted_net_income", 0)
         ),
+        "outstanding_student_loan_balance": money(
+            row_value(row, "student_loan_balance", 0)
+        ),
+    }
+
+
+def project_closed_legacy_benefits_final_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "contribution_based_jobseekers_allowance_reported_for_year": money(
+            row_value(row, "jsa_contrib", 0)
+        ),
+        "income_related_employment_and_support_allowance_for_year": money(
+            row_value(row, "esa_income", 0)
+        ),
+        "contribution_based_employment_and_support_allowance_reported_for_year": money(
+            row_value(row, "esa_contrib", 0)
+        ),
     }
 
 
@@ -6266,6 +8764,369 @@ def project_dla_final_inputs(row: Any) -> dict[str, Any]:
         "person_has_lower_rate_dla_self_care_category": self_care_category == "LOWER",
         "person_has_higher_rate_dla_mobility_category": mobility_category == "HIGHER",
         "person_has_lower_rate_dla_mobility_category": mobility_category == "LOWER",
+    }
+
+
+def project_attendance_allowance_final_inputs(row: Any) -> dict[str, Any]:
+    category = enum_name(row_value(row, "aa_category", "NONE")).upper()
+    return {
+        "person_has_higher_rate_attendance_allowance_category": category == "HIGHER",
+        "person_has_lower_rate_attendance_allowance_category": category == "LOWER",
+    }
+
+
+def project_winter_fuel_allowance_final_inputs(row: Any) -> dict[str, Any]:
+    country = enum_name(row_value(row, "country", "")).upper()
+    receives_means_tested_benefit = (
+        money(row_value(row, "pension_credit", 0))
+        + money(row_value(row, "income_support", 0))
+        + money(row_value(row, "esa_income", 0))
+        + money(row_value(row, "jsa_income", 0))
+    ) > 0
+    return {
+        "household_is_in_scotland": country == "SCOTLAND",
+        "household_receives_relevant_means_tested_benefit": receives_means_tested_benefit,
+        "winter_fuel_payment_means_tested_benefits_required": bool_row_value(
+            row,
+            "winter_fuel_payment_means_tested_benefits_required",
+            False,
+        ),
+        "household_meets_winter_fuel_payment_income_passport": bool_row_value(
+            row,
+            "household_meets_winter_fuel_payment_income_passport",
+            False,
+        ),
+        "household_has_state_pension_age_person": bool_row_value(
+            row,
+            "household_has_state_pension_age_person",
+            False,
+        ),
+        "winter_fuel_payment_state_pension_age_required": bool_row_value(
+            row,
+            "winter_fuel_payment_state_pension_age_required",
+            False,
+        ),
+        "oldest_household_member_age": money(
+            row_value(row, "oldest_household_member_age", 0)
+        ),
+    }
+
+
+def project_tax_free_childcare_final_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "tax_free_childcare_benefit_unit_is_eligible": bool_row_value(
+            row,
+            "tax_free_childcare_eligible",
+            False,
+        ),
+        "tax_free_childcare_child_is_qualifying_child": bool_row_value(
+            row,
+            "tax_free_childcare_qualifying_child",
+            False,
+        ),
+        "tax_free_childcare_child_is_disabled_or_blind": bool_row_value(
+            row,
+            "is_disabled_for_benefits",
+            False,
+        )
+        or bool_row_value(row, "is_blind", False),
+        "tax_free_childcare_uses_qualifying_provider": bool_row_value(
+            row,
+            "tax_free_childcare_uses_qualifying_provider",
+            False,
+        ),
+        "tax_free_childcare_eligible_declaration_period_count": money(
+            row_value(row, "tax_free_childcare_eligible_declaration_periods", 0)
+        ),
+        "tax_free_childcare_qualifying_childcare_payment_annual_amount": money(
+            row_value(row, "childcare_expenses", 0)
+        ),
+    }
+
+
+def project_vat_final_inputs(
+    row: Any,
+    *,
+    parameters: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "full_rate_vat_consumption_for_year": money(
+            row_value(row, "full_rate_vat_consumption", 0)
+        ),
+        "reduced_rate_vat_consumption_for_year": money(
+            row_value(row, "reduced_rate_vat_consumption", 0)
+        ),
+        "microdata_vat_coverage_fraction": money(
+            parameters["microdata_vat_coverage"]
+        ),
+    }
+
+
+def project_capital_gains_tax_final_inputs(
+    row: Any,
+    *,
+    parameters: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "capital_gains_for_year": money(row_value(row, "capital_gains", 0)),
+        "adjusted_net_income_for_year": money(
+            row_value(row, "adjusted_net_income", 0)
+        ),
+        "allowances_for_year": money(row_value(row, "allowances", 0)),
+        "gift_aid_for_year": money(row_value(row, "gift_aid", 0)),
+        "gift_aid_grossed_up_for_year": money(
+            row_value(row, "gift_aid_grossed_up", 0)
+        ),
+        "personal_pension_contributions_for_year": money(
+            row_value(row, "personal_pension_contributions", 0)
+        ),
+        "pension_contributions_relief_for_year": money(
+            row_value(row, "pension_contributions_relief", 0)
+        ),
+        "income_tax_basic_rate_limit_for_year": money(
+            parameters["income_tax_basic_rate_limit"]
+        ),
+        "income_tax_higher_rate_limit_for_year": money(
+            parameters["income_tax_higher_rate_limit"]
+        ),
+    }
+
+
+def project_stamp_duty_land_tax_final_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "household_is_sdlt_liable": bool_row_value(row, "sdlt_liable", False),
+        "main_residential_property_purchased_for_year": money(
+            row_value(row, "main_residential_property_purchased", 0)
+        ),
+        "main_residential_property_purchased_is_first_home": bool_row_value(
+            row,
+            "main_residential_property_purchased_is_first_home",
+            False,
+        ),
+        "additional_residential_property_purchased_for_year": money(
+            row_value(row, "additional_residential_property_purchased", 0)
+        ),
+        "non_residential_property_purchased_for_year": money(
+            row_value(row, "non_residential_property_purchased", 0)
+        ),
+        "cumulative_residential_rent_for_year": money(
+            row_value(row, "cumulative_residential_rent", 0)
+        ),
+        "residential_rent_for_year": money(row_value(row, "rent", 0)),
+        "cumulative_non_residential_rent_for_year": money(
+            row_value(row, "cumulative_non_residential_rent", 0)
+        ),
+        "non_residential_rent_for_year": money(
+            row_value(row, "non_residential_rent", 0)
+        ),
+    }
+
+
+def project_lbtt_final_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "household_is_lbtt_liable": bool_row_value(row, "lbtt_liable", False),
+        "lbtt_on_transactions_for_year": money(
+            row_value(row, "lbtt_on_transactions", 0)
+        ),
+        "lbtt_on_rent_for_year": money(row_value(row, "lbtt_on_rent", 0)),
+    }
+
+
+def project_ltt_final_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "household_is_ltt_liable": bool_row_value(row, "ltt_liable", False),
+        "ltt_on_transactions_for_year": money(
+            row_value(row, "ltt_on_transactions", 0)
+        ),
+        "ltt_on_rent_for_year": money(row_value(row, "ltt_on_rent", 0)),
+    }
+
+
+def project_fuel_duty_final_inputs(
+    row: Any,
+    *,
+    parameters: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "petrol_litres_for_year": money(row_value(row, "petrol_litres", 0)),
+        "diesel_litres_for_year": money(row_value(row, "diesel_litres", 0)),
+        "petrol_and_diesel_fuel_duty_rate_per_litre": money(
+            parameters["petrol_and_diesel"]
+        ),
+        "fuel_is_purchased_in_rural_fuel_duty_relief_area": bool_row_value(
+            row,
+            "in_rural_fuel_duty_relief_area",
+            False,
+        ),
+    }
+
+
+def project_free_tv_licence_value_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "household_owns_tv": bool_row_value(row, "household_owns_tv", False),
+        "household_would_evade_tv_licence_fee": bool_row_value(
+            row,
+            "would_evade_tv_licence_fee",
+            False,
+        ),
+        "tv_licence_discount_fraction": money(row_value(row, "tv_licence_discount", 0)),
+    }
+
+
+def project_cost_of_living_support_payment_final_inputs(row: Any) -> dict[str, Any]:
+    receives_means_tested_benefit = (
+        money(row_value(row, "universal_credit", 0))
+        + money(row_value(row, "pension_credit", 0))
+        + money(row_value(row, "housing_benefit", 0))
+        + money(row_value(row, "jsa_income", 0))
+        + money(row_value(row, "income_support", 0))
+        + money(row_value(row, "esa_income", 0))
+    ) > 0
+    receives_disability_benefit = (
+        money(row_value(row, "pip", 0))
+        + money(row_value(row, "dla", 0))
+        + money(row_value(row, "attendance_allowance", 0))
+        + money(row_value(row, "armed_forces_independence_payment", 0))
+    ) > 0
+    return {
+        "household_receives_qualifying_means_tested_benefit_for_cost_of_living_payment": receives_means_tested_benefit,
+        "household_receives_winter_fuel_payment_for_cost_of_living_payment": money(
+            row_value(row, "winter_fuel_allowance", 0)
+        )
+        > 0,
+        "household_receives_qualifying_disability_benefit_for_cost_of_living_payment": receives_disability_benefit,
+    }
+
+
+def project_energy_price_guarantee_final_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "domestic_energy_consumption_for_year": money(
+            row_value(row, "domestic_energy_consumption", 0)
+        ),
+    }
+
+
+def project_dfe_person_programs_final_inputs(row: Any) -> dict[str, Any]:
+    living_arrangement = enum_key(row_value(row, "maintenance_loan_living_arrangement", ""))
+    region = enum_key(row_value(row, "region", ""))
+    return {
+        "person_age": money(row_value(row, "age", 0)),
+        "max_free_entitlement_hours_used": money(
+            row_value(row, "max_free_entitlement_hours_used", 0)
+        ),
+        "universal_childcare_entitlement_is_eligible": bool_row_value(
+            row,
+            "universal_childcare_entitlement_eligible",
+            False,
+        ),
+        "targeted_childcare_entitlement_is_eligible": bool_row_value(
+            row,
+            "targeted_childcare_entitlement_eligible",
+            False,
+        ),
+        "childcare_grant_is_eligible": bool_row_value(
+            row,
+            "childcare_grant_eligible",
+            False,
+        ),
+        "childcare_grant_eligible_child_count": money(
+            row_value(row, "childcare_grant_eligible_children", 0)
+        ),
+        "childcare_expenses_for_year": money(row_value(row, "childcare_expenses", 0)),
+        "parents_learning_allowance_is_eligible": bool_row_value(
+            row,
+            "parents_learning_allowance_eligible",
+            False,
+        ),
+        "adult_dependants_grant_is_eligible": bool_row_value(
+            row,
+            "adult_dependants_grant_eligible",
+            False,
+        ),
+        "travel_grant_is_eligible": bool_row_value(
+            row,
+            "travel_grant_eligible",
+            False,
+        ),
+        "travel_grant_eligible_expenses_for_year": money(
+            row_value(row, "travel_grant_eligible_expenses", 0)
+        ),
+        "travel_grant_household_income_for_year": money(
+            row_value(row, "travel_grant_household_income", 0)
+        ),
+        "disabled_students_allowance_is_eligible": bool_row_value(
+            row,
+            "disabled_students_allowance_eligible",
+            False,
+        ),
+        "disabled_students_allowance_eligible_expenses_for_year": money(
+            row_value(row, "disabled_students_allowance_eligible_expenses", 0)
+        ),
+        "care_to_learn_is_eligible": bool_row_value(
+            row,
+            "care_to_learn_eligible",
+            False,
+        ),
+        "household_region_is_london": region == "LONDON",
+        "maintenance_loan_is_eligible": bool_row_value(
+            row,
+            "maintenance_loan_eligible",
+            False,
+        ),
+        "maintenance_loan_household_income_for_year": money(
+            row_value(row, "maintenance_loan_household_income", 0)
+        ),
+        "maintenance_loan_living_with_parents": living_arrangement
+        == "LIVING_WITH_PARENTS",
+        "maintenance_loan_away_in_london": living_arrangement == "AWAY_IN_LONDON",
+        "maintenance_loan_entitled_to_benefits": bool_row_value(
+            row,
+            "maintenance_loan_entitled_to_benefits",
+            False,
+        ),
+        "bursary_fund_16_to_19_vulnerable_group_is_eligible": bool_row_value(
+            row,
+            "bursary_fund_16_to_19_vulnerable_group_eligible",
+            False,
+        ),
+        "bursary_fund_16_to_19_participation_costs_for_year": money(
+            row_value(row, "bursary_fund_16_to_19_participation_costs", 0)
+        ),
+    }
+
+
+def project_dfe_extended_childcare_child_inputs(
+    row: Any,
+    *,
+    maximum_hours_usage: float,
+) -> dict[str, Any]:
+    return {
+        "child_age": money(row_value(row, "age", 0)),
+        "max_free_entitlement_hours_used": money(
+            row_value(row, "max_free_entitlement_hours_used", 0)
+        ),
+        "maximum_extended_childcare_hours_usage_for_family": money(
+            maximum_hours_usage
+        ),
+        "extended_childcare_child_counts_for_entitlement": True,
+    }
+
+
+def person_rows_by_benunit(pe_data: dict[str, Any]) -> dict[int, list[dict[str, Any]]]:
+    rows: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for row in pe_data.get("all_persons") or pe_data["persons"]:
+        benunit_id = row_value(row, "person_benunit_id")
+        if benunit_id is None:
+            continue
+        rows[int(benunit_id)].append(row)
+    return rows
+
+
+def project_ssmg_final_inputs(row: Any) -> dict[str, Any]:
+    return {
+        "reported_sure_start_maternity_grant_for_year": money(
+            row_value(row, "ssmg_reported", 0)
+        ),
     }
 
 
@@ -6493,6 +9354,106 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             or enum_name(row_value(row, "dla_sc_category", "NONE")).upper() != "NONE"
             or enum_name(row_value(row, "dla_m_category", "NONE")).upper() != "NONE"
         ]
+    if surface == "attendance-allowance-final":
+        return [
+            row
+            for row in persons
+            if money(row_value(row, "attendance_allowance", 0)) > 0
+            or enum_name(row_value(row, "aa_category", "NONE")).upper() != "NONE"
+        ]
+    if surface == "tax-free-childcare-final":
+        return [
+            row
+            for row in persons
+            if money(row_value(row, "tax_free_childcare", 0)) > 0
+            or (
+                bool_row_value(row, "tax_free_childcare_eligible", False)
+                and bool_row_value(row, "tax_free_childcare_qualifying_child", False)
+                and money(row_value(row, "childcare_expenses", 0)) > 0
+            )
+        ]
+    if surface == "capital-gains-tax-final":
+        return [
+            row
+            for row in persons
+            if money(row_value(row, "capital_gains_tax", 0)) > 0
+            or money(row_value(row, "capital_gains", 0)) > 0
+            or money(row_value(row, "gift_aid", 0)) > 0
+            or money(row_value(row, "gift_aid_grossed_up", 0)) > 0
+            or money(row_value(row, "personal_pension_contributions", 0)) > 0
+            or money(row_value(row, "pension_contributions_relief", 0)) > 0
+        ]
+    if surface == "sure-start-maternity-grant-final":
+        return [
+            row
+            for row in persons
+            if money(row_value(row, "ssmg", 0)) > 0
+            or money(row_value(row, "ssmg_reported", 0)) > 0
+        ]
+    households = pe_data.get("households", [])
+    if surface == "vat-final":
+        return [
+            row
+            for row in households
+            if money(row_value(row, "vat", 0)) > 0
+            or money(row_value(row, "full_rate_vat_consumption", 0)) > 0
+            or money(row_value(row, "reduced_rate_vat_consumption", 0)) > 0
+        ]
+    if surface == "stamp-duty-land-tax-final":
+        return [
+            row
+            for row in households
+            if money(row_value(row, "stamp_duty_land_tax", 0)) > 0
+            or money(row_value(row, "main_residential_property_purchased", 0)) > 0
+            or money(row_value(row, "additional_residential_property_purchased", 0))
+            > 0
+            or money(row_value(row, "non_residential_property_purchased", 0)) > 0
+            or money(row_value(row, "cumulative_residential_rent", 0)) > 0
+            or money(row_value(row, "rent", 0)) > 0
+            or money(row_value(row, "cumulative_non_residential_rent", 0)) > 0
+            or money(row_value(row, "non_residential_rent", 0)) > 0
+        ]
+    if surface == "land-and-buildings-transaction-tax-final":
+        return list(households)
+    if surface == "land-transaction-tax-final":
+        return list(households)
+    if surface == "fuel-duty-final":
+        return [
+            row
+            for row in households
+            if money(row_value(row, "fuel_duty", 0)) > 0
+            or money(row_value(row, "petrol_litres", 0)) > 0
+            or money(row_value(row, "diesel_litres", 0)) > 0
+        ]
+    if surface == "winter-fuel-allowance-final":
+        return [
+            row
+            for row in households
+            if money(row_value(row, "winter_fuel_allowance", 0)) > 0
+            or bool_row_value(row, "household_has_state_pension_age_person", False)
+            or bool_row_value(
+                row,
+                "household_meets_winter_fuel_payment_income_passport",
+                False,
+            )
+            or money(row_value(row, "pension_credit", 0)) > 0
+            or money(row_value(row, "income_support", 0)) > 0
+            or money(row_value(row, "esa_income", 0)) > 0
+            or money(row_value(row, "jsa_income", 0)) > 0
+        ]
+    if surface == "free-tv-licence-value":
+        return [
+            row
+            for row in households
+            if money(row_value(row, "free_tv_licence_value", 0)) > 0
+            or money(row_value(row, "tv_licence", 0)) > 0
+        ]
+    if surface == "cost-of-living-support-payment-final":
+        return list(households)
+    if surface == "energy-bills-rebate-final":
+        return list(households)
+    if surface == "energy-price-guarantee-final":
+        return list(households)
     if surface == "pension-credit-final":
         return [
             row
@@ -6508,6 +9469,8 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             or money(row_value(row, "esa_income_reported_for_year", 0)) > 0
             or money(row_value(row, "esa_income_tariff_income", 0)) > 0
         ]
+    if surface == "closed-legacy-benefits-final":
+        return list(benunits)
     if surface == "housing-benefit-final":
         return [
             row
@@ -6532,6 +9495,8 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
         ]
     if SURFACE_SPECS[surface].entity == "benunit":
         return benunits
+    if SURFACE_SPECS[surface].entity == "household":
+        return households
     return persons
 
 
@@ -6621,6 +9586,7 @@ def compare_outputs(
     return UKEFRSComparisonReport(
         compared_persons=len(pe_data["person_ids"]),
         compared_benunits=len(pe_data.get("benunit_ids", [])),
+        compared_households=len(pe_data.get("household_ids", [])),
         compared_values=compared_values,
         mismatches=mismatches,
         oracle_divergences=oracle_divergences,
@@ -6731,6 +9697,14 @@ def compare_outputs(
             "projects PolicyEngine UK's DLA self-care and mobility category "
             "enums into boolean category leaves, then compares selected weekly "
             "components and the final annual aggregate.",
+            "PolicyEngine-aligned Attendance Allowance final comparison projects "
+            "PolicyEngine UK's Attendance Allowance category enum into higher "
+            "and lower boolean category leaves, then compares the selected weekly "
+            "amount and final annual aggregate.",
+            "PolicyEngine-aligned Winter Fuel Allowance final comparison runs at "
+            "household level, projects household pension-age, income-passport, "
+            "means-tested-benefit, Scotland, and age-80 gates from PolicyEngine "
+            "outputs, and compares the final annual household amount.",
             "When a local EFRS .h5 predates the PolicyEngine UK disability "
             "category-input migration, the oracle derives PIP, DLA, and "
             "Attendance Allowance category inputs in memory from reported "
@@ -6847,6 +9821,8 @@ def compare_outputs(
 def entity_id_for_surface(surface: str, row: Any) -> str:
     if SURFACE_SPECS[surface].entity == "benunit":
         return benunit_entity_id(int(row_value(row, "benunit_id")))
+    if SURFACE_SPECS[surface].entity == "household":
+        return household_entity_id(int(row_value(row, "household_id")))
     return person_entity_id(int(row_value(row, "person_id")))
 
 
@@ -6955,6 +9931,10 @@ def enum_name(value: Any) -> str:
     if "." in text:
         return text.rsplit(".", 1)[-1]
     return text
+
+
+def enum_key(value: Any) -> str:
+    return enum_name(value).upper().replace(" ", "_").replace("-", "_")
 
 
 def known_policyengine_divergence(
@@ -7090,6 +10070,7 @@ def print_report(
     print("PolicyEngine UK EFRS comparison")
     print(f"Compared persons: {report.compared_persons:,}")
     print(f"Compared benefit units: {report.compared_benunits:,}")
+    print(f"Compared households: {report.compared_households:,}")
     print(f"Compared values: {report.compared_values:,}")
     print(f"Tolerance: {tolerance:g}")
     print(f"Relative tolerance: {relative_tolerance:g}")
@@ -7196,6 +10177,24 @@ def uk_tax_year_interval(year: int) -> dict[str, str]:
     }
 
 
+def calendar_year_interval(year: int) -> dict[str, str]:
+    return {
+        "period_kind": "custom",
+        "name": "calendar_year",
+        "start": f"{year:04d}-01-01",
+        "end": f"{year:04d}-12-31",
+    }
+
+
+def licence_year_interval(year: int) -> dict[str, str]:
+    return {
+        "period_kind": "custom",
+        "name": "licence_year",
+        "start": f"{year:04d}-04-01",
+        "end": f"{year + 1:04d}-03-31",
+    }
+
+
 def day_interval(year: int) -> dict[str, str]:
     return {
         "period_kind": "custom",
@@ -7242,6 +10241,10 @@ def income_tax_component_entity_id(person_id: int, component: str) -> str:
 
 def benunit_entity_id(benunit_id: int) -> str:
     return f"benunit_{benunit_id}"
+
+
+def household_entity_id(household_id: int) -> str:
+    return f"household_{household_id}"
 
 
 def resolve_workspace_root(root: Path | None) -> Path:

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -121,13 +121,9 @@ STUDENT_LOAN_REPAYMENT_PROGRAM_PATH = Path(
     "policies/govuk/student-loan-repayments.yaml"
 )
 STUDENT_LOAN_REPAYMENT_BASE = "uk:policies/govuk/student-loan-repayments"
-CAPITAL_GAINS_TAX_FINAL_PROGRAM_PATH = Path(
-    "policies/govuk/capital-gains-tax.yaml"
-)
+CAPITAL_GAINS_TAX_FINAL_PROGRAM_PATH = Path("policies/govuk/capital-gains-tax.yaml")
 CAPITAL_GAINS_TAX_FINAL_BASE = "uk:policies/govuk/capital-gains-tax"
-STAMP_DUTY_LAND_TAX_FINAL_PROGRAM_PATH = Path(
-    "policies/govuk/stamp-duty-land-tax.yaml"
-)
+STAMP_DUTY_LAND_TAX_FINAL_PROGRAM_PATH = Path("policies/govuk/stamp-duty-land-tax.yaml")
 STAMP_DUTY_LAND_TAX_FINAL_BASE = "uk:policies/govuk/stamp-duty-land-tax"
 LBTT_FINAL_PROGRAM_PATH = Path("policies/govuk/land-and-buildings-transaction-tax.yaml")
 LBTT_FINAL_BASE = "uk:policies/govuk/land-and-buildings-transaction-tax"
@@ -175,9 +171,7 @@ COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_PROGRAM_PATH = Path(
 COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_BASE = (
     "uk:policies/govuk/cost-of-living-support-payment"
 )
-ENERGY_BILLS_REBATE_FINAL_PROGRAM_PATH = Path(
-    "policies/govuk/energy-bills-rebate.yaml"
-)
+ENERGY_BILLS_REBATE_FINAL_PROGRAM_PATH = Path("policies/govuk/energy-bills-rebate.yaml")
 ENERGY_BILLS_REBATE_FINAL_BASE = "uk:policies/govuk/energy-bills-rebate"
 ENERGY_PRICE_GUARANTEE_FINAL_PROGRAM_PATH = Path(
     "policies/govuk/energy-price-guarantee.yaml"
@@ -906,9 +900,7 @@ TAX_FREE_CHILDCARE_FINAL_OUTPUTS = {
 
 CAPITAL_GAINS_TAX_FINAL_OUTPUTS = {
     "capital_gains_tax_annual_amount": {
-        "axiom": (
-            f"{CAPITAL_GAINS_TAX_FINAL_BASE}#capital_gains_tax_annual_amount"
-        ),
+        "axiom": (f"{CAPITAL_GAINS_TAX_FINAL_BASE}#capital_gains_tax_annual_amount"),
         "pe": "capital_gains_tax",
         "tolerance": 0.01,
     },
@@ -917,8 +909,7 @@ CAPITAL_GAINS_TAX_FINAL_OUTPUTS = {
 STAMP_DUTY_LAND_TAX_FINAL_OUTPUTS = {
     "stamp_duty_land_tax_annual_amount": {
         "axiom": (
-            f"{STAMP_DUTY_LAND_TAX_FINAL_BASE}"
-            "#stamp_duty_land_tax_annual_amount"
+            f"{STAMP_DUTY_LAND_TAX_FINAL_BASE}#stamp_duty_land_tax_annual_amount"
         ),
         "pe": "stamp_duty_land_tax",
         "tolerance": 0.01,
@@ -928,8 +919,7 @@ STAMP_DUTY_LAND_TAX_FINAL_OUTPUTS = {
 LBTT_FINAL_OUTPUTS = {
     "land_and_buildings_transaction_tax_annual_amount": {
         "axiom": (
-            f"{LBTT_FINAL_BASE}"
-            "#land_and_buildings_transaction_tax_annual_amount"
+            f"{LBTT_FINAL_BASE}#land_and_buildings_transaction_tax_annual_amount"
         ),
         "pe": "land_and_buildings_transaction_tax",
         "tolerance": 0.01,
@@ -995,16 +985,14 @@ COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_OUTPUTS = {
 ENERGY_BILLS_REBATE_FINAL_OUTPUTS = {
     "energy_bills_rebate_council_tax_rebate": {
         "axiom": (
-            f"{ENERGY_BILLS_REBATE_FINAL_BASE}"
-            "#energy_bills_rebate_council_tax_rebate"
+            f"{ENERGY_BILLS_REBATE_FINAL_BASE}#energy_bills_rebate_council_tax_rebate"
         ),
         "pe": "ebr_council_tax_rebate",
         "tolerance": 0.01,
     },
     "energy_bills_rebate_energy_bills_credit": {
         "axiom": (
-            f"{ENERGY_BILLS_REBATE_FINAL_BASE}"
-            "#energy_bills_rebate_energy_bills_credit"
+            f"{ENERGY_BILLS_REBATE_FINAL_BASE}#energy_bills_rebate_energy_bills_credit"
         ),
         "pe": "ebr_energy_bills_credit",
         "tolerance": 0.01,
@@ -1051,16 +1039,14 @@ DFE_PERSON_PROGRAMS_FINAL_OUTPUTS = {
     },
     "parents_learning_allowance_annual_amount": {
         "axiom": (
-            f"{DFE_PERSON_PROGRAMS_FINAL_BASE}"
-            "#parents_learning_allowance_annual_amount"
+            f"{DFE_PERSON_PROGRAMS_FINAL_BASE}#parents_learning_allowance_annual_amount"
         ),
         "pe": "parents_learning_allowance",
         "tolerance": 0.01,
     },
     "adult_dependants_grant_annual_amount": {
         "axiom": (
-            f"{DFE_PERSON_PROGRAMS_FINAL_BASE}"
-            "#adult_dependants_grant_annual_amount"
+            f"{DFE_PERSON_PROGRAMS_FINAL_BASE}#adult_dependants_grant_annual_amount"
         ),
         "pe": "adult_dependants_grant",
         "tolerance": 0.01,
@@ -1090,8 +1076,7 @@ DFE_PERSON_PROGRAMS_FINAL_OUTPUTS = {
     },
     "bursary_fund_16_to_19_annual_amount": {
         "axiom": (
-            f"{DFE_PERSON_PROGRAMS_FINAL_BASE}"
-            "#bursary_fund_16_to_19_annual_amount"
+            f"{DFE_PERSON_PROGRAMS_FINAL_BASE}#bursary_fund_16_to_19_annual_amount"
         ),
         "pe": "bursary_fund_16_to_19",
         "tolerance": 0.01,
@@ -4196,9 +4181,7 @@ def policyengine_uk_fuel_duty_parameters(year: int) -> dict[str, Any]:
     except ImportError as exc:  # pragma: no cover - optional runtime dependency
         raise SystemExit(policyengine_uk_install_message()) from exc
 
-    fuel_duty = CountryTaxBenefitSystem().parameters(
-        year
-    ).baseline.gov.hmrc.fuel_duty
+    fuel_duty = CountryTaxBenefitSystem().parameters(year).baseline.gov.hmrc.fuel_duty
     return {
         "petrol_and_diesel": float(fuel_duty.petrol_and_diesel),
     }
@@ -7653,8 +7636,7 @@ def build_capital_gains_tax_final_request(
                 "entity_id": entity_id,
                 "period": interval,
                 "outputs": [
-                    spec["axiom"]
-                    for spec in CAPITAL_GAINS_TAX_FINAL_OUTPUTS.values()
+                    spec["axiom"] for spec in CAPITAL_GAINS_TAX_FINAL_OUTPUTS.values()
                 ],
             }
         )
@@ -7688,8 +7670,7 @@ def build_stamp_duty_land_tax_final_request(
                 "entity_id": entity_id,
                 "period": interval,
                 "outputs": [
-                    spec["axiom"]
-                    for spec in STAMP_DUTY_LAND_TAX_FINAL_OUTPUTS.values()
+                    spec["axiom"] for spec in STAMP_DUTY_LAND_TAX_FINAL_OUTPUTS.values()
                 ],
             }
         )
@@ -7820,9 +7801,7 @@ def build_fuel_duty_final_request(
             {
                 "entity_id": entity_id,
                 "period": interval,
-                "outputs": [
-                    spec["axiom"] for spec in FUEL_DUTY_FINAL_OUTPUTS.values()
-                ],
+                "outputs": [spec["axiom"] for spec in FUEL_DUTY_FINAL_OUTPUTS.values()],
             }
         )
 
@@ -7915,8 +7894,7 @@ def build_energy_bills_rebate_final_request(
                 "entity_id": household_entity_id(int(row_value(row, "household_id"))),
                 "period": interval,
                 "outputs": [
-                    spec["axiom"]
-                    for spec in ENERGY_BILLS_REBATE_FINAL_OUTPUTS.values()
+                    spec["axiom"] for spec in ENERGY_BILLS_REBATE_FINAL_OUTPUTS.values()
                 ],
             }
         )
@@ -7985,8 +7963,7 @@ def build_dfe_person_programs_final_request(
                 "entity_id": entity_id,
                 "period": interval,
                 "outputs": [
-                    spec["axiom"]
-                    for spec in DFE_PERSON_PROGRAMS_FINAL_OUTPUTS.values()
+                    spec["axiom"] for spec in DFE_PERSON_PROGRAMS_FINAL_OUTPUTS.values()
                 ],
             }
         )
@@ -8856,9 +8833,7 @@ def project_vat_final_inputs(
         "reduced_rate_vat_consumption_for_year": money(
             row_value(row, "reduced_rate_vat_consumption", 0)
         ),
-        "microdata_vat_coverage_fraction": money(
-            parameters["microdata_vat_coverage"]
-        ),
+        "microdata_vat_coverage_fraction": money(parameters["microdata_vat_coverage"]),
     }
 
 
@@ -8869,14 +8844,10 @@ def project_capital_gains_tax_final_inputs(
 ) -> dict[str, Any]:
     return {
         "capital_gains_for_year": money(row_value(row, "capital_gains", 0)),
-        "adjusted_net_income_for_year": money(
-            row_value(row, "adjusted_net_income", 0)
-        ),
+        "adjusted_net_income_for_year": money(row_value(row, "adjusted_net_income", 0)),
         "allowances_for_year": money(row_value(row, "allowances", 0)),
         "gift_aid_for_year": money(row_value(row, "gift_aid", 0)),
-        "gift_aid_grossed_up_for_year": money(
-            row_value(row, "gift_aid_grossed_up", 0)
-        ),
+        "gift_aid_grossed_up_for_year": money(row_value(row, "gift_aid_grossed_up", 0)),
         "personal_pension_contributions_for_year": money(
             row_value(row, "personal_pension_contributions", 0)
         ),
@@ -8935,9 +8906,7 @@ def project_lbtt_final_inputs(row: Any) -> dict[str, Any]:
 def project_ltt_final_inputs(row: Any) -> dict[str, Any]:
     return {
         "household_is_ltt_liable": bool_row_value(row, "ltt_liable", False),
-        "ltt_on_transactions_for_year": money(
-            row_value(row, "ltt_on_transactions", 0)
-        ),
+        "ltt_on_transactions_for_year": money(row_value(row, "ltt_on_transactions", 0)),
         "ltt_on_rent_for_year": money(row_value(row, "ltt_on_rent", 0)),
     }
 
@@ -9007,7 +8976,9 @@ def project_energy_price_guarantee_final_inputs(row: Any) -> dict[str, Any]:
 
 
 def project_dfe_person_programs_final_inputs(row: Any) -> dict[str, Any]:
-    living_arrangement = enum_key(row_value(row, "maintenance_loan_living_arrangement", ""))
+    living_arrangement = enum_key(
+        row_value(row, "maintenance_loan_living_arrangement", "")
+    )
     region = enum_key(row_value(row, "region", ""))
     return {
         "person_age": money(row_value(row, "age", 0)),
@@ -9105,9 +9076,7 @@ def project_dfe_extended_childcare_child_inputs(
         "max_free_entitlement_hours_used": money(
             row_value(row, "max_free_entitlement_hours_used", 0)
         ),
-        "maximum_extended_childcare_hours_usage_for_family": money(
-            maximum_hours_usage
-        ),
+        "maximum_extended_childcare_hours_usage_for_family": money(maximum_hours_usage),
         "extended_childcare_child_counts_for_entitlement": True,
     }
 
@@ -9405,8 +9374,7 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
             for row in households
             if money(row_value(row, "stamp_duty_land_tax", 0)) > 0
             or money(row_value(row, "main_residential_property_purchased", 0)) > 0
-            or money(row_value(row, "additional_residential_property_purchased", 0))
-            > 0
+            or money(row_value(row, "additional_residential_property_purchased", 0)) > 0
             or money(row_value(row, "non_residential_property_purchased", 0)) > 0
             or money(row_value(row, "cumulative_residential_rent", 0)) > 0
             or money(row_value(row, "rent", 0)) > 0

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1108,30 +1108,36 @@ mappings:
     program: capital_gains_tax
     mapping_type: parameter_value
     policyengine_parameter: gov.hmrc.cgt.basic_rate
+    aliases:
+      - uk:policies/govuk/capital-gains-tax#capital_gains_tax_annual_amount
     period: year
     unit: /1
     comparison: rate
-    rationale: Same basic-rate CGT parameter used by PolicyEngine UK after the Finance Act 2025 rate change.
+    rationale: Same basic-rate CGT parameter used by PolicyEngine UK after the Finance Act 2025 rate change. Companion tests exercise this rate through final annual Capital Gains Tax outputs.
 
   - legal_id: uk:policies/govuk/capital-gains-tax#cgt_higher_rate
     country: uk
     program: capital_gains_tax
     mapping_type: parameter_value
     policyengine_parameter: gov.hmrc.cgt.higher_rate
+    aliases:
+      - uk:policies/govuk/capital-gains-tax#capital_gains_tax_annual_amount
     period: year
     unit: /1
     comparison: rate
-    rationale: Same higher-rate CGT parameter used by PolicyEngine UK after the Finance Act 2025 rate change.
+    rationale: Same higher-rate CGT parameter used by PolicyEngine UK after the Finance Act 2025 rate change. Companion tests exercise this rate through final annual Capital Gains Tax outputs.
 
   - legal_id: uk:policies/govuk/capital-gains-tax#cgt_additional_rate
     country: uk
     program: capital_gains_tax
     mapping_type: parameter_value
     policyengine_parameter: gov.hmrc.cgt.additional_rate
+    aliases:
+      - uk:policies/govuk/capital-gains-tax#capital_gains_tax_annual_amount
     period: year
     unit: /1
     comparison: rate
-    rationale: Same additional-rate CGT parameter used by PolicyEngine UK; current main-rate gains use the same 24% rate as the higher-rate slice.
+    rationale: Same additional-rate CGT parameter used by PolicyEngine UK; current main-rate gains use the same 24% rate as the higher-rate slice. Companion tests exercise this rate through final annual Capital Gains Tax outputs.
 
   - legal_id: uk:policies/govuk/capital-gains-tax#capital_gains_tax_annual_amount
     country: uk
@@ -2760,6 +2766,48 @@ prefixes:
     program: state_pension
     mapping_type: not_comparable
     rationale: State Pension final receipt helper outputs not listed above are Axiom-side type-selection and dataset-year proration helpers rather than separate PolicyEngine UK oracle variables.
+
+  - legal_id_prefix: uk:policies/govuk/student-loan-repayments#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Student-loan repayment helper outputs not listed above are selected thresholds, pre-cap repayment amounts, and branch-control intermediates used inside the final PolicyEngine UK student-loan repayment variables.
+
+  - legal_id_prefix: uk:policies/govuk/cost-of-living-support-payment#
+    country: uk
+    program: cost_of_living_support_payment
+    mapping_type: not_comparable
+    rationale: Cost-of-living support helper outputs not listed above are instalment selectors, current-year parameter projections, and branch-level household predicates; PolicyEngine UK exposes the annual aggregate support payment rather than each Axiom helper one-to-one.
+
+  - legal_id_prefix: uk:policies/govuk/dfe-person-programs#
+    country: uk
+    program: dfe
+    mapping_type: not_comparable
+    rationale: DfE person-program helper outputs not listed above are source-parameter snapshots, age/rate selectors, loan taper stages, annualization factors, and intermediate caps used inside the final person-level childcare, student-support, and bursary outputs exposed by PolicyEngine UK.
+
+  - legal_id_prefix: uk:policies/govuk/dfe-extended-childcare-entitlement#
+    country: uk
+    program: dfe_childcare
+    mapping_type: not_comparable
+    rationale: Extended-childcare helper outputs not listed above are source-parameter snapshots, child age/rate selectors, and weekly entitlement intermediates used inside the final benefit-unit extended childcare entitlement exposed by PolicyEngine UK.
+
+  - legal_id_prefix: uk:policies/govuk/energy-bills-rebate#
+    country: uk
+    program: energy_bills_rebate
+    mapping_type: not_comparable
+    rationale: Energy Bills Rebate helper outputs not listed above are current-year parameter projections and component selectors used inside the final household rebate outputs exposed by PolicyEngine UK.
+
+  - legal_id_prefix: uk:policies/govuk/energy-price-guarantee#
+    country: uk
+    program: energy_price_guarantee
+    mapping_type: not_comparable
+    rationale: Energy Price Guarantee helper outputs not listed above are current-year price-cap and guarantee-level parameter projections used inside PolicyEngine UK's final household subsidy output.
+
+  - legal_id_prefix: uk:policies/govuk/stamp-duty-land-tax#
+    country: uk
+    program: stamp_duty_land_tax
+    mapping_type: not_comparable
+    rationale: Stamp Duty Land Tax helper outputs not listed above are band parameters, taxable-base splits, purchase/rent branch liabilities, and transaction-type intermediates used inside PolicyEngine UK's final household SDLT output.
 
   - legal_id_prefix: uk:regulations/uksi/2002/1792/6#
     country: uk

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -602,7 +602,7 @@ mappings:
     period: year
     unit: GBP
     comparison: money
-    rationale: Same modelled annual student-loan repayment from adjusted net income, loan plan, threshold, and rate.
+    rationale: Same modelled annual student-loan repayment from adjusted net income, loan plan, threshold, rate, and the outstanding-balance cap when a balance is available.
 
   - legal_id: uk:policies/govuk/student-loan-repayments#student_loan_repayments
     country: uk
@@ -1022,6 +1022,446 @@ mappings:
     comparison: money
     rationale: Same annual individual adjusted-net-income limit for Tax-Free Childcare eligibility.
 
+  - legal_id: uk:policies/govuk/tax-free-childcare#tax_free_childcare_standard_qualifying_payment_limit_per_entitlement_period
+    country: uk
+    program: tax_free_childcare
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hmrc.tax_free_childcare.contribution.standard_child
+    candidate_priority: P4
+    rationale: Section 19 states the maximum qualifying payment paid into the childcare account per entitlement period; PolicyEngine stores the derived annual standard-child government top-up cap instead.
+
+  - legal_id: uk:policies/govuk/tax-free-childcare#tax_free_childcare_disabled_qualifying_payment_limit_per_entitlement_period
+    country: uk
+    program: tax_free_childcare
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hmrc.tax_free_childcare.contribution.disabled_child
+    candidate_priority: P4
+    rationale: Section 19 states the maximum qualifying payment paid into the childcare account per entitlement period; PolicyEngine stores the derived annual disabled-child government top-up cap instead.
+
+  - legal_id: uk:policies/govuk/tax-free-childcare#tax_free_childcare_declaration_periods_per_year
+    country: uk
+    program: tax_free_childcare
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.tax_free_childcare.declaration_periods_per_year
+    period: year
+    unit: declaration_period
+    comparison: count
+    rationale: Same number of Tax-Free Childcare declaration periods per year.
+
+  - legal_id: uk:policies/govuk/tax-free-childcare#tax_free_childcare_standard_child_yearly_top_up_limit
+    country: uk
+    program: tax_free_childcare
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.tax_free_childcare.contribution.standard_child
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual standard-child government top-up cap after deriving it from the per-entitlement-period qualifying-payment cap and the top-up rate.
+
+  - legal_id: uk:policies/govuk/tax-free-childcare#tax_free_childcare_disabled_child_yearly_top_up_limit
+    country: uk
+    program: tax_free_childcare
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.tax_free_childcare.contribution.disabled_child
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual disabled-child government top-up cap after deriving it from the per-entitlement-period qualifying-payment cap and the top-up rate.
+
+  - legal_id: uk:policies/govuk/tax-free-childcare#tax_free_childcare_selected_child_yearly_top_up_limit
+    country: uk
+    program: tax_free_childcare
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Row-level branch helper selecting the standard or disabled-child annual cap; PolicyEngine exposes the branch inputs and final Tax-Free Childcare variable, not this helper as a standalone variable.
+
+  - legal_id: uk:policies/govuk/tax-free-childcare#tax_free_childcare_annual_top_up_limit_for_eligible_periods
+    country: uk
+    program: tax_free_childcare
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Row-level cap helper prorated by eligible declaration periods; PolicyEngine applies the same helper internally inside the final tax_free_childcare formula rather than exposing it separately.
+
+  - legal_id: uk:policies/govuk/tax-free-childcare#tax_free_childcare_annual_amount
+    country: uk
+    program: tax_free_childcare
+    mapping_type: direct_variable
+    policyengine_variable: tax_free_childcare
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final annual Tax-Free Childcare person amount after eligibility, provider, child-status, declaration-period, and cap gates.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#cgt_annual_exempt_amount
+    country: uk
+    program: capital_gains_tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.cgt.annual_exempt_amount
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual exempt amount used by PolicyEngine UK's Capital Gains Tax formula.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#cgt_basic_rate
+    country: uk
+    program: capital_gains_tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.cgt.basic_rate
+    period: year
+    unit: /1
+    comparison: rate
+    rationale: Same basic-rate CGT parameter used by PolicyEngine UK after the Finance Act 2025 rate change.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#cgt_higher_rate
+    country: uk
+    program: capital_gains_tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.cgt.higher_rate
+    period: year
+    unit: /1
+    comparison: rate
+    rationale: Same higher-rate CGT parameter used by PolicyEngine UK after the Finance Act 2025 rate change.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#cgt_additional_rate
+    country: uk
+    program: capital_gains_tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.cgt.additional_rate
+    period: year
+    unit: /1
+    comparison: rate
+    rationale: Same additional-rate CGT parameter used by PolicyEngine UK; current main-rate gains use the same 24% rate as the higher-rate slice.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#capital_gains_tax_annual_amount
+    country: uk
+    program: capital_gains_tax
+    mapping_type: direct_variable
+    policyengine_variable: capital_gains_tax
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final annual person-level Capital Gains Tax amount after annual exempt amount, income-tax band usage, Gift Aid and pension band extensions, and main CGT rates.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#personal_pension_band_extension_for_cgt
+    country: uk
+    program: capital_gains_tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom helper mirroring an intermediate expression inside PolicyEngine UK's capital_gains_tax formula.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#basic_rate_band_extension_for_cgt
+    country: uk
+    program: capital_gains_tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom helper mirroring PolicyEngine UK's Gift Aid and pension extension of the basic-rate band inside capital_gains_tax.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#allowances_for_cgt_income
+    country: uk
+    program: capital_gains_tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom helper for the allowance amount used to compute taxable income for CGT band allocation.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#taxable_income_for_cgt
+    country: uk
+    program: capital_gains_tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom helper for taxable income used only to allocate gains across CGT rate bands.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#positive_capital_gains_for_year
+    country: uk
+    program: capital_gains_tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom helper flooring negative capital gains before applying the annual exempt amount, matching PolicyEngine UK's formula internals.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#capital_gains_less_annual_exempt_amount
+    country: uk
+    program: capital_gains_tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom helper for positive gains after the annual exempt amount; PolicyEngine computes this internally.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#cgt_basic_rate_limit_with_extension
+    country: uk
+    program: capital_gains_tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom helper for the income-tax basic-rate limit after Gift Aid and pension band extension.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#cgt_higher_rate_limit_with_extension
+    country: uk
+    program: capital_gains_tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom helper for the income-tax higher-rate limit after Gift Aid and pension band extension.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#cgt_remaining_basic_rate_band
+    country: uk
+    program: capital_gains_tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom helper for the unused basic-rate band available to capital gains.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#capital_gains_charged_at_basic_rate
+    country: uk
+    program: capital_gains_tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom per-rate gain slice; PolicyEngine UK exposes only the final capital_gains_tax output.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#capital_gains_above_basic_rate_band
+    country: uk
+    program: capital_gains_tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom helper for gains remaining after the basic-rate slice.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#capital_gains_charged_at_higher_rate
+    country: uk
+    program: capital_gains_tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom per-rate gain slice; PolicyEngine UK exposes only the final capital_gains_tax output.
+
+  - legal_id: uk:policies/govuk/capital-gains-tax#capital_gains_charged_at_additional_rate
+    country: uk
+    program: capital_gains_tax
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom per-rate gain slice; PolicyEngine UK exposes only the final capital_gains_tax output.
+
+  - legal_id: uk:policies/govuk/stamp-duty-land-tax#stamp_duty_land_tax_annual_amount
+    country: uk
+    program: stamp_duty_land_tax
+    mapping_type: direct_variable
+    policyengine_variable: stamp_duty_land_tax
+    entity: household
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final annual household Stamp Duty Land Tax amount after residential purchase, additional-dwelling purchase, non-residential purchase, lease-rent, and SDLT liability gates.
+
+  - legal_id: uk:policies/govuk/land-and-buildings-transaction-tax#land_and_buildings_transaction_tax_annual_amount
+    country: uk
+    program: land_and_buildings_transaction_tax
+    mapping_type: direct_variable
+    policyengine_variable: land_and_buildings_transaction_tax
+    entity: household
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final annual household Land and Buildings Transaction Tax amount after PolicyEngine UK's LBTT transaction, rent, and Scotland liability gates.
+
+  - legal_id: uk:policies/govuk/land-transaction-tax#land_transaction_tax_annual_amount
+    country: uk
+    program: land_transaction_tax
+    mapping_type: direct_variable
+    policyengine_variable: land_transaction_tax
+    entity: household
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final annual household Land Transaction Tax amount after PolicyEngine UK's LTT transaction, rent, and Wales liability gates.
+
+  - legal_id: uk:policies/govuk/dfe-person-programs#universal_childcare_entitlement_annual_amount
+    country: uk
+    program: dfe_childcare
+    mapping_type: direct_variable
+    policyengine_variable: universal_childcare_entitlement
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same person-level universal childcare entitlement amount as PolicyEngine UK's DfE formula.
+
+  - legal_id: uk:policies/govuk/dfe-person-programs#targeted_childcare_entitlement_annual_amount
+    country: uk
+    program: dfe_childcare
+    mapping_type: direct_variable
+    policyengine_variable: targeted_childcare_entitlement
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same person-level targeted childcare entitlement amount as PolicyEngine UK's DfE formula.
+
+  - legal_id: uk:policies/govuk/dfe-extended-childcare-entitlement#extended_childcare_entitlement_annual_amount
+    country: uk
+    program: dfe_childcare
+    mapping_type: direct_variable
+    policyengine_variable: extended_childcare_entitlement
+    entity: benunit
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same benefit-unit extended childcare entitlement amount as PolicyEngine UK's DfE formula.
+
+  - legal_id: uk:policies/govuk/dfe-person-programs#childcare_grant_annual_amount
+    country: uk
+    program: student_support
+    mapping_type: direct_variable
+    policyengine_variable: childcare_grant
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same person-level Student Finance England Childcare Grant as PolicyEngine UK's DfE formula.
+
+  - legal_id: uk:policies/govuk/dfe-person-programs#parents_learning_allowance_annual_amount
+    country: uk
+    program: student_support
+    mapping_type: direct_variable
+    policyengine_variable: parents_learning_allowance
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same person-level Parents' Learning Allowance as PolicyEngine UK's DfE formula.
+
+  - legal_id: uk:policies/govuk/dfe-person-programs#adult_dependants_grant_annual_amount
+    country: uk
+    program: student_support
+    mapping_type: direct_variable
+    policyengine_variable: adult_dependants_grant
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same person-level Adult Dependants' Grant as PolicyEngine UK's DfE formula.
+
+  - legal_id: uk:policies/govuk/dfe-person-programs#travel_grant_annual_amount
+    country: uk
+    program: student_support
+    mapping_type: direct_variable
+    policyengine_variable: travel_grant
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same person-level Travel Grant as PolicyEngine UK's DfE formula.
+
+  - legal_id: uk:policies/govuk/dfe-person-programs#disabled_students_allowance_annual_amount
+    country: uk
+    program: student_support
+    mapping_type: direct_variable
+    policyengine_variable: disabled_students_allowance
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same person-level Disabled Students' Allowance as PolicyEngine UK's DfE formula.
+
+  - legal_id: uk:policies/govuk/dfe-person-programs#care_to_learn_annual_amount
+    country: uk
+    program: student_support
+    mapping_type: direct_variable
+    policyengine_variable: care_to_learn
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same person-level Care to Learn amount as PolicyEngine UK's DfE formula.
+
+  - legal_id: uk:policies/govuk/dfe-person-programs#maintenance_loan_annual_amount
+    country: uk
+    program: student_support
+    mapping_type: direct_variable
+    policyengine_variable: maintenance_loan
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same person-level maintenance loan amount as PolicyEngine UK's DfE formula.
+
+  - legal_id: uk:policies/govuk/dfe-person-programs#bursary_fund_16_to_19_annual_amount
+    country: uk
+    program: student_support
+    mapping_type: direct_variable
+    policyengine_variable: bursary_fund_16_to_19
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same person-level 16 to 19 Bursary Fund amount as PolicyEngine UK's DfE formula.
+
+  - legal_id: uk:policies/govuk/vat#vat_standard_rate
+    country: uk
+    program: vat
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.vat.standard_rate
+    period: year
+    unit: /1
+    comparison: rate
+    rationale: Same standard VAT rate used by PolicyEngine UK's VAT formula.
+
+  - legal_id: uk:policies/govuk/vat#vat_reduced_rate
+    country: uk
+    program: vat
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.vat.reduced_rate
+    period: year
+    unit: /1
+    comparison: rate
+    rationale: Same reduced VAT rate used by PolicyEngine UK's VAT formula.
+
+  - legal_id: uk:policies/govuk/vat#vat_raw_annual_amount
+    country: uk
+    program: vat
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom helper for statutory VAT before PE's microdata-coverage calibration; PolicyEngine computes this internally inside the final vat formula.
+
+  - legal_id: uk:policies/govuk/vat#vat_annual_amount
+    country: uk
+    program: vat
+    mapping_type: direct_variable
+    policyengine_variable: vat
+    entity: household
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final annual household VAT amount after standard-rate consumption, reduced-rate consumption, and PE microdata-coverage calibration.
+
+  - legal_id: uk:policies/govuk/fuel-duty#rural_fuel_duty_relief_rate_per_litre
+    country: uk
+    program: fuel_duty
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hmrc.fuel_duty.rural_fuel_duty_relief
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same rural fuel duty relief per litre used to reduce the main petrol and diesel fuel duty rate in eligible rural relief areas.
+
+  - legal_id: uk:policies/govuk/fuel-duty#fuel_duty_petrol_and_diesel_litres_for_year
+    country: uk
+    program: fuel_duty
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom helper summing petrol and diesel litres for the year; PolicyEngine exposes the component litre inputs rather than this derived total.
+
+  - legal_id: uk:policies/govuk/fuel-duty#fuel_duty_effective_rate_per_litre
+    country: uk
+    program: fuel_duty
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom helper applying rural fuel duty relief to the supplied petrol/diesel rate; PolicyEngine applies this inside the final fuel_duty formula rather than exposing the effective rate as a variable.
+
+  - legal_id: uk:policies/govuk/fuel-duty#fuel_duty_annual_amount
+    country: uk
+    program: fuel_duty
+    mapping_type: direct_variable
+    policyengine_variable: fuel_duty
+    entity: household
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual household fuel duty amount from petrol and diesel litres, main petrol/diesel duty rate, and rural fuel duty relief.
+
   - legal_id: uk:regulations/uksi/2005/3061/5#sure_start_maternity_grant_amount
     country: uk
     program: ssmg
@@ -1032,6 +1472,17 @@ mappings:
     comparison: money
     rationale: Same Sure Start Maternity Grant amount payable when the regulation's entitlement conditions are satisfied.
 
+  - legal_id: uk:policies/govuk/sure-start-maternity-grant#sure_start_maternity_grant_annual_amount
+    country: uk
+    program: ssmg
+    mapping_type: direct_variable
+    policyengine_variable: ssmg
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual person Sure Start Maternity Grant amount after the reported-receipt gate used by PolicyEngine UK.
+
   - legal_id: uk:regulations/uksi/2004/692/schedule/1#colour_tv_licence_general_form_issue_fee
     country: uk
     program: tv_licence
@@ -1041,6 +1492,28 @@ mappings:
     unit: GBP
     comparison: money
     rationale: Same annual colour TV licence General Form issue fee used by PolicyEngine UK's TV licence and free-TV-licence-value formulas.
+
+  - legal_id: uk:policies/govuk/tv-licence#free_tv_licence_value
+    country: uk
+    program: tv_licence
+    mapping_type: direct_variable
+    policyengine_variable: free_tv_licence_value
+    entity: household
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual household free TV licence value after household ownership, evasion, and TV licence discount fraction gates.
+
+  - legal_id: uk:policies/govuk/tv-licence#tv_licence_annual_amount
+    country: uk
+    program: tv_licence
+    mapping_type: direct_variable
+    policyengine_variable: tv_licence
+    entity: household
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual household TV licence tax after household ownership, evasion, and TV licence discount fraction gates.
 
   - legal_id: uk:regulations/ssi/2020/351/20#scottish_child_payment_weekly_amount
     country: uk
@@ -1197,6 +1670,138 @@ mappings:
     unit: GBP
     comparison: money
     rationale: Same one-off Disability Cost-of-Living Payment amount for 2023-24.
+
+  - legal_id: uk:policies/govuk/cost-of-living-support-payment#cost_of_living_support_payment_annual_amount
+    country: uk
+    program: cost_of_living_support_payment
+    mapping_type: direct_variable
+    policyengine_variable: cost_of_living_support_payment
+    entity: household
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Final annual household Cost-of-Living Support Payment output is the same PolicyEngine UK variable after the means-tested, pensioner, and disability qualifying-benefit branches.
+
+  - legal_id: uk:policies/govuk/energy-bills-rebate#energy_bills_rebate_council_tax_rebate
+    country: uk
+    program: energy_bills_rebate
+    mapping_type: direct_variable
+    policyengine_variable: ebr_council_tax_rebate
+    entity: household
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual Energy Bills Rebate council-tax-rebate component after PolicyEngine UK's active temporary-support parameter is zero for 2026.
+
+  - legal_id: uk:policies/govuk/energy-bills-rebate#energy_bills_rebate_energy_bills_credit
+    country: uk
+    program: energy_bills_rebate
+    mapping_type: direct_variable
+    policyengine_variable: ebr_energy_bills_credit
+    entity: household
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual Energy Bills Rebate energy-bills-credit component after PolicyEngine UK's active temporary-support parameter is zero for 2026.
+
+  - legal_id: uk:policies/govuk/energy-bills-rebate#energy_bills_rebate_annual_amount
+    country: uk
+    program: energy_bills_rebate
+    mapping_type: direct_variable
+    policyengine_variable: energy_bills_rebate
+    entity: household
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual household Energy Bills Rebate aggregate, composed from the council-tax rebate and energy-bills credit components.
+
+  - legal_id: uk:policies/govuk/energy-price-guarantee#energy_price_guarantee_subsidy_annual_amount
+    country: uk
+    program: energy_price_guarantee
+    mapping_type: direct_variable
+    policyengine_variable: epg_subsidy
+    entity: household
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual household Energy Price Guarantee subsidy after applying PolicyEngine UK's Ofgem price-cap and price-guarantee parameters to annual domestic energy consumption.
+
+  - legal_id: uk:policies/govuk/closed-legacy-benefits#income_support
+    country: uk
+    program: income_support
+    mapping_type: direct_variable
+    policyengine_variable: income_support
+    entity: benunit
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same current-law final nil Income Support amount after DWP closed the remaining Income Support legacy caseload through managed migration.
+
+  - legal_id: uk:policies/govuk/closed-legacy-benefits#jsa_income
+    country: uk
+    program: jobseekers_allowance
+    mapping_type: direct_variable
+    policyengine_variable: jsa_income
+    entity: benunit
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same current-law final nil income-based Jobseeker's Allowance amount after DWP closed the remaining income-related JSA legacy caseload through managed migration.
+
+  - legal_id: uk:policies/govuk/closed-legacy-benefits#working_tax_credit
+    country: uk
+    program: working_tax_credit
+    mapping_type: direct_variable
+    policyengine_variable: working_tax_credit
+    entity: benunit
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same current-law final nil Working Tax Credit amount after tax credits ended on 5 April 2025.
+
+  - legal_id: uk:policies/govuk/closed-legacy-benefits#child_tax_credit
+    country: uk
+    program: child_tax_credit
+    mapping_type: direct_variable
+    policyengine_variable: child_tax_credit
+    entity: benunit
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same current-law final nil Child Tax Credit amount after tax credits ended on 5 April 2025.
+
+  - legal_id: uk:policies/govuk/closed-legacy-benefits#tax_credits
+    country: uk
+    program: tax_credits
+    mapping_type: direct_variable
+    policyengine_variable: tax_credits
+    entity: benunit
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same current-law final nil aggregate Tax Credits amount after Child Tax Credit and Working Tax Credit ended on 5 April 2025.
+
+  - legal_id: uk:policies/govuk/closed-legacy-benefits#jsa
+    country: uk
+    program: jobseekers_allowance
+    mapping_type: direct_variable
+    policyengine_variable: jsa
+    entity: benunit
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual aggregate Jobseeker's Allowance amount after current-law income-based JSA closure and reported contribution-based JSA receipt.
+
+  - legal_id: uk:policies/govuk/closed-legacy-benefits#esa
+    country: uk
+    program: employment_and_support_allowance
+    mapping_type: direct_variable
+    policyengine_variable: esa
+    entity: benunit
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual aggregate Employment and Support Allowance amount after income-related ESA and reported contribution-based ESA receipt.
 
   - legal_id: uk:regulations/uksi/2013/377/24#pip_daily_living_standard_weekly_rate
     country: uk
@@ -1530,6 +2135,37 @@ mappings:
     comparison: money
     rationale: Same weekly lower Attendance Allowance rate in Schedule 1 Part III of the 2026 up-rating order.
 
+  - legal_id: uk:policies/govuk/attendance-allowance#attendance_allowance_weeks_in_year
+    country: uk
+    program: attendance_allowance
+    mapping_type: not_comparable
+    comparable: false
+    candidate_priority: P4
+    rationale: Source-backed annualization helper for the policy-level final amount wrapper; PolicyEngine exposes the final annual Attendance Allowance variable and weekly higher/lower parameters, not this multiplication factor as a separate oracle target.
+
+  - legal_id: uk:policies/govuk/attendance-allowance#attendance_allowance_weekly_amount
+    country: uk
+    program: attendance_allowance
+    mapping_type: direct_variable
+    policyengine_variable: attendance_allowance
+    entity: person
+    period: week
+    unit: GBP
+    comparison: money
+    result_multiplier: 0.019230769230769232
+    rationale: Same selected weekly Attendance Allowance amount, with PolicyEngine UK's annual attendance_allowance converted to a weekly amount.
+
+  - legal_id: uk:policies/govuk/attendance-allowance#attendance_allowance_annual_amount
+    country: uk
+    program: attendance_allowance
+    mapping_type: direct_variable
+    policyengine_variable: attendance_allowance
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final annual Attendance Allowance amount after selecting the higher, lower, or nil category.
+
   - legal_id: uk:regulations/uksi/2026/148/schedule/1#severe_disablement_allowance_basic_weekly_rate
     country: uk
     program: sda
@@ -1717,6 +2353,17 @@ mappings:
     unit: GBP
     comparison: money
     rationale: Same PE-shaped ordinary higher Winter Fuel Payment amount derived from Regulation 3(4).
+
+  - legal_id: uk:policies/govuk/winter-fuel-allowance#winter_fuel_allowance_annual_amount
+    country: uk
+    program: winter_fuel_allowance
+    mapping_type: direct_variable
+    policyengine_variable: winter_fuel_allowance
+    entity: household
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same final annual household Winter Fuel Allowance amount after PolicyEngine UK's Scotland, pension-age, means-tested-benefit, income-passport, and age-80 gates.
 
   - legal_id: uk:regulations/uksi/2002/1792/15#capital_deemed_weekly_income
     country: uk

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1,4 +1,58 @@
 mappings:
+  - legal_id: uk:policies/govuk/business-rates#business_rates_annual_amount
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: business_rates
+    entity: household
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same PolicyEngine UK household business-rates incidence amount, modeled as shareholding multiplied by aggregate business-rates revenue.
+
+  - legal_id: uk:policies/govuk/business-rates#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    match: prefix
+    rationale: Helper parameters and projected inputs for the PolicyEngine UK business-rates parity surface; only the final annual amount maps directly to a PE output variable.
+
+  - legal_id: uk:policies/govuk/national-minimum-wage#national_minimum_wage_hourly_rate
+    country: uk
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: minimum_wage
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same PolicyEngine UK National Minimum Wage hourly-rate output selected by apprentice status and age.
+
+  - legal_id: uk:policies/govuk/national-minimum-wage#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    match: prefix
+    rationale: Helper parameters and projected inputs for the PolicyEngine UK National Minimum Wage parity surface; only the final hourly rate maps directly to a PE output variable.
+
+  - legal_id: uk:policies/govuk/maternity-allowance#maternity_allowance_annual_amount
+    country: uk
+    program: benefits
+    mapping_type: direct_variable
+    policyengine_variable: maternity_allowance
+    entity: person
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same PolicyEngine UK Maternity Allowance amount, which delegates to reported maternity_allowance_reported survey receipt.
+
+  - legal_id: uk:policies/govuk/maternity-allowance#
+    country: uk
+    program: benefits
+    mapping_type: not_comparable
+    match: prefix
+    rationale: Projected-input helpers for the PolicyEngine UK Maternity Allowance parity surface; only the final annual amount maps directly to a PE output variable.
+
   - legal_id: uk:statutes/ukpga/2007/3/10#income_charged_at_basic_rate
     country: uk
     program: tax

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -372,6 +372,16 @@ class TestMain:
                 assert exc_info.value.code == 0
                 mock_cmd.assert_called_once()
 
+    def test_uk_efrs_national_coverage_command_dispatches(self):
+        with patch("sys.argv", ["axiom_encode", "uk-efrs-national-coverage"]):
+            with patch(
+                "axiom_encode.cli.run_uk_efrs_national_coverage", return_value=0
+            ) as mock_cmd:
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 0
+                mock_cmd.assert_called_once()
+
     def test_calibration_command_dispatches(self):
         with patch("sys.argv", ["axiom_encode", "calibration"]):
             with patch("axiom_encode.cli.cmd_calibration") as mock_cmd:

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -8,8 +8,12 @@ import pytest
 
 import axiom_encode.oracles.policyengine.efrs_uk as efrs_uk
 from axiom_encode.oracles.policyengine.efrs_uk import (
+    ATTENDANCE_ALLOWANCE_FINAL_BASE,
+    ATTENDANCE_ALLOWANCE_FINAL_OUTPUTS,
     BENEFIT_CAP_REGULATION_80A_BASE,
     BENEFIT_CAP_RELEVANT_AMOUNT_OUTPUTS,
+    CAPITAL_GAINS_TAX_FINAL_BASE,
+    CAPITAL_GAINS_TAX_FINAL_OUTPUTS,
     CARER_SUPPORT_PAYMENT_FINAL_BASE,
     CARER_SUPPORT_PAYMENT_FINAL_OUTPUTS,
     CARERS_ALLOWANCE_FINAL_BASE,
@@ -19,12 +23,25 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     CHILD_BENEFIT_FINAL_OUTPUTS,
     CHILD_BENEFIT_OUTPUTS,
     CHILD_BENEFIT_SECTION_141_BASE,
+    CLOSED_LEGACY_BENEFITS_FINAL_BASE,
+    CLOSED_LEGACY_BENEFITS_FINAL_OUTPUTS,
+    COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_BASE,
+    COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_OUTPUTS,
+    DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_BASE,
+    DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_OUTPUTS,
+    DFE_PERSON_PROGRAMS_FINAL_BASE,
+    DFE_PERSON_PROGRAMS_FINAL_OUTPUTS,
     DLA_FINAL_BASE,
     DLA_FINAL_OUTPUTS,
+    ENERGY_BILLS_REBATE_FINAL_OUTPUTS,
+    ENERGY_PRICE_GUARANTEE_FINAL_BASE,
+    ENERGY_PRICE_GUARANTEE_FINAL_OUTPUTS,
     ESA_FINAL_BASE,
     ESA_FINAL_OUTPUTS,
     ESA_REGULATION_118_BASE,
     ESA_TARIFF_INCOME_OUTPUTS,
+    FUEL_DUTY_FINAL_BASE,
+    FUEL_DUTY_FINAL_OUTPUTS,
     HOUSING_BENEFIT_FINAL_BASE,
     HOUSING_BENEFIT_FINAL_OUTPUTS,
     HOUSING_BENEFIT_PENSION_AGE_REGULATION_29_BASE,
@@ -46,6 +63,10 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     INCOME_TAX_SECTION_23_REDUCTION_COMPONENTS,
     JSA_REGULATION_116_BASE,
     JSA_TARIFF_INCOME_OUTPUTS,
+    LBTT_FINAL_BASE,
+    LBTT_FINAL_OUTPUTS,
+    LTT_FINAL_BASE,
+    LTT_FINAL_OUTPUTS,
     NATIONAL_INSURANCE_CLASS_1_OUTPUTS,
     NATIONAL_INSURANCE_CLASS_4_OUTPUTS,
     NATIONAL_INSURANCE_FINAL_OUTPUTS,
@@ -69,6 +90,10 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     SCOTTISH_CHILD_PAYMENT_FINAL_OUTPUTS,
     SDA_FINAL_BASE,
     SDA_FINAL_OUTPUTS,
+    SSMG_FINAL_BASE,
+    SSMG_FINAL_OUTPUTS,
+    STAMP_DUTY_LAND_TAX_FINAL_BASE,
+    STAMP_DUTY_LAND_TAX_FINAL_OUTPUTS,
     STATE_PENSION_CREDIT_GUARANTEE_CREDIT_OUTPUTS,
     STATE_PENSION_CREDIT_QUALIFYING_AGE_OUTPUTS,
     STATE_PENSION_CREDIT_SAVINGS_CREDIT_OUTPUTS,
@@ -79,6 +104,10 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     STATE_PENSION_FINAL_OUTPUTS,
     STUDENT_LOAN_REPAYMENT_BASE,
     STUDENT_LOAN_REPAYMENT_OUTPUTS,
+    TAX_FREE_CHILDCARE_FINAL_BASE,
+    TAX_FREE_CHILDCARE_FINAL_OUTPUTS,
+    TV_LICENCE_FINAL_BASE,
+    TV_LICENCE_FINAL_OUTPUTS,
     UNIVERSAL_CREDIT_ASSESSABLE_CAPITAL_OUTPUTS,
     UNIVERSAL_CREDIT_AWARD_OUTPUTS,
     UNIVERSAL_CREDIT_CHILD_ELEMENT_OUTPUTS,
@@ -97,18 +126,33 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     UNIVERSAL_CREDIT_STANDARD_ALLOWANCE_OUTPUTS,
     UNIVERSAL_CREDIT_TARIFF_INCOME_OUTPUTS,
     UNIVERSAL_CREDIT_WORK_ALLOWANCE_OUTPUTS,
+    VAT_FINAL_BASE,
+    VAT_FINAL_OUTPUTS,
     WEEKS_IN_YEAR,
     WELFARE_REFORM_ACT_SECTION_8_BASE,
     WELFARE_REFORM_ACT_SECTION_11_BASE,
+    WINTER_FUEL_ALLOWANCE_FINAL_BASE,
+    WINTER_FUEL_ALLOWANCE_FINAL_OUTPUTS,
+    UKEFRSVariableMetadata,
     add_policyengine_uk_disability_categories_from_reported_amounts,
+    build_attendance_allowance_final_request,
     build_benefit_cap_relevant_amount_request,
+    build_capital_gains_tax_final_request,
     build_carer_support_payment_final_request,
     build_carers_allowance_final_request,
     build_child_benefit_final_request,
     build_child_benefit_request,
+    build_closed_legacy_benefits_final_request,
+    build_cost_of_living_support_payment_final_request,
+    build_dfe_extended_childcare_entitlement_final_request,
+    build_dfe_person_programs_final_request,
     build_dla_final_request,
+    build_energy_bills_rebate_final_request,
+    build_energy_price_guarantee_final_request,
     build_esa_income_final_request,
     build_esa_income_tariff_income_request,
+    build_free_tv_licence_value_request,
+    build_fuel_duty_final_request,
     build_housing_benefit_final_request,
     build_housing_benefit_pension_age_tariff_income_request,
     build_housing_benefit_working_age_tariff_income_request,
@@ -118,6 +162,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_income_tax_section_11d_request,
     build_income_tax_section_13_request,
     build_jsa_income_tariff_income_request,
+    build_lbtt_final_request,
+    build_ltt_final_request,
     build_national_insurance_class_1_request,
     build_national_insurance_class_4_final_request,
     build_national_insurance_class_4_request,
@@ -129,13 +175,17 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_personal_allowance_request,
     build_scottish_child_payment_final_request,
     build_sda_final_request,
+    build_ssmg_final_request,
+    build_stamp_duty_land_tax_final_request,
     build_state_pension_credit_guarantee_credit_request,
     build_state_pension_credit_qualifying_age_request,
     build_state_pension_credit_savings_credit_request,
     build_state_pension_final_request,
     build_student_loan_repayment_request,
+    build_tax_free_childcare_final_request,
     build_uk_efrs_coverage_report,
     build_uk_hbai_policy_coverage_report,
+    build_uk_national_policy_coverage_report,
     build_universal_credit_assessable_capital_request,
     build_universal_credit_award_request,
     build_universal_credit_childcare_element_request,
@@ -146,19 +196,30 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     build_universal_credit_request,
     build_universal_credit_tariff_income_request,
     build_universal_credit_work_allowance_request,
+    build_vat_final_request,
+    build_winter_fuel_allowance_final_request,
     compare_outputs,
     compare_uk_efrs,
     disability_category_from_reported_amounts,
     normalize_policyengine_entity,
     policyengine_benunit_variables_for_surfaces,
+    policyengine_household_variables_for_surfaces,
     policyengine_person_variables_for_surfaces,
+    project_attendance_allowance_final_inputs,
     project_benefit_cap_relevant_amount_inputs,
+    project_capital_gains_tax_final_inputs,
     project_carer_support_payment_final_inputs,
     project_carers_allowance_final_inputs,
     project_child_benefit_inputs,
+    project_closed_legacy_benefits_final_inputs,
+    project_cost_of_living_support_payment_final_inputs,
+    project_dfe_person_programs_final_inputs,
     project_dla_final_inputs,
+    project_energy_price_guarantee_final_inputs,
     project_esa_income_final_inputs,
     project_esa_income_tariff_income_inputs,
+    project_free_tv_licence_value_inputs,
+    project_fuel_duty_final_inputs,
     project_housing_benefit_final_inputs,
     project_housing_benefit_pension_age_tariff_income_inputs,
     project_housing_benefit_working_age_tariff_income_inputs,
@@ -169,6 +230,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_income_tax_section_13_inputs,
     project_income_tax_section_23_inputs,
     project_jsa_income_tariff_income_inputs,
+    project_lbtt_final_inputs,
+    project_ltt_final_inputs,
     project_national_insurance_class_4_final_inputs,
     project_national_insurance_class_4_inputs,
     project_national_insurance_final_inputs,
@@ -179,11 +242,14 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_personal_allowance_inputs,
     project_scottish_child_payment_final_inputs,
     project_sda_final_inputs,
+    project_ssmg_final_inputs,
+    project_stamp_duty_land_tax_final_inputs,
     project_state_pension_credit_guarantee_credit_inputs,
     project_state_pension_credit_qualifying_age_inputs,
     project_state_pension_credit_savings_credit_inputs,
     project_state_pension_final_inputs,
     project_student_loan_repayment_inputs,
+    project_tax_free_childcare_final_inputs,
     project_universal_credit_assessable_capital_inputs,
     project_universal_credit_award_inputs,
     project_universal_credit_childcare_element_inputs,
@@ -193,6 +259,8 @@ from axiom_encode.oracles.policyengine.efrs_uk import (
     project_universal_credit_income_deduction_inputs,
     project_universal_credit_tariff_income_inputs,
     project_universal_credit_work_allowance_inputs,
+    project_vat_final_inputs,
+    project_winter_fuel_allowance_final_inputs,
     require_policyengine_uk_versions,
     select_person_indices,
 )
@@ -673,6 +741,7 @@ def test_student_loan_repayment_projection_uses_policyengine_plan_enum():
         {
             "student_loan_plan": "StudentLoanPlan.PLAN_4",
             "adjusted_net_income": 40_000,
+            "student_loan_balance": 500,
         }
     ) == {
         "loan_plan_is_plan_1": False,
@@ -681,6 +750,7 @@ def test_student_loan_repayment_projection_uses_policyengine_plan_enum():
         "loan_plan_is_plan_5": False,
         "loan_plan_is_postgraduate": False,
         "annual_income_before_tax_and_other_deductions": 40_000,
+        "outstanding_student_loan_balance": 500,
     }
 
     assert project_student_loan_repayment_inputs(
@@ -695,6 +765,7 @@ def test_student_loan_repayment_projection_uses_policyengine_plan_enum():
         "loan_plan_is_plan_5": False,
         "loan_plan_is_postgraduate": True,
         "annual_income_before_tax_and_other_deductions": 35_000,
+        "outstanding_student_loan_balance": 0,
     }
 
     assert project_student_loan_repayment_inputs(
@@ -709,6 +780,7 @@ def test_student_loan_repayment_projection_uses_policyengine_plan_enum():
         "loan_plan_is_plan_5": False,
         "loan_plan_is_postgraduate": False,
         "annual_income_before_tax_and_other_deductions": 100_000,
+        "outstanding_student_loan_balance": 0,
     }
 
 
@@ -720,6 +792,7 @@ def test_student_loan_repayment_request_projects_plan_inputs():
                     "person_id": 7,
                     "student_loan_plan": "StudentLoanPlan.PLAN_1",
                     "adjusted_net_income": 40_000,
+                    "student_loan_balance": 800,
                     "student_loan_repayment": 1_179,
                     "student_loan_repayments": 1_179,
                 }
@@ -777,6 +850,11 @@ def test_student_loan_repayment_request_projects_plan_inputs():
             "person_7",
             period,
             {"kind": "decimal", "value": "40000.0"},
+        ),
+        f"{STUDENT_LOAN_REPAYMENT_BASE}#input.outstanding_student_loan_balance": (
+            "person_7",
+            period,
+            {"kind": "decimal", "value": "800.0"},
         ),
     }
 
@@ -1979,6 +2057,83 @@ def test_legacy_tariff_income_requests_project_benefit_week_inputs(
     }
 
 
+def test_closed_legacy_benefits_final_request_compares_all_benunits():
+    request = build_closed_legacy_benefits_final_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 11,
+                    "jsa_contrib": 0,
+                    "esa_income": 0,
+                    "esa_contrib": 0,
+                },
+                {
+                    "benunit_id": 12,
+                    "jsa_contrib": 125,
+                    "esa_income": 200,
+                    "esa_contrib": 450,
+                },
+            ],
+            "benunit_ids": [11, 12],
+        },
+        year=2026,
+    )
+
+    period = {
+        "period_kind": "tax_year",
+        "start": "2026-01-01",
+        "end": "2026-12-31",
+    }
+    outputs = [
+        output["axiom"] for output in CLOSED_LEGACY_BENEFITS_FINAL_OUTPUTS.values()
+    ]
+    assert request == {
+        "mode": "explain",
+        "dataset": {
+            "inputs": request["dataset"]["inputs"],
+            "relations": [],
+        },
+        "queries": [
+            {
+                "entity_id": "benunit_11",
+                "period": period,
+                "outputs": outputs,
+            },
+            {
+                "entity_id": "benunit_12",
+                "period": period,
+                "outputs": outputs,
+            },
+        ],
+    }
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{CLOSED_LEGACY_BENEFITS_FINAL_BASE}#input.contribution_based_jobseekers_allowance_reported_for_year:benunit_12"
+    ] == {"kind": "decimal", "value": "125.0"}
+    assert inputs[
+        f"{CLOSED_LEGACY_BENEFITS_FINAL_BASE}#input.income_related_employment_and_support_allowance_for_year:benunit_12"
+    ] == {"kind": "decimal", "value": "200.0"}
+
+
+def test_closed_legacy_benefits_final_projection_uses_reported_inputs():
+    assert project_closed_legacy_benefits_final_inputs(
+        {
+            "jsa_contrib": 125,
+            "esa_income": 200,
+            "esa_contrib": 450,
+        }
+    ) == {
+        "contribution_based_jobseekers_allowance_reported_for_year": 125,
+        "income_related_employment_and_support_allowance_for_year": 200,
+        "contribution_based_employment_and_support_allowance_reported_for_year": 450,
+    }
+
+
 def test_state_pension_credit_guarantee_credit_projection_uses_section_2_inputs():
     projected = project_state_pension_credit_guarantee_credit_inputs(
         {
@@ -2680,6 +2835,1241 @@ def test_dla_final_request_projects_final_inputs():
     assert inputs[
         f"{DLA_FINAL_BASE}#input.person_has_higher_rate_dla_mobility_category:person_2"
     ] == {"kind": "bool", "value": True}
+
+
+def test_attendance_allowance_final_projection_uses_category_inputs():
+    assert project_attendance_allowance_final_inputs(
+        {
+            "aa_category": "HIGHER",
+        }
+    ) == {
+        "person_has_higher_rate_attendance_allowance_category": True,
+        "person_has_lower_rate_attendance_allowance_category": False,
+    }
+    assert project_attendance_allowance_final_inputs(
+        {
+            "aa_category": "LowerOrHigher.LOWER",
+        }
+    ) == {
+        "person_has_higher_rate_attendance_allowance_category": False,
+        "person_has_lower_rate_attendance_allowance_category": True,
+    }
+    assert project_attendance_allowance_final_inputs(
+        {
+            "aa_category": "NONE",
+        }
+    ) == {
+        "person_has_higher_rate_attendance_allowance_category": False,
+        "person_has_lower_rate_attendance_allowance_category": False,
+    }
+
+
+def test_attendance_allowance_final_request_projects_final_inputs():
+    request = build_attendance_allowance_final_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 1,
+                    "attendance_allowance": 0,
+                    "aa_category": "NONE",
+                },
+                {
+                    "person_id": 2,
+                    "attendance_allowance": 5_959.20,
+                    "aa_category": "HIGHER",
+                },
+            ],
+            "person_ids": [1, 2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_2",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-04-06",
+                "end": "2027-04-05",
+            },
+            "outputs": [
+                ATTENDANCE_ALLOWANCE_FINAL_OUTPUTS[
+                    "attendance_allowance_weekly_amount"
+                ]["axiom"],
+                ATTENDANCE_ALLOWANCE_FINAL_OUTPUTS[
+                    "attendance_allowance_annual_amount"
+                ]["axiom"],
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{ATTENDANCE_ALLOWANCE_FINAL_BASE}#input.person_has_higher_rate_attendance_allowance_category:person_2"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{ATTENDANCE_ALLOWANCE_FINAL_BASE}#input.person_has_lower_rate_attendance_allowance_category:person_2"
+    ] == {"kind": "bool", "value": False}
+
+
+def test_winter_fuel_allowance_final_projection_uses_household_inputs():
+    assert project_winter_fuel_allowance_final_inputs(
+        {
+            "country": "Country.ENGLAND",
+            "pension_credit": 0,
+            "income_support": 0,
+            "esa_income": 0,
+            "jsa_income": 0,
+            "winter_fuel_payment_means_tested_benefits_required": True,
+            "household_meets_winter_fuel_payment_income_passport": True,
+            "household_has_state_pension_age_person": True,
+            "winter_fuel_payment_state_pension_age_required": True,
+            "oldest_household_member_age": 82,
+        }
+    ) == {
+        "household_is_in_scotland": False,
+        "household_receives_relevant_means_tested_benefit": False,
+        "winter_fuel_payment_means_tested_benefits_required": True,
+        "household_meets_winter_fuel_payment_income_passport": True,
+        "household_has_state_pension_age_person": True,
+        "winter_fuel_payment_state_pension_age_required": True,
+        "oldest_household_member_age": 82,
+    }
+    assert (
+        project_winter_fuel_allowance_final_inputs(
+            {
+                "country": "SCOTLAND",
+                "pension_credit": 10,
+                "income_support": 0,
+                "esa_income": 0,
+                "jsa_income": 0,
+            }
+        )["household_receives_relevant_means_tested_benefit"]
+        is True
+    )
+
+
+def test_winter_fuel_allowance_final_request_projects_final_inputs():
+    request = build_winter_fuel_allowance_final_request(
+        pe_data={
+            "households": [
+                {
+                    "household_id": 1,
+                    "household_weight": 1,
+                    "country": "ENGLAND",
+                    "winter_fuel_allowance": 0,
+                    "pension_credit": 0,
+                    "income_support": 0,
+                    "esa_income": 0,
+                    "jsa_income": 0,
+                    "household_has_state_pension_age_person": False,
+                    "household_meets_winter_fuel_payment_income_passport": False,
+                    "winter_fuel_payment_means_tested_benefits_required": True,
+                    "winter_fuel_payment_state_pension_age_required": True,
+                    "oldest_household_member_age": 45,
+                },
+                {
+                    "household_id": 2,
+                    "household_weight": 1,
+                    "country": "ENGLAND",
+                    "winter_fuel_allowance": 300,
+                    "pension_credit": 100,
+                    "income_support": 0,
+                    "esa_income": 0,
+                    "jsa_income": 0,
+                    "household_has_state_pension_age_person": True,
+                    "household_meets_winter_fuel_payment_income_passport": False,
+                    "winter_fuel_payment_means_tested_benefits_required": True,
+                    "winter_fuel_payment_state_pension_age_required": True,
+                    "oldest_household_member_age": 82,
+                },
+            ],
+            "household_ids": [1, 2],
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "household_2",
+            "period": {
+                "period_kind": "custom",
+                "name": "calendar_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": [
+                WINTER_FUEL_ALLOWANCE_FINAL_OUTPUTS[
+                    "winter_fuel_allowance_annual_amount"
+                ]["axiom"],
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{WINTER_FUEL_ALLOWANCE_FINAL_BASE}#input.household_receives_relevant_means_tested_benefit:household_2"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{WINTER_FUEL_ALLOWANCE_FINAL_BASE}#input.oldest_household_member_age:household_2"
+    ] == {"kind": "decimal", "value": "82.0"}
+
+
+def test_tax_free_childcare_final_projection_uses_person_inputs():
+    assert project_tax_free_childcare_final_inputs(
+        {
+            "tax_free_childcare_eligible": True,
+            "tax_free_childcare_qualifying_child": True,
+            "is_disabled_for_benefits": False,
+            "is_blind": True,
+            "tax_free_childcare_uses_qualifying_provider": True,
+            "tax_free_childcare_eligible_declaration_periods": 2,
+            "childcare_expenses": 3_500,
+        }
+    ) == {
+        "tax_free_childcare_benefit_unit_is_eligible": True,
+        "tax_free_childcare_child_is_qualifying_child": True,
+        "tax_free_childcare_child_is_disabled_or_blind": True,
+        "tax_free_childcare_uses_qualifying_provider": True,
+        "tax_free_childcare_eligible_declaration_period_count": 2,
+        "tax_free_childcare_qualifying_childcare_payment_annual_amount": 3_500,
+    }
+
+
+def test_tax_free_childcare_final_request_projects_final_inputs():
+    request = build_tax_free_childcare_final_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 1,
+                    "tax_free_childcare": 0,
+                    "tax_free_childcare_eligible": False,
+                    "tax_free_childcare_qualifying_child": True,
+                    "childcare_expenses": 9_000,
+                },
+                {
+                    "person_id": 2,
+                    "tax_free_childcare": 2_000,
+                    "tax_free_childcare_eligible": True,
+                    "tax_free_childcare_qualifying_child": True,
+                    "is_disabled_for_benefits": False,
+                    "is_blind": False,
+                    "tax_free_childcare_uses_qualifying_provider": True,
+                    "tax_free_childcare_eligible_declaration_periods": 4,
+                    "childcare_expenses": 9_000,
+                },
+            ],
+            "person_ids": [1, 2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_2",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-04-06",
+                "end": "2027-04-05",
+            },
+            "outputs": [
+                TAX_FREE_CHILDCARE_FINAL_OUTPUTS["tax_free_childcare_annual_amount"][
+                    "axiom"
+                ],
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{TAX_FREE_CHILDCARE_FINAL_BASE}#input.tax_free_childcare_benefit_unit_is_eligible:person_2"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{TAX_FREE_CHILDCARE_FINAL_BASE}#input.tax_free_childcare_qualifying_childcare_payment_annual_amount:person_2"
+    ] == {"kind": "decimal", "value": "9000.0"}
+
+
+def test_capital_gains_tax_final_projection_uses_person_inputs():
+    assert project_capital_gains_tax_final_inputs(
+        {
+            "capital_gains": 50_000,
+            "adjusted_net_income": 50_000,
+            "allowances": 12_570,
+            "gift_aid": 100,
+            "gift_aid_grossed_up": 125,
+            "personal_pension_contributions": 1_000,
+            "pension_contributions_relief": 800,
+        },
+        parameters={
+            "income_tax_basic_rate_limit": 37_700,
+            "income_tax_higher_rate_limit": 125_140,
+        },
+    ) == {
+        "capital_gains_for_year": 50000,
+        "adjusted_net_income_for_year": 50000,
+        "allowances_for_year": 12570,
+        "gift_aid_for_year": 100,
+        "gift_aid_grossed_up_for_year": 125,
+        "personal_pension_contributions_for_year": 1000,
+        "pension_contributions_relief_for_year": 800,
+        "income_tax_basic_rate_limit_for_year": 37700,
+        "income_tax_higher_rate_limit_for_year": 125140,
+    }
+
+
+def test_capital_gains_tax_final_request_projects_final_inputs(monkeypatch):
+    monkeypatch.setattr(
+        efrs_uk,
+        "policyengine_uk_capital_gains_tax_parameters",
+        lambda year: {
+            "income_tax_basic_rate_limit": 37_700,
+            "income_tax_higher_rate_limit": 125_140,
+        },
+    )
+
+    request = build_capital_gains_tax_final_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 1,
+                    "capital_gains": 0,
+                    "capital_gains_tax": 0,
+                    "gift_aid": 0,
+                    "gift_aid_grossed_up": 0,
+                    "personal_pension_contributions": 0,
+                    "pension_contributions_relief": 0,
+                },
+                {
+                    "person_id": 2,
+                    "capital_gains": 50_000,
+                    "capital_gains_tax": 11_263.8,
+                    "adjusted_net_income": 50_000,
+                    "allowances": 12_570,
+                    "gift_aid": 0,
+                    "gift_aid_grossed_up": 0,
+                    "personal_pension_contributions": 0,
+                    "pension_contributions_relief": 0,
+                },
+            ],
+            "person_ids": [1, 2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_2",
+            "period": {
+                "period_kind": "custom",
+                "name": "calendar_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": [
+                CAPITAL_GAINS_TAX_FINAL_OUTPUTS[
+                    "capital_gains_tax_annual_amount"
+                ]["axiom"]
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{CAPITAL_GAINS_TAX_FINAL_BASE}#input.capital_gains_for_year:person_2"
+    ] == {"kind": "decimal", "value": "50000.0"}
+    assert inputs[
+        f"{CAPITAL_GAINS_TAX_FINAL_BASE}#input.income_tax_basic_rate_limit_for_year:person_2"
+    ] == {"kind": "decimal", "value": "37700.0"}
+
+
+def test_stamp_duty_land_tax_final_projection_uses_household_inputs():
+    assert project_stamp_duty_land_tax_final_inputs(
+        {
+            "sdlt_liable": True,
+            "main_residential_property_purchased": 445_000,
+            "main_residential_property_purchased_is_first_home": True,
+            "additional_residential_property_purchased": 350_000,
+            "non_residential_property_purchased": 300_000,
+            "cumulative_residential_rent": 100_000,
+            "rent": 50_000,
+            "cumulative_non_residential_rent": 100_000,
+            "non_residential_rent": 200_000,
+        }
+    ) == {
+        "household_is_sdlt_liable": True,
+        "main_residential_property_purchased_for_year": 445000,
+        "main_residential_property_purchased_is_first_home": True,
+        "additional_residential_property_purchased_for_year": 350000,
+        "non_residential_property_purchased_for_year": 300000,
+        "cumulative_residential_rent_for_year": 100000,
+        "residential_rent_for_year": 50000,
+        "cumulative_non_residential_rent_for_year": 100000,
+        "non_residential_rent_for_year": 200000,
+    }
+
+
+def test_stamp_duty_land_tax_final_request_projects_final_inputs():
+    request = build_stamp_duty_land_tax_final_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+            "households": [
+                {
+                    "household_id": 1,
+                    "stamp_duty_land_tax": 0,
+                    "main_residential_property_purchased": 0,
+                    "additional_residential_property_purchased": 0,
+                    "non_residential_property_purchased": 0,
+                    "cumulative_residential_rent": 0,
+                    "rent": 0,
+                    "cumulative_non_residential_rent": 0,
+                    "non_residential_rent": 0,
+                },
+                {
+                    "household_id": 2,
+                    "stamp_duty_land_tax": 18_000,
+                    "sdlt_liable": True,
+                    "main_residential_property_purchased": 0,
+                    "main_residential_property_purchased_is_first_home": False,
+                    "additional_residential_property_purchased": 350_000,
+                    "non_residential_property_purchased": 0,
+                    "cumulative_residential_rent": 0,
+                    "rent": 0,
+                    "cumulative_non_residential_rent": 0,
+                    "non_residential_rent": 0,
+                },
+            ],
+            "household_ids": [1, 2],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "household_2",
+            "period": {
+                "period_kind": "custom",
+                "name": "calendar_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": [
+                STAMP_DUTY_LAND_TAX_FINAL_OUTPUTS[
+                    "stamp_duty_land_tax_annual_amount"
+                ]["axiom"]
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{STAMP_DUTY_LAND_TAX_FINAL_BASE}#input.household_is_sdlt_liable:household_2"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{STAMP_DUTY_LAND_TAX_FINAL_BASE}#input.additional_residential_property_purchased_for_year:household_2"
+    ] == {"kind": "decimal", "value": "350000.0"}
+
+
+def test_lbtt_final_projection_uses_household_inputs():
+    assert project_lbtt_final_inputs(
+        {
+            "lbtt_liable": True,
+            "lbtt_on_transactions": 4_200,
+            "lbtt_on_rent": 125,
+        }
+    ) == {
+        "household_is_lbtt_liable": True,
+        "lbtt_on_transactions_for_year": 4200,
+        "lbtt_on_rent_for_year": 125,
+    }
+
+
+def test_lbtt_final_request_compares_all_households():
+    request = build_lbtt_final_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+            "households": [
+                {
+                    "household_id": 1,
+                    "land_and_buildings_transaction_tax": 0,
+                    "lbtt_liable": False,
+                    "lbtt_on_transactions": 0,
+                    "lbtt_on_rent": 0,
+                },
+                {
+                    "household_id": 2,
+                    "land_and_buildings_transaction_tax": 4325,
+                    "lbtt_liable": True,
+                    "lbtt_on_transactions": 4200,
+                    "lbtt_on_rent": 125,
+                },
+            ],
+            "household_ids": [1, 2],
+        },
+        year=2026,
+    )
+
+    assert [query["entity_id"] for query in request["queries"]] == [
+        "household_1",
+        "household_2",
+    ]
+    assert request["queries"][0]["outputs"] == [
+        LBTT_FINAL_OUTPUTS["land_and_buildings_transaction_tax_annual_amount"][
+            "axiom"
+        ]
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{LBTT_FINAL_BASE}#input.household_is_lbtt_liable:household_2"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{LBTT_FINAL_BASE}#input.lbtt_on_transactions_for_year:household_2"
+    ] == {"kind": "decimal", "value": "4200.0"}
+
+
+def test_ltt_final_projection_uses_household_inputs():
+    assert project_ltt_final_inputs(
+        {
+            "ltt_liable": True,
+            "ltt_on_transactions": 2_900,
+            "ltt_on_rent": 80,
+        }
+    ) == {
+        "household_is_ltt_liable": True,
+        "ltt_on_transactions_for_year": 2900,
+        "ltt_on_rent_for_year": 80,
+    }
+
+
+def test_ltt_final_request_compares_all_households():
+    request = build_ltt_final_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+            "households": [
+                {
+                    "household_id": 1,
+                    "land_transaction_tax": 0,
+                    "ltt_liable": False,
+                    "ltt_on_transactions": 0,
+                    "ltt_on_rent": 0,
+                },
+                {
+                    "household_id": 2,
+                    "land_transaction_tax": 2980,
+                    "ltt_liable": True,
+                    "ltt_on_transactions": 2900,
+                    "ltt_on_rent": 80,
+                },
+            ],
+            "household_ids": [1, 2],
+        },
+        year=2026,
+    )
+
+    assert [query["entity_id"] for query in request["queries"]] == [
+        "household_1",
+        "household_2",
+    ]
+    assert request["queries"][0]["outputs"] == [
+        LTT_FINAL_OUTPUTS["land_transaction_tax_annual_amount"]["axiom"]
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{LTT_FINAL_BASE}#input.household_is_ltt_liable:household_2"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{LTT_FINAL_BASE}#input.ltt_on_transactions_for_year:household_2"
+    ] == {"kind": "decimal", "value": "2900.0"}
+
+
+def test_vat_final_projection_uses_household_inputs():
+    assert project_vat_final_inputs(
+        {
+            "full_rate_vat_consumption": 1_000,
+            "reduced_rate_vat_consumption": 400,
+        },
+        parameters={"microdata_vat_coverage": 0.38},
+    ) == {
+        "full_rate_vat_consumption_for_year": 1000,
+        "reduced_rate_vat_consumption_for_year": 400,
+        "microdata_vat_coverage_fraction": 0.38,
+    }
+
+
+def test_vat_final_request_projects_final_inputs(monkeypatch):
+    monkeypatch.setattr(
+        efrs_uk,
+        "policyengine_uk_vat_parameters",
+        lambda year: {"microdata_vat_coverage": 0.38},
+    )
+
+    request = build_vat_final_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+            "households": [
+                {
+                    "household_id": 1,
+                    "vat": 0,
+                    "full_rate_vat_consumption": 0,
+                    "reduced_rate_vat_consumption": 0,
+                },
+                {
+                    "household_id": 2,
+                    "vat": 1_000,
+                    "full_rate_vat_consumption": 1_000,
+                    "reduced_rate_vat_consumption": 400,
+                },
+            ],
+            "household_ids": [1, 2],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "household_2",
+            "period": {
+                "period_kind": "custom",
+                "name": "calendar_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": [VAT_FINAL_OUTPUTS["vat_annual_amount"]["axiom"]],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{VAT_FINAL_BASE}#input.full_rate_vat_consumption_for_year:household_2"
+    ] == {"kind": "decimal", "value": "1000.0"}
+    assert inputs[
+        f"{VAT_FINAL_BASE}#input.microdata_vat_coverage_fraction:household_2"
+    ] == {"kind": "decimal", "value": "0.38"}
+
+
+def test_fuel_duty_final_projection_uses_household_inputs():
+    assert project_fuel_duty_final_inputs(
+        {
+            "petrol_litres": 600,
+            "diesel_litres": 400,
+            "in_rural_fuel_duty_relief_area": True,
+        },
+        parameters={"petrol_and_diesel": 0.5345},
+    ) == {
+        "petrol_litres_for_year": 600,
+        "diesel_litres_for_year": 400,
+        "petrol_and_diesel_fuel_duty_rate_per_litre": 0.5345,
+        "fuel_is_purchased_in_rural_fuel_duty_relief_area": True,
+    }
+
+
+def test_fuel_duty_final_request_projects_final_inputs(monkeypatch):
+    monkeypatch.setattr(
+        efrs_uk,
+        "policyengine_uk_fuel_duty_parameters",
+        lambda year: {"petrol_and_diesel": 0.5345},
+    )
+
+    request = build_fuel_duty_final_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+            "households": [
+                {
+                    "household_id": 1,
+                    "fuel_duty": 0,
+                    "petrol_litres": 0,
+                    "diesel_litres": 0,
+                },
+                {
+                    "household_id": 2,
+                    "fuel_duty": 534.5,
+                    "petrol_litres": 600,
+                    "diesel_litres": 400,
+                    "in_rural_fuel_duty_relief_area": True,
+                },
+            ],
+            "household_ids": [1, 2],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "household_2",
+            "period": {
+                "period_kind": "custom",
+                "name": "calendar_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": [FUEL_DUTY_FINAL_OUTPUTS["fuel_duty_annual_amount"]["axiom"]],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{FUEL_DUTY_FINAL_BASE}#input.petrol_litres_for_year:household_2"
+    ] == {"kind": "decimal", "value": "600.0"}
+    assert inputs[
+        f"{FUEL_DUTY_FINAL_BASE}#input.petrol_and_diesel_fuel_duty_rate_per_litre:household_2"
+    ] == {"kind": "decimal", "value": "0.5345"}
+    assert inputs[
+        f"{FUEL_DUTY_FINAL_BASE}#input.fuel_is_purchased_in_rural_fuel_duty_relief_area:household_2"
+    ] == {"kind": "bool", "value": True}
+
+
+def test_free_tv_licence_value_projection_uses_household_inputs():
+    assert project_free_tv_licence_value_inputs(
+        {
+            "household_owns_tv": True,
+            "would_evade_tv_licence_fee": False,
+            "tv_licence_discount": 0.5,
+        }
+    ) == {
+        "household_owns_tv": True,
+        "household_would_evade_tv_licence_fee": False,
+        "tv_licence_discount_fraction": 0.5,
+    }
+
+
+def test_free_tv_licence_value_request_projects_final_inputs():
+    request = build_free_tv_licence_value_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "households": [
+                {
+                    "household_id": 1,
+                    "free_tv_licence_value": 0,
+                    "tv_licence": 180,
+                    "household_owns_tv": True,
+                    "would_evade_tv_licence_fee": False,
+                    "tv_licence_discount": 0,
+                },
+                {
+                    "household_id": 2,
+                    "free_tv_licence_value": 90,
+                    "tv_licence": 90,
+                    "household_owns_tv": True,
+                    "would_evade_tv_licence_fee": False,
+                    "tv_licence_discount": 0.5,
+                },
+            ],
+            "household_ids": [1, 2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "household_1",
+            "period": {
+                "period_kind": "custom",
+                "name": "licence_year",
+                "start": "2026-04-01",
+                "end": "2027-03-31",
+            },
+            "outputs": [
+                TV_LICENCE_FINAL_OUTPUTS["free_tv_licence_value"]["axiom"],
+                TV_LICENCE_FINAL_OUTPUTS["tv_licence_annual_amount"]["axiom"],
+            ],
+        },
+        {
+            "entity_id": "household_2",
+            "period": {
+                "period_kind": "custom",
+                "name": "licence_year",
+                "start": "2026-04-01",
+                "end": "2027-03-31",
+            },
+            "outputs": [
+                TV_LICENCE_FINAL_OUTPUTS["free_tv_licence_value"]["axiom"],
+                TV_LICENCE_FINAL_OUTPUTS["tv_licence_annual_amount"]["axiom"],
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[f"{TV_LICENCE_FINAL_BASE}#input.household_owns_tv:household_2"] == {
+        "kind": "bool",
+        "value": True,
+    }
+    assert inputs[
+        f"{TV_LICENCE_FINAL_BASE}#input.tv_licence_discount_fraction:household_2"
+    ] == {"kind": "decimal", "value": "0.5"}
+
+
+def test_cost_of_living_support_payment_final_projection_uses_household_inputs():
+    assert project_cost_of_living_support_payment_final_inputs(
+        {
+            "universal_credit": 0,
+            "pension_credit": 50,
+            "housing_benefit": 0,
+            "jsa_income": 0,
+            "income_support": 0,
+            "esa_income": 0,
+            "winter_fuel_allowance": 300,
+            "pip": 0,
+            "dla": 0,
+            "attendance_allowance": 114.60,
+            "armed_forces_independence_payment": 0,
+        }
+    ) == {
+        "household_receives_qualifying_means_tested_benefit_for_cost_of_living_payment": True,
+        "household_receives_winter_fuel_payment_for_cost_of_living_payment": True,
+        "household_receives_qualifying_disability_benefit_for_cost_of_living_payment": True,
+    }
+
+
+def test_cost_of_living_support_payment_final_request_compares_zero_rows():
+    request = build_cost_of_living_support_payment_final_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "households": [
+                {
+                    "household_id": 1,
+                    "cost_of_living_support_payment": 0,
+                    "universal_credit": 0,
+                    "pension_credit": 0,
+                    "housing_benefit": 0,
+                    "jsa_income": 0,
+                    "income_support": 0,
+                    "esa_income": 0,
+                    "winter_fuel_allowance": 0,
+                    "pip": 0,
+                    "dla": 0,
+                    "attendance_allowance": 0,
+                    "armed_forces_independence_payment": 0,
+                },
+                {
+                    "household_id": 2,
+                    "cost_of_living_support_payment": 0,
+                    "universal_credit": 2_000,
+                    "pension_credit": 0,
+                    "housing_benefit": 0,
+                    "jsa_income": 0,
+                    "income_support": 0,
+                    "esa_income": 0,
+                    "winter_fuel_allowance": 300,
+                    "pip": 750,
+                    "dla": 0,
+                    "attendance_allowance": 0,
+                    "armed_forces_independence_payment": 0,
+                },
+            ],
+            "household_ids": [1, 2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "household_1",
+            "period": {
+                "period_kind": "custom",
+                "name": "calendar_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": [
+                COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_OUTPUTS[
+                    "cost_of_living_support_payment_annual_amount"
+                ]["axiom"],
+            ],
+        },
+        {
+            "entity_id": "household_2",
+            "period": {
+                "period_kind": "custom",
+                "name": "calendar_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": [
+                COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_OUTPUTS[
+                    "cost_of_living_support_payment_annual_amount"
+                ]["axiom"],
+            ],
+        },
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_BASE}#input.household_receives_qualifying_means_tested_benefit_for_cost_of_living_payment:household_1"
+    ] == {"kind": "bool", "value": False}
+    assert inputs[
+        f"{COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_BASE}#input.household_receives_qualifying_means_tested_benefit_for_cost_of_living_payment:household_2"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_BASE}#input.household_receives_winter_fuel_payment_for_cost_of_living_payment:household_2"
+    ] == {"kind": "bool", "value": True}
+    assert inputs[
+        f"{COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_BASE}#input.household_receives_qualifying_disability_benefit_for_cost_of_living_payment:household_2"
+    ] == {"kind": "bool", "value": True}
+
+
+def test_energy_bills_rebate_final_request_compares_all_households():
+    request = build_energy_bills_rebate_final_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "households": [
+                {"household_id": 1, "energy_bills_rebate": 0},
+                {"household_id": 2, "energy_bills_rebate": 0},
+            ],
+            "household_ids": [1, 2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    period = {
+        "period_kind": "custom",
+        "name": "calendar_year",
+        "start": "2026-01-01",
+        "end": "2026-12-31",
+    }
+    outputs = [
+        output["axiom"] for output in ENERGY_BILLS_REBATE_FINAL_OUTPUTS.values()
+    ]
+    assert request == {
+        "mode": "explain",
+        "dataset": {"inputs": [], "relations": []},
+        "queries": [
+            {"entity_id": "household_1", "period": period, "outputs": outputs},
+            {"entity_id": "household_2", "period": period, "outputs": outputs},
+        ],
+    }
+
+
+def test_energy_price_guarantee_final_projection_uses_energy_consumption():
+    assert project_energy_price_guarantee_final_inputs(
+        {"domestic_energy_consumption": 2_000}
+    ) == {"domestic_energy_consumption_for_year": 2000.0}
+
+
+def test_energy_price_guarantee_final_request_compares_all_households():
+    request = build_energy_price_guarantee_final_request(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "households": [
+                {
+                    "household_id": 1,
+                    "domestic_energy_consumption": 0,
+                    "epg_subsidy": 0,
+                },
+                {
+                    "household_id": 2,
+                    "domestic_energy_consumption": 2_000,
+                    "epg_subsidy": 0,
+                },
+            ],
+            "household_ids": [1, 2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    period = {
+        "period_kind": "custom",
+        "name": "calendar_year",
+        "start": "2026-01-01",
+        "end": "2026-12-31",
+    }
+    outputs = [
+        output["axiom"] for output in ENERGY_PRICE_GUARANTEE_FINAL_OUTPUTS.values()
+    ]
+    assert request["queries"] == [
+        {"entity_id": "household_1", "period": period, "outputs": outputs},
+        {"entity_id": "household_2", "period": period, "outputs": outputs},
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{ENERGY_PRICE_GUARANTEE_FINAL_BASE}#input.domestic_energy_consumption_for_year:household_2"
+    ] == {"kind": "decimal", "value": "2000.0"}
+
+
+def test_dfe_person_programs_projection_uses_pe_leaf_inputs():
+    projected = project_dfe_person_programs_final_inputs(
+        {
+            "adult_dependants_grant_eligible": True,
+            "age": 19,
+            "bursary_fund_16_to_19_participation_costs": 1_500,
+            "bursary_fund_16_to_19_vulnerable_group_eligible": True,
+            "care_to_learn_eligible": True,
+            "childcare_expenses": 10_000,
+            "childcare_grant_eligible": True,
+            "childcare_grant_eligible_children": 1,
+            "disabled_students_allowance_eligible": True,
+            "disabled_students_allowance_eligible_expenses": 30_000,
+            "maintenance_loan_eligible": True,
+            "maintenance_loan_entitled_to_benefits": False,
+            "maintenance_loan_household_income": 25_000,
+            "maintenance_loan_living_arrangement": (
+                "MaintenanceLoanLivingArrangement.LIVING_WITH_PARENTS"
+            ),
+            "max_free_entitlement_hours_used": 20,
+            "parents_learning_allowance_eligible": True,
+            "region": "Region.LONDON",
+            "targeted_childcare_entitlement_eligible": True,
+            "travel_grant_eligible": True,
+            "travel_grant_eligible_expenses": 5_000,
+            "travel_grant_household_income": 39_796,
+            "universal_childcare_entitlement_eligible": True,
+        }
+    )
+
+    assert projected["person_age"] == 19.0
+    assert projected["household_region_is_london"] is True
+    assert projected["maintenance_loan_living_with_parents"] is True
+    assert projected["maintenance_loan_away_in_london"] is False
+    assert projected["childcare_grant_eligible_child_count"] == 1.0
+    assert projected["bursary_fund_16_to_19_participation_costs_for_year"] == 1500.0
+
+
+def test_dfe_person_programs_request_compares_person_outputs():
+    request = build_dfe_person_programs_final_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 1,
+                    "age": 19,
+                    "region": "Region.LONDON",
+                    "maintenance_loan_living_arrangement": (
+                        "MaintenanceLoanLivingArrangement.LIVING_WITH_PARENTS"
+                    ),
+                    "max_free_entitlement_hours_used": 0,
+                }
+            ],
+            "person_ids": [1],
+            "households": [],
+            "household_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    period = {
+        "period_kind": "custom",
+        "name": "calendar_year",
+        "start": "2026-01-01",
+        "end": "2026-12-31",
+    }
+    outputs = [
+        output["axiom"] for output in DFE_PERSON_PROGRAMS_FINAL_OUTPUTS.values()
+    ]
+    assert request["queries"] == [
+        {"entity_id": "person_1", "period": period, "outputs": outputs},
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{DFE_PERSON_PROGRAMS_FINAL_BASE}#input.person_age:person_1"
+    ] == {"kind": "decimal", "value": "19.0"}
+    assert (
+        inputs[
+            f"{DFE_PERSON_PROGRAMS_FINAL_BASE}#input.household_region_is_london:person_1"
+        ]
+        == {"kind": "bool", "value": True}
+    )
+
+
+def test_dfe_extended_childcare_request_builds_child_relations():
+    request = build_dfe_extended_childcare_entitlement_final_request(
+        pe_data={
+            "all_persons": [
+                {
+                    "person_id": 1,
+                    "person_benunit_id": 10,
+                    "age": 3,
+                    "max_free_entitlement_hours_used": 30,
+                },
+                {
+                    "person_id": 2,
+                    "person_benunit_id": 10,
+                    "age": 5,
+                    "max_free_entitlement_hours_used": 30,
+                },
+            ],
+            "persons": [],
+            "person_ids": [],
+            "households": [],
+            "household_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 10,
+                    "extended_childcare_entitlement": 0,
+                    "extended_childcare_entitlement_eligible": True,
+                    "maximum_extended_childcare_hours_usage": 15,
+                }
+            ],
+            "benunit_ids": [10],
+        },
+        year=2026,
+    )
+
+    assert request["dataset"]["relations"] == [
+        {
+            "name": (
+                f"{DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_BASE}"
+                "#relation.extended_childcare_entitlement_children"
+            ),
+            "tuple": ["person_1", "benunit_10"],
+            "interval": {
+                "period_kind": "custom",
+                "name": "calendar_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+        },
+        {
+            "name": (
+                f"{DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_BASE}"
+                "#relation.extended_childcare_entitlement_children"
+            ),
+            "tuple": ["person_2", "benunit_10"],
+            "interval": {
+                "period_kind": "custom",
+                "name": "calendar_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+        },
+    ]
+    outputs = [
+        output["axiom"]
+        for output in DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_OUTPUTS.values()
+    ]
+    assert request["queries"][0]["outputs"] == outputs
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_BASE}#input.child_age:person_1"
+    ] == {"kind": "decimal", "value": "3.0"}
+    assert (
+        inputs[
+            (
+                f"{DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_BASE}"
+                "#input.extended_childcare_child_counts_for_entitlement:person_1"
+            )
+        ]
+        == {"kind": "bool", "value": True}
+    )
+
+
+def test_ssmg_final_projection_uses_reported_receipt():
+    assert project_ssmg_final_inputs({"ssmg_reported": 500}) == {
+        "reported_sure_start_maternity_grant_for_year": 500.0,
+    }
+
+
+def test_ssmg_final_request_projects_final_inputs():
+    request = build_ssmg_final_request(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 1,
+                    "ssmg": 0,
+                    "ssmg_reported": 0,
+                },
+                {
+                    "person_id": 2,
+                    "ssmg": 500,
+                    "ssmg_reported": 500,
+                },
+            ],
+            "person_ids": [1, 2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        year=2026,
+    )
+
+    assert request["queries"] == [
+        {
+            "entity_id": "person_2",
+            "period": {
+                "period_kind": "custom",
+                "name": "calendar_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": [
+                SSMG_FINAL_OUTPUTS["sure_start_maternity_grant_annual_amount"]["axiom"],
+            ],
+        }
+    ]
+    inputs = {
+        record["name"] + ":" + record["entity_id"]: record["value"]
+        for record in request["dataset"]["inputs"]
+    }
+    assert inputs[
+        f"{SSMG_FINAL_BASE}#input.reported_sure_start_maternity_grant_for_year:person_2"
+    ] == {"kind": "decimal", "value": "500.0"}
 
 
 def test_pension_credit_final_projection_uses_entitlement_components():
@@ -3852,6 +5242,7 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
     )
     assert policyengine_person_variables_for_surfaces(["student-loan-repayment"]) == (
         "adjusted_net_income",
+        "student_loan_balance",
         "student_loan_plan",
         "student_loan_repayment",
     )
@@ -3964,6 +5355,22 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
     assert policyengine_benunit_variables_for_surfaces(
         ["universal-credit-childcare-work-condition"]
     ) == ("uc_childcare_work_condition",)
+    assert policyengine_person_variables_for_surfaces(["tax-free-childcare-final"]) == (
+        "childcare_expenses",
+        "is_blind",
+        "is_disabled_for_benefits",
+        "tax_free_childcare",
+        "tax_free_childcare_eligible",
+        "tax_free_childcare_eligible_declaration_periods",
+        "tax_free_childcare_qualifying_child",
+        "tax_free_childcare_uses_qualifying_provider",
+    )
+    assert policyengine_person_variables_for_surfaces(
+        ["sure-start-maternity-grant-final"]
+    ) == (
+        "ssmg",
+        "ssmg_reported",
+    )
     assert policyengine_benunit_variables_for_surfaces(
         ["universal-credit-work-allowance"]
     ) == (
@@ -3997,6 +5404,104 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
         "uc_tariff_income",
     )
     assert policyengine_benunit_variables_for_surfaces(["student-loan-repayment"]) == ()
+    assert policyengine_benunit_variables_for_surfaces(
+        ["closed-legacy-benefits-final"]
+    ) == (
+        "child_tax_credit",
+        "esa",
+        "esa_contrib",
+        "esa_income",
+        "income_support",
+        "jsa",
+        "jsa_contrib",
+        "jsa_income",
+        "tax_credits",
+        "working_tax_credit",
+    )
+    assert policyengine_household_variables_for_surfaces(
+        ["winter-fuel-allowance-final"]
+    ) == (
+        "country",
+        "esa_income",
+        "income_support",
+        "jsa_income",
+        "pension_credit",
+        "winter_fuel_allowance",
+    )
+    assert policyengine_household_variables_for_surfaces(
+        ["stamp-duty-land-tax-final"]
+    ) == (
+        "additional_residential_property_purchased",
+        "country",
+        "cumulative_non_residential_rent",
+        "cumulative_residential_rent",
+        "main_residential_property_purchased",
+        "main_residential_property_purchased_is_first_home",
+        "non_residential_property_purchased",
+        "non_residential_rent",
+        "rent",
+        "sdlt_liable",
+        "stamp_duty_land_tax",
+    )
+    assert policyengine_household_variables_for_surfaces(
+        ["land-and-buildings-transaction-tax-final"]
+    ) == (
+        "land_and_buildings_transaction_tax",
+        "lbtt_liable",
+        "lbtt_on_rent",
+        "lbtt_on_transactions",
+    )
+    assert policyengine_household_variables_for_surfaces(
+        ["land-transaction-tax-final"]
+    ) == (
+        "land_transaction_tax",
+        "ltt_liable",
+        "ltt_on_rent",
+        "ltt_on_transactions",
+    )
+    assert policyengine_household_variables_for_surfaces(["free-tv-licence-value"]) == (
+        "free_tv_licence_value",
+        "household_owns_tv",
+        "tv_licence",
+        "tv_licence_discount",
+        "would_evade_tv_licence_fee",
+    )
+    assert policyengine_household_variables_for_surfaces(
+        ["cost-of-living-support-payment-final"]
+    ) == (
+        "armed_forces_independence_payment",
+        "attendance_allowance",
+        "cost_of_living_support_payment",
+        "dla",
+        "esa_income",
+        "housing_benefit",
+        "income_support",
+        "jsa_income",
+        "pension_credit",
+        "pip",
+        "universal_credit",
+        "winter_fuel_allowance",
+    )
+    assert policyengine_household_variables_for_surfaces(
+        ["energy-bills-rebate-final"]
+    ) == (
+        "ebr_council_tax_rebate",
+        "ebr_energy_bills_credit",
+        "energy_bills_rebate",
+    )
+    assert policyengine_household_variables_for_surfaces(
+        ["energy-price-guarantee-final"]
+    ) == (
+        "domestic_energy_consumption",
+        "epg_subsidy",
+    )
+    assert policyengine_person_variables_for_surfaces(
+        ["winter-fuel-allowance-final"]
+    ) == (
+        "age",
+        "is_SP_age",
+        "total_income",
+    )
     assert policyengine_person_variables_for_surfaces(
         ["income-tax-section-11d-savings-income"]
     ) == (
@@ -4169,6 +5674,8 @@ class hbai_household_net_income(Variable):
         "esa_income",
         "esa_contrib",
         "housing_benefit",
+        "income_support",
+        "jsa_income",
         "universal_credit",
         "pension_credit",
         "working_tax_credit",
@@ -4221,6 +5728,8 @@ class hbai_household_net_income(Variable):
         "esa_income",
         "esa_contrib",
         "housing_benefit",
+        "income_support",
+        "jsa_income",
         "universal_credit",
         "pension_credit",
         "working_tax_credit",
@@ -4266,8 +5775,16 @@ class hbai_household_net_income(Variable):
     assert by_name["free_school_fruit_veg"].policy_component is False
     assert by_name["free_school_milk"].status == "fixed_input"
     assert by_name["free_school_milk"].policy_component is False
-    assert by_name["free_tv_licence_value"].status == "partial"
+    assert by_name["free_tv_licence_value"].status == "exact"
     assert by_name["free_tv_licence_value"].policy_component is True
+    assert by_name["free_tv_licence_value"].surfaces == (
+        "tv-licence-fee",
+        "free-tv-licence-value",
+    )
+    assert by_name["free_tv_licence_value"].covered_outputs == (
+        "colour_tv_licence_general_form_issue_fee",
+        "free_tv_licence_value",
+    )
     assert by_name["child_benefit"].status == "exact"
     assert by_name["child_benefit"].surfaces == (
         "child-benefit",
@@ -4313,7 +5830,12 @@ class hbai_household_net_income(Variable):
         "ni_class_4",
         "national_insurance",
     )
-    assert by_name["student_loan_repayments"].status == "partial"
+    assert by_name["student_loan_repayments"].status == "exact"
+    assert by_name["student_loan_repayments"].surfaces == ("student-loan-repayment",)
+    assert by_name["student_loan_repayments"].covered_outputs == (
+        "student_loan_repayment",
+        "student_loan_repayments",
+    )
     assert by_name["universal_credit"].status == "exact"
     assert by_name["universal_credit"].surfaces == (
         "universal-credit-standard-allowance",
@@ -4385,9 +5907,55 @@ class hbai_household_net_income(Variable):
         "housing_benefit_tariff_income",
         "housing_benefit",
     )
-    assert by_name["working_tax_credit"].status == "partial"
-    assert by_name["child_tax_credit"].status == "partial"
-    assert by_name["tax_free_childcare"].status == "partial"
+    assert by_name["income_support"].status == "exact"
+    assert by_name["income_support"].surfaces == (
+        "income-support-tariff-income",
+        "closed-legacy-benefits-final",
+    )
+    assert by_name["income_support"].covered_outputs == (
+        "income_support_tariff_income",
+        "income_support",
+    )
+    assert by_name["jsa_income"].status == "exact"
+    assert by_name["jsa_income"].surfaces == (
+        "jsa-income-tariff-income",
+        "closed-legacy-benefits-final",
+    )
+    assert by_name["jsa_income"].covered_outputs == (
+        "jsa_income_tariff_income",
+        "jsa_income",
+    )
+    assert by_name["working_tax_credit"].status == "exact"
+    assert by_name["working_tax_credit"].surfaces == (
+        "working-tax-credit-elements",
+        "closed-legacy-benefits-final",
+    )
+    assert by_name["working_tax_credit"].covered_outputs == (
+        "wtc_basic_element",
+        "wtc_couple_element",
+        "wtc_lone_parent_element",
+        "wtc_disabled_worker_element",
+        "wtc_severely_disabled_worker_element",
+        "working_tax_credit",
+    )
+    assert by_name["child_tax_credit"].status == "exact"
+    assert by_name["child_tax_credit"].surfaces == (
+        "child-tax-credit-elements",
+        "closed-legacy-benefits-final",
+    )
+    assert by_name["child_tax_credit"].covered_outputs == (
+        "CTC_family_element",
+        "CTC_child_element",
+        "CTC_disabled_child_element",
+        "CTC_severely_disabled_child_element",
+        "child_tax_credit",
+    )
+    assert by_name["tax_free_childcare"].status == "exact"
+    assert by_name["tax_free_childcare"].surfaces == (
+        "tax-free-childcare-parameters",
+        "tax-free-childcare-final",
+    )
+    assert by_name["tax_free_childcare"].covered_outputs == ("tax_free_childcare",)
     assert by_name["pip"].status == "exact"
     assert by_name["dla"].status == "exact"
     assert by_name["dla"].surfaces == (
@@ -4399,7 +5967,12 @@ class hbai_household_net_income(Variable):
         "dla_m",
         "dla",
     )
-    assert by_name["attendance_allowance"].status == "partial"
+    assert by_name["attendance_allowance"].status == "exact"
+    assert by_name["attendance_allowance"].surfaces == (
+        "attendance-allowance-rates",
+        "attendance-allowance-final",
+    )
+    assert by_name["attendance_allowance"].covered_outputs == ("attendance_allowance",)
     assert by_name["carers_allowance"].status == "exact"
     assert by_name["carers_allowance"].surfaces == (
         "carers-allowance-rate",
@@ -4411,7 +5984,15 @@ class hbai_household_net_income(Variable):
         "severe-disablement-allowance-final",
     )
     assert by_name["sda"].covered_outputs == ("sda",)
-    assert by_name["ssmg"].status == "partial"
+    assert by_name["ssmg"].status == "exact"
+    assert by_name["ssmg"].surfaces == (
+        "sure-start-maternity-grant-rate",
+        "sure-start-maternity-grant-final",
+    )
+    assert by_name["ssmg"].covered_outputs == (
+        "sure_start_maternity_grant_amount",
+        "ssmg",
+    )
     assert by_name["scottish_child_payment"].status == "exact"
     assert by_name["scottish_child_payment"].surfaces == (
         "scottish-child-payment-parameters",
@@ -4428,24 +6009,35 @@ class hbai_household_net_income(Variable):
     assert by_name["carer_support_payment"].covered_outputs == (
         "carer_support_payment",
     )
-    assert by_name["cost_of_living_support_payment"].status == "partial"
+    assert by_name["cost_of_living_support_payment"].status == "exact"
+    assert by_name["cost_of_living_support_payment"].surfaces == (
+        "cost-of-living-support-payment-parameters",
+        "cost-of-living-support-payment-final",
+    )
+    assert by_name["cost_of_living_support_payment"].covered_outputs == (
+        "cost_of_living_support_payment",
+    )
     assert by_name["state_pension"].status == "exact"
     assert by_name["state_pension"].surfaces == (
         "state-pension-rates",
         "state-pension-final",
     )
-    assert by_name["winter_fuel_allowance"].status == "partial"
+    assert by_name["winter_fuel_allowance"].status == "exact"
+    assert by_name["winter_fuel_allowance"].surfaces == (
+        "winter-fuel-payment-rates",
+        "winter-fuel-allowance-final",
+    )
     assert by_name["council_tax"].status == "fixed_input"
     assert by_name["council_tax"].policy_component is False
     assert by_name["domestic_rates"].status == "fixed_input"
     assert by_name["domestic_rates"].policy_component is False
     assert by_name["LVT"].status == "out_of_scope"
     assert by_name["LVT"].policy_component is False
-    assert report.policy_component_count == 23
-    assert report.covered_policy_component_count == 23
-    assert report.exact_policy_component_count == 14
+    assert report.policy_component_count == 25
+    assert report.covered_policy_component_count == 25
+    assert report.exact_policy_component_count == 25
     assert report.covered_policy_component_share == 1
-    assert math.isclose(report.exact_policy_component_share, 14 / 23)
+    assert report.exact_policy_component_share == 1
 
 
 def test_uk_hbai_policy_coverage_report_reads_module_level_component_constants(
@@ -4515,6 +6107,197 @@ class hbai_household_net_income(Variable):
     }
     assert payload["activity_totals"] is None
     assert payload["components"][0]["name"] == "employment_income"
+
+
+def test_uk_national_policy_coverage_report_classifies_non_ctr_manifest(
+    monkeypatch,
+    tmp_path,
+):
+    variables = [
+        UKEFRSVariableMetadata(
+            name="income_tax",
+            entity="person",
+            domain="gov",
+            path="gov/hmrc/income_tax/income_tax.py",
+            computed=True,
+            computation_kind="formula",
+            covered_output=True,
+        ),
+        UKEFRSVariableMetadata(
+            name="fuel_duty",
+            entity="household",
+            domain="gov",
+            path="gov/hmrc/fuel_duty/fuel_duty.py",
+            computed=True,
+            computation_kind="formula",
+            covered_output=False,
+        ),
+        UKEFRSVariableMetadata(
+            name="council_tax",
+            entity="household",
+            domain="input",
+            path="input/consumption/property/council_tax.py",
+            computed=False,
+            computation_kind="input",
+            covered_output=False,
+        ),
+        UKEFRSVariableMetadata(
+            name="vat",
+            entity="household",
+            domain="gov",
+            path="gov/hmrc/vat/vat.py",
+            computed=True,
+            computation_kind="formula",
+            covered_output=False,
+        ),
+        UKEFRSVariableMetadata(
+            name="capital_gains_tax",
+            entity="person",
+            domain="gov",
+            path="gov/hmrc/cgt/capital_gains_tax.py",
+            computed=True,
+            computation_kind="formula",
+            covered_output=False,
+        ),
+        UKEFRSVariableMetadata(
+            name="stamp_duty_land_tax",
+            entity="household",
+            domain="gov",
+            path="gov/hmrc/stamp_duty/stamp_duty_land_tax.py",
+            computed=True,
+            computation_kind="formula",
+            covered_output=False,
+        ),
+        UKEFRSVariableMetadata(
+            name="land_and_buildings_transaction_tax",
+            entity="household",
+            domain="gov",
+            path="gov/revenue_scotland/land_and_buildings_transaction_tax.py",
+            computed=True,
+            computation_kind="formula",
+            covered_output=False,
+        ),
+        UKEFRSVariableMetadata(
+            name="land_transaction_tax",
+            entity="household",
+            domain="gov",
+            path="gov/wra/land_transaction_tax.py",
+            computed=True,
+            computation_kind="formula",
+            covered_output=False,
+        ),
+        UKEFRSVariableMetadata(
+            name="tax_credits",
+            entity="benunit",
+            domain="gov",
+            path="gov/dwp/tax_credits.py",
+            computed=True,
+            computation_kind="formula",
+            covered_output=False,
+        ),
+        UKEFRSVariableMetadata(
+            name="energy_bills_rebate",
+            entity="household",
+            domain="gov",
+            path="gov/treasury/energy_bills_rebate/energy_bills_rebate.py",
+            computed=True,
+            computation_kind="adds",
+            covered_output=False,
+        ),
+        UKEFRSVariableMetadata(
+            name="epg_subsidy",
+            entity="household",
+            domain="gov",
+            path="gov/treasury/price_cap_subsidy/epg_subsidy.py",
+            computed=True,
+            computation_kind="formula",
+            covered_output=False,
+        ),
+        UKEFRSVariableMetadata(
+            name="maintenance_loan",
+            entity="person",
+            domain="gov",
+            path="gov/dfe/maintenance_loan.py",
+            computed=True,
+            computation_kind="formula",
+            covered_output=False,
+        ),
+    ]
+
+    monkeypatch.setattr(
+        efrs_uk,
+        "policyengine_uk_versions",
+        lambda: {
+            "policyengine": "test",
+            "policyengine-core": "test",
+            "policyengine-uk": "test",
+        },
+    )
+    monkeypatch.setattr(
+        efrs_uk,
+        "policyengine_uk_variables_source_root",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        efrs_uk,
+        "discover_policyengine_uk_variables",
+        lambda **kwargs: variables,
+    )
+
+    report = build_uk_national_policy_coverage_report(source_root=tmp_path)
+    by_variable = {component.variable: component for component in report.components}
+
+    assert by_variable["income_tax"].status == "exact"
+    assert by_variable["income_tax"].policy_component is True
+    assert by_variable["fuel_duty"].status == "exact"
+    assert by_variable["fuel_duty"].surfaces == ("fuel-duty-final",)
+    assert by_variable["fuel_duty"].policy_component is True
+    assert by_variable["vat"].status == "exact"
+    assert by_variable["vat"].surfaces == ("vat-final",)
+    assert by_variable["vat"].policy_component is True
+    assert by_variable["capital_gains_tax"].status == "exact"
+    assert by_variable["capital_gains_tax"].surfaces == (
+        "capital-gains-tax-final",
+    )
+    assert by_variable["capital_gains_tax"].policy_component is True
+    assert by_variable["stamp_duty_land_tax"].status == "exact"
+    assert by_variable["stamp_duty_land_tax"].surfaces == (
+        "stamp-duty-land-tax-final",
+    )
+    assert by_variable["stamp_duty_land_tax"].policy_component is True
+    assert by_variable["land_and_buildings_transaction_tax"].status == "exact"
+    assert by_variable["land_and_buildings_transaction_tax"].surfaces == (
+        "land-and-buildings-transaction-tax-final",
+    )
+    assert by_variable["land_and_buildings_transaction_tax"].policy_component is True
+    assert by_variable["land_transaction_tax"].status == "exact"
+    assert by_variable["land_transaction_tax"].surfaces == (
+        "land-transaction-tax-final",
+    )
+    assert by_variable["land_transaction_tax"].policy_component is True
+    assert by_variable["tax_credits"].status == "exact"
+    assert by_variable["tax_credits"].surfaces == (
+        "working-tax-credit-elements",
+        "child-tax-credit-elements",
+        "closed-legacy-benefits-final",
+    )
+    assert by_variable["tax_credits"].policy_component is True
+    assert by_variable["energy_bills_rebate"].status == "exact"
+    assert by_variable["energy_bills_rebate"].surfaces == (
+        "energy-bills-rebate-final",
+    )
+    assert by_variable["energy_bills_rebate"].policy_component is True
+    assert by_variable["epg_subsidy"].status == "exact"
+    assert by_variable["epg_subsidy"].surfaces == (
+        "energy-price-guarantee-final",
+    )
+    assert by_variable["epg_subsidy"].policy_component is True
+    assert by_variable["maintenance_loan"].status == "exact"
+    assert by_variable["maintenance_loan"].surfaces == ("dfe-person-programs-final",)
+    assert by_variable["maintenance_loan"].policy_component is True
+    assert by_variable["council_tax"].status == "out_of_scope"
+    assert by_variable["council_tax"].policy_component is False
+    assert report.covered_policy_component_count == report.policy_component_count
 
 
 def test_policyengine_uk_version_guard_rejects_unpinned_version(monkeypatch):
@@ -4979,6 +6762,65 @@ def test_compare_outputs_compares_universal_credit_final_annual_amount():
     assert report.oracle_divergences == []
 
 
+def test_compare_outputs_compares_closed_legacy_benefits_final_amounts():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "households": [],
+            "household_ids": [],
+            "benunits": [
+                {
+                    "benunit_id": 2,
+                    "income_support": 0,
+                    "jsa_income": 0,
+                    "working_tax_credit": 0,
+                    "child_tax_credit": 0,
+                    "tax_credits": 0,
+                    "jsa": 125,
+                    "esa": 650,
+                },
+            ],
+            "benunit_ids": [2],
+        },
+        axiom_outputs_by_surface={
+            "closed-legacy-benefits-final": [
+                {
+                    "outputs": {
+                        CLOSED_LEGACY_BENEFITS_FINAL_OUTPUTS["income_support"][
+                            "axiom"
+                        ]: decimal_output(0),
+                        CLOSED_LEGACY_BENEFITS_FINAL_OUTPUTS["jsa_income"][
+                            "axiom"
+                        ]: decimal_output(0),
+                        CLOSED_LEGACY_BENEFITS_FINAL_OUTPUTS["working_tax_credit"][
+                            "axiom"
+                        ]: decimal_output(0),
+                        CLOSED_LEGACY_BENEFITS_FINAL_OUTPUTS["child_tax_credit"][
+                            "axiom"
+                        ]: decimal_output(0),
+                        CLOSED_LEGACY_BENEFITS_FINAL_OUTPUTS["tax_credits"][
+                            "axiom"
+                        ]: decimal_output(0),
+                        CLOSED_LEGACY_BENEFITS_FINAL_OUTPUTS["jsa"][
+                            "axiom"
+                        ]: decimal_output(125),
+                        CLOSED_LEGACY_BENEFITS_FINAL_OUTPUTS["esa"][
+                            "axiom"
+                        ]: decimal_output(650),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 7
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
 def test_compare_outputs_compares_carers_allowance_final_annual_amount():
     report = compare_outputs(
         pe_data={
@@ -5150,6 +6992,517 @@ def test_compare_outputs_compares_dla_final_components_and_annual_amount():
     )
 
     assert report.compared_values == 3
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_attendance_allowance_final_amounts():
+    report = compare_outputs(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 2,
+                    "attendance_allowance": 5_959.20,
+                    "aa_category": "HIGHER",
+                },
+            ],
+            "person_ids": [2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        axiom_outputs_by_surface={
+            "attendance-allowance-final": [
+                {
+                    "outputs": {
+                        ATTENDANCE_ALLOWANCE_FINAL_OUTPUTS[
+                            "attendance_allowance_weekly_amount"
+                        ]["axiom"]: decimal_output(114.60),
+                        ATTENDANCE_ALLOWANCE_FINAL_OUTPUTS[
+                            "attendance_allowance_annual_amount"
+                        ]["axiom"]: decimal_output(5_959.20),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 2
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_winter_fuel_allowance_final_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+            "households": [
+                {
+                    "household_id": 4,
+                    "winter_fuel_allowance": 300,
+                },
+            ],
+            "household_ids": [4],
+        },
+        axiom_outputs_by_surface={
+            "winter-fuel-allowance-final": [
+                {
+                    "outputs": {
+                        WINTER_FUEL_ALLOWANCE_FINAL_OUTPUTS[
+                            "winter_fuel_allowance_annual_amount"
+                        ]["axiom"]: decimal_output(300),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_tax_free_childcare_final_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 2,
+                    "tax_free_childcare": 2_000,
+                },
+            ],
+            "person_ids": [2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        axiom_outputs_by_surface={
+            "tax-free-childcare-final": [
+                {
+                    "outputs": {
+                        TAX_FREE_CHILDCARE_FINAL_OUTPUTS[
+                            "tax_free_childcare_annual_amount"
+                        ]["axiom"]: decimal_output(2_000),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_capital_gains_tax_final_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 2,
+                    "capital_gains": 50_000,
+                    "capital_gains_tax": 11_263.8,
+                },
+            ],
+            "person_ids": [2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        axiom_outputs_by_surface={
+            "capital-gains-tax-final": [
+                {
+                    "outputs": {
+                        CAPITAL_GAINS_TAX_FINAL_OUTPUTS[
+                            "capital_gains_tax_annual_amount"
+                        ]["axiom"]: decimal_output(11_263.8),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_stamp_duty_land_tax_final_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+            "households": [
+                {
+                    "household_id": 2,
+                    "stamp_duty_land_tax": 18_000,
+                    "additional_residential_property_purchased": 350_000,
+                },
+            ],
+            "household_ids": [2],
+        },
+        axiom_outputs_by_surface={
+            "stamp-duty-land-tax-final": [
+                {
+                    "outputs": {
+                        STAMP_DUTY_LAND_TAX_FINAL_OUTPUTS[
+                            "stamp_duty_land_tax_annual_amount"
+                        ]["axiom"]: decimal_output(18_000),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_lbtt_final_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+            "households": [
+                {
+                    "household_id": 2,
+                    "land_and_buildings_transaction_tax": 4_325,
+                    "lbtt_liable": True,
+                    "lbtt_on_transactions": 4_200,
+                    "lbtt_on_rent": 125,
+                },
+            ],
+            "household_ids": [2],
+        },
+        axiom_outputs_by_surface={
+            "land-and-buildings-transaction-tax-final": [
+                {
+                    "outputs": {
+                        LBTT_FINAL_OUTPUTS[
+                            "land_and_buildings_transaction_tax_annual_amount"
+                        ]["axiom"]: decimal_output(4_325),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_ltt_final_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+            "households": [
+                {
+                    "household_id": 2,
+                    "land_transaction_tax": 2_980,
+                    "ltt_liable": True,
+                    "ltt_on_transactions": 2_900,
+                    "ltt_on_rent": 80,
+                },
+            ],
+            "household_ids": [2],
+        },
+        axiom_outputs_by_surface={
+            "land-transaction-tax-final": [
+                {
+                    "outputs": {
+                        LTT_FINAL_OUTPUTS["land_transaction_tax_annual_amount"][
+                            "axiom"
+                        ]: decimal_output(2_980),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_vat_final_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+            "households": [
+                {
+                    "household_id": 2,
+                    "vat": 578.95,
+                    "full_rate_vat_consumption": 1000,
+                    "reduced_rate_vat_consumption": 400,
+                },
+            ],
+            "household_ids": [2],
+        },
+        axiom_outputs_by_surface={
+            "vat-final": [
+                {
+                    "outputs": {
+                        VAT_FINAL_OUTPUTS["vat_annual_amount"][
+                            "axiom"
+                        ]: decimal_output(578.95),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_fuel_duty_final_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+            "households": [
+                {
+                    "household_id": 2,
+                    "fuel_duty": 534.5,
+                    "petrol_litres": 600,
+                    "diesel_litres": 400,
+                },
+            ],
+            "household_ids": [2],
+        },
+        axiom_outputs_by_surface={
+            "fuel-duty-final": [
+                {
+                    "outputs": {
+                        FUEL_DUTY_FINAL_OUTPUTS["fuel_duty_annual_amount"][
+                            "axiom"
+                        ]: decimal_output(534.5),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_tv_licence_outputs():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+            "households": [
+                {
+                    "household_id": 2,
+                    "free_tv_licence_value": 90,
+                    "tv_licence": 90,
+                },
+            ],
+            "household_ids": [2],
+        },
+        axiom_outputs_by_surface={
+            "free-tv-licence-value": [
+                {
+                    "outputs": {
+                        TV_LICENCE_FINAL_OUTPUTS["free_tv_licence_value"][
+                            "axiom"
+                        ]: decimal_output(90),
+                        TV_LICENCE_FINAL_OUTPUTS["tv_licence_annual_amount"][
+                            "axiom"
+                        ]: decimal_output(90),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 2
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_cost_of_living_support_payment_final_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+            "households": [
+                {
+                    "household_id": 3,
+                    "cost_of_living_support_payment": 0,
+                },
+            ],
+            "household_ids": [3],
+        },
+        axiom_outputs_by_surface={
+            "cost-of-living-support-payment-final": [
+                {
+                    "outputs": {
+                        COST_OF_LIVING_SUPPORT_PAYMENT_FINAL_OUTPUTS[
+                            "cost_of_living_support_payment_annual_amount"
+                        ]["axiom"]: decimal_output(0),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_energy_bills_rebate_final_amounts():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+            "households": [
+                {
+                    "household_id": 3,
+                    "ebr_council_tax_rebate": 0,
+                    "ebr_energy_bills_credit": 0,
+                    "energy_bills_rebate": 0,
+                },
+            ],
+            "household_ids": [3],
+        },
+        axiom_outputs_by_surface={
+            "energy-bills-rebate-final": [
+                {
+                    "outputs": {
+                        ENERGY_BILLS_REBATE_FINAL_OUTPUTS[
+                            "energy_bills_rebate_council_tax_rebate"
+                        ]["axiom"]: decimal_output(0),
+                        ENERGY_BILLS_REBATE_FINAL_OUTPUTS[
+                            "energy_bills_rebate_energy_bills_credit"
+                        ]["axiom"]: decimal_output(0),
+                        ENERGY_BILLS_REBATE_FINAL_OUTPUTS[
+                            "energy_bills_rebate_annual_amount"
+                        ]["axiom"]: decimal_output(0),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 3
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_energy_price_guarantee_final_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [],
+            "person_ids": [],
+            "benunits": [],
+            "benunit_ids": [],
+            "households": [
+                {
+                    "household_id": 3,
+                    "epg_subsidy": 0,
+                },
+            ],
+            "household_ids": [3],
+        },
+        axiom_outputs_by_surface={
+            "energy-price-guarantee-final": [
+                {
+                    "outputs": {
+                        ENERGY_PRICE_GUARANTEE_FINAL_OUTPUTS[
+                            "energy_price_guarantee_subsidy_annual_amount"
+                        ]["axiom"]: decimal_output(0),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
+    assert report.mismatches == []
+    assert report.oracle_divergences == []
+
+
+def test_compare_outputs_compares_ssmg_final_amount():
+    report = compare_outputs(
+        pe_data={
+            "persons": [
+                {
+                    "person_id": 2,
+                    "ssmg": 500,
+                    "ssmg_reported": 500,
+                },
+            ],
+            "person_ids": [2],
+            "benunits": [],
+            "benunit_ids": [],
+        },
+        axiom_outputs_by_surface={
+            "sure-start-maternity-grant-final": [
+                {
+                    "outputs": {
+                        SSMG_FINAL_OUTPUTS["sure_start_maternity_grant_annual_amount"][
+                            "axiom"
+                        ]: decimal_output(500),
+                    }
+                }
+            ]
+        },
+        tolerance=0.01,
+        relative_tolerance=2e-7,
+    )
+
+    assert report.compared_values == 1
     assert report.mismatches == []
     assert report.oracle_divergences == []
 
@@ -6579,11 +8932,12 @@ def test_main_returns_nonzero_when_requested_for_mismatches(monkeypatch, tmp_pat
     monkeypatch.setattr(
         efrs_uk,
         "compare_uk_efrs",
-        lambda **_: efrs_uk.UKEFRSComparisonReport(
-            compared_persons=1,
-            compared_benunits=0,
-            compared_values=1,
-            mismatches=[
+            lambda **_: efrs_uk.UKEFRSComparisonReport(
+                compared_persons=1,
+                compared_benunits=0,
+                compared_households=0,
+                compared_values=1,
+                mismatches=[
                 efrs_uk.UKEFRSComparisonRow(
                     surface="personal-allowance",
                     entity_id="person_7",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -3182,9 +3182,9 @@ def test_capital_gains_tax_final_request_projects_final_inputs(monkeypatch):
                 "end": "2026-12-31",
             },
             "outputs": [
-                CAPITAL_GAINS_TAX_FINAL_OUTPUTS[
-                    "capital_gains_tax_annual_amount"
-                ]["axiom"]
+                CAPITAL_GAINS_TAX_FINAL_OUTPUTS["capital_gains_tax_annual_amount"][
+                    "axiom"
+                ]
             ],
         }
     ]
@@ -3274,9 +3274,9 @@ def test_stamp_duty_land_tax_final_request_projects_final_inputs():
                 "end": "2026-12-31",
             },
             "outputs": [
-                STAMP_DUTY_LAND_TAX_FINAL_OUTPUTS[
-                    "stamp_duty_land_tax_annual_amount"
-                ]["axiom"]
+                STAMP_DUTY_LAND_TAX_FINAL_OUTPUTS["stamp_duty_land_tax_annual_amount"][
+                    "axiom"
+                ]
             ],
         }
     ]
@@ -3339,17 +3339,16 @@ def test_lbtt_final_request_compares_all_households():
         "household_2",
     ]
     assert request["queries"][0]["outputs"] == [
-        LBTT_FINAL_OUTPUTS["land_and_buildings_transaction_tax_annual_amount"][
-            "axiom"
-        ]
+        LBTT_FINAL_OUTPUTS["land_and_buildings_transaction_tax_annual_amount"]["axiom"]
     ]
     inputs = {
         record["name"] + ":" + record["entity_id"]: record["value"]
         for record in request["dataset"]["inputs"]
     }
-    assert inputs[
-        f"{LBTT_FINAL_BASE}#input.household_is_lbtt_liable:household_2"
-    ] == {"kind": "bool", "value": True}
+    assert inputs[f"{LBTT_FINAL_BASE}#input.household_is_lbtt_liable:household_2"] == {
+        "kind": "bool",
+        "value": True,
+    }
     assert inputs[
         f"{LBTT_FINAL_BASE}#input.lbtt_on_transactions_for_year:household_2"
     ] == {"kind": "decimal", "value": "4200.0"}
@@ -3408,9 +3407,10 @@ def test_ltt_final_request_compares_all_households():
         record["name"] + ":" + record["entity_id"]: record["value"]
         for record in request["dataset"]["inputs"]
     }
-    assert inputs[
-        f"{LTT_FINAL_BASE}#input.household_is_ltt_liable:household_2"
-    ] == {"kind": "bool", "value": True}
+    assert inputs[f"{LTT_FINAL_BASE}#input.household_is_ltt_liable:household_2"] == {
+        "kind": "bool",
+        "value": True,
+    }
     assert inputs[
         f"{LTT_FINAL_BASE}#input.ltt_on_transactions_for_year:household_2"
     ] == {"kind": "decimal", "value": "2900.0"}
@@ -3632,7 +3632,7 @@ def test_free_tv_licence_value_request_projects_final_inputs():
                 TV_LICENCE_FINAL_OUTPUTS["free_tv_licence_value"]["axiom"],
                 TV_LICENCE_FINAL_OUTPUTS["tv_licence_annual_amount"]["axiom"],
             ],
-        }
+        },
     ]
     inputs = {
         record["name"] + ":" + record["entity_id"]: record["value"]
@@ -3783,9 +3783,7 @@ def test_energy_bills_rebate_final_request_compares_all_households():
         "start": "2026-01-01",
         "end": "2026-12-31",
     }
-    outputs = [
-        output["axiom"] for output in ENERGY_BILLS_REBATE_FINAL_OUTPUTS.values()
-    ]
+    outputs = [output["axiom"] for output in ENERGY_BILLS_REBATE_FINAL_OUTPUTS.values()]
     assert request == {
         "mode": "explain",
         "dataset": {"inputs": [], "relations": []},
@@ -3915,9 +3913,7 @@ def test_dfe_person_programs_request_compares_person_outputs():
         "start": "2026-01-01",
         "end": "2026-12-31",
     }
-    outputs = [
-        output["axiom"] for output in DFE_PERSON_PROGRAMS_FINAL_OUTPUTS.values()
-    ]
+    outputs = [output["axiom"] for output in DFE_PERSON_PROGRAMS_FINAL_OUTPUTS.values()]
     assert request["queries"] == [
         {"entity_id": "person_1", "period": period, "outputs": outputs},
     ]
@@ -3925,15 +3921,13 @@ def test_dfe_person_programs_request_compares_person_outputs():
         record["name"] + ":" + record["entity_id"]: record["value"]
         for record in request["dataset"]["inputs"]
     }
+    assert inputs[f"{DFE_PERSON_PROGRAMS_FINAL_BASE}#input.person_age:person_1"] == {
+        "kind": "decimal",
+        "value": "19.0",
+    }
     assert inputs[
-        f"{DFE_PERSON_PROGRAMS_FINAL_BASE}#input.person_age:person_1"
-    ] == {"kind": "decimal", "value": "19.0"}
-    assert (
-        inputs[
-            f"{DFE_PERSON_PROGRAMS_FINAL_BASE}#input.household_region_is_london:person_1"
-        ]
-        == {"kind": "bool", "value": True}
-    )
+        f"{DFE_PERSON_PROGRAMS_FINAL_BASE}#input.household_region_is_london:person_1"
+    ] == {"kind": "bool", "value": True}
 
 
 def test_dfe_extended_childcare_request_builds_child_relations():
@@ -4010,15 +4004,12 @@ def test_dfe_extended_childcare_request_builds_child_relations():
     assert inputs[
         f"{DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_BASE}#input.child_age:person_1"
     ] == {"kind": "decimal", "value": "3.0"}
-    assert (
-        inputs[
-            (
-                f"{DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_BASE}"
-                "#input.extended_childcare_child_counts_for_entitlement:person_1"
-            )
-        ]
-        == {"kind": "bool", "value": True}
-    )
+    assert inputs[
+        (
+            f"{DFE_EXTENDED_CHILDCARE_ENTITLEMENT_FINAL_BASE}"
+            "#input.extended_childcare_child_counts_for_entitlement:person_1"
+        )
+    ] == {"kind": "bool", "value": True}
 
 
 def test_ssmg_final_projection_uses_reported_receipt():
@@ -6256,14 +6247,10 @@ def test_uk_national_policy_coverage_report_classifies_non_ctr_manifest(
     assert by_variable["vat"].surfaces == ("vat-final",)
     assert by_variable["vat"].policy_component is True
     assert by_variable["capital_gains_tax"].status == "exact"
-    assert by_variable["capital_gains_tax"].surfaces == (
-        "capital-gains-tax-final",
-    )
+    assert by_variable["capital_gains_tax"].surfaces == ("capital-gains-tax-final",)
     assert by_variable["capital_gains_tax"].policy_component is True
     assert by_variable["stamp_duty_land_tax"].status == "exact"
-    assert by_variable["stamp_duty_land_tax"].surfaces == (
-        "stamp-duty-land-tax-final",
-    )
+    assert by_variable["stamp_duty_land_tax"].surfaces == ("stamp-duty-land-tax-final",)
     assert by_variable["stamp_duty_land_tax"].policy_component is True
     assert by_variable["land_and_buildings_transaction_tax"].status == "exact"
     assert by_variable["land_and_buildings_transaction_tax"].surfaces == (
@@ -6283,14 +6270,10 @@ def test_uk_national_policy_coverage_report_classifies_non_ctr_manifest(
     )
     assert by_variable["tax_credits"].policy_component is True
     assert by_variable["energy_bills_rebate"].status == "exact"
-    assert by_variable["energy_bills_rebate"].surfaces == (
-        "energy-bills-rebate-final",
-    )
+    assert by_variable["energy_bills_rebate"].surfaces == ("energy-bills-rebate-final",)
     assert by_variable["energy_bills_rebate"].policy_component is True
     assert by_variable["epg_subsidy"].status == "exact"
-    assert by_variable["epg_subsidy"].surfaces == (
-        "energy-price-guarantee-final",
-    )
+    assert by_variable["epg_subsidy"].surfaces == ("energy-price-guarantee-final",)
     assert by_variable["epg_subsidy"].policy_component is True
     assert by_variable["maintenance_loan"].status == "exact"
     assert by_variable["maintenance_loan"].surfaces == ("dfe-person-programs-final",)
@@ -7268,9 +7251,9 @@ def test_compare_outputs_compares_vat_final_amount():
             "vat-final": [
                 {
                     "outputs": {
-                        VAT_FINAL_OUTPUTS["vat_annual_amount"][
-                            "axiom"
-                        ]: decimal_output(578.95),
+                        VAT_FINAL_OUTPUTS["vat_annual_amount"]["axiom"]: decimal_output(
+                            578.95
+                        ),
                     }
                 }
             ]
@@ -8932,12 +8915,12 @@ def test_main_returns_nonzero_when_requested_for_mismatches(monkeypatch, tmp_pat
     monkeypatch.setattr(
         efrs_uk,
         "compare_uk_efrs",
-            lambda **_: efrs_uk.UKEFRSComparisonReport(
-                compared_persons=1,
-                compared_benunits=0,
-                compared_households=0,
-                compared_values=1,
-                mismatches=[
+        lambda **_: efrs_uk.UKEFRSComparisonReport(
+            compared_persons=1,
+            compared_benunits=0,
+            compared_households=0,
+            compared_values=1,
+            mismatches=[
                 efrs_uk.UKEFRSComparisonRow(
                     surface="personal-allowance",
                     entity_id="person_7",

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -5798,8 +5798,9 @@ class hbai_household_net_income(Variable):
     assert by_name["incapacity_benefit"].policy_component is False
     assert by_name["jsa_contrib"].status == "fixed_input"
     assert by_name["jsa_contrib"].policy_component is False
-    assert by_name["maternity_allowance"].status == "fixed_input"
-    assert by_name["maternity_allowance"].policy_component is False
+    assert by_name["maternity_allowance"].status == "exact"
+    assert by_name["maternity_allowance"].surfaces == ("maternity-allowance-final",)
+    assert by_name["maternity_allowance"].policy_component is True
     assert by_name["statutory_sick_pay"].status == "fixed_input"
     assert by_name["statutory_sick_pay"].policy_component is False
     assert by_name["statutory_maternity_pay"].status == "fixed_input"
@@ -6024,9 +6025,9 @@ class hbai_household_net_income(Variable):
     assert by_name["domestic_rates"].policy_component is False
     assert by_name["LVT"].status == "out_of_scope"
     assert by_name["LVT"].policy_component is False
-    assert report.policy_component_count == 25
-    assert report.covered_policy_component_count == 25
-    assert report.exact_policy_component_count == 25
+    assert report.policy_component_count == 26
+    assert report.covered_policy_component_count == 26
+    assert report.exact_policy_component_count == 26
     assert report.covered_policy_component_share == 1
     assert report.exact_policy_component_share == 1
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.621"
+version = "0.2.622"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.622"
+version = "0.2.623"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add UK EFRS oracle surfaces and mappings for remaining national PE-UK components, including DfE childcare/student-support programs plus business rates, National Minimum Wage, and Maternity Allowance
- update national policy coverage classification so all non-CTR national policy components are exact; marriage allowance is intentionally not added because PE-UK does not compute it as a separate oracle surface
- add/refresh tests for DfE projections, family-child relations, coverage counts, comparison report shape, and encoder version provenance

## Validation
- `uv run --extra dev ruff check src/ tests/` -> passed
- `uv run --extra dev ruff format --check src/ tests/` -> 62 files already formatted
- `uv run --extra dev pytest tests/test_policyengine_coverage.py tests/test_policyengine_efrs_uk.py tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q` -> 488 passed, 2 skipped
- `uv run --with policyengine-core==3.26.11 --with policyengine-uk==2.88.56 axiom-encode uk-efrs-compare --rulespec-root /Users/maxghenis/_axiom-worktrees/rulespec-uk-hbai-partials-20260607 --surface all --dataset /tmp/axiom-efrs/enhanced_frs_2023_24.h5 --year 2026 --sample-size 0 --json --fail-on-mismatch` -> 6,934,456 compared values, 0 mismatches, 0 oracle divergences, no skipped surfaces
- `uv run --with policyengine-core==3.26.11 --with policyengine-uk==2.88.56 axiom-encode uk-efrs-national-coverage --with-efrs-activity --dataset /tmp/axiom-efrs/enhanced_frs_2023_24.h5 --year 2026 --json` -> 47/47 national policy components exact; Council Tax/CTR remains local-government out of scope
