### PR TITLE
Repair generated eval scalar relation rows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.686"
+version = "0.2.687"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.686"
+__version__ = "0.2.687"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3058,6 +3058,7 @@ _EVAL_COMPANION_REPAIR_MARKERS = (
     "Derived rule missing companion output coverage:",
     "Zero branch test coverage missing:",
     "mixes derived output entities",
+    "input invalid: relation ",
 )
 _EVAL_SCALAR_REPAIR_MARKERS = (
     "Proof import not referenced:",
@@ -3095,6 +3096,22 @@ def _apply_generated_eval_repairs(
     # Reuse the CLI's deterministic companion-test repair helpers lazily to
     # avoid an import cycle: cli imports this module during startup.
     from axiom_encode import cli as cli_helpers
+
+    scalar_relation_issues = []
+    for issue in companion_issues:
+        parsed = cli_helpers._parse_scalar_relation_row_issue(str(issue))
+        if parsed is not None:
+            scalar_relation_issues.append(parsed)
+    if scalar_relation_issues:
+        repairs.extend(
+            f"relation_row:{name}"
+            for name in cli_helpers._repair_scalar_relation_rows(
+                rules_file=rulespec_file,
+                test_file=test_file,
+                policy_repo_path=policy_repo_root,
+                parsed_issues=scalar_relation_issues,
+            )
+        )
 
     if any("mixes derived output entities" in str(issue) for issue in companion_issues):
         repairs.extend(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3413,6 +3413,75 @@ rules:
             for case in repaired_tests
         )
 
+    def test_generated_eval_repairs_scalar_relation_rows(self, tmp_path):
+        repo = tmp_path / "rulespec-us-co"
+        rulespec_file = repo / "regulations" / "example.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/7/2012/j#relation.member_of_household
+rules:
+  - name: household_has_elderly_or_disabled_member
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: count_where(member_of_household, member_of_household.snap_member_is_elderly_or_disabled) > 0
+"""
+        )
+        rulespec_file.with_name("example.test.yaml").write_text(
+            """- name: elderly_case
+  period: 2026-01
+  input:
+    us:statutes/7/2012/j#relation.member_of_household:
+      - true
+  output:
+    us-co:regulations/example#household_has_elderly_or_disabled_member: holds
+"""
+        )
+        relation_issue = (
+            "Test case `elderly_case` input invalid: relation "
+            "`us:statutes/7/2012/j#relation.member_of_household` item #1 "
+            "must be a mapping"
+        )
+        with (
+            patch.object(
+                ValidatorPipeline,
+                "_run_compile_check",
+                return_value=ValidationResult("compile", passed=True),
+            ),
+            patch.object(
+                ValidatorPipeline,
+                "_run_ci",
+                side_effect=[
+                    ValidationResult("ci", passed=False, issues=[relation_issue]),
+                    ValidationResult("ci", passed=True, issues=[]),
+                ],
+            ) as mock_ci,
+        ):
+            metrics = _evaluate_generated_artifact_with_repairs(
+                rulespec_file=rulespec_file,
+                policy_repo_root=repo,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text="An elderly or disabled member qualifies the household.",
+                skip_reviewers=True,
+            )
+
+        repaired_tests = yaml.safe_load(
+            rulespec_file.with_name("example.test.yaml").read_text()
+        )
+        rows = repaired_tests[0]["input"][
+            "us:statutes/7/2012/j#relation.member_of_household"
+        ]
+        assert mock_ci.call_count == 2
+        assert metrics.ci_pass
+        assert rows == [
+            {"us:statutes/7/2012/j#input.snap_member_is_elderly_or_disabled": True}
+        ]
+
     def test_generated_eval_repairs_zero_branch_companions(self, tmp_path):
         repo = tmp_path / "rulespec-us-co"
         rulespec_file = repo / "regulations" / "example.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.686"
+version = "0.2.687"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- route generated eval companion-test relation-row validation failures through the existing deterministic scalar relation row repair
- add regression coverage for a generated companion test that writes a relation row as `- true` instead of a relation-member input mapping
- bump axiom-encode to 0.2.687

## CO SNAP stress signal
- replayed the 280-row CO SNAP manual generated corpus in scratch at `/tmp/axiom-co-snap-manual-stress/full-20260617-rescore-0.2.687-relation-rows.jsonl`
- scalar relation-row validation errors dropped from 6 to 0 across the three affected rows: 4.401, 4.407.6, and 4.407.61
- those rows still expose real remaining blockers such as source-scope mismatch, missing named scalar parameters, stale proof hashes, and bad generated input refs

## Validation
- `uv run --with ruff ruff format --check src/axiom_encode/harness/evals.py tests/test_evals.py`
- `uv run --with ruff ruff check src/axiom_encode/harness/evals.py tests/test_evals.py`
- `git diff --check`
- `uv run --with pytest --with pytest-cov pytest tests/test_evals.py::TestEvaluateArtifact::test_generated_eval_repairs_scalar_relation_rows tests/test_evals.py::TestEvaluateArtifact::test_generated_eval_repairs_companions_with_unrelated_issues tests/test_evals.py::TestEvaluateArtifact::test_generated_eval_repairs_positive_judgment_companions tests/test_evals.py::TestEvaluateArtifact::test_generated_eval_repairs_zero_branch_companions`
- `uv run --with pytest --with pytest-cov pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
