### PR TITLE
Add Arizona SNAP composition repair

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.629"
+version = "0.2.630"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.626"
+version = "0.2.629"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.626"
+__version__ = "0.2.629"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.629"
+__version__ = "0.2.630"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1213,6 +1213,25 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_az_snap_composition_parser = subparsers.add_parser(
+        "repair-arizona-snap-composition",
+        help="Install signed deterministic Arizona SNAP FY 2026 composition",
+    )
+    repair_az_snap_composition_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="rulespec-us-az repository root used for manifest signing",
+    )
+    repair_az_snap_composition_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_snap_273_10_parser = subparsers.add_parser(
         "repair-snap-273-10-allotment",
         help="Apply signed deterministic repairs for 7 CFR 273.10 maximum-allotment drift",
@@ -1875,6 +1894,8 @@ def main():
         cmd_repair_colorado_snap_federal_refs(args)
     elif args.command == "repair-california-snap-shelter-surface":
         cmd_repair_california_snap_shelter_surface(args)
+    elif args.command == "repair-arizona-snap-composition":
+        cmd_repair_arizona_snap_composition(args)
     elif args.command == "repair-snap-273-10-allotment":
         cmd_repair_snap_273_10_allotment(args)
     elif args.command == "repair-new-york-snap-categorical-eligibility":
@@ -3576,6 +3597,15 @@ CALIFORNIA_SNAP_REPAIR_RELATIVE_OUTPUTS = (
     CALIFORNIA_SNAP_SUA_RELATIVE,
 )
 
+ARIZONA_SNAP_COMPOSITION_MODEL = "arizona-snap-composition-v1"
+ARIZONA_SNAP_PROGRAM_RELATIVE = Path(
+    "policies/des/faa5/na-eligibility-and-benefit-determination/"
+    "fy-2026-benefit-calculation.yaml"
+)
+ARIZONA_SNAP_BENEFIT_RELATIVE = Path(
+    "policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount.yaml"
+)
+
 
 def cmd_repair_colorado_snap_federal_refs(args):
     """Apply signed deterministic repairs for Colorado SNAP federal ref drift."""
@@ -3934,6 +3964,334 @@ def _write_california_snap_repair_manifests(
                 )
             )
     return manifest_paths
+
+
+def cmd_repair_arizona_snap_composition(args):
+    """Install the Arizona SNAP composition module with signed provenance."""
+    repo_path = Path(args.repo).resolve()
+    if _repo_jurisdiction_prefix(repo_path) != "us-az":
+        print(
+            "repair-arizona-snap-composition must run against rulespec-us-az; "
+            f"got {repo_path}"
+        )
+        sys.exit(1)
+
+    benefit_file = repo_path / ARIZONA_SNAP_BENEFIT_RELATIVE
+    if not benefit_file.exists():
+        print(f"Arizona SNAP benefit-amount RuleSpec file not found: {benefit_file}")
+        sys.exit(1)
+
+    rules_file = repo_path / ARIZONA_SNAP_PROGRAM_RELATIVE
+    test_file = _rulespec_test_path(rules_file)
+    manifest_groups = [(ARIZONA_SNAP_PROGRAM_RELATIVE, [rules_file, test_file])]
+    try:
+        _ensure_no_unmanifested_preexisting_rulespec_changes(repo_path, manifest_groups)
+    except RuntimeError as exc:
+        print(str(exc))
+        sys.exit(1)
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+
+    originals = {
+        rules_file: rules_file.read_text() if rules_file.exists() else None,
+        test_file: test_file.read_text() if test_file.exists() else None,
+    }
+    try:
+        changed = _write_arizona_snap_composition_files(rules_file, test_file)
+        refresh_manifest = False
+        if not changed:
+            if not _applied_manifest_matches_current_deterministic_repair(
+                repo_path=repo_path,
+                relative_output=ARIZONA_SNAP_PROGRAM_RELATIVE,
+                applied_files=[rules_file, test_file],
+                model=ARIZONA_SNAP_COMPOSITION_MODEL,
+                axiom_encode_git=axiom_encode_git,
+                signing_key=signing_key,
+            ):
+                refresh_manifest = True
+            else:
+                print("No Arizona SNAP composition repairs found.")
+                return
+
+        validation = ValidatorPipeline(
+            policy_repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+            enable_oracles=False,
+            require_policy_proofs=False,
+        ).validate(rules_file, skip_reviewers=True)
+        if not validation.all_passed:
+            issues = [
+                result.error for result in validation.results.values() if result.error
+            ]
+            raise RuntimeError("\n".join(issues) or "validation failed")
+
+        test_issues = _companion_test_issues(
+            test_files=[test_file],
+            repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+        )
+        if test_issues:
+            raise RuntimeError(
+                "Companion tests failed after Arizona SNAP composition install:\n"
+                + "\n".join(f"- {issue}" for issue in test_issues)
+            )
+    except Exception:
+        _restore_original_files(originals)
+        raise
+
+    changed_by_command = _unique_paths(
+        [
+            path
+            for path in changed
+            if _path_differs_from_original(path, originals.get(path))
+        ]
+    )
+    refresh_only = not changed_by_command and refresh_manifest
+    if refresh_only:
+        changed_by_command = [rules_file, test_file]
+    if not changed_by_command:
+        print("No Arizona SNAP composition repairs found.")
+        return
+
+    manifest_paths = _write_grouped_deterministic_repair_manifests(
+        repo_path=repo_path,
+        signing_key=signing_key,
+        axiom_encode_git=axiom_encode_git,
+        manifest_groups=manifest_groups,
+        changed_files=changed_by_command,
+        model=ARIZONA_SNAP_COMPOSITION_MODEL,
+        tool="axiom-encode repair-arizona-snap-composition",
+    )
+
+    if refresh_only:
+        print("Refreshed Arizona SNAP composition repair manifest")
+    else:
+        print("Applied Arizona SNAP composition repair")
+        for path in changed_by_command:
+            print(f"changed={path.relative_to(repo_path)}")
+    for manifest_path in manifest_paths:
+        print(f"manifest={manifest_path}")
+
+
+def _applied_manifest_matches_current_deterministic_repair(
+    *,
+    repo_path: Path,
+    relative_output: Path,
+    applied_files: list[Path],
+    model: str,
+    axiom_encode_git: dict[str, object],
+    signing_key: str,
+) -> bool:
+    manifest_path = repo_path / _applied_encoding_manifest_path(relative_output)
+    if not manifest_path.exists():
+        return False
+    try:
+        payload = json.loads(manifest_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return False
+    if payload.get("schema_version") != APPLIED_ENCODING_MANIFEST_SCHEMA:
+        return False
+    if payload.get("model") != model:
+        return False
+    if payload.get("axiom_encode_version") != __version__:
+        return False
+    signature_issue = _applied_encoding_manifest_signature_issue(payload, signing_key)
+    if signature_issue:
+        return False
+
+    payload_git = payload.get("axiom_encode_git")
+    if not isinstance(payload_git, dict):
+        return False
+    for key in ("commit", "dirty_tracked", "version", "version_commit"):
+        if key in axiom_encode_git and payload_git.get(key) != axiom_encode_git.get(
+            key
+        ):
+            return False
+
+    expected_hashes = {
+        path.relative_to(repo_path).as_posix(): _sha256_file(path)
+        for path in applied_files
+        if path.exists()
+    }
+    applied_entries = payload.get("applied_files")
+    if not isinstance(applied_entries, list):
+        return False
+    actual_hashes = {
+        str(entry.get("path")): str(entry.get("sha256"))
+        for entry in applied_entries
+        if isinstance(entry, dict)
+        and isinstance(entry.get("path"), str)
+        and isinstance(entry.get("sha256"), str)
+    }
+    return actual_hashes == expected_hashes
+
+
+def _write_arizona_snap_composition_files(
+    rules_file: Path,
+    test_file: Path,
+) -> list[Path]:
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    changed: list[Path] = []
+    rules_content = _arizona_snap_composition_rulespec()
+    test_content = _arizona_snap_composition_tests()
+    if not rules_file.exists() or rules_file.read_text() != rules_content:
+        rules_file.write_text(rules_content)
+        changed.append(rules_file)
+    if not test_file.exists() or test_file.read_text() != test_content:
+        test_file.write_text(test_content)
+        changed.append(test_file)
+    return changed
+
+
+def _arizona_snap_composition_rulespec() -> str:
+    return """format: rulespec/v1
+module:
+  kind: composition
+  source_verification:
+    corpus_citation_path: us-az/manual/des/faa5/na-eligibility-and-benefit-determination/block-9
+  summary: |-
+    Arizona Nutrition Assistance FY 2026 benefit calculation composition. This
+    module exposes the final regular-month SNAP/NA allotment surface for oracle
+    comparison by composing the encoded Arizona benefit-amount rule and boundary
+    bridge outputs for gross income, net income, eligibility, maximum allotment,
+    minimum allotment, and shelter deduction values. Those upstream bridge
+    values remain inputs until the full Arizona NA eligibility chain is encoded.
+imports:
+  - us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount
+rules:
+  - name: snap_gross_monthly_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Arizona Nutrition Assistance FY 2026 benefit calculation composition
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          max(0, snap_gross_monthly_earned_income + snap_total_monthly_unearned_income)
+
+  - name: snap_net_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Arizona Nutrition Assistance FY 2026 benefit calculation composition
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          max(0, na_net_income)
+
+  - name: snap_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: Arizona Nutrition Assistance FY 2026 benefit calculation composition
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          na_budgetary_unit_is_eligible
+
+  - name: snap_maximum_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Arizona Nutrition Assistance FY 2026 benefit calculation composition
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          max(0, thrifty_food_plan_amount_for_budgetary_unit_size)
+
+  - name: snap_excess_shelter_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Arizona Nutrition Assistance FY 2026 benefit calculation composition
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          max(0, snap_excess_shelter_deduction_for_net_income)
+
+  - name: snap_regular_month_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: FAA5 NA Eligibility and Benefit Determination, block 9
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          benefit_amount_after_allotment_test
+"""
+
+
+def _arizona_snap_composition_tests() -> str:
+    return """- name: regular_month_allotment_uses_arizona_benefit_amount
+  period: 2026-01
+  input:
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_gross_monthly_earned_income: 1000
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_total_monthly_unearned_income: 200
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.na_net_income: 800
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_excess_shelter_deduction_for_net_income: 150
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.thrifty_food_plan_amount_for_budgetary_unit_size: 536
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.na_budgetary_unit_is_eligible: true
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.budgetary_unit_participant_count: 2
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.minimum_na_allotment: 24
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.initial_month_proration_applies: false
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.prorated_initial_month_na_benefit: 0
+  output:
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_gross_monthly_income: 1200
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_net_income: 800
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_eligible: holds
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_maximum_allotment: 536
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 150
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_regular_month_allotment: 296
+
+- name: ineligible_unit_receives_zero_regular_month_allotment
+  period: 2026-01
+  input:
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_gross_monthly_earned_income: 0
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_total_monthly_unearned_income: 0
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.na_net_income: 0
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_excess_shelter_deduction_for_net_income: 0
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.thrifty_food_plan_amount_for_budgetary_unit_size: 536
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.na_budgetary_unit_is_eligible: false
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.budgetary_unit_participant_count: 3
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.minimum_na_allotment: 24
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.initial_month_proration_applies: false
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.prorated_initial_month_na_benefit: 0
+  output:
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_eligible: not_holds
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_regular_month_allotment: 0
+
+- name: one_person_zero_pre_allotment_rounds_up_to_minimum
+  period: 2026-01
+  input:
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_gross_monthly_earned_income: 0
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_total_monthly_unearned_income: 0
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.na_net_income: 2000
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#input.snap_excess_shelter_deduction_for_net_income: 0
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.thrifty_food_plan_amount_for_budgetary_unit_size: 298
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.na_budgetary_unit_is_eligible: true
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.budgetary_unit_participant_count: 1
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.minimum_na_allotment: 24
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.initial_month_proration_applies: false
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount#input.prorated_initial_month_na_benefit: 0
+  output:
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_eligible: holds
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_regular_month_allotment: 24
+"""
 
 
 def _migrate_california_snap_sua_layout(repo_path: Path) -> None:

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -165,6 +165,46 @@ JURISDICTION_CONFIGS = {
         display_name="California SNAP",
         additional_relation_ids=(AXIOM_RELATION_ID_BY_LABEL["member_of_household"],),
     ),
+    "us-az": JurisdictionConfig(
+        jurisdiction="us-az",
+        state_code="AZ",
+        repo_name="rulespec-us-az",
+        program_relative_path=Path(
+            "policies/des/faa5/na-eligibility-and-benefit-determination/"
+            "fy-2026-benefit-calculation.yaml"
+        ),
+        output_id_by_label={
+            "snap_regular_month_allotment": (
+                "us-az:policies/des/faa5/na-eligibility-and-benefit-determination/"
+                "fy-2026-benefit-calculation#snap_regular_month_allotment"
+            ),
+            "snap_gross_monthly_income": (
+                "us-az:policies/des/faa5/na-eligibility-and-benefit-determination/"
+                "fy-2026-benefit-calculation#snap_gross_monthly_income"
+            ),
+            "snap_net_income": (
+                "us-az:policies/des/faa5/na-eligibility-and-benefit-determination/"
+                "fy-2026-benefit-calculation#snap_net_income"
+            ),
+            "snap_eligible": (
+                "us-az:policies/des/faa5/na-eligibility-and-benefit-determination/"
+                "fy-2026-benefit-calculation#snap_eligible"
+            ),
+            "snap_maximum_allotment": (
+                "us-az:policies/des/faa5/na-eligibility-and-benefit-determination/"
+                "fy-2026-benefit-calculation#snap_maximum_allotment"
+            ),
+            "snap_excess_shelter_deduction": (
+                "us-az:policies/des/faa5/na-eligibility-and-benefit-determination/"
+                "fy-2026-benefit-calculation#snap_excess_shelter_deduction"
+            ),
+        },
+        utility_allowance_labels=(),
+        relation_id=AXIOM_RELATION_ID_BY_LABEL["member_of_household"],
+        member_entity_type="Person",
+        temp_prefix="az-snap-pe-ecps-",
+        display_name="Arizona SNAP",
+    ),
     "us-ny": JurisdictionConfig(
         jurisdiction="us-ny",
         state_code="NY",
@@ -871,6 +911,11 @@ def project_income_resource_inputs(
                 values["meets_snap_categorical_eligibility"][idx]
             ),
         }
+    if config.jurisdiction == "us-az":
+        return {
+            "snap_gross_monthly_earned_income": earned_income,
+            "snap_total_monthly_unearned_income": unearned_income,
+        }
     return {
         "employee_wages_received": earned_income,
         "other_gain_or_benefit_payments": unearned_income,
@@ -1118,6 +1163,7 @@ def load_policyengine_cases(
         "snap_unearned_income": calculate(sim, "snap_unearned_income", period_label),
         "snap_net_income": calculate(sim, "snap_net_income", period_label),
         "snap_max_allotment": calculate(sim, "snap_max_allotment", period_label),
+        "snap_min_allotment": calculate(sim, "snap_min_allotment", period_label),
         "snap_standard_deduction": calculate(
             sim, "snap_standard_deduction", period_label
         ),
@@ -1284,6 +1330,21 @@ def project_jurisdiction_household_inputs(
             "household_member_disqualified_for_failure_to_comply_with_periodic_reporting_requirements": False,
             "household_member_disqualified_for_intentional_program_violation": False,
             "household_member_ineligible_to_participate_in_snap": False,
+        }
+    if config.jurisdiction == "us-az":
+        return {
+            "na_net_income": money(values["snap_net_income"][idx]),
+            "na_budgetary_unit_is_eligible": bool(values["is_snap_eligible"][idx]),
+            "budgetary_unit_participant_count": int(values["snap_unit_size"][idx]),
+            "thrifty_food_plan_amount_for_budgetary_unit_size": money(
+                values["snap_max_allotment"][idx]
+            ),
+            "minimum_na_allotment": money(values["snap_min_allotment"][idx]),
+            "initial_month_proration_applies": False,
+            "prorated_initial_month_na_benefit": 0,
+            "snap_excess_shelter_deduction_for_net_income": money(
+                values["snap_excess_shelter_expense_deduction"][idx]
+            ),
         }
     return {}
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -755,6 +755,14 @@ mappings:
     candidate_priority: P4
     rationale: California CalFresh household bridge counts Axiom member eligibility over the household relation; PolicyEngine's SNAP eligibility is adjacent but includes PE's full eligibility graph.
 
+  - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#calfresh_income_and_resource_eligible
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: is_snap_eligible
+    candidate_priority: P4
+    rationale: California CalFresh income-and-resource bridge combines categorical eligibility, resource eligibility, and income eligibility as one composition predicate; PolicyEngine's SNAP eligibility is adjacent but computed through PE's full eligibility graph.
+
   - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_eligible
     country: us
     program: snap
@@ -892,6 +900,54 @@ mappings:
     policyengine_variable: snap_excess_shelter_expense_deduction
     candidate_priority: P4
     rationale: Arizona manual shelter deduction output uses source-specific allowable shelter and utility inputs and cap-oriented homeless-deduction wording; PolicyEngine's final excess shelter deduction is adjacent but not a one-to-one output for this source boundary.
+
+  - legal_id: us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_gross_monthly_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_gross_income
+    candidate_priority: P4
+    rationale: Arizona FY 2026 composition sums Axiom boundary earned and unearned inputs for the ECPS surface; PolicyEngine's SNAP gross income is adjacent but computed from PE's own income source graph.
+
+  - legal_id: us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_net_income
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_net_income
+    candidate_priority: P4
+    rationale: Arizona FY 2026 composition passes the Axiom net-income boundary into the ECPS surface; PolicyEngine's SNAP net income is adjacent but computed from PE's deduction graph.
+
+  - legal_id: us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_eligible
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: is_snap_eligible
+    candidate_priority: P4
+    rationale: Arizona FY 2026 composition gates the benefit surface through Axiom NA eligibility; PolicyEngine eligibility is adjacent but computed from PE's full eligibility graph.
+
+  - legal_id: us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_maximum_allotment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_max_allotment
+    candidate_priority: P4
+    rationale: Arizona FY 2026 composition passes the Axiom Thrifty Food Plan allotment boundary for the budgetary-unit size; PolicyEngine's maximum allotment is adjacent but derives from PE household size and region.
+
+  - legal_id: us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_excess_shelter_deduction
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_excess_shelter_expense_deduction
+    candidate_priority: P4
+    rationale: Arizona FY 2026 composition passes the Axiom shelter-deduction boundary into the ECPS surface; PolicyEngine's shelter deduction is adjacent but uses PE housing and utility inputs.
+
+  - legal_id: us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_regular_month_allotment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap
+    candidate_priority: P4
+    rationale: Arizona FY 2026 composition exposes the regular-month NA allotment after Axiom eligibility and benefit-amount inputs; PolicyEngine's SNAP amount is adjacent but computed from PE's full graph.
 
   - legal_id: us-az:policies/des/faa5/ca-payment-standard-a1-2fa2#a1_annual_payment_standard_percentage_of_base_year_fpl
     country: us

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -15718,6 +15718,24 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 1396a(xx) Medicaid community-engagement outputs implement the H.R.1 work-requirement mandate and source-specific exceptions; PolicyEngine US does not expose this federal Medicaid work-requirement workflow as one-to-one oracle variables.
 
+  - legal_id_prefix: us:regulations/42-cfr/431/213#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 431.213 advance-notice exception predicates are Medicaid notice-administration rules; PolicyEngine US does not expose these process predicates as one-to-one oracle variables.
+
+  - legal_id_prefix: us:regulations/42-cfr/431/231#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 431.231 reinstatement predicates are Medicaid notice and service-administration rules outside PolicyEngine US's one-to-one oracle surface.
+
+  - legal_id_prefix: us:regulations/42-cfr/438/58#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 438.58 community-engagement contractor conflict safeguards are Medicaid managed-care administration rules not represented as PolicyEngine US variables or parameters.
+
   - legal_id_prefix: us:regulations/42-cfr/435/110#
     country: us
     program: medicaid
@@ -15825,3 +15843,21 @@ prefixes:
     program: medicaid
     mapping_type: not_comparable
     rationale: 42 CFR 435.563 reporting obligations are CMS Medicaid work-requirement administration rules outside PolicyEngine US's one-to-one oracle surface.
+
+  - legal_id_prefix: us:regulations/42-cfr/457/340#
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    rationale: 42 CFR 457.340 timely-determination cross-reference predicates are CHIP administration rules; PolicyEngine US does not expose this CFR-level compliance surface as one-to-one variables.
+
+  - legal_id_prefix: us:regulations/42-cfr/457/960#
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    rationale: 42 CFR 457.960 CHIP change-reporting and redetermination process predicates are administration rules not represented as one-to-one PolicyEngine US outputs.
+
+  - legal_id_prefix: us:regulations/42-cfr/600/320#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    rationale: 42 CFR 600.320 Basic Health Program timely-determination cross-reference predicates are program-administration rules outside PolicyEngine US's one-to-one oracle surface.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,6 +125,7 @@ from axiom_encode.cli import (
     cmd_log_event,
     cmd_oracle_candidates,
     cmd_oracle_coverage,
+    cmd_repair_arizona_snap_composition,
     cmd_repair_current_year_final_amounts,
     cmd_repair_imported_test_inputs,
     cmd_repair_judgment_positive_tests,
@@ -164,7 +165,11 @@ from axiom_encode.harness.encoding_db import (
 )
 from axiom_encode.harness.evals import EvalArtifactMetrics
 from axiom_encode.harness.validator_pipeline import _load_nearby_eval_source_metadata
-from axiom_encode.oracles.policyengine.ecps_snap import JURISDICTION_CONFIGS
+from axiom_encode.oracles.policyengine.ecps_snap import (
+    JURISDICTION_CONFIGS,
+    project_income_resource_inputs,
+    project_jurisdiction_household_inputs,
+)
 from axiom_encode.statute import citation_to_citation_path, parse_usc_citation
 
 TEST_APPLY_SIGNING_KEY = "test-apply-signing-key"
@@ -202,6 +207,42 @@ def test_colorado_snap_ecps_uses_absolute_member_relation_only():
 
     assert config.relation_id == "us:statutes/7/2012/j#relation.member_of_household"
     assert config.additional_relation_ids == ()
+
+
+def test_arizona_snap_ecps_projects_boundary_inputs():
+    config = JURISDICTION_CONFIGS["us-az"]
+    values = {
+        "snap_earned_income": [1000],
+        "snap_unearned_income": [200],
+        "snap_assets": [500],
+        "snap_net_income": [750],
+        "is_snap_eligible": [True],
+        "snap_unit_size": [2],
+        "snap_max_allotment": [536],
+        "snap_min_allotment": [24],
+        "snap_excess_shelter_expense_deduction": [150],
+        "snap_dependent_care_deduction": [0],
+    }
+
+    assert config.program_relative_path.as_posix() == (
+        "policies/des/faa5/na-eligibility-and-benefit-determination/"
+        "fy-2026-benefit-calculation.yaml"
+    )
+    assert config.utility_allowance_labels == ()
+    assert project_income_resource_inputs(config, values, 0) == {
+        "snap_gross_monthly_earned_income": 1000.0,
+        "snap_total_monthly_unearned_income": 200.0,
+    }
+    assert project_jurisdiction_household_inputs(config, values, 0) == {
+        "na_net_income": 750.0,
+        "na_budgetary_unit_is_eligible": True,
+        "budgetary_unit_participant_count": 2,
+        "thrifty_food_plan_amount_for_budgetary_unit_size": 536.0,
+        "minimum_na_allotment": 24.0,
+        "initial_month_proration_applies": False,
+        "prorated_initial_month_na_benefit": 0,
+        "snap_excess_shelter_deduction_for_net_income": 150.0,
+    }
 
 
 def _signed_manifest_payload(payload: dict) -> dict:
@@ -7416,6 +7457,157 @@ rules:
             ".axiom/encoding-manifests/guidance/cdss/acin-2025-i-46-25/standard-utility-allowance.json"
             in str(exc.value)
         )
+
+    def test_repair_arizona_snap_composition_writes_signed_manifest(self, tmp_path):
+        policy_repo = tmp_path / "rulespec-us-az"
+        _init_test_git_repo(policy_repo)
+        benefit_file = (
+            policy_repo
+            / "policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount.yaml"
+        )
+        benefit_file.parent.mkdir(parents=True)
+        benefit_file.write_text("format: rulespec/v1\nrules: []\n")
+        _git(policy_repo, "add", ".")
+        _git(policy_repo, "commit", "-m", "initial")
+
+        target = (
+            policy_repo / "policies/des/faa5/na-eligibility-and-benefit-determination/"
+            "fy-2026-benefit-calculation.yaml"
+        )
+        test_file = target.with_name("fy-2026-benefit-calculation.test.yaml")
+        args = SimpleNamespace(
+            repo=policy_repo,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is False
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._companion_test_issues",
+                return_value=[],
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_arizona_snap_composition(args)
+
+        content = target.read_text()
+        assert "kind: composition" in content
+        assert "snap_regular_month_allotment" in content
+        assert "snap_maximum_allotment" in content
+        assert "snap_excess_shelter_deduction" in content
+        test_content = test_file.read_text()
+        assert "regular_month_allotment_uses_arizona_benefit_amount" in test_content
+        assert "snap_excess_shelter_deduction_for_net_income: 150" in test_content
+        manifest = (
+            policy_repo / ".axiom/encoding-manifests/policies/des/faa5/"
+            "na-eligibility-and-benefit-determination/"
+            "fy-2026-benefit-calculation.json"
+        )
+        payload = json.loads(manifest.read_text())
+        assert payload["schema_version"] == APPLIED_ENCODING_MANIFEST_SCHEMA
+        assert payload["model"] == "arizona-snap-composition-v1"
+        assert payload["tool"] == "axiom-encode repair-arizona-snap-composition"
+        assert [applied_file["path"] for applied_file in payload["applied_files"]] == [
+            "policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.yaml",
+            "policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.test.yaml",
+        ]
+
+    def test_repair_arizona_snap_composition_refreshes_stale_manifest(self, tmp_path):
+        policy_repo = tmp_path / "rulespec-us-az"
+        _init_test_git_repo(policy_repo)
+        benefit_file = (
+            policy_repo
+            / "policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount.yaml"
+        )
+        benefit_file.parent.mkdir(parents=True)
+        benefit_file.write_text("format: rulespec/v1\nrules: []\n")
+        _git(policy_repo, "add", ".")
+        _git(policy_repo, "commit", "-m", "initial")
+
+        target = (
+            policy_repo / "policies/des/faa5/na-eligibility-and-benefit-determination/"
+            "fy-2026-benefit-calculation.yaml"
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is False
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        manifest = (
+            policy_repo / ".axiom/encoding-manifests/policies/des/faa5/"
+            "na-eligibility-and-benefit-determination/"
+            "fy-2026-benefit-calculation.json"
+        )
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._companion_test_issues",
+                return_value=[],
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "old123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_arizona_snap_composition(args)
+
+        first_payload = json.loads(manifest.read_text())
+        assert first_payload["axiom_encode_git"]["commit"] == "old123"
+        first_rules_content = target.read_text()
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._companion_test_issues",
+                return_value=[],
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "new456", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_arizona_snap_composition(args)
+
+        refreshed_payload = json.loads(manifest.read_text())
+        assert target.read_text() == first_rules_content
+        assert refreshed_payload["axiom_encode_git"]["commit"] == "new456"
+        assert [item["path"] for item in refreshed_payload["applied_files"]] == [
+            "policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.yaml",
+            "policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.test.yaml",
+        ]
 
     def test_repair_new_york_snap_categorical_eligibility_adds_final_outputs(self):
         rules = """format: rulespec/v1

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4471,6 +4471,147 @@ rules:
     assert deduction["tested"] is True
 
 
+def test_policyengine_coverage_classifies_california_income_resource_bridge(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-ca"
+        / "policies/cdss/snap/fy-2026-benefit-calculation.yaml",
+        """format: rulespec/v1
+rules:
+  - name: calfresh_income_and_resource_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: snap_categorically_eligible_for_resource_exemption or (snap_resource_eligible and snap_standard_income_eligible)
+""",
+    )
+
+    coverage = build_policyengine_coverage_report(tmp_path, program="snap")
+    candidates = build_policyengine_candidate_report(tmp_path, program="snap")
+
+    assert coverage["status_counts"] == {"known_not_comparable": 1}
+    item = coverage["items"][0]
+    assert item["legal_id"] == (
+        "us-ca:policies/cdss/snap/fy-2026-benefit-calculation"
+        "#calfresh_income_and_resource_eligible"
+    )
+    assert item["status"] == "known_not_comparable"
+    assert item["policyengine_variable"] == "is_snap_eligible"
+    assert item["candidate_priority"] == "P4"
+    assert candidates["category_counts"] == {"known_adjacent_target": 1}
+    assert candidates["priority_counts"] == {"P4": 1}
+
+
+def test_policyengine_coverage_classifies_arizona_snap_composition_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.yaml",
+        """format: rulespec/v1
+rules:
+  - name: snap_gross_monthly_income
+    kind: derived
+    versions:
+      - effective_from: '2025-10-01'
+        formula: earned_income + unearned_income
+  - name: snap_net_income
+    kind: derived
+    versions:
+      - effective_from: '2025-10-01'
+        formula: max(0, snap_gross_monthly_income - deductions)
+  - name: snap_eligible
+    kind: derived
+    versions:
+      - effective_from: '2025-10-01'
+        formula: income_eligible and resource_eligible
+  - name: snap_maximum_allotment
+    kind: derived
+    versions:
+      - effective_from: '2025-10-01'
+        formula: thrift_food_plan_amount
+  - name: snap_excess_shelter_deduction
+    kind: derived
+    versions:
+      - effective_from: '2025-10-01'
+        formula: shelter_deduction
+  - name: snap_regular_month_allotment
+    kind: derived
+    versions:
+      - effective_from: '2025-10-01'
+        formula: max(0, snap_maximum_allotment - expected_contribution)
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-az"
+        / "policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.test.yaml",
+        """- name: composition_outputs_are_tested
+  period: 2026-01
+  input: {}
+  output:
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_gross_monthly_income: 2000
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_net_income: 1200
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_eligible: holds
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_maximum_allotment: 768
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_excess_shelter_deduction: 350
+    us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_regular_month_allotment: 408
+""",
+    )
+
+    coverage = build_policyengine_coverage_report(tmp_path, program="snap")
+
+    assert coverage["status_counts"] == {"known_not_comparable": 6}
+    composition_items = {
+        item["rule_name"]: item
+        for item in coverage["items"]
+        if item["file"].endswith("fy-2026-benefit-calculation.yaml")
+    }
+    assert set(composition_items) == {
+        "snap_gross_monthly_income",
+        "snap_net_income",
+        "snap_eligible",
+        "snap_maximum_allotment",
+        "snap_excess_shelter_deduction",
+        "snap_regular_month_allotment",
+    }
+    assert {item["status"] for item in composition_items.values()} == {
+        "known_not_comparable"
+    }
+    assert {item["candidate_priority"] for item in composition_items.values()} == {"P4"}
+    assert {item["tested"] for item in composition_items.values()} == {True}
+    assert (
+        composition_items["snap_gross_monthly_income"]["policyengine_variable"]
+        == "snap_gross_income"
+    )
+    assert (
+        composition_items["snap_net_income"]["policyengine_variable"]
+        == "snap_net_income"
+    )
+    assert (
+        composition_items["snap_eligible"]["policyengine_variable"]
+        == "is_snap_eligible"
+    )
+    assert (
+        composition_items["snap_maximum_allotment"]["policyengine_variable"]
+        == "snap_max_allotment"
+    )
+    assert (
+        composition_items["snap_excess_shelter_deduction"]["policyengine_variable"]
+        == "snap_excess_shelter_expense_deduction"
+    )
+    assert (
+        composition_items["snap_regular_month_allotment"]["policyengine_variable"]
+        == "snap"
+    )
+
+
 def test_policyengine_coverage_classifies_arizona_snap_utility_eligibility(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.629"
+version = "0.2.630"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.626"
+version = "0.2.629"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a deterministic `repair-arizona-snap-composition` command
- allow the Arizona repair command to refresh stale signed manifests when generated files are already canonical
- add Arizona SNAP ECPS projection config for PE-adjacent SNAP outputs
- classify the Arizona SNAP composition outputs and California CalFresh income/resource bridge so SNAP oracle coverage has zero unmapped outputs for these surfaces
- classify CMS Medicaid/CHIP/BHP CFR process outputs as known non-comparable so the paired CMS RuleSpec PR clears PolicyEngine oracle coverage
- bump axiom-encode to 0.2.630 so generated manifests can point at the repair command and mapping changes after #579/#392 landed

## Gates
- `uv run --extra dev python -m pytest tests/test_cli.py -k "current_encoder_affecting_changes_are_behind_version_bump or arizona_snap_ecps_projects_boundary_inputs or repair_arizona_snap_composition"`
- `uv run --extra dev python -m pytest tests/test_cli.py -k "current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject"`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k "arizona_snap_composition or california_income_resource_bridge"`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `git diff --check`
- `uv run axiom-encode oracle-coverage --root /tmp/axiom-az-coverage-copy --oracle policyengine --program snap --json` shows `rulespec-us-az` SNAP coverage with `comparable=4`, `known_not_comparable=45`, zero unmapped outputs, and zero untested comparable outputs
- `uv run axiom-encode oracle-coverage --root /tmp/axiom-cms-coverage-root --oracle policyengine --json` shows the paired CMS CFR outputs as `known_not_comparable`

## Notes
- Draft until the refreshed CI for this branch is green.
- The paired Arizona rulespec PR is TheAxiomFoundation/rulespec-us-az#7 and references encoder commit `e116e453d8816eecf202b61d801193b2cca7e9b7`.
- The paired CMS rulespec PR is TheAxiomFoundation/rulespec-us#393 and depends on these CMS PolicyEngine oracle mappings.