### PR TITLE
Allow Codex eval timeout overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.670"
+version = "0.2.671"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.670"
+__version__ = "0.2.671"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -6995,10 +6995,36 @@ def _codex_prompt_timeouts(workspace: EvalWorkspace) -> tuple[int, int]:
         source_length = 0
     if source_length >= _CODEX_LONG_SOURCE_CHAR_THRESHOLD:
         return (
-            _CODEX_LONG_SOURCE_TIMEOUT_SECONDS,
-            _CODEX_LONG_SOURCE_IDLE_TIMEOUT_SECONDS,
+            _positive_int_env(
+                "AXIOM_ENCODE_CODEX_LONG_TIMEOUT_SECONDS",
+                _CODEX_LONG_SOURCE_TIMEOUT_SECONDS,
+            ),
+            _positive_int_env(
+                "AXIOM_ENCODE_CODEX_LONG_IDLE_TIMEOUT_SECONDS",
+                _CODEX_LONG_SOURCE_IDLE_TIMEOUT_SECONDS,
+            ),
         )
-    return (_CODEX_DEFAULT_TIMEOUT_SECONDS, _CODEX_DEFAULT_IDLE_TIMEOUT_SECONDS)
+    return (
+        _positive_int_env(
+            "AXIOM_ENCODE_CODEX_TIMEOUT_SECONDS",
+            _CODEX_DEFAULT_TIMEOUT_SECONDS,
+        ),
+        _positive_int_env(
+            "AXIOM_ENCODE_CODEX_IDLE_TIMEOUT_SECONDS",
+            _CODEX_DEFAULT_IDLE_TIMEOUT_SECONDS,
+        ),
+    )
+
+
+def _positive_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
 
 
 def _wait_for_codex_process(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -2298,6 +2298,38 @@ def test_codex_prompt_timeouts_use_default_for_short_source(tmp_path):
     assert _codex_prompt_timeouts(workspace) == (600, 300)
 
 
+def test_codex_prompt_timeouts_use_env_for_short_source(tmp_path, monkeypatch):
+    monkeypatch.setenv("AXIOM_ENCODE_CODEX_TIMEOUT_SECONDS", "90")
+    monkeypatch.setenv("AXIOM_ENCODE_CODEX_IDLE_TIMEOUT_SECONDS", "30")
+    workspace = prepare_eval_workspace(
+        citation="us/statute/7/2012",
+        runner=parse_runner_spec("codex:gpt-5.4"),
+        output_root=tmp_path / "out",
+        source_text="short source",
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        mode="cold",
+        extra_context_paths=[],
+    )
+
+    assert _codex_prompt_timeouts(workspace) == (90, 30)
+
+
+def test_codex_prompt_timeouts_ignore_invalid_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("AXIOM_ENCODE_CODEX_TIMEOUT_SECONDS", "not-a-number")
+    monkeypatch.setenv("AXIOM_ENCODE_CODEX_IDLE_TIMEOUT_SECONDS", "0")
+    workspace = prepare_eval_workspace(
+        citation="us/statute/7/2012",
+        runner=parse_runner_spec("codex:gpt-5.4"),
+        output_root=tmp_path / "out",
+        source_text="short source",
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        mode="cold",
+        extra_context_paths=[],
+    )
+
+    assert _codex_prompt_timeouts(workspace) == (600, 300)
+
+
 def test_codex_prompt_timeouts_use_long_limits_for_large_source(tmp_path):
     workspace = prepare_eval_workspace(
         citation="us/statute/7/2014",
@@ -2310,6 +2342,22 @@ def test_codex_prompt_timeouts_use_long_limits_for_large_source(tmp_path):
     )
 
     assert _codex_prompt_timeouts(workspace) == (1800, 900)
+
+
+def test_codex_prompt_timeouts_use_long_env_for_large_source(tmp_path, monkeypatch):
+    monkeypatch.setenv("AXIOM_ENCODE_CODEX_LONG_TIMEOUT_SECONDS", "240")
+    monkeypatch.setenv("AXIOM_ENCODE_CODEX_LONG_IDLE_TIMEOUT_SECONDS", "60")
+    workspace = prepare_eval_workspace(
+        citation="us/statute/7/2014",
+        runner=parse_runner_spec("codex:gpt-5.4"),
+        output_root=tmp_path / "out",
+        source_text="x" * 40000,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        mode="cold",
+        extra_context_paths=[],
+    )
+
+    assert _codex_prompt_timeouts(workspace) == (240, 60)
 
 
 def test_run_source_eval_does_not_retry_when_first_response_writes_rulespec(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.670"
+version = "0.2.671"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- allow Codex prompt wall/idle timeouts to be overridden with environment variables
- support separate long-source timeout overrides
- bump axiom-encode to 0.2.671

## Environment variables
- AXIOM_ENCODE_CODEX_TIMEOUT_SECONDS
- AXIOM_ENCODE_CODEX_IDLE_TIMEOUT_SECONDS
- AXIOM_ENCODE_CODEX_LONG_TIMEOUT_SECONDS
- AXIOM_ENCODE_CODEX_LONG_IDLE_TIMEOUT_SECONDS

## Validation
- uv run --python 3.13 --with pytest --with pytest-cov python -m pytest tests/test_evals.py -k "codex_prompt_timeouts"
- uv run --python 3.13 ruff check tests/test_evals.py src/axiom_encode/harness/evals.py
- uv run --python 3.13 ruff format --check tests/test_evals.py src/axiom_encode/harness/evals.py