### PR TITLE
Coverage classifier: monorepo-aware output ids + jurisdiction classifications

### DIFF
--- a/changelog.d/coverage-monorepo-ids.fixed.md
+++ b/changelog.d/coverage-monorepo-ids.fixed.md
@@ -1,0 +1,1 @@
+Derive PolicyEngine oracle-coverage output IDs through the jurisdiction-aware repo-routing helpers so country-monorepo checkouts (`rulespec-us/us-al/...`) produce the same `us-al:policies/X#name` IDs as legacy standalone checkouts instead of jurisdiction-doubled `us:us-al/...` IDs, unblocking the country-monorepo consolidation runs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.654"
+version = "0.2.655"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.654"
+__version__ = "0.2.655"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -10,6 +10,13 @@ from typing import Any
 
 import yaml
 
+from axiom_encode.repo_routing import (
+    canonical_rulespec_repo_name,
+    iter_jurisdiction_content_dirs,
+    jurisdiction_subdir_names,
+    legacy_checkout_name,
+)
+
 from .registry import PolicyEngineMapping, load_policyengine_registry
 
 EXECUTABLE_RULE_KINDS = {"parameter", "derived", "derived_relation"}
@@ -192,14 +199,31 @@ def _iter_policyengine_coverage_items(
     registry,
 ) -> list[PolicyEngineCoverageItem]:
     items: list[PolicyEngineCoverageItem] = []
-    for repo in sorted(root.glob("rulespec-*")):
-        if not repo.is_dir():
-            continue
-        prefix = repo.name.removeprefix("rulespec-")
-        for rulespec_file in sorted(repo.rglob("*.y*ml")):
+    # Enumerate each jurisdiction's content root under the workspace, handling
+    # both layouts: a legacy ``rulespec-<prefix>`` checkout contributes itself
+    # under its prefix; a country monorepo ``rulespec-<country>`` contributes
+    # each first-level jurisdiction directory (``us``, ``us-al``, ...,
+    # ``uk-kingston-upon-thames``). ``prefix`` is the jurisdiction and
+    # ``content_dir`` is the directory whose repo-relative paths form the
+    # ``<prefix>:...`` portion of each output's legal ID, so a file at
+    # ``<rulespec-us>/us-al/policies/X.yaml`` yields ``us-al:policies/X#name``
+    # in either layout instead of a jurisdiction-doubled ``us:us-al/...`` ID.
+    for prefix, content_dir in iter_jurisdiction_content_dirs(root):
+        repo_name = canonical_rulespec_repo_name(content_dir) or legacy_checkout_name(
+            prefix
+        )
+        # In a partially migrated monorepo a country root can be both the
+        # content_dir for the country prefix and the parent of sibling
+        # jurisdiction directories; skip those sibling subtrees here so each
+        # output is attributed to exactly one (prefix, content_dir) pair.
+        nested_subdirs = jurisdiction_subdir_names(content_dir)
+        for rulespec_file in sorted(content_dir.rglob("*.y*ml")):
             if rulespec_file.name.endswith(".test.yaml"):
                 continue
-            if "_axiom" in rulespec_file.relative_to(repo).parts:
+            rel_parts = rulespec_file.relative_to(content_dir).parts
+            if "_axiom" in rel_parts:
+                continue
+            if rel_parts and rel_parts[0] in nested_subdirs:
                 continue
             payload = _load_rulespec_payload(rulespec_file)
             if not payload:
@@ -219,7 +243,7 @@ def _iter_policyengine_coverage_items(
                     continue
                 legal_id = _canonical_rulespec_legal_id(
                     prefix=prefix,
-                    repo=repo,
+                    content_dir=content_dir,
                     rulespec_file=rulespec_file,
                     rule_name=rule_name,
                 )
@@ -235,7 +259,7 @@ def _iter_policyengine_coverage_items(
                 items.append(
                     _coverage_item_from_mapping(
                         legal_id=legal_id,
-                        repo=repo,
+                        repo_name=repo_name,
                         root=root,
                         rulespec_file=rulespec_file,
                         rule_name=rule_name,
@@ -479,11 +503,19 @@ def _mapping_test_output_count(
 def _canonical_rulespec_legal_id(
     *,
     prefix: str,
-    repo: Path,
+    content_dir: Path,
     rulespec_file: Path,
     rule_name: str,
 ) -> str:
-    relative = rulespec_file.resolve().relative_to(repo.resolve())
+    """Derive an output's canonical legal ID from its jurisdiction content root.
+
+    ``content_dir`` is the jurisdiction's content root (a ``rulespec-<prefix>``
+    checkout root in the legacy layout, or the ``<prefix>`` directory inside a
+    country monorepo). Paths are taken relative to that root so both layouts
+    yield identical IDs: ``<rulespec-us>/us-al/policies/X.yaml`` and
+    ``<rulespec-us-al>/policies/X.yaml`` both produce ``us-al:policies/X#name``.
+    """
+    relative = rulespec_file.relative_to(content_dir)
     if relative.suffix in {".yaml", ".yml"}:
         relative = relative.with_suffix("")
     return f"{prefix}:{relative.as_posix()}#{rule_name}"
@@ -494,10 +526,26 @@ def _country_from_rulespec_prefix(prefix: str) -> str:
     return prefix.split("-", 1)[0]
 
 
+def _display_file_path(rulespec_file: Path, root: Path) -> str:
+    """Return a file path relative to the workspace ``root`` for reporting.
+
+    Prefers the unresolved path so a file reached through a sibling-checkout
+    symlink keeps its symlink-name prefix (``rulespec-us/us-al/...`` rather
+    than ``_axiom/rulespec-us/us-al/...``); CI matches changed files against
+    ``<consumer-repo-name>/<path>`` keys built from that symlink name.
+    """
+    for candidate in (rulespec_file, rulespec_file.resolve()):
+        try:
+            return str(candidate.relative_to(root))
+        except ValueError:
+            continue
+    return str(rulespec_file)
+
+
 def _coverage_item_from_mapping(
     *,
     legal_id: str,
-    repo: Path,
+    repo_name: str,
     root: Path,
     rulespec_file: Path,
     rule_name: str,
@@ -506,13 +554,14 @@ def _coverage_item_from_mapping(
     mapping: PolicyEngineMapping | None,
     test_output_count: int,
 ) -> PolicyEngineCoverageItem:
+    file_path = _display_file_path(rulespec_file, root)
     if mapping is None:
         program = _infer_program_from_legal_id(legal_id, rule_name=rule_name)
         if _is_interval_bound_helper_rule(rule_name, rule):
             return PolicyEngineCoverageItem(
                 legal_id=legal_id,
-                repo=repo.name,
-                file=str(rulespec_file.resolve().relative_to(root)),
+                repo=repo_name,
+                file=file_path,
                 rule_name=rule_name,
                 kind=kind,
                 status="known_not_comparable",
@@ -545,8 +594,8 @@ def _coverage_item_from_mapping(
 
     return PolicyEngineCoverageItem(
         legal_id=legal_id,
-        repo=repo.name,
-        file=str(rulespec_file.resolve().relative_to(root)),
+        repo=repo_name,
+        file=file_path,
         rule_name=rule_name,
         kind=kind,
         status=status,

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -2640,3 +2640,9 @@ prefixes:
     program: tax
     mapping_type: not_comparable
     rationale: Regulation 10 outputs are the National Insurance earnings limits and thresholds; PolicyEngine UK carries these in its parameter tree rather than as simulated variables, and parameter-level comparisons are not yet registered.
+  # Council-level schemes are outside PolicyEngine-UK's model; exact
+  # mappings take precedence. Added for rulespec-uk#43.
+  - legal_id_prefix: "uk-kingston-upon-thames:"
+    country: uk
+    mapping_type: not_comparable
+    rationale: PolicyEngine-UK does not model council-level Council Tax Reduction schemes; Kingston upon Thames CTR is grounded to the council's published scheme document.

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -16598,3 +16598,97 @@ prefixes:
     program: medicaid
     mapping_type: not_comparable
     rationale: 42 CFR 600.320 Basic Health Program timely-determination cross-reference predicates are program-administration rules outside PolicyEngine US's one-to-one oracle surface.
+
+  # State agency policy manuals and regulations are not modeled by
+  # PolicyEngine-US except where an exact mapping above says otherwise;
+  # exact entries take precedence over these jurisdiction-wide prefixes.
+  # Added for the country-monorepo consolidation (rulespec-us#395).
+  - legal_id_prefix: "us-al:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model AL agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-ar:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model AR agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-az:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model AZ agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-ca:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model CA agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-co:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model CO agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-de:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model DE agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-fl:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model FL agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-ga:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model GA agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-id:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model ID agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-ma:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model MA agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-md:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model MD agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-nc:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model NC agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-nh:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model NH agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-ny:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model NY agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-ok:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model OK agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-sc:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model SC agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-tn:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model TN agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
+  - legal_id_prefix: "us-tx:"
+    country: us
+    mapping_type: not_comparable
+    rationale: PolicyEngine-US does not model TX agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -5906,7 +5906,10 @@ rules:
     report = build_policyengine_coverage_report(tmp_path, program="tax")
 
     assert report["total_outputs"] == 1
-    assert report["status_counts"] == {"unmapped": 1}
+    # The jurisdiction-wide `us-co:` prefix mapping classifies the output as
+    # not comparable (no exact mapping exists for it); program inference
+    # still runs because prefix entries carry no program.
+    assert report["status_counts"] == {"known_not_comparable": 1}
     item = report["items"][0]
     assert item["legal_id"] == (
         "us-co:statutes/39/39-22-999#unmapped_colorado_tax_output"

--- a/tests/test_policyengine_coverage_monorepo.py
+++ b/tests/test_policyengine_coverage_monorepo.py
@@ -1,0 +1,275 @@
+"""Coverage classifier ID derivation across monorepo and legacy layouts.
+
+The PolicyEngine oracle-coverage classifier must derive identical canonical
+legal IDs whether a jurisdiction's RuleSpec content lives in a country
+monorepo (``rulespec-us/us-al/...``) or a legacy standalone checkout
+(``rulespec-us-al/...``). Earlier the classifier took the repo directory name
+as the prefix and treated everything beneath it as the relative path, which
+doubled the jurisdiction in monorepo IDs (``us:us-al/policies/X#r`` instead of
+``us-al:policies/X#r``). These tests pin the cross-layout equivalence and the
+absence of jurisdiction-doubled IDs.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+from axiom_encode.oracles.policyengine.coverage import (
+    build_policyengine_coverage_report,
+)
+
+# An output with no registry mapping stays ``unmapped`` regardless of layout,
+# which keeps these assertions independent of the packaged mapping registry.
+_UNMAPPED_US_RULESPEC = """format: rulespec/v1
+rules:
+  - name: brand_new_state_helper_xyz
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: state_input
+"""
+
+_UNMAPPED_UK_RULESPEC = """format: rulespec/v1
+rules:
+  - name: brand_new_local_helper_xyz
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: local_input
+"""
+
+
+def _write(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _malformed_doubled_ids(report: dict) -> list[str]:
+    """Return IDs whose jurisdiction prefix is doubled (``us:us-...``)."""
+    pattern = re.compile(r"^([a-z]{2}):\1[-/]")
+    return [
+        item["legal_id"] for item in report["items"] if pattern.match(item["legal_id"])
+    ]
+
+
+def test_monorepo_and_legacy_layouts_derive_identical_ids(tmp_path):
+    """A file under ``rulespec-us/us-al`` and one under a legacy
+    ``rulespec-us-al`` checkout must produce the same ``us-al:policies/X#r``."""
+    monorepo_root = tmp_path / "mono"
+    _write(
+        monorepo_root / "rulespec-us" / "us-al" / "policies" / "dhr" / "poe.yaml",
+        _UNMAPPED_US_RULESPEC,
+    )
+
+    legacy_root = tmp_path / "legacy"
+    _write(
+        legacy_root / "rulespec-us-al" / "policies" / "dhr" / "poe.yaml",
+        _UNMAPPED_US_RULESPEC,
+    )
+
+    monorepo_report = build_policyengine_coverage_report(monorepo_root)
+    legacy_report = build_policyengine_coverage_report(legacy_root)
+
+    expected_id = "us-al:policies/dhr/poe#brand_new_state_helper_xyz"
+    monorepo_ids = [item["legal_id"] for item in monorepo_report["items"]]
+    legacy_ids = [item["legal_id"] for item in legacy_report["items"]]
+
+    assert monorepo_ids == [expected_id]
+    assert legacy_ids == [expected_id]
+    assert monorepo_ids == legacy_ids
+
+    # The repo attribution is the canonical legacy repo name in both layouts.
+    assert {item["repo"] for item in monorepo_report["items"]} == {"rulespec-us-al"}
+    assert {item["repo"] for item in legacy_report["items"]} == {"rulespec-us-al"}
+
+
+def test_monorepo_country_directory_is_not_doubled(tmp_path):
+    """Country-level content in ``rulespec-us/us`` keeps the ``us:`` prefix."""
+    root = tmp_path / "mono"
+    _write(
+        root / "rulespec-us" / "us" / "statutes" / "26" / "9999.yaml",
+        _UNMAPPED_US_RULESPEC,
+    )
+
+    report = build_policyengine_coverage_report(root)
+    ids = [item["legal_id"] for item in report["items"]]
+
+    assert ids == ["us:statutes/26/9999#brand_new_state_helper_xyz"]
+    assert _malformed_doubled_ids(report) == []
+
+
+def test_monorepo_uk_jurisdiction_directories(tmp_path):
+    """``uk`` and ``uk-kingston-upon-thames`` directories keep their prefixes."""
+    root = tmp_path / "mono"
+    _write(
+        root
+        / "rulespec-uk"
+        / "uk-kingston-upon-thames"
+        / "policies"
+        / "kingston-upon-thames"
+        / "council-tax-reduction.yaml",
+        _UNMAPPED_UK_RULESPEC,
+    )
+    _write(
+        root / "rulespec-uk" / "uk" / "policies" / "govuk" / "child-benefit.yaml",
+        _UNMAPPED_UK_RULESPEC,
+    )
+
+    report = build_policyengine_coverage_report(root)
+    ids = {item["legal_id"] for item in report["items"]}
+
+    assert ids == {
+        "uk-kingston-upon-thames:policies/kingston-upon-thames/"
+        "council-tax-reduction#brand_new_local_helper_xyz",
+        "uk:policies/govuk/child-benefit#brand_new_local_helper_xyz",
+    }
+    assert _malformed_doubled_ids(report) == []
+    repos = {item["repo"] for item in report["items"]}
+    assert repos == {"rulespec-uk", "rulespec-uk-kingston-upon-thames"}
+
+
+def test_monorepo_skips_non_jurisdiction_directories(tmp_path):
+    """Shared directories such as ``programs/`` are not treated as a
+    jurisdiction, so no ``programs:...`` IDs are emitted."""
+    root = tmp_path / "mono"
+    _write(
+        root / "rulespec-us" / "us-al" / "policies" / "dhr" / "poe.yaml",
+        _UNMAPPED_US_RULESPEC,
+    )
+    # A shared non-encoding directory holding non-rulespec program manifests.
+    _write(
+        root / "rulespec-us" / "programs" / "us-al" / "snap" / "fy-2026.yaml",
+        "program: us-al/snap\noutputs:\n  - snap_eligible\n",
+    )
+
+    report = build_policyengine_coverage_report(root)
+    ids = [item["legal_id"] for item in report["items"]]
+
+    assert ids == ["us-al:policies/dhr/poe#brand_new_state_helper_xyz"]
+    assert all(not legal_id.startswith("programs:") for legal_id in ids)
+    assert not any(":programs/" in legal_id for legal_id in ids)
+
+
+def test_fake_monorepo_produces_no_malformed_country_doubled_ids(tmp_path):
+    """A classifier run over a fake multi-jurisdiction monorepo emits zero
+    malformed ``<country>:<country>-`` IDs."""
+    root = tmp_path / "mono"
+    jurisdiction_files = {
+        ("rulespec-us", "us"): "statutes/26/100.yaml",
+        ("rulespec-us", "us-al"): "policies/dhr/poe/100.yaml",
+        ("rulespec-us", "us-ca"): "regulations/mpp/63-300/1.yaml",
+        ("rulespec-us", "us-ny"): "policies/otda/snap/100.yaml",
+        ("rulespec-us", "us-tx"): "policies/hhsc/snap/100.yaml",
+        ("rulespec-uk", "uk"): "policies/govuk/child-benefit.yaml",
+        ("rulespec-uk", "uk-kingston-upon-thames"): (
+            "policies/kingston-upon-thames/council-tax-reduction.yaml"
+        ),
+    }
+    for (checkout, prefix), rel in jurisdiction_files.items():
+        content = (
+            _UNMAPPED_UK_RULESPEC if prefix.startswith("uk") else _UNMAPPED_US_RULESPEC
+        )
+        _write(root / checkout / prefix / rel, content)
+
+    report = build_policyengine_coverage_report(root)
+
+    assert _malformed_doubled_ids(report) == []
+    prefixes = {item["legal_id"].split(":", 1)[0] for item in report["items"]}
+    assert prefixes == {
+        "us",
+        "us-al",
+        "us-ca",
+        "us-ny",
+        "us-tx",
+        "uk",
+        "uk-kingston-upon-thames",
+    }
+
+
+def test_multi_checkout_symlink_layout_matches_ci(tmp_path):
+    """Mirror CI: the workspace root holds a real consumer monorepo checkout
+    plus a sibling-checkout symlink to a nested second monorepo. Both walk
+    correctly, output IDs are not doubled, and the symlinked checkout's outputs
+    are not double-counted (the resolved-path dedup collapses the symlink and
+    the nested checkout)."""
+    workspace = tmp_path / "work"
+    workspace.mkdir()
+    consumer = workspace / "rulespec-uk"
+    _write(
+        consumer
+        / "uk-kingston-upon-thames"
+        / "policies"
+        / "kingston-upon-thames"
+        / "council-tax-reduction.yaml",
+        _UNMAPPED_UK_RULESPEC,
+    )
+    _write(
+        consumer / "uk" / "policies" / "govuk" / "child-benefit.yaml",
+        _UNMAPPED_UK_RULESPEC,
+    )
+
+    # A second monorepo nested under the consumer checkout's _axiom/ directory,
+    # exposed at the workspace root through a sibling-checkout symlink.
+    nested_us = consumer / "_axiom" / "rulespec-us"
+    _write(
+        nested_us / "us-al" / "policies" / "dhr" / "poe.yaml",
+        _UNMAPPED_US_RULESPEC,
+    )
+    _write(
+        nested_us / "us" / "statutes" / "26" / "9999.yaml",
+        _UNMAPPED_US_RULESPEC,
+    )
+    os.symlink(nested_us, workspace / "rulespec-us")
+
+    report = build_policyengine_coverage_report(workspace)
+
+    ids = sorted(item["legal_id"] for item in report["items"])
+    assert ids == [
+        "uk-kingston-upon-thames:policies/kingston-upon-thames/"
+        "council-tax-reduction#brand_new_local_helper_xyz",
+        "uk:policies/govuk/child-benefit#brand_new_local_helper_xyz",
+        "us-al:policies/dhr/poe#brand_new_state_helper_xyz",
+        "us:statutes/26/9999#brand_new_state_helper_xyz",
+    ]
+    # No output is attributed twice despite the symlink + nested checkout.
+    assert len(ids) == len(set(ids))
+    assert _malformed_doubled_ids(report) == []
+
+    # The reported file path keeps the symlink-name prefix (``rulespec-us/...``)
+    # so CI's changed-file matching against ``<consumer-repo>/<path>`` works.
+    files_by_id = {item["legal_id"]: item["file"] for item in report["items"]}
+    assert (
+        files_by_id["us-al:policies/dhr/poe#brand_new_state_helper_xyz"]
+        == "rulespec-us/us-al/policies/dhr/poe.yaml"
+    )
+    assert (
+        files_by_id["uk:policies/govuk/child-benefit#brand_new_local_helper_xyz"]
+        == "rulespec-uk/uk/policies/govuk/child-benefit.yaml"
+    )
+
+
+def test_legacy_and_monorepo_unmapped_outputs_match_for_real_prefix(tmp_path):
+    """A genuinely-new (unmapped) output remains unmapped in both layouts,
+    confirming the registry lookup is keyed on the same canonical ID."""
+    monorepo_root = tmp_path / "mono"
+    _write(
+        monorepo_root / "rulespec-us" / "us-zz" / "policies" / "new" / "x.yaml",
+        _UNMAPPED_US_RULESPEC,
+    )
+    legacy_root = tmp_path / "legacy"
+    _write(
+        legacy_root / "rulespec-us-zz" / "policies" / "new" / "x.yaml",
+        _UNMAPPED_US_RULESPEC,
+    )
+
+    monorepo_report = build_policyengine_coverage_report(monorepo_root)
+    legacy_report = build_policyengine_coverage_report(legacy_root)
+
+    assert monorepo_report["status_counts"] == {"unmapped": 1}
+    assert legacy_report["status_counts"] == {"unmapped": 1}
+    assert [item["legal_id"] for item in monorepo_report["items"]] == [
+        item["legal_id"] for item in legacy_report["items"]
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.654"
+version = "0.2.655"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Unblocks rulespec-us#395 and rulespec-uk#43 — their only remaining failing step is oracle-coverage classification, failing for two reasons fixed here:

1. **Monorepo id bug**: the classifier derived `us:us-al/policies/...` / `uk:uk-kingston-upon-thames/...` (jurisdiction doubled) for files inside country monorepos. Path→id derivation now routes through repo_routing's jurisdiction-dir helpers; both layouts yield byte-identical ids (tmp_path tests for both layouts + a no-malformed-ids classifier run; 7 new tests).
2. **Classification gap**: first use of the registry's `match_type: prefix` — jurisdiction-wide `not_comparable` entries for the 18 states and Kingston, carrying no `program` so inference still runs (the three inference tests prove it; one updated to the classified-status reality with a comment). Exact mappings take precedence, so NY/CO comparable outputs keep their classifications.

Single commit bumping to 0.2.654 per the governance gate. Coverage suite: 291/291; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)