### PR TITLE
Assert delegated policy setting shape

### DIFF
--- a/changelog.d/delegated-policy-setting-apply-repair.fixed.md
+++ b/changelog.d/delegated-policy-setting-apply-repair.fixed.md
@@ -1,0 +1,1 @@
+Repair generated SNAP delegated policy-setting source relations before signed apply.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.661"
+version = "0.2.662"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.659"
+version = "0.2.660"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.663"
+version = "0.2.664"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.662"
+version = "0.2.663"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.660"
+version = "0.2.661"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.658"
+version = "0.2.659"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.661"
+__version__ = "0.2.662"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.660"
+__version__ = "0.2.661"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.662"
+__version__ = "0.2.663"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.663"
+__version__ = "0.2.664"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.658"
+__version__ = "0.2.659"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.659"
+__version__ = "0.2.660"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -72,6 +72,7 @@ from .harness.evals import (
 )
 from .harness.proof_validator import validate_rulespec_proofs
 from .harness.validator_pipeline import (
+    _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS,
     _US_TAX_JOINT_ONLY_ANY_OTHER_CASE_TEXT_PATTERN,
     _US_TAX_JOINT_SURVIVING_SPOUSE_GROUP_TEXT_PATTERN,
     ValidatorPipeline,
@@ -82,6 +83,7 @@ from .harness.validator_pipeline import (
     _filing_status_rule_source_context,
     _is_executable_rulespec_rule,
     _load_nearby_eval_source_metadata,
+    _matching_delegated_setting_rule_names,
     _rulespec_executable_index_for_roots,
     _rulespec_executable_signature,
     _rulespec_public_item_keys,
@@ -16006,6 +16008,35 @@ def cmd_encode(args):
             )
             outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_delegated_settings = (
+                    _try_repair_generated_delegated_policy_settings_for_apply(
+                        result,
+                        output_root=args.output,
+                        policy_repo_path=policy_repo_path,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_delegated_settings:
+                    outcome["auto_repaired_delegated_policy_settings"] = (
+                        repaired_delegated_settings
+                    )
+                    print(
+                        "  apply=auto_repaired_delegated_policy_settings:"
+                        + ",".join(repaired_delegated_settings)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_source_relations = (
                     _try_repair_generated_source_relation_delegations_for_apply(
                         result,
@@ -17577,6 +17608,191 @@ def _try_repair_generated_boolean_parameter_inputs_for_apply(
         rules_file,
         names=missing_inputs,
     )
+
+
+def _try_repair_generated_delegated_policy_settings_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path | None = None,
+    issues: list[str],
+) -> list[str]:
+    """Insert canonical state `sets` edges for generated delegated settings."""
+    if not any(_issue_mentions_delegated_policy_setting(issue) for issue in issues):
+        return []
+    try:
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    target_anchor = _relative_output_to_anchor(
+        relative_output,
+        policy_repo_path=policy_repo_path,
+    )
+    existing_names = {
+        str(rule.get("name") or "").strip()
+        for rule in rules
+        if isinstance(rule, dict)
+    }
+    additions: list[dict[str, Any]] = []
+    repaired: list[str] = []
+    for setting_target in _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS:
+        if _generated_rules_include_source_relation_target(rules, setting_target.target):
+            continue
+        local_rule_names = _matching_delegated_setting_rule_names(
+            rules,
+            setting_target.rule_name_patterns,
+        )
+        if not local_rule_names:
+            continue
+        value_rule = _preferred_delegated_setting_value_rule(rules, local_rule_names)
+        if value_rule is None:
+            continue
+        value_name = str(value_rule.get("name") or "").strip()
+        if not value_name:
+            continue
+        target_symbol = setting_target.target.rsplit("#", 1)[-1]
+        relation_stem = target_symbol.removesuffix("_state_option")
+        relation_name = _unique_generated_rule_name(
+            f"sets_{relation_stem}",
+            existing_names,
+        )
+        existing_names.add(relation_name)
+        source_relation_rule: dict[str, Any] = {
+            "name": relation_name,
+            "kind": "source_relation",
+            "source_relation": {
+                "type": "sets",
+                "target": setting_target.target,
+                "authority": "state",
+                "value": f"{target_anchor}#{value_name}",
+                "basis": {
+                    "delegation": "us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation",
+                },
+            },
+        }
+        source = value_rule.get("source")
+        if isinstance(source, str) and source.strip():
+            source_relation_rule["source"] = source.strip()
+        additions.append(source_relation_rule)
+        repaired.append(relation_name)
+
+    if not additions:
+        return []
+
+    insert_at = 0
+    while insert_at < len(rules):
+        rule = rules[insert_at]
+        if not isinstance(rule, dict):
+            break
+        if str(rule.get("kind") or "").strip().lower() != "source_relation":
+            break
+        insert_at += 1
+    payload["rules"] = [*rules[:insert_at], *additions, *rules[insert_at:]]
+    rules_file.write_text(
+        yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
+    )
+    return repaired
+
+
+def _issue_mentions_delegated_policy_setting(issue: str) -> bool:
+    return "Delegated policy setting missing source_relation" in issue
+
+
+def _generated_rules_include_source_relation_target(
+    rules: list[Any],
+    target: str,
+) -> bool:
+    normalized_target = _normalize_source_relation_target_ref(target)
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "source_relation":
+            continue
+        source_relation = rule.get("source_relation")
+        if not isinstance(source_relation, dict):
+            continue
+        if str(source_relation.get("type") or "").strip().lower() != "sets":
+            continue
+        if (
+            _normalize_source_relation_target_ref(source_relation.get("target"))
+            == normalized_target
+        ):
+            return True
+    return False
+
+
+def _preferred_delegated_setting_value_rule(
+    rules: list[Any],
+    local_rule_names: list[str],
+) -> dict[str, Any] | None:
+    local_names = set(local_rule_names)
+    candidates: list[tuple[int, int, dict[str, Any]]] = []
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            continue
+        name = str(rule.get("name") or "").strip()
+        if name not in local_names or not _is_executable_rulespec_rule(rule):
+            continue
+        score = _delegated_setting_value_rule_score(rule)
+        candidates.append((score, -index, rule))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    return candidates[0][2]
+
+
+_PREFERRED_DELEGATED_SETTING_VALUE_NAMES = {
+    "snap_standard_utility_allowance",
+    "heating_cooling_standard_utility_allowance",
+    "snap_limited_utility_allowance",
+    "non_heating_non_cooling_basic_utility_allowance",
+    "snap_basic_utility_allowance",
+    "snap_individual_utility_allowance",
+    "telephone_utility_allowance",
+    "snap_one_utility_allowance",
+}
+
+
+def _delegated_setting_value_rule_score(rule: dict[str, Any]) -> int:
+    name = str(rule.get("name") or "").strip()
+    kind = str(rule.get("kind") or "").strip().lower()
+    score = 0
+    if name in _PREFERRED_DELEGATED_SETTING_VALUE_NAMES:
+        score += 100
+    if kind == "derived":
+        score += 40
+    if name.startswith("snap_"):
+        score += 10
+    if name.endswith("_amount"):
+        score -= 20
+    if name.endswith("_for_unit_size"):
+        score -= 30
+    return score
+
+
+def _unique_generated_rule_name(base: str, existing_names: set[str]) -> str:
+    if base not in existing_names:
+        return base
+    suffix = 2
+    while f"{base}_{suffix}" in existing_names:
+        suffix += 1
+    return f"{base}_{suffix}"
 
 
 def _try_repair_generated_source_relation_delegations_for_apply(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -15399,7 +15399,7 @@ def _all_protected_rulespec_yaml_paths(
 
 
 def _all_applied_encoding_manifest_paths(
-    repo_path: Path, *, roots: tuple[str, ...]
+    repo_path: Path, *, roots: tuple[str, ...] = tuple(sorted(RULESPEC_SOURCE_ROOTS))
 ) -> list[str]:
     manifest_roots = [repo_path / APPLIED_ENCODING_MANIFEST_DIR]
     manifest_roots.extend(
@@ -15494,7 +15494,10 @@ def _applied_encoding_manifest_root_prefix(
 
 
 def _load_applied_encoding_manifest_entries(
-    repo_path: Path, manifest_paths: list[str], *, roots: tuple[str, ...]
+    repo_path: Path,
+    manifest_paths: list[str],
+    *,
+    roots: tuple[str, ...] = tuple(sorted(RULESPEC_SOURCE_ROOTS)),
 ) -> tuple[dict[str, set[str]], list[str]]:
     entries: dict[str, set[str]] = defaultdict(set)
     issues: list[str] = []

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -17949,14 +17949,6 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
     wrapper_additions: list[dict[str, Any]] = []
     repaired: list[str] = []
     for setting_target in _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS:
-        if _generated_rules_include_source_relation_target(rules, setting_target.target):
-            continue
-        local_rule_names = _matching_delegated_setting_rule_names(
-            rules,
-            setting_target.rule_name_patterns,
-        )
-        if not local_rule_names:
-            continue
         target_rule = _rulespec_rule_for_absolute_ref(
             setting_target.target,
             current_payload=payload,
@@ -17964,6 +17956,37 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
             policy_repo_path=policy_repo_path,
         )
         target_kind = _rulespec_rule_kind(target_rule)
+        existing_relation = _generated_source_relation_for_target(
+            rules,
+            setting_target.target,
+        )
+        if existing_relation is not None:
+            existing_repair = _repair_delegated_setting_relation_value_kind(
+                existing_relation,
+                rules,
+                current_payload=payload,
+                current_rules_file=rules_file,
+                policy_repo_path=policy_repo_path,
+                target_anchor=target_anchor,
+                target_rule=target_rule,
+                target_kind=target_kind,
+                existing_names=existing_names,
+            )
+            if existing_repair is not None:
+                wrapper_additions.append(existing_repair)
+                wrapper_name = str(existing_repair.get("name") or "").strip()
+                if wrapper_name:
+                    existing_names.add(wrapper_name)
+                    repaired.append(wrapper_name)
+            if _ensure_rulespec_payload_import(payload, setting_target.target):
+                repaired.append(f"import:{setting_target.target.split('#', 1)[0]}")
+            continue
+        local_rule_names = _matching_delegated_setting_rule_names(
+            rules,
+            setting_target.rule_name_patterns,
+        )
+        if not local_rule_names:
+            continue
         value_rule = _preferred_delegated_setting_value_rule(rules, local_rule_names)
         if value_rule is None:
             continue
@@ -18009,8 +18032,10 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
             source_relation_rule["source"] = source.strip()
         source_relation_additions.append(source_relation_rule)
         repaired.append(relation_name)
+        if _ensure_rulespec_payload_import(payload, setting_target.target):
+            repaired.append(f"import:{setting_target.target.split('#', 1)[0]}")
 
-    if not source_relation_additions:
+    if not source_relation_additions and not wrapper_additions and not repaired:
         return []
 
     insert_at = 0
@@ -18034,7 +18059,35 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
 
 
 def _issue_mentions_delegated_policy_setting(issue: str) -> bool:
-    return "Delegated policy setting missing source_relation" in issue
+    if "Delegated policy setting missing source_relation" in issue:
+        return True
+    if "RuleSpec source relation" not in issue:
+        return False
+    return any(
+        setting_target.target in issue
+        for setting_target in _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS
+    )
+
+
+def _ensure_rulespec_payload_import(payload: dict[str, Any], target: str) -> bool:
+    import_target = target.split("#", 1)[0].strip()
+    if not import_target:
+        return False
+    imports = payload.get("imports")
+    if imports is None:
+        payload["imports"] = [import_target]
+        return True
+    if not isinstance(imports, list):
+        return False
+    normalized_imports = {
+        str(item).split("#", 1)[0].strip()
+        for item in imports
+        if isinstance(item, str)
+    }
+    if import_target in normalized_imports:
+        return False
+    imports.append(import_target)
+    return True
 
 
 def _rulespec_rule_kind(rule: dict[str, Any] | None) -> str:
@@ -18183,14 +18236,17 @@ def _delegated_setting_eligibility_rule(
     rules: list[Any],
     value_name: str,
 ) -> dict[str, Any] | None:
-    candidate_names = [f"{value_name}_eligible"]
+    candidate_names = [f"{value_name}_eligible", f"{value_name}_applies"]
     for suffix in ("_amount", "_for_unit_size", "_standard"):
         if value_name.endswith(suffix):
             candidate_names.append(f"{value_name.removesuffix(suffix)}_eligible")
+            candidate_names.append(f"{value_name.removesuffix(suffix)}_applies")
     if "basic_utility_allowance" in value_name:
         candidate_names.append("snap_basic_utility_allowance_eligible")
+        candidate_names.append("snap_basic_utility_allowance_applies")
     if "telephone" in value_name:
         candidate_names.append("snap_telephone_allowance_eligible")
+        candidate_names.append("snap_telephone_allowance_applies")
 
     seen: set[str] = set()
     for candidate_name in candidate_names:
@@ -18211,6 +18267,13 @@ def _generated_rules_include_source_relation_target(
     rules: list[Any],
     target: str,
 ) -> bool:
+    return _generated_source_relation_for_target(rules, target) is not None
+
+
+def _generated_source_relation_for_target(
+    rules: list[Any],
+    target: str,
+) -> dict[str, Any] | None:
     normalized_target = _normalize_source_relation_target_ref(target)
     for rule in rules:
         if not isinstance(rule, dict):
@@ -18226,8 +18289,57 @@ def _generated_rules_include_source_relation_target(
             _normalize_source_relation_target_ref(source_relation.get("target"))
             == normalized_target
         ):
-            return True
-    return False
+            return rule
+    return None
+
+
+def _repair_delegated_setting_relation_value_kind(
+    relation_rule: dict[str, Any],
+    rules: list[Any],
+    *,
+    current_payload: dict[str, Any],
+    current_rules_file: Path,
+    policy_repo_path: Path | None,
+    target_anchor: str,
+    target_rule: dict[str, Any] | None,
+    target_kind: str,
+    existing_names: set[str],
+) -> dict[str, Any] | None:
+    source_relation = relation_rule.get("source_relation")
+    if not isinstance(source_relation, dict):
+        return None
+    value_ref = str(source_relation.get("value") or "").strip()
+    if not value_ref:
+        return None
+    value_rule = _rulespec_rule_for_absolute_ref(
+        value_ref,
+        current_payload=current_payload,
+        current_rules_file=current_rules_file,
+        policy_repo_path=policy_repo_path,
+    )
+    if value_rule is None:
+        return None
+    if target_kind != "derived" or _rulespec_rule_kind(value_rule) != "parameter":
+        return None
+    target_ref = str(source_relation.get("target") or "").strip()
+    if "#" not in target_ref:
+        return None
+    relation_stem = target_ref.rsplit("#", 1)[-1].removesuffix("_state_option")
+    wrapper_rule = _delegated_setting_derived_value_wrapper(
+        rules,
+        value_rule=value_rule,
+        target_rule=target_rule,
+        target_anchor=target_anchor,
+        relation_stem=relation_stem,
+        existing_names=existing_names,
+    )
+    if wrapper_rule is None:
+        return None
+    wrapper_name = str(wrapper_rule.get("name") or "").strip()
+    if not wrapper_name:
+        return None
+    source_relation["value"] = f"{target_anchor}#{wrapper_name}"
+    return wrapper_rule
 
 
 def _preferred_delegated_setting_value_rule(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -25267,6 +25267,9 @@ def _stage_apply_overlay_dependency_roots(
 def _stage_apply_overlay_dependency_root(*, source: Path, target: Path) -> None:
     if target.exists() or target.is_symlink():
         return
+    if source.name != target.name:
+        shutil.copytree(source, target, dirs_exist_ok=True)
+        return
     try:
         target.symlink_to(source.resolve(), target_is_directory=True)
     except OSError:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -84,8 +84,11 @@ from .harness.validator_pipeline import (
     _is_executable_rulespec_rule,
     _load_nearby_eval_source_metadata,
     _matching_delegated_setting_rule_names,
+    _parse_rulespec_target,
+    _resolve_rulespec_target_file,
     _rulespec_executable_index_for_roots,
     _rulespec_executable_signature,
+    _rulespec_payload_from_file,
     _rulespec_public_item_keys,
     _rulespec_repo_prefix,
     _rulespec_rule_formula_rule_records,
@@ -17649,7 +17652,8 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
         for rule in rules
         if isinstance(rule, dict)
     }
-    additions: list[dict[str, Any]] = []
+    source_relation_additions: list[dict[str, Any]] = []
+    wrapper_additions: list[dict[str, Any]] = []
     repaired: list[str] = []
     for setting_target in _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS:
         if _generated_rules_include_source_relation_target(rules, setting_target.target):
@@ -17660,6 +17664,13 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
         )
         if not local_rule_names:
             continue
+        target_rule = _rulespec_rule_for_absolute_ref(
+            setting_target.target,
+            current_payload=payload,
+            current_rules_file=rules_file,
+            policy_repo_path=policy_repo_path,
+        )
+        target_kind = _rulespec_rule_kind(target_rule)
         value_rule = _preferred_delegated_setting_value_rule(rules, local_rule_names)
         if value_rule is None:
             continue
@@ -17668,6 +17679,20 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
             continue
         target_symbol = setting_target.target.rsplit("#", 1)[-1]
         relation_stem = target_symbol.removesuffix("_state_option")
+        if target_kind == "derived" and _rulespec_rule_kind(value_rule) == "parameter":
+            wrapper_rule = _delegated_setting_derived_value_wrapper(
+                rules,
+                value_rule=value_rule,
+                target_rule=target_rule,
+                target_anchor=target_anchor,
+                relation_stem=relation_stem,
+                existing_names=existing_names,
+            )
+            if wrapper_rule is not None:
+                value_rule = wrapper_rule
+                value_name = str(wrapper_rule.get("name") or "").strip()
+                existing_names.add(value_name)
+                wrapper_additions.append(wrapper_rule)
         relation_name = _unique_generated_rule_name(
             f"sets_{relation_stem}",
             existing_names,
@@ -17689,10 +17714,10 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
         source = value_rule.get("source")
         if isinstance(source, str) and source.strip():
             source_relation_rule["source"] = source.strip()
-        additions.append(source_relation_rule)
+        source_relation_additions.append(source_relation_rule)
         repaired.append(relation_name)
 
-    if not additions:
+    if not source_relation_additions:
         return []
 
     insert_at = 0
@@ -17703,7 +17728,12 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
         if str(rule.get("kind") or "").strip().lower() != "source_relation":
             break
         insert_at += 1
-    payload["rules"] = [*rules[:insert_at], *additions, *rules[insert_at:]]
+    payload["rules"] = [
+        *rules[:insert_at],
+        *source_relation_additions,
+        *wrapper_additions,
+        *rules[insert_at:],
+    ]
     rules_file.write_text(
         yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
     )
@@ -17712,6 +17742,176 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
 
 def _issue_mentions_delegated_policy_setting(issue: str) -> bool:
     return "Delegated policy setting missing source_relation" in issue
+
+
+def _rulespec_rule_kind(rule: dict[str, Any] | None) -> str:
+    if not isinstance(rule, dict):
+        return ""
+    return str(rule.get("kind") or "").strip().lower()
+
+
+def _rulespec_rule_for_absolute_ref(
+    reference: str,
+    *,
+    current_payload: dict[str, Any],
+    current_rules_file: Path,
+    policy_repo_path: Path | None,
+) -> dict[str, Any] | None:
+    target_ref = _parse_rulespec_target(reference)
+    if target_ref is None or target_ref.symbol is None:
+        return None
+    target_payload: dict[str, Any] | None = None
+    if _rulespec_generated_file_matches_target_ref(current_rules_file, target_ref):
+        target_payload = current_payload
+    else:
+        target_file = _resolve_rulespec_target_file(target_ref, policy_repo_path)
+        if target_file is not None and target_file.exists():
+            target_payload = _rulespec_payload_from_file(target_file)
+    if target_payload is None:
+        return None
+    rules = target_payload.get("rules")
+    if not isinstance(rules, list):
+        return None
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("name") or "").strip() == target_ref.symbol:
+            return rule
+    return None
+
+
+def _rulespec_generated_file_matches_target_ref(
+    rules_file: Path,
+    target_ref: Any,
+) -> bool:
+    target_parts = target_ref.relative_path.parts
+    path_parts = Path(rules_file).resolve().parts
+    return len(path_parts) >= len(target_parts) and path_parts[
+        -len(target_parts) :
+    ] == target_parts
+
+
+def _delegated_setting_derived_value_wrapper(
+    rules: list[Any],
+    *,
+    value_rule: dict[str, Any],
+    target_rule: dict[str, Any] | None,
+    target_anchor: str,
+    relation_stem: str,
+    existing_names: set[str],
+) -> dict[str, Any] | None:
+    value_name = str(value_rule.get("name") or "").strip()
+    if not value_name:
+        return None
+    wrapper_name = _unique_generated_rule_name(
+        f"{relation_stem}_state_value",
+        existing_names,
+    )
+    effective_dates = _rulespec_rule_effective_dates(value_rule)
+    if not effective_dates:
+        return None
+    eligible_rule = _delegated_setting_eligibility_rule(rules, value_name)
+    eligible_name = (
+        str(eligible_rule.get("name") or "").strip()
+        if isinstance(eligible_rule, dict)
+        else ""
+    )
+    formula = value_name
+    if eligible_name:
+        formula = f"if {eligible_name}: {value_name} else: 0"
+
+    wrapper_rule: dict[str, Any] = {
+        "name": wrapper_name,
+        "kind": "derived",
+        "versions": [
+            {
+                "effective_from": effective_from,
+                "formula": formula,
+            }
+            for effective_from in effective_dates
+        ],
+        "metadata": {
+            "proof": {
+                "atoms": [
+                    {
+                        "path": "versions[0].formula",
+                        "kind": "import",
+                        "import": {
+                            "target": f"{target_anchor}#{value_name}",
+                            "output": value_name,
+                            "hash": "sha256:local",
+                        },
+                    }
+                ]
+            }
+        },
+    }
+    for field in ("entity", "dtype", "period", "unit"):
+        value = (
+            target_rule.get(field)
+            if isinstance(target_rule, dict) and target_rule.get(field) is not None
+            else value_rule.get(field)
+        )
+        if value is not None:
+            wrapper_rule[field] = value
+    source = value_rule.get("source")
+    if isinstance(source, str) and source.strip():
+        wrapper_rule["source"] = source.strip()
+    if eligible_name:
+        wrapper_rule["metadata"]["proof"]["atoms"].append(
+            {
+                "path": "versions[0].formula",
+                "kind": "import",
+                "import": {
+                    "target": f"{target_anchor}#{eligible_name}",
+                    "output": eligible_name,
+                    "hash": "sha256:local",
+                },
+            }
+        )
+    return wrapper_rule
+
+
+def _rulespec_rule_effective_dates(rule: dict[str, Any]) -> list[str]:
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return []
+    dates: list[str] = []
+    for version in versions:
+        if not isinstance(version, dict):
+            continue
+        effective_from = version.get("effective_from")
+        if isinstance(effective_from, str) and effective_from.strip():
+            dates.append(effective_from.strip())
+    return dates
+
+
+def _delegated_setting_eligibility_rule(
+    rules: list[Any],
+    value_name: str,
+) -> dict[str, Any] | None:
+    candidate_names = [f"{value_name}_eligible"]
+    for suffix in ("_amount", "_for_unit_size", "_standard"):
+        if value_name.endswith(suffix):
+            candidate_names.append(f"{value_name.removesuffix(suffix)}_eligible")
+    if "basic_utility_allowance" in value_name:
+        candidate_names.append("snap_basic_utility_allowance_eligible")
+    if "telephone" in value_name:
+        candidate_names.append("snap_telephone_allowance_eligible")
+
+    seen: set[str] = set()
+    for candidate_name in candidate_names:
+        if candidate_name in seen:
+            continue
+        seen.add(candidate_name)
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            if str(rule.get("name") or "").strip() != candidate_name:
+                continue
+            if _rulespec_rule_kind(rule) == "derived":
+                return rule
+    return None
 
 
 def _generated_rules_include_source_relation_target(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -17739,7 +17739,19 @@ def _extract_embedded_scalar_literal_record(
         parameter_name = _embedded_scalar_parameter_name(rule_name, expression)
         if not parameter_name:
             return None
-        parameter_name = _unique_generated_rule_name(parameter_name, existing_names)
+        existing_parameter_name = _existing_embedded_scalar_parameter_name(
+            rules,
+            base_name=parameter_name,
+            literal=literal,
+        )
+        insert_parameter = existing_parameter_name is None
+        if existing_parameter_name is not None:
+            parameter_name = existing_parameter_name
+        else:
+            parameter_name = _unique_generated_rule_name(
+                parameter_name,
+                existing_names,
+            )
         versions = rule.get("versions")
         if not isinstance(versions, list) or not versions:
             return None
@@ -17761,17 +17773,18 @@ def _extract_embedded_scalar_literal_record(
                 changed = True
         if not changed:
             return None
-        parameter_rule = _embedded_scalar_parameter_rule(
-            rule,
-            name=parameter_name,
-            literal=literal,
-        )
         _add_formula_proof_import(
             rule,
             target=f"{target_anchor}#{parameter_name}",
             output=parameter_name,
         )
-        rules.insert(index, parameter_rule)
+        if insert_parameter:
+            parameter_rule = _embedded_scalar_parameter_rule(
+                rule,
+                name=parameter_name,
+                literal=literal,
+            )
+            rules.insert(index, parameter_rule)
         return parameter_name
     return None
 
@@ -17782,6 +17795,31 @@ def _embedded_scalar_parameter_name(rule_name: str, expression: str) -> str | No
     if re.search(r"\bmax\s*\(", expression):
         return f"{rule_name}_floor"
     return f"{rule_name}_scalar_limit"
+
+
+def _existing_embedded_scalar_parameter_name(
+    rules: list[Any],
+    *,
+    base_name: str,
+    literal: str,
+) -> str | None:
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("name") or "").strip() != base_name:
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "parameter":
+            return None
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            return None
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if str(formula).strip() == literal:
+                return base_name
+    return None
 
 
 def _replace_embedded_scalar_literal(
@@ -17797,12 +17835,11 @@ def _replace_embedded_scalar_literal(
         expression,
     )
     if expression_replacement != expression and expression in formula:
-        return formula.replace(expression, expression_replacement, 1)
+        formula = formula.replace(expression, expression_replacement, 1)
     return re.sub(
         rf"(?<![A-Za-z0-9_.]){re.escape(literal)}(?![A-Za-z0-9_.])",
         parameter_name,
         formula,
-        count=1,
     )
 
 
@@ -17894,6 +17931,13 @@ def _add_formula_proof_import(
     if not isinstance(atoms, list):
         atoms = []
         proof["atoms"] = atoms
+    if any(
+        isinstance(atom, dict)
+        and isinstance(atom.get("import"), dict)
+        and atom["import"].get("target") == target
+        for atom in atoms
+    ):
+        return
     atoms.append(
         {
             "path": "versions[0].formula",

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -16572,6 +16572,35 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_embedded_scalar_literals = (
+                    _try_repair_generated_embedded_scalar_literals_for_apply(
+                        result,
+                        output_root=args.output,
+                        policy_repo_path=policy_repo_path,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_embedded_scalar_literals:
+                    outcome["auto_repaired_embedded_scalar_literals"] = (
+                        repaired_embedded_scalar_literals
+                    )
+                    print(
+                        "  apply=auto_repaired_embedded_scalar_literals:"
+                        + ",".join(repaired_embedded_scalar_literals)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_table_band_scalars = (
                     _try_repair_generated_source_table_band_scalars_for_apply(
                         result,
@@ -17610,6 +17639,270 @@ def _try_repair_generated_boolean_parameter_inputs_for_apply(
     return _convert_versioned_boolean_parameters_to_indicators(
         rules_file,
         names=missing_inputs,
+    )
+
+
+def _try_repair_generated_embedded_scalar_literals_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path | None = None,
+    issues: list[str],
+) -> list[str]:
+    """Extract CI-reported formula scalar literals into named parameters."""
+    records = _embedded_scalar_literal_issue_records(issues)
+    if not records:
+        return []
+    try:
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    target_anchor = _relative_output_to_anchor(
+        relative_output,
+        policy_repo_path=policy_repo_path,
+    )
+    existing_names = {
+        str(rule.get("name") or "").strip()
+        for rule in rules
+        if isinstance(rule, dict)
+    }
+    repaired: list[str] = []
+    for record in records:
+        changed = _extract_embedded_scalar_literal_record(
+            rules,
+            record,
+            target_anchor=target_anchor,
+            existing_names=existing_names,
+        )
+        if changed:
+            repaired.append(changed)
+            existing_names.add(changed)
+
+    if not repaired:
+        return []
+    rules_file.write_text(
+        yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
+    )
+    return repaired
+
+
+def _embedded_scalar_literal_issue_records(
+    issues: list[str],
+) -> list[dict[str, str]]:
+    records: list[dict[str, str]] = []
+    pattern = re.compile(
+        r"Embedded scalar literal:\s+"
+        r"(?P<rule>[A-Za-z_][A-Za-z0-9_]*)\s+line\s+\d+\s+"
+        r"embeds\s+(?P<literal>-?\d+(?:\.\d+)?)\s+in\s+`(?P<expression>[^`]+)`"
+    )
+    for issue in issues:
+        match = pattern.search(issue)
+        if match is None:
+            continue
+        records.append(match.groupdict())
+    return records
+
+
+def _extract_embedded_scalar_literal_record(
+    rules: list[Any],
+    record: dict[str, str],
+    *,
+    target_anchor: str,
+    existing_names: set[str],
+) -> str | None:
+    rule_name = record["rule"]
+    literal = record["literal"]
+    expression = record["expression"]
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("name") or "").strip() != rule_name:
+            continue
+        parameter_name = _embedded_scalar_parameter_name(rule_name, expression)
+        if not parameter_name:
+            return None
+        parameter_name = _unique_generated_rule_name(parameter_name, existing_names)
+        versions = rule.get("versions")
+        if not isinstance(versions, list) or not versions:
+            return None
+        changed = False
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            replacement = _replace_embedded_scalar_literal(
+                formula,
+                literal=literal,
+                expression=expression,
+                parameter_name=parameter_name,
+            )
+            if replacement != formula:
+                version["formula"] = replacement
+                changed = True
+        if not changed:
+            return None
+        parameter_rule = _embedded_scalar_parameter_rule(
+            rule,
+            name=parameter_name,
+            literal=literal,
+        )
+        _add_formula_proof_import(
+            rule,
+            target=f"{target_anchor}#{parameter_name}",
+            output=parameter_name,
+        )
+        rules.insert(index, parameter_rule)
+        return parameter_name
+    return None
+
+
+def _embedded_scalar_parameter_name(rule_name: str, expression: str) -> str | None:
+    if re.search(r"\bmin\s*\(", expression) and rule_name.endswith("_size_category"):
+        return f"{rule_name.removesuffix('_size_category')}_max_household_size"
+    if re.search(r"\bmax\s*\(", expression):
+        return f"{rule_name}_floor"
+    return f"{rule_name}_scalar_limit"
+
+
+def _replace_embedded_scalar_literal(
+    formula: str,
+    *,
+    literal: str,
+    expression: str,
+    parameter_name: str,
+) -> str:
+    expression_replacement = re.sub(
+        rf"(?<![A-Za-z0-9_.]){re.escape(literal)}(?![A-Za-z0-9_.])",
+        parameter_name,
+        expression,
+        count=1,
+    )
+    if expression_replacement != expression and expression in formula:
+        return formula.replace(expression, expression_replacement, 1)
+    return re.sub(
+        rf"(?<![A-Za-z0-9_.]){re.escape(literal)}(?![A-Za-z0-9_.])",
+        parameter_name,
+        formula,
+        count=1,
+    )
+
+
+def _embedded_scalar_parameter_rule(
+    source_rule: dict[str, Any],
+    *,
+    name: str,
+    literal: str,
+) -> dict[str, Any]:
+    first_effective_from = "0001-01-01"
+    versions = source_rule.get("versions")
+    if isinstance(versions, list):
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            effective_from = version.get("effective_from")
+            if isinstance(effective_from, str) and effective_from.strip():
+                first_effective_from = effective_from.strip()
+                break
+    parameter_rule: dict[str, Any] = {
+        "name": name,
+        "kind": "parameter",
+        "dtype": "Count",
+        "source": source_rule.get("source"),
+        "metadata": {
+            "proof": {
+                "atoms": [
+                    _source_atom_for_embedded_scalar_parameter(
+                        source_rule,
+                        literal=literal,
+                    )
+                ]
+            }
+        },
+        "versions": [
+            {
+                "effective_from": first_effective_from,
+                "formula": literal,
+            }
+        ],
+    }
+    if not parameter_rule["source"]:
+        parameter_rule.pop("source", None)
+    return parameter_rule
+
+
+def _source_atom_for_embedded_scalar_parameter(
+    source_rule: dict[str, Any],
+    *,
+    literal: str,
+) -> dict[str, Any]:
+    proof = source_rule.get("metadata", {}).get("proof")
+    atoms = proof.get("atoms") if isinstance(proof, dict) else None
+    if isinstance(atoms, list):
+        for atom in atoms:
+            if not isinstance(atom, dict):
+                continue
+            source = atom.get("source")
+            if not isinstance(source, dict):
+                continue
+            excerpt = source.get("excerpt")
+            if isinstance(excerpt, str) and literal in excerpt:
+                return {
+                    "path": "versions[0].formula",
+                    "kind": "parameter",
+                    "source": dict(source),
+                }
+    return {
+        "path": "versions[0].formula",
+        "kind": "parameter",
+    }
+
+
+def _add_formula_proof_import(
+    rule: dict[str, Any],
+    *,
+    target: str,
+    output: str,
+) -> None:
+    metadata = rule.setdefault("metadata", {})
+    if not isinstance(metadata, dict):
+        metadata = {}
+        rule["metadata"] = metadata
+    proof = metadata.setdefault("proof", {})
+    if not isinstance(proof, dict):
+        proof = {}
+        metadata["proof"] = proof
+    atoms = proof.setdefault("atoms", [])
+    if not isinstance(atoms, list):
+        atoms = []
+        proof["atoms"] = atoms
+    atoms.append(
+        {
+            "path": "versions[0].formula",
+            "kind": "import",
+            "import": {
+                "target": target,
+                "output": output,
+                "hash": "sha256:local",
+            },
+        }
     )
 
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -144,6 +144,7 @@ from .repo_routing import (
     candidate_jurisdiction_content_dirs,
     canonical_rulespec_repo_name,
     find_policy_repo_root,
+    monorepo_checkout_name,
     resolve_jurisdiction_content_dir,
 )
 
@@ -24940,16 +24941,11 @@ def _validate_generated_encoding_in_policy_overlay(
             overlay_parent=overlay_parent,
             relative_output=relative_output,
         )
-        for sibling in policy_repo_path.parent.glob("rulespec-*"):
-            if sibling.resolve() == policy_repo_path.resolve() or not sibling.is_dir():
-                continue
-            if sibling.name == overlay_repo_name:
-                continue
-            sibling_target = overlay_parent / sibling.name
-            try:
-                sibling_target.symlink_to(sibling.resolve(), target_is_directory=True)
-            except OSError:
-                shutil.copytree(sibling, sibling_target, dirs_exist_ok=True)
+        _stage_apply_overlay_dependency_roots(
+            overlay_parent=overlay_parent,
+            policy_repo_path=policy_repo_path,
+            overlay_repo_name=overlay_repo_name,
+        )
 
         overlay_repo = overlay_parent / overlay_repo_name
         shutil.copytree(policy_repo_path, overlay_repo)
@@ -25233,6 +25229,48 @@ def _validate_generated_encoding_in_policy_overlay(
                         f"{relative_file}: {validator_result.validator_name}: {validator_result.error}"
                     )
         return False, issues, {}
+
+
+def _stage_apply_overlay_dependency_roots(
+    *,
+    overlay_parent: Path,
+    policy_repo_path: Path,
+    overlay_repo_name: str,
+) -> None:
+    """Stage sibling RuleSpec roots that imported modules may resolve through."""
+    staged_names = {overlay_repo_name}
+    for sibling in policy_repo_path.parent.glob("rulespec-*"):
+        if sibling.resolve() == policy_repo_path.resolve() or not sibling.is_dir():
+            continue
+        if sibling.name in staged_names:
+            continue
+        _stage_apply_overlay_dependency_root(
+            source=sibling,
+            target=overlay_parent / sibling.name,
+        )
+        staged_names.add(sibling.name)
+
+    if policy_repo_path.name.startswith("rulespec-"):
+        return
+    monorepo_parent = policy_repo_path.parent
+    if not monorepo_parent.name.startswith("rulespec-") or not monorepo_parent.is_dir():
+        return
+    checkout_name = monorepo_checkout_name(policy_repo_path.name)
+    if checkout_name in staged_names:
+        return
+    _stage_apply_overlay_dependency_root(
+        source=monorepo_parent,
+        target=overlay_parent / checkout_name,
+    )
+
+
+def _stage_apply_overlay_dependency_root(*, source: Path, target: Path) -> None:
+    if target.exists() or target.is_symlink():
+        return
+    try:
+        target.symlink_to(source.resolve(), target_is_directory=True)
+    except OSError:
+        shutil.copytree(source, target, dirs_exist_ok=True)
 
 
 def _write_overlay_eval_source_metadata_for_generated_output(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -17795,7 +17795,6 @@ def _replace_embedded_scalar_literal(
         rf"(?<![A-Za-z0-9_.]){re.escape(literal)}(?![A-Za-z0-9_.])",
         parameter_name,
         expression,
-        count=1,
     )
     if expression_replacement != expression and expression in formula:
         return formula.replace(expression, expression_replacement, 1)

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -17680,9 +17680,7 @@ def _try_repair_generated_embedded_scalar_literals_for_apply(
         policy_repo_path=policy_repo_path,
     )
     existing_names = {
-        str(rule.get("name") or "").strip()
-        for rule in rules
-        if isinstance(rule, dict)
+        str(rule.get("name") or "").strip() for rule in rules if isinstance(rule, dict)
     }
     repaired: list[str] = []
     for record in records:
@@ -17698,9 +17696,7 @@ def _try_repair_generated_embedded_scalar_literals_for_apply(
 
     if not repaired:
         return []
-    rules_file.write_text(
-        yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
-    )
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
     return repaired
 
 
@@ -17986,9 +17982,7 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
         policy_repo_path=policy_repo_path,
     )
     existing_names = {
-        str(rule.get("name") or "").strip()
-        for rule in rules
-        if isinstance(rule, dict)
+        str(rule.get("name") or "").strip() for rule in rules if isinstance(rule, dict)
     }
     source_relation_additions: list[dict[str, Any]] = []
     wrapper_additions: list[dict[str, Any]] = []
@@ -18114,9 +18108,7 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
         *wrapper_additions,
         *rules[insert_at:],
     ]
-    rules_file.write_text(
-        yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
-    )
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
     return repaired
 
 
@@ -18133,10 +18125,14 @@ def _issue_mentions_delegated_policy_setting(issue: str) -> bool:
         return True
     if "RuleSpec source relation" not in issue:
         return False
-    return any(
-        setting_target.target in issue
-        for setting_target in _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS
-    ) or "us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs" in issue
+    return (
+        any(
+            setting_target.target in issue
+            for setting_target in _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS
+        )
+        or "us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs"
+        in issue
+    )
 
 
 def _ensure_rulespec_payload_import(payload: dict[str, Any], target: str) -> bool:
@@ -18150,9 +18146,7 @@ def _ensure_rulespec_payload_import(payload: dict[str, Any], target: str) -> boo
     if not isinstance(imports, list):
         return False
     normalized_imports = {
-        str(item).split("#", 1)[0].strip()
-        for item in imports
-        if isinstance(item, str)
+        str(item).split("#", 1)[0].strip() for item in imports if isinstance(item, str)
     }
     if import_target in normalized_imports:
         return False
@@ -18202,9 +18196,10 @@ def _rulespec_generated_file_matches_target_ref(
 ) -> bool:
     target_parts = target_ref.relative_path.parts
     path_parts = Path(rules_file).resolve().parts
-    return len(path_parts) >= len(target_parts) and path_parts[
-        -len(target_parts) :
-    ] == target_parts
+    return (
+        len(path_parts) >= len(target_parts)
+        and path_parts[-len(target_parts) :] == target_parts
+    )
 
 
 def _delegated_setting_derived_value_wrapper(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -17950,6 +17950,23 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
     source_relation_additions: list[dict[str, Any]] = []
     wrapper_additions: list[dict[str, Any]] = []
     repaired: list[str] = []
+    retargeted_wrappers, retargeted_relations = (
+        _repair_delegated_setting_relation_targets(
+            rules,
+            current_payload=payload,
+            current_rules_file=rules_file,
+            policy_repo_path=policy_repo_path,
+            target_anchor=target_anchor,
+            existing_names=existing_names,
+        )
+    )
+    if retargeted_wrappers:
+        wrapper_additions.extend(retargeted_wrappers)
+        for wrapper_rule in retargeted_wrappers:
+            wrapper_name = str(wrapper_rule.get("name") or "").strip()
+            if wrapper_name:
+                existing_names.add(wrapper_name)
+    repaired.extend(retargeted_relations)
     for setting_target in _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS:
         target_rule = _rulespec_rule_for_absolute_ref(
             setting_target.target,
@@ -18063,12 +18080,20 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
 def _issue_mentions_delegated_policy_setting(issue: str) -> bool:
     if "Delegated policy setting missing source_relation" in issue:
         return True
+    if "Delegated policy setting wrong source_relation target" in issue:
+        return True
+    if (
+        "RuleSpec source relation" in issue
+        and "sets target" in issue
+        and "#snap_utility_allowance_for_shelter_costs" in issue
+    ):
+        return True
     if "RuleSpec source relation" not in issue:
         return False
     return any(
         setting_target.target in issue
         for setting_target in _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS
-    )
+    ) or "us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs" in issue
 
 
 def _ensure_rulespec_payload_import(payload: dict[str, Any], target: str) -> bool:
@@ -18292,6 +18317,110 @@ def _generated_source_relation_for_target(
             == normalized_target
         ):
             return rule
+    return None
+
+
+def _repair_delegated_setting_relation_targets(
+    rules: list[Any],
+    *,
+    current_payload: dict[str, Any],
+    current_rules_file: Path,
+    policy_repo_path: Path | None,
+    target_anchor: str,
+    existing_names: set[str],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Retarget generated SNAP utility `sets` relations to canonical hooks."""
+    canonical_targets = {
+        _normalize_source_relation_target_ref(setting_target.target)
+        for setting_target in _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS
+    }
+    wrapper_additions: list[dict[str, Any]] = []
+    repaired: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "source_relation":
+            continue
+        source_relation = rule.get("source_relation")
+        if not isinstance(source_relation, dict):
+            continue
+        if str(source_relation.get("type") or "").strip().lower() != "sets":
+            continue
+        target_ref = _normalize_source_relation_target_ref(
+            source_relation.get("target")
+        )
+        if not target_ref or target_ref in canonical_targets:
+            continue
+        value_ref = str(source_relation.get("value") or "").strip()
+        if not value_ref:
+            continue
+        value_rule = _rulespec_rule_for_absolute_ref(
+            value_ref,
+            current_payload=current_payload,
+            current_rules_file=current_rules_file,
+            policy_repo_path=policy_repo_path,
+        )
+        if value_rule is None:
+            continue
+        value_name = str(value_rule.get("name") or "").strip()
+        setting_target = _delegated_setting_target_for_value_name(value_name)
+        if setting_target is None:
+            continue
+        target_rule = _rulespec_rule_for_absolute_ref(
+            setting_target.target,
+            current_payload=current_payload,
+            current_rules_file=current_rules_file,
+            policy_repo_path=policy_repo_path,
+        )
+        target_kind = _rulespec_rule_kind(target_rule)
+        target_symbol = setting_target.target.rsplit("#", 1)[-1]
+        relation_stem = target_symbol.removesuffix("_state_option")
+        if target_kind == "derived" and _rulespec_rule_kind(value_rule) == "parameter":
+            wrapper_rule = _delegated_setting_derived_value_wrapper(
+                rules,
+                value_rule=value_rule,
+                target_rule=target_rule,
+                target_anchor=target_anchor,
+                relation_stem=relation_stem,
+                existing_names=existing_names,
+            )
+            if wrapper_rule is not None:
+                wrapper_name = str(wrapper_rule.get("name") or "").strip()
+                if wrapper_name:
+                    existing_names.add(wrapper_name)
+                    source_relation["value"] = f"{target_anchor}#{wrapper_name}"
+                    wrapper_additions.append(wrapper_rule)
+                    repaired.append(wrapper_name)
+        source_relation["target"] = setting_target.target
+        source_relation["authority"] = "state"
+        basis = source_relation.get("basis")
+        if not isinstance(basis, dict):
+            basis = {}
+            source_relation["basis"] = basis
+        basis["delegation"] = (
+            "us:regulations/7-cfr/273/9#"
+            "snap_state_standard_utility_allowance_delegation"
+        )
+        relation_name = str(rule.get("name") or f"sets_{relation_stem}").strip()
+        if relation_name:
+            repaired.append(relation_name)
+        if _ensure_rulespec_payload_import(current_payload, setting_target.target):
+            repaired.append(f"import:{setting_target.target.split('#', 1)[0]}")
+    return wrapper_additions, repaired
+
+
+def _delegated_setting_target_for_value_name(
+    value_name: str,
+) -> Any | None:
+    if not value_name:
+        return None
+    probe_rule = {"name": value_name, "kind": "derived", "dtype": "Money"}
+    for setting_target in _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS:
+        if _matching_delegated_setting_rule_names(
+            [probe_rule],
+            setting_target.rule_name_patterns,
+        ):
+            return setting_target
     return None
 
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -15308,13 +15308,12 @@ def guard_generated_change_issues(
         return []
 
     manifest_paths = (
-        _all_applied_encoding_manifest_paths(repo_path)
+        _all_applied_encoding_manifest_paths(repo_path, roots=roots)
         if all_files
         else [
             path
             for path in changed
-            if Path(path).parts[:2] == APPLIED_ENCODING_MANIFEST_DIR.parts
-            and path.endswith(".json")
+            if _is_applied_encoding_manifest_path(Path(path), roots=roots)
         ]
     )
     if not manifest_paths:
@@ -15339,7 +15338,7 @@ def guard_generated_change_issues(
         path for path in manifest_paths if not (repo_path / path).exists()
     ]
     manifest_entries, manifest_issues = _load_applied_encoding_manifest_entries(
-        repo_path, surviving_manifest_paths
+        repo_path, surviving_manifest_paths, roots=roots
     )
     if manifest_issues:
         return manifest_issues
@@ -15399,15 +15398,23 @@ def _all_protected_rulespec_yaml_paths(
     return sorted(paths)
 
 
-def _all_applied_encoding_manifest_paths(repo_path: Path) -> list[str]:
-    manifest_root = repo_path / APPLIED_ENCODING_MANIFEST_DIR
-    if not manifest_root.exists():
-        return []
-    return sorted(
-        path.relative_to(repo_path).as_posix()
-        for path in manifest_root.rglob("*.json")
-        if path.is_file()
+def _all_applied_encoding_manifest_paths(
+    repo_path: Path, *, roots: tuple[str, ...]
+) -> list[str]:
+    manifest_roots = [repo_path / APPLIED_ENCODING_MANIFEST_DIR]
+    manifest_roots.extend(
+        repo_path / root / APPLIED_ENCODING_MANIFEST_DIR for root in roots
     )
+    paths: set[str] = set()
+    for manifest_root in manifest_roots:
+        if not manifest_root.exists():
+            continue
+        paths.update(
+            path.relative_to(repo_path).as_posix()
+            for path in manifest_root.rglob("*.json")
+            if path.is_file()
+        )
+    return sorted(paths)
 
 
 def _git_changed_files(
@@ -15464,8 +15471,30 @@ def _is_protected_rulespec_yaml_path(path: Path, *, roots: tuple[str, ...]) -> b
     return path.suffix in {".yaml", ".yml"}
 
 
+def _is_applied_encoding_manifest_path(path: Path, *, roots: tuple[str, ...]) -> bool:
+    if path.suffix != ".json":
+        return False
+    return _applied_encoding_manifest_root_prefix(path, roots=roots) is not None
+
+
+def _applied_encoding_manifest_root_prefix(
+    path: Path, *, roots: tuple[str, ...]
+) -> str | None:
+    parts = path.parts
+    manifest_parts = APPLIED_ENCODING_MANIFEST_DIR.parts
+    if parts[: len(manifest_parts)] == manifest_parts:
+        return ""
+    if (
+        len(parts) > len(manifest_parts)
+        and parts[0] in roots
+        and parts[1 : 1 + len(manifest_parts)] == manifest_parts
+    ):
+        return parts[0]
+    return None
+
+
 def _load_applied_encoding_manifest_entries(
-    repo_path: Path, manifest_paths: list[str]
+    repo_path: Path, manifest_paths: list[str], *, roots: tuple[str, ...]
 ) -> tuple[dict[str, set[str]], list[str]]:
     entries: dict[str, set[str]] = defaultdict(set)
     issues: list[str] = []
@@ -15480,6 +15509,11 @@ def _load_applied_encoding_manifest_entries(
 
     for manifest_path in manifest_paths:
         manifest_label = Path(manifest_path).as_posix()
+        root_prefix = _applied_encoding_manifest_root_prefix(
+            Path(manifest_path), roots=roots
+        )
+        if root_prefix is None:
+            continue
         path = repo_path / manifest_path
         if not path.exists():
             issues.append(f"{manifest_label} does not exist in the working tree")
@@ -15508,10 +15542,20 @@ def _load_applied_encoding_manifest_entries(
             file_path = item.get("path")
             file_hash = item.get("sha256")
             if isinstance(file_path, str) and item.get("deleted") is True:
-                entries[file_path].add(APPLIED_ENCODING_DELETED_MARKER)
+                entries[_prefix_applied_manifest_path(file_path, root_prefix)].add(
+                    APPLIED_ENCODING_DELETED_MARKER
+                )
             elif isinstance(file_path, str) and isinstance(file_hash, str):
-                entries[file_path].add(file_hash)
+                entries[_prefix_applied_manifest_path(file_path, root_prefix)].add(
+                    file_hash
+                )
     return dict(entries), issues
+
+
+def _prefix_applied_manifest_path(file_path: str, root_prefix: str) -> str:
+    if not root_prefix:
+        return file_path
+    return Path(root_prefix, file_path).as_posix()
 
 
 def _applied_encoding_manifest_signing_key() -> str | None:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -13873,6 +13873,7 @@ def _append_generated_derived_output_tests_if_missing(
         f"{target_base}#input.{input_name}": _default_generated_test_input_value(
             input_name,
             rules_payload=rules_payload,
+            prefer_positive_counts=True,
         )
         for input_name in sorted(factual_inputs)
     }
@@ -24380,11 +24381,32 @@ def _parse_test_input_assignment_issue(issue: str) -> tuple[str, set[str]] | Non
 
 
 def _default_generated_test_input_value(
-    input_name: str, *, rules_payload: dict[str, object]
+    input_name: str,
+    *,
+    rules_payload: dict[str, object],
+    prefer_positive_counts: bool = False,
 ) -> bool | int:
     if _factual_input_appears_numeric(input_name, rules_payload=rules_payload):
+        if prefer_positive_counts and _factual_input_name_looks_positive_count(
+            input_name
+        ):
+            return 1
         return 0
     return False
+
+
+def _factual_input_name_looks_positive_count(input_name: str) -> bool:
+    tokens = set(input_name.lower().split("_"))
+    if "count" in tokens or "size" in tokens:
+        return True
+    positive_suffixes = (
+        "_member_count",
+        "_household_size",
+        "_unit_size",
+        "_family_size",
+        "_assistance_unit_size",
+    )
+    return input_name.lower().endswith(positive_suffixes)
 
 
 def _factual_input_appears_numeric(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -16998,6 +16998,54 @@ class _RuleSpecTargetRef:
     symbol: str | None
 
 
+@dataclass(frozen=True)
+class _DelegatedPolicySettingTarget:
+    """Canonical target for a delegated downstream policy setting."""
+
+    label: str
+    target: str
+    rule_name_patterns: tuple[str, ...]
+
+
+_US_STATE_RULESPEC_PATH_PART = re.compile(r"(?:rulespec-)?us-[a-z]{2}(?:-[a-z0-9]+)*")
+_SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS = (
+    _DelegatedPolicySettingTarget(
+        label="standard utility allowance",
+        target=(
+            "us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option"
+        ),
+        rule_name_patterns=(
+            r"^snap_standard_utility_allowance(?:_amount)?$",
+            r"^.*heating_cooling_standard_utility_allowance.*$",
+            r"^.*standard_utility_allowance.*$",
+        ),
+    ),
+    _DelegatedPolicySettingTarget(
+        label="limited utility allowance",
+        target=(
+            "us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option"
+        ),
+        rule_name_patterns=(
+            r"^snap_limited_utility_allowance(?:_amount)?$",
+            r"^.*basic_utility_allowance.*$",
+            r"^.*limited_utility_allowance.*$",
+        ),
+    ),
+    _DelegatedPolicySettingTarget(
+        label="individual utility allowance",
+        target=(
+            "us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option"
+        ),
+        rule_name_patterns=(
+            r"^snap_individual_utility_allowance(?:_amount)?$",
+            r"^.*telephone_utility_allowance.*$",
+            r"^.*one_utility_allowance.*$",
+        ),
+    ),
+)
+_DELEGATED_SETTING_AMOUNT_DTYPES = {"money"}
+
+
 def find_source_relation_issues(
     content: str,
     *,
@@ -17027,7 +17075,13 @@ def find_source_relation_issues(
         relation_type = ""
         if isinstance(source_relation, dict):
             relation_type = str(source_relation.get("type") or "").strip().lower()
-        if relation_type != "restates":
+        if relation_type not in {
+            "amends",
+            "delegates",
+            "implements",
+            "restates",
+            "sets",
+        }:
             continue
         if (
             not isinstance(source_relation, dict)
@@ -17045,7 +17099,7 @@ def find_source_relation_issues(
                     "Source relation target invalid: "
                     f"{name} uses `{target}`, expected `<jurisdiction>:<path>#<rule>`."
                 )
-            elif target_ref.symbol is None:
+            elif target_ref.symbol is None and relation_type in {"restates", "sets"}:
                 issues.append(
                     "Source relation target rule required: "
                     f"{name} must point to a specific RuleSpec rule with `#rule_name`."
@@ -17055,9 +17109,36 @@ def find_source_relation_issues(
                 "Source relation must be non-executable: "
                 f"{name} should not declare `versions`; use the canonical target for formulas and values."
             )
+        if relation_type == "sets":
+            value = (
+                source_relation.get("value")
+                if isinstance(source_relation, dict)
+                else None
+            )
+            if value is None or (isinstance(value, str) and not value.strip()):
+                issues.append(
+                    "Source relation setting value required: "
+                    f"{name} uses `source_relation.type: sets` and must declare "
+                    "`source_relation.value` pointing to the local value or formula "
+                    "that fills the delegated slot."
+                )
+            basis = (
+                source_relation.get("basis")
+                if isinstance(source_relation, dict)
+                else None
+            )
+            delegation = basis.get("delegation") if isinstance(basis, dict) else None
+            if not isinstance(delegation, str) or not delegation.strip():
+                issues.append(
+                    "Source relation delegation basis required: "
+                    f"{name} uses `source_relation.type: sets` and must declare "
+                    "`source_relation.basis.delegation` pointing to the upstream "
+                    "delegation authority."
+                )
         verification = rule.get("verification")
         if (
-            target
+            relation_type == "restates"
+            and target
             and target_ref is not None
             and target_ref.symbol is not None
             and isinstance(verification, dict)
@@ -17073,6 +17154,110 @@ def find_source_relation_issues(
                 )
             )
     return issues
+
+
+def find_delegated_policy_setting_issues(
+    content: str,
+    *,
+    rules_file: Path | None = None,
+) -> list[str]:
+    """Require downstream state settings to use the canonical delegated hook."""
+    payload = _rulespec_payload(content)
+    if payload is None or payload.get("format") != "rulespec/v1":
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list) or not _is_us_state_rulespec_path(rules_file):
+        return []
+    if not _looks_like_snap_utility_allowance_module(payload, rules_file=rules_file):
+        return []
+
+    issues: list[str] = []
+    for setting_target in _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS:
+        local_rule_names = _matching_delegated_setting_rule_names(
+            rules,
+            setting_target.rule_name_patterns,
+        )
+        if not local_rule_names:
+            continue
+        if _rules_include_source_relation_target(
+            rules,
+            setting_target.target,
+            relation_type="sets",
+        ):
+            continue
+        local_list = ", ".join(f"`{name}`" for name in local_rule_names)
+        issues.append(
+            "Delegated policy setting missing source_relation: "
+            f"{local_list} encodes a state-set SNAP {setting_target.label}. "
+            "The canonical encoding is a non-executable `kind: source_relation` "
+            "record with `source_relation.type: sets`, "
+            f"`source_relation.target: {setting_target.target}`, "
+            "`source_relation.value` pointing to the local setting, and "
+            "`source_relation.basis.delegation` pointing to the upstream "
+            "delegation authority. Executable formulas should consume the "
+            "federal delegated hook rather than a state-specific local output."
+        )
+    return issues
+
+
+def _is_us_state_rulespec_path(rules_file: Path | None) -> bool:
+    if rules_file is None:
+        return False
+    return any(
+        _US_STATE_RULESPEC_PATH_PART.fullmatch(part) is not None
+        for part in rules_file.parts
+    )
+
+
+def _looks_like_snap_utility_allowance_module(
+    payload: dict[str, Any],
+    *,
+    rules_file: Path | None,
+) -> bool:
+    text_parts: list[str] = []
+    if rules_file is not None:
+        text_parts.extend(part.lower() for part in rules_file.parts)
+    module = payload.get("module")
+    if isinstance(module, dict):
+        summary = module.get("summary")
+        if isinstance(summary, str):
+            text_parts.append(summary.lower())
+    rules = payload.get("rules")
+    if isinstance(rules, list):
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            text_parts.append(str(rule.get("name") or "").lower())
+            source = rule.get("source")
+            if isinstance(source, str):
+                text_parts.append(source.lower())
+    text = "\n".join(text_parts)
+    return (
+        "snap" in text
+        or "supplemental nutrition" in text
+        or "food and nutrition" in text
+        or re.search(r"(?:^|[/_\-\s])fns(?:$|[/_\-\s])", text) is not None
+    )
+
+
+def _matching_delegated_setting_rule_names(
+    rules: list[Any],
+    patterns: tuple[str, ...],
+) -> list[str]:
+    compiled_patterns = tuple(re.compile(pattern) for pattern in patterns)
+    matches: list[str] = []
+    for rule in rules:
+        if not _is_executable_rulespec_rule(rule):
+            continue
+        assert isinstance(rule, dict)
+        dtype = str(rule.get("dtype") or "").strip().lower()
+        if dtype not in _DELEGATED_SETTING_AMOUNT_DTYPES:
+            continue
+        name = _rulespec_rule_name(rule)
+        normalized_name = name.lower()
+        if any(pattern.fullmatch(normalized_name) for pattern in compiled_patterns):
+            matches.append(name)
+    return sorted(dict.fromkeys(matches))
 
 
 def _find_source_relation_value_verification_issues(
@@ -19440,6 +19625,9 @@ class ValidatorPipeline:
         issues.extend(self._check_unapplied_cross_reference_base_mechanics(rules_file))
         issues.extend(
             find_source_relation_issues(content, policy_repo_path=self.policy_repo_path)
+        )
+        issues.extend(
+            find_delegated_policy_setting_issues(content, rules_file=rules_file)
         )
         issues.extend(
             find_rule_name_path_suffix_issues(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -17186,6 +17186,21 @@ def find_delegated_policy_setting_issues(
             relation_type="sets",
         ):
             continue
+        wrong_relations = _source_relation_sets_rules_for_local_values(
+            rules,
+            local_rule_names,
+        )
+        if wrong_relations:
+            for relation_name, target in wrong_relations:
+                issues.append(
+                    "Delegated policy setting wrong source_relation target: "
+                    f"`{relation_name}` points a state-set SNAP {setting_target.label} "
+                    f"to `{target}`. The canonical target is "
+                    f"`{setting_target.target}`; `source_relation.value` should "
+                    "point to the local setting and `source_relation.basis.delegation` "
+                    "should point to the upstream delegation authority."
+                )
+            continue
         local_list = ", ".join(f"`{name}`" for name in local_rule_names)
         issues.append(
             "Delegated policy setting missing source_relation: "
@@ -17199,6 +17214,35 @@ def find_delegated_policy_setting_issues(
             "federal delegated hook rather than a state-specific local output."
         )
     return issues
+
+
+def _source_relation_sets_rules_for_local_values(
+    rules: list[Any],
+    local_rule_names: list[str],
+) -> list[tuple[str, str]]:
+    local_names = set(local_rule_names)
+    matches: list[tuple[str, str]] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "source_relation":
+            continue
+        source_relation = rule.get("source_relation")
+        if not isinstance(source_relation, dict):
+            continue
+        if str(source_relation.get("type") or "").strip().lower() != "sets":
+            continue
+        value = _normalize_relation_target(source_relation.get("value"))
+        if not value:
+            continue
+        value_name = value.rsplit("#", 1)[-1] if "#" in value else value
+        if value_name not in local_names:
+            continue
+        target = _normalize_relation_target(source_relation.get("target"))
+        if not target:
+            continue
+        matches.append((_rulespec_rule_name(rule), target))
+    return matches
 
 
 def _is_us_state_rulespec_path(rules_file: Path | None) -> bool:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -17039,6 +17039,7 @@ _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS = (
         rule_name_patterns=(
             r"^snap_individual_utility_allowance(?:_amount)?$",
             r"^.*telephone_utility_allowance.*$",
+            r"^.*telephone_standard.*$",
             r"^.*one_utility_allowance.*$",
         ),
     ),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4832,9 +4832,7 @@ rules:
             ]["value"]
             == "us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#telephone_utility_allowance"
         )
-        assert {
-            relation["basis"]["delegation"] for relation in relations.values()
-        } == {
+        assert {relation["basis"]["delegation"] for relation in relations.values()} == {
             "us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation"
         }
 
@@ -4950,8 +4948,7 @@ rules:
         assert "[10]" not in repaired_formula
         assert " - 10" not in repaired_formula
         assert (
-            "snap_gross_income_standard_for_household_scalar_limit"
-            in repaired_formula
+            "snap_gross_income_standard_for_household_scalar_limit" in repaired_formula
         )
 
     def test_embedded_scalar_literal_repair_reuses_existing_scalar_parameter(
@@ -5012,16 +5009,20 @@ rules:
         assert repaired == ["snap_gross_income_standard_for_household_scalar_limit"]
         payload = yaml.safe_load(rules_file.read_text())
         rule_names = [rule["name"] for rule in payload["rules"]]
-        assert rule_names.count(
-            "snap_gross_income_standard_for_household_scalar_limit"
-        ) == 1
+        assert (
+            rule_names.count("snap_gross_income_standard_for_household_scalar_limit")
+            == 1
+        )
         derived = payload["rules"][1]
         repaired_formula = derived["versions"][0]["formula"]
         assert "[10]" not in repaired_formula
         assert " - 10" not in repaired_formula
-        assert repaired_formula.count(
-            "snap_gross_income_standard_for_household_scalar_limit"
-        ) == 3
+        assert (
+            repaired_formula.count(
+                "snap_gross_income_standard_for_household_scalar_limit"
+            )
+            == 3
+        )
         assert len(derived["metadata"]["proof"]["atoms"]) == 1
 
     def test_delegated_policy_setting_repair_skips_existing_sets_edge(self, tmp_path):
@@ -5202,22 +5203,25 @@ rules:
             ),
         }
         wrappers = {rule["name"]: rule for rule in payload["rules"][3:6]}
-        assert wrappers["snap_standard_utility_allowance_state_value"][
-            "versions"
-        ][0]["formula"] == "snap_standard_utility_allowance"
-        assert wrappers["snap_limited_utility_allowance_state_value"][
-            "versions"
-        ][0]["formula"] == (
+        assert (
+            wrappers["snap_standard_utility_allowance_state_value"]["versions"][0][
+                "formula"
+            ]
+            == "snap_standard_utility_allowance"
+        )
+        assert wrappers["snap_limited_utility_allowance_state_value"]["versions"][0][
+            "formula"
+        ] == (
             "if snap_basic_utility_allowance_eligible: "
             "snap_basic_utility_allowance else: 0"
         )
-        assert wrappers["snap_individual_utility_allowance_state_value"][
-            "versions"
-        ][0]["formula"] == "snap_telephone_standard"
-        assert {
-            wrappers[name]["entity"]
-            for name in wrappers
-        } == {"Household"}
+        assert (
+            wrappers["snap_individual_utility_allowance_state_value"]["versions"][0][
+                "formula"
+            ]
+            == "snap_telephone_standard"
+        )
+        assert {wrappers[name]["entity"] for name in wrappers} == {"Household"}
 
     def test_delegated_policy_setting_repair_retargets_aggregate_hook_edge(
         self, tmp_path
@@ -5307,8 +5311,7 @@ rules:
         assert payload["imports"] == ["us:regulations/7-cfr/273/9"]
         relation = payload["rules"][0]["source_relation"]
         assert relation["target"] == (
-            "us:regulations/7-cfr/273/9#"
-            "snap_standard_utility_allowance_state_option"
+            "us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option"
         )
         assert relation["authority"] == "state"
         assert relation["value"] == (
@@ -5405,7 +5408,9 @@ rules:
             "us-tn:regulations/1240-01/04/27/block-1#"
             "snap_standard_utility_allowance_state_value"
         )
-        assert payload["rules"][1]["name"] == "snap_standard_utility_allowance_state_value"
+        assert (
+            payload["rules"][1]["name"] == "snap_standard_utility_allowance_state_value"
+        )
         assert payload["rules"][1]["versions"][0]["formula"] == (
             "snap_standard_utility_allowance"
         )
@@ -5490,8 +5495,7 @@ rules:
         assert payload["imports"] == ["us:regulations/7-cfr/273/9"]
         relation = payload["rules"][0]["source_relation"]
         assert relation["target"] == (
-            "us:regulations/7-cfr/273/9#"
-            "snap_standard_utility_allowance_state_option"
+            "us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option"
         )
         assert relation["value"] == (
             "us-tn:regulations/1240-01/04/27/block-1#"
@@ -5502,7 +5506,9 @@ rules:
             "us:regulations/7-cfr/273/9#"
             "snap_state_standard_utility_allowance_delegation"
         )
-        assert payload["rules"][1]["name"] == "snap_standard_utility_allowance_state_value"
+        assert (
+            payload["rules"][1]["name"] == "snap_standard_utility_allowance_state_value"
+        )
         assert payload["rules"][1]["versions"][0]["formula"] == (
             "snap_standard_utility_allowance"
         )
@@ -10609,9 +10615,7 @@ rules:
             "us:statutes/26/3241/b#average_account_benefits_ratio_bracket": 1
         }
 
-    def test_derived_output_test_repair_uses_positive_count_defaults(
-        self, tmp_path
-    ):
+    def test_derived_output_test_repair_uses_positive_count_defaults(self, tmp_path):
         repo_path = tmp_path / "rulespec-us" / "us-tn"
         rules_file = (
             repo_path / "regulations" / "1240-01" / "04" / "27" / "block-1.yaml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13763,6 +13763,49 @@ class TestGuardGenerated:
 
         assert issues == []
 
+    def test_accepts_monorepo_rulespec_change_with_nested_encoder_manifest(
+        self, tmp_path
+    ):
+        rule = tmp_path / "us-ca/policies/example.yaml"
+        test = tmp_path / "us-ca/policies/example.test.yaml"
+        rule.parent.mkdir(parents=True)
+        rule.write_text("format: rulespec/v1\nrules: []\n")
+        test.write_text("cases: []\n")
+        manifest = tmp_path / "us-ca/.axiom/encoding-manifests/policies/example.json"
+        manifest.parent.mkdir(parents=True)
+        manifest_payload = _signed_manifest_payload(
+            {
+                "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+                "applied_files": [
+                    {
+                        "path": "policies/example.yaml",
+                        "sha256": _sha256_file(rule),
+                    },
+                    {
+                        "path": "policies/example.test.yaml",
+                        "sha256": _sha256_file(test),
+                    },
+                ],
+            }
+        )
+        manifest.write_text(json.dumps(manifest_payload) + "\n")
+
+        with patch.dict(
+            os.environ,
+            {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+        ):
+            issues = guard_generated_change_issues(
+                tmp_path,
+                roots=("us-ca",),
+                changed_files=[
+                    "us-ca/policies/example.yaml",
+                    "us-ca/policies/example.test.yaml",
+                    "us-ca/.axiom/encoding-manifests/policies/example.json",
+                ],
+            )
+
+        assert issues == []
+
     def test_accepts_protected_deletion_listed_in_changed_manifest(self, tmp_path):
         manifest = tmp_path / ".axiom/encoding-manifests/regulations/removal.json"
         manifest.parent.mkdir(parents=True)
@@ -13936,6 +13979,45 @@ class TestGuardGenerated:
             issues = guard_generated_change_issues(
                 tmp_path,
                 roots=("regulations",),
+                all_files=True,
+            )
+
+        assert issues == []
+
+    def test_accepts_monorepo_existing_rulespec_with_nested_manifest_in_all_mode(
+        self, tmp_path
+    ):
+        rule = tmp_path / "us-ca/policies/example.yaml"
+        test = tmp_path / "us-ca/policies/example.test.yaml"
+        rule.parent.mkdir(parents=True)
+        rule.write_text("format: rulespec/v1\nrules: []\n")
+        test.write_text("cases: []\n")
+        manifest = tmp_path / "us-ca/.axiom/encoding-manifests/policies/example.json"
+        manifest.parent.mkdir(parents=True)
+        manifest_payload = _signed_manifest_payload(
+            {
+                "schema_version": APPLIED_ENCODING_MANIFEST_SCHEMA,
+                "applied_files": [
+                    {
+                        "path": "policies/example.yaml",
+                        "sha256": _sha256_file(rule),
+                    },
+                    {
+                        "path": "policies/example.test.yaml",
+                        "sha256": _sha256_file(test),
+                    },
+                ],
+            }
+        )
+        manifest.write_text(json.dumps(manifest_payload) + "\n")
+
+        with patch.dict(
+            os.environ,
+            {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+        ):
+            issues = guard_generated_change_issues(
+                tmp_path,
+                roots=("us-ca",),
                 all_files=True,
             )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4902,6 +4902,58 @@ rules:
             "us-tn:regulations/block-1#snap_standard_deduction_max_household_size"
         )
 
+    def test_embedded_scalar_literal_repair_replaces_repeated_expression_literals(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "regulations" / "block-1.yaml"
+        rules_file.parent.mkdir(parents=True)
+        formula = (
+            "if household_size <= 10: snap_gross_income_standard[household_size] "
+            "else: snap_gross_income_standard[10] + ((household_size - 10) * "
+            "snap_gross_income_standard_additional_member)"
+        )
+        rules_file.write_text(
+            f"""format: rulespec/v1
+module:
+  summary: Tennessee SNAP standards.
+rules:
+- name: snap_gross_income_standard_for_household
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  source: Table I
+  versions:
+  - effective_from: '0001-01-01'
+    formula: {formula!r}
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=tmp_path / "rulespec-us-tn",
+            issues=[
+                "Embedded scalar literal: snap_gross_income_standard_for_household "
+                f"line 10 embeds 10 in `{formula}`; extract the value to its own "
+                "named numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == ["snap_gross_income_standard_for_household_scalar_limit"]
+        payload = yaml.safe_load(rules_file.read_text())
+        derived = payload["rules"][1]
+        repaired_formula = derived["versions"][0]["formula"]
+        assert " 10" not in repaired_formula
+        assert "[10]" not in repaired_formula
+        assert " - 10" not in repaired_formula
+        assert (
+            "snap_gross_income_standard_for_household_scalar_limit"
+            in repaired_formula
+        )
+
     def test_delegated_policy_setting_repair_skips_existing_sets_edge(self, tmp_path):
         output_root = tmp_path / "out"
         rules_file = output_root / "runner" / "state_rule.yaml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4803,10 +4803,12 @@ rules:
 
         assert repaired == [
             "sets_snap_standard_utility_allowance",
+            "import:us:regulations/7-cfr/273/9",
             "sets_snap_limited_utility_allowance",
             "sets_snap_individual_utility_allowance",
         ]
         payload = yaml.safe_load(rules_file.read_text())
+        assert payload["imports"] == ["us:regulations/7-cfr/273/9"]
         relations = {
             rule["source_relation"]["target"]: rule["source_relation"]
             for rule in payload["rules"][:3]
@@ -4935,7 +4937,9 @@ rules:
             issues=["Delegated policy setting missing source_relation"],
         )
 
-        assert repaired == []
+        assert repaired == ["import:us:regulations/7-cfr/273/9"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["imports"] == ["us:regulations/7-cfr/273/9"]
 
     def test_delegated_policy_setting_repair_wraps_parameter_values_for_derived_slots(
         self, tmp_path
@@ -5050,10 +5054,12 @@ rules:
 
         assert repaired == [
             "sets_snap_standard_utility_allowance",
+            "import:us:regulations/7-cfr/273/9",
             "sets_snap_limited_utility_allowance",
             "sets_snap_individual_utility_allowance",
         ]
         payload = yaml.safe_load(rules_file.read_text())
+        assert payload["imports"] == ["us:regulations/7-cfr/273/9"]
         relation_values = {
             rule["name"]: rule["source_relation"]["value"]
             for rule in payload["rules"][:3]
@@ -5089,6 +5095,94 @@ rules:
             wrappers[name]["entity"]
             for name in wrappers
         } == {"Household"}
+
+    def test_delegated_policy_setting_repair_retargets_existing_parameter_sets_edge(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us" / "us-tn"
+        federal_file = (
+            tmp_path / "rulespec-us" / "us" / "regulations" / "7-cfr" / "273" / "9.yaml"
+        )
+        federal_file.parent.mkdir(parents=True)
+        federal_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: snap_standard_utility_allowance_state_option
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0'
+"""
+        )
+        rules_file = (
+            output_root
+            / "runner"
+            / "regulations"
+            / "1240-01"
+            / "04"
+            / "27"
+            / "block-1.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: Tennessee SNAP utility allowance table.
+rules:
+- name: sets_existing_standard
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+    value: us-tn:regulations/1240-01/04/27/block-1#snap_standard_utility_allowance
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: snap_standard_utility_allowance
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: household_size
+  source: Table V-A
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      1: 314
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_delegated_policy_settings_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "RuleSpec source relation `sets_existing_standard` cannot bind "
+                "`us-tn:regulations/1240-01/04/27/block-1#snap_standard_utility_allowance` "
+                "(parameter) to "
+                "`us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option` "
+                "(derived)"
+            ],
+        )
+
+        assert repaired == [
+            "snap_standard_utility_allowance_state_value",
+            "import:us:regulations/7-cfr/273/9",
+        ]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["imports"] == ["us:regulations/7-cfr/273/9"]
+        assert payload["rules"][0]["source_relation"]["value"] == (
+            "us-tn:regulations/1240-01/04/27/block-1#"
+            "snap_standard_utility_allowance_state_value"
+        )
+        assert payload["rules"][1]["name"] == "snap_standard_utility_allowance_state_value"
+        assert payload["rules"][1]["versions"][0]["formula"] == (
+            "snap_standard_utility_allowance"
+        )
 
     def test_source_relation_delegation_repair_drops_unsupported_federal_cfr_implements(
         self, tmp_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -98,6 +98,7 @@ from axiom_encode.cli import (
     _split_table_row_relation_test_cases,
     _suppress_rulespec_ancestor_targets_for_subsection_overlay,
     _try_repair_generated_boolean_comparison_predicates_for_apply,
+    _try_repair_generated_delegated_policy_settings_for_apply,
     _try_repair_generated_empty_test_outputs_for_apply,
     _try_repair_generated_judgment_numeric_comparisons_for_apply,
     _try_repair_generated_missing_deferred_outputs_for_apply,
@@ -4714,6 +4715,162 @@ rules:
 
         assert repaired == []
         assert rules_file.read_text() == original
+
+    def test_delegated_policy_setting_repair_adds_snap_utility_sets_edges(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us-nc"
+        rules_file = (
+            output_root
+            / "runner"
+            / "policies"
+            / "dhhs"
+            / "fns"
+            / "fns-360-determining-benefit-levels"
+            / "page-1.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: North Carolina FNS SNAP utility allowance table.
+rules:
+- name: heating_cooling_standard_utility_allowance_for_unit_size
+  kind: parameter
+  dtype: Money
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 637
+- name: heating_cooling_standard_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  source: FNS 360.01(A)
+  versions:
+  - effective_from: '2025-10-01'
+    formula: heating_cooling_standard_utility_allowance_for_unit_size[1]
+- name: non_heating_non_cooling_basic_utility_allowance_for_unit_size
+  kind: parameter
+  dtype: Money
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 392
+- name: non_heating_non_cooling_basic_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  source: FNS 360.01(A)
+  versions:
+  - effective_from: '2025-10-01'
+    formula: non_heating_non_cooling_basic_utility_allowance_for_unit_size[1]
+- name: telephone_utility_allowance_for_unit_size
+  kind: parameter
+  dtype: Money
+  versions:
+  - effective_from: '2025-10-01'
+    values:
+      1: 42
+- name: telephone_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  source: FNS 360.01(A)
+  versions:
+  - effective_from: '2025-10-01'
+    formula: telephone_utility_allowance_for_unit_size[1]
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_delegated_policy_settings_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "Delegated policy setting missing source_relation: "
+                "`heating_cooling_standard_utility_allowance`, "
+                "`heating_cooling_standard_utility_allowance_for_unit_size` "
+                "encodes a state-set SNAP standard utility allowance."
+            ],
+        )
+
+        assert repaired == [
+            "sets_snap_standard_utility_allowance",
+            "sets_snap_limited_utility_allowance",
+            "sets_snap_individual_utility_allowance",
+        ]
+        payload = yaml.safe_load(rules_file.read_text())
+        relations = {
+            rule["source_relation"]["target"]: rule["source_relation"]
+            for rule in payload["rules"][:3]
+        }
+        assert (
+            relations[
+                "us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option"
+            ]["value"]
+            == "us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#heating_cooling_standard_utility_allowance"
+        )
+        assert (
+            relations[
+                "us:regulations/7-cfr/273/9#snap_limited_utility_allowance_state_option"
+            ]["value"]
+            == "us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#non_heating_non_cooling_basic_utility_allowance"
+        )
+        assert (
+            relations[
+                "us:regulations/7-cfr/273/9#snap_individual_utility_allowance_state_option"
+            ]["value"]
+            == "us-nc:policies/dhhs/fns/fns-360-determining-benefit-levels/page-1#telephone_utility_allowance"
+        )
+        assert {
+            relation["basis"]["delegation"] for relation in relations.values()
+        } == {
+            "us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation"
+        }
+
+    def test_delegated_policy_setting_repair_skips_existing_sets_edge(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "state_rule.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: State SNAP standard utility allowance.
+rules:
+- name: sets_snap_standard_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+    value: us-ca:policies/cdss/snap/standard-utility-allowance#snap_standard_utility_allowance
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: snap_standard_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 663
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_delegated_policy_settings_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=tmp_path / "rulespec-us-ca",
+            issues=["Delegated policy setting missing source_relation"],
+        )
+
+        assert repaired == []
 
     def test_source_relation_delegation_repair_drops_unsupported_federal_cfr_implements(
         self, tmp_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4872,6 +4872,159 @@ rules:
 
         assert repaired == []
 
+    def test_delegated_policy_setting_repair_wraps_parameter_values_for_derived_slots(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us" / "us-tn"
+        federal_file = (
+            tmp_path / "rulespec-us" / "us" / "regulations" / "7-cfr" / "273" / "9.yaml"
+        )
+        federal_file.parent.mkdir(parents=True)
+        federal_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: snap_state_standard_utility_allowance_delegation
+  kind: source_relation
+  source_relation:
+    type: delegates
+    target: us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs
+    authority: federal
+- name: snap_standard_utility_allowance_state_option
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0'
+- name: snap_limited_utility_allowance_state_option
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0'
+- name: snap_individual_utility_allowance_state_option
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0'
+"""
+        )
+        rules_file = (
+            output_root
+            / "runner"
+            / "regulations"
+            / "1240-01"
+            / "04"
+            / "27"
+            / "block-1.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: Tennessee SNAP utility allowance tables.
+rules:
+- name: snap_standard_utility_allowance
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: capped_household_size_for_utility_allowances
+  source: Table V-A
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      1: 314
+- name: snap_basic_utility_allowance
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: capped_household_size_for_utility_allowances
+  source: Table V-B
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      1: 126
+- name: snap_basic_utility_allowance_eligible
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '0001-01-01'
+    formula: household_incurs_non_heating_cooling_utility_costs
+- name: snap_telephone_standard
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: capped_household_size_for_utility_allowances
+  source: Food Stamp Standard Telephone Allowance
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      1: 25
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_delegated_policy_settings_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=["Delegated policy setting missing source_relation"],
+        )
+
+        assert repaired == [
+            "sets_snap_standard_utility_allowance",
+            "sets_snap_limited_utility_allowance",
+            "sets_snap_individual_utility_allowance",
+        ]
+        payload = yaml.safe_load(rules_file.read_text())
+        relation_values = {
+            rule["name"]: rule["source_relation"]["value"]
+            for rule in payload["rules"][:3]
+        }
+        assert relation_values == {
+            "sets_snap_standard_utility_allowance": (
+                "us-tn:regulations/1240-01/04/27/block-1#"
+                "snap_standard_utility_allowance_state_value"
+            ),
+            "sets_snap_limited_utility_allowance": (
+                "us-tn:regulations/1240-01/04/27/block-1#"
+                "snap_limited_utility_allowance_state_value"
+            ),
+            "sets_snap_individual_utility_allowance": (
+                "us-tn:regulations/1240-01/04/27/block-1#"
+                "snap_individual_utility_allowance_state_value"
+            ),
+        }
+        wrappers = {rule["name"]: rule for rule in payload["rules"][3:6]}
+        assert wrappers["snap_standard_utility_allowance_state_value"][
+            "versions"
+        ][0]["formula"] == "snap_standard_utility_allowance"
+        assert wrappers["snap_limited_utility_allowance_state_value"][
+            "versions"
+        ][0]["formula"] == (
+            "if snap_basic_utility_allowance_eligible: "
+            "snap_basic_utility_allowance else: 0"
+        )
+        assert wrappers["snap_individual_utility_allowance_state_value"][
+            "versions"
+        ][0]["formula"] == "snap_telephone_standard"
+        assert {
+            wrappers[name]["entity"]
+            for name in wrappers
+        } == {"Household"}
+
     def test_source_relation_delegation_repair_drops_unsupported_federal_cfr_implements(
         self, tmp_path
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10287,6 +10287,67 @@ rules:
             "us:statutes/26/3241/b#average_account_benefits_ratio_bracket": 1
         }
 
+    def test_derived_output_test_repair_uses_positive_count_defaults(
+        self, tmp_path
+    ):
+        repo_path = tmp_path / "rulespec-us" / "us-tn"
+        rules_file = (
+            repo_path / "regulations" / "1240-01" / "04" / "27" / "block-1.yaml"
+        )
+        test_file = rules_file.with_name("block-1.test.yaml")
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: household_size
+    kind: derived
+    entity: Household
+    dtype: Count
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: household_member_count
+  - name: snap_standard_utility_allowance
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    indexed_by: household_size
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          1: 200
+  - name: snap_standard_utility_allowance_state_value
+    kind: derived
+    entity: Household
+    dtype: Money
+    unit: USD
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: snap_standard_utility_allowance[household_size]
+"""
+        )
+        test_file.write_text("[]\n")
+
+        repaired = _append_generated_derived_output_tests_if_missing(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=repo_path,
+            relative_output=Path("regulations/1240-01/04/27/block-1.yaml"),
+            issues=[
+                "Derived rule missing companion output coverage: "
+                "`us-tn:regulations/1240-01/04/27/block-1#snap_standard_utility_allowance_state_value` "
+                "is not asserted by the companion `.test.yaml` file."
+            ],
+        )
+
+        assert repaired == ["auto_output_snap_standard_utility_allowance_state_value"]
+        test_payload = yaml.safe_load(test_file.read_text())
+        assert test_payload[0]["input"] == {
+            "us-tn:regulations/1240-01/04/27/block-1#input.household_member_count": 1
+        }
+
     def test_judgment_positive_test_repair_clones_existing_scenario(self, tmp_path):
         repo_path = tmp_path / "rulespec-us"
         test_file = repo_path / "statutes" / "26" / "3102" / "f" / "1.test.yaml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15125,6 +15125,57 @@ rules: []
         assert issues == []
         assert supplemental == {}
 
+    def test_apply_overlay_validation_stages_country_monorepo_dependencies(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        monorepo = tmp_path / "rulespec-us"
+        policy_repo = monorepo / "us-tn"
+        federal_file = monorepo / "us/regulations/7-cfr/273/9.yaml"
+        generated = (
+            output_root / "codex-test-model" / "regulations/1240-01/04/27/block-1.yaml"
+        )
+        federal_file.parent.mkdir(parents=True)
+        policy_repo.mkdir(parents=True)
+        generated.parent.mkdir(parents=True)
+        federal_file.write_text("format: rulespec/v1\nrules: []\n")
+        generated.write_text(
+            """format: rulespec/v1
+imports:
+  - us:regulations/7-cfr/273/9
+rules: []
+"""
+        )
+        result = SimpleNamespace(output_file=str(generated), runner="codex-test-model")
+        staged_federal_files: list[Path] = []
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                repo_path = Path(kwargs["policy_repo_path"])
+                staged_federal = (
+                    repo_path.parent / "rulespec-us/us/regulations/7-cfr/273/9.yaml"
+                )
+                staged_federal_files.append(staged_federal)
+                assert staged_federal.exists()
+
+            def validate(self, _path, *, skip_reviewers):
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with patch("axiom_encode.cli.ValidatorPipeline", FakePipeline):
+            ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                validate_dependents=False,
+            )
+
+        assert ok is True
+        assert issues == []
+        assert supplemental == {}
+        assert len(staged_federal_files) == 1
+
     def test_apply_overlay_validation_requires_policy_proofs(self, tmp_path):
         output_root = tmp_path / "out"
         policy_repo = tmp_path / "rulespec-us"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4954,6 +4954,76 @@ rules:
             in repaired_formula
         )
 
+    def test_embedded_scalar_literal_repair_reuses_existing_scalar_parameter(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "regulations" / "block-1.yaml"
+        rules_file.parent.mkdir(parents=True)
+        formula = (
+            "if household_size <= snap_gross_income_standard_for_household_scalar_limit: "
+            "snap_gross_income_standard[household_size] else: "
+            "snap_gross_income_standard[10] + ((household_size - 10) * "
+            "snap_gross_income_standard_additional_member)"
+        )
+        rules_file.write_text(
+            f"""format: rulespec/v1
+rules:
+- name: snap_gross_income_standard_for_household_scalar_limit
+  kind: parameter
+  dtype: Count
+  versions:
+  - effective_from: '0001-01-01'
+    formula: '10'
+- name: snap_gross_income_standard_for_household
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  source: Table I
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: import
+        import:
+          target: us-tn:regulations/block-1#snap_gross_income_standard_for_household_scalar_limit
+          output: snap_gross_income_standard_for_household_scalar_limit
+          hash: sha256:local
+  versions:
+  - effective_from: '0001-01-01'
+    formula: {formula!r}
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=tmp_path / "rulespec-us-tn",
+            issues=[
+                "Embedded scalar literal: snap_gross_income_standard_for_household "
+                "line 10 embeds 10 in `snap_gross_income_standard[10]`; "
+                "extract the value to its own named numeric concept or indexed "
+                "table/grid value"
+            ],
+        )
+
+        assert repaired == ["snap_gross_income_standard_for_household_scalar_limit"]
+        payload = yaml.safe_load(rules_file.read_text())
+        rule_names = [rule["name"] for rule in payload["rules"]]
+        assert rule_names.count(
+            "snap_gross_income_standard_for_household_scalar_limit"
+        ) == 1
+        derived = payload["rules"][1]
+        repaired_formula = derived["versions"][0]["formula"]
+        assert "[10]" not in repaired_formula
+        assert " - 10" not in repaired_formula
+        assert repaired_formula.count(
+            "snap_gross_income_standard_for_household_scalar_limit"
+        ) == 3
+        assert len(derived["metadata"]["proof"]["atoms"]) == 1
+
     def test_delegated_policy_setting_repair_skips_existing_sets_edge(self, tmp_path):
         output_root = tmp_path / "out"
         rules_file = output_root / "runner" / "state_rule.yaml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5097,6 +5097,109 @@ rules:
             for name in wrappers
         } == {"Household"}
 
+    def test_delegated_policy_setting_repair_retargets_aggregate_hook_edge(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us" / "us-tn"
+        federal_file = (
+            tmp_path / "rulespec-us" / "us" / "regulations" / "7-cfr" / "273" / "9.yaml"
+        )
+        federal_file.parent.mkdir(parents=True)
+        federal_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: snap_state_standard_utility_allowance_delegation
+  kind: source_relation
+  source_relation:
+    type: delegates
+    target: us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs
+    authority: federal
+- name: snap_standard_utility_allowance_state_option
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0'
+"""
+        )
+        rules_file = (
+            output_root
+            / "runner"
+            / "regulations"
+            / "1240-01"
+            / "04"
+            / "27"
+            / "block-1.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: Tennessee SNAP utility allowance table.
+rules:
+- name: snap_standard_utility_allowance_sets_federal_delegated_slot
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs
+    value: us-tn:regulations/1240-01/04/27/block-1#snap_standard_utility_allowance
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: snap_standard_utility_allowance
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: household_size
+  source: Table V-A
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      1: 314
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_delegated_policy_settings_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "RuleSpec source relation "
+                "`snap_standard_utility_allowance_sets_federal_delegated_slot` "
+                "sets target "
+                "`us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs`, "
+                "but the target does not resolve to a parameter in the merged program"
+            ],
+        )
+
+        assert repaired == [
+            "snap_standard_utility_allowance_state_value",
+            "snap_standard_utility_allowance_sets_federal_delegated_slot",
+            "import:us:regulations/7-cfr/273/9",
+        ]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["imports"] == ["us:regulations/7-cfr/273/9"]
+        relation = payload["rules"][0]["source_relation"]
+        assert relation["target"] == (
+            "us:regulations/7-cfr/273/9#"
+            "snap_standard_utility_allowance_state_option"
+        )
+        assert relation["authority"] == "state"
+        assert relation["value"] == (
+            "us-tn:regulations/1240-01/04/27/block-1#"
+            "snap_standard_utility_allowance_state_value"
+        )
+        assert payload["rules"][1]["name"] == (
+            "snap_standard_utility_allowance_state_value"
+        )
+        assert payload["rules"][1]["versions"][0]["formula"] == (
+            "snap_standard_utility_allowance"
+        )
+
     def test_delegated_policy_setting_repair_retargets_existing_parameter_sets_edge(
         self, tmp_path
     ):
@@ -5179,6 +5282,103 @@ rules:
         assert payload["rules"][0]["source_relation"]["value"] == (
             "us-tn:regulations/1240-01/04/27/block-1#"
             "snap_standard_utility_allowance_state_value"
+        )
+        assert payload["rules"][1]["name"] == "snap_standard_utility_allowance_state_value"
+        assert payload["rules"][1]["versions"][0]["formula"] == (
+            "snap_standard_utility_allowance"
+        )
+
+    def test_delegated_policy_setting_repair_retargets_aggregate_sets_edge(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us" / "us-tn"
+        federal_file = (
+            tmp_path / "rulespec-us" / "us" / "regulations" / "7-cfr" / "273" / "9.yaml"
+        )
+        federal_file.parent.mkdir(parents=True)
+        federal_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: snap_standard_utility_allowance_state_option
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0'
+"""
+        )
+        rules_file = (
+            output_root
+            / "runner"
+            / "regulations"
+            / "1240-01"
+            / "04"
+            / "27"
+            / "block-1.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: Tennessee SNAP utility allowance table.
+rules:
+- name: sets_existing_standard
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs
+    value: us-tn:regulations/1240-01/04/27/block-1#snap_standard_utility_allowance
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: snap_standard_utility_allowance
+  kind: parameter
+  dtype: Money
+  unit: USD
+  indexed_by: household_size
+  source: Table V-A
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      1: 314
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_delegated_policy_settings_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "RuleSpec source relation `sets_existing_standard` sets target "
+                "`us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs`, "
+                "but the target does not resolve to a parameter in the merged program"
+            ],
+        )
+
+        assert repaired == [
+            "snap_standard_utility_allowance_state_value",
+            "sets_existing_standard",
+            "import:us:regulations/7-cfr/273/9",
+        ]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["imports"] == ["us:regulations/7-cfr/273/9"]
+        relation = payload["rules"][0]["source_relation"]
+        assert relation["target"] == (
+            "us:regulations/7-cfr/273/9#"
+            "snap_standard_utility_allowance_state_option"
+        )
+        assert relation["value"] == (
+            "us-tn:regulations/1240-01/04/27/block-1#"
+            "snap_standard_utility_allowance_state_value"
+        )
+        assert relation["authority"] == "state"
+        assert relation["basis"]["delegation"] == (
+            "us:regulations/7-cfr/273/9#"
+            "snap_state_standard_utility_allowance_delegation"
         )
         assert payload["rules"][1]["name"] == "snap_standard_utility_allowance_state_value"
         assert payload["rules"][1]["versions"][0]["formula"] == (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -96,6 +96,7 @@ from axiom_encode.cli import (
     _sign_applied_encoding_manifest,
     _source_relation_preservation_issues,
     _split_table_row_relation_test_cases,
+    _stage_apply_overlay_dependency_root,
     _suppress_rulespec_ancestor_targets_for_subsection_overlay,
     _try_repair_generated_boolean_comparison_predicates_for_apply,
     _try_repair_generated_delegated_policy_settings_for_apply,
@@ -15175,6 +15176,20 @@ rules: []
         assert issues == []
         assert supplemental == {}
         assert len(staged_federal_files) == 1
+
+    def test_apply_overlay_dependency_alias_copies_when_canonical_name_differs(
+        self, tmp_path
+    ):
+        source = tmp_path / "rulespec-us-worktree"
+        target = tmp_path / "overlay" / "rulespec-us"
+        federal_file = source / "us/regulations/7-cfr/273/9.yaml"
+        federal_file.parent.mkdir(parents=True)
+        federal_file.write_text("format: rulespec/v1\nrules: []\n")
+
+        _stage_apply_overlay_dependency_root(source=source, target=target)
+
+        assert (target / "us/regulations/7-cfr/273/9.yaml").exists()
+        assert not target.is_symlink()
 
     def test_apply_overlay_validation_requires_policy_proofs(self, tmp_path):
         output_root = tmp_path / "out"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,6 +99,7 @@ from axiom_encode.cli import (
     _suppress_rulespec_ancestor_targets_for_subsection_overlay,
     _try_repair_generated_boolean_comparison_predicates_for_apply,
     _try_repair_generated_delegated_policy_settings_for_apply,
+    _try_repair_generated_embedded_scalar_literals_for_apply,
     _try_repair_generated_empty_test_outputs_for_apply,
     _try_repair_generated_judgment_numeric_comparisons_for_apply,
     _try_repair_generated_missing_deferred_outputs_for_apply,
@@ -4833,6 +4834,70 @@ rules:
         } == {
             "us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation"
         }
+
+    def test_embedded_scalar_literal_repair_extracts_min_bound(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "regulations" / "block-1.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: Tennessee SNAP standards.
+rules:
+- name: household_size
+  kind: derived
+  entity: Household
+  dtype: Count
+  period: Month
+  versions:
+  - effective_from: '0001-01-01'
+    formula: household_member_count
+- name: snap_standard_deduction_size_category
+  kind: derived
+  entity: Household
+  dtype: Count
+  period: Month
+  source: Table IV-A, Standard Deduction household-size categories
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-tn/regulation/1240-01/04/27/block-1
+          excerpt: Household Size 1 2 3 4 5 6+
+  versions:
+  - effective_from: '0001-01-01'
+    formula: min(household_size, 6)
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=tmp_path / "rulespec-us-tn",
+            issues=[
+                "Embedded scalar literal: snap_standard_deduction_size_category "
+                "line 7 embeds 6 in `min(household_size, 6)`; extract the value "
+                "to its own named numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == ["snap_standard_deduction_max_household_size"]
+        payload = yaml.safe_load(rules_file.read_text())
+        parameter = payload["rules"][1]
+        assert parameter["name"] == "snap_standard_deduction_max_household_size"
+        assert parameter["kind"] == "parameter"
+        assert parameter["versions"][0]["formula"] == "6"
+        derived = payload["rules"][2]
+        assert (
+            derived["versions"][0]["formula"]
+            == "min(household_size, snap_standard_deduction_max_household_size)"
+        )
+        assert derived["metadata"]["proof"]["atoms"][-1]["import"]["target"] == (
+            "us-tn:regulations/block-1#snap_standard_deduction_max_household_size"
+        )
 
     def test_delegated_policy_setting_repair_skips_existing_sets_edge(self, tmp_path):
         output_root = tmp_path / "out"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -39,6 +39,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_current_year_final_amount_table_issues,
     find_deferred_output_issues,
     find_deferred_purpose_specific_limitation_issues,
+    find_delegated_policy_setting_issues,
     find_deprecated_source_url_issues,
     find_employer_scoped_entity_issues,
     find_empty_rules_module_issues,
@@ -75,6 +76,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_source_claim_reference_issues,
     find_source_condition_coverage_issues,
     find_source_limitation_application_issues,
+    find_source_relation_issues,
     find_source_scope_consistency_issues,
     find_source_subparagraph_coverage_issues,
     find_source_table_row_scalar_parameter_issues,
@@ -19920,6 +19922,179 @@ rules:
 
     assert result.passed is False
     assert any("Source relation target required" in issue for issue in result.issues)
+
+
+def test_source_relation_sets_requires_value_and_delegation_basis():
+    content = """format: rulespec/v1
+rules:
+  - name: standard_utility_allowance_setting
+    kind: source_relation
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      authority: state
+"""
+
+    issues = find_source_relation_issues(content)
+
+    assert any("Source relation setting value required" in issue for issue in issues)
+    assert any("Source relation delegation basis required" in issue for issue in issues)
+
+
+def test_source_relation_sets_accepts_canonical_metadata():
+    content = """format: rulespec/v1
+rules:
+  - name: standard_utility_allowance_setting
+    kind: source_relation
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      authority: state
+      value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+"""
+
+    assert find_source_relation_issues(content) == []
+
+
+def test_delegated_policy_setting_requires_snap_utility_sets_relation(tmp_path):
+    rules_file = (
+        tmp_path
+        / "rulespec-us"
+        / "us-co"
+        / "regulations"
+        / "10-ccr-2506-1"
+        / "4.407.31.yaml"
+    )
+    content = """format: rulespec/v1
+module:
+  summary: Colorado SNAP rules set the standard utility allowance.
+rules:
+  - name: snap_standard_utility_allowance
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2025-10-01'
+        formula: '626'
+"""
+
+    issues = find_delegated_policy_setting_issues(content, rules_file=rules_file)
+
+    assert len(issues) == 1
+    assert "Delegated policy setting missing source_relation" in issues[0]
+    assert "source_relation.type: sets" in issues[0]
+    assert (
+        "us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option"
+        in issues[0]
+    )
+
+
+def test_rulespec_ci_rejects_delegated_policy_setting_without_sets_relation(tmp_path):
+    if not AXIOM_RULES_ENGINE_BINARY.exists():
+        pytest.skip("local axiom-rules-engine binary is not built")
+
+    repo_root = tmp_path / "rulespec-us"
+    rules_file = repo_root / "us-co" / "regulations" / "10-ccr-2506-1" / "4.407.31.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: Colorado SNAP rules set the standard utility allowance.
+rules:
+  - name: snap_standard_utility_allowance
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2025-10-01'
+        formula: '626'
+"""
+    )
+    rules_file.with_name("4.407.31.test.yaml").write_text(
+        """- name: standard_utility_allowance
+  period: 2025-10
+  input: {}
+  output:
+    snap_standard_utility_allowance: 626
+"""
+    )
+
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo_root,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    result = pipeline._run_ci(rules_file)
+
+    assert result.passed is False
+    assert any(
+        "Delegated policy setting missing source_relation" in issue
+        and "snap_standard_utility_allowance_state_option" in issue
+        for issue in result.issues
+    )
+
+
+def test_delegated_policy_setting_accepts_snap_utility_sets_relation(tmp_path):
+    rules_file = (
+        tmp_path
+        / "rulespec-us"
+        / "us-co"
+        / "regulations"
+        / "10-ccr-2506-1"
+        / "4.407.31.yaml"
+    )
+    content = """format: rulespec/v1
+module:
+  summary: Colorado SNAP rules set the standard utility allowance.
+rules:
+  - name: sets_snap_standard_utility_allowance
+    kind: source_relation
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      authority: state
+      value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  - name: snap_standard_utility_allowance
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2025-10-01'
+        formula: '626'
+"""
+
+    assert find_delegated_policy_setting_issues(content, rules_file=rules_file) == []
+
+
+def test_delegated_policy_setting_ignores_snap_utility_eligibility(tmp_path):
+    rules_file = (
+        tmp_path / "rulespec-us" / "us-az" / "policies" / "des" / "faa5" / "snap.yaml"
+    )
+    content = """format: rulespec/v1
+module:
+  summary: Arizona SNAP rules define utility allowance eligibility.
+rules:
+  - name: snap_standard_utility_allowance
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: household_has_heating_or_cooling_expense
+"""
+
+    assert find_delegated_policy_setting_issues(content, rules_file=rules_file) == []
 
 
 def test_rulespec_ci_rejects_scalar_kind_mismatches(tmp_path):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -19993,6 +19993,50 @@ rules:
     )
 
 
+def test_delegated_policy_setting_rejects_wrong_snap_utility_sets_target(tmp_path):
+    rules_file = (
+        tmp_path
+        / "rulespec-us"
+        / "us-tn"
+        / "regulations"
+        / "1240-01"
+        / "04"
+        / "27"
+        / "block-1.yaml"
+    )
+    content = """format: rulespec/v1
+module:
+  summary: Tennessee SNAP rules set the standard utility allowance.
+rules:
+  - name: sets_existing_standard
+    kind: source_relation
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs
+      value: us-tn:regulations/1240-01/04/27/block-1#snap_standard_utility_allowance
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  - name: snap_standard_utility_allowance
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: '626'
+"""
+
+    issues = find_delegated_policy_setting_issues(content, rules_file=rules_file)
+
+    assert len(issues) == 1
+    assert "Delegated policy setting wrong source_relation target" in issues[0]
+    assert "snap_utility_allowance_for_shelter_costs" in issues[0]
+    assert (
+        "us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option"
+        in issues[0]
+    )
+
+
 def test_rulespec_ci_rejects_delegated_policy_setting_without_sets_relation(tmp_path):
     if not AXIOM_RULES_ENGINE_BINARY.exists():
         pytest.skip("local axiom-rules-engine binary is not built")

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.663"
+version = "0.2.664"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.660"
+version = "0.2.661"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.659"
+version = "0.2.660"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.658"
+version = "0.2.659"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.661"
+version = "0.2.662"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.662"
+version = "0.2.663"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Require `source_relation.type: sets` records to include a target rule, `source_relation.value`, and `source_relation.basis.delegation`.
- Add a CI harness check for state SNAP utility allowance outputs that must set the federal delegated hooks instead of remaining standalone local outputs.
- Add direct and `_run_ci` regression coverage for the canonical delegated-setting shape.

## Validation
- `uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_rulespec_validation.py` (600 passed, 1 pytest config warning for unknown `asyncio_mode`)

## Current rulespec-us noncompliance found by the new check
- `us-ca/policies/cdss/snap/standard-utility-allowance.yaml`: missing standard utility allowance `sets` relation.
- `us-co/regulations/10-ccr-2506-1/4.407.31.yaml`: missing standard, limited, and individual utility allowance `sets` relations.
- `us-nc/policies/dhhs/fns/fns-360-determining-benefit-levels/page-1.yaml`: missing standard, limited, and individual utility allowance `sets` relations.
- `us-tn/regulations/1240-01/04/27/block-1.yaml`: missing standard and limited utility allowance `sets` relations.
