### PR TITLE
Loop bare SnapUnit apply repair

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.668"
+version = "0.2.669"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.668"
+__version__ = "0.2.669"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -16654,20 +16654,24 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
-                repaired_bare_snapunit_entities = (
-                    _try_repair_generated_bare_snapunit_entity_for_apply(
-                        result,
-                        output_root=args.output,
-                        issues=apply_issues,
+                repaired_bare_snapunit_entities: list[str] = []
+                while not can_apply:
+                    repaired_snapunit_pass = (
+                        _try_repair_generated_bare_snapunit_entity_for_apply(
+                            result,
+                            output_root=args.output,
+                            issues=apply_issues,
+                        )
                     )
-                )
-                if repaired_bare_snapunit_entities:
+                    if not repaired_snapunit_pass:
+                        break
+                    repaired_bare_snapunit_entities.extend(repaired_snapunit_pass)
                     outcome["auto_repaired_bare_snapunit_entity"] = (
                         repaired_bare_snapunit_entities
                     )
                     print(
                         "  apply=auto_repaired_bare_snapunit_entity:"
-                        + ",".join(repaired_bare_snapunit_entities)
+                        + ",".join(repaired_snapunit_pass)
                     )
                     can_apply, apply_issues, supplemental_files = (
                         _validate_generated_encoding_in_policy_overlay(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.668"
+version = "0.2.669"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- loop the generated bare SnapUnit entity apply repair until overlay validation reaches a fixed point
- preserve the per-pass repair output for the encode outcome
- bump axiom-encode to 0.2.669

## Validation
- uv run --python 3.13 --with pytest --with pytest-cov python -m pytest tests/test_cli.py -k "embedded_scalar_literal_repair or bare_snapunit_entity_repair"
- uv run --python 3.13 ruff check tests/test_cli.py src/axiom_encode/cli.py
- uv run --python 3.13 ruff format --check tests/test_cli.py src/axiom_encode/cli.py