### PR TITLE
Handle country subdir companion targets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.679"
+version = "0.2.680"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.679"
+__version__ = "0.2.680"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -6277,6 +6277,8 @@ def _canonical_rulespec_target(
     relative = rules_file.resolve().relative_to(repo_root.resolve())
     if relative.suffix in {".yaml", ".yml"}:
         relative = relative.with_suffix("")
+    if relative.parts and relative.parts[0] == prefix:
+        relative = Path(*relative.parts[1:])
     return f"{prefix}:{relative.as_posix()}#{symbol}"
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -975,6 +975,41 @@ rules:
     ]
 
 
+def test_missing_derived_companion_output_strips_country_subdir(tmp_path):
+    policy_repo = tmp_path / "rulespec-nz"
+    rules_file = policy_repo / "nz" / "statutes" / "income_tax" / "rates.yaml"
+    rules_file.parent.mkdir(parents=True)
+    content = """format: rulespec/v1
+rules:
+  - name: income_tax_before_credits
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    source: Income Tax Act 2007 Schedule 1
+    versions:
+      - effective_from: '2026-01-01'
+        formula: taxable_income * 0.105
+"""
+    cases = [
+        {
+            "name": "basic",
+            "period": "2026",
+            "input": {},
+            "output": {"nz:statutes/income_tax/rates#income_tax_before_credits": 105},
+        }
+    ]
+
+    issues = find_missing_derived_companion_output_issues(
+        content,
+        cases,
+        rules_file=rules_file,
+        policy_repo_path=policy_repo,
+    )
+
+    assert issues == []
+
+
 def test_judgment_positive_companion_output_rejects_never_holds(tmp_path):
     policy_repo = tmp_path / "rulespec-us"
     rules_file = policy_repo / "statutes" / "26" / "3102" / "f" / "1.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.679"
+version = "0.2.680"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- strip a leading country directory from canonical RuleSpec companion targets when it matches the repo prefix
- add regression coverage for rulespec-nz/nz/statutes/... resolving to nz:statutes/... companion outputs

## Tests
- /Users/maxghenis/TheAxiomFoundation/axiom-encode/.venv/bin/python -m pytest tests/test_rulespec_validation.py -k "missing_derived_companion_output" -q
- /Users/maxghenis/TheAxiomFoundation/axiom-encode/.venv/bin/ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- PYTHONPATH=/Users/maxghenis/_axiom-worktrees/axiom-encode-nz-companion-target/src /Users/maxghenis/TheAxiomFoundation/axiom-encode/.venv/bin/python -m axiom_encode.cli validate nz/statutes/income_tax/schedule_1/individual_income_tax.yaml --skip-reviewers