### PR TITLE
Harden CFR paragraph encoding for Part 275

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.669"
+version = "0.2.670"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.676"
+version = "0.2.677"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.670"
+version = "0.2.671"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.673"
+version = "0.2.674"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.666"
+version = "0.2.667"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.671"
+version = "0.2.672"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.672"
+version = "0.2.673"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.678"
+version = "0.2.679"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.675"
+version = "0.2.676"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.667"
+version = "0.2.668"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.674"
+version = "0.2.675"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.668"
+version = "0.2.669"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.667"
+__version__ = "0.2.668"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.676"
+__version__ = "0.2.677"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.675"
+__version__ = "0.2.676"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.669"
+__version__ = "0.2.670"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.678"
+__version__ = "0.2.679"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.666"
+__version__ = "0.2.667"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.672"
+__version__ = "0.2.673"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.671"
+__version__ = "0.2.672"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.674"
+__version__ = "0.2.675"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.673"
+__version__ = "0.2.674"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.670"
+__version__ = "0.2.671"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.668"
+__version__ = "0.2.669"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -82,6 +82,7 @@ from .harness.validator_pipeline import (
     _candidate_upstream_rulespec_roots,
     _canonical_rulespec_compile_path,
     _canonical_rulespec_target,
+    _engine_rulespec_item_path_for_policy_root,
     _extract_source_verification_text,
     _filing_status_rule_source_context,
     _is_executable_rulespec_rule,
@@ -91,6 +92,7 @@ from .harness.validator_pipeline import (
     _resolve_rulespec_target_file,
     _rulespec_executable_index_for_roots,
     _rulespec_executable_signature,
+    _rulespec_local_item_prefix,
     _rulespec_payload_from_file,
     _rulespec_public_item_keys,
     _rulespec_repo_prefix,
@@ -2903,9 +2905,18 @@ def _rulespec_test_relation_request_name(
     if ":" in key:
         prefix, relative = key.split(":", 1)
         canonical_prefix = _repo_jurisdiction_prefix(policy_repo_path)
-        local_prefix = policy_repo_path.name.removeprefix("rulespec-")
-        if prefix == canonical_prefix and local_prefix != canonical_prefix:
-            return f"{local_prefix}:{relative}"
+        local_prefix = _rulespec_local_item_prefix(policy_repo_path)
+        if (
+            prefix == canonical_prefix
+            and local_prefix
+            and local_prefix != canonical_prefix
+        ):
+            item_path = _engine_rulespec_item_path_for_policy_root(
+                relative,
+                policy_repo_path=policy_repo_path,
+                canonical_prefix=canonical_prefix,
+            )
+            return f"{local_prefix}:{item_path}"
     return key
 
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -20453,11 +20453,21 @@ def _try_repair_generated_invalid_deferred_source_values_for_apply(
     output_root: Path,
     issues: list[str],
 ) -> list[str]:
-    """Remove optional prose source_values from deferred outputs."""
+    """Remove optional invalid source_values from deferred outputs."""
     if not any(
-        "module.deferred_outputs[" in str(issue)
-        and ".source_values entry `" in str(issue)
-        and "must be an absolute RuleSpec target" in str(issue)
+        (
+            "module.deferred_outputs[" in str(issue)
+            and (
+                (
+                    ".source_values entry `" in str(issue)
+                    and "must be an absolute RuleSpec target" in str(issue)
+                )
+                or (
+                    ".source_values must list absolute RuleSpec targets"
+                    in str(issue)
+                )
+            )
+        )
         for issue in issues
     ):
         return []
@@ -20549,13 +20559,16 @@ def _remove_invalid_deferred_source_values(*, rules_file: Path) -> list[str]:
         if not isinstance(record, dict):
             continue
         source_values = record.get("source_values")
-        if not isinstance(source_values, list):
+        if source_values is None:
             continue
-        invalid_values = [
-            value
-            for value in source_values
-            if not _looks_like_absolute_rulespec_output_target(value)
-        ]
+        invalid_values = (
+            not isinstance(source_values, list)
+            or not source_values
+            or any(
+                not _looks_like_absolute_rulespec_output_target(value)
+                for value in source_values
+            )
+        )
         if not invalid_values:
             continue
         record.pop("source_values", None)

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -16095,6 +16095,21 @@ def cmd_encode(args):
                     "  apply=auto_repaired_admin_agency_aggregate_entities:"
                     + ",".join(repaired_admin_aggregate_entities)
                 )
+            repaired_parameter_only_tests = (
+                _try_repair_generated_parameter_only_companion_tests_for_apply(
+                    result,
+                    output_root=args.output,
+                    policy_repo_path=policy_repo_path,
+                )
+            )
+            if repaired_parameter_only_tests:
+                outcome["auto_repaired_parameter_only_companion_tests"] = (
+                    repaired_parameter_only_tests
+                )
+                print(
+                    "  apply=auto_repaired_parameter_only_companion_tests:"
+                    + ",".join(repaired_parameter_only_tests)
+                )
             can_apply, apply_issues, supplemental_files = (
                 _validate_generated_encoding_in_policy_overlay(
                     result,
@@ -20912,6 +20927,83 @@ def _try_repair_generated_admin_agency_aggregate_entities_for_apply(
         test_file.write_text("[]\n")
 
     return [str(record["output"]) for record in deferred_outputs]
+
+
+def _try_repair_generated_parameter_only_companion_tests_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+) -> list[str]:
+    """Empty generated tests that only assert local parameter constants."""
+    try:
+        relative_output = _relative_generated_output_path(
+            result,
+            output_root=output_root,
+        )
+    except RuntimeError:
+        return []
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    test_file = _rulespec_test_path(rules_file)
+    if not test_file.exists():
+        return []
+    parameter_names = _parameter_only_rule_names(rules_file)
+    if not parameter_names:
+        return []
+    try:
+        cases = _load_rulespec_test_cases(test_file)
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    if not cases:
+        return []
+
+    target_base = (
+        f"{_repo_jurisdiction_prefix(policy_repo_path)}:"
+        f"{_relative_rulespec_import_target(relative_output)}"
+    )
+    repaired_cases: list[str] = []
+    for index, case in enumerate(cases, 1):
+        if not isinstance(case, dict):
+            return []
+        outputs = case.get("output")
+        if not isinstance(outputs, dict) or not outputs:
+            return []
+        for key in outputs:
+            key_text = str(key)
+            if not key_text.startswith(f"{target_base}#"):
+                return []
+            if _rulespec_test_key_fragment(key_text) not in parameter_names:
+                return []
+        repaired_cases.append(str(case.get("name") or f"case_{index}"))
+    if not repaired_cases:
+        return []
+    test_file.write_text("[]\n")
+    return repaired_cases
+
+
+def _parameter_only_rule_names(rules_file: Path) -> set[str]:
+    if not rules_file.exists():
+        return set()
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return set()
+    if not isinstance(payload, dict):
+        return set()
+    rules = payload.get("rules")
+    if not isinstance(rules, list) or not rules:
+        return set()
+    names: set[str] = set()
+    for rule in rules:
+        if not isinstance(rule, dict):
+            return set()
+        if str(rule.get("kind") or "").strip().lower() != "parameter":
+            return set()
+        name = str(rule.get("name") or "").strip()
+        if not name:
+            return set()
+        names.add(name)
+    return names
 
 
 def _try_repair_generated_nonoperative_source_coverage_for_apply(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -16080,6 +16080,21 @@ def cmd_encode(args):
                     "  apply=auto_repaired_indexed_parameter_lookups:"
                     + ",".join(repaired_indexed_parameter_lookups)
                 )
+            repaired_admin_aggregate_entities = (
+                _try_repair_generated_admin_agency_aggregate_entities_for_apply(
+                    result,
+                    output_root=args.output,
+                    policy_repo_path=policy_repo_path,
+                )
+            )
+            if repaired_admin_aggregate_entities:
+                outcome["auto_repaired_admin_agency_aggregate_entities"] = (
+                    repaired_admin_aggregate_entities
+                )
+                print(
+                    "  apply=auto_repaired_admin_agency_aggregate_entities:"
+                    + ",".join(repaired_admin_aggregate_entities)
+                )
             can_apply, apply_issues, supplemental_files = (
                 _validate_generated_encoding_in_policy_overlay(
                     result,
@@ -20789,6 +20804,101 @@ def _try_repair_generated_missing_deferred_outputs_for_apply(
     payload["rules"] = []
     rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
     return [output]
+
+
+def _try_repair_generated_admin_agency_aggregate_entities_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+) -> list[str]:
+    """Defer State-agency/FNS aggregate measures emitted on supported entities."""
+    metrics = getattr(result, "metrics", None)
+    issues = list(getattr(metrics, "ci_issues", []) or [])
+    if not any(
+        str(issue).startswith("Unsupported administrative aggregate entity:")
+        for issue in issues
+    ):
+        return []
+    try:
+        relative_output = _relative_generated_output_path(
+            result,
+            output_root=output_root,
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+
+    rules = payload.get("rules")
+    if not isinstance(rules, list) or not rules:
+        return []
+    module = payload.get("module")
+    if not isinstance(module, dict):
+        module = {}
+        payload["module"] = module
+    module["status"] = "entity_not_supported"
+
+    base_anchor = _relative_output_to_anchor(
+        relative_output,
+        policy_repo_path=policy_repo_path,
+    )
+    deferred_outputs = []
+    seen_outputs: set[str] = set()
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            continue
+        if not str(rule.get("entity") or "").strip():
+            continue
+        symbol = str(rule.get("name") or f"deferred_output_{index + 1}").strip()
+        if not symbol:
+            symbol = f"deferred_output_{index + 1}"
+        output = f"{base_anchor}#{symbol}"
+        if output in seen_outputs:
+            continue
+        seen_outputs.add(output)
+        deferred_outputs.append(
+            {
+                "output": output,
+                "reason": (
+                    "The source defines a State agency/FNS aggregate "
+                    "performance, sampling, liability, waiver, or bonus "
+                    "measure. The supported RuleSpec entity set does not "
+                    "include the administrative entity needed to encode this "
+                    "as an executable rule."
+                ),
+            }
+        )
+    if not deferred_outputs:
+        output = f"{base_anchor}#deferred_output"
+        deferred_outputs.append(
+            {
+                "output": output,
+                "reason": (
+                    "The source defines a State agency/FNS administrative "
+                    "aggregate measure, which cannot be encoded as an "
+                    "executable RuleSpec output until that entity is supported."
+                ),
+            }
+        )
+
+    module["deferred_outputs"] = deferred_outputs
+    payload["rules"] = []
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+
+    test_file = _rulespec_test_path(rules_file)
+    if test_file.exists():
+        test_file.write_text("[]\n")
+
+    return [str(record["output"]) for record in deferred_outputs]
 
 
 def _try_repair_generated_nonoperative_source_coverage_for_apply(

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -60,8 +60,11 @@ from .harness.encoding_db import (
     ReviewResults,
 )
 from .harness.evals import (
+    _canonical_target_ref_prefix,
     _canonical_uk_legislation_tail,
     _eval_result_from_payload,
+    _source_identifier_to_relative_rulespec_path,
+    _target_source_scope_for_heuristics,
     evaluate_artifact,
     load_eval_suite_manifest,
     resolve_corpus_source_unit,
@@ -15872,6 +15875,31 @@ def _require_clean_axiom_encode_git_provenance() -> dict[str, object]:
 # =========================================================================
 
 
+def _scoped_source_text_for_encode_source_id(
+    source_text: str,
+    *,
+    source_id: str,
+    policy_repo_path: Path,
+) -> str:
+    """Return the target leaf source text for source-id encodes when possible."""
+    try:
+        relative_output = _source_identifier_to_relative_rulespec_path(source_id)
+        target_ref_prefix = _canonical_target_ref_prefix(
+            source_id,
+            relative_output,
+            policy_repo_path=policy_repo_path,
+        )
+    except Exception:
+        return source_text
+    if not target_ref_prefix:
+        return source_text
+    scoped_source_text = _target_source_scope_for_heuristics(
+        source_text,
+        target_ref_prefix,
+    )
+    return scoped_source_text if scoped_source_text.strip() else source_text
+
+
 def cmd_encode(args):
     """Encode a corpus-backed source unit through the RuleSpec eval pipeline."""
     model = args.model or DEFAULT_OPENAI_MODEL
@@ -15898,9 +15926,14 @@ def cmd_encode(args):
     source_unit = None
     if source_id:
         source_unit = resolve_corpus_source_unit(args.citation, corpus_path)
+        source_text = _scoped_source_text_for_encode_source_id(
+            source_unit.body,
+            source_id=source_id,
+            policy_repo_path=policy_repo_path,
+        )
         results = run_source_eval(
             source_id=source_id,
-            source_text=source_unit.body,
+            source_text=source_text,
             runner_specs=[runner],
             output_root=args.output,
             policy_path=policy_repo_path,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -20477,10 +20477,7 @@ def _try_repair_generated_invalid_deferred_source_values_for_apply(
                     ".source_values entry `" in str(issue)
                     and "must be an absolute RuleSpec target" in str(issue)
                 )
-                or (
-                    ".source_values must list absolute RuleSpec targets"
-                    in str(issue)
-                )
+                or (".source_values must list absolute RuleSpec targets" in str(issue))
             )
         )
         for issue in issues

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -5254,28 +5254,103 @@ def _target_source_scope_for_heuristics(
         return source_text
 
     start = 0
-    for fragment in fragments:
-        match = re.search(
-            rf"\({re.escape(fragment)}\)",
-            source_text[start:],
-            flags=re.IGNORECASE,
+    end = len(source_text)
+    search_from = 0
+    for depth, fragment in enumerate(fragments):
+        match = _find_structural_parenthetical_marker(
+            source_text,
+            fragment,
+            search_from,
+            end,
+            depth=depth,
         )
         if not match:
             return source_text
-        start += match.start()
-        search_from = start + len(match.group(0))
+        start = match.start("marker")
+        search_from = match.end("marker")
 
-    sibling_pattern = _sibling_marker_pattern(fragments[-1])
-    end = len(source_text)
-    if sibling_pattern:
-        sibling = re.search(
-            sibling_pattern,
-            source_text[search_from:],
-            flags=re.IGNORECASE,
+        sibling = _find_structural_sibling_marker(
+            source_text,
+            fragment,
+            search_from,
+            end,
+            depth=depth,
         )
         if sibling:
-            end = search_from + sibling.start()
+            end = sibling.start("marker")
     return source_text[start:end]
+
+
+def _find_structural_parenthetical_marker(
+    source_text: str,
+    fragment: str,
+    start: int,
+    end: int,
+    *,
+    depth: int,
+) -> re.Match[str] | None:
+    """Find a paragraph marker while ignoring inline cross-references.
+
+    eCFR section text often contains references such as ``paragraph (b)(4)``
+    before the actual ``(b)`` paragraph. For target-scope heuristics, prefer
+    markers that look structural: top-level markers must begin a line; nested
+    markers may also appear inline after punctuation, as in ``(2) Heading.
+    (i) Text``.
+    """
+    pattern = _structural_parenthetical_marker_pattern(
+        rf"\({re.escape(fragment)}\)",
+        allow_inline=depth > 0,
+    )
+    return pattern.search(source_text, start, end)
+
+
+def _find_structural_sibling_marker(
+    source_text: str,
+    fragment: str,
+    start: int,
+    end: int,
+    *,
+    depth: int,
+) -> re.Match[str] | None:
+    marker = _structural_sibling_marker_fragment(fragment, depth=depth)
+    if not marker:
+        return None
+    pattern = _structural_parenthetical_marker_pattern(
+        marker,
+        allow_inline=depth > 0,
+    )
+    return pattern.search(source_text, start, end)
+
+
+def _structural_parenthetical_marker_pattern(
+    marker_pattern: str,
+    *,
+    allow_inline: bool,
+) -> re.Pattern[str]:
+    boundary = r"(?P<prefix>\A|\n"
+    if allow_inline:
+        boundary += r"|[.;:]\s+"
+    boundary += r")"
+    return re.compile(
+        rf"{boundary}\s*(?P<marker>{marker_pattern})\s+",
+        flags=re.IGNORECASE,
+    )
+
+
+def _structural_sibling_marker_fragment(fragment: str, *, depth: int) -> str | None:
+    """Return a marker regex for the next same-level structural sibling."""
+    if re.fullmatch(r"\d+(?:\.\d+)*", fragment):
+        return _numeric_sibling_parenthetical_marker(fragment)
+    if _is_roman_parenthetical_fragment(fragment, depth=depth):
+        return r"\([ivxlcdm]+\)"
+    if re.fullmatch(r"[a-z](?:\.\d+)*", fragment, flags=re.IGNORECASE):
+        return _alpha_sibling_parenthetical_marker(fragment, top_level=depth == 0)
+    return None
+
+
+def _is_roman_parenthetical_fragment(fragment: str, *, depth: int) -> bool:
+    """Treat nested lower-case roman markers as roman, not alpha letters."""
+    return depth > 0 and re.fullmatch(r"[ivxlcdm]+", fragment, re.IGNORECASE) is not None
 
 
 def _legal_fragments_from_rulespec_ref(target_ref_prefix: str) -> list[str]:
@@ -5288,6 +5363,10 @@ def _legal_fragments_from_rulespec_ref(target_ref_prefix: str) -> list[str]:
             return parts[idx + 3 :]
     if "regulations" in parts:
         idx = parts.index("regulations")
+        if len(parts) > idx + 4 and re.fullmatch(
+            r"\d+-cfr", parts[idx + 1], flags=re.IGNORECASE
+        ):
+            return parts[idx + 4 :]
         if len(parts) > idx + 3:
             return parts[idx + 3 :]
     return []

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3934,6 +3934,7 @@ RuleSpec requirements:
 - Use `rules:` as a list of rule objects. The filepath is the ID; do not add an `id:` field.
 - Do not invent schema keys like `namespace:`, `parameter`, `variable`, or `rule:`.
 - Rule kinds are `parameter`, `derived`, `derived_relation`, `data_relation`, or `source_relation`. Use `parameter` for named source scalars when it fits the local schema, `derived` for entity-scoped outputs, `derived_relation` when source text defines a filtered legal membership relation, `data_relation` for runtime predicates, and `source_relation` for non-executable legal/provenance edges. The numeric invariant is the named concept: source-stated amounts, rates, thresholds, caps, limits, and table/grid cells should be named so consuming formulas can reference names instead of embedding literals.
+- This numeric invariant applies in mixed deferred or entity-unsupported provisions too. Defer the unsupported output under `module.deferred_outputs[]`, but keep any independent source-stated scalar legal values as `kind: parameter` rules rather than dropping them into prose.
 - Use `kind: parameter` with `indexed_by` and versioned `values` for source-stated numeric tables/scales keyed by household size, family size, income band, age band, or another row key. Do not encode those cells as `match` arms or numeric literals inside a derived formula. For source tables with interval/range row labels such as "at least / but less than" bands, do not create one scalar parameter per row, bound, or cell with names like `*_row_0_upper_*`, `*_row_3_rate`, or `*_lower_bound_band_9`. Define a source-backed band selector as a `derived` rule, store each substantive output column as a `kind: parameter` with `indexed_by: <band_selector>` and versioned `values`, and have the exported outputs look up the indexed table. Indexed table keys must be integer band ids such as `0`, `1`, and `2`; do not use decimal row thresholds like `1.33`, `2.5`, or strings such as `2_5_to_less_than_3_0` as lookup keys. Store source-stated row bounds as private named bound concepts or private indexed table/grid bound columns, and have the selector reference those names while returning integer band ids. If interpolation or clamping needs the active row bounds before native interval-table support exists, store lower/upper bounds as private indexed parameter columns and reference those names in derived formulas; do not repeat bound literals outside the selector. Preserve source row identity: open lower or upper interval cells are real rows, not defaults and not dropped rows; omit only the open side of the predicate.
 - Do not treat the final interval row as open-ended unless the source row is actually open-ended. If the last source row has an upper bound, the selector must return an out-of-table sentinel above that bound and the principal output must handle that sentinel. Include a companion test above the final bounded row so the generated artifact cannot silently extend the table.
 - The out-of-table sentinel is not itself a source table row. Do not add sentinel entries to indexed parameter tables and do not clamp sentinel cases to the final table row's values. Handle the sentinel before table lookups, using the existing target's source-grounded out-of-range branch when repairing an existing artifact. Use a negative sentinel such as `-1`; do not use the next positive band id such as `6` merely because there are six legal rows, because that positive id is not source-stated and will fail numeric grounding.
@@ -4093,6 +4094,9 @@ RuleSpec requirements:
   mixed provision, add `module.deferred_outputs[]` with absolute RuleSpec
   targets for `output`, a plain-language `reason`, and `source_values` entries
   for any source-stated local parameters retained only for that deferred output.
+  If those scalar legal values are independently encoded as `kind: parameter`
+  rules in the same file, do not also demote them to prose or rely on
+  `source_values` instead.
   Treat category membership phrases such as `person described in section X`,
   `organization described in section X`, or `service described in section X` as
   factual boundary predicates when the current source states the legal effect.
@@ -4456,10 +4460,13 @@ RuleSpec requirements:
   untested just because another negative case toggles a different gate.
 - If a formula negates multiple exception predicates, include a separate companion test for each predicate that sets that exception input true and expects the directly affected Judgment rule to be `not_holds`.
 - For any negated exception predicate, include a paired positive case with the same output rule where only the exception input changes from `false` to `true`; do not combine the exception test with another branch change.
-- Every local executable `kind: parameter` and `kind: derived` rule must appear
-  at least once under an `output:` block in the companion `.test.yaml`; do not
-  leave scalar parameters, helper parameters, or helper derived rules
-  unasserted.
+- Every local executable `kind: derived` or `kind: derived_relation` rule must
+  appear at least once under an `output:` block in the companion `.test.yaml`;
+  do not leave helper derived rules unasserted.
+- Do not assert raw `kind: parameter` rules directly in companion test
+  `output:` blocks. Cover parameters through derived outputs that consume them.
+  If a module only contains parameters and has no derived output to assert,
+  leave the companion test file empty.
 - Each `.test.yaml` case may assert derived outputs for only one entity type. If
   a module defines outputs on multiple entities, create separate cases for each
   entity pair, such as `Person`/`TaxUnit`, `Person`/`Employer`, or

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -5385,11 +5385,7 @@ def _iter_cfr_structural_markers(source_text: str) -> Iterable[re.Match[str]]:
             and marker_start > 0
             and source_text[marker_start - 1].isspace()
         )
-        if (
-            previous < 0
-            or source_text[previous] in "\n.;:"
-            or follows_spaced_marker
-        ):
+        if previous < 0 or source_text[previous] in "\n.;:" or follows_spaced_marker:
             yield match
 
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -117,6 +117,21 @@ SUPPORTED_EVAL_DTYPES = (
 )
 _PURE_NUMERIC_EXPRESSION_PATTERN = re.compile(r"^[\d\s()+\-*/.,]+$")
 _ISO_WEEK_PERIOD_PATTERN = re.compile(r"^\d{4}-W\d{2}(?:-\d)?$")
+_ADMIN_AGENCY_AGGREGATE_SUBJECT_PATTERN = re.compile(
+    r"\b(?:FNS|State\s+agenc(?:y|ies)|State(?:'s)?\s+administration|"
+    r"Federal\s+(?:reviewer|case\s+reviews?|subsample)|"
+    r"national\s+performance\s+measure)\b",
+    flags=re.IGNORECASE,
+)
+_ADMIN_AGENCY_AGGREGATE_MEASURE_PATTERN = re.compile(
+    r"\b(?:active\s+case|negative\s+case|payment\s+error|negative\s+error|"
+    r"error\s+rates?|quality\s+control\s+sample|rereview\s+sample|"
+    r"regress(?:ed|ion)|subsample|sample\s+size|liabilit(?:y|ies)|"
+    r"waiver\s+of\s+liability|at-risk|new\s+investment|caseload\s+growth|"
+    r"high\s+performance\s+bonuses?|bonus\s+payments?|program\s+access\s+index|"
+    r"application\s+processing\s+timeliness)\b",
+    flags=re.IGNORECASE,
+)
 _CONDITIONAL_AMOUNT_SLICE_PATTERN = re.compile(
     r"\b(?:if|where|unless|except|subject to|treated as paid)\b",
     re.IGNORECASE,
@@ -2711,10 +2726,17 @@ def evaluate_artifact(
         content,
         numeric_grounding_source_text,
     )
+    admin_agency_aggregate_issues = find_admin_agency_aggregate_entity_issues(
+        content,
+        source_text,
+    )
     ci_issues = []
     seen_ci_issues: set[str] = set()
     for issue in (
-        list(ci_result.issues) + ungrounded_numeric_issues + numeric_occurrence_issues
+        list(ci_result.issues)
+        + ungrounded_numeric_issues
+        + numeric_occurrence_issues
+        + admin_agency_aggregate_issues
     ):
         if issue in seen_ci_issues:
             continue
@@ -2724,6 +2746,7 @@ def evaluate_artifact(
         ci_result.passed
         and not ungrounded_numeric_issues
         and not numeric_occurrence_issues
+        and not admin_agency_aggregate_issues
     )
 
     return EvalArtifactMetrics(
@@ -6306,6 +6329,53 @@ def _context_file_hash(source_path: str) -> str | None:
     except OSError:
         return None
     return f"sha256:{digest}"
+
+
+def find_admin_agency_aggregate_entity_issues(
+    content: str,
+    source_text: str,
+) -> list[str]:
+    """Reject executable entity rules for State-agency/FNS aggregate measures."""
+    if not (
+        _ADMIN_AGENCY_AGGREGATE_SUBJECT_PATTERN.search(source_text)
+        and _ADMIN_AGENCY_AGGREGATE_MEASURE_PATTERN.search(source_text)
+    ):
+        return []
+    try:
+        payload = yaml.safe_load(content)
+    except (yaml.YAMLError, TypeError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    module = payload.get("module")
+    if isinstance(module, dict):
+        status = str(module.get("status") or "").strip().lower()
+        if status in {"deferred", "entity_not_supported"}:
+            return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    issues: list[str] = []
+    supported_entities = {entity.lower(): entity for entity in SUPPORTED_EVAL_ENTITIES}
+    for index, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            continue
+        entity = str(rule.get("entity") or "").strip()
+        if not entity:
+            continue
+        if entity.lower() not in supported_entities:
+            continue
+        name = str(rule.get("name") or f"rules[{index}]").strip()
+        issues.append(
+            "Unsupported administrative aggregate entity: "
+            f"`{name}` is declared on `{entity}`, but the authoritative source "
+            "defines a State agency/FNS aggregate performance, sampling, "
+            "liability, waiver, or bonus measure. Emit "
+            "`module.status: entity_not_supported` or `deferred` with "
+            "`rules: []` until RuleSpec supports that administrative entity."
+        )
+    return issues
 
 
 def _context_file_export_detail(item: EvalContextFile) -> str:

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -5333,7 +5333,6 @@ def _structural_parenthetical_marker_pattern(
     boundary += r")"
     return re.compile(
         rf"{boundary}\s*(?P<marker>{marker_pattern})\s+",
-        flags=re.IGNORECASE,
     )
 
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -17,7 +17,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import date, datetime, timezone
 from pathlib import Path
 from statistics import mean
-from typing import Any, Callable, Iterator, Literal, Sequence
+from typing import Any, Callable, Iterable, Iterator, Literal, Sequence
 
 import requests
 import yaml
@@ -5253,6 +5253,10 @@ def _target_source_scope_for_heuristics(
     if not fragments:
         return source_text
 
+    hierarchical_scope = _target_source_scope_by_cfr_hierarchy(source_text, fragments)
+    if hierarchical_scope is not None:
+        return hierarchical_scope
+
     start = 0
     end = len(source_text)
     search_from = 0
@@ -5281,6 +5285,141 @@ def _target_source_scope_for_heuristics(
     return source_text[start:end]
 
 
+def _target_source_scope_by_cfr_hierarchy(
+    source_text: str,
+    fragments: list[str],
+) -> str | None:
+    """Slice CFR-style parenthetical hierarchy by legal marker level.
+
+    CFR paragraphs reuse marker spellings at deeper levels, such as top-level
+    numeric ``(3)`` paragraphs and nested upper-alpha list item ``(3)`` markers.
+    A simple regex search for ``(3)`` can therefore select the wrong branch. This
+    scanner tracks the conventional CFR marker sequence:
+    lower-alpha, then numeric/lower-roman/upper-alpha repeating.
+    """
+    if any(not _cfr_marker_kind_ordinals(fragment) for fragment in fragments):
+        return None
+
+    stack: list[tuple[str, str, int]] = []
+    target = tuple(fragments)
+    target_start: int | None = None
+    target_level: int | None = None
+
+    for match in _iter_cfr_structural_markers(source_text):
+        token = match.group("token")
+        assigned = _assign_cfr_marker_level(stack, token)
+        if assigned is None:
+            continue
+        level, kind, ordinal = assigned
+        stack = stack[:level]
+        stack.append((kind, token, ordinal))
+        path = tuple(item[1] for item in stack)
+
+        if target_start is None:
+            if path == target:
+                target_start = match.start("marker")
+                target_level = level
+            continue
+
+        if target_level is not None and level <= target_level:
+            return source_text[target_start : match.start("marker")]
+
+    if target_start is not None:
+        return source_text[target_start:]
+    return None
+
+
+def _iter_cfr_structural_markers(source_text: str) -> Iterable[re.Match[str]]:
+    """Yield parenthetical markers that appear in structural positions."""
+    marker_pattern = re.compile(r"(?P<marker>\((?P<token>[A-Za-z0-9]+)\))\s+")
+    for match in marker_pattern.finditer(source_text):
+        marker_start = match.start("marker")
+        line_start = source_text.rfind("\n", 0, marker_start) + 1
+        if not source_text[line_start:marker_start].strip():
+            yield match
+            continue
+
+        previous = match.start("marker") - 1
+        while previous >= 0 and source_text[previous].isspace():
+            previous -= 1
+        follows_spaced_marker = (
+            previous >= 0
+            and source_text[previous] == ")"
+            and marker_start > 0
+            and source_text[marker_start - 1].isspace()
+        )
+        if (
+            previous < 0
+            or source_text[previous] in "\n.;:"
+            or follows_spaced_marker
+        ):
+            yield match
+
+
+def _assign_cfr_marker_level(
+    stack: list[tuple[str, str, int]],
+    token: str,
+) -> tuple[int, str, int] | None:
+    possible = _cfr_marker_kind_ordinals(token)
+    if not possible:
+        return None
+
+    child_level = len(stack)
+    expected_child_kind = _cfr_marker_kind_for_level(child_level)
+    if expected_child_kind == "lower_roman":
+        for kind, ordinal in possible:
+            if kind == expected_child_kind:
+                return (child_level, kind, ordinal)
+
+    for level in range(len(stack) - 1, -1, -1):
+        expected_kind = _cfr_marker_kind_for_level(level)
+        for kind, ordinal in possible:
+            if kind == expected_kind and ordinal > stack[level][2]:
+                return (level, kind, ordinal)
+
+    for kind, ordinal in possible:
+        if kind == expected_child_kind:
+            return (child_level, kind, ordinal)
+    return None
+
+
+def _cfr_marker_kind_for_level(level: int) -> str:
+    if level == 0:
+        return "lower_alpha"
+    return ("numeric", "lower_roman", "upper_alpha")[(level - 1) % 3]
+
+
+def _cfr_marker_kind_ordinals(token: str) -> list[tuple[str, int]]:
+    kinds: list[tuple[str, int]] = []
+    if re.fullmatch(r"\d+", token):
+        kinds.append(("numeric", int(token)))
+    if re.fullmatch(r"[a-z]", token):
+        kinds.append(("lower_alpha", ord(token) - ord("a") + 1))
+    if re.fullmatch(r"[A-Z]", token):
+        kinds.append(("upper_alpha", ord(token) - ord("A") + 1))
+    if re.fullmatch(r"[ivxlcdm]+", token):
+        roman = _lower_roman_to_int(token)
+        if roman is not None:
+            kinds.append(("lower_roman", roman))
+    return kinds
+
+
+def _lower_roman_to_int(token: str) -> int | None:
+    values = {"i": 1, "v": 5, "x": 10, "l": 50, "c": 100, "d": 500, "m": 1000}
+    total = 0
+    previous = 0
+    for char in reversed(token):
+        value = values.get(char)
+        if value is None:
+            return None
+        if value < previous:
+            total -= value
+        else:
+            total += value
+            previous = value
+    return total or None
+
+
 def _find_structural_parenthetical_marker(
     source_text: str,
     fragment: str,
@@ -5299,9 +5438,16 @@ def _find_structural_parenthetical_marker(
     """
     pattern = _structural_parenthetical_marker_pattern(
         rf"\({re.escape(fragment)}\)",
-        allow_inline=depth > 0,
+        allow_inline=False,
     )
-    return pattern.search(source_text, start, end)
+    match = pattern.search(source_text, start, end)
+    if match or depth == 0:
+        return match
+    inline_pattern = _structural_parenthetical_marker_pattern(
+        rf"\({re.escape(fragment)}\)",
+        allow_inline=True,
+    )
+    return inline_pattern.search(source_text, start, end)
 
 
 def _find_structural_sibling_marker(
@@ -5317,9 +5463,16 @@ def _find_structural_sibling_marker(
         return None
     pattern = _structural_parenthetical_marker_pattern(
         marker,
-        allow_inline=depth > 0,
+        allow_inline=False,
     )
-    return pattern.search(source_text, start, end)
+    match = pattern.search(source_text, start, end)
+    if match or depth == 0:
+        return match
+    inline_pattern = _structural_parenthetical_marker_pattern(
+        marker,
+        allow_inline=True,
+    )
+    return inline_pattern.search(source_text, start, end)
 
 
 def _structural_parenthetical_marker_pattern(
@@ -5349,7 +5502,7 @@ def _structural_sibling_marker_fragment(fragment: str, *, depth: int) -> str | N
 
 def _is_roman_parenthetical_fragment(fragment: str, *, depth: int) -> bool:
     """Treat nested lower-case roman markers as roman, not alpha letters."""
-    return depth > 0 and re.fullmatch(r"[ivxlcdm]+", fragment, re.IGNORECASE) is not None
+    return depth > 0 and re.fullmatch(r"[ivxlcdm]+", fragment) is not None
 
 
 def _legal_fragments_from_rulespec_ref(target_ref_prefix: str) -> list[str]:

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -132,6 +132,13 @@ _ADMIN_AGENCY_AGGREGATE_MEASURE_PATTERN = re.compile(
     r"application\s+processing\s+timeliness)\b",
     flags=re.IGNORECASE,
 )
+_ADMIN_AGENCY_BONUS_USE_RESTRICTION_PATTERN = re.compile(
+    r"\b(?:bonus\s+award\s+money|bonus\s+payments?)\b[\s\S]{0,160}"
+    r"\b(?:shall\s+be\s+used\s+only|shall\s+not\s+be\s+used|"
+    r"household\s+benefits?|incentive\s+payments?|"
+    r"SNAP-related\s+expenses?)\b",
+    flags=re.IGNORECASE,
+)
 _CONDITIONAL_AMOUNT_SLICE_PATTERN = re.compile(
     r"\b(?:if|where|unless|except|subject to|treated as paid)\b",
     re.IGNORECASE,
@@ -6336,10 +6343,11 @@ def find_admin_agency_aggregate_entity_issues(
     source_text: str,
 ) -> list[str]:
     """Reject executable entity rules for State-agency/FNS aggregate measures."""
-    if not (
+    is_admin_agency_aggregate = (
         _ADMIN_AGENCY_AGGREGATE_SUBJECT_PATTERN.search(source_text)
         and _ADMIN_AGENCY_AGGREGATE_MEASURE_PATTERN.search(source_text)
-    ):
+    ) or _ADMIN_AGENCY_BONUS_USE_RESTRICTION_PATTERN.search(source_text)
+    if not is_admin_agency_aggregate:
         return []
     try:
         payload = yaml.safe_load(content)

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -17759,13 +17759,100 @@ def _canonical_rulespec_item_id_alias(
 ) -> str | None:
     if ":" not in item_id:
         return None
-    local_prefix = policy_repo_path.name.removeprefix("rulespec-")
+    raw_prefix, raw_path = item_id.split(":", 1)
     canonical_prefix = jurisdiction_prefix(policy_repo_path)
-    if not local_prefix or local_prefix == canonical_prefix:
+    local_prefixes = _rulespec_local_item_prefixes(policy_repo_path)
+    if raw_prefix != canonical_prefix and raw_prefix not in local_prefixes:
         return None
-    if not item_id.startswith(f"{local_prefix}:"):
+    canonical_path = _canonical_rulespec_item_path_for_policy_root(
+        raw_path,
+        policy_repo_path=policy_repo_path,
+        canonical_prefix=canonical_prefix,
+    )
+    alias = f"{canonical_prefix}:{canonical_path}"
+    if alias == item_id:
         return None
-    return f"{canonical_prefix}:{item_id.split(':', 1)[1]}"
+    return alias
+
+
+def _rulespec_local_item_prefixes(policy_repo_path: Path) -> set[str]:
+    """Return noncanonical prefixes the engine may stamp for this checkout."""
+    canonical_prefix = jurisdiction_prefix(policy_repo_path)
+    prefixes: set[str] = set()
+    current = Path(policy_repo_path).resolve()
+    for candidate in (current, *current.parents):
+        name = candidate.name
+        if name.startswith("rulespec-"):
+            prefixes.add(name.removeprefix("rulespec-"))
+            break
+    local_prefix = Path(policy_repo_path).name.removeprefix("rulespec-")
+    if local_prefix:
+        prefixes.add(local_prefix)
+    canonical_name = canonical_rulespec_repo_name(policy_repo_path)
+    if canonical_name and canonical_name.startswith("rulespec-"):
+        prefixes.add(canonical_name.removeprefix("rulespec-"))
+    prefixes.discard(canonical_prefix)
+    return {prefix for prefix in prefixes if prefix}
+
+
+def _rulespec_local_item_prefix(policy_repo_path: Path) -> str | None:
+    """Return the preferred engine-local prefix for same-repo test requests."""
+    canonical_prefix = jurisdiction_prefix(policy_repo_path)
+    current = Path(policy_repo_path).resolve()
+    for candidate in (current, *current.parents):
+        name = candidate.name
+        if name.startswith("rulespec-"):
+            prefix = name.removeprefix("rulespec-")
+            if prefix and prefix != canonical_prefix:
+                return prefix
+            break
+    return None
+
+
+def _rulespec_content_prefix_segment(
+    *,
+    policy_repo_path: Path,
+    canonical_prefix: str,
+) -> str | None:
+    """Return a monorepo content-root path segment when engine ids include it."""
+    policy_path = Path(policy_repo_path)
+    if policy_path.name == canonical_prefix and policy_path.parent.name.startswith(
+        "rulespec-"
+    ):
+        return canonical_prefix
+    if (policy_path / canonical_prefix).is_dir():
+        return canonical_prefix
+    return None
+
+
+def _canonical_rulespec_item_path_for_policy_root(
+    item_path: str,
+    *,
+    policy_repo_path: Path,
+    canonical_prefix: str,
+) -> str:
+    content_segment = _rulespec_content_prefix_segment(
+        policy_repo_path=policy_repo_path,
+        canonical_prefix=canonical_prefix,
+    )
+    if content_segment and item_path.startswith(f"{content_segment}/"):
+        return item_path.split("/", 1)[1]
+    return item_path
+
+
+def _engine_rulespec_item_path_for_policy_root(
+    item_path: str,
+    *,
+    policy_repo_path: Path,
+    canonical_prefix: str,
+) -> str:
+    content_segment = _rulespec_content_prefix_segment(
+        policy_repo_path=policy_repo_path,
+        canonical_prefix=canonical_prefix,
+    )
+    if content_segment and not item_path.startswith(f"{content_segment}/"):
+        return f"{content_segment}/{item_path}"
+    return item_path
 
 
 def _rulespec_public_item_keys(
@@ -18106,12 +18193,17 @@ def _rulespec_engine_request_name_for_test_key(
 ) -> str:
     if not require_legal_input_keys or not _RULESPEC_ABSOLUTE_REFERENCE.match(test_key):
         return runtime_name
-    local_prefix = policy_repo_path.name.removeprefix("rulespec-")
+    local_prefix = _rulespec_local_item_prefix(policy_repo_path)
     canonical_prefix = jurisdiction_prefix(policy_repo_path)
     if local_prefix and local_prefix != canonical_prefix:
         canonical_head = f"{canonical_prefix}:"
         if test_key.startswith(canonical_head):
-            return f"{local_prefix}:{test_key.split(':', 1)[1]}"
+            item_path = _engine_rulespec_item_path_for_policy_root(
+                test_key.split(":", 1)[1],
+                policy_repo_path=policy_repo_path,
+                canonical_prefix=canonical_prefix,
+            )
+            return f"{local_prefix}:{item_path}"
     return test_key
 
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -563,6 +563,7 @@ Scoring rubric:
 GROUNDING_ALLOWED_VALUES = {-1, 0, 1, 2, 3}
 GROUNDING_DATE_PATTERN = re.compile(r"\b\d{4}-\d{2}-\d{2}\b")
 GROUNDING_MONTH_PERIOD_PATTERN = re.compile(r"\b\d{4}-\d{2}\b")
+_SOURCE_URL_PATTERN = re.compile(r"https?://[^\s)\"'<>]+", re.IGNORECASE)
 GROUNDING_FORMULA_NUMBER_PATTERN = re.compile(
     r"(?<![\w./])(-?[\d,]+(?:\.\d+)?)(?![\w./])"
 )
@@ -2783,6 +2784,7 @@ def _clean_source_text_for_numeric_extraction(text: str) -> str:
         cleaned_lines.append(_STRUCTURAL_SOURCE_PREFIX_PATTERN.sub("", normalized_line))
 
     cleaned = "\n".join(cleaned_lines)
+    cleaned = _SOURCE_URL_PATTERN.sub(" ", cleaned)
     cleaned = re.sub(
         r"\[[^\]]*\d[^\]]*\]",
         _strip_superseded_bracketed_numeric_text,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -567,7 +567,7 @@ GROUNDING_FORMULA_NUMBER_PATTERN = re.compile(
     r"(?<![\w./])(-?[\d,]+(?:\.\d+)?)(?![\w./])"
 )
 SOURCE_TEXT_NUMBER_PATTERN = re.compile(
-    r"(?:^|(?<=[\s$£€(\[,]))(-?(?:[\d,]+(?:\.\d+)?|\.\d+))\b"
+    r"(?:^|(?<=[\s$£€(\[,+\-−*/]))(-?(?:[\d,]+(?:\.\d+)?|\.\d+))\b"
 )
 SOURCE_TEXT_RATIO_NUMBER_PATTERN = re.compile(
     r"(?<![\w.])(\d{1,3})\s*/\s*(\d{1,3})(?![\w/])"
@@ -822,8 +822,8 @@ _SOURCE_REFERENCE_PATTERNS = (
         re.IGNORECASE,
     ),
     re.compile(
-        r"\b(?:\d+\s+(?:U\.?\s*S\.?\s*C\.?|USC|C\.?\s*F\.?\s*R\.?|CFR|CCR)\s+)?"
-        r"\d+[A-Za-z0-9./-]*(?:\([^)]+\))+",
+        r"(?<!\.)\b(?:\d+\s+(?:U\.?\s*S\.?\s*C\.?|USC|C\.?\s*F\.?\s*R\.?|CFR|CCR)\s+)?"
+        r"\d+[A-Za-z0-9./-]*(?:\([A-Za-z0-9ivxlcdmIVXLCDM]+\))+",
         re.IGNORECASE,
     ),
     re.compile(
@@ -2783,7 +2783,11 @@ def _clean_source_text_for_numeric_extraction(text: str) -> str:
         cleaned_lines.append(_STRUCTURAL_SOURCE_PREFIX_PATTERN.sub("", normalized_line))
 
     cleaned = "\n".join(cleaned_lines)
-    cleaned = re.sub(r"\[[^\]]*\d[^\]]*\]", " ", cleaned)
+    cleaned = re.sub(
+        r"\[[^\]]*\d[^\]]*\]",
+        _strip_superseded_bracketed_numeric_text,
+        cleaned,
+    )
     cleaned = _STRUCTURAL_SOURCE_MANUAL_NUMBER_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_MANUAL_VOLUME_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_POLICY_LABEL_PATTERN.sub(" ", cleaned)
@@ -2809,6 +2813,15 @@ def _clean_source_text_for_numeric_extraction(text: str) -> str:
     for pattern in _SOURCE_REFERENCE_PATTERNS:
         cleaned = pattern.sub(" ", cleaned)
     return cleaned
+
+
+def _strip_superseded_bracketed_numeric_text(match: re.Match[str]) -> str:
+    """Drop superseded bracketed numerics but preserve bracketed formulas."""
+    bracketed = match.group(0)
+    inner = bracketed[1:-1]
+    if re.search(r"[+\-−*/]", inner) or re.search(r"[A-Za-z_]", inner):
+        return bracketed
+    return " "
 
 
 def _extract_collapsed_schedule_row_occurrences(

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -16599,6 +16599,13 @@ prefixes:
     mapping_type: not_comparable
     rationale: 42 CFR 600.320 Basic Health Program timely-determination cross-reference predicates are program-administration rules outside PolicyEngine US's one-to-one oracle surface.
 
+  - legal_id_prefix: us:regulations/7-cfr/275/
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: 7 CFR part 275 encodes SNAP State agency performance reporting, quality-control, payment-error-rate, and Federal/State administrative liability rules. PolicyEngine-US models household SNAP eligibility and benefits, not FNS and State agency administrative reporting or liability determinations; comparable exact mappings should be added only if PolicyEngine later exposes matching targets.
+
   # State agency policy manuals and regulations are not modeled by
   # PolicyEngine-US except where an exact mapping above says otherwise;
   # exact entries take precedence over these jurisdiction-wide prefixes.

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -102,8 +102,15 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   not put those outputs on `Household`, `Person`, `TaxUnit`, or another
   supported benefit-unit entity. If the source defines a State agency/FNS
   aggregate measure and the supported ontology has no StateAgency/FNS review
-  entity for it, emit `module.status: entity_not_supported` or `deferred` with
-  `rules: []` and a concrete `module.deferred_outputs[]` record.
+  entity for it, defer that aggregate output. If the same source also states
+  independent amounts, rates, thresholds, caps, or limits, retain those scalar
+  legal values as `kind: parameter` rules and add `module.deferred_outputs[]`
+  for only the unsupported aggregate output. Do not drop source-stated scalar
+  legal values solely because the surrounding administrative aggregate is
+  unsupported. For a pure unsupported administrative surface with no retained
+  scalar or source-relation rules, emit `module.status: entity_not_supported`
+  or `deferred` with `rules: []` and a concrete `module.deferred_outputs[]`
+  record.
 - Bonus award money and bonus-payment spending restrictions are part of that
   administrative surface. If the source says bonus money may be used only for
   SNAP-related expenses or may not be used for household benefits or incentive
@@ -230,6 +237,10 @@ Hard requirements:
   it fits the local schema, but the invariant is the named concept: consuming
   formulas reference that name, so the concept can later change from a direct
   scalar to a computed formula without rewriting every consumer.
+- This applies in mixed deferred or entity-unsupported provisions too. Defer
+  the unsupported output under `module.deferred_outputs[]`, but keep any
+  independent source-stated scalar legal values as `kind: parameter` rules
+  rather than dropping them into prose.
 - If a source-stated scalar is needed to compute another local scalar, reference
   the named scalar concept instead of repeating its literal value in a formula.
   For example, if the source states a five-year period and a one-fifth fraction,
@@ -580,6 +591,9 @@ _NAMING_PROTOCOL = """- Do not create standalone small-number parameters just to
   mixed provision, add `module.deferred_outputs[]` with absolute RuleSpec
   targets for `output`, a plain-language `reason`, and `source_values` entries
   for any source-stated local parameters retained only for that deferred output.
+  If those scalar legal values are independently encoded as `kind: parameter`
+  rules in the same file, do not also demote them to prose or rely on
+  `source_values` instead.
   Non-operative legislative findings, preambles, intent clauses, and purpose
   clauses still count for source coverage. Do not turn them into executable
   formulas; add `module.deferred_outputs[]` for the specific subparagraph with

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -95,6 +95,15 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   source's executable output to the source-stated lower entity, or defer it if
   the needed lower-entity facts cannot be represented. Do not preserve the
   aggregate entity just to keep old output names or tests compatible.
+- State agency/FNS performance reporting, quality-control sampling statistics,
+  error rates, liability amounts, waiver formulas, high-performance bonuses,
+  and similar administrative aggregates are not household benefit rules merely
+  because they mention household cases, allotments, or SNAP participation. Do
+  not put those outputs on `Household`, `Person`, `TaxUnit`, or another
+  supported benefit-unit entity. If the source defines a State agency/FNS
+  aggregate measure and the supported ontology has no StateAgency/FNS review
+  entity for it, emit `module.status: entity_not_supported` or `deferred` with
+  `rules: []` and a concrete `module.deferred_outputs[]` record.
 - When a definition uses "taxpayer" but also says the amount is "of an
   individual" or applies exclusions for services, income, payments, or statuses
   of an individual/person/employee/member, encode those components on `Person`.

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -104,6 +104,10 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   aggregate measure and the supported ontology has no StateAgency/FNS review
   entity for it, emit `module.status: entity_not_supported` or `deferred` with
   `rules: []` and a concrete `module.deferred_outputs[]` record.
+- Bonus award money and bonus-payment spending restrictions are part of that
+  administrative surface. If the source says bonus money may be used only for
+  SNAP-related expenses or may not be used for household benefits or incentive
+  payments, do not invent a `Payment` entity rule; defer the output.
 - When a definition uses "taxpayer" but also says the amount is "of an
   individual" or applies exclusions for services, income, payments, or statuses
   of an individual/person/employee/member, encode those components on `Person`.

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -836,10 +836,13 @@ _TESTS_PROTOCOL = """- Emit only RuleSpec YAML; use `.test.yaml` companions when
   consumed by that file, `<jurisdiction>:<repo-path>#relation.<name>` for
   relation inputs, and `<jurisdiction>:<repo-path>#<rule_or_parameter>` for
   executable outputs or imported legal values. Never use bare friendly keys.
-- Every local executable `kind: parameter` and `kind: derived` rule must appear
-  at least once under an `output:` block in the companion `.test.yaml`; do not
-  leave scalar parameters, helper parameters, or helper derived rules
-  unasserted.
+- Every local executable `kind: derived` or `kind: derived_relation` rule must
+  appear at least once under an `output:` block in the companion `.test.yaml`;
+  do not leave helper derived rules unasserted.
+- Do not assert raw `kind: parameter` rules directly in companion test
+  `output:` blocks. Cover parameters through derived outputs that consume them.
+  If a module only contains parameters and has no derived output to assert,
+  leave the companion test file empty.
 - Never emit a concrete test case with `output: {}` or an empty `output` map.
   If no executable output can be asserted, leave the test file empty instead of
   adding placeholder cases.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,6 +100,7 @@ from axiom_encode.cli import (
     _split_table_row_relation_test_cases,
     _stage_apply_overlay_dependency_root,
     _suppress_rulespec_ancestor_targets_for_subsection_overlay,
+    _try_repair_generated_admin_agency_aggregate_entities_for_apply,
     _try_repair_generated_boolean_comparison_predicates_for_apply,
     _try_repair_generated_delegated_policy_settings_for_apply,
     _try_repair_generated_embedded_scalar_literals_for_apply,
@@ -12811,6 +12812,86 @@ rules:
                 },
             }
         ]
+        assert yaml.safe_load(test_file.read_text()) == []
+
+    def test_admin_agency_aggregate_repair_defers_entity_rule(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = (
+            output_root
+            / "codex-gpt-5.5"
+            / "regulations/7-cfr/275/23/b/2/i/B.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        test_file = rules_file.with_suffix(".test.yaml")
+        policy_repo = tmp_path / "rulespec-us"
+        policy_repo.mkdir()
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/7/275/23
+  summary: y2′ = y2 + b2(X2−x2).
+rules:
+  - name: average_allotments_underissued_active_error_rate
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    source: 7 CFR 275.23(b)(2)(i)(B)
+    versions:
+      - effective_from: '0001-01-01'
+        formula: federal_average + coefficient * difference
+"""
+        )
+        test_file.write_text(
+            """- name: generated_household_formula
+  period: 2026
+  input: {}
+  output:
+    us:regulations/7-cfr/275/23/b/2/i/B#average_allotments_underissued_active_error_rate: 1
+"""
+        )
+        result = SimpleNamespace(
+            runner="codex-gpt-5.5",
+            output_file=str(rules_file),
+            metrics=SimpleNamespace(
+                ci_issues=[
+                    "Unsupported administrative aggregate entity: "
+                    "`average_allotments_underissued_active_error_rate` is "
+                    "declared on `Household`."
+                ]
+            ),
+        )
+
+        repaired = _try_repair_generated_admin_agency_aggregate_entities_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+        )
+
+        payload = yaml.safe_load(rules_file.read_text())
+        assert repaired == [
+            "us:regulations/7-cfr/275/23/b/2/i/B#average_allotments_underissued_active_error_rate"
+        ]
+        assert payload["module"]["status"] == "entity_not_supported"
+        assert payload["module"]["deferred_outputs"] == [
+            {
+                "output": (
+                    "us:regulations/7-cfr/275/23/b/2/i/B"
+                    "#average_allotments_underissued_active_error_rate"
+                ),
+                "reason": (
+                    "The source defines a State agency/FNS aggregate "
+                    "performance, sampling, liability, waiver, or bonus "
+                    "measure. The supported RuleSpec entity set does not "
+                    "include the administrative entity needed to encode this "
+                    "as an executable rule."
+                ),
+            }
+        ]
+        assert payload["rules"] == []
         assert yaml.safe_load(test_file.read_text()) == []
 
     def test_missing_deferred_output_repair_adds_definition_target(self, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4220,9 +4220,7 @@ rules: []
 """
         )
         result.output_file = str(output_file)
-        applied_file = (
-            args.policy_repo_path / "regulations/7-cfr/275/24/b/3/i.yaml"
-        )
+        applied_file = args.policy_repo_path / "regulations/7-cfr/275/24/b/3/i.yaml"
 
         with (
             patch("axiom_encode.cli.run_model_eval", return_value=[result]),
@@ -12897,9 +12895,7 @@ rules:
     def test_admin_agency_aggregate_repair_defers_entity_rule(self, tmp_path):
         output_root = tmp_path / "out"
         rules_file = (
-            output_root
-            / "codex-gpt-5.5"
-            / "regulations/7-cfr/275/23/b/2/i/B.yaml"
+            output_root / "codex-gpt-5.5" / "regulations/7-cfr/275/23/b/2/i/B.yaml"
         )
         rules_file.parent.mkdir(parents=True)
         test_file = rules_file.with_suffix(".test.yaml")
@@ -12978,11 +12974,7 @@ rules:
         self, tmp_path
     ):
         output_root = tmp_path / "out"
-        rules_file = (
-            output_root
-            / "codex-gpt-5.5"
-            / "regulations/7-cfr/275/23/e/1.yaml"
-        )
+        rules_file = output_root / "codex-gpt-5.5" / "regulations/7-cfr/275/23/e/1.yaml"
         rules_file.parent.mkdir(parents=True)
         test_file = rules_file.with_suffix(".test.yaml")
         policy_repo = tmp_path / "rulespec-us"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,6 +109,7 @@ from axiom_encode.cli import (
     _try_repair_generated_missing_deferred_outputs_for_apply,
     _try_repair_generated_missing_same_section_subsection_imports_for_apply,
     _try_repair_generated_nonoperative_source_coverage_for_apply,
+    _try_repair_generated_parameter_only_companion_tests_for_apply,
     _try_repair_generated_policyengine_oracle_inputs_for_apply,
     _try_repair_generated_section_1401_b_1_self_employment_income_for_apply,
     _try_repair_generated_source_relation_delegations_for_apply,
@@ -12971,6 +12972,64 @@ rules:
             }
         ]
         assert payload["rules"] == []
+        assert yaml.safe_load(test_file.read_text()) == []
+
+    def test_parameter_only_companion_test_repair_empties_parameter_outputs(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = (
+            output_root
+            / "codex-gpt-5.5"
+            / "regulations/7-cfr/275/23/e/1.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        test_file = rules_file.with_suffix(".test.yaml")
+        policy_repo = tmp_path / "rulespec-us"
+        policy_repo.mkdir()
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/regulation/7/275/23
+rules:
+  - name: program_administration_investment_liability_cap_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '0001-01-01'
+        formula: 0.5
+  - name: at_risk_repayment_liability_cap_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '0001-01-01'
+        formula: 0.5
+"""
+        )
+        test_file.write_text(
+            """- name: liability_percentage_caps
+  period: 2026
+  input: {}
+  output:
+    us:regulations/7-cfr/275/23/e/1#program_administration_investment_liability_cap_rate: 0.5
+    us:regulations/7-cfr/275/23/e/1#at_risk_repayment_liability_cap_rate: 0.5
+"""
+        )
+        result = SimpleNamespace(
+            runner="codex-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = _try_repair_generated_parameter_only_companion_tests_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+        )
+
+        assert repaired == ["liability_percentage_caps"]
         assert yaml.safe_load(test_file.read_text()) == []
 
     def test_missing_deferred_output_repair_adds_definition_target(self, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4184,6 +4184,85 @@ rules: []
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_removes_mapping_deferred_source_values(
+        self, capsys, tmp_path
+    ):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path
+            / "out"
+            / "codex-test-model"
+            / "regulations"
+            / "7-cfr"
+            / "275"
+            / "24"
+            / "b"
+            / "3"
+            / "i.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  status: entity_not_supported
+  source_verification:
+    corpus_citation_path: us/regulation/7/275/24
+  deferred_outputs:
+    - output: us:regulations/7-cfr/275/24/b/3/i#high_program_access_index_bonus_states
+      reason: FNS administrative bonus selection has no State-agency entity.
+      source_values:
+        high_program_access_index_bonus_state_count: 4
+rules: []
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = (
+            args.policy_repo_path / "regulations/7-cfr/275/24/b/3/i.yaml"
+        )
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "regulations/7-cfr/275/24/b/3/i.yaml: ci: "
+                            "module.deferred_outputs[0].source_values must list "
+                            "absolute RuleSpec targets for source-stated values "
+                            "retained for the deferred output."
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert "apply=auto_repaired_invalid_deferred_source_values:" in output
+        assert "source_values:" not in output_file.read_text()
+        assert mock_overlay.call_count == 2
+        mock_apply.assert_called_once()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_invalid_deferred_source_values"] == [
+            "source_values[0]"
+        ]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_rulespec_output_target_check_rejects_dict_source_values(self):
         assert _looks_like_absolute_rulespec_output_target(
             "us:statutes/26/3132/c#modified_section_110_b_aggregate_limit_amount"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,6 +92,7 @@ from axiom_encode.cli import (
     _rewrite_gpt_runner_backend,
     _rewrite_import_output_test_input_refs,
     _rewrite_judgment_numeric_comparisons,
+    _scoped_source_text_for_encode_source_id,
     _sha256_file,
     _sha256_text,
     _sign_applied_encoding_manifest,
@@ -207,6 +208,32 @@ def test_current_encoder_affecting_changes_are_behind_version_bump():
     provenance = _require_axiom_encode_version_provenance(repo)
 
     assert provenance["version"] == AXIOM_ENCODE_TEST_VERSION
+
+
+def test_source_id_encode_scopes_cfr_section_text_to_target_leaf(tmp_path):
+    source = "\n\n".join(
+        [
+            "(b) State agency error rates.",
+            "(2) Determination of payment error rates.",
+            "(i) FNS shall calculate regressed error rates.",
+            "(A) y1' = y1 + b1 (X1 - x1).",
+            "(B) y2' = y2 + b2 (X2 - x2).",
+            "(C) The regressed error rates are r1' = y1'/u and r2' = y2'/u.",
+            "(D) The adjusted regressed payment error rate is r1'' + r2''.",
+            "(d) State agencies' liabilities for payment error rates.",
+        ]
+    )
+
+    scoped = _scoped_source_text_for_encode_source_id(
+        source,
+        source_id="us/regulation/7/275/23/b/2/i/C",
+        policy_repo_path=tmp_path,
+    )
+
+    assert scoped.lstrip().startswith("(C) The regressed error rates")
+    assert "r1' = y1'/u" in scoped
+    assert "adjusted regressed payment error rate" not in scoped
+    assert "liabilities for payment error rates" not in scoped
 
 
 def test_colorado_snap_ecps_uses_absolute_member_relation_only():

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -43,6 +43,7 @@ from axiom_encode.harness.evals import (
     _run_codex_prompt_eval,
     _select_cross_section_context_files,
     _source_identifier_to_relative_rulespec_path,
+    _target_source_scope_for_heuristics,
     _wait_for_codex_process,
     evaluate_artifact,
     load_eval_suite_manifest,
@@ -1142,6 +1143,62 @@ def test_build_eval_prompt_for_rate_only_source_id_limits_scope(tmp_path):
     assert "companion tests may assert" in prompt
     assert "canonical parameter output directly" in prompt
     assert "Explicit rate-only source-boundary artifacts" in prompt
+
+
+def test_target_source_scope_ignores_cross_references_before_structural_marker():
+    source = "\n\n".join(
+        [
+            "(a) Sampling plan. The plan references paragraph (b)(4), paragraph "
+            "(b)(1)(iii), and paragraph (b)(2)(ii) before the actual sample-size "
+            "paragraph.",
+            "(b) Sample size. The State agency shall review active and negative cases.",
+            "(1) Active cases. (i) All active cases shall be selected.",
+            "(ii) Unless the alternate active case formula applies, the sample size is:",
+            "Average monthly reviewable caseload (N) | Minimum annual sample size (n)\n"
+            "60,000 and over | n = 2400\n"
+            "10,000 to 59,999 | n = 300 + [0.042(N-10,000)]\n"
+            "Under 10,000 | n = 300",
+            "(iii) A State agency with the certification may instead use 0.0153.",
+            "(2) Negative cases. (i) Unless the State agency uses paragraph "
+            "(b)(2)(ii), the negative sample size is:",
+            "Average monthly reviewable negative caseload (N) | Minimum annual sample size (n)\n"
+            "5,000 and over | n = 800\n"
+            "500 to 4,999 | n = 150 + [0.144(N-500)]\n"
+            "Under 500 | n = 150",
+            "(ii) A State agency with the certification may determine the negative "
+            "sample size as follows:",
+            "Average monthly reviewable negative caseload (N) | Minimum annual sample size (n)\n"
+            "5,000 and over | n = 680\n"
+            "684 to 4,999 | n = 150 + [0.1224(N-683)]\n"
+            "Under 684 | n = 150",
+            "(iii) In the formulas, n is the required negative sample size.",
+            "(c) Review process.",
+        ]
+    )
+
+    regular_negative = _target_source_scope_for_heuristics(
+        source,
+        "us:regulations/7-cfr/275/11/b/2/i",
+    )
+    assert regular_negative.lstrip().startswith("(i) Unless")
+    assert "0.144" in regular_negative
+    assert "0.1224" not in regular_negative
+
+    alternate_negative = _target_source_scope_for_heuristics(
+        source,
+        "us:regulations/7-cfr/275/11/b/2/ii",
+    )
+    assert alternate_negative.lstrip().startswith("(ii) A State agency")
+    assert "0.1224" in alternate_negative
+    assert "0.144" not in alternate_negative
+
+    regular_active = _target_source_scope_for_heuristics(
+        source,
+        "us:regulations/7-cfr/275/11/b/1/ii",
+    )
+    assert regular_active.lstrip().startswith("(ii) Unless")
+    assert "0.042" in regular_active
+    assert "0.0153" not in regular_active
 
 
 def test_build_eval_prompt_does_not_treat_rates_path_as_rate_only(tmp_path):
@@ -3163,6 +3220,14 @@ rules:
 
         assert metrics.ci_pass
         assert not any("31" in issue for issue in metrics.numeric_occurrence_issues)
+
+    def test_preserves_bracketed_formula_numeric_source_text(self):
+        numbers = validator_pipeline.extract_numbers_from_text(
+            "684 to 4,999 | n = 150 + [ 0.1224(N-683)]"
+        )
+
+        assert 0.1224 in numbers
+        assert 683 in numbers
 
     def test_accepts_pence_threshold_grounded_as_decimal_gbp(self, tmp_path):
         rulespec_file = tmp_path / "example.yaml"

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -9446,9 +9446,10 @@ class TestSourceEval:
         assert "mirror the imported file's companion test pattern" in prompt
         assert "Never turn an imported derived rule into a fabricated" in prompt
         assert (
-            "Every local executable `kind: parameter` and `kind: derived` rule"
+            "Every local executable `kind: derived` or `kind: derived_relation` rule"
             in prompt
         )
+        assert "Do not assert raw `kind: parameter` rules directly" in prompt
         assert "Use `holds` and `not_holds` for actual `dtype: Judgment`" in prompt
         assert "Use YAML booleans `true` and `false` for local factual" in prompt
         assert (

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -157,6 +157,39 @@ rules:
     ]
 
 
+def test_admin_agency_aggregate_rejects_bonus_payment_spending_restriction():
+    source_text = (
+        "Bonus payments shall not be used for household benefits, including "
+        "incentive payments."
+    )
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/7/275/24
+rules:
+  - name: bonus_payment_may_be_used_for_household_benefits
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    source: 7 CFR 275.24(a)(8)(i)
+    versions:
+      - effective_from: '0001-01-01'
+        formula: not payment_is_bonus_payment or not payment_use_is_household_benefit
+"""
+
+    issues = find_admin_agency_aggregate_entity_issues(content, source_text)
+
+    assert issues == [
+        "Unsupported administrative aggregate entity: "
+        "`bonus_payment_may_be_used_for_household_benefits` is declared on "
+        "`Payment`, but the authoritative source defines a State agency/FNS "
+        "aggregate performance, sampling, liability, waiver, or bonus measure. "
+        "Emit `module.status: entity_not_supported` or `deferred` with "
+        "`rules: []` until RuleSpec supports that administrative entity."
+    ]
+
+
 def test_admin_agency_aggregate_allows_household_level_source():
     source_text = (
         "A household is eligible for SNAP if it meets the household income "

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1232,6 +1232,67 @@ def test_target_source_scope_distinguishes_alpha_marker_case_by_level():
     assert "(e) State corrective action" not in negative_review
 
 
+def test_target_source_scope_treats_uppercase_alpha_as_non_roman():
+    source = "\n\n".join(
+        [
+            "(b) State agency error rates.",
+            "(2) Determination of payment error rates.",
+            "(i) FNS shall calculate regressed error rates.",
+            "(A) y1' = y1 + b1 (X1 - x1).",
+            "(B) y2' = y2 + b2 (X2 - x2).",
+            "(C) The regressed error rates are r1' = y1'/u and r2' = y2'/u.",
+            "(D) The adjusted regressed payment error rate is r1'' + r2''.",
+            "(ii) Other review steps.",
+        ]
+    )
+
+    regressed_rates = _target_source_scope_for_heuristics(
+        source,
+        "us:regulations/7-cfr/275/23/b/2/i/C",
+    )
+
+    assert regressed_rates.lstrip().startswith("(C) The regressed error rates")
+    assert "r1' = y1'/u" in regressed_rates
+    assert "adjusted regressed payment error rate" not in regressed_rates
+
+
+def test_target_source_scope_prefers_line_start_nested_markers():
+    source = "\n\n".join(
+        [
+            "(f) Good cause.",
+            "(1) Natural disasters. (i) The State agency shall document impacts.",
+            "(ii) (A) The following criteria apply:",
+            "(1) Geographic impact;",
+            "(2) Duration;",
+            "(3) The proportion of caseload affected; and/or",
+            "(4) Operational impact.",
+            "(2) Strikes.",
+            "(3) Caseload growth.",
+            "(i) A State agency may request relief for unusual caseload growth.",
+            "(ii) Criteria apply.",
+            "(iii) If information is insufficient, use this five-step calculation:",
+            "(A) Step 1--determine the base-period average.",
+            "(B) Step 2--determine the percentage increase.",
+            "(C) Step 3--determine the percentage the error rate exceeds the national performance measure.",
+            "(D) Step 4--divide the percentage increase by the percentage excess.",
+            "(E) Step 5--multiply the quotient by the liability amount.",
+            "(iv) Caseload growth of less than 15 percent is not considered.",
+            "(4) Program changes.",
+            "(g) Results of appeals.",
+        ]
+    )
+
+    step_three = _target_source_scope_for_heuristics(
+        source,
+        "us:regulations/7-cfr/275/23/f/3/iii/C",
+    )
+
+    assert step_three.lstrip().startswith("(C) Step 3")
+    assert "percentage the error rate exceeds" in step_three
+    assert "Step 4" not in step_three
+    assert "The proportion of caseload affected" not in step_three
+
+
 def test_build_eval_prompt_does_not_treat_rates_path_as_rate_only(tmp_path):
     runner = parse_runner_spec("codex:gpt-5.4")
     workspace = prepare_eval_workspace(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -46,6 +46,7 @@ from axiom_encode.harness.evals import (
     _target_source_scope_for_heuristics,
     _wait_for_codex_process,
     evaluate_artifact,
+    find_admin_agency_aggregate_entity_issues,
     load_eval_suite_manifest,
     parse_runner_spec,
     prepare_eval_workspace,
@@ -119,6 +120,65 @@ def test_source_identifier_maps_state_manual_to_policies_repo_path():
     assert _source_identifier_to_relative_rulespec_path(
         "us-az/manual/des/faa5/na-child-support-expense/block-2"
     ) == Path("policies/des/faa5/na-child-support-expense/block-2.yaml")
+
+
+def test_admin_agency_aggregate_rejects_household_executable_rule():
+    source_text = (
+        "FNS shall estimate each State agency's active case, payment, and negative "
+        "case error rate. y2′ = y2 + b2(X2−x2), where X2 is the average value of "
+        "allotments underissued to participating households in the State agency "
+        "full quality control sample."
+    )
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/7/275/23
+rules:
+  - name: average_allotments_underissued_active_error_rate
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    source: 7 CFR 275.23(b)(2)(i)(B)
+    versions:
+      - effective_from: '0001-01-01'
+        formula: y2 + b2 * (x2_full_sample - x2_rereview)
+"""
+
+    issues = find_admin_agency_aggregate_entity_issues(content, source_text)
+
+    assert issues == [
+        "Unsupported administrative aggregate entity: "
+        "`average_allotments_underissued_active_error_rate` is declared on "
+        "`Household`, but the authoritative source defines a State agency/FNS "
+        "aggregate performance, sampling, liability, waiver, or bonus measure. "
+        "Emit `module.status: entity_not_supported` or `deferred` with "
+        "`rules: []` until RuleSpec supports that administrative entity."
+    ]
+
+
+def test_admin_agency_aggregate_allows_household_level_source():
+    source_text = (
+        "A household is eligible for SNAP if it meets the household income "
+        "standard and resource test."
+    )
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/7/273/9
+rules:
+  - name: household_snap_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    source: 7 CFR 273.9
+    versions:
+      - effective_from: '0001-01-01'
+        formula: household_income_eligible and household_resource_eligible
+"""
+
+    assert find_admin_agency_aggregate_entity_issues(content, source_text) == []
 
 
 def test_source_identifier_maps_federal_regulation_to_cfr_repo_path():

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1201,6 +1201,37 @@ def test_target_source_scope_ignores_cross_references_before_structural_marker()
     assert "0.0153" not in regular_active
 
 
+def test_target_source_scope_distinguishes_alpha_marker_case_by_level():
+    source = "\n\n".join(
+        [
+            "(d) Validation of State Agency error rates.",
+            "(1) Payment error rate. (i) FNS will select a subsample.",
+            "(A) First active subsample formula.",
+            "(B) Second active subsample formula.",
+            "(E) N is the State agency's minimum active case sample size.",
+            "(2) Other payment-error review steps.",
+            "(3) Negative case error rate. (i) FNS will select a subsample of "
+            "completed negative cases as follows:",
+            "Average monthly reviewable negative caseload (N) | Federal subsample target (n')\n"
+            "12,000 and over | n' = 400\n"
+            "1,001 to 11,999 | n' = .011634 N + 40\n"
+            "1,000 and under | n' = 150",
+            "(ii) The negative case record review follows.",
+            "(e) State corrective action.",
+        ]
+    )
+
+    negative_review = _target_source_scope_for_heuristics(
+        source,
+        "us:regulations/7-cfr/275/3/d/3/i",
+    )
+
+    assert negative_review.lstrip().startswith("(i) FNS will select")
+    assert "Federal subsample target" in negative_review
+    assert "Second active subsample formula" not in negative_review
+    assert "(e) State corrective action" not in negative_review
+
+
 def test_build_eval_prompt_does_not_treat_rates_path_as_rate_only(tmp_path):
     runner = parse_runner_spec("codex:gpt-5.4")
     workspace = prepare_eval_workspace(

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -91,6 +91,41 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_7_cfr_275_admin_prefix(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "regulations/7-cfr/275/23/e/1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: investment_liability_cap_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2000-01-01'
+        formula: 0.5
+  - name: at_risk_repayment_liability_cap_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2000-01-01'
+        formula: 0.5
+  - name: new_investment_federal_match_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2000-01-01'
+        formula: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="snap")
+
+    assert report["total_outputs"] == 3
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    for item in report["items"]:
+        assert item["mapping_type"] == "not_comparable"
+        assert "7 CFR part 275" in str(item["rationale"])
+
+
 def test_policyengine_coverage_classifies_conclusive_agency_determinations(
     tmp_path,
 ):

--- a/tests/test_repo_routing.py
+++ b/tests/test_repo_routing.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 from pathlib import Path
 
+from axiom_encode.cli import _rulespec_test_relation_request_name
 from axiom_encode.concepts.jurisdiction import jurisdiction_prefix
 from axiom_encode.harness.validator_pipeline import (
     ValidatorPipeline,
@@ -103,6 +104,63 @@ def test_compiled_program_maps_alias_temp_prefix_to_canonical_legal_id(tmp_path)
     }
 
 
+def test_compiled_program_maps_alias_country_subdir_temp_prefix_to_canonical_legal_id(
+    tmp_path,
+):
+    checkout = tmp_path / "rulespec-us-clean.abcd"
+    _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")
+    policy_root = checkout / "us"
+    policy_root.mkdir()
+    rules_file = policy_root / "regulations" / "7-cfr" / "275" / "23" / "d" / "2.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: payment_liability_amount
+    kind: derived
+    entity: StateAgency
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2003-01-01'
+        formula: payment_error_rate
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=policy_root,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+    payload = {
+        "program": {
+            "derived": [
+                {
+                    "name": "payment_liability_amount",
+                    "id": (
+                        "us-clean.abcd:us/regulations/7-cfr/275/23/d/2"
+                        "#payment_liability_amount"
+                    ),
+                }
+            ],
+            "parameters": [],
+        }
+    }
+
+    derived, _parameters = pipeline._rulespec_program_maps(payload)
+    legal_ids = pipeline._rulespec_legal_ids_by_friendly_output_name(payload)
+
+    assert "us:regulations/7-cfr/275/23/d/2#payment_liability_amount" in derived
+    assert (
+        "us-clean.abcd:us/regulations/7-cfr/275/23/d/2#payment_liability_amount"
+        in derived
+    )
+    assert legal_ids == {
+        "payment_liability_amount": [
+            "us:regulations/7-cfr/275/23/d/2#payment_liability_amount"
+        ]
+    }
+
+
 def test_dataset_rewrites_canonical_same_repo_refs_to_engine_temp_prefix(tmp_path):
     checkout = tmp_path / "rulespec-us-clean.abcd"
     _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")
@@ -176,4 +234,64 @@ rules:
     )
     assert dataset["inputs"][1]["name"] == (
         "us-clean.abcd:statutes/26/63/f#input.taxpayer_is_blind_at_close_of_taxable_year"
+    )
+
+
+def test_dataset_rewrites_country_subdir_canonical_refs_to_engine_temp_prefix(
+    tmp_path,
+):
+    checkout = tmp_path / "rulespec-us-clean.abcd"
+    _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")
+    policy_root = checkout / "us"
+    policy_root.mkdir()
+    rules_file = policy_root / "regulations" / "7-cfr" / "275" / "23" / "d" / "2.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: payment_liability_amount
+    kind: derived
+    entity: StateAgency
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2003-01-01'
+        formula: payment_error_rate
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=policy_root,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    dataset = pipeline._build_rulespec_dataset(
+        {
+            "us:regulations/7-cfr/275/23/d/2#input.payment_error_rate": 0.08,
+        },
+        period={"start": "2003-01-01", "end": "2003-12-31"},
+        query_entity="StateAgency",
+        query_entity_id="state-agency",
+        require_legal_input_keys=True,
+    )
+
+    assert dataset["inputs"][0]["name"] == (
+        "us-clean.abcd:us/regulations/7-cfr/275/23/d/2#input.payment_error_rate"
+    )
+
+
+def test_cli_relation_request_rewrites_country_subdir_canonical_refs(tmp_path):
+    checkout = tmp_path / "rulespec-us-clean.abcd"
+    _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")
+    policy_root = checkout / "us"
+    policy_root.mkdir()
+
+    relation_name = _rulespec_test_relation_request_name(
+        "us:regulations/7-cfr/275/23/d/1#relation.state_agencies_for_quality_control_fiscal_year",
+        policy_repo_path=policy_root,
+    )
+
+    assert relation_name == (
+        "us-clean.abcd:us/regulations/7-cfr/275/23/d/1"
+        "#relation.state_agencies_for_quality_control_fiscal_year"
     )

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5454,6 +5454,15 @@ def test_numeric_occurrence_extraction_ignores_comma_conjoined_section_reference
     assert extract_numeric_occurrences_from_text(text) == []
 
 
+def test_numeric_occurrence_extraction_ignores_source_urls():
+    text = (
+        "https://www.legislation.gov.uk/uksi/2006/965/regulation/2 states "
+        "the enhanced rate is £26.05."
+    )
+
+    assert extract_numeric_occurrences_from_text(text) == [26.05]
+
+
 def test_numeric_occurrence_extraction_ignores_parenthetical_subdivision_labels():
     text = (
         "(b) Fraud and misrepresentation; disqualification penalties. "

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.666"
+version = "0.2.667"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.667"
+version = "0.2.668"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.670"
+version = "0.2.671"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.676"
+version = "0.2.677"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.673"
+version = "0.2.674"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.671"
+version = "0.2.672"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.668"
+version = "0.2.669"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.678"
+version = "0.2.679"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.669"
+version = "0.2.670"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.674"
+version = "0.2.675"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.675"
+version = "0.2.676"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.672"
+version = "0.2.673"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Fix CFR paragraph slicing and hierarchy-aware source scoping for generated encodings.
- Add guards/repairs for unsupported State agency/FNS administrative aggregates and invalid deferred source values.
- Stop emitting companion tests that assert raw parameter-only outputs; preserve scalar parameters in mixed deferred/entity-unsupported provisions.
- Bump axiom-encode through 0.2.676 so applied manifests carry the toolchain provenance.

## Tests
- uv run --extra dev ruff check src/axiom_encode/cli.py src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_cli.py tests/test_evals.py pyproject.toml src/axiom_encode/__init__.py
- uv run --extra dev pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::TestCmdEncode::test_parameter_only_companion_test_repair_empties_parameter_outputs tests/test_cli.py::TestCmdEncode::test_admin_agency_aggregate_repair_defers_entity_rule tests/test_evals.py::test_admin_agency_aggregate_rejects_bonus_payment_spending_restriction tests/test_evals.py::TestSourceEval::test_build_eval_prompt_includes_sets_source_metadata_guidance -q