### PR TITLE
Credit numeric concept names in eval coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.687"
+version = "0.2.688"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.687"
+__version__ = "0.2.688"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -205,6 +205,61 @@ def _matching_numeric_occurrence_count(
     )
 
 
+_DECIMAL_PERCENT_CONCEPT_NAME_RE = re.compile(
+    r"(?<!\d)(?P<integer>\d{1,3})_(?P<fraction>\d{1,4})_percent\b",
+    re.IGNORECASE,
+)
+_CONCEPT_IDENTIFIER_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")
+
+
+def _numeric_occurrences_from_concept_text(text: str) -> Counter[float]:
+    """Extract numeric semantics from concept names and labels.
+
+    This credits names such as ``under_18`` or ``130_percent`` when a source
+    number is represented by an imported predicate/table rather than a local
+    scalar formula.
+    """
+    normalized = _DECIMAL_PERCENT_CONCEPT_NAME_RE.sub(
+        lambda match: f"{match.group('integer')}.{match.group('fraction')} percent",
+        text,
+    )
+    normalized = normalized.replace("_", " ").replace("-", " ")
+    return Counter(extract_numeric_occurrences_from_text(normalized))
+
+
+def _numeric_concept_name_occurrences(content: str) -> Counter[float]:
+    """Count source numeric values represented in local rule/input names."""
+    occurrences: Counter[float] = Counter()
+    with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
+        payload = yaml.safe_load(content)
+        if not (
+            isinstance(payload, dict)
+            and payload.get("format") == "rulespec/v1"
+            and isinstance(payload.get("rules"), list)
+        ):
+            return occurrences
+        for rule in payload["rules"]:
+            if not isinstance(rule, dict):
+                continue
+            name = str(rule.get("name") or "").strip()
+            if name:
+                occurrences.update(_numeric_occurrences_from_concept_text(name))
+            versions = rule.get("versions")
+            if not isinstance(versions, list):
+                continue
+            for version in versions:
+                if not isinstance(version, dict):
+                    continue
+                formula = version.get("formula")
+                if not isinstance(formula, str):
+                    continue
+                for identifier in set(_CONCEPT_IDENTIFIER_RE.findall(formula)):
+                    occurrences.update(
+                        _numeric_occurrences_from_concept_text(identifier)
+                    )
+    return occurrences
+
+
 _SECTION_CROSS_REFERENCE_PATTERN = re.compile(
     r"\b(?:sections?|secs?\.?|regs?\.?|regulations?|paragraphs?)\s+"
     r"\d+(?:\.\d+)+(?:\s*(?:through|to|-|and|,)\s*\d+(?:\.\d+)+)*",
@@ -2907,6 +2962,7 @@ def evaluate_artifact(
     named_scalar_occurrences = Counter(
         item.value for item in extract_named_scalar_occurrences(content)
     )
+    named_scalar_occurrences.update(_numeric_concept_name_occurrences(content))
     named_scalar_occurrences.update(
         _imported_named_scalar_occurrences(content, policy_repo_root)
     )
@@ -3171,20 +3227,26 @@ def _imported_named_scalar_occurrences(
     content: str,
     policy_repo_root: Path,
 ) -> Counter[float]:
-    """Count direct scalar definitions from imported RuleSpec files."""
+    """Count numeric values from imported RuleSpec files and import symbols."""
     occurrences: Counter[float] = Counter()
     seen: set[Path] = set()
     for import_target in _extract_import_targets(content):
+        if "#" in import_target:
+            occurrences.update(
+                _numeric_occurrences_from_concept_text(import_target.rsplit("#", 1)[1])
+            )
         for path in _candidate_import_rule_files(import_target, policy_repo_root):
             resolved = path.resolve()
             if resolved in seen or not path.exists():
                 continue
             seen.add(resolved)
             with contextlib.suppress(OSError):
+                imported_content = path.read_text()
                 occurrences.update(
                     item.value
-                    for item in extract_named_scalar_occurrences(path.read_text())
+                    for item in extract_named_scalar_occurrences(imported_content)
                 )
+                occurrences.update(_numeric_concept_name_occurrences(imported_content))
             break
     return occurrences
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -781,7 +781,8 @@ _STRUCTURAL_SOURCE_FORM_LINE_PATTERN = re.compile(
 _STRUCTURAL_SOURCE_CODE_CITATION_PATTERN = re.compile(
     r"\b\d+\s+"
     r"(?:U\.?\s*S\.?\s*C\.?|USC|C\.?\s*F\.?\s*R\.?|CFR|C\.?\s*C\.?\s*R\.?|CCR)\s+"
-    r"\d+(?:[.-]\d+)*(?:\([A-Za-z0-9]+\))*"
+    r"\d+[A-Za-z]*(?:[.-]\d+[A-Za-z]*)*(?:\([A-Za-z0-9]+\))*"
+    r"(?:\s*(?:,|and|or)\s*\d+[A-Za-z]*(?:[.-]\d+[A-Za-z]*)*(?:\([A-Za-z0-9]+\))*)*"
     r"(?=$|[\s,.;:])",
     re.IGNORECASE,
 )

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3902,6 +3902,111 @@ rules:
         assert metrics.ci_pass
         assert metrics.numeric_occurrence_issues == []
 
+    def test_numeric_occurrence_check_counts_imported_numeric_concept_names(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us-co"
+        federal_repo = tmp_path / "rulespec-us"
+        child = (
+            federal_repo
+            / "policies"
+            / "usda"
+            / "snap"
+            / "fy-2026-cola"
+            / "income-eligibility-standards.yaml"
+        )
+        child.parent.mkdir(parents=True)
+        child.write_text(
+            """format: rulespec/v1
+rules:
+  - name: snap_gross_income_limit_130_percent_fpl_48_states_dc
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: snap_gross_income_limit_130_percent_fpl_48_states_dc_table[household_size]
+"""
+        )
+        parent = policy_repo / "regulations" / "example.yaml"
+        parent.parent.mkdir(parents=True)
+        parent.write_text(
+            """format: rulespec/v1
+module:
+  summary: |-
+    Other households must meet the 130% gross income standard.
+imports:
+  - us:policies/usda/snap/fy-2026-cola/income-eligibility-standards#snap_gross_income_limit_130_percent_fpl_48_states_dc
+rules:
+  - name: colorado_snap_gross_income_limit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: snap_gross_income_limit_130_percent_fpl_48_states_dc
+"""
+        )
+
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline, "_run_compile_check", return_value=compile_result
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=parent,
+                policy_repo_root=policy_repo,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text="Other households must meet the 130% gross income standard.",
+            )
+
+        assert metrics.ci_pass
+        assert metrics.numeric_occurrence_issues == []
+
+    def test_numeric_occurrence_check_counts_formula_identifier_numbers(self, tmp_path):
+        rulespec_file = tmp_path / "example.yaml"
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: |-
+    Children under age 18 qualify.
+rules:
+  - name: qualifying_child
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: child_under_18
+"""
+        )
+
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline, "_run_compile_check", return_value=compile_result
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=tmp_path,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text="Children under age 18 qualify.",
+            )
+
+        assert metrics.ci_pass
+        assert metrics.numeric_occurrence_issues == []
+
     def test_repeated_source_scalar_is_covered_by_one_named_definition(self, tmp_path):
         rulespec_file = tmp_path / "example.yaml"
         rulespec_file.write_text(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5489,6 +5489,15 @@ def test_numeric_occurrence_extraction_ignores_comma_conjoined_section_reference
     assert extract_numeric_occurrences_from_text(text) == []
 
 
+def test_numeric_occurrence_extraction_ignores_alternative_code_citations():
+    text = (
+        "The source covers residents of federally subsidized housing under "
+        "12 U.S.C. 1701Q or 1715Z-1 and sets a minimum age of sixty."
+    )
+
+    assert extract_numeric_occurrences_from_text(text) == [60.0]
+
+
 def test_numeric_occurrence_extraction_ignores_source_urls():
     text = (
         "https://www.legislation.gov.uk/uksi/2006/965/regulation/2 states "

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.687"
+version = "0.2.688"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- count numeric semantics represented in local formula identifiers and imported RuleSpec concept names when applying the eval source-numeric coverage gate
- extend source numeric cleaning for alternative legal code citations like `12 U.S.C. 1701Q or 1715Z-1`
- add regression tests for imported `130_percent` concepts, formula identifiers like `child_under_18`, and alternate code citations
- bump axiom-encode to 0.2.688

## CO SNAP stress signal
- replayed the 19 CO SNAP rows that previously had source-numeric occurrence deficits at `/tmp/axiom-co-snap-manual-stress/numeric-subset-0.2.688-concept-coverage.jsonl`
- numeric occurrence issues dropped from 30 to 20
- affected rows dropped from 19 to 12
- 5 rows moved from failing to passing: 4.203.1, 4.208.1, 4.304.41, 4.402.1, and 4.405
- remaining numeric deficits look like real encoding gaps or harder modeling decisions, including table bounds, deduction rates, and resource thresholds

## Validation
- `uv run --with ruff ruff format --check src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py tests/test_rulespec_validation.py`
- `uv run --with ruff ruff check src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py tests/test_rulespec_validation.py`
- `git diff --check`
- `uv run --with pytest --with pytest-cov pytest tests/test_evals.py::TestEvaluateArtifact::test_numeric_occurrence_check_counts_imported_numeric_concept_names tests/test_evals.py::TestEvaluateArtifact::test_numeric_occurrence_check_counts_formula_identifier_numbers tests/test_evals.py::TestEvaluateArtifact::test_numeric_occurrence_check_counts_imported_named_scalars tests/test_rulespec_validation.py::test_numeric_occurrence_extraction_ignores_alternative_code_citations tests/test_rulespec_validation.py::test_numeric_occurrence_extraction_ignores_nested_subsection_references tests/test_rulespec_validation.py::test_numeric_occurrence_extraction_ignores_form_and_line_identifiers`
- `uv run --with pytest --with pytest-cov pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
