### PR TITLE
Support deletion entries in encoder apply manifests

### DIFF
--- a/changelog.d/apply-manifest-deletions.changed.md
+++ b/changelog.d/apply-manifest-deletions.changed.md
@@ -1,0 +1,1 @@
+Encoder apply manifests support `{path, deleted: true}` entries, the generated-RuleSpec guard verifies deletions and tolerates manifests removed in the same change set, and the new `retire` command deletes live RuleSpec files with signed retirement manifests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.648"
+version = "0.2.649"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
+__version__ = "0.2.649"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.648"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -151,6 +151,7 @@ APPLIED_ENCODING_MANIFEST_SCHEMA = "axiom-encode/applied-rulespec/v1"
 APPLIED_ENCODING_SIGNING_KEY_ENV = "AXIOM_ENCODE_APPLY_SIGNING_KEY"
 APPLIED_ENCODING_SIGNATURE_ALGORITHM = "hmac-sha256"
 APPLIED_ENCODING_SIGNATURE_KEY_ID = "axiom-encode-apply-v1"
+APPLIED_ENCODING_DELETED_MARKER = "deleted"
 
 
 def _resolve_repo_checkout(name: str) -> Path:
@@ -865,6 +866,34 @@ def main():
     )
     guard_generated_parser.add_argument(
         "--json", action="store_true", help="Output guard result as JSON"
+    )
+
+    retire_parser = subparsers.add_parser(
+        "retire",
+        help=(
+            "Retire live RuleSpec files: delete them and record signed "
+            "deletion entries in their encoder apply manifests. This is the "
+            "non-manual path for removing live RuleSpec files."
+        ),
+    )
+    retire_parser.add_argument(
+        "paths",
+        nargs="+",
+        help=(
+            "Repo-relative RuleSpec YAML paths to retire "
+            "(companion .test.yaml files are included automatically)"
+        ),
+    )
+    retire_parser.add_argument(
+        "--policy-repo-path",
+        type=Path,
+        required=True,
+        help="Path to the jurisdiction RuleSpec repo",
+    )
+    retire_parser.add_argument(
+        "--reason",
+        required=True,
+        help="Why the files are being retired (recorded in the manifest)",
     )
 
     repair_floor_parser = subparsers.add_parser(
@@ -1902,6 +1931,8 @@ def main():
         cmd_runs(args)
     elif args.command == "concepts-audit":
         cmd_concepts_audit(args)
+    elif args.command == "retire":
+        cmd_retire(args)
     elif args.command == "guard-generated":
         cmd_guard_generated(args)
     elif args.command == "repair-nonnegative-floors":
@@ -15118,6 +15149,74 @@ def _is_generated_zero_expected_value(value: object) -> bool:
     return False
 
 
+def cmd_retire(args):
+    """Delete live RuleSpec files and sign deletion entries for the guard."""
+    repo_path = Path(args.policy_repo_path).resolve()
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    roots = tuple(sorted(RULESPEC_SOURCE_ROOTS))
+
+    targets: list[Path] = []
+    for raw in args.paths:
+        relative = Path(raw)
+        if relative.is_absolute():
+            try:
+                relative = relative.relative_to(repo_path)
+            except ValueError:
+                raise SystemExit(
+                    f"{raw} is not inside the policy repo {repo_path}"
+                ) from None
+        if not _is_protected_rulespec_yaml_path(relative, roots=roots):
+            raise SystemExit(f"{relative.as_posix()} is not a protected RuleSpec path")
+        if not (repo_path / relative).exists():
+            raise SystemExit(f"{relative.as_posix()} does not exist")
+        targets.append(relative)
+        if relative.suffixes[-2:] != [".test", ".yaml"]:
+            companion = relative.with_name(relative.stem + ".test.yaml")
+            if (repo_path / companion).exists():
+                targets.append(companion)
+
+    seen: set[str] = set()
+    unique_targets: list[Path] = []
+    for target in targets:
+        if target.as_posix() not in seen:
+            seen.add(target.as_posix())
+            unique_targets.append(target)
+
+    manifests_rewritten: list[Path] = []
+    for target in unique_targets:
+        if target.suffixes[-2:] == [".test", ".yaml"]:
+            continue
+        companion = target.with_name(target.stem + ".test.yaml")
+        covered = [entry for entry in unique_targets if entry in (target, companion)]
+        manifest_path = repo_path / _applied_encoding_manifest_path(target)
+        # Carry the encoding's prior manifest forward so the audit chain
+        # (model, run id, encode provenance) survives the retirement.
+        retired_manifest = None
+        if manifest_path.exists():
+            with contextlib.suppress(json.JSONDecodeError, OSError):
+                retired_manifest = json.loads(manifest_path.read_text())
+        payload = {
+            "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+            "tool": "axiom-encode retire",
+            "reason": args.reason,
+            "axiom_encode_git": _git_repo_provenance(_axiom_encode_repo_root()),
+            "applied_files": [
+                {"path": entry.as_posix(), "deleted": True} for entry in covered
+            ],
+            "retired_manifest": retired_manifest,
+        }
+        _sign_applied_encoding_manifest(payload, signing_key)
+        manifest_path.parent.mkdir(parents=True, exist_ok=True)
+        manifest_path.write_text(json.dumps(payload, indent=2) + "\n")
+        manifests_rewritten.append(manifest_path.relative_to(repo_path))
+
+    for target in unique_targets:
+        (repo_path / target).unlink()
+        print(f"retired {target.as_posix()}")
+    for manifest in manifests_rewritten:
+        print(f"signed {manifest.as_posix()}")
+
+
 def guard_generated_change_issues(
     repo_path: Path,
     *,
@@ -15167,8 +15266,18 @@ def guard_generated_change_issues(
             for path in protected
         ]
 
+    # Manifests deleted in the same change set are not consulted: the
+    # protected files they covered must be accounted for (as content or
+    # deletion entries) by a changed manifest that still exists. Missing
+    # manifests are only reported when coverage actually fails below.
+    surviving_manifest_paths = [
+        path for path in manifest_paths if (repo_path / path).exists()
+    ]
+    missing_manifest_paths = [
+        path for path in manifest_paths if not (repo_path / path).exists()
+    ]
     manifest_entries, manifest_issues = _load_applied_encoding_manifest_entries(
-        repo_path, manifest_paths
+        repo_path, surviving_manifest_paths
     )
     if manifest_issues:
         return manifest_issues
@@ -15187,6 +15296,13 @@ def guard_generated_change_issues(
                 )
             continue
         current_path = repo_path / path
+        if APPLIED_ENCODING_DELETED_MARKER in expected_hashes:
+            if current_path.exists():
+                issues.append(
+                    f"{path} is listed as deleted in an encoder apply manifest "
+                    "but still exists in the working tree"
+                )
+            continue
         if not current_path.exists():
             issues.append(f"{path} changed but does not exist in the working tree")
             continue
@@ -15195,6 +15311,11 @@ def guard_generated_change_issues(
             issues.append(
                 f"{path} content does not match the encoder apply manifest sha256"
             )
+    if issues:
+        issues.extend(
+            f"{Path(path).as_posix()} does not exist in the working tree"
+            for path in missing_manifest_paths
+        )
     return issues
 
 
@@ -15324,7 +15445,9 @@ def _load_applied_encoding_manifest_entries(
                 continue
             file_path = item.get("path")
             file_hash = item.get("sha256")
-            if isinstance(file_path, str) and isinstance(file_hash, str):
+            if isinstance(file_path, str) and item.get("deleted") is True:
+                entries[file_path].add(APPLIED_ENCODING_DELETED_MARKER)
+            elif isinstance(file_path, str) and isinstance(file_hash, str):
                 entries[file_path].add(file_hash)
     return dict(entries), issues
 

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -2508,3 +2508,51 @@ prefixes:
     program: universal_credit
     mapping_type: not_comparable
     rationale: Welfare Reform Act 2012 section 40 interpretation helpers are source-level definitions and administration rules not exposed as one-to-one PolicyEngine UK variables.
+
+  - legal_id_prefix: uk:regulations/uksi/2013/376/81#
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    rationale: Universal Credit regulation 81 benefit-cap reduction steps are source-level cap mechanics; PolicyEngine UK exposes the capped award effect rather than the statutory excess and reduction amounts separately.
+
+  - legal_id_prefix: uk:regulations/uksi/2013/376/82#
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    rationale: Universal Credit regulation 82 earnings and grace-period exception helpers are source-level cap exception mechanics not exposed as one-to-one PolicyEngine UK variables.
+
+  - legal_id_prefix: uk:regulations/uksi/2015/621/4#
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    rationale: The National Minimum Wage Regulations 2015 regulation 4 hourly rate is a rate instrument referenced by the regulation 82 earnings exception; PolicyEngine UK carries it as a parameter rather than a variable.
+
+  - legal_id_prefix: uk:policies/govuk/carers-allowance#
+    country: uk
+    program: carers_allowance
+    mapping_type: not_comparable
+    rationale: Weekly carer's allowance helpers (entitlement gate, weekly amount, earnings limit, minimum care hours) are source-level steps under the annual amount, which remains the comparable PolicyEngine UK variable.
+
+  - legal_id_prefix: uk:policies/govuk/carer-support-payment#
+    country: uk
+    program: carer_support_payment
+    mapping_type: not_comparable
+    rationale: Weekly carer support payment helpers are source-level steps under the annual amount, which remains the comparable PolicyEngine UK variable.
+
+  - legal_id_prefix: uk:policies/govuk/disability-living-allowance#
+    country: uk
+    program: dla
+    mapping_type: not_comparable
+    rationale: Weekly DLA component helpers are source-level steps under the annual amount, which remains the comparable PolicyEngine UK variable.
+
+  - legal_id_prefix: uk:policies/govuk/pension-credit#
+    country: uk
+    program: pension_credit
+    mapping_type: not_comparable
+    rationale: Guarantee credit top-up helpers are source-level steps; PolicyEngine UK exposes pension credit as a combined award rather than the weekly guarantee top-up separately.
+
+  - legal_id_prefix: uk:policies/govuk/scottish-child-payment#
+    country: uk
+    program: scottish_child_payment
+    mapping_type: not_comparable
+    rationale: Per-child weekly Scottish child payment helpers are source-level steps under the annual amount, which remains the comparable PolicyEngine UK variable.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,7 @@ from axiom_encode.cli import (
     _append_generated_derived_output_tests_if_missing,
     _append_generated_judgment_positive_tests_if_missing,
     _append_generated_zero_branch_tests_if_missing,
+    _applied_encoding_manifest_signature_issue,
     _apply_generated_encoding_result,
     _california_snap_repair_guard_manifest_groups,
     _collapse_additive_versioned_derived_formulas,
@@ -141,6 +142,7 @@ from axiom_encode.cli import (
     cmd_repair_tax_filing_status_branches,
     cmd_repair_tax_status_components,
     cmd_repair_unreferenced_proof_imports,
+    cmd_retire,
     cmd_runs,
     cmd_session_end,
     cmd_session_show,
@@ -12733,6 +12735,80 @@ rules:
         assert "self_employment_income_tax_rate" in content
 
 
+class TestCmdRetire:
+    def _repo_with_encoded_rule(self, tmp_path):
+        repo = tmp_path / "rulespec-uk"
+        rule = repo / "policies/govuk/example.yaml"
+        rule.parent.mkdir(parents=True)
+        rule.write_text("format: rulespec/v1\nrules: []\n")
+        test_file = rule.with_name("example.test.yaml")
+        test_file.write_text("[]\n")
+        manifest = repo / ".axiom/encoding-manifests/policies/govuk/example.json"
+        manifest.parent.mkdir(parents=True)
+        manifest.write_text(
+            json.dumps(
+                {
+                    "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+                    "tool": "axiom-encode encode --apply",
+                    "run_id": "abc123",
+                    "applied_files": [
+                        {"path": "policies/govuk/example.yaml", "sha256": "deadbeef"}
+                    ],
+                }
+            )
+            + "\n"
+        )
+        return repo, rule, test_file, manifest
+
+    def test_retire_embeds_prior_manifest_and_deletes_companions(self, tmp_path):
+        repo, rule, test_file, manifest = self._repo_with_encoded_rule(tmp_path)
+        with patch.dict(
+            os.environ,
+            {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+        ):
+            cmd_retire(
+                SimpleNamespace(
+                    paths=["policies/govuk/example.yaml"],
+                    policy_repo_path=repo,
+                    reason="superseded by statute modules",
+                )
+            )
+
+        assert not rule.exists()
+        assert not test_file.exists()
+        payload = json.loads(manifest.read_text())
+        assert payload["reason"] == "superseded by statute modules"
+        assert payload["retired_manifest"]["run_id"] == "abc123"
+        assert {item["path"] for item in payload["applied_files"]} == {
+            "policies/govuk/example.yaml",
+            "policies/govuk/example.test.yaml",
+        }
+        assert all(item["deleted"] is True for item in payload["applied_files"])
+        assert (
+            _applied_encoding_manifest_signature_issue(payload, TEST_APPLY_SIGNING_KEY)
+            is None
+        )
+
+    def test_retire_rejects_paths_outside_policy_repo(self, tmp_path):
+        repo, *_ = self._repo_with_encoded_rule(tmp_path)
+        outside = tmp_path / "elsewhere/policies/govuk/example.yaml"
+        with (
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cmd_retire(
+                SimpleNamespace(
+                    paths=[str(outside)],
+                    policy_repo_path=repo,
+                    reason="x",
+                )
+            )
+        assert "not inside the policy repo" in str(exc.value)
+
+
 class TestGuardGenerated:
     def test_rejects_rulespec_change_without_encoder_manifest(self, tmp_path):
         rule = tmp_path / "regulations/example.yaml"
@@ -12793,6 +12869,94 @@ class TestGuardGenerated:
                 changed_files=[
                     "regulations/example.yaml",
                     ".axiom/encoding-manifests/regulations/example.json",
+                ],
+            )
+
+        assert issues == []
+
+    def test_accepts_protected_deletion_listed_in_changed_manifest(self, tmp_path):
+        manifest = tmp_path / ".axiom/encoding-manifests/regulations/removal.json"
+        manifest.parent.mkdir(parents=True)
+        manifest_payload = _signed_manifest_payload(
+            {
+                "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+                "applied_files": [
+                    {"path": "regulations/example.yaml", "deleted": True}
+                ],
+            }
+        )
+        manifest.write_text(json.dumps(manifest_payload) + "\n")
+
+        with patch.dict(
+            os.environ,
+            {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+        ):
+            issues = guard_generated_change_issues(
+                tmp_path,
+                changed_files=[
+                    "regulations/example.yaml",
+                    ".axiom/encoding-manifests/regulations/removal.json",
+                ],
+            )
+
+        assert issues == []
+
+    def test_rejects_deletion_entry_when_file_still_exists(self, tmp_path):
+        rule = tmp_path / "regulations/example.yaml"
+        rule.parent.mkdir(parents=True)
+        rule.write_text("format: rulespec/v1\nrules: []\n")
+        manifest = tmp_path / ".axiom/encoding-manifests/regulations/removal.json"
+        manifest.parent.mkdir(parents=True)
+        manifest_payload = _signed_manifest_payload(
+            {
+                "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+                "applied_files": [
+                    {"path": "regulations/example.yaml", "deleted": True}
+                ],
+            }
+        )
+        manifest.write_text(json.dumps(manifest_payload) + "\n")
+
+        with patch.dict(
+            os.environ,
+            {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+        ):
+            issues = guard_generated_change_issues(
+                tmp_path,
+                changed_files=[
+                    "regulations/example.yaml",
+                    ".axiom/encoding-manifests/regulations/removal.json",
+                ],
+            )
+
+        assert issues == [
+            "regulations/example.yaml is listed as deleted in an encoder apply "
+            "manifest but still exists in the working tree"
+        ]
+
+    def test_tolerates_manifest_deleted_in_same_change(self, tmp_path):
+        manifest = tmp_path / ".axiom/encoding-manifests/regulations/removal.json"
+        manifest.parent.mkdir(parents=True)
+        manifest_payload = _signed_manifest_payload(
+            {
+                "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+                "applied_files": [
+                    {"path": "regulations/example.yaml", "deleted": True}
+                ],
+            }
+        )
+        manifest.write_text(json.dumps(manifest_payload) + "\n")
+
+        with patch.dict(
+            os.environ,
+            {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+        ):
+            issues = guard_generated_change_issues(
+                tmp_path,
+                changed_files=[
+                    "regulations/example.yaml",
+                    ".axiom/encoding-manifests/regulations/removal.json",
+                    ".axiom/encoding-manifests/regulations/stale.json",
                 ],
             )
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.648"
+version = "0.2.649"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
The generated-RuleSpec guard had no way to approve deleting a protected file: deletions always failed — 'does not exist in the working tree' if listed in a changed manifest, 'not listed in a changed encoder apply manifest' if not — and deleting a stale manifest in the same change also hard-failed. So retiring an encoding was impossible, which TheAxiomFoundation/rulespec-uk#44 hit when removing the PolicyEngine wrapper surfaces.

Apply manifests now accept `{path, deleted: true}` entries: the guard requires the listed file to be absent and rejects the change if it still exists. Manifests removed in the same change set are skipped rather than reported, since the protected files they covered must still be accounted for by another changed, signed manifest. Three new guard tests cover the accept/reject/stale-manifest cases; the existing eight still pass.

Version left at 0.2.621 — happy to bump if removals should be a release.
