### PR TITLE
Classify Arizona CA JOBS JPPO outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.635"
+version = "0.2.636"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.635"
+__version__ = "0.2.636"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1085,6 +1085,27 @@ mappings:
     candidate_priority: P4
     rationale: Arizona FAA5 CA JOBS referral-required output is a TANF work-program administrative referral decision; PolicyEngine does not expose this source-specific work-program referral predicate.
 
+  - legal_id: us-az:policies/des/faa5/ca-jobs-program-preliminary-orientation-jppo#jppo_completion_required_before_ca_approval
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 JPPO preapproval completion requirement is a TANF work-program administrative compliance predicate; PolicyEngine does not expose this source-specific JPPO approval gate.
+
+  - legal_id: us-az:policies/des/faa5/ca-jobs-program-preliminary-orientation-jppo#jppo_compliance_completed_with_faa_worker
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 JPPO completion with an FAA worker is a TANF work-program administrative compliance predicate; PolicyEngine does not expose this source-specific JPPO completion predicate.
+
+  - legal_id: us-az:policies/des/faa5/ca-jobs-program-preliminary-orientation-jppo#jppo_requirement_exception_applies
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 JPPO exception handling is a TANF work-program administrative compliance boundary; PolicyEngine does not expose this source-specific JPPO exception predicate.
+
   - legal_id: us:statutes/7/2017/a#snap_allotment_before_minimum
     country: us
     program: snap

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.635"
+version = "0.2.636"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary\n- Adds PolicyEngine oracle mappings for Arizona CA JOBS JPPO outputs as not comparable.\n- Bumps axiom-encode to 0.2.636.\n\n## Validation\n- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q: 283 passed\n- uv run --extra dev python -m pytest tests/test_cli.py -k "current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject" -q: 2 passed\n- uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && git diff --check: passed\n- axiom-encode validate JPPO RuleSpec with --oracle policyengine --require-oracle-classification: passed; 6 unsupported, 0 unmapped\n