### PR TITLE
Loop embedded scalar apply repair

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.666"
+version = "0.2.667"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.666"
+__version__ = "0.2.667"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -16621,21 +16621,53 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
-                repaired_embedded_scalar_literals = (
-                    _try_repair_generated_embedded_scalar_literals_for_apply(
-                        result,
-                        output_root=args.output,
-                        policy_repo_path=policy_repo_path,
-                        issues=apply_issues,
+                repaired_embedded_scalar_literals: list[str] = []
+                while not can_apply:
+                    repaired_scalar_pass = (
+                        _try_repair_generated_embedded_scalar_literals_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            issues=apply_issues,
+                        )
                     )
-                )
-                if repaired_embedded_scalar_literals:
+                    if not repaired_scalar_pass:
+                        break
+                    repaired_embedded_scalar_literals.extend(repaired_scalar_pass)
                     outcome["auto_repaired_embedded_scalar_literals"] = (
                         repaired_embedded_scalar_literals
                     )
                     print(
                         "  apply=auto_repaired_embedded_scalar_literals:"
-                        + ",".join(repaired_embedded_scalar_literals)
+                        + ",".join(repaired_scalar_pass)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
+                repaired_bare_snapunit_entities = (
+                    _try_repair_generated_bare_snapunit_entity_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_bare_snapunit_entities:
+                    outcome["auto_repaired_bare_snapunit_entity"] = (
+                        repaired_bare_snapunit_entities
+                    )
+                    print(
+                        "  apply=auto_repaired_bare_snapunit_entity:"
+                        + ",".join(repaired_bare_snapunit_entities)
                     )
                     can_apply, apply_issues, supplemental_files = (
                         _validate_generated_encoding_in_policy_overlay(
@@ -17762,6 +17794,130 @@ def _embedded_scalar_literal_issue_records(
             continue
         records.append(match.groupdict())
     return records
+
+
+def _try_repair_generated_bare_snapunit_entity_for_apply(
+    result,
+    *,
+    output_root: Path,
+    issues: list[str],
+) -> list[str]:
+    """Scope generated assistance-group rules to Household when SnapUnit is undeclared."""
+    records = _bare_snapunit_entity_issue_records(issues)
+    if not records:
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    if not rules_file.exists():
+        return []
+    try:
+        content = rules_file.read_text()
+        payload = yaml.safe_load(content) or {}
+    except (OSError, yaml.YAMLError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+    if _declares_or_imports_snapunit_relation(payload):
+        return []
+    source_text_value = extract_embedded_source_text(content)
+    if not source_text_value:
+        module = payload.get("module")
+        if isinstance(module, dict):
+            fallback_source_text = module.get("source_text")
+            if isinstance(fallback_source_text, str):
+                source_text_value = fallback_source_text
+    source_text = (source_text_value or "").lower()
+    if "snapunit" in source_text or "snap unit" in source_text:
+        return []
+    if "assistance group" not in source_text and "household" not in source_text:
+        return []
+
+    requested_names = {record["rule"] for record in records}
+    repaired: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        name = str(rule.get("name") or "").strip()
+        if not name:
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "derived":
+            continue
+        if str(rule.get("entity") or "").strip() != "SnapUnit":
+            continue
+        if name not in requested_names and not _rule_mentions_assistance_group(rule):
+            continue
+        rule["entity"] = "Household"
+        repaired.append(name)
+
+    if not repaired:
+        return []
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repaired
+
+
+def _bare_snapunit_entity_issue_records(issues: list[str]) -> list[dict[str, str]]:
+    records: list[dict[str, str]] = []
+    pattern = re.compile(
+        r"Filtered entity dependency missing:\s+"
+        r"`(?P<rule>[A-Za-z_][A-Za-z0-9_]*)`\s+uses\s+`entity:\s+SnapUnit`"
+    )
+    for issue in issues:
+        match = pattern.search(issue)
+        if match is None:
+            continue
+        records.append(match.groupdict())
+    return records
+
+
+def _declares_or_imports_snapunit_relation(payload: dict[str, Any]) -> bool:
+    imports = payload.get("imports")
+    if isinstance(imports, list):
+        for item in imports:
+            if isinstance(item, str) and item.rsplit("#", 1)[-1].strip() == "snap_unit":
+                return True
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return False
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "derived_relation":
+            continue
+        relation = rule.get("derived_relation")
+        if not isinstance(relation, dict):
+            continue
+        if str(relation.get("entity") or "").strip() == "SnapUnit":
+            return True
+    return False
+
+
+def _rule_mentions_assistance_group(rule: dict[str, Any]) -> bool:
+    text_parts: list[str] = []
+    for key in ("name", "source"):
+        value = rule.get(key)
+        if isinstance(value, str):
+            text_parts.append(value)
+    proof = rule.get("metadata", {}).get("proof")
+    atoms = proof.get("atoms") if isinstance(proof, dict) else None
+    if isinstance(atoms, list):
+        for atom in atoms:
+            if not isinstance(atom, dict):
+                continue
+            source = atom.get("source")
+            if not isinstance(source, dict):
+                continue
+            excerpt = source.get("excerpt")
+            if isinstance(excerpt, str):
+                text_parts.append(excerpt)
+    haystack = " ".join(text_parts).lower()
+    return "assistance_group" in haystack or "assistance group" in haystack
 
 
 def _extract_embedded_scalar_literal_record(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,6 +99,7 @@ from axiom_encode.cli import (
     _split_table_row_relation_test_cases,
     _stage_apply_overlay_dependency_root,
     _suppress_rulespec_ancestor_targets_for_subsection_overlay,
+    _try_repair_generated_bare_snapunit_entity_for_apply,
     _try_repair_generated_boolean_comparison_predicates_for_apply,
     _try_repair_generated_delegated_policy_settings_for_apply,
     _try_repair_generated_embedded_scalar_literals_for_apply,
@@ -5025,6 +5026,55 @@ rules:
             == 3
         )
         assert len(derived["metadata"]["proof"]["atoms"]) == 1
+
+    def test_bare_snapunit_entity_repair_scopes_assistance_group_to_household(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "fl.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-fl/manual/example
+  source_text: |-
+    The assistance group's monthly benefit is based on net monthly income.
+rules:
+- name: monthly_benefit
+  kind: derived
+  entity: SnapUnit
+  dtype: Money
+  period: Month
+  source: Florida ESS manual
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          excerpt: assistance group's monthly benefit
+  versions:
+  - effective_from: '0001-01-01'
+    formula: maximum_benefit - income_reduction
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_bare_snapunit_entity_for_apply(
+            result,
+            output_root=output_root,
+            issues=[
+                "Filtered entity dependency missing: `monthly_benefit` uses "
+                "`entity: SnapUnit`, but this RuleSpec file does not declare "
+                "`SnapUnit` with a `kind: derived_relation` rule or import its "
+                "declaring relation (`snap_unit`)."
+            ],
+        )
+
+        assert repaired == ["monthly_benefit"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["rules"][0]["entity"] == "Household"
 
     def test_delegated_policy_setting_repair_skips_existing_sets_edge(self, tmp_path):
         output_root = tmp_path / "out"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.666"
+version = "0.2.667"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Loops the apply-time embedded-scalar auto-repair until validation stops reporting new embedded scalar literals or no further repair is possible.
- This handles generated formulas where the validator exposes one scalar literal per pass, such as SNAP odd-dollar benefit rounding tables.

## Verification
- `uv run --python 3.13 --with pytest --with pytest-cov python -m pytest tests/test_cli.py -k embedded_scalar_literal_repair`