### PR TITLE
Allow member helpers in unit aggregate scope checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.623"
+version = "0.2.624"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.624"
+version = "0.2.625"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.623"
+__version__ = "0.2.624"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.624"
+__version__ = "0.2.625"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -7275,6 +7275,23 @@ _HOUSEHOLD_MEMBER_MIXED_SCOPE_PATTERN = re.compile(
     r"\b(?:each|every|all|no)\s+(?:household\s+)?member\b",
     flags=re.IGNORECASE,
 )
+_UNIT_MEMBER_AGGREGATE_HELPER_SOURCE_PATTERN = re.compile(
+    r"\b(?:households?|snap\s+units?|food\s+assistance\s+units?|"
+    r"assistance\s+units?|tax\s+units?|filing\s+units?|famil(?:y|ies)|"
+    r"spm\s+units?)\b[\s\S]{0,240}\b(?:all|each|every|no)\s+"
+    r"(?:individuals?|persons?|(?:household\s+|family\s+)?members?)\b"
+    r"|"
+    r"\b(?:all|each|every|no)\s+"
+    r"(?:individuals?|persons?|(?:household\s+|family\s+)?members?)\b"
+    r"[\s\S]{0,240}\b(?:households?|snap\s+units?|food\s+assistance\s+"
+    r"units?|assistance\s+units?|tax\s+units?|filing\s+units?|"
+    r"famil(?:y|ies)|spm\s+units?)\b"
+    r"|"
+    r"\ball[-\s]+member[-\s]+(?:disqualif|ineligib|exclud)"
+    r"[\s\S]{0,120}\b(?:households?|snap\s+units?|food\s+assistance\s+"
+    r"units?|assistance\s+units?|famil(?:y|ies))\b",
+    flags=re.IGNORECASE,
+)
 _SOURCE_SCOPE_PERSON = "person"
 _SOURCE_SCOPE_UNIT = "unit"
 
@@ -7592,6 +7609,9 @@ def find_source_scope_consistency_issues(content: str) -> list[str]:
     rules = payload.get("rules")
     if not isinstance(rules, list):
         return []
+    unit_relation_aggregate_helper_names = (
+        _unit_relation_aggregate_helper_names_by_rule(payload, source_text)
+    )
     issues: list[str] = []
     for rule in rules:
         if not isinstance(rule, dict):
@@ -7623,6 +7643,13 @@ def find_source_scope_consistency_issues(content: str) -> list[str]:
                 fallback_source_text=source_text,
             ):
                 continue
+            if _person_rule_can_use_unit_member_aggregate_source(
+                rule,
+                name=name,
+                fallback_source_text=source_text,
+                unit_relation_aggregate_helper_names=unit_relation_aggregate_helper_names,
+            ):
+                continue
             issues.append(
                 "Source scope mismatch: "
                 f"`{name}` is declared on `Person`, but the embedded source "
@@ -7649,6 +7676,52 @@ def find_source_scope_consistency_issues(content: str) -> list[str]:
                 "scope or cite source text that states the declared unit scope."
             )
     return issues
+
+
+def _unit_relation_aggregate_helper_names_by_rule(
+    payload: dict[str, Any],
+    fallback_source_text: str,
+) -> set[str]:
+    helper_names: set[str] = set()
+    for _name, kind, formula, _rule_source, rule in _rulespec_rule_formula_rule_records(
+        payload
+    ):
+        if kind != "derived":
+            continue
+        entity = str(rule.get("entity") or "").strip().lower()
+        if entity not in _UNIT_SCOPED_ENTITY_NAMES:
+            continue
+        if not _RELATION_AGGREGATE_PATTERN.search(formula):
+            continue
+        source_scope_record = _rule_source_scope(rule, fallback_source_text)
+        if (
+            source_scope_record is not None
+            and source_scope_record[0] == _SOURCE_SCOPE_PERSON
+        ):
+            continue
+        helper_names.update(_formula_local_identifiers(formula))
+    return helper_names
+
+
+def _person_rule_can_use_unit_member_aggregate_source(
+    rule: dict[str, Any],
+    *,
+    name: str,
+    fallback_source_text: str,
+    unit_relation_aggregate_helper_names: set[str],
+) -> bool:
+    """Allow person helpers used only to evaluate all-member unit tests."""
+    if name not in unit_relation_aggregate_helper_names:
+        return False
+    if str(rule.get("dtype") or "").strip().lower() != "judgment":
+        return False
+    source_contexts = _rule_proof_source_excerpts(rule)
+    if not source_contexts and fallback_source_text:
+        source_contexts = [fallback_source_text]
+    return any(
+        _UNIT_MEMBER_AGGREGATE_HELPER_SOURCE_PATTERN.search(text)
+        for text in source_contexts
+    )
 
 
 def _formula_or_referenced_helpers_use_relation_aggregate(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -38,7 +38,7 @@ from dataclasses import dataclass, field
 from datetime import date
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Optional
+from typing import Any, Iterable, Iterator, Mapping, Optional
 
 import yaml
 
@@ -7699,7 +7699,46 @@ def _unit_relation_aggregate_helper_names_by_rule(
             and source_scope_record[0] == _SOURCE_SCOPE_PERSON
         ):
             continue
-        helper_names.update(_formula_local_identifiers(formula))
+        helper_names.update(_relation_aggregate_helper_identifiers(formula))
+    return helper_names
+
+
+_RELATION_AGGREGATE_CALL_START_PATTERN = re.compile(
+    r"\b(?P<function>count_where|sum_where|len|sum)\s*\(",
+    flags=re.IGNORECASE,
+)
+
+
+def _relation_aggregate_call_arguments(formula: str) -> Iterator[tuple[str, list[str]]]:
+    for match in _RELATION_AGGREGATE_CALL_START_PATTERN.finditer(formula):
+        depth = 1
+        index = match.end()
+        while index < len(formula):
+            char = formula[index]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    yield (
+                        match.group("function").lower(),
+                        _split_top_level_call_arguments(formula[match.end() : index]),
+                    )
+                    break
+            index += 1
+
+
+def _relation_aggregate_helper_identifiers(formula: str) -> set[str]:
+    helper_names: set[str] = set()
+    for function_name, arguments in _relation_aggregate_call_arguments(formula):
+        if len(arguments) < 2:
+            continue
+        relation_name = arguments[0].strip()
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", relation_name):
+            continue
+        if function_name in {"count_where", "sum_where"}:
+            for helper_argument in arguments[1:]:
+                helper_names.update(_formula_local_identifiers(helper_argument))
     return helper_names
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -12862,6 +12862,82 @@ rules:
     ]
 
 
+def test_source_scope_consistency_allows_person_helper_for_all_member_unit_aggregate():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    "Households that receive SNAP and Colorado Works (CW) basic cash assistance
+    that become ineligible" because of household income changes "are eligible
+    to receive T-SNAP." Eligible households have the "SNAP allotment continued
+    for five (5) months"; listed sanctioned or all-member-disqualified
+    households are not eligible.
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      predicate: member_of_household
+      arity: 2
+  - name: t_snap_member_snap_ineligibility_criterion
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: state regulation
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          member_disqualified_for_intentional_program_violation
+          or member_is_ineligible_student
+  - name: household_members_all_snap_ineligible_for_t_snap
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: state regulation
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          len(member_of_household) > 0
+          and count_where(member_of_household, t_snap_member_snap_ineligibility_criterion) == len(member_of_household)
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_rejects_unaggregated_person_helper_from_unit_source():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    "Households that receive SNAP and Colorado Works (CW) basic cash assistance
+    that become ineligible" because of household income changes "are eligible
+    to receive T-SNAP." Eligible households have the "SNAP allotment continued
+    for five (5) months"; listed sanctioned or all-member-disqualified
+    households are not eligible.
+rules:
+  - name: t_snap_member_snap_ineligibility_criterion
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: state regulation
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          member_disqualified_for_intentional_program_violation
+          or member_is_ineligible_student
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: "
+        "`t_snap_member_snap_ineligibility_criterion` is declared on `Person`, "
+        "but the embedded source states a household/unit-scoped test. Encode "
+        "the rule at the source-stated unit scope or cite source text that "
+        "states the person-level test."
+    ]
+
+
 def test_source_scope_consistency_allows_medicaid_magi_person_eligibility_with_household_income():
     content = """format: rulespec/v1
 module:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -12938,6 +12938,56 @@ rules:
     ]
 
 
+def test_source_scope_consistency_rejects_direct_person_helper_with_unrelated_unit_aggregate():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    "Households that receive SNAP and Colorado Works (CW) basic cash assistance
+    that become ineligible" because of household income changes "are eligible
+    to receive T-SNAP." Eligible households have the "SNAP allotment continued
+    for five (5) months"; listed sanctioned or all-member-disqualified
+    households are not eligible.
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      predicate: member_of_household
+      arity: 2
+  - name: t_snap_member_snap_ineligibility_criterion
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: state regulation
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          member_disqualified_for_intentional_program_violation
+          or member_is_ineligible_student
+  - name: household_has_direct_member_snap_ineligibility
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: state regulation
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          len(member_of_household) > 0
+          and t_snap_member_snap_ineligibility_criterion
+"""
+
+    issues = find_source_scope_consistency_issues(content)
+
+    assert issues == [
+        "Source scope mismatch: "
+        "`t_snap_member_snap_ineligibility_criterion` is declared on `Person`, "
+        "but the embedded source states a household/unit-scoped test. Encode "
+        "the rule at the source-stated unit scope or cite source text that "
+        "states the person-level test."
+    ]
+
+
 def test_source_scope_consistency_allows_medicaid_magi_person_eligibility_with_household_income():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.623"
+version = "0.2.624"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.624"
+version = "0.2.625"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- allow source-scope validation to accept Person judgment helpers only when a unit-scoped rule aggregates that helper through a relation
- recognize all-member unit source wording, including the generated Colorado T-SNAP summary shape
- keep rejecting unaggregated Person helpers derived from household/unit source text

## Tests
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py -k 'source_scope_consistency'
- uv run --extra dev ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py