### PR TITLE
Treat NZ outputs outside PolicyEngine coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.682"
+version = "0.2.683"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.682"
+__version__ = "0.2.683"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -635,6 +635,8 @@ def _infer_program_from_legal_id(legal_id: str, *, rule_name: str = "") -> str:
         )
     ):
         return "tax"
+    if lowered.startswith("nz:statutes/income_tax/"):
+        return "tax"
     if lowered.startswith("uk:regulations/uksi/2006/965/2"):
         return "child_benefit"
     if lowered.startswith("uk:policies/govuk/child-benefit"):

--- a/src/axiom_encode/oracles/policyengine/mappings/nz.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/nz.yaml
@@ -1,24 +1,6 @@
-mappings:
-  - legal_id: nz:statutes/income_tax/schedule_1/individual_income_tax#individual_income_tax_bracket_rates
+prefixes:
+  - legal_id_prefix: "nz:"
     country: nz
-    program: tax
     mapping_type: not_comparable
-    policyengine_parameter: gov.ird.income_tax.rates.rates
     candidate_priority: P4
-    rationale: Axiom encodes the Income Tax Act 2007 Schedule 1 table as five statutory marginal rates applying from the first dollar of taxable income. PolicyEngine NZ's adjacent rate parameter includes a zero first bracket and shifts those rates into later bracket keys, so it is not a one-to-one oracle target for this RuleSpec output.
-
-  - legal_id: nz:statutes/income_tax/schedule_1/individual_income_tax#individual_income_tax_bracket_thresholds
-    country: nz
-    program: tax
-    mapping_type: not_comparable
-    policyengine_parameter: gov.ird.income_tax.thresholds.thresholds
-    candidate_priority: P4
-    rationale: Axiom stores the Schedule 1 taxable-income range upper bounds for the statutory rate table. PolicyEngine NZ's adjacent threshold parameter stores lower-bound starts after a zero-tax first bracket, so the parameter shape and legal boundary do not match this RuleSpec output.
-
-  - legal_id: nz:statutes/income_tax/schedule_1/individual_income_tax#individual_income_tax_before_credits
-    country: nz
-    program: tax
-    mapping_type: not_comparable
-    policyengine_variable: income_tax
-    candidate_priority: P4
-    rationale: Axiom computes the Schedule 1 basic tax before credits from the statutory marginal rates starting at the first dollar of taxable income. PolicyEngine NZ's adjacent income_tax variable currently treats income up to $15,600 as untaxed, so it is not comparable without correcting or adapting the oracle.
+    rationale: PolicyEngine NZ is too minimal to serve as a full New Zealand tax-benefit oracle. Axiom NZ outputs are built from official legislation, agency sources, and NZ-specific pinned source oracles; exact PolicyEngine mappings should be added only after a real one-to-one NZ oracle target is implemented and verified.

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -91,7 +91,7 @@ rules:
     )
 
 
-def test_policyengine_coverage_classifies_nz_income_tax_outputs(tmp_path):
+def test_policyengine_coverage_classifies_nz_outputs_outside_policyengine(tmp_path):
     _write_rulespec_file(
         tmp_path
         / "rulespec-nz"
@@ -119,24 +119,40 @@ rules:
         formula: taxable_income * individual_income_tax_bracket_rates[1]
 """,
     )
+    _write_rulespec_file(
+        tmp_path / "rulespec-nz" / "nz/statutes/social_security/example.yaml",
+        """format: rulespec/v1
+rules:
+  - name: jobseeker_support_placeholder
+    kind: derived
+    versions:
+      - effective_from: '2025-04-01'
+        formula: 1
+""",
+    )
 
-    report = build_policyengine_coverage_report(tmp_path, program="tax")
+    report = build_policyengine_coverage_report(tmp_path)
 
-    assert report["total_outputs"] == 3
-    assert report["status_counts"] == {"known_not_comparable": 3}
+    assert report["total_outputs"] == 4
+    assert report["status_counts"] == {"known_not_comparable": 4}
     items_by_id = {item["legal_id"]: item for item in report["items"]}
+    income_tax_item = items_by_id[
+        "nz:statutes/income_tax/schedule_1/individual_income_tax#individual_income_tax_before_credits"
+    ]
+    assert income_tax_item["mapping_type"] == "not_comparable"
+    assert income_tax_item["policyengine_variable"] is None
+    assert income_tax_item["policyengine_parameter"] is None
+    assert income_tax_item["program"] == "tax"
     assert (
         items_by_id[
-            "nz:statutes/income_tax/schedule_1/individual_income_tax#individual_income_tax_before_credits"
-        ]["policyengine_variable"]
-        == "income_tax"
+            "nz:statutes/social_security/example#jobseeker_support_placeholder"
+        ]["program"]
+        == "unknown"
     )
-    assert (
-        items_by_id[
-            "nz:statutes/income_tax/schedule_1/individual_income_tax#individual_income_tax_bracket_rates"
-        ]["policyengine_parameter"]
-        == "gov.ird.income_tax.rates.rates"
-    )
+
+    tax_report = build_policyengine_coverage_report(tmp_path, program="tax")
+    assert tax_report["total_outputs"] == 3
+    assert tax_report["status_counts"] == {"known_not_comparable": 3}
 
 
 def test_policyengine_coverage_classifies_7_cfr_275_admin_prefix(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.682"
+version = "0.2.683"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify all nz: RuleSpec outputs as outside PolicyEngine oracle coverage by default
- remove adjacent PolicyEngine NZ variable/parameter targets from the NZ coverage registry
- keep NZ income-tax outputs grouped as tax in coverage summaries
- bump axiom-encode to 0.2.683

## Tests
- python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_nz_outputs_outside_policyengine tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- ruff check src/ tests/
- ruff format --check src/ tests/