### PR TITLE
Classify NZ income tax oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.680"
+version = "0.2.681"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.680"
+__version__ = "0.2.681"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/nz.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/nz.yaml
@@ -1,0 +1,24 @@
+mappings:
+  - legal_id: nz:statutes/income_tax/schedule_1/individual_income_tax#individual_income_tax_bracket_rates
+    country: nz
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ird.income_tax.rates.rates
+    candidate_priority: P4
+    rationale: Axiom encodes the Income Tax Act 2007 Schedule 1 table as five statutory marginal rates applying from the first dollar of taxable income. PolicyEngine NZ's adjacent rate parameter includes a zero first bracket and shifts those rates into later bracket keys, so it is not a one-to-one oracle target for this RuleSpec output.
+
+  - legal_id: nz:statutes/income_tax/schedule_1/individual_income_tax#individual_income_tax_bracket_thresholds
+    country: nz
+    program: tax
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ird.income_tax.thresholds.thresholds
+    candidate_priority: P4
+    rationale: Axiom stores the Schedule 1 taxable-income range upper bounds for the statutory rate table. PolicyEngine NZ's adjacent threshold parameter stores lower-bound starts after a zero-tax first bracket, so the parameter shape and legal boundary do not match this RuleSpec output.
+
+  - legal_id: nz:statutes/income_tax/schedule_1/individual_income_tax#individual_income_tax_before_credits
+    country: nz
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: income_tax
+    candidate_priority: P4
+    rationale: Axiom computes the Schedule 1 basic tax before credits from the statutory marginal rates starting at the first dollar of taxable income. PolicyEngine NZ's adjacent income_tax variable currently treats income up to $15,600 as untaxed, so it is not comparable without correcting or adapting the oracle.

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -91,6 +91,54 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_nz_income_tax_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-nz"
+        / "nz/statutes/income_tax/schedule_1/individual_income_tax.yaml",
+        """format: rulespec/v1
+rules:
+  - name: individual_income_tax_bracket_rates
+    kind: parameter
+    indexed_by: bracket
+    versions:
+      - effective_from: '2025-04-01'
+        values:
+          1: 0.105
+  - name: individual_income_tax_bracket_thresholds
+    kind: parameter
+    indexed_by: bracket
+    versions:
+      - effective_from: '2025-04-01'
+        values:
+          1: 15600
+  - name: individual_income_tax_before_credits
+    kind: derived
+    versions:
+      - effective_from: '2025-04-01'
+        formula: taxable_income * individual_income_tax_bracket_rates[1]
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["total_outputs"] == 3
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id[
+            "nz:statutes/income_tax/schedule_1/individual_income_tax#individual_income_tax_before_credits"
+        ]["policyengine_variable"]
+        == "income_tax"
+    )
+    assert (
+        items_by_id[
+            "nz:statutes/income_tax/schedule_1/individual_income_tax#individual_income_tax_bracket_rates"
+        ]["policyengine_parameter"]
+        == "gov.ird.income_tax.rates.rates"
+    )
+
+
 def test_policyengine_coverage_classifies_7_cfr_275_admin_prefix(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "regulations/7-cfr/275/23/e/1.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.680"
+version = "0.2.681"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add NZ PolicyEngine oracle coverage mappings for the first income-tax Schedule 1 outputs
- mark the adjacent PolicyEngine NZ targets as not comparable because the current oracle shifts the statutory first bracket into a zero-tax bracket
- bump axiom-encode to 0.2.681 and add a regression test

## Tests
- python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_nz_income_tax_outputs tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- ruff check src/ tests/
- ruff format --check src/ tests/