### PR TITLE
Add UK income tax and NI oracle coverage prefixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.653"
+version = "0.2.654"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.653"
+__version__ = "0.2.654"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -2556,3 +2556,87 @@ prefixes:
     program: scottish_child_payment
     mapping_type: not_comparable
     rationale: Per-child weekly Scottish child payment helpers are source-level steps under the annual amount, which remains the comparable PolicyEngine UK variable.
+
+  - legal_id_prefix: uk:statutes/ukpga/2007/3/8#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 8 outputs are the statutory dividend rate percentages; PolicyEngine UK carries these in its parameter tree rather than as simulated variables, and parameter-level comparisons for this section are not yet registered.
+
+  - legal_id_prefix: uk:statutes/ukpga/2007/3/10#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 10 outputs not listed above are the basic and higher rate limit parameters; PolicyEngine UK carries these in its parameter tree rather than as simulated variables, and parameter-level comparisons are not yet registered.
+
+  - legal_id_prefix: uk:statutes/ukpga/2007/3/12#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 12 starting rate for savings outputs are intra-section band helpers and the statutory limit parameter; PolicyEngine UK computes savings income tax within combined band variables rather than exposing these steps one-to-one.
+
+  - legal_id_prefix: uk:statutes/ukpga/2007/3/12A#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 12A savings nil rate outputs are intra-section applicability predicates and band helpers; PolicyEngine UK applies the personal savings allowance within combined savings tax variables rather than exposing these steps one-to-one.
+
+  - legal_id_prefix: uk:statutes/ukpga/2007/3/12B#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 12B outputs are the savings allowance determination predicates and amount parameters; PolicyEngine UK carries the allowance amounts in its parameter tree and applies them inside savings tax variables, and parameter-level comparisons are not yet registered.
+
+  - legal_id_prefix: uk:statutes/ukpga/2007/3/13A#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 13A dividend nil rate outputs are intra-section band helpers and the dividend allowance parameter; PolicyEngine UK applies the dividend allowance inside dividend tax variables, and parameter-level comparisons are not yet registered.
+
+  - legal_id_prefix: uk:statutes/ukpga/2007/3/16#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 16 outputs are ordering predicates that fix the highest-part treatment of savings and dividend income; PolicyEngine UK hard-codes this ordering inside its band variables rather than exposing it.
+
+  - legal_id_prefix: uk:statutes/ukpga/2021/26/5#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Finance Act 2021 section 5 outputs are the frozen personal allowance and basic rate limit amounts; PolicyEngine UK carries these in its parameter tree rather than as simulated variables, and parameter-level comparisons are not yet registered.
+
+  - legal_id_prefix: uk:statutes/ukpga/2023/1/5#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Finance Act 2023 section 5 outputs are the extended freeze amounts and an uprating-disapplied predicate; PolicyEngine UK carries the amounts in its parameter tree rather than as simulated variables, and parameter-level comparisons are not yet registered.
+
+  - legal_id_prefix: uk:statutes/ukpga/2026/11/1#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: The Finance Act 2026 section 1 output is the annual charge-to-tax predicate, a legal applicability gate that PolicyEngine UK does not expose as an oracle variable.
+
+  - legal_id_prefix: uk:statutes/ukpga/2026/11/2#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Finance Act 2026 section 2 outputs are the main income tax rate percentages; PolicyEngine UK carries these in its parameter tree rather than as simulated variables, and parameter-level comparisons are not yet registered.
+
+  - legal_id_prefix: uk:statutes/ukpga/2026/11/3#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Finance Act 2026 section 3 outputs are the default and savings rate percentages; PolicyEngine UK carries these in its parameter tree rather than as simulated variables, and parameter-level comparisons are not yet registered.
+
+  - legal_id_prefix: uk:statutes/ukpga/2026/11/9#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: The Finance Act 2026 section 9 output is the starting rate limit for savings amount; PolicyEngine UK carries this in its parameter tree rather than as a simulated variable, and parameter-level comparisons are not yet registered.
+
+  - legal_id_prefix: uk:regulations/uksi/2001/1004/10#
+    country: uk
+    program: tax
+    mapping_type: not_comparable
+    rationale: Regulation 10 outputs are the National Insurance earnings limits and thresholds; PolicyEngine UK carries these in its parameter tree rather than as simulated variables, and parameter-level comparisons are not yet registered.

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.653"
+version = "0.2.654"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
TheAxiomFoundation/rulespec-uk#48 adds income tax rate/limit encodings (ITA 2007 ss.8/10/12/12A/12B/13A/16, FA 2021 s.5, FA 2023 s.5, FA 2026 ss.1-3/9 and SSCR 2001 reg 10), but its CI fails the changed-coverage check with 52 unmapped outputs.

This adds 14 `not_comparable` prefix mappings covering those modules, following the existing s.35 prefix pattern: the outputs are statutory rate/limit parameters, band helpers and ordering predicates that PolicyEngine UK carries in its parameter tree or hard-codes inside band variables rather than exposing one-to-one. The genuinely comparable income tax surfaces (basic/higher/additional rate amounts and tax, dividend income tax) already have exact mappings, which take precedence over these prefixes. Parameter-level (`parameter_value`) comparisons for the rates and limits would be a sensible follow-up via the candidate queue once the PolicyEngine parameter paths are verified.

Version bumped to 0.2.654 so rulespec-uk can pin to this in its toolchain.

Checks run: registry self-validation (no issues), `oracle-coverage` against rulespec-uk (0 unmapped, 0 comparable-untested), `pytest tests/test_policyengine_classifier.py tests/test_policyengine_coverage.py` (297 passed).