### PR TITLE
Fix benchmark allow_context paths for the country-monorepo layout

### DIFF
--- a/benchmarks/us_snap_asset_test_current_effective_refresh.yaml
+++ b/benchmarks/us_snap_asset_test_current_effective_refresh.yaml
@@ -16,7 +16,7 @@ cases:
     source_id: USDA SNAP FY2026 maximum asset limits
     corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-2
     allow_context:
-      - ../../rulespec-us/policies/usda/snap/fy-2026-cola/deductions.yaml
+      - ../../rulespec-us/us/policies/usda/snap/fy-2026-cola/deductions.yaml
     oracle: policyengine
     policyengine_country: auto
     policyengine_rule_hint: meets_snap_asset_test

--- a/benchmarks/us_snap_asset_test_refresh.yaml
+++ b/benchmarks/us_snap_asset_test_refresh.yaml
@@ -16,7 +16,7 @@ cases:
     source_id: 7 USC 2014(g)(1)
     corpus_citation_path: us/statute/7/2014/g/1
     allow_context:
-      - ../../rulespec-us/policies/usda/snap/fy-2026-cola/deductions.yaml
+      - ../../rulespec-us/us/policies/usda/snap/fy-2026-cola/deductions.yaml
     oracle: policyengine
     policyengine_country: auto
     policyengine_rule_hint: meets_snap_asset_test

--- a/benchmarks/us_snap_eligibility_refresh.yaml
+++ b/benchmarks/us_snap_eligibility_refresh.yaml
@@ -16,9 +16,9 @@ cases:
     source_id: Federal SNAP current-effective household eligibility
     corpus_citation_path: us/statute/7/2014
     allow_context:
-      - ../../rulespec-us/statutes/7/2014/e/2.yaml
-      - ../../rulespec-us/statutes/7/2014/e/6/A.yaml
-      - ../../rulespec-us/policies/usda/snap/fy-2026-cola/income-eligibility-standards.yaml
+      - ../../rulespec-us/us/statutes/7/2014/e/2.yaml
+      - ../../rulespec-us/us/statutes/7/2014/e/6/A.yaml
+      - ../../rulespec-us/us/policies/usda/snap/fy-2026-cola/income-eligibility-standards.yaml
     oracle: policyengine
     policyengine_country: auto
     policyengine_rule_hint: is_snap_eligible

--- a/benchmarks/us_snap_federal_c3_repair.yaml
+++ b/benchmarks/us_snap_federal_c3_repair.yaml
@@ -16,4 +16,4 @@ cases:
     source_id: 7 USC 2017(c)(3)
     corpus_citation_path: us/statute/7/2017/c/3
     allow_context:
-      - ../../rulespec-us/statutes/7/2017/a.yaml
+      - ../../rulespec-us/us/statutes/7/2017/a.yaml

--- a/benchmarks/us_snap_federal_reconstruction_seed.yaml
+++ b/benchmarks/us_snap_federal_reconstruction_seed.yaml
@@ -16,26 +16,26 @@ cases:
     source_id: 7 USC 2017(a)
     corpus_citation_path: us/statute/7/2017/a
     allow_context:
-      - ../../rulespec-us/statutes/7/2014/e/2.yaml
-      - ../../rulespec-us/statutes/7/2014/e/6/A.yaml
+      - ../../rulespec-us/us/statutes/7/2014/e/2.yaml
+      - ../../rulespec-us/us/statutes/7/2014/e/6/A.yaml
 
   - kind: source
     name: snap-2017-c-1
     source_id: 7 USC 2017(c)(1)
     corpus_citation_path: us/statute/7/2017/c/1
     allow_context:
-      - ../../rulespec-us/statutes/7/2017/a.yaml
+      - ../../rulespec-us/us/statutes/7/2017/a.yaml
 
   - kind: source
     name: snap-2017-c-3
     source_id: 7 USC 2017(c)(3)
     corpus_citation_path: us/statute/7/2017/c/3
     allow_context:
-      - ../../rulespec-us/statutes/7/2017/a.yaml
+      - ../../rulespec-us/us/statutes/7/2017/a.yaml
 
   - kind: source
     name: snap-fy2026-cola-allotments
     source_id: USDA SNAP FY 2026 COLA allotment table
     corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
     allow_context:
-      - ../../rulespec-us/statutes/7/2017/a.yaml
+      - ../../rulespec-us/us/statutes/7/2017/a.yaml

--- a/benchmarks/us_snap_fy2026_cola_table_repair.yaml
+++ b/benchmarks/us_snap_fy2026_cola_table_repair.yaml
@@ -16,4 +16,4 @@ cases:
     source_id: USDA SNAP FY 2026 COLA allotment table
     corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
     allow_context:
-      - ../../rulespec-us/statutes/7/2017/a.yaml
+      - ../../rulespec-us/us/statutes/7/2017/a.yaml

--- a/changelog.d/benchmark-allow-context-monorepo-paths.fixed.md
+++ b/changelog.d/benchmark-allow-context-monorepo-paths.fixed.md
@@ -1,0 +1,1 @@
+- Benchmark suite `allow_context` entries now point at the country-monorepo layout (`rulespec-us/us/statutes/...`, `rulespec-us/us/policies/...`) instead of the legacy pre-consolidation federal paths, so corpus-backed SNAP suites can resolve their repo-augmented context again.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.656"
+version = "0.2.657"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.656"
+__version__ = "0.2.657"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.656"
+version = "0.2.657"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

The benchmark suites' `allow_context` entries still referenced the legacy
pre-consolidation federal layout (`rulespec-us/statutes/...`,
`rulespec-us/policies/...`). The `rulespec-us` country monorepo moved federal
content under `us/`, so those relative paths no longer resolved from
`benchmarks/`, and the corpus-backed SNAP suites could not load their
repo-augmented context. This blocked running any of these benchmark lanes.

This PR rewrites the six affected suites to the monorepo layout and bumps the
encoder version so the change is behind a version commit.

## Path fixes

`allow_context` entries are resolved relative to the `benchmarks/` directory
(`_resolve_manifest_path` in `src/axiom_encode/harness/evals.py`), so
`../../rulespec-us/statutes/...` resolved to a path that no longer exists.
Each entry was rewritten to `../../rulespec-us/us/statutes/...` /
`../../rulespec-us/us/policies/...` and verified to exist in a fresh
`rulespec-us` checkout.

Affected files (12 `allow_context` entries total):

- `benchmarks/us_snap_eligibility_refresh.yaml`
- `benchmarks/us_snap_federal_c3_repair.yaml`
- `benchmarks/us_snap_fy2026_cola_table_repair.yaml`
- `benchmarks/us_snap_asset_test_current_effective_refresh.yaml`
- `benchmarks/us_snap_asset_test_refresh.yaml`
- `benchmarks/us_snap_federal_reconstruction_seed.yaml`

Only `allow_context` filesystem paths were stale. `corpus_citation_path`
values (e.g. `us/statute/7/2014`, `us-co/regulation/...`) are corpus citation
IDs, not filesystem paths, and were already in the correct monorepo form, so
they are unchanged. No state (`us-xx`) `allow_context` filesystem paths exist
in `benchmarks/`, so none needed the `rulespec-us/us-xx/...` rewrite.

## Version bump

Encoder version bumped `0.2.656 -> 0.2.657` in the same commit across
`pyproject.toml`, `src/axiom_encode/__init__.py`, and `uv.lock` (via
`uv lock`), with a `changelog.d` fragment, satisfying the version-provenance
governance gate and the changelog check.

## Verification

- `ruff check src/ tests/` - passed
- `ruff format --check src/ tests/` - passed (66 files)
- `python -m towncrier build --draft` - fragment renders
- `pytest tests/test_cli.py -k version` - 12 passed (includes
  `test_package_version_metadata_matches_pyproject` and
  `test_current_encoder_affecting_changes_are_behind_version_bump`)
- Every rewritten path confirmed present in a fresh `rulespec-us` checkout.

This change is independent of the encoder prompt and unblocks running all
benchmark suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
