### PR TITLE
Accept multiple files in validate and proof-validate

### DIFF
--- a/changelog.d/validate-multiple-files.changed.md
+++ b/changelog.d/validate-multiple-files.changed.md
@@ -1,0 +1,1 @@
+- `axiom-encode validate` and `axiom-encode proof-validate` now accept multiple files in one invocation, reusing the validator pipeline (and its registry load) across files; `--json` emits an array when more than one file is passed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.650"
+version = "0.2.651"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,7 +1,7 @@
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 
-__version__ = "0.2.650"
+__version__ = "0.2.651"
 
 from .constants import (
     DEFAULT_CLI_MODEL,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -518,9 +518,14 @@ def main():
 
     # validate command
     validate_parser = subparsers.add_parser(
-        "validate", help="Validate a RuleSpec YAML file (CI + reviewer agents)"
+        "validate", help="Validate RuleSpec YAML files (CI + reviewer agents)"
     )
-    validate_parser.add_argument("file", type=Path, help="Path to RuleSpec YAML file")
+    validate_parser.add_argument(
+        "files",
+        type=Path,
+        nargs="+",
+        help="Paths to RuleSpec YAML files (--json emits an array for multiple files)",
+    )
     validate_parser.add_argument("--json", action="store_true", help="Output as JSON")
     validate_parser.add_argument("--skip-reviewers", action="store_true")
     validate_parser.add_argument(
@@ -545,7 +550,10 @@ def main():
         help="Validate explicit RuleSpec proof trees without reviewers or oracles",
     )
     proof_validate_parser.add_argument(
-        "file", type=Path, help="Path to RuleSpec YAML file"
+        "files",
+        type=Path,
+        nargs="+",
+        help="Paths to RuleSpec YAML files (--json emits an array for multiple files)",
     )
     proof_validate_parser.add_argument(
         "--json", action="store_true", help="Output as JSON"
@@ -1988,14 +1996,12 @@ def main():
 
 
 def cmd_validate(args):
-    """Validate a RuleSpec YAML file."""
-    if not args.file.exists():
-        print(f"File not found: {args.file}")
+    """Validate one or more RuleSpec YAML files in a single process."""
+    missing = [file for file in args.files if not file.exists()]
+    if missing:
+        for file in missing:
+            print(f"File not found: {file}")
         sys.exit(1)
-
-    rulespec_file = args.file.resolve()
-
-    policy_repo_root, axiom_rules_path = _resolve_validation_repo_roots(rulespec_file)
 
     # Enable oracles if --oracle flag is set
     enable_oracles = args.oracle is not None
@@ -2005,13 +2011,47 @@ def cmd_validate(args):
     elif args.oracle == "taxsim":
         oracle_validators = ("taxsim",)
 
-    pipeline = ValidatorPipeline(
-        policy_repo_path=policy_repo_root,
-        axiom_rules_path=axiom_rules_path,
-        enable_oracles=enable_oracles,
-        oracle_validators=oracle_validators,
-    )
+    # Pipelines are reused across files sharing repo roots so per-process
+    # setup (registry load, repo resolution) is paid once, not per file.
+    pipelines: dict[tuple[Path, Path], ValidatorPipeline] = {}
+    json_outputs = []
+    failed_files = []
+    for index, file in enumerate(args.files):
+        rulespec_file = file.resolve()
+        roots = _resolve_validation_repo_roots(rulespec_file)
+        pipeline = pipelines.get(roots)
+        if pipeline is None:
+            policy_repo_root, axiom_rules_path = roots
+            pipeline = ValidatorPipeline(
+                policy_repo_path=policy_repo_root,
+                axiom_rules_path=axiom_rules_path,
+                enable_oracles=enable_oracles,
+                oracle_validators=oracle_validators,
+            )
+            pipelines[roots] = pipeline
+        if not args.json and index:
+            print()
+        all_passed, output = _validate_one(args, pipeline, rulespec_file)
+        if output is not None:
+            json_outputs.append(output)
+        if not all_passed:
+            failed_files.append(file)
 
+    if args.json:
+        if len(args.files) == 1:
+            print(json.dumps(json_outputs[0], indent=2))
+        else:
+            print(json.dumps(json_outputs, indent=2))
+    elif failed_files and len(args.files) > 1:
+        print(f"\n{len(failed_files)} of {len(args.files)} file(s) failed:")
+        for file in failed_files:
+            print(f"  - {file}")
+
+    sys.exit(1 if failed_files else 0)
+
+
+def _validate_one(args, pipeline, rulespec_file):
+    """Validate a single file; return (all_passed, JSON payload or None)."""
     result = pipeline.validate(rulespec_file, skip_reviewers=args.skip_reviewers)
     scores = result.to_review_results()
     review_scores = (
@@ -2088,7 +2128,7 @@ def cmd_validate(args):
     all_passed = result.all_passed and oracle_passed
 
     if args.json:
-        output = {
+        return all_passed, {
             "file": str(rulespec_file),
             "ci_pass": result.ci_pass,
             "scores": {
@@ -2110,7 +2150,6 @@ def cmd_validate(args):
             "errors": errors,
             "duration_ms": result.total_duration_ms,
         }
-        print(json.dumps(output, indent=2))
     else:
         print(f"File: {rulespec_file}")
         print(f"CI: {'✓' if result.ci_pass else '✗'}")
@@ -2152,43 +2191,59 @@ def cmd_validate(args):
                 if len(issues) > 10:
                     print(f"  - {name}: ... {len(issues) - 10} more oracle issue(s)")
 
-    sys.exit(0 if all_passed else 1)
+    return all_passed, None
 
 
 def cmd_proof_validate(args):
-    """Validate explicit RuleSpec proof trees."""
-    if not args.file.exists():
-        print(f"File not found: {args.file}")
+    """Validate explicit RuleSpec proof trees for one or more files."""
+    missing = [file for file in args.files if not file.exists()]
+    if missing:
+        for file in missing:
+            print(f"File not found: {file}")
         sys.exit(1)
 
-    rulespec_file = args.file.resolve()
-    result = validate_rulespec_proofs(
-        rulespec_file.read_text(encoding="utf-8"),
-        validate_claim_records=True,
-    )
+    json_outputs = []
+    failed_files = []
+    for index, file in enumerate(args.files):
+        rulespec_file = file.resolve()
+        result = validate_rulespec_proofs(
+            rulespec_file.read_text(encoding="utf-8"),
+            validate_claim_records=True,
+        )
+        if not result.passed:
+            failed_files.append(file)
 
-    if args.json:
-        print(
-            json.dumps(
+        if args.json:
+            json_outputs.append(
                 {
                     "file": str(rulespec_file),
                     "passed": result.passed,
                     "proof_required": result.proof_required,
                     "atoms_checked": result.atoms_checked,
                     "issues": result.issues,
-                },
-                indent=2,
+                }
             )
-        )
-    else:
-        print(f"File: {rulespec_file}")
-        print(f"Proofs required: {'yes' if result.proof_required else 'no'}")
-        print(f"Atoms checked: {result.atoms_checked}")
-        print(f"Result: {'✓ PASSED' if result.passed else '✗ FAILED'}")
-        for issue in result.issues:
-            print(f"  - {issue}")
+        else:
+            if index:
+                print()
+            print(f"File: {rulespec_file}")
+            print(f"Proofs required: {'yes' if result.proof_required else 'no'}")
+            print(f"Atoms checked: {result.atoms_checked}")
+            print(f"Result: {'✓ PASSED' if result.passed else '✗ FAILED'}")
+            for issue in result.issues:
+                print(f"  - {issue}")
 
-    sys.exit(0 if result.passed else 1)
+    if args.json:
+        if len(args.files) == 1:
+            print(json.dumps(json_outputs[0], indent=2))
+        else:
+            print(json.dumps(json_outputs, indent=2))
+    elif failed_files and len(args.files) > 1:
+        print(f"\n{len(failed_files)} of {len(args.files)} file(s) failed:")
+        for file in failed_files:
+            print(f"  - {file}")
+
+    sys.exit(1 if failed_files else 0)
 
 
 def cmd_test(args):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1363,7 +1363,7 @@ class TestCmdEvalSuiteArchive:
 class TestCmdValidate:
     def test_file_not_found(self, capsys):
         args = MagicMock()
-        args.file = Path("/nonexistent/file.yaml")
+        args.files = [Path("/nonexistent/file.yaml")]
         with pytest.raises(SystemExit) as exc_info:
             cmd_validate(args)
         assert exc_info.value.code == 1
@@ -1374,7 +1374,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = False
         args.oracle = None
@@ -1406,7 +1406,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = True
         args.skip_reviewers = False
         args.oracle = None
@@ -1438,11 +1438,43 @@ class TestCmdValidate:
         output = json.loads(captured.out)
         assert output["all_passed"] is False
 
+    def test_validate_multiple_files_reuses_pipeline(self, capsys, tmp_path):
+        first = tmp_path / "first.yaml"
+        second = tmp_path / "second.yaml"
+        first.write_text("# test")
+        second.write_text("# test")
+        args = MagicMock()
+        args.files = [first, second]
+        args.json = True
+        args.skip_reviewers = True
+        args.oracle = None
+        args.min_match = 0.95
+
+        mock_result = MagicMock()
+        mock_result.all_passed = True
+        mock_result.ci_pass = True
+        mock_result.results = {}
+        mock_result.total_duration_ms = 100
+
+        with patch("axiom_encode.cli.ValidatorPipeline") as mock_pipeline_cls:
+            mock_pipeline_cls.return_value.validate.return_value = mock_result
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_validate(args)
+            assert exc_info.value.code == 0
+            assert mock_pipeline_cls.call_count == 1
+            assert mock_pipeline_cls.return_value.validate.call_count == 2
+        output = json.loads(capsys.readouterr().out)
+        assert isinstance(output, list)
+        assert [entry["file"] for entry in output] == [
+            str(first.resolve()),
+            str(second.resolve()),
+        ]
+
     def test_validate_with_oracle_policyengine_pass(self, capsys, tmp_path):
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = False
         args.oracle = "policyengine"
@@ -1476,7 +1508,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = False
         args.oracle = "policyengine"
@@ -1512,7 +1544,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = True
         args.skip_reviewers = True
         args.oracle = "policyengine"
@@ -1560,7 +1592,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = True
         args.oracle = "policyengine"
@@ -1719,7 +1751,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = True
         args.skip_reviewers = False
         args.oracle = "taxsim"
@@ -1751,7 +1783,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = False
         args.oracle = "all"
@@ -1784,7 +1816,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = True
         args.skip_reviewers = False
         args.oracle = "policyengine"
@@ -1843,7 +1875,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = True
         args.oracle = None
@@ -1878,7 +1910,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = True
         args.skip_reviewers = True
         args.oracle = "policyengine"
@@ -1910,7 +1942,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = True
         args.oracle = None
@@ -19493,7 +19525,7 @@ class TestCmdValidateEdgeCases:
         axiom_rules_path.mkdir(parents=True)
 
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = False
         args.oracle = None
@@ -19529,7 +19561,7 @@ class TestCmdValidateEdgeCases:
         (tmp_path / "axiom-rules-engine").mkdir()
 
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = True
         args.oracle = None
@@ -19569,7 +19601,7 @@ class TestCmdValidateEdgeCases:
         axiom_rules_path.mkdir()
 
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = True
         args.oracle = None

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.650"
+version = "0.2.651"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Stacked on #604; retarget to main once that merges.

Consumer repo workflows (validate-rulespec.yml in TheAxiomFoundation/.github) loop over changed RuleSpec files spawning one `axiom-encode validate` process per file. Each process pays Python startup plus a full parse of the ~1MB packaged PolicyEngine registry, about 4s per file in rulespec-uk's CI — its validate step takes 7m42s for ~125 files while the actual checks are milliseconds each. The proofs step has the same per-file loop.

`validate` and `proof-validate` now accept multiple files in one invocation and reuse the validator pipeline (and its registry load) across files sharing repo roots. Single-file output and exit semantics are unchanged; `--json` with multiple files emits an array, and text mode prints a trailing summary listing failed files. Locally, batching 10 rulespec-uk files takes 8.7s against 16.1s for the per-file loop, and the CI gap is bigger because each spawned process there parses the registry without the C loader.

Follow-up to make this land end to end: update the shared validate-rulespec.yml workflow to pass the file list in one call (needs consumer toolchains pinned to >= this version first), then bump rulespec-uk's .axiom/toolchain.toml.