### PR TITLE
Repair generated judgment conditionals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.669"
+version = "0.2.670"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.669"
+__version__ = "0.2.670"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -16297,6 +16297,34 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_judgment_conditionals = (
+                    _try_repair_generated_judgment_conditionals_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_judgment_conditionals:
+                    outcome["auto_repaired_judgment_conditionals"] = (
+                        repaired_judgment_conditionals
+                    )
+                    print(
+                        "  apply=auto_repaired_judgment_conditionals:"
+                        + ",".join(repaired_judgment_conditionals)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_deferred_source_values = (
                     _try_repair_generated_empty_deferred_source_values_for_apply(
                         result,
@@ -17705,6 +17733,24 @@ def _try_repair_generated_judgment_numeric_comparisons_for_apply(
     return _rewrite_judgment_numeric_comparisons(rules_file, names=rule_names)
 
 
+def _try_repair_generated_judgment_conditionals_for_apply(
+    result,
+    *,
+    output_root: Path,
+    issues: list[str],
+) -> list[str]:
+    """Rewrite generated inline Judgment conditionals into boolean branches."""
+    if not any(_issue_mentions_judgment_conditional_shape(issue) for issue in issues):
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    return _rewrite_judgment_conditional_formulas(rules_file)
+
+
 def _try_repair_generated_boolean_parameter_inputs_for_apply(
     result,
     *,
@@ -19076,6 +19122,14 @@ def _issue_mentions_judgment_scalar_request(issue: str) -> bool:
     return "is judgment, but a scalar was requested" in str(issue).lower()
 
 
+def _issue_mentions_judgment_conditional_shape(issue: str) -> bool:
+    text = str(issue).lower()
+    return (
+        "expression shape not supported in judgment position" in text
+        and "discriminant" in text
+    )
+
+
 def _boolean_comparison_rule_names_from_issues(issues: list[str]) -> set[str]:
     names: set[str] = set()
     for issue in issues:
@@ -19778,6 +19832,151 @@ def _rewrite_judgment_numeric_comparisons(
 
     rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
     return repaired
+
+
+def _rewrite_judgment_conditional_formulas(rules_file: Path) -> list[str]:
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    repaired: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "derived":
+            continue
+        if str(rule.get("dtype") or "").strip() != "Judgment":
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        rule_changed = False
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            rewritten = _rewrite_inline_judgment_conditional_formula(formula)
+            if rewritten is None:
+                continue
+            version["formula"] = rewritten
+            rule_changed = True
+        if rule_changed:
+            repaired.append(str(rule.get("name") or "judgment_rule"))
+
+    if not repaired:
+        return []
+
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repaired
+
+
+def _rewrite_inline_judgment_conditional_formula(formula: str) -> str | None:
+    stripped = " ".join(str(formula).strip().split())
+    if not stripped.startswith("if "):
+        return None
+    branches = _inline_if_judgment_branches(stripped, [])
+    if not branches:
+        return None
+    disjuncts: list[str] = []
+    for conditions, result in branches:
+        cleaned_result = result.strip()
+        if not cleaned_result or cleaned_result.startswith("if "):
+            return None
+        terms = [*_parenthesized_condition_terms(conditions), cleaned_result]
+        disjuncts.append("(" + " and ".join(terms) + ")")
+    return "\n  or ".join(disjuncts)
+
+
+def _inline_if_judgment_branches(
+    expression: str,
+    conditions: list[str],
+) -> list[tuple[list[str], str]] | None:
+    split = _split_inline_if_expression(expression)
+    if split is None:
+        return [(conditions, expression)]
+    condition, true_branch, false_branch = split
+    true_branches = _inline_if_judgment_branches(
+        true_branch,
+        [*conditions, condition],
+    )
+    false_branches = _inline_if_judgment_branches(
+        false_branch,
+        [*conditions, f"not ({condition})"],
+    )
+    if true_branches is None or false_branches is None:
+        return None
+    return [*true_branches, *false_branches]
+
+
+def _split_inline_if_expression(expression: str) -> tuple[str, str, str] | None:
+    text = expression.strip()
+    if not text.startswith("if "):
+        return None
+    colon_index = _find_top_level_token(text, ":", start=3)
+    if colon_index is None:
+        return None
+    condition = text[3:colon_index].strip()
+    remainder = text[colon_index + 1 :].strip()
+    else_index = _find_top_level_token(remainder, " else:")
+    if else_index is None:
+        return None
+    true_branch = remainder[:else_index].strip()
+    false_branch = remainder[else_index + len(" else:") :].strip()
+    if not condition or not true_branch or not false_branch:
+        return None
+    return condition, true_branch, false_branch
+
+
+def _find_top_level_token(text: str, token: str, *, start: int = 0) -> int | None:
+    depth = 0
+    quote: str | None = None
+    index = max(start, 0)
+    while index < len(text):
+        char = text[index]
+        if quote:
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            continue
+        if char in "([{":
+            depth += 1
+            index += 1
+            continue
+        if char in ")]}":
+            depth = max(0, depth - 1)
+            index += 1
+            continue
+        if depth == 0 and text.startswith(token, index):
+            return index
+        index += 1
+    return None
+
+
+def _parenthesized_condition_terms(conditions: list[str]) -> list[str]:
+    terms: list[str] = []
+    for condition in conditions:
+        stripped = condition.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("not (") and stripped.endswith(")"):
+            terms.append(stripped)
+        else:
+            terms.append(f"({stripped})")
+    return terms
 
 
 def _rewrite_judgment_numeric_comparison_formula(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,6 +91,7 @@ from axiom_encode.cli import (
     _require_axiom_encode_version_provenance,
     _rewrite_gpt_runner_backend,
     _rewrite_import_output_test_input_refs,
+    _rewrite_judgment_conditional_formulas,
     _rewrite_judgment_numeric_comparisons,
     _sha256_file,
     _sha256_text,
@@ -104,6 +105,7 @@ from axiom_encode.cli import (
     _try_repair_generated_delegated_policy_settings_for_apply,
     _try_repair_generated_embedded_scalar_literals_for_apply,
     _try_repair_generated_empty_test_outputs_for_apply,
+    _try_repair_generated_judgment_conditionals_for_apply,
     _try_repair_generated_judgment_numeric_comparisons_for_apply,
     _try_repair_generated_missing_deferred_outputs_for_apply,
     _try_repair_generated_missing_same_section_subsection_imports_for_apply,
@@ -6306,6 +6308,68 @@ rules:
         )
         assert payload["rules"][1]["versions"][0]["formula"] == (
             "if other_status == 0: 0 else: 100"
+        )
+
+    def test_rewrite_judgment_conditionals_updates_formula(self, tmp_path):
+        rules_file = tmp_path / "snap.yaml"
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: assistance_group_passes_required_income_test
+  kind: derived
+  entity: SnapUnit
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if standard_filing_unit_is_broad_based_categorically_eligible: standard_filing_unit_meets_broad_based_categorical_gross_income_limit else: if assistance_group_contains_elderly_or_disabled_member_and_is_not_categorically_eligible: assistance_group_meets_net_income_limit else: assistance_group_meets_gross_income_test'
+"""
+        )
+
+        repaired = _rewrite_judgment_conditional_formulas(rules_file)
+
+        assert repaired == ["assistance_group_passes_required_income_test"]
+        payload = yaml.safe_load(rules_file.read_text())
+        formula = payload["rules"][0]["versions"][0]["formula"]
+        assert (
+            formula
+            == "((standard_filing_unit_is_broad_based_categorically_eligible) and standard_filing_unit_meets_broad_based_categorical_gross_income_limit)\n"
+            "  or (not (standard_filing_unit_is_broad_based_categorically_eligible) and (assistance_group_contains_elderly_or_disabled_member_and_is_not_categorically_eligible) and assistance_group_meets_net_income_limit)\n"
+            "  or (not (standard_filing_unit_is_broad_based_categorically_eligible) and not (assistance_group_contains_elderly_or_disabled_member_and_is_not_categorically_eligible) and assistance_group_meets_gross_income_test)"
+        )
+
+    def test_judgment_conditional_repair_uses_discriminant_issue(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "snap.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: required_income_test
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 'if broad_based_categorically_eligible: bbce_income_test else: regular_income_test'
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_judgment_conditionals_for_apply(
+            result,
+            output_root=output_root,
+            issues=[
+                "formula lower error: expression shape not supported in judgment position: Discriminant(10)"
+            ],
+        )
+
+        assert repaired == ["required_income_test"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["rules"][0]["versions"][0]["formula"] == (
+            "((broad_based_categorically_eligible) and bbce_income_test)\n"
+            "  or (not (broad_based_categorically_eligible) and regular_income_test)"
         )
 
     def test_judgment_numeric_comparison_repair_skips_non_truth_decimals(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.669"
+version = "0.2.670"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair generated inline conditional formulas in derived Judgment rules into boolean branch formulas
- trigger the repair on the engine's Discriminant-in-judgment-position compile error
- add regression coverage for the Florida SNAP page 8 generated shape
- bump axiom-encode to 0.2.670

## Validation
- uv run --python 3.13 --with pytest --with pytest-cov python -m pytest tests/test_cli.py -k "judgment_conditional or judgment_numeric_comparison"
- uv run --python 3.13 ruff check tests/test_cli.py src/axiom_encode/cli.py
- uv run --python 3.13 ruff format --check tests/test_cli.py src/axiom_encode/cli.py