### PR TITLE
Classify Arizona CA JOBS age outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.630"
+version = "0.2.631"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.630"
+__version__ = "0.2.631"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -995,6 +995,20 @@ mappings:
     comparison: rate
     rationale: Same Arizona TANF base income-limit rate for parent or non-parent caretaker relative self-and-child cases.
 
+  - legal_id: us-az:policies/des/faa5/ca-jobs-exemptions/age#jobs_program_participation_age_exemption_applies
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 JOBS participation age exemption is a TANF work-program administrative exemption; PolicyEngine does not expose this work-program participation predicate.
+
+  - legal_id: us-az:policies/des/faa5/ca-jobs-exemptions/age#minor_parent_head_or_spouse_exception_applies
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 minor-parent exception to the JOBS age exemption is an administrative work-program branch; PolicyEngine does not expose this exception predicate.
+
   - legal_id: us:statutes/7/2017/a#snap_allotment_before_minimum
     country: us
     program: snap

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.630"
+version = "0.2.631"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify the Arizona CA JOBS age exemption outputs as PolicyEngine not-comparable
- bump axiom-encode to 0.2.631 for oracle mapping provenance

## Why
The Arizona RuleSpec PR for CA JOBS age exemptions locally validates, but CI cannot complete oracle coverage until these administrative TANF work-program predicates are explicitly classified.

## Validation
- uv run --extra dev python -m pytest tests/test_cli.py -k "current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject" -q
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check