### PR TITLE
Map Arizona cash assistance oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.625"
+version = "0.2.626"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.625"
+__version__ = "0.2.626"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -893,6 +893,52 @@ mappings:
     candidate_priority: P4
     rationale: Arizona manual shelter deduction output uses source-specific allowable shelter and utility inputs and cap-oriented homeless-deduction wording; PolicyEngine's final excess shelter deduction is adjacent but not a one-to-one output for this source boundary.
 
+  - legal_id: us-az:policies/des/faa5/ca-payment-standard-a1-2fa2#a1_annual_payment_standard_percentage_of_base_year_fpl
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.az.hhs.tanf.payment_standard.rate
+    period: year
+    comparison: rate
+    rationale: Same Arizona TANF A1 payment-standard percentage of the 1992 FPL.
+
+  - legal_id: us-az:policies/des/faa5/ca-benefit-determination/earned-income-deduction#ca_earned_income_deduction_rate
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.az.hhs.tanf.income.deductions.percentage
+    period: month
+    comparison: rate
+    rationale: Same Arizona TANF earned-income percentage disregard.
+
+  - legal_id: us-az:policies/des/faa5/ca-benefit-determination/cost-of-employment-deduction#cost_of_employment_monthly_deduction_amount
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.az.hhs.tanf.income.deductions.flat
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Arizona TANF flat earned-income disregard amount.
+
+  - legal_id: us-az:policies/des/faa5/ca-benefit-determination/needy-family-test#npcr_child_only_needy_family_fpl_limit_rate
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.az.hhs.tanf.income.fpg_limit.non_parent
+    period: year
+    comparison: rate
+    rationale: Same Arizona TANF non-parent caretaker relative child-only income-limit rate.
+
+  - legal_id: us-az:policies/des/faa5/ca-benefit-determination/needy-family-test#parent_or_npcr_self_and_child_needy_family_fpl_limit_rate
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.az.hhs.tanf.income.fpg_limit.base
+    period: year
+    comparison: rate
+    rationale: Same Arizona TANF base income-limit rate for parent or non-parent caretaker relative self-and-child cases.
+
   - legal_id: us:statutes/7/2017/a#snap_allotment_before_minimum
     country: us
     program: snap

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -14241,6 +14241,20 @@ prefixes:
     mapping_type: not_comparable
     rationale: Arizona manual net-income-test outputs decompose earned-income deduction, net-income construction, income-standard pass/fail, and denial predicates; PolicyEngine computes SNAP income eligibility through its own scenario and program variables rather than exposing these FAA5 source-slice helper outputs as one-to-one oracle targets.
 
+  - legal_id_prefix: us-az:policies/des/faa5/ca-payment-standard-a1-2fa2#
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona Cash Assistance A1/A2 payment-standard outputs are source-specific TANF payment-level predicates and 1992-FPL standard calculations. PolicyEngine-US exposes adjacent Arizona TANF grant variables through its own annual parameter graph, but does not expose these DES FAA5 A1/A2 legal helper boundaries one-to-one.
+
+  - legal_id_prefix: us-az:policies/des/faa5/ca-benefit-determination/
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona Cash Assistance benefit-determination outputs decompose DES FAA5 needy-family, payment-standard, under-$10 no-pay, and earned-income-deduction mechanics. PolicyEngine-US exposes adjacent TANF variables, but direct oracle comparison should wait for an adapter that targets the same Arizona CA source slices and helper boundaries.
+
   - legal_id_prefix: us:statutes/26/3102/a#
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -347,9 +347,9 @@ rules:
         "known_not_comparable": 4,
     }
     assert report["untested_comparable"] == 0
-    assert {
-        items_by_id[legal_id]["mapping_type"] for legal_id in exact_ids
-    } == {"parameter_value"}
+    assert {items_by_id[legal_id]["mapping_type"] for legal_id in exact_ids} == {
+        "parameter_value"
+    }
     assert {items_by_id[legal_id]["tested"] for legal_id in exact_ids} == {True}
     assert (
         items_by_id[

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -201,6 +201,170 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_arizona_tanf_exact_parameters(tmp_path):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/ca-payment-standard-a1-2fa2.yaml",
+        """format: rulespec/v1
+rules:
+  - name: a1_annual_payment_standard_percentage_of_base_year_fpl
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2025-09-02'
+        formula: 0.36
+  - name: a1_payment_standard_applies
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    versions:
+      - effective_from: '2025-09-02'
+        formula: budgetary_unit_has_obligation_to_pay_shelter_cost
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/ca-payment-standard-a1-2fa2.test.yaml",
+        """- name: a1_rate
+  output:
+    us-az:policies/des/faa5/ca-payment-standard-a1-2fa2#a1_annual_payment_standard_percentage_of_base_year_fpl: 0.36
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/ca-benefit-determination/earned-income-deduction.yaml",
+        """format: rulespec/v1
+rules:
+  - name: ca_earned_income_deduction_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2025-09-02'
+        formula: 0.30
+  - name: ca_earned_income_deduction
+    kind: derived
+    entity: Person
+    dtype: Money
+    versions:
+      - effective_from: '2025-09-02'
+        formula: ca_earned_income_deduction_rate * countable_earned_income
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/ca-benefit-determination/earned-income-deduction.test.yaml",
+        """- name: earned_income_rate
+  output:
+    us-az:policies/des/faa5/ca-benefit-determination/earned-income-deduction#ca_earned_income_deduction_rate: 0.3
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/ca-benefit-determination/cost-of-employment-deduction.yaml",
+        """format: rulespec/v1
+rules:
+  - name: cost_of_employment_monthly_deduction_amount
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2025-09-02'
+        formula: 90
+  - name: cost_of_employment_deduction_applies
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    versions:
+      - effective_from: '2025-09-02'
+        formula: participant_is_employed
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/ca-benefit-determination/cost-of-employment-deduction.test.yaml",
+        """- name: cost_of_employment_amount
+  output:
+    us-az:policies/des/faa5/ca-benefit-determination/cost-of-employment-deduction#cost_of_employment_monthly_deduction_amount: 90
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/ca-benefit-determination/needy-family-test.yaml",
+        """format: rulespec/v1
+rules:
+  - name: npcr_child_only_needy_family_fpl_limit_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2025-09-02'
+        formula: 1.30
+  - name: parent_or_npcr_self_and_child_needy_family_fpl_limit_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2025-09-02'
+        formula: 1.00
+  - name: needy_family_criteria_met
+    kind: derived
+    entity: TanfUnit
+    dtype: Judgment
+    versions:
+      - effective_from: '2025-09-02'
+        formula: caretaker_relative_family_income <= current_federal_poverty_level
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/ca-benefit-determination/needy-family-test.test.yaml",
+        """- name: needy_family_rates
+  output:
+    us-az:policies/des/faa5/ca-benefit-determination/needy-family-test#npcr_child_only_needy_family_fpl_limit_rate: 1.3
+    us-az:policies/des/faa5/ca-benefit-determination/needy-family-test#parent_or_npcr_self_and_child_needy_family_fpl_limit_rate: 1.0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tanf")
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+
+    exact_ids = {
+        "us-az:policies/des/faa5/ca-payment-standard-a1-2fa2#a1_annual_payment_standard_percentage_of_base_year_fpl",
+        "us-az:policies/des/faa5/ca-benefit-determination/earned-income-deduction#ca_earned_income_deduction_rate",
+        "us-az:policies/des/faa5/ca-benefit-determination/cost-of-employment-deduction#cost_of_employment_monthly_deduction_amount",
+        "us-az:policies/des/faa5/ca-benefit-determination/needy-family-test#npcr_child_only_needy_family_fpl_limit_rate",
+        "us-az:policies/des/faa5/ca-benefit-determination/needy-family-test#parent_or_npcr_self_and_child_needy_family_fpl_limit_rate",
+    }
+
+    assert report["total_outputs"] == 9
+    assert report["status_counts"] == {
+        "comparable": 5,
+        "known_not_comparable": 4,
+    }
+    assert report["untested_comparable"] == 0
+    assert {
+        items_by_id[legal_id]["mapping_type"] for legal_id in exact_ids
+    } == {"parameter_value"}
+    assert {items_by_id[legal_id]["tested"] for legal_id in exact_ids} == {True}
+    assert (
+        items_by_id[
+            "us-az:policies/des/faa5/ca-benefit-determination/earned-income-deduction#ca_earned_income_deduction"
+        ]["status"]
+        == "known_not_comparable"
+    )
+    assert (
+        items_by_id[
+            "us-az:policies/des/faa5/ca-payment-standard-a1-2fa2#a1_payment_standard_applies"
+        ]["candidate_priority"]
+        == "P4"
+    )
+
+
 def test_policyengine_coverage_classifies_new_york_tanf_state_plan_outputs(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.625"
+version = "0.2.626"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark Arizona DES FAA5 Cash Assistance payment-standard and benefit-determination outputs as TANF not-comparable oracle surfaces
- mirrors the existing CO/NY TANF pattern for source-specific legal helper boundaries where PolicyEngine-US exposes adjacent variables but not one-to-one outputs

## Validation
- parsed `src/axiom_encode/oracles/policyengine/mappings/us.yaml`
- local oracle-coverage CI mimic over the AZ CA RuleSpec branch checked 33 changed outputs with no unmapped/comparable-untested failures