### PR TITLE
Apply eval companion repairs after generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.684"
+version = "0.2.685"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.684"
+__version__ = "0.2.685"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -221,6 +221,7 @@ _UNREFERENCED_PROOF_IMPORT_RE = re.compile(
     r"Proof import not referenced:\s*`(?P<rule>[^`]+)`\s+"
     r"proof imports\s+`(?P<symbol>[^`]+)`"
 )
+_UNUSED_IMPORT_RE = re.compile(r"Unused import `(?P<target>[^`]+)`")
 
 
 def _strip_yaml_scalar_quotes(value: str) -> str:
@@ -377,6 +378,23 @@ def _remove_unreferenced_proof_import_atoms(
     repaired_content, pruned_imports = _prune_unused_imports(repaired_content)
     rules_file.write_text(repaired_content)
     return sorted([*removed, *[f"unused_import:{item}" for item in pruned_imports]])
+
+
+def _prune_unused_imports_from_file(
+    rules_file: Path,
+    issues: Sequence[str],
+) -> list[str]:
+    if not rules_file.exists():
+        return []
+    if not any(_UNUSED_IMPORT_RE.search(str(issue)) for issue in issues):
+        return []
+
+    original_content = rules_file.read_text()
+    repaired_content, removed = _prune_unused_imports(original_content)
+    if not removed or repaired_content == original_content:
+        return []
+    rules_file.write_text(repaired_content)
+    return sorted(removed)
 
 
 def _is_empty_nonassertable_artifact(content: str) -> bool:
@@ -3015,11 +3033,13 @@ def _evaluate_generated_artifact_with_repairs(
     )
     if metrics is None:
         return None
-    repaired = _remove_unreferenced_proof_import_atoms(
-        rulespec_file,
-        metrics.ci_issues,
+    repairs = _apply_generated_eval_repairs(
+        rulespec_file=rulespec_file,
+        policy_repo_root=policy_repo_root,
+        axiom_rules_path=axiom_rules_path,
+        issues=metrics.ci_issues,
     )
-    if not repaired:
+    if not repairs:
         return metrics
     return evaluate_artifact(
         rulespec_file=rulespec_file,
@@ -3031,6 +3051,93 @@ def _evaluate_generated_artifact_with_repairs(
         policyengine_rule_hint=policyengine_rule_hint,
         skip_reviewers=skip_reviewers,
     )
+
+
+_EVAL_COMPANION_REPAIR_MARKERS = (
+    "Judgment rule missing positive companion output coverage:",
+    "Derived rule missing companion output coverage:",
+    "Zero branch test coverage missing:",
+    "mixes derived output entities",
+)
+_EVAL_SCALAR_REPAIR_MARKERS = (
+    "Proof import not referenced:",
+    "Unused import `",
+)
+
+
+def _apply_generated_eval_repairs(
+    *,
+    rulespec_file: Path,
+    policy_repo_root: Path,
+    axiom_rules_path: Path,
+    issues: list[str],
+) -> list[str]:
+    """Apply deterministic generated-artifact repairs before final eval scoring."""
+    repairs: list[str] = []
+    proof_repairs = _remove_unreferenced_proof_import_atoms(rulespec_file, issues)
+    repairs.extend(f"proof_import:{name}" for name in proof_repairs)
+    unused_import_repairs = _prune_unused_imports_from_file(rulespec_file, issues)
+    repairs.extend(f"unused_import:{name}" for name in unused_import_repairs)
+
+    if not issues or not all(
+        any(marker in str(issue) for marker in _EVAL_COMPANION_REPAIR_MARKERS)
+        or any(marker in str(issue) for marker in _EVAL_SCALAR_REPAIR_MARKERS)
+        for issue in issues
+    ):
+        return repairs
+
+    relative_output = _relative_rulespec_source_path(rulespec_file)
+    test_file = _rulespec_test_path(rulespec_file)
+    if relative_output is None or not test_file.exists():
+        return repairs
+
+    # Reuse the CLI's deterministic companion-test repair helpers lazily to
+    # avoid an import cycle: cli imports this module during startup.
+    from axiom_encode import cli as cli_helpers
+
+    if any("mixes derived output entities" in str(issue) for issue in issues):
+        repairs.extend(
+            f"mixed_entity:{name}"
+            for name in cli_helpers._repair_mixed_derived_entity_output_tests(
+                rules_file=rulespec_file,
+                test_file=test_file,
+                repo_path=policy_repo_root,
+                relative_output=relative_output,
+            )
+        )
+    repairs.extend(
+        f"derived_output:{name}"
+        for name in cli_helpers._append_generated_derived_output_tests_if_missing(
+            rules_file=rulespec_file,
+            test_file=test_file,
+            repo_path=policy_repo_root,
+            relative_output=relative_output,
+            issues=issues,
+        )
+    )
+    repairs.extend(
+        f"judgment_positive:{name}"
+        for name in cli_helpers._append_generated_judgment_positive_tests_if_missing(
+            rules_file=rulespec_file,
+            test_file=test_file,
+            repo_path=policy_repo_root,
+            axiom_rules_path=axiom_rules_path,
+            relative_output=relative_output,
+            issues=issues,
+            test_failure_checker=cli_helpers._rulespec_companion_test_failures,
+        )
+    )
+    repairs.extend(
+        f"zero_branch:{name}"
+        for name in cli_helpers._append_generated_zero_branch_tests_if_missing(
+            rules_file=rulespec_file,
+            test_file=test_file,
+            repo_path=policy_repo_root,
+            relative_output=relative_output,
+            issues=issues,
+        )
+    )
+    return repairs
 
 
 def _validation_policy_repo_root(validation_file: Path, policy_repo_root: Path) -> Path:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3207,6 +3207,205 @@ rules:
         assert "kind: import" not in repaired_text
         assert "output: deadline" not in repaired_text
 
+    def test_generated_eval_repairs_unused_imports(self, tmp_path):
+        repo = tmp_path / "rulespec-us"
+        rulespec_file = repo / "statutes" / "26" / "example.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/source#unused_rate
+  - us:statutes/26/source#used_rate
+rules:
+  - name: copied_rate
+    kind: derived
+    dtype: Rate
+    period: Year
+    versions:
+      - effective_from: '2025-01-01'
+        formula: used_rate
+"""
+        )
+
+        ci_issue = (
+            "Unused import `us:statutes/26/source#unused_rate`: imported symbol "
+            "`unused_rate` is not referenced by any formula or proof import."
+        )
+        with (
+            patch.object(
+                ValidatorPipeline,
+                "_run_compile_check",
+                return_value=ValidationResult("compile", passed=True),
+            ),
+            patch.object(
+                ValidatorPipeline,
+                "_run_ci",
+                side_effect=[
+                    ValidationResult("ci", passed=False, issues=[ci_issue]),
+                    ValidationResult("ci", passed=True, issues=[]),
+                ],
+            ) as mock_ci,
+        ):
+            metrics = _evaluate_generated_artifact_with_repairs(
+                rulespec_file=rulespec_file,
+                policy_repo_root=repo,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text="The copied rate uses the used rate.",
+                skip_reviewers=True,
+            )
+
+        repaired_text = rulespec_file.read_text()
+        assert mock_ci.call_count == 2
+        assert metrics.ci_pass
+        assert "unused_rate" not in repaired_text
+        assert "used_rate" in repaired_text
+
+    def test_generated_eval_repairs_positive_judgment_companions(self, tmp_path):
+        repo = tmp_path / "rulespec-us-co"
+        rulespec_file = repo / "regulations" / "example.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: work_study_exemption
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-01-01'
+        formula: enrolled_in_work_study
+"""
+        )
+        rulespec_file.with_name("example.test.yaml").write_text(
+            """- name: existing_negative
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:regulations/example#input.enrolled_in_work_study: false
+  output:
+    us-co:regulations/example#work_study_exemption: not_holds
+"""
+        )
+        ci_issue = (
+            "Judgment rule missing positive companion output coverage: "
+            "`us-co:regulations/example#work_study_exemption` is not asserted "
+            "as `holds` by the companion `.test.yaml` file."
+        )
+        with (
+            patch.object(
+                ValidatorPipeline,
+                "_run_compile_check",
+                return_value=ValidationResult("compile", passed=True),
+            ),
+            patch.object(
+                ValidatorPipeline,
+                "_run_ci",
+                side_effect=[
+                    ValidationResult("ci", passed=False, issues=[ci_issue]),
+                    ValidationResult("ci", passed=True, issues=[]),
+                ],
+            ) as mock_ci,
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures",
+                return_value=[],
+            ),
+        ):
+            metrics = _evaluate_generated_artifact_with_repairs(
+                rulespec_file=rulespec_file,
+                policy_repo_root=repo,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text="Students in work study are exempt.",
+                skip_reviewers=True,
+            )
+
+        repaired_tests = yaml.safe_load(
+            rulespec_file.with_name("example.test.yaml").read_text()
+        )
+        assert mock_ci.call_count == 2
+        assert metrics.ci_pass
+        assert any(
+            case.get("output", {}).get("us-co:regulations/example#work_study_exemption")
+            == "holds"
+            for case in repaired_tests
+        )
+
+    def test_generated_eval_repairs_zero_branch_companions(self, tmp_path):
+        repo = tmp_path / "rulespec-us-co"
+        rulespec_file = repo / "regulations" / "example.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: benefit_limit
+    kind: parameter
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 100
+  - name: benefit_amount
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 'if household_eligible: benefit_limit else: 0'
+"""
+        )
+        rulespec_file.with_name("example.test.yaml").write_text(
+            """- name: positive
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:regulations/example#input.household_eligible: true
+  output:
+    us-co:regulations/example#benefit_amount: 100
+"""
+        )
+        ci_issue = (
+            "Zero branch test coverage missing: `benefit_amount` has a formula "
+            "branch that returns 0, but no companion test asserts that output "
+            "is zero."
+        )
+        with (
+            patch.object(
+                ValidatorPipeline,
+                "_run_compile_check",
+                return_value=ValidationResult("compile", passed=True),
+            ),
+            patch.object(
+                ValidatorPipeline,
+                "_run_ci",
+                side_effect=[
+                    ValidationResult("ci", passed=False, issues=[ci_issue]),
+                    ValidationResult("ci", passed=True, issues=[]),
+                ],
+            ) as mock_ci,
+        ):
+            metrics = _evaluate_generated_artifact_with_repairs(
+                rulespec_file=rulespec_file,
+                policy_repo_root=repo,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text="Eligible households receive a $100 benefit limit; otherwise zero.",
+                skip_reviewers=True,
+            )
+
+        repaired_tests = yaml.safe_load(
+            rulespec_file.with_name("example.test.yaml").read_text()
+        )
+        assert mock_ci.call_count == 2
+        assert metrics.ci_pass
+        assert any(
+            case.get("output", {}).get("us-co:regulations/example#benefit_amount") == 0
+            for case in repaired_tests
+        )
+
     def test_test_input_assignment_ignores_formula_builtins(self):
         content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.684"
+version = "0.2.685"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- reuse deterministic generated-artifact repairs during eval scoring for proof imports, unused imports, companion output coverage, positive Judgment coverage, zero-branch coverage, and mixed derived-output test cases
- rerun eval validation after those deterministic repairs so bulk stress runs score the repaired artifact instead of the first generated draft
- add focused eval tests for proof import, unused import, positive Judgment, and zero-branch repair paths

## Tests
- uv run --with ruff ruff format --check src/axiom_encode/harness/evals.py tests/test_evals.py
- uv run --with ruff ruff check src/axiom_encode/harness/evals.py tests/test_evals.py
- uv run --with pytest --with pytest-cov pytest tests/test_evals.py::TestEvaluateArtifact
- git diff --check