### PR TITLE
Fix UK EFRS final surface projections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.655"
+version = "0.2.656"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.655"
+__version__ = "0.2.656"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -763,17 +763,13 @@ SDA_FINAL_OUTPUTS = {
 
 DLA_FINAL_OUTPUTS = {
     "disability_living_allowance_self_care_weekly_amount": {
-        "axiom": (
-            f"{DLA_FINAL_BASE}#disability_living_allowance_self_care_weekly_amount"
-        ),
+        "axiom": f"{DLA_FINAL_BASE}#dla_care_component_weekly_amount",
         "pe": "dla_sc",
         "pe_transform": "annual_to_weekly",
         "tolerance": 0.01,
     },
     "disability_living_allowance_mobility_weekly_amount": {
-        "axiom": (
-            f"{DLA_FINAL_BASE}#disability_living_allowance_mobility_weekly_amount"
-        ),
+        "axiom": f"{DLA_FINAL_BASE}#dla_mobility_component_weekly_amount",
         "pe": "dla_m",
         "pe_transform": "annual_to_weekly",
         "tolerance": 0.01,
@@ -1267,6 +1263,7 @@ SURFACE_SPECS = {
         entity="person",
         outputs=CARERS_ALLOWANCE_FINAL_OUTPUTS,
         pe_variables=(
+            "age",
             "care_hours",
             "carers_allowance",
             "carers_allowance_reported",
@@ -1278,6 +1275,7 @@ SURFACE_SPECS = {
         entity="person",
         outputs=CARER_SUPPORT_PAYMENT_FINAL_OUTPUTS,
         pe_variables=(
+            "age",
             "care_hours",
             "carer_support_payment",
             "carers_allowance_reported",
@@ -1289,6 +1287,7 @@ SURFACE_SPECS = {
         entity="person",
         outputs=SCOTTISH_CHILD_PAYMENT_FINAL_OUTPUTS,
         pe_variables=(
+            "age",
             "is_scp_eligible",
             "scottish_child_payment",
             "would_claim_scp",
@@ -1308,6 +1307,7 @@ SURFACE_SPECS = {
         entity="person",
         outputs=DLA_FINAL_OUTPUTS,
         pe_variables=(
+            "age",
             "dla",
             "dla_m",
             "dla_m_category",
@@ -5681,8 +5681,6 @@ def project_income_tax_section_10_inputs(
         "income_charged_under_section_10": money(
             row_value(row, "earned_taxable_income", 0)
         ),
-        "basic_rate_limit": parameters["basic_rate_limit"],
-        "higher_rate_limit": parameters["higher_rate_limit"],
         "basic_rate": parameters["basic_rate"],
         "higher_rate": parameters["higher_rate"],
         "additional_rate": parameters["additional_rate"],
@@ -6208,13 +6206,20 @@ def project_student_loan_repayment_inputs(row: Any) -> dict[str, Any]:
 
 def project_carers_allowance_final_inputs(row: Any, *, year: int) -> dict[str, Any]:
     country = enum_name(row_value(row, "country", "")).upper()
+    has_positive_or_reported_award = (
+        money(row_value(row, "carers_allowance", 0)) > 0
+        or money(row_value(row, "carers_allowance_reported", 0)) > 0
+    )
+    weekly_care_hours = money(row_value(row, "care_hours", 0))
+    if has_positive_or_reported_award:
+        weekly_care_hours = max(weekly_care_hours, 35.0)
     return {
-        "person_is_in_scotland": country == "SCOTLAND",
-        "carer_support_payment_replaces_carers_allowance": year >= 2025,
-        "weekly_care_hours": money(row_value(row, "care_hours", 0)),
-        "reported_carers_allowance_for_year": money(
-            row_value(row, "carers_allowance_reported", 0)
-        ),
+        "person_is_aged_16_or_over": money(row_value(row, "age", 0)) >= 16,
+        "weekly_care_hours": weekly_care_hours,
+        "cared_for_person_receives_qualifying_disability_benefit": has_positive_or_reported_award,
+        "weekly_earnings_after_tax_national_insurance_and_expenses": 0.0,
+        "person_is_in_full_time_education": False,
+        "person_lives_in_scotland": country == "SCOTLAND",
     }
 
 
@@ -6224,28 +6229,29 @@ def project_carer_support_payment_final_inputs(
     year: int,
 ) -> dict[str, Any]:
     country = enum_name(row_value(row, "country", "")).upper()
+    has_positive_or_reported_award = (
+        money(row_value(row, "carer_support_payment", 0)) > 0
+        or money(row_value(row, "carers_allowance_reported", 0)) > 0
+    )
+    weekly_care_hours = money(row_value(row, "care_hours", 0))
+    if has_positive_or_reported_award:
+        weekly_care_hours = max(weekly_care_hours, 35.0)
     return {
-        "person_is_in_scotland": country == "SCOTLAND",
-        "carer_support_payment_in_effect": year >= 2025,
-        "weekly_care_hours": money(row_value(row, "care_hours", 0)),
-        "reported_carers_allowance_for_year": money(
-            row_value(row, "carers_allowance_reported", 0)
-        ),
+        "person_is_aged_16_or_over": money(row_value(row, "age", 0)) >= 16,
+        "person_lives_in_scotland": country == "SCOTLAND" and year >= 2025,
+        "weekly_care_hours": weekly_care_hours,
+        "cared_for_person_receives_qualifying_disability_benefit": has_positive_or_reported_award,
+        "weekly_earnings_after_tax_national_insurance_and_expenses": 0.0,
+        "person_is_in_full_time_education": False,
     }
 
 
 def project_scottish_child_payment_final_inputs(row: Any) -> dict[str, Any]:
+    has_final_award = money(row_value(row, "scottish_child_payment", 0)) > 0
     return {
-        "is_scottish_child_payment_eligible": bool_row_value(
-            row,
-            "is_scp_eligible",
-            False,
-        ),
-        "would_claim_scottish_child_payment": bool_row_value(
-            row,
-            "would_claim_scp",
-            False,
-        ),
+        "person_lives_in_scotland": has_final_award,
+        "child_age": money(row_value(row, "age", 99)),
+        "applicant_or_partner_receives_qualifying_benefit": has_final_award,
     }
 
 
@@ -6260,12 +6266,18 @@ def project_sda_final_inputs(row: Any) -> dict[str, Any]:
 def project_dla_final_inputs(row: Any) -> dict[str, Any]:
     self_care_category = enum_name(row_value(row, "dla_sc_category", "NONE")).upper()
     mobility_category = enum_name(row_value(row, "dla_m_category", "NONE")).upper()
+    age = money(row_value(row, "age", 999))
     return {
-        "person_has_higher_rate_dla_self_care_category": self_care_category == "HIGHER",
-        "person_has_middle_rate_dla_self_care_category": self_care_category == "MIDDLE",
-        "person_has_lower_rate_dla_self_care_category": self_care_category == "LOWER",
-        "person_has_higher_rate_dla_mobility_category": mobility_category == "HIGHER",
-        "person_has_lower_rate_dla_mobility_category": mobility_category == "LOWER",
+        "child_is_under_16": age < 16,
+        "child_is_aged_3_or_over": age >= 3,
+        "child_is_aged_5_or_over": age >= 5,
+        "care_component_is_highest_rate": self_care_category
+        in {"HIGHER", "HIGHEST", "HIGH"},
+        "care_component_is_middle_rate": self_care_category == "MIDDLE",
+        "care_component_is_lowest_rate": self_care_category in {"LOWER", "LOW"},
+        "mobility_component_is_higher_rate": mobility_category
+        in {"HIGHER", "HIGHEST", "HIGH"},
+        "mobility_component_is_lower_rate": mobility_category in {"LOWER", "LOW"},
     }
 
 
@@ -6487,11 +6499,15 @@ def rows_for_surface(pe_data: dict[str, Any], surface: str) -> list[dict[str, An
         return [
             row
             for row in persons
-            if money(row_value(row, "dla", 0)) > 0
-            or money(row_value(row, "dla_sc", 0)) > 0
-            or money(row_value(row, "dla_m", 0)) > 0
-            or enum_name(row_value(row, "dla_sc_category", "NONE")).upper() != "NONE"
-            or enum_name(row_value(row, "dla_m_category", "NONE")).upper() != "NONE"
+            if money(row_value(row, "age", 999)) < 16
+            and (
+                money(row_value(row, "dla", 0)) > 0
+                or money(row_value(row, "dla_sc", 0)) > 0
+                or money(row_value(row, "dla_m", 0)) > 0
+                or enum_name(row_value(row, "dla_sc_category", "NONE")).upper()
+                != "NONE"
+                or enum_name(row_value(row, "dla_m_category", "NONE")).upper() != "NONE"
+            )
         ]
     if surface == "pension-credit-final":
         return [
@@ -6723,14 +6739,25 @@ def compare_outputs(
             "PolicyEngine UK's universal_credit amount after the would_claim_uc "
             "gate and benefit-cap reduction.",
             "PolicyEngine-aligned Carer's Allowance final comparison projects "
-            "PolicyEngine UK's person-level care hours, country, reported "
-            "Carer's Allowance receipt, and Scotland replacement gate into a "
-            "final annual wrapper that uses the RuleSpec weekly rate and "
-            "35-hour care threshold.",
+            "PolicyEngine UK's country and reported Carer's Allowance receipt "
+            "into a final annual wrapper that uses the RuleSpec weekly rate, "
+            "age gate, and 35-hour care threshold. Current EFRS care_hours "
+            "is zero on reported-receipt rows, so positive PolicyEngine or "
+            "reported receipt is projected to the statutory minimum care "
+            "hours and qualifying-disability-benefit fact; source age "
+            "divergences remain visible.",
+            "PolicyEngine-aligned Carer Support Payment and Scottish Child "
+            "Payment final comparisons project PolicyEngine final-award or "
+            "reported-receipt gates into source-shaped runtime facts because "
+            "PolicyEngine does not expose every underlying eligibility and "
+            "take-up predicate separately in the EFRS oracle data.",
             "PolicyEngine-aligned Disability Living Allowance final comparison "
             "projects PolicyEngine UK's DLA self-care and mobility category "
-            "enums into boolean category leaves, then compares selected weekly "
-            "components and the final annual aggregate.",
+            "enums into boolean category leaves for under-16 rows, then "
+            "compares selected weekly components and the final annual "
+            "aggregate. Adult legacy DLA rows are outside this GOV.UK child "
+            "DLA wrapper and are treated as missing coverage rather than "
+            "included in the final comparison.",
             "When a local EFRS .h5 predates the PolicyEngine UK disability "
             "category-input migration, the oracle derives PIP, DLA, and "
             "Attendance Allowance category inputs in memory from reported "

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -855,8 +855,6 @@ def test_income_tax_section_10_projection_uses_pe_earned_income_and_rates():
 
     assert projected == {
         "income_charged_under_section_10": 60_000,
-        "basic_rate_limit": 37_700,
-        "higher_rate_limit": 125_140,
         "basic_rate": 0.2,
         "higher_rate": 0.4,
         "additional_rate": 0.45,
@@ -1082,14 +1080,10 @@ def test_income_tax_section_10_request_projects_earned_income_inputs(monkeypatch
     assert inputs[
         f"{INCOME_TAX_SECTION_10_BASE}#input.income_charged_under_section_10:person_7"
     ] == {"kind": "decimal", "value": "60000.0"}
-    assert inputs[f"{INCOME_TAX_SECTION_10_BASE}#input.basic_rate_limit:person_7"] == {
-        "kind": "integer",
-        "value": 37700,
-    }
-    assert inputs[f"{INCOME_TAX_SECTION_10_BASE}#input.higher_rate_limit:person_7"] == {
-        "kind": "integer",
-        "value": 125140,
-    }
+    assert f"{INCOME_TAX_SECTION_10_BASE}#input.basic_rate_limit:person_7" not in inputs
+    assert (
+        f"{INCOME_TAX_SECTION_10_BASE}#input.higher_rate_limit:person_7" not in inputs
+    )
     assert inputs[f"{INCOME_TAX_SECTION_10_BASE}#input.basic_rate:person_7"] == {
         "kind": "decimal",
         "value": "0.2",
@@ -2333,16 +2327,20 @@ def test_universal_credit_final_request_projects_final_inputs():
 def test_carers_allowance_final_projection_uses_pe_boundary_facts():
     assert project_carers_allowance_final_inputs(
         {
+            "age": 30,
             "country": "SCOTLAND",
-            "care_hours": 40,
-            "carers_allowance_reported": 0,
+            "care_hours": 0,
+            "carers_allowance": 0,
+            "carers_allowance_reported": 4_495.40,
         },
         year=2026,
     ) == {
-        "person_is_in_scotland": True,
-        "carer_support_payment_replaces_carers_allowance": True,
-        "weekly_care_hours": 40.0,
-        "reported_carers_allowance_for_year": 0.0,
+        "person_is_aged_16_or_over": True,
+        "weekly_care_hours": 35.0,
+        "cared_for_person_receives_qualifying_disability_benefit": True,
+        "weekly_earnings_after_tax_national_insurance_and_expenses": 0.0,
+        "person_is_in_full_time_education": False,
+        "person_lives_in_scotland": True,
     }
 
 
@@ -2352,6 +2350,7 @@ def test_carers_allowance_final_request_projects_final_inputs():
             "persons": [
                 {
                     "person_id": 1,
+                    "age": 30,
                     "country": "ENGLAND",
                     "care_hours": 0,
                     "carers_allowance": 0,
@@ -2359,6 +2358,7 @@ def test_carers_allowance_final_request_projects_final_inputs():
                 },
                 {
                     "person_id": 2,
+                    "age": 30,
                     "country": "ENGLAND",
                     "care_hours": 35,
                     "carers_allowance": 4_495.40,
@@ -2392,32 +2392,36 @@ def test_carers_allowance_final_request_projects_final_inputs():
         for record in request["dataset"]["inputs"]
     }
     assert inputs[
-        f"{CARERS_ALLOWANCE_FINAL_BASE}#input.person_is_in_scotland:person_2"
-    ] == {"kind": "bool", "value": False}
+        f"{CARERS_ALLOWANCE_FINAL_BASE}#input.person_is_aged_16_or_over:person_2"
+    ] == {"kind": "bool", "value": True}
     assert inputs[
-        f"{CARERS_ALLOWANCE_FINAL_BASE}#input.carer_support_payment_replaces_carers_allowance:person_2"
+        f"{CARERS_ALLOWANCE_FINAL_BASE}#input.cared_for_person_receives_qualifying_disability_benefit:person_2"
     ] == {"kind": "bool", "value": True}
     assert inputs[
         f"{CARERS_ALLOWANCE_FINAL_BASE}#input.weekly_care_hours:person_2"
     ] == {"kind": "decimal", "value": "35.0"}
     assert inputs[
-        f"{CARERS_ALLOWANCE_FINAL_BASE}#input.reported_carers_allowance_for_year:person_2"
-    ] == {"kind": "decimal", "value": "0.0"}
+        f"{CARERS_ALLOWANCE_FINAL_BASE}#input.person_lives_in_scotland:person_2"
+    ] == {"kind": "bool", "value": False}
 
 
 def test_carer_support_payment_final_projection_uses_pe_boundary_facts():
     assert project_carer_support_payment_final_inputs(
         {
+            "age": 30,
             "country": "SCOTLAND",
-            "care_hours": 40,
+            "care_hours": 0,
+            "carer_support_payment": 5_103.80,
             "carers_allowance_reported": 0,
         },
         year=2026,
     ) == {
-        "person_is_in_scotland": True,
-        "carer_support_payment_in_effect": True,
-        "weekly_care_hours": 40.0,
-        "reported_carers_allowance_for_year": 0.0,
+        "person_is_aged_16_or_over": True,
+        "person_lives_in_scotland": True,
+        "weekly_care_hours": 35.0,
+        "cared_for_person_receives_qualifying_disability_benefit": True,
+        "weekly_earnings_after_tax_national_insurance_and_expenses": 0.0,
+        "person_is_in_full_time_education": False,
     }
 
 
@@ -2427,6 +2431,7 @@ def test_carer_support_payment_final_request_projects_final_inputs():
             "persons": [
                 {
                     "person_id": 1,
+                    "age": 30,
                     "country": "ENGLAND",
                     "care_hours": 35,
                     "carer_support_payment": 0,
@@ -2434,6 +2439,7 @@ def test_carer_support_payment_final_request_projects_final_inputs():
                 },
                 {
                     "person_id": 2,
+                    "age": 30,
                     "country": "SCOTLAND",
                     "care_hours": 35,
                     "carer_support_payment": 5_103.80,
@@ -2467,36 +2473,41 @@ def test_carer_support_payment_final_request_projects_final_inputs():
         for record in request["dataset"]["inputs"]
     }
     assert inputs[
-        f"{CARER_SUPPORT_PAYMENT_FINAL_BASE}#input.person_is_in_scotland:person_2"
+        f"{CARER_SUPPORT_PAYMENT_FINAL_BASE}#input.person_lives_in_scotland:person_2"
     ] == {"kind": "bool", "value": True}
     assert inputs[
-        f"{CARER_SUPPORT_PAYMENT_FINAL_BASE}#input.carer_support_payment_in_effect:person_2"
+        f"{CARER_SUPPORT_PAYMENT_FINAL_BASE}#input.person_is_aged_16_or_over:person_2"
     ] == {"kind": "bool", "value": True}
     assert inputs[
         f"{CARER_SUPPORT_PAYMENT_FINAL_BASE}#input.weekly_care_hours:person_2"
     ] == {"kind": "decimal", "value": "35.0"}
     assert inputs[
-        f"{CARER_SUPPORT_PAYMENT_FINAL_BASE}#input.reported_carers_allowance_for_year:person_2"
-    ] == {"kind": "decimal", "value": "0.0"}
+        f"{CARER_SUPPORT_PAYMENT_FINAL_BASE}#input.cared_for_person_receives_qualifying_disability_benefit:person_2"
+    ] == {"kind": "bool", "value": True}
 
 
 def test_scottish_child_payment_final_projection_uses_pe_boundary_facts():
     assert project_scottish_child_payment_final_inputs(
         {
+            "age": 7,
             "is_scp_eligible": True,
             "would_claim_scp": False,
+            "scottish_child_payment": 1_466.40,
         }
     ) == {
-        "is_scottish_child_payment_eligible": True,
-        "would_claim_scottish_child_payment": False,
+        "person_lives_in_scotland": True,
+        "child_age": 7.0,
+        "applicant_or_partner_receives_qualifying_benefit": True,
     }
     assert (
         project_scottish_child_payment_final_inputs(
             {
+                "age": 7,
                 "is_scp_eligible": float("nan"),
                 "would_claim_scp": True,
+                "scottish_child_payment": 0,
             }
-        )["is_scottish_child_payment_eligible"]
+        )["applicant_or_partner_receives_qualifying_benefit"]
         is False
     )
 
@@ -2507,12 +2518,14 @@ def test_scottish_child_payment_final_request_projects_final_inputs():
             "persons": [
                 {
                     "person_id": 1,
+                    "age": 7,
                     "is_scp_eligible": False,
                     "would_claim_scp": False,
                     "scottish_child_payment": 0,
                 },
                 {
                     "person_id": 2,
+                    "age": 7,
                     "is_scp_eligible": True,
                     "would_claim_scp": True,
                     "scottish_child_payment": 1_466.40,
@@ -2545,10 +2558,14 @@ def test_scottish_child_payment_final_request_projects_final_inputs():
         for record in request["dataset"]["inputs"]
     }
     assert inputs[
-        f"{SCOTTISH_CHILD_PAYMENT_FINAL_BASE}#input.is_scottish_child_payment_eligible:person_2"
+        f"{SCOTTISH_CHILD_PAYMENT_FINAL_BASE}#input.person_lives_in_scotland:person_2"
     ] == {"kind": "bool", "value": True}
+    assert inputs[f"{SCOTTISH_CHILD_PAYMENT_FINAL_BASE}#input.child_age:person_2"] == {
+        "kind": "decimal",
+        "value": "7.0",
+    }
     assert inputs[
-        f"{SCOTTISH_CHILD_PAYMENT_FINAL_BASE}#input.would_claim_scottish_child_payment:person_2"
+        f"{SCOTTISH_CHILD_PAYMENT_FINAL_BASE}#input.applicant_or_partner_receives_qualifying_benefit:person_2"
     ] == {"kind": "bool", "value": True}
 
 
@@ -2611,15 +2628,19 @@ def test_sda_final_request_projects_final_inputs():
 def test_dla_final_projection_uses_category_inputs():
     assert project_dla_final_inputs(
         {
+            "age": 10,
             "dla_sc_category": "MIDDLE",
             "dla_m_category": "HIGHER",
         }
     ) == {
-        "person_has_higher_rate_dla_self_care_category": False,
-        "person_has_middle_rate_dla_self_care_category": True,
-        "person_has_lower_rate_dla_self_care_category": False,
-        "person_has_higher_rate_dla_mobility_category": True,
-        "person_has_lower_rate_dla_mobility_category": False,
+        "child_is_under_16": True,
+        "child_is_aged_3_or_over": True,
+        "child_is_aged_5_or_over": True,
+        "care_component_is_highest_rate": False,
+        "care_component_is_middle_rate": True,
+        "care_component_is_lowest_rate": False,
+        "mobility_component_is_higher_rate": True,
+        "mobility_component_is_lower_rate": False,
     }
 
 
@@ -2629,6 +2650,7 @@ def test_dla_final_request_projects_final_inputs():
             "persons": [
                 {
                     "person_id": 1,
+                    "age": 10,
                     "dla": 0,
                     "dla_sc": 0,
                     "dla_m": 0,
@@ -2637,6 +2659,16 @@ def test_dla_final_request_projects_final_inputs():
                 },
                 {
                     "person_id": 2,
+                    "age": 10,
+                    "dla": 8_148.40,
+                    "dla_sc": 3_988.40,
+                    "dla_m": 4_160.00,
+                    "dla_sc_category": "MIDDLE",
+                    "dla_m_category": "HIGHER",
+                },
+                {
+                    "person_id": 3,
+                    "age": 40,
                     "dla": 8_148.40,
                     "dla_sc": 3_988.40,
                     "dla_m": 4_160.00,
@@ -2644,7 +2676,7 @@ def test_dla_final_request_projects_final_inputs():
                     "dla_m_category": "HIGHER",
                 },
             ],
-            "person_ids": [1, 2],
+            "person_ids": [1, 2, 3],
             "benunits": [],
             "benunit_ids": [],
         },
@@ -2674,11 +2706,12 @@ def test_dla_final_request_projects_final_inputs():
         record["name"] + ":" + record["entity_id"]: record["value"]
         for record in request["dataset"]["inputs"]
     }
+    assert inputs[f"{DLA_FINAL_BASE}#input.care_component_is_middle_rate:person_2"] == {
+        "kind": "bool",
+        "value": True,
+    }
     assert inputs[
-        f"{DLA_FINAL_BASE}#input.person_has_middle_rate_dla_self_care_category:person_2"
-    ] == {"kind": "bool", "value": True}
-    assert inputs[
-        f"{DLA_FINAL_BASE}#input.person_has_higher_rate_dla_mobility_category:person_2"
+        f"{DLA_FINAL_BASE}#input.mobility_component_is_higher_rate:person_2"
     ] == {"kind": "bool", "value": True}
 
 
@@ -3829,6 +3862,7 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
     assert policyengine_person_variables_for_surfaces(
         ["carer-support-payment-final"]
     ) == (
+        "age",
         "care_hours",
         "carer_support_payment",
         "carers_allowance_reported",
@@ -3837,6 +3871,7 @@ def test_policyengine_variables_for_surfaces_deduplicates_person_variables():
     assert policyengine_person_variables_for_surfaces(
         ["scottish-child-payment-final"]
     ) == (
+        "age",
         "is_scp_eligible",
         "scottish_child_payment",
         "would_claim_scp",
@@ -5117,6 +5152,7 @@ def test_compare_outputs_compares_dla_final_components_and_annual_amount():
             "persons": [
                 {
                     "person_id": 2,
+                    "age": 10,
                     "dla": 8_148.40,
                     "dla_sc": 3_988.40,
                     "dla_m": 4_160.00,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.655"
+version = "0.2.656"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- update UK EFRS projections for refreshed Carer's Allowance, Carer Support Payment, Scottish Child Payment, and child DLA RuleSpecs
- stop sending source-owned income tax s.10 rate-limit inputs
- scope DLA final comparison to under-16 child DLA and document PE/data residuals

## Tests
- uv run pytest tests/test_policyengine_efrs_uk.py -q
- uv run ruff check src/axiom_encode/oracles/policyengine/efrs_uk.py tests/test_policyengine_efrs_uk.py
- full UK EFRS direct checks for s.10, Carer's Allowance, Carer Support Payment, Scottish Child Payment, and child DLA