### PR TITLE
Add Georgia SNAP and Medicaid oracle mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.652"
+version = "0.2.653"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.652"
+__version__ = "0.2.653"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2964,6 +2964,106 @@ mappings:
     candidate_priority: P4
     rationale: Axiom exposes the raw Colorado CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective adult Medicaid expansion income limit including that disregard.
 
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#magi_fpl_disregard_rate
+    country: us
+    program: health
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table's separate 5% MAGI FPL disregard. PolicyEngine-US bakes that disregard into Medicaid and CHIP income-limit parameters rather than exposing it as a separate parameter.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_medicaid_ages_0_to_1_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: GA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Georgia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective infant Medicaid income limit including that disregard.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_medicaid_ages_1_to_5_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: GA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Georgia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective young-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_medicaid_ages_6_to_18_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: GA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Georgia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective older-child Medicaid income limit including that disregard.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_separate_chip_fpl_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: GA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Georgia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective child CHIP income limit including that disregard.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_pregnant_women_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: GA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Georgia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_parent_caretaker_adults_medicaid_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.parent.income_limit
+    parameter_key: GA
+    candidate_priority: P4
+    rationale: Axiom exposes the raw Georgia CMS table value and the CMS dollar-amount indicator for parent and caretaker adults. PolicyEngine-US stores an effective parent and caretaker Medicaid income limit including MAGI treatment, so the raw CMS row is not a one-to-one oracle target.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_parent_caretaker_standard_uses_dollar_amounts
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the CMS table footnote that Georgia's parent and caretaker adult standard is represented using dollar amounts. PolicyEngine-US does not expose that source footnote as a separate variable or parameter.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_pregnant_women_chip_available
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.chip.pregnant.income_limit
+    parameter_key: GA
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for separate CHIP coverage of pregnant women. PolicyEngine-US represents unavailable pregnant-women CHIP coverage through its income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_adult_medicaid_expansion_available
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.adult.income_limit
+    parameter_key: GA
+    candidate_priority: P4
+    rationale: Axiom exposes CMS table availability for adult Medicaid expansion. PolicyEngine-US represents unavailable adult expansion through its adult Medicaid income-limit parameter rather than a separate availability boolean.
+
+  - legal_id: us-ga:policies/dfcs/snap/3210/block-2#assistance_unit_member_receives_tanf_wsp_or_ssi
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Georgia DFCS SNAP Manual 3210 block 2 defines this per-member categorical eligibility helper for composing Georgia's manual categorical eligibility test. PolicyEngine-US models SNAP eligibility and benefits, not this state-manual helper as a one-to-one output.
+
+  - legal_id: us-ga:policies/dfcs/snap/3210/block-2#categorically_eligible_for_snap
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Georgia DFCS SNAP Manual 3210 block 2 defines a state-manual categorical eligibility helper based on TANF, WSP, SSI, and TCOS receipt or authorization. PolicyEngine-US models broader SNAP eligibility and benefits, not this manual helper as a one-to-one output.
+
   - legal_id: us:statutes/26/3201#tier_2_employee_tax
     country: us
     program: tax

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -629,6 +629,125 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_georgia_snap_medicaid_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-ga"
+        / "policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml",
+        """format: rulespec/v1
+rules:
+  - name: magi_fpl_disregard_rate
+    kind: parameter
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 0.05
+  - name: georgia_children_medicaid_ages_0_to_1_fpl_limit
+    kind: parameter
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 2.05
+  - name: georgia_children_medicaid_ages_1_to_5_fpl_limit
+    kind: parameter
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 1.49
+  - name: georgia_children_medicaid_ages_6_to_18_fpl_limit
+    kind: parameter
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 1.33
+  - name: georgia_children_separate_chip_fpl_limit
+    kind: parameter
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 2.47
+  - name: georgia_pregnant_women_medicaid_fpl_limit
+    kind: parameter
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 2.20
+  - name: georgia_parent_caretaker_adults_medicaid_fpl_limit
+    kind: parameter
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 0.28
+  - name: georgia_parent_caretaker_standard_uses_dollar_amounts
+    kind: parameter
+    versions:
+      - effective_from: '2025-01-01'
+        formula: true
+  - name: georgia_pregnant_women_chip_available
+    kind: parameter
+    versions:
+      - effective_from: '2025-01-01'
+        formula: false
+  - name: georgia_adult_medicaid_expansion_available
+    kind: parameter
+    versions:
+      - effective_from: '2025-01-01'
+        formula: false
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-ga" / "policies/dfcs/snap/3210/block-2.yaml",
+        """format: rulespec/v1
+rules:
+  - name: assistance_unit_member_receives_tanf_wsp_or_ssi
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: receives_tanf or receives_wsp or receives_ssi
+  - name: categorically_eligible_for_snap
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: all_au_members_receive_tanf_wsp_or_ssi or receives_or_authorized_for_tcos
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path)
+
+    assert report["total_outputs"] == 12
+    assert report["status_counts"] == {"known_not_comparable": 12}
+    assert report["untested_comparable"] == 0
+    assert report["program_counts"] == {
+        "chip": 2,
+        "health": 1,
+        "medicaid": 7,
+        "snap": 2,
+    }
+    assert {item["candidate_priority"] for item in report["items"]} == {"P4"}
+
+    items_by_name = {item["rule_name"]: item for item in report["items"]}
+    assert (
+        items_by_name["georgia_children_medicaid_ages_0_to_1_fpl_limit"][
+            "policyengine_parameter"
+        ]
+        == "gov.hhs.medicaid.eligibility.categories.infant.income_limit"
+    )
+    assert (
+        items_by_name["georgia_children_separate_chip_fpl_limit"][
+            "policyengine_parameter"
+        ]
+        == "gov.hhs.chip.child.income_limit"
+    )
+    assert (
+        items_by_name["georgia_pregnant_women_chip_available"]["policyengine_parameter"]
+        == "gov.hhs.chip.pregnant.income_limit"
+    )
+    assert items_by_name["categorically_eligible_for_snap"]["program"] == "snap"
+    assert (
+        items_by_name["categorically_eligible_for_snap"]["policyengine_variable"]
+        is None
+    )
+    assert (
+        items_by_name["assistance_unit_member_receives_tanf_wsp_or_ssi"][
+            "policyengine_variable"
+        ]
+        is None
+    )
+
+
 def test_policyengine_coverage_classifies_aca_ptc_percentage_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "policies/irs/rev-proc-2025-25/aca-ptc.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.652"
+version = "0.2.653"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Georgia CMS Medicaid/CHIP/BHP eligibility-level outputs in PolicyEngine oracle coverage
- classify Georgia DFCS SNAP Manual 3210 categorical eligibility helper as reviewed not-comparable
- bump axiom-encode to 0.2.646 for the packaged mapping update

## Validation
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_colorado_medicaid_chip_thresholds tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_georgia_snap_medicaid_outputs -q
- uvx ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run axiom-encode oracle-coverage --root <tmp rulespec-us-ga root> --oracle policyengine --fail-on-unmapped --fail-on-untested-comparable