### PR TITLE
Add Arizona NA TBA oracle mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.638"
+version = "0.2.639"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.638"
+__version__ = "0.2.639"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1134,6 +1134,55 @@ mappings:
     candidate_priority: P4
     rationale: Arizona FAA5 TPEP Jobs benefit release after participant compliance is a TANF work-program administrative compliance gate; PolicyEngine does not expose this source-specific TPEP Jobs release predicate.
 
+  - legal_id: us-az:policies/des/faa5/na-transitional-benefit-assistance-tba#tba_max_consecutive_months
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 NA Transitional Benefit Assistance maximum consecutive-month parameter is a state-specific transitional NA rule; PolicyEngine does not expose this Arizona TBA duration as a comparable SNAP parameter.
+
+  - legal_id: us-az:policies/des/faa5/na-transitional-benefit-assistance-tba#tba_closure_reason_qualifies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 NA Transitional Benefit Assistance closure-reason qualifier depends on source-specific CA closure administration; PolicyEngine does not expose this Arizona TBA transition predicate as a comparable SNAP output.
+
+  - legal_id: us-az:policies/des/faa5/na-transitional-benefit-assistance-tba#tribal_tanf_transition_program_qualifies
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 NA Transitional Benefit Assistance Tribal TANF program qualifier is a source-specific HFAP/SRP-MIC LEARN transition boundary; PolicyEngine does not expose this Arizona TBA predicate.
+
+  - legal_id: us-az:policies/des/faa5/na-transitional-benefit-assistance-tba#na_tba_potentially_eligible
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 NA Transitional Benefit Assistance potential eligibility is a state-specific transition predicate combining CA closure and Tribal TANF gates; PolicyEngine does not expose this Arizona TBA eligibility boundary.
+
+  - legal_id: us-az:policies/des/faa5/na-transitional-benefit-assistance-tba#na_tba_five_month_period_ended
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 NA Transitional Benefit Assistance five-month-period-ended output is a state-specific TBA closure predicate; PolicyEngine does not expose this Arizona TBA administrative duration gate.
+
+  - legal_id: us-az:policies/des/faa5/na-transitional-benefit-assistance-tba#na_tba_no_longer_eligible
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 NA Transitional Benefit Assistance no-longer-eligible output is a source-specific closure predicate; PolicyEngine does not expose this Arizona TBA closure boundary as a comparable SNAP output.
+
+  - legal_id: us-az:policies/des/faa5/na-transitional-benefit-assistance-tba#na_tba_eligible
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Arizona FAA5 NA Transitional Benefit Assistance eligibility is a state-specific transitional NA benefit rule combining CA closure, compliance, disqualification, and closure gates; PolicyEngine does not expose Arizona TBA eligibility as a comparable SNAP variable.
+
   - legal_id: us:statutes/7/2017/a#snap_allotment_before_minimum
     country: us
     program: snap

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.638"
+version = "0.2.639"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Adds PolicyEngine oracle classifications for Arizona DES FAA5 NA Transitional Benefit Assistance (TBA) outputs.

These are classified as `not_comparable` because PolicyEngine does not expose Arizona-specific TBA transition eligibility, closure, Tribal TANF qualifier, or five-month duration boundaries as comparable SNAP variables/parameters.

Version: 0.2.639

Local checks:
- `pytest tests/test_policyengine_coverage.py -q`: 283 passed
- `pytest tests/test_cli.py -k "current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject" -q`: 2 passed
- `ruff check src/ tests/`: passed
- `ruff format --check src/ tests/`: passed
- `git diff --check`: passed
- TBA direct `axiom-encode validate ... --oracle policyengine --require-oracle-classification --json`: passed, 13 unsupported / 0 unmapped
- One-repo TBA coverage with this branch: 9 comparable, 96 known_not_comparable, 0 unmapped