### PR TITLE
Preserve source proof for scalar repair fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.667"
+version = "0.2.668"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.667"
+__version__ = "0.2.668"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -18092,6 +18092,7 @@ def _source_atom_for_embedded_scalar_parameter(
 ) -> dict[str, Any]:
     proof = source_rule.get("metadata", {}).get("proof")
     atoms = proof.get("atoms") if isinstance(proof, dict) else None
+    fallback_source: dict[str, Any] | None = None
     if isinstance(atoms, list):
         for atom in atoms:
             if not isinstance(atom, dict):
@@ -18099,6 +18100,8 @@ def _source_atom_for_embedded_scalar_parameter(
             source = atom.get("source")
             if not isinstance(source, dict):
                 continue
+            if fallback_source is None:
+                fallback_source = dict(source)
             excerpt = source.get("excerpt")
             if isinstance(excerpt, str) and literal in excerpt:
                 return {
@@ -18106,6 +18109,12 @@ def _source_atom_for_embedded_scalar_parameter(
                     "kind": "parameter",
                     "source": dict(source),
                 }
+    if fallback_source is not None:
+        return {
+            "path": "versions[0].formula",
+            "kind": "parameter",
+            "source": fallback_source,
+        }
     return {
         "path": "versions[0].formula",
         "kind": "parameter",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4902,6 +4902,53 @@ rules:
             "us-tn:regulations/block-1#snap_standard_deduction_max_household_size"
         )
 
+    def test_embedded_scalar_literal_repair_falls_back_to_source_atom(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "fl.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: maximum_food_assistance_benefit
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  source: Appendix A-1, Maximum Benefit Effective October 1, 2025
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: formula
+        source:
+          corpus_citation_path: us-fl/manual/example
+          excerpt: Maximum Benefit Effective October 1, 2025; Each Additional Member Add +$218
+  versions:
+  - effective_from: '2025-10-01'
+    formula: "if assistance_group_size <= 10: maximum_food_assistance_benefit_table[assistance_group_size] else: maximum_food_assistance_benefit_table[10]"
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=tmp_path / "rulespec-us-fl",
+            issues=[
+                "Embedded scalar literal: maximum_food_assistance_benefit line 10 "
+                "embeds 10 in `assistance_group_size <= 10`; extract the value "
+                "to its own named numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == ["maximum_food_assistance_benefit_scalar_limit"]
+        payload = yaml.safe_load(rules_file.read_text())
+        parameter = payload["rules"][0]
+        assert parameter["name"] == "maximum_food_assistance_benefit_scalar_limit"
+        atom = parameter["metadata"]["proof"]["atoms"][0]
+        assert atom["source"]["corpus_citation_path"] == "us-fl/manual/example"
+        assert "Maximum Benefit Effective" in atom["source"]["excerpt"]
+
     def test_embedded_scalar_literal_repair_replaces_repeated_expression_literals(
         self, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.667"
+version = "0.2.668"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Make embedded scalar apply repair fall back to the source rule's first source proof atom when the scalar literal is not present in an excerpt
- Add a regression test for table-derived scalar limit helpers
- Bump axiom-encode to 0.2.668

## Validation
- `uv run --python 3.13 --with pytest --with pytest-cov python -m pytest tests/test_cli.py -k "embedded_scalar_literal_repair"`
- `uv run --python 3.13 ruff check tests/test_cli.py src/axiom_encode/cli.py`
