### PR TITLE
Accept multiple files in validate and proof-validate (re-land on main)

### DIFF
--- a/changelog.d/validate-multiple-files.changed.md
+++ b/changelog.d/validate-multiple-files.changed.md
@@ -1,0 +1,1 @@
+- `axiom-encode validate` and `axiom-encode proof-validate` now accept multiple files in one invocation, reusing the validator pipeline (and its registry load) across files; `--json` emits an array when more than one file is passed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.649"
+version = "0.2.652"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.649"
+__version__ = "0.2.652"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -519,9 +519,14 @@ def main():
 
     # validate command
     validate_parser = subparsers.add_parser(
-        "validate", help="Validate a RuleSpec YAML file (CI + reviewer agents)"
+        "validate", help="Validate RuleSpec YAML files (CI + reviewer agents)"
     )
-    validate_parser.add_argument("file", type=Path, help="Path to RuleSpec YAML file")
+    validate_parser.add_argument(
+        "files",
+        type=Path,
+        nargs="+",
+        help="Paths to RuleSpec YAML files (--json emits an array for multiple files)",
+    )
     validate_parser.add_argument("--json", action="store_true", help="Output as JSON")
     validate_parser.add_argument("--skip-reviewers", action="store_true")
     validate_parser.add_argument(
@@ -546,7 +551,10 @@ def main():
         help="Validate explicit RuleSpec proof trees without reviewers or oracles",
     )
     proof_validate_parser.add_argument(
-        "file", type=Path, help="Path to RuleSpec YAML file"
+        "files",
+        type=Path,
+        nargs="+",
+        help="Paths to RuleSpec YAML files (--json emits an array for multiple files)",
     )
     proof_validate_parser.add_argument(
         "--json", action="store_true", help="Output as JSON"
@@ -2019,14 +2027,12 @@ def main():
 
 
 def cmd_validate(args):
-    """Validate a RuleSpec YAML file."""
-    if not args.file.exists():
-        print(f"File not found: {args.file}")
+    """Validate one or more RuleSpec YAML files in a single process."""
+    missing = [file for file in args.files if not file.exists()]
+    if missing:
+        for file in missing:
+            print(f"File not found: {file}")
         sys.exit(1)
-
-    rulespec_file = args.file.resolve()
-
-    policy_repo_root, axiom_rules_path = _resolve_validation_repo_roots(rulespec_file)
 
     # Enable oracles if --oracle flag is set
     enable_oracles = args.oracle is not None
@@ -2036,13 +2042,47 @@ def cmd_validate(args):
     elif args.oracle == "taxsim":
         oracle_validators = ("taxsim",)
 
-    pipeline = ValidatorPipeline(
-        policy_repo_path=policy_repo_root,
-        axiom_rules_path=axiom_rules_path,
-        enable_oracles=enable_oracles,
-        oracle_validators=oracle_validators,
-    )
+    # Pipelines are reused across files sharing repo roots so per-process
+    # setup (registry load, repo resolution) is paid once, not per file.
+    pipelines: dict[tuple[Path, Path], ValidatorPipeline] = {}
+    json_outputs = []
+    failed_files = []
+    for index, file in enumerate(args.files):
+        rulespec_file = file.resolve()
+        roots = _resolve_validation_repo_roots(rulespec_file)
+        pipeline = pipelines.get(roots)
+        if pipeline is None:
+            policy_repo_root, axiom_rules_path = roots
+            pipeline = ValidatorPipeline(
+                policy_repo_path=policy_repo_root,
+                axiom_rules_path=axiom_rules_path,
+                enable_oracles=enable_oracles,
+                oracle_validators=oracle_validators,
+            )
+            pipelines[roots] = pipeline
+        if not args.json and index:
+            print()
+        all_passed, output = _validate_one(args, pipeline, rulespec_file)
+        if output is not None:
+            json_outputs.append(output)
+        if not all_passed:
+            failed_files.append(file)
 
+    if args.json:
+        if len(args.files) == 1:
+            print(json.dumps(json_outputs[0], indent=2))
+        else:
+            print(json.dumps(json_outputs, indent=2))
+    elif failed_files and len(args.files) > 1:
+        print(f"\n{len(failed_files)} of {len(args.files)} file(s) failed:")
+        for file in failed_files:
+            print(f"  - {file}")
+
+    sys.exit(1 if failed_files else 0)
+
+
+def _validate_one(args, pipeline, rulespec_file):
+    """Validate a single file; return (all_passed, JSON payload or None)."""
     result = pipeline.validate(rulespec_file, skip_reviewers=args.skip_reviewers)
     scores = result.to_review_results()
     review_scores = (
@@ -2119,7 +2159,7 @@ def cmd_validate(args):
     all_passed = result.all_passed and oracle_passed
 
     if args.json:
-        output = {
+        return all_passed, {
             "file": str(rulespec_file),
             "ci_pass": result.ci_pass,
             "scores": {
@@ -2141,7 +2181,6 @@ def cmd_validate(args):
             "errors": errors,
             "duration_ms": result.total_duration_ms,
         }
-        print(json.dumps(output, indent=2))
     else:
         print(f"File: {rulespec_file}")
         print(f"CI: {'✓' if result.ci_pass else '✗'}")
@@ -2183,43 +2222,59 @@ def cmd_validate(args):
                 if len(issues) > 10:
                     print(f"  - {name}: ... {len(issues) - 10} more oracle issue(s)")
 
-    sys.exit(0 if all_passed else 1)
+    return all_passed, None
 
 
 def cmd_proof_validate(args):
-    """Validate explicit RuleSpec proof trees."""
-    if not args.file.exists():
-        print(f"File not found: {args.file}")
+    """Validate explicit RuleSpec proof trees for one or more files."""
+    missing = [file for file in args.files if not file.exists()]
+    if missing:
+        for file in missing:
+            print(f"File not found: {file}")
         sys.exit(1)
 
-    rulespec_file = args.file.resolve()
-    result = validate_rulespec_proofs(
-        rulespec_file.read_text(encoding="utf-8"),
-        validate_claim_records=True,
-    )
+    json_outputs = []
+    failed_files = []
+    for index, file in enumerate(args.files):
+        rulespec_file = file.resolve()
+        result = validate_rulespec_proofs(
+            rulespec_file.read_text(encoding="utf-8"),
+            validate_claim_records=True,
+        )
+        if not result.passed:
+            failed_files.append(file)
 
-    if args.json:
-        print(
-            json.dumps(
+        if args.json:
+            json_outputs.append(
                 {
                     "file": str(rulespec_file),
                     "passed": result.passed,
                     "proof_required": result.proof_required,
                     "atoms_checked": result.atoms_checked,
                     "issues": result.issues,
-                },
-                indent=2,
+                }
             )
-        )
-    else:
-        print(f"File: {rulespec_file}")
-        print(f"Proofs required: {'yes' if result.proof_required else 'no'}")
-        print(f"Atoms checked: {result.atoms_checked}")
-        print(f"Result: {'✓ PASSED' if result.passed else '✗ FAILED'}")
-        for issue in result.issues:
-            print(f"  - {issue}")
+        else:
+            if index:
+                print()
+            print(f"File: {rulespec_file}")
+            print(f"Proofs required: {'yes' if result.proof_required else 'no'}")
+            print(f"Atoms checked: {result.atoms_checked}")
+            print(f"Result: {'✓ PASSED' if result.passed else '✗ FAILED'}")
+            for issue in result.issues:
+                print(f"  - {issue}")
 
-    sys.exit(0 if result.passed else 1)
+    if args.json:
+        if len(args.files) == 1:
+            print(json.dumps(json_outputs[0], indent=2))
+        else:
+            print(json.dumps(json_outputs, indent=2))
+    elif failed_files and len(args.files) > 1:
+        print(f"\n{len(failed_files)} of {len(args.files)} file(s) failed:")
+        for file in failed_files:
+            print(f"  - {file}")
+
+    sys.exit(1 if failed_files else 0)
 
 
 def cmd_test(args):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1365,7 +1365,7 @@ class TestCmdEvalSuiteArchive:
 class TestCmdValidate:
     def test_file_not_found(self, capsys):
         args = MagicMock()
-        args.file = Path("/nonexistent/file.yaml")
+        args.files = [Path("/nonexistent/file.yaml")]
         with pytest.raises(SystemExit) as exc_info:
             cmd_validate(args)
         assert exc_info.value.code == 1
@@ -1376,7 +1376,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = False
         args.oracle = None
@@ -1408,7 +1408,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = True
         args.skip_reviewers = False
         args.oracle = None
@@ -1440,11 +1440,43 @@ class TestCmdValidate:
         output = json.loads(captured.out)
         assert output["all_passed"] is False
 
+    def test_validate_multiple_files_reuses_pipeline(self, capsys, tmp_path):
+        first = tmp_path / "first.yaml"
+        second = tmp_path / "second.yaml"
+        first.write_text("# test")
+        second.write_text("# test")
+        args = MagicMock()
+        args.files = [first, second]
+        args.json = True
+        args.skip_reviewers = True
+        args.oracle = None
+        args.min_match = 0.95
+
+        mock_result = MagicMock()
+        mock_result.all_passed = True
+        mock_result.ci_pass = True
+        mock_result.results = {}
+        mock_result.total_duration_ms = 100
+
+        with patch("axiom_encode.cli.ValidatorPipeline") as mock_pipeline_cls:
+            mock_pipeline_cls.return_value.validate.return_value = mock_result
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_validate(args)
+            assert exc_info.value.code == 0
+            assert mock_pipeline_cls.call_count == 1
+            assert mock_pipeline_cls.return_value.validate.call_count == 2
+        output = json.loads(capsys.readouterr().out)
+        assert isinstance(output, list)
+        assert [entry["file"] for entry in output] == [
+            str(first.resolve()),
+            str(second.resolve()),
+        ]
+
     def test_validate_with_oracle_policyengine_pass(self, capsys, tmp_path):
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = False
         args.oracle = "policyengine"
@@ -1478,7 +1510,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = False
         args.oracle = "policyengine"
@@ -1514,7 +1546,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = True
         args.skip_reviewers = True
         args.oracle = "policyengine"
@@ -1562,7 +1594,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = True
         args.oracle = "policyengine"
@@ -1721,7 +1753,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = True
         args.skip_reviewers = False
         args.oracle = "taxsim"
@@ -1753,7 +1785,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = False
         args.oracle = "all"
@@ -1786,7 +1818,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = True
         args.skip_reviewers = False
         args.oracle = "policyengine"
@@ -1845,7 +1877,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = True
         args.oracle = None
@@ -1880,7 +1912,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = True
         args.skip_reviewers = True
         args.oracle = "policyengine"
@@ -1912,7 +1944,7 @@ class TestCmdValidate:
         rulespec_file = tmp_path / "test.yaml"
         rulespec_file.write_text("# test")
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = True
         args.oracle = None
@@ -19657,7 +19689,7 @@ class TestCmdValidateEdgeCases:
         axiom_rules_path.mkdir(parents=True)
 
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = False
         args.oracle = None
@@ -19693,7 +19725,7 @@ class TestCmdValidateEdgeCases:
         (tmp_path / "axiom-rules-engine").mkdir()
 
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = True
         args.oracle = None
@@ -19733,7 +19765,7 @@ class TestCmdValidateEdgeCases:
         axiom_rules_path.mkdir()
 
         args = MagicMock()
-        args.file = rulespec_file
+        args.files = [rulespec_file]
         args.json = False
         args.skip_reviewers = True
         args.oracle = None

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.649"
+version = "0.2.652"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Re-lands #605, which was accidentally merged into its stacked base branch `cache-policyengine-registry` rather than main, so the change never reached main. This is the same diff cherry-picked onto current main, with the version bump resolved to 0.2.652 (0.2.649 landed via #602; 0.2.650/0.2.651 are claimed by commits on the dead side branch).

Original rationale: consumer repo workflows loop over changed RuleSpec files spawning one `axiom-encode validate` process per file, each paying Python startup plus a full parse of the ~1MB packaged PolicyEngine registry (~4s per file in rulespec-uk's CI). `validate` and `proof-validate` now accept multiple files per invocation and reuse the validator pipeline across files sharing repo roots. `--json` emits an array for multiple files; single-file output is unchanged.

After this merges: bump consumer repos' `.axiom/toolchain.toml` to 0.2.652, then merge TheAxiomFoundation/.github#11.