### PR TITLE
Add Arizona disqualified participant oracle mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.642"
+version = "0.2.643"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.642"
+__version__ = "0.2.643"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -961,6 +961,46 @@ mappings:
     candidate_priority: P4
     rationale: Arizona eligible-no-pay status after NA proration is an administrative status predicate for prorated benefits below the minimum allotment; PolicyEngine's final SNAP benefit amount is adjacent but does not expose this no-pay status.
 
+  - legal_id: us-az:policies/des/faa5/disqualified-na-participant-s-effect-on-the-na/disqualified-participant-effect-on-na-benefit-amount#disqualified_participant_excluded_from_budgetary_unit_size_and_benefit_level
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_unit_size
+    candidate_priority: P4
+    rationale: Arizona states a participant-level exclusion from budgetary-unit size and benefit-level assignment for disqualified participants; PolicyEngine exposes resulting SNAP unit size surfaces, but not this Arizona disqualified-participant exclusion predicate.
+
+  - legal_id: us-az:policies/des/faa5/disqualified-na-participant-s-effect-on-the-na/disqualified-participant-effect-on-na-benefit-amount#disqualified_participant_included_for_utility_allowance
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_standard_utility_allowance
+    candidate_priority: P4
+    rationale: Arizona includes disqualified participants when determining the correct utility allowance amount; PolicyEngine exposes utility allowance amounts, not this participant-level inclusion rule for Arizona disqualified participants.
+
+  - legal_id: us-az:policies/des/faa5/disqualified-na-participant-s-effect-on-the-na/disqualified-participant-effect-on-na-benefit-amount#disqualified_participant_income_and_expenses_counted_in_full
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap
+    candidate_priority: P4
+    rationale: Arizona lists disqualification reasons whose income and expenses are counted in full; PolicyEngine computes final SNAP amounts from PE scenario inputs and does not expose this source-specific disqualification-reason bucket.
+
+  - legal_id: us-az:policies/des/faa5/disqualified-na-participant-s-effect-on-the-na/disqualified-participant-effect-on-na-benefit-amount#disqualified_participant_income_and_some_expenses_prorated
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap
+    candidate_priority: P4
+    rationale: Arizona lists SSN and selected noncitizen disqualification reasons whose income and some expenses are prorated to remaining eligible participants; PolicyEngine does not expose this Arizona proration-reason bucket as a one-to-one SNAP output.
+
+  - legal_id: us-az:policies/des/faa5/disqualified-na-participant-s-effect-on-the-na/disqualified-participant-effect-on-na-benefit-amount#expense_subject_to_proration
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    policyengine_variable: snap_excess_shelter_expense_deduction
+    candidate_priority: P4
+    rationale: Arizona marks shelter, dependent-care, and child-support expenses as subject to proration while excluding utility expenses; PolicyEngine exposes final deduction amounts, not this source-specific expense-type proration predicate.
+
   - legal_id: us-az:policies/des/faa5/na-medical-expenses-and-deduction/medical-deduction#medical_expense_disregard
     country: us
     program: snap

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.642"
+version = "0.2.643"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Adds PolicyEngine oracle classifications for the generated Arizona NA disqualified-participant effects block. These are marked not comparable because they are intermediate Arizona disqualification predicates; PolicyEngine exposes adjacent final SNAP size, utility allowance, deduction, and benefit surfaces rather than one-to-one predicate outputs.

Validation run locally:
- YAML mapping parse: 2,199 mappings
- one-repo oracle coverage for rulespec-us-az disqualified-participant worktree: 154 total outputs, 10 comparable, 144 known-not-comparable, 0 unmapped, 0 untested comparable
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q: 283 passed
- uv run --extra dev python -m pytest tests/test_cli.py::TestCmdEncode::test_apply_version_provenance_allows_changes_in_version_bump_commit tests/test_cli.py::TestCmdEncode::test_apply_version_provenance_rejects_code_after_version_bump tests/test_cli.py::TestCmdEncode::test_apply_version_provenance_rejects_stale_lockfile tests/test_cli.py::TestCmdEncode::test_apply_version_provenance_rejects_version_downgrade -q: 4 passed
- uv run --extra dev ruff check src/axiom_encode/__init__.py
- uv run --extra dev ruff format --check src/axiom_encode/__init__.py
- git diff --check