### PR TITLE
Classify Arizona CA JOBS Tribal NEW output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.631"
+version = "0.2.632"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.631"
+__version__ = "0.2.632"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1009,6 +1009,13 @@ mappings:
     candidate_priority: P4
     rationale: Arizona FAA5 minor-parent exception to the JOBS age exemption is an administrative work-program branch; PolicyEngine does not expose this exception predicate.
 
+  - legal_id: us-az:policies/des/faa5/ca-jobs-exemptions/tribal-new#exempt_from_jobs_participation
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 Tribal NEW JOBS exemption is a TANF work-program administrative exemption; PolicyEngine does not expose this source-specific work-program participation predicate.
+
   - legal_id: us:statutes/7/2017/a#snap_allotment_before_minimum
     country: us
     program: snap

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.631"
+version = "0.2.632"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify the Arizona CA JOBS Tribal NEW exemption output as not comparable to PolicyEngine
- bump axiom-encode to 0.2.632

## Why
The Arizona FAA5 Tribal NEW exemption is a source-specific TANF work-program participation exemption. PolicyEngine does not expose that administrative predicate, so the generated RuleSpec policy needs an explicit oracle mapping before its changed-oracle coverage gate can pass.

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev python -m pytest tests/test_cli.py -k "current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject" -q
- uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && git diff --check