### PR TITLE
Classify UK council tax reduction oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.622"
+version = "0.2.623"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.621"
+version = "0.2.622"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.622"
+__version__ = "0.2.623"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.621"
+__version__ = "0.2.622"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2586,6 +2586,21 @@ def _iter_normalized_special_numeric_matches(
             sign = -1 if whole < 0 else 1
             matches.append((match.span(), (whole + sign * fraction) / 100))
 
+    for match in re.finditer(
+        r"(-?[\d,]+)\s+(\d+)\s*/\s*(\d+)"
+        r"(?:\s+|-)(?:percent|per\s*cent(?:um)?)",
+        text,
+        re.IGNORECASE,
+    ):
+        with contextlib.suppress(ValueError, ZeroDivisionError):
+            whole = float(match.group(1).replace(",", ""))
+            numerator = float(match.group(2).replace(",", ""))
+            denominator = float(match.group(3).replace(",", ""))
+            sign = -1 if whole < 0 else 1
+            matches.append(
+                (match.span(), (whole + sign * numerator / denominator) / 100)
+            )
+
     for pattern in (
         re.compile(
             r"(\d+(?:\.\d+)?)(?:\s+|-)(?:percent|per\s*cent(?:um)?)",

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -2101,6 +2101,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Council Tax Reduction helper outputs expose source-law scheme selection, capital, excess-income, taper, and simulated-award mechanics; PolicyEngine UK exposes the final household council_tax_reduction variable rather than these helpers one-to-one.
 
+  - legal_id_prefix: uk-kingston-upon-thames:policies/kingston-upon-thames/council-tax-reduction#
+    country: uk
+    program: council_tax_reduction
+    mapping_type: not_comparable
+    rationale: Kingston upon Thames Council Tax Reduction outputs are jurisdiction-specific local-scheme RuleSpec surfaces; the released PolicyEngine UK oracle does not yet expose this draft local CTR scheme one-to-one.
+
   - legal_id_prefix: uk:statutes/ukpga/2007/3/35#
     country: uk
     program: tax

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -1,4 +1,15 @@
 mappings:
+  - legal_id: uk:policies/govuk/council-tax-reduction#council_tax_reduction_annual_amount
+    country: uk
+    program: council_tax_reduction
+    mapping_type: direct_variable
+    policyengine_variable: council_tax_reduction
+    entity: household
+    period: year
+    unit: GBP
+    comparison: money
+    rationale: Same annual household Council Tax Reduction amount as PolicyEngine UK's final council_tax_reduction variable, including supported national schemes and the reported-benefit fallback for unsupported schemes.
+
   - legal_id: uk:statutes/ukpga/2007/3/10#income_charged_at_basic_rate
     country: uk
     program: tax
@@ -2084,6 +2095,12 @@ mappings:
     rationale: Same Universal Credit childcare work-condition predicate, with the EFRS oracle projecting person-level adult work status into the Regulation 32 claimant and other-member work leaves.
 
 prefixes:
+  - legal_id_prefix: uk:policies/govuk/council-tax-reduction#
+    country: uk
+    program: council_tax_reduction
+    mapping_type: not_comparable
+    rationale: Council Tax Reduction helper outputs expose source-law scheme selection, capital, excess-income, taper, and simulated-award mechanics; PolicyEngine UK exposes the final household council_tax_reduction variable rather than these helpers one-to-one.
+
   - legal_id_prefix: uk:statutes/ukpga/2007/3/35#
     country: uk
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -12148,6 +12148,33 @@ rules:
     assert capital_limit["mapping_type"] == "not_comparable"
 
 
+def test_kingston_council_tax_reduction_policy_surface_is_classified(tmp_path):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-uk-kingston-upon-thames"
+        / "policies/kingston-upon-thames/council-tax-reduction.yaml",
+        """format: rulespec/v1
+rules:
+  - name: kingston_upon_thames_council_tax_reduction_annual_amount
+    kind: derived
+    versions:
+      - effective_from: '2026-04-01'
+        formula: simulated_kingston_upon_thames_council_tax_reduction_annual_amount
+  - name: simulated_kingston_upon_thames_council_tax_reduction_annual_amount
+    kind: derived
+    versions:
+      - effective_from: '2026-04-01'
+        formula: council_tax_liability_for_year
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path)
+
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["program"] for item in report["items"]} == {"council_tax_reduction"}
+    assert {item["mapping_type"] for item in report["items"]} == {"not_comparable"}
+
+
 def test_universal_credit_housing_schedule_prefixes_are_classified(tmp_path):
     _write_rulespec_file(
         tmp_path

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -12088,6 +12088,66 @@ rules:
     assert item["mapping_type"] == "not_comparable"
 
 
+def test_council_tax_reduction_policy_surface_is_classified(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/council-tax-reduction.yaml",
+        """format: rulespec/v1
+rules:
+  - name: council_tax_reduction_annual_amount
+    kind: derived
+    versions:
+      - effective_from: '2026-04-01'
+        formula: simulated_council_tax_reduction_annual_amount
+  - name: simulated_council_tax_reduction_annual_amount
+    kind: derived
+    versions:
+      - effective_from: '2026-04-01'
+        formula: council_tax_liability_for_year
+  - name: council_tax_reduction_capital_limit
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-04-01'
+        value: 16000
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "policies/govuk/council-tax-reduction.test.yaml",
+        """- name: council_tax_reduction_award
+  period: 2026
+  output:
+    uk:policies/govuk/council-tax-reduction#council_tax_reduction_annual_amount: 1200
+    uk:policies/govuk/council-tax-reduction#simulated_council_tax_reduction_annual_amount: 1200
+    uk:policies/govuk/council-tax-reduction#council_tax_reduction_capital_limit: 16000
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path)
+
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 2,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    final = items_by_id[
+        "uk:policies/govuk/council-tax-reduction#council_tax_reduction_annual_amount"
+    ]
+    assert final["status"] == "comparable"
+    assert final["mapping_type"] == "direct_variable"
+    assert final["policyengine_variable"] == "council_tax_reduction"
+    assert final["tested"] is True
+    simulated = items_by_id[
+        "uk:policies/govuk/council-tax-reduction#simulated_council_tax_reduction_annual_amount"
+    ]
+    capital_limit = items_by_id[
+        "uk:policies/govuk/council-tax-reduction#council_tax_reduction_capital_limit"
+    ]
+    assert simulated["status"] == "known_not_comparable"
+    assert simulated["mapping_type"] == "not_comparable"
+    assert capital_limit["status"] == "known_not_comparable"
+    assert capital_limit["mapping_type"] == "not_comparable"
+
+
 def test_universal_credit_housing_schedule_prefixes_are_classified(tmp_path):
     _write_rulespec_file(
         tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -20796,6 +20796,33 @@ rules:
     assert 0.075 in extract_numeric_occurrences_from_text(source_text)
 
 
+def test_ungrounded_numeric_accepts_source_mixed_ascii_fraction_percentage():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: uk-kingston-upon-thames/manual/council-tax-reduction-scheme-2026-2027/page-28
+rules:
+  - name: council_tax_reduction_daily_excess_income_taper_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          0.02857142857142857
+"""
+
+    source_text = (
+        "amount B is 2 6/7 per cent of the difference between his income "
+        "for the relevant week and his applicable amount"
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert any(
+        math.isclose(value, 0.02857142857142857)
+        for value in extract_numeric_occurrences_from_text(source_text)
+    )
+
+
 def test_ungrounded_numeric_accepts_spelled_hundredths_percentage():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.621"
+version = "0.2.622"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.622"
+version = "0.2.623"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map the UK Council Tax Reduction final amount to PolicyEngine UK's `council_tax_reduction` variable
- classify CTR helper outputs under a UK RuleSpec prefix as known not comparable
- add coverage tests for the CTR policy surface

## Tests
- `.venv/bin/python -m pytest tests/test_policyengine_coverage.py`
- `.venv/bin/ruff check tests/test_policyengine_coverage.py && .venv/bin/ruff format --check tests/test_policyengine_coverage.py`
- `.venv/bin/python -m towncrier build --draft --version 0.0.0`
- `uv run axiom-encode oracle-coverage --root /tmp/axiom-ctr-coverage-root --json | jq '{status_counts, untested_comparable, total_outputs}'`
