### PR TITLE
Count verification values in numeric coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.688"
+version = "0.2.689"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.688"
+__version__ = "0.2.689"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -260,6 +260,48 @@ def _numeric_concept_name_occurrences(content: str) -> Counter[float]:
     return occurrences
 
 
+def _verification_value_numeric_occurrences(content: str) -> Counter[float]:
+    """Count source values recorded in RuleSpec verification payloads."""
+    occurrences: Counter[float] = Counter()
+
+    def visit(value: object) -> None:
+        if isinstance(value, bool):
+            return
+        if isinstance(value, (int, float)):
+            occurrences.update([float(value)])
+            return
+        if isinstance(value, str):
+            stripped = value.strip().replace(",", "")
+            with contextlib.suppress(ValueError):
+                occurrences.update([float(stripped)])
+            return
+        if isinstance(value, dict):
+            for key, item in value.items():
+                visit(key)
+                visit(item)
+            return
+        if isinstance(value, list):
+            for item in value:
+                visit(item)
+
+    with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
+        payload = yaml.safe_load(content)
+        if not (
+            isinstance(payload, dict)
+            and payload.get("format") == "rulespec/v1"
+            and isinstance(payload.get("rules"), list)
+        ):
+            return occurrences
+        for rule in payload["rules"]:
+            if not isinstance(rule, dict):
+                continue
+            verification = rule.get("verification")
+            if not isinstance(verification, dict):
+                continue
+            visit(verification.get("values"))
+    return occurrences
+
+
 _SECTION_CROSS_REFERENCE_PATTERN = re.compile(
     r"\b(?:sections?|secs?\.?|regs?\.?|regulations?|paragraphs?)\s+"
     r"\d+(?:\.\d+)+(?:\s*(?:through|to|-|and|,)\s*\d+(?:\.\d+)+)*",
@@ -2963,6 +3005,7 @@ def evaluate_artifact(
         item.value for item in extract_named_scalar_occurrences(content)
     )
     named_scalar_occurrences.update(_numeric_concept_name_occurrences(content))
+    named_scalar_occurrences.update(_verification_value_numeric_occurrences(content))
     named_scalar_occurrences.update(
         _imported_named_scalar_occurrences(content, policy_repo_root)
     )

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -4007,6 +4007,52 @@ rules:
         assert metrics.ci_pass
         assert metrics.numeric_occurrence_issues == []
 
+    def test_numeric_occurrence_check_counts_verification_values(self, tmp_path):
+        rulespec_file = tmp_path / "example.yaml"
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: |-
+    The standard deduction amounts are $209 for household sizes 1 through 3 and $223 for household size 4.
+rules:
+  - name: restates_standard_deduction
+    kind: source_relation
+    source_relation:
+      type: restates
+      target: us:policies/usda/snap/fy-2026-cola/deductions#snap_standard_deduction
+      authority: federal
+    verification:
+      values:
+        snap_standard_deduction_table:
+          1: 209
+          2: 209
+          3: 209
+          4: 223
+"""
+        )
+
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline, "_run_compile_check", return_value=compile_result
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=tmp_path,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text=(
+                    "The standard deduction amounts are $209 for household sizes "
+                    "1 through 3 and $223 for household size 4."
+                ),
+            )
+
+        assert metrics.ci_pass
+        assert metrics.numeric_occurrence_issues == []
+
     def test_repeated_source_scalar_is_covered_by_one_named_definition(self, tmp_path):
         rulespec_file = tmp_path / "example.yaml"
         rulespec_file.write_text(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.688"
+version = "0.2.689"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- count numeric keys and values recorded under RuleSpec `verification.values` as source numeric coverage
- keep booleans excluded and support numeric strings with comma separators
- bump package version to `0.2.689`

## CO SNAP manual replay
Replayed the 19 rows from the CO SNAP manual stress run that had numeric coverage issues. Compared against `/tmp/axiom-co-snap-manual-stress/full-20260617-rescore-source-filter-companion-scope.jsonl`.

- numeric occurrence issues: 30 -> 10
- rows with numeric occurrence issues: 19 -> 10
- rows newly passing: 6 (`4.203.1`, `4.208.1`, `4.304.41`, `4.402.1`, `4.405`, `4.407.2`)

Replay output: `/tmp/axiom-co-snap-manual-stress/numeric-subset-0.2.689-verification-values.jsonl`

## Tests
- `uv run --with ruff ruff format src/axiom_encode/harness/evals.py tests/test_evals.py`
- `uv run --with ruff ruff check src/axiom_encode/harness/evals.py tests/test_evals.py`
- `uv run --with pytest --with pytest-cov pytest tests/test_evals.py::TestEvaluateArtifact::test_numeric_occurrence_check_counts_verification_values tests/test_evals.py::TestEvaluateArtifact::test_numeric_occurrence_check_counts_imported_numeric_concept_names tests/test_evals.py::TestEvaluateArtifact::test_numeric_occurrence_check_counts_formula_identifier_numbers tests/test_evals.py::TestEvaluateArtifact::test_numeric_occurrence_check_counts_imported_named_scalars`
- `uv run --with pytest --with pytest-cov pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`