### PR TITLE
Improve generated eval source filtering and repairs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.685"
+version = "0.2.686"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.685"
+__version__ = "0.2.686"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3079,11 +3079,12 @@ def _apply_generated_eval_repairs(
     unused_import_repairs = _prune_unused_imports_from_file(rulespec_file, issues)
     repairs.extend(f"unused_import:{name}" for name in unused_import_repairs)
 
-    if not issues or not all(
-        any(marker in str(issue) for marker in _EVAL_COMPANION_REPAIR_MARKERS)
-        or any(marker in str(issue) for marker in _EVAL_SCALAR_REPAIR_MARKERS)
+    companion_issues = [
+        issue
         for issue in issues
-    ):
+        if any(marker in str(issue) for marker in _EVAL_COMPANION_REPAIR_MARKERS)
+    ]
+    if not companion_issues:
         return repairs
 
     relative_output = _relative_rulespec_source_path(rulespec_file)
@@ -3095,7 +3096,7 @@ def _apply_generated_eval_repairs(
     # avoid an import cycle: cli imports this module during startup.
     from axiom_encode import cli as cli_helpers
 
-    if any("mixes derived output entities" in str(issue) for issue in issues):
+    if any("mixes derived output entities" in str(issue) for issue in companion_issues):
         repairs.extend(
             f"mixed_entity:{name}"
             for name in cli_helpers._repair_mixed_derived_entity_output_tests(
@@ -3112,7 +3113,7 @@ def _apply_generated_eval_repairs(
             test_file=test_file,
             repo_path=policy_repo_root,
             relative_output=relative_output,
-            issues=issues,
+            issues=companion_issues,
         )
     )
     repairs.extend(
@@ -3123,7 +3124,7 @@ def _apply_generated_eval_repairs(
             repo_path=policy_repo_root,
             axiom_rules_path=axiom_rules_path,
             relative_output=relative_output,
-            issues=issues,
+            issues=companion_issues,
             test_failure_checker=cli_helpers._rulespec_companion_test_failures,
         )
     )
@@ -3134,7 +3135,7 @@ def _apply_generated_eval_repairs(
             test_file=test_file,
             repo_path=policy_repo_root,
             relative_output=relative_output,
-            issues=issues,
+            issues=companion_issues,
         )
     )
     return repairs

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -770,7 +770,12 @@ _STRUCTURAL_SOURCE_HANDBOOK_SECTION_PATTERN = re.compile(
     r"\b[A-Z]-\d+(?:\.\d+)+(?:\([A-Za-z0-9]+\))*\b"
 )
 _STRUCTURAL_SOURCE_FORM_NUMBER_PATTERN = re.compile(
-    r"\bForm\s+[A-Z]?\d+[A-Za-z0-9-]*\b",
+    r"\b(?:Form\s+(?:[A-Z]{1,8}-?\d+[A-Za-z0-9-]*|[A-Z]?\d+[A-Za-z0-9-]*)|"
+    r"[A-Z]{2,8}-\d+[A-Za-z0-9-]*)\b",
+    re.IGNORECASE,
+)
+_STRUCTURAL_SOURCE_FORM_LINE_PATTERN = re.compile(
+    r"\bLine\s+\d+[A-Za-z]?\b",
     re.IGNORECASE,
 )
 _STRUCTURAL_SOURCE_CODE_CITATION_PATTERN = re.compile(
@@ -779,6 +784,9 @@ _STRUCTURAL_SOURCE_CODE_CITATION_PATTERN = re.compile(
     r"\d+(?:[.-]\d+)*(?:\([A-Za-z0-9]+\))*"
     r"(?=$|[\s,.;:])",
     re.IGNORECASE,
+)
+_STRUCTURAL_SOURCE_BARE_DOTTED_REFERENCE_PATTERN = re.compile(
+    r"(?<![\w$£€])\d+(?:\.\d+){2,}(?![\w%])"
 )
 _STRUCTURAL_SOURCE_SECTION_PATTERN = re.compile(
     r"\b(?:section|sec\.?)\s+\d+(?:[.-]\d+)*"
@@ -2798,7 +2806,9 @@ def _clean_source_text_for_numeric_extraction(text: str) -> str:
     cleaned = _STRUCTURAL_SOURCE_REVISION_CODE_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_HANDBOOK_SECTION_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_FORM_NUMBER_PATTERN.sub(" ", cleaned)
+    cleaned = _STRUCTURAL_SOURCE_FORM_LINE_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_CODE_CITATION_PATTERN.sub(" ", cleaned)
+    cleaned = _STRUCTURAL_SOURCE_BARE_DOTTED_REFERENCE_PATTERN.sub(" ", cleaned)
     cleaned = _STRUCTURAL_SOURCE_SECTION_PATTERN.sub(" ", cleaned)
     cleaned = GROUNDING_DATE_PATTERN.sub(" ", cleaned)
     cleaned = GROUNDING_MONTH_PERIOD_PATTERN.sub(" ", cleaned)
@@ -7318,7 +7328,11 @@ _SHARED_STATUTORY_RATE_SECTION_PREFIX_PATTERN = re.compile(
 )
 _HOUSEHOLD_MEMBER_MIXED_SCOPE_PATTERN = re.compile(
     r"\bhousehold\b(?!\s+member\b)[\s\S]{0,180}"
-    r"\b(?:each|every|all|no)\s+(?:household\s+)?member\b",
+    r"\b(?:each|every|all|no)\s+(?:household\s+)?member\b"
+    r"|"
+    r"\b(?:individuals?|persons?|clients?|participants?|recipients?)\b"
+    r"[\s\S]{0,80}\b(?:resid(?:e|es|ing)|liv(?:e|es|ing))\s+with\s+"
+    r"(?:a\s+)?household\b",
     flags=re.IGNORECASE,
 )
 _UNIT_MEMBER_AGGREGATE_HELPER_SOURCE_PATTERN = re.compile(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3332,6 +3332,87 @@ rules:
             for case in repaired_tests
         )
 
+    def test_generated_eval_repairs_companions_with_unrelated_issues(self, tmp_path):
+        repo = tmp_path / "rulespec-us-co"
+        rulespec_file = repo / "regulations" / "example.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: work_study_exemption
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-01-01'
+        formula: enrolled_in_work_study
+"""
+        )
+        rulespec_file.with_name("example.test.yaml").write_text(
+            """- name: existing_negative
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us-co:regulations/example#input.enrolled_in_work_study: false
+  output:
+    us-co:regulations/example#work_study_exemption: not_holds
+"""
+        )
+        companion_issue = (
+            "Judgment rule missing positive companion output coverage: "
+            "`us-co:regulations/example#work_study_exemption` is not asserted "
+            "as `holds` by the companion `.test.yaml` file."
+        )
+        unrelated_issue = (
+            "Source scope mismatch: `work_study_exemption` is declared on "
+            "`Person`, but the embedded source states a household/unit-scoped test."
+        )
+        with (
+            patch.object(
+                ValidatorPipeline,
+                "_run_compile_check",
+                return_value=ValidationResult("compile", passed=True),
+            ),
+            patch.object(
+                ValidatorPipeline,
+                "_run_ci",
+                side_effect=[
+                    ValidationResult(
+                        "ci",
+                        passed=False,
+                        issues=[companion_issue, unrelated_issue],
+                    ),
+                    ValidationResult("ci", passed=False, issues=[unrelated_issue]),
+                ],
+            ) as mock_ci,
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures",
+                return_value=[],
+            ),
+        ):
+            metrics = _evaluate_generated_artifact_with_repairs(
+                rulespec_file=rulespec_file,
+                policy_repo_root=repo,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text="Students in work study are exempt.",
+                skip_reviewers=True,
+            )
+
+        repaired_tests = yaml.safe_load(
+            rulespec_file.with_name("example.test.yaml").read_text()
+        )
+        assert mock_ci.call_count == 2
+        assert not metrics.ci_pass
+        assert metrics.ci_issues == [unrelated_issue]
+        assert any(
+            case.get("output", {}).get("us-co:regulations/example#work_study_exemption")
+            == "holds"
+            for case in repaired_tests
+        )
+
     def test_generated_eval_repairs_zero_branch_companions(self, tmp_path):
         repo = tmp_path / "rulespec-us-co"
         rulespec_file = repo / "regulations" / "example.yaml"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5517,6 +5517,25 @@ def test_numeric_occurrence_extraction_ignores_decimal_subsection_label():
     assert extract_numeric_occurrences_from_text(text) == [0.0475]
 
 
+def test_numeric_occurrence_extraction_ignores_bare_dotted_regulatory_reference():
+    text = (
+        "Household members shall not be counted unless otherwise stated in "
+        "4.304.3. The standard deduction is 8.31% of the federal poverty "
+        "income guidelines."
+    )
+
+    assert extract_numeric_occurrences_from_text(text) == [pytest.approx(0.0831)]
+
+
+def test_numeric_occurrence_extraction_ignores_form_and_line_identifiers():
+    text = (
+        "Show the shortage on Line 13 of Form FNS-250. Attach Form G-845 "
+        "when verification applies. The monthly excess medical threshold is $35."
+    )
+
+    assert extract_numeric_occurrences_from_text(text) == [35.0]
+
+
 def test_broad_application_passthrough_rejects_furnishing_output():
     content = """format: rulespec/v1
 module:
@@ -12874,6 +12893,60 @@ rules:
       - effective_from: '2026-01-01'
         formula: |-
           member_has_provided_ssn
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_allows_individual_residing_with_household_rule():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    The following individuals residing with a household shall not be considered
+    household members in determining the household's eligibility or allotment:
+    boarders, roomers, and live-in attendants.
+rules:
+  - name: snap_boarder
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 10 CCR 2506-1 4.304.31
+    versions:
+      - effective_from: '2025-10-01'
+        formula: person_is_boarder
+  - name: snap_boarder_excluded_from_household_membership
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 10 CCR 2506-1 4.304.31
+    versions:
+      - effective_from: '2025-10-01'
+        formula: snap_boarder
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
+def test_source_scope_consistency_allows_ineligible_member_exclusion_rule():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Ineligible students and household members who are ineligible due to
+    citizenship status, intentional program violation, or failure to provide a
+    Social Security Number shall be excluded when determining the household
+    size and level of benefits.
+rules:
+  - name: member_excluded_from_household_size_and_benefit_level
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 10 CCR 2506-1 4.401
+    versions:
+      - effective_from: '2025-10-01'
+        formula: ineligible_student or ineligible_due_to_citizenship_status
 """
 
     assert find_source_scope_consistency_issues(content) == []

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.685"
+version = "0.2.686"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- ignore structural regulatory refs, form IDs, and form line labels in source numeric occurrence extraction
- let generated companion eval repairs run even when unrelated CI issues remain, while preserving unrelated failures after recheck
- classify source text about individuals living/residing with a household as mixed person/household scope instead of household-only

## CO SNAP manual stress result
- Before these fixes, after #626: 280/280 generated, 277/280 compile pass, 179/280 strict CI pass
- After this branch: 280/280 generated, 277/280 compile pass, 193/280 strict CI pass
- Latest re-score artifact: /tmp/axiom-co-snap-manual-stress/full-20260617-rescore-source-filter-companion-scope.jsonl

## Validation
- uv run --with ruff ruff check src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py tests/test_rulespec_validation.py
- uv run --with ruff ruff format --check src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py tests/test_rulespec_validation.py
- uv run --with pytest --with pytest-cov pytest tests/test_rulespec_validation.py::test_numeric_occurrence_extraction_ignores_bare_dotted_regulatory_reference tests/test_rulespec_validation.py::test_numeric_occurrence_extraction_ignores_form_and_line_identifiers tests/test_rulespec_validation.py::test_source_scope_consistency_allows_individual_residing_with_household_rule tests/test_rulespec_validation.py::test_source_scope_consistency_allows_ineligible_member_exclusion_rule tests/test_rulespec_validation.py::test_source_scope_consistency_rejects_household_source_as_person_rule tests/test_evals.py::TestEvaluateArtifact::test_generated_eval_repairs_positive_judgment_companions tests/test_evals.py::TestEvaluateArtifact::test_generated_eval_repairs_companions_with_unrelated_issues tests/test_evals.py::TestEvaluateArtifact::test_generated_eval_repairs_zero_branch_companions
- uv run --with pytest --with pytest-cov pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
- git diff --check