### PR TITLE
Add Arizona CA JOBS work requirements oracle mapping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.636"
+version = "0.2.637"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.636"
+__version__ = "0.2.637"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1106,6 +1106,13 @@ mappings:
     candidate_priority: P4
     rationale: Arizona FAA5 JPPO exception handling is a TANF work-program administrative compliance boundary; PolicyEngine does not expose this source-specific JPPO exception predicate.
 
+  - legal_id: us-az:policies/des/faa5/ca-jobs-work-program-requirements#ca_jobs_program_participation_required
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 CA JOBS work-program participation requirement is a TANF work-program administrative participation predicate; PolicyEngine does not expose this source-specific work-program participation requirement.
+
   - legal_id: us:statutes/7/2017/a#snap_allotment_before_minimum
     country: us
     program: snap

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.636"
+version = "0.2.637"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Arizona CA JOBS work-program participation requirement as not comparable to PolicyEngine
- bump axiom-encode to 0.2.637

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev python -m pytest tests/test_cli.py -k "current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject" -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check
- RuleSpec validation for policies/des/faa5/ca-jobs-work-program-requirements.yaml with PolicyEngine oracle classification
- one-repo oracle coverage: 9 comparable, 89 known_not_comparable, 0 unmapped