### PR TITLE
Cache the packaged PolicyEngine registry (~21 min test suite -> ~2 min)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: .venv/bin/python -m towncrier build --draft --version 0.0.0
 
       - name: Run tests
-        run: .venv/bin/pytest tests/ -v
+        run: .venv/bin/pytest tests/
 
   lint:
     runs-on: ubuntu-latest

--- a/changelog.d/cache-policyengine-registry.changed.md
+++ b/changelog.d/cache-policyengine-registry.changed.md
@@ -1,0 +1,1 @@
+- `load_policyengine_registry` now parses the packaged mapping YAML once per process (cached, C loader when available) instead of on every call, cutting the test suite from ~21 to ~3 minutes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.647"
+version = "0.2.648"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.647"
+__version__ = "0.2.648"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/oracles/policyengine/registry.py
+++ b/src/axiom_encode/oracles/policyengine/registry.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+try:
+    from yaml import CSafeLoader as _YamlLoader
+except ImportError:
+    from yaml import SafeLoader as _YamlLoader
 
 SUPPORTED_MAPPING_TYPES = {
     "direct_variable",
@@ -214,13 +220,18 @@ class PolicyEngineOracleRegistry:
         return issues
 
 
+@lru_cache(maxsize=1)
 def load_policyengine_registry() -> PolicyEngineOracleRegistry:
-    """Load packaged PolicyEngine mappings."""
+    """Load packaged PolicyEngine mappings.
+
+    The packaged mappings are static (~1MB of YAML), so the parsed registry is
+    cached for the lifetime of the process; callers must treat it as read-only.
+    """
     mappings: dict[str, PolicyEngineMapping] = {}
     prefix_mappings: list[PolicyEngineMapping] = []
     mapping_dir = Path(__file__).with_name("mappings")
     for mapping_path in sorted(mapping_dir.glob("*.yaml")):
-        payload = yaml.safe_load(mapping_path.read_text()) or {}
+        payload = yaml.load(mapping_path.read_text(), Loader=_YamlLoader) or {}
         raw_mappings = payload.get("mappings", [])
         if not isinstance(raw_mappings, list):
             raise ValueError(f"{mapping_path} mappings must be a list")

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.647"
+version = "0.2.648"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
The test suite takes 21 minutes in CI, and 93% of that is one function: `load_policyengine_registry` re-parses ~1MB of packaged mapping YAML with the pure-Python loader (~3s per call) on every call. It's called fresh by every `build_policyengine_coverage_report` call (283 tests in test_policyengine_coverage.py, some calling it 4x) and every `ValidatorPipeline` init (108 tests in test_rulespec_validation.py) — about 1,160s of the 1,254s suite, measured from CI log timestamps on run 27305011892.

The mappings are static packaged data, so this caches the parsed registry for the process lifetime with `lru_cache` and uses yaml's C loader when available. Callers already treat the registry as read-only — the one test that customises mappings builds a fresh `PolicyEngineOracleRegistry` rather than mutating.

Locally the three heaviest test files (test_policyengine_coverage, test_rulespec_validation, test_evals — previously ~20 min of CI time) now run in 21 seconds: 1,098 passed, 28 skipped.