### PR TITLE
Classify Arizona CA JOBS generated outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.632"
+version = "0.2.633"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.633"
+version = "0.2.634"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.632"
+__version__ = "0.2.633"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.633"
+__version__ = "0.2.634"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1022,6 +1022,13 @@ mappings:
     candidate_priority: P4
     rationale: Arizona FAA5 Tribal NEW JOBS exemption is a TANF work-program administrative exemption; PolicyEngine does not expose this source-specific work-program participation predicate.
 
+  - legal_id: us-az:policies/des/faa5/ca-jobs-exemptions/working-in-unsubsidized-employment#unsubsidized_employment_exemption_applies
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 unsubsidized-employment JOBS exemption is a TANF work-program administrative exemption; PolicyEngine does not expose this source-specific work-program participation predicate.
+
   - legal_id: us:statutes/7/2017/a#snap_allotment_before_minimum
     country: us
     program: snap

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1015,6 +1015,12 @@ mappings:
     mapping_type: not_comparable
     candidate_priority: P4
     rationale: Arizona FAA5 Tribal NEW JOBS exemption is a TANF work-program administrative exemption; PolicyEngine does not expose this source-specific work-program participation predicate.
+  - legal_id: us-az:policies/des/faa5/ca-jobs-exemptions/tribal-new#tribal_new_program_area_exemption_applies
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 Tribal NEW JOBS exemption is a TANF work-program administrative exemption; PolicyEngine does not expose this source-specific work-program participation predicate.
 
   - legal_id: us:statutes/7/2017/a#snap_allotment_before_minimum
     country: us

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.632"
+version = "0.2.633"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.633"
+version = "0.2.634"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated Arizona CA JOBS Tribal NEW and unsubsidized-employment exemption outputs as not comparable to PolicyEngine
- bump axiom-encode to 0.2.634

## Why
Both generated RuleSpec outputs are source-specific TANF work-program participation predicates. PolicyEngine does not expose these administrative JOBS exemption predicates, so downstream changed-oracle coverage needs them mapped explicitly rather than treated as missing comparable outputs.

## Validation
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev python -m pytest tests/test_cli.py -k "current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject" -q`
- `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && git diff --check`
