### PR TITLE
Stress test Colorado SNAP procedural encodings

### DIFF
--- a/docs/co-snap-manual-procedural-stress-2026-06-17.md
+++ b/docs/co-snap-manual-procedural-stress-2026-06-17.md
@@ -1,0 +1,241 @@
+# Colorado SNAP Manual Procedural Encoding Stress Test
+
+Date: 2026-06-17
+
+## Purpose
+
+Stress test Axiom encoding on procedural SNAP rules from the Colorado manual,
+especially interview, application, recertification, notice, office-duty, and
+deadline rules. The goal was to find where the encoder or RuleSpec validation
+breaks before attempting a full install into `rulespec-us-co`.
+
+No generated Colorado RuleSpec artifacts from this run were installed or edited
+by hand.
+
+## Inputs
+
+- Corpus: `/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus/provisions/us-co/regulation/2026-04-29-10-ccr-2506-1.jsonl`
+- Corpus size: 290 JSONL rows, 280 non-empty provisions, about 672k characters.
+- Encoder worktree: `/Users/maxghenis/_axiom-worktrees/axiom-encode-co-snap-manual-stress-20260616`
+- Validation RuleSpec worktree: `/Users/maxghenis/TheAxiomFoundation/rulespec-us-co-manual-stress-20260616`
+
+## Harness
+
+Added a local stress harness:
+
+- `scripts/co_snap_manual_stress.py`
+
+The harness calls:
+
+```bash
+uv run axiom-encode encode <citation_path> \
+  --backend openai \
+  --model gpt-5.5 \
+  --output /tmp/axiom-co-snap-manual-stress/<run> \
+  --corpus-path /Users/maxghenis/TheAxiomFoundation/axiom-corpus \
+  --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine \
+  --policy-repo-path /Users/maxghenis/TheAxiomFoundation/rulespec-us-co-manual-stress-20260616 \
+  --mode repo-augmented \
+  --no-sync
+```
+
+It writes generated artifacts under `/tmp/axiom-co-snap-manual-stress`, records
+stdout/stderr per provision, and then runs deterministic compile/CI validation
+against the scratch artifact. It does not install results into a live RuleSpec
+repo.
+
+The harness currently terminates the encoder process after the expected YAML
+artifact is non-empty and stable. That is a workaround because `encode` runs the
+generalist reviewer through `evaluate_artifact`, and there is not yet a clean
+bulk/deterministic encode mode that skips the LLM reviewer tier.
+
+## Runs
+
+### Top-of-manual sample
+
+- Output: `/tmp/axiom-co-snap-manual-stress/top-012`
+- Results: `/tmp/axiom-co-snap-manual-stress/top-012/revalidated-results.jsonl`
+- Scope: first 12 non-empty manual provisions, including definitions,
+  introduction, benefit use, confidentiality, and fair-hearing headings.
+
+### Application and recertification band
+
+- Output: `/tmp/axiom-co-snap-manual-stress/application-4.20x`
+- Results: `/tmp/axiom-co-snap-manual-stress/application-4.20x/revalidated-results.jsonl`
+- Scope: 33 provisions matching `4.20x`, including application filing,
+  authorized representatives, interviews, processing standards, expedited
+  service, categories of eligibility, prorating, certification periods, and
+  recertification.
+
+### Post-fix spot check
+
+- Output: `/tmp/axiom-co-snap-manual-stress/postfix-4.205`
+- Scope: `us-co/regulation/10-ccr-2506-1/4.205`
+- Result: the provision now generates both YAML and a companion test and
+  compiles. It still fails CI on substantive proof/test-input issues.
+
+## Results
+
+Across the two main samples:
+
+| Metric | Count |
+| --- | ---: |
+| Unique provisions attempted | 45 |
+| Generated main YAML | 42 |
+| Generated companion test | 38 |
+| Compile pass after revalidation | 41 |
+| Full deterministic CI pass | 18 |
+| No-artifact timeouts | 2 |
+
+Failure buckets:
+
+| Bucket | Count |
+| --- | ---: |
+| Pass | 18 |
+| Companion test coverage gaps | 12 |
+| Harness crash / no tests emitted | 4 |
+| Source scope or entity mismatch | 3 |
+| Proof/import hygiene | 2 |
+| No artifact: timeout | 2 |
+| Schema/source-relation delegation | 1 |
+| Mixed entity outputs in one test | 1 |
+| Ungrounded scalar/numeric | 1 |
+| No artifact: network/other | 1 |
+
+After the normalizer fix, one prior "harness crash / no tests emitted" case
+(`4.205`) became a clean encode+compile with CI failures about proof import
+references and missing explicit test inputs.
+
+## What Broke
+
+### 1. Bulk encoding needs a deterministic mode
+
+The public `encode` path creates the artifact but then continues into the LLM
+reviewer tier. For a whole-manual stress run, we need a first-class mode that:
+
+- Writes the artifact and companion test.
+- Runs compile and deterministic CI.
+- Skips LLM reviewers/oracles unless explicitly requested.
+- Emits one structured result row per source provision.
+
+The local stress harness proves the workflow but uses process termination as a
+workaround. That should move into `axiom-encode`.
+
+### 2. Procedural provisions need stricter companion tests
+
+Most failures were not compile failures. They were validation failures because
+the generated test did not assert every derived procedural output, especially
+Judgment outputs. Examples:
+
+- `4.130` benefit-use rules.
+- `4.140` confidentiality.
+- `4.201` application processing.
+- `4.204` interviews.
+- `4.205.3` and `4.205.32` processing-delay rules.
+- `4.208` certification periods.
+
+The encoder prompt and/or post-generation harness should require:
+
+- Every derived output is asserted in the companion test.
+- Every Judgment rule has at least one positive `holds` assertion.
+- Every branch returning zero/false has an explicit companion case when the
+  formula has such a branch.
+- Tests assign all local factual inputs, including false facts.
+
+### 3. Entity boundaries are stressed by procedural rules
+
+Colorado SNAP procedure rules often speak about households, household members,
+authorized representatives, local offices, county departments, SSA offices, and
+the State agency in the same provision. The encoder frequently picked an entity
+that the source-scope validator rejected.
+
+Examples:
+
+- `4.000.1`: ABAWD definition encoded person-scoped where source wording was
+  treated as household/unit-scoped.
+- `4.202.2`: ineligible-person income/resources counted for the household.
+- `4.206`: categorical eligibility mixes member-level conditions and
+  household-level consequences.
+
+This supports adding or improving flexible procedural entities and making the
+prompt explicit about separating person/member facts from household/unit
+consequences.
+
+### 4. Multi-entity output tests need splitting
+
+`4.202.3` generated one test case with derived outputs across `Household` and
+`Person`. The validator correctly rejected it. Procedural encodings need test
+generation to split outputs by entity.
+
+### 5. Proof/import hygiene is a repeatable failure
+
+The encoder sometimes imports proof atoms without referencing the imported
+symbol in the formula, or omits proof atoms on policy-bearing rules.
+
+Examples:
+
+- `4.202.32`
+- `4.205.11`
+- `4.207.2`
+- `4.207.3`
+- post-fix `4.205`
+
+The prompt should state that every proof import must be formula-referenced, and
+every policy-bearing rule must carry proof atoms.
+
+### 6. Constants need extraction even in procedural formulas
+
+`4.207.2` embedded `30` directly in a formula. Even when the source is
+procedural, numeric thresholds should be extracted to named concepts or table
+values rather than embedded as scalar literals.
+
+### 7. Source relation schema needs clearer instructions
+
+`4.100` tried to encode incorporation of federal SNAP regulations using an
+`implements` source relation but omitted `source_relation.basis.delegation`.
+The prompt needs clearer guidance for incorporation/delegation relationships.
+
+### 8. Names need collision avoidance
+
+`4.208.1` generated a generic `member_of_household` rule name that collided with
+a sibling export. Procedural sections need semantic branch-specific names.
+
+## Small Fix Made
+
+The stress run exposed a harness crash in test normalization: strings matching
+the numeric-expression regex could be sent to `_format_safe_numeric_expression`,
+which returns `None` for invalid expressions. The caller passed `None` into
+`yaml.safe_load`, causing an `AttributeError` and preventing companion test
+materialization.
+
+Changed:
+
+- `src/axiom_encode/harness/evals.py`
+- `tests/test_evals.py`
+
+The normalizer now preserves unsupported numeric-looking strings instead of
+crashing. Added a regression for `"30 / 0"`.
+
+Verification:
+
+```bash
+uv run python -m py_compile scripts/co_snap_manual_stress.py src/axiom_encode/harness/evals.py
+uv run --with pytest --with pytest-cov python -m pytest tests/test_evals.py -k 'invalid_numeric_expression or materialize_eval_artifact_normalizes_mapping_style_tests_to_list or normalize_test_periods_drops_speculative'
+```
+
+## Recommended Next Steps
+
+1. Add a first-class deterministic bulk encode mode to `axiom-encode` so the
+   stress harness no longer has to terminate the process after artifact
+   stabilization.
+2. Strengthen procedural-test prompt/harness requirements: assert every derived
+   output, split test outputs by entity, assign every local factual input, and
+   require positive Judgment coverage.
+3. Strengthen proof guidance and/or validator repair loops for formula-referenced
+   proof imports and policy-bearing proof atoms.
+4. Improve entity handling for procedural actors: household, member, authorized
+   representative, local office/county, SSA office, and State agency.
+5. Re-run the full 280 non-empty Colorado SNAP manual provisions in chunks after
+   the deterministic bulk mode and prompt changes.
+6. Install only passing generated provisions into `rulespec-us-co`; do not
+   hand-edit generated RuleSpec to make failing rows pass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.681"
+version = "0.2.682"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/co_snap_manual_stress.py
+++ b/scripts/co_snap_manual_stress.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Stress-run Axiom encoding across the Colorado SNAP rule manual.
+
+This is intentionally a local harness, not an installer. It calls the public
+`axiom-encode encode` CLI for each corpus provision, keeps generated artifacts
+under a scratch output root, and records deterministic compile/CI results without
+running the slower LLM reviewer tier.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import re
+import signal
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+from axiom_encode.harness.evals import (
+    _rulespec_validation_target,
+    _validation_policy_repo_root,
+)
+from axiom_encode.harness.validator_pipeline import ValidatorPipeline
+
+DEFAULT_CORPUS = (
+    Path.home()
+    / "TheAxiomFoundation/axiom-corpus/data/corpus/provisions/us-co/regulation/"
+    / "2026-04-29-10-ccr-2506-1.jsonl"
+)
+DEFAULT_OUTPUT_ROOT = Path("/tmp/axiom-co-snap-manual-stress/bulk")
+DEFAULT_AXIOM_CORPUS = Path.home() / "TheAxiomFoundation/axiom-corpus"
+DEFAULT_RULES_ENGINE = Path.home() / "TheAxiomFoundation/axiom-rules-engine"
+DEFAULT_POLICY_REPO = Path.home() / "TheAxiomFoundation/rulespec-us-co"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_CORPUS)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--axiom-corpus", type=Path, default=DEFAULT_AXIOM_CORPUS)
+    parser.add_argument("--axiom-rules-engine", type=Path, default=DEFAULT_RULES_ENGINE)
+    parser.add_argument("--policy-repo", type=Path, default=DEFAULT_POLICY_REPO)
+    parser.add_argument("--backend", choices=["openai", "codex", "claude"], default="openai")
+    parser.add_argument("--model", default="gpt-5.5")
+    parser.add_argument("--mode", choices=["cold", "repo-augmented"], default="repo-augmented")
+    parser.add_argument("--timeout-seconds", type=int, default=210)
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--start-index", type=int, default=0)
+    parser.add_argument("--filter-regex")
+    parser.add_argument("--resume", action="store_true")
+    return parser.parse_args()
+
+
+def load_provisions(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text().splitlines(), start=1):
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        body = str(payload.get("body") or "")
+        if not body:
+            continue
+        records.append(
+            {
+                "line": line_number,
+                "citation_label": payload.get("citation_label"),
+                "citation_path": payload.get("citation_path"),
+                "heading": payload.get("heading"),
+                "body_length": len(body),
+            }
+        )
+    return records
+
+
+def runner_name(backend: str, model: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9._-]+", "-", f"{backend}-{model}")
+
+
+def expected_rulespec_path(output_root: Path, runner: str, citation_path: str) -> Path:
+    parts = citation_path.split("/")
+    if len(parts) < 4:
+        return output_root / runner / f"{safe_slug(citation_path)}.yaml"
+    jurisdiction, document_class, *rest = parts
+    del jurisdiction
+    class_dir = {
+        "regulation": "regulations",
+        "statute": "statutes",
+        "policy": "policies",
+        "manual": "manuals",
+    }.get(document_class, f"{document_class}s")
+    if not rest:
+        return output_root / runner / class_dir / "index.yaml"
+    return output_root / runner / class_dir / Path(*rest[:-1]) / f"{rest[-1]}.yaml"
+
+
+def safe_slug(value: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9._-]+", "-", value).strip("-")
+
+
+def run_command(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    timeout_seconds: int,
+    env: dict[str, str],
+    expected_artifact: Path,
+) -> tuple[int | None, bool, bool, float, str, str]:
+    start = time.time()
+    process = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    timed_out = False
+    terminated_after_artifact = False
+    artifact_snapshot: tuple[int, int] | None = None
+    artifact_seen_since: float | None = None
+    try:
+        while process.poll() is None:
+            if time.time() - start > timeout_seconds:
+                timed_out = True
+                break
+            if expected_artifact.exists() and expected_artifact.stat().st_size > 0:
+                stat = expected_artifact.stat()
+                snapshot = (stat.st_size, stat.st_mtime_ns)
+                if snapshot == artifact_snapshot:
+                    artifact_seen_since = artifact_seen_since or time.time()
+                    if time.time() - artifact_seen_since >= 1:
+                        terminated_after_artifact = True
+                        break
+                else:
+                    artifact_snapshot = snapshot
+                    artifact_seen_since = time.time()
+            time.sleep(0.5)
+        if timed_out or terminated_after_artifact:
+            os.killpg(process.pid, signal.SIGTERM)
+        try:
+            stdout, stderr = process.communicate(timeout=8)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGKILL)
+            stdout, stderr = process.communicate()
+    except BaseException:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        raise
+    return (
+        process.returncode,
+        timed_out,
+        terminated_after_artifact,
+        time.time() - start,
+        stdout,
+        stderr,
+    )
+
+
+def tail(text: str, limit: int = 4000) -> str:
+    return text[-limit:] if len(text) > limit else text
+
+
+def validate_generated(
+    rules_file: Path,
+    *,
+    policy_repo: Path,
+    axiom_rules_engine: Path,
+) -> dict[str, Any]:
+    try:
+        with _rulespec_validation_target(rules_file, policy_repo) as validation_file:
+            validation_policy_repo = _validation_policy_repo_root(
+                validation_file, policy_repo
+            )
+            pipeline = ValidatorPipeline(
+                policy_repo_path=validation_policy_repo,
+                axiom_rules_path=axiom_rules_engine,
+                enable_oracles=False,
+                require_policy_proofs=True,
+            )
+            compile_result = pipeline._run_compile_check(validation_file)
+            ci_result = pipeline._run_ci(validation_file)
+    except Exception as exc:
+        return {
+            "compile_pass": False,
+            "ci_pass": False,
+            "validation_error": str(exc),
+        }
+    return {
+        "compile_pass": compile_result.passed,
+        "compile_error": compile_result.error,
+        "compile_issues": compile_result.issues,
+        "ci_pass": ci_result.passed,
+        "ci_error": ci_result.error,
+        "ci_issues": ci_result.issues,
+    }
+
+
+def existing_completed(results_path: Path) -> set[str]:
+    completed: set[str] = set()
+    if not results_path.exists():
+        return completed
+    for line in results_path.read_text().splitlines():
+        if not line.strip():
+            continue
+        with contextlib.suppress(json.JSONDecodeError):
+            payload = json.loads(line)
+            citation_path = payload.get("citation_path")
+            if citation_path:
+                completed.add(str(citation_path))
+    return completed
+
+
+def main() -> int:
+    args = parse_args()
+    provisions = load_provisions(args.manifest)
+    if args.filter_regex:
+        pattern = re.compile(args.filter_regex)
+        provisions = [
+            item
+            for item in provisions
+            if pattern.search(str(item["citation_path"]))
+            or pattern.search(str(item.get("heading") or ""))
+        ]
+    provisions = provisions[args.start_index :]
+    if args.limit is not None:
+        provisions = provisions[: args.limit]
+
+    args.output_root.mkdir(parents=True, exist_ok=True)
+    logs_dir = args.output_root / "_logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    results_path = args.output_root / "results.jsonl"
+    completed = existing_completed(results_path) if args.resume else set()
+    runner = runner_name(args.backend, args.model)
+
+    env = os.environ.copy()
+    env.setdefault("AXIOM_ENCODE_CODEX_TIMEOUT_SECONDS", "90")
+    env.setdefault("AXIOM_ENCODE_CODEX_IDLE_TIMEOUT_SECONDS", "35")
+    env.setdefault("AXIOM_ENCODE_CODEX_LONG_TIMEOUT_SECONDS", "150")
+    env.setdefault("AXIOM_ENCODE_CODEX_LONG_IDLE_TIMEOUT_SECONDS", "45")
+
+    print(
+        json.dumps(
+            {
+                "event": "stress_start",
+                "count": len(provisions),
+                "output_root": str(args.output_root),
+                "backend": args.backend,
+                "model": args.model,
+                "runner": runner,
+            },
+            sort_keys=True,
+        ),
+        flush=True,
+    )
+
+    for index, item in enumerate(provisions, start=args.start_index):
+        citation_path = str(item["citation_path"])
+        if citation_path in completed:
+            continue
+        expected = expected_rulespec_path(args.output_root, runner, citation_path)
+        slug = safe_slug(citation_path)
+        stdout_log = logs_dir / f"{index:03d}-{slug}.stdout.log"
+        stderr_log = logs_dir / f"{index:03d}-{slug}.stderr.log"
+        cmd = [
+            "uv",
+            "run",
+            "axiom-encode",
+            "encode",
+            citation_path,
+            "--backend",
+            args.backend,
+            "--model",
+            args.model,
+            "--output",
+            str(args.output_root),
+            "--corpus-path",
+            str(args.axiom_corpus),
+            "--axiom-rules-engine-path",
+            str(args.axiom_rules_engine),
+            "--policy-repo-path",
+            str(args.policy_repo),
+            "--mode",
+            args.mode,
+            "--no-sync",
+        ]
+        print(
+            json.dumps(
+                {
+                    "event": "provision_start",
+                    "index": index,
+                    "citation_path": citation_path,
+                    "expected_file": str(expected),
+                },
+                sort_keys=True,
+            ),
+            flush=True,
+        )
+        (
+            returncode,
+            timed_out,
+            terminated_after_artifact,
+            duration,
+            stdout,
+            stderr,
+        ) = run_command(
+            cmd,
+            cwd=Path.cwd(),
+            timeout_seconds=args.timeout_seconds,
+            env=env,
+            expected_artifact=expected,
+        )
+        stdout_log.write_text(stdout)
+        stderr_log.write_text(stderr)
+        generated = expected.exists()
+        test_file = expected.with_name(f"{expected.stem}.test.yaml")
+        validation = (
+            validate_generated(
+                expected,
+                policy_repo=args.policy_repo,
+                axiom_rules_engine=args.axiom_rules_engine,
+            )
+            if generated
+            else {}
+        )
+        result = {
+            **item,
+            "index": index,
+            "backend": args.backend,
+            "model": args.model,
+            "returncode": returncode,
+            "timed_out": timed_out,
+            "terminated_after_artifact": terminated_after_artifact,
+            "duration_seconds": round(duration, 3),
+            "generated": generated,
+            "generated_file": str(expected) if generated else None,
+            "generated_test": test_file.exists(),
+            "stdout_log": str(stdout_log),
+            "stderr_log": str(stderr_log),
+            "stdout_tail": tail(stdout),
+            "stderr_tail": tail(stderr),
+            **validation,
+        }
+        with results_path.open("a") as stream:
+            stream.write(json.dumps(result, sort_keys=True) + "\n")
+        print(json.dumps(result, sort_keys=True), flush=True)
+
+    print(
+        json.dumps({"event": "stress_done", "results": str(results_path)}, sort_keys=True),
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.681"
+__version__ = "0.2.682"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -8250,7 +8250,10 @@ def _normalize_test_case_value(value: object) -> object:
         expression = value.strip()
         if _PURE_NUMERIC_EXPRESSION_PATTERN.fullmatch(expression):
             try:
-                return yaml.safe_load(_format_safe_numeric_expression(expression))
+                formatted = _format_safe_numeric_expression(expression)
+                if formatted is None:
+                    return value
+                return yaml.safe_load(formatted)
             except (TypeError, ValueError, yaml.YAMLError):
                 return value
         return value

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -35,6 +35,7 @@ from axiom_encode.harness.evals import (
     _is_single_amount_table_slice,
     _materialize_eval_artifact,
     _normalize_nonannual_test_period_value,
+    _normalize_test_case_value,
     _normalize_test_periods_to_effective_dates,
     _post_openai_eval_request,
     _resolve_eval_output_path,
@@ -4621,6 +4622,9 @@ rules:
 
         assert "pre_effective_month_zero" not in test_text
         assert "period: 2026-01" in test_text
+
+    def test_normalize_test_case_value_preserves_invalid_numeric_expression(self):
+        assert _normalize_test_case_value("30 / 0") == "30 / 0"
 
     def test_materialize_eval_artifact_adds_missing_oracle_hint_output_from_rulespec(
         self, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.681"
+version = "0.2.682"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- add a local Colorado SNAP manual stress harness for deterministic compile/CI checks on generated scratch artifacts
- document the first procedural stress-test run over 45 Colorado SNAP manual provisions plus a post-fix spot check
- fix test normalization so unsupported numeric-looking expressions are preserved instead of crashing during companion test materialization

## Stress-test result

The stress run attempted 45 unique Colorado SNAP provisions from the top-of-manual and application/recertification sections:

- 42 generated main YAML
- 38 generated companion tests
- 41 revalidated compile passes
- 18 deterministic CI passes

The main failure buckets were companion-test coverage gaps, entity/source-scope mismatches, proof/import hygiene, and missing deterministic bulk-encode support. The report is in `docs/co-snap-manual-procedural-stress-2026-06-17.md`.

## Verification

- `uv run --with ruff ruff check scripts/co_snap_manual_stress.py src/axiom_encode/harness/evals.py tests/test_evals.py`
- `uv run python -m py_compile scripts/co_snap_manual_stress.py src/axiom_encode/harness/evals.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_evals.py -k 'invalid_numeric_expression or materialize_eval_artifact_normalizes_mapping_style_tests_to_list or normalize_test_periods_drops_speculative'`
