### PR TITLE
Count deferred output reasons in numeric coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.689"
+version = "0.2.690"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.689"
+__version__ = "0.2.690"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -302,6 +302,32 @@ def _verification_value_numeric_occurrences(content: str) -> Counter[float]:
     return occurrences
 
 
+def _deferred_output_numeric_occurrences(content: str) -> Counter[float]:
+    """Count source values explicitly scoped to deferred output reasons."""
+    occurrences: Counter[float] = Counter()
+    with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
+        payload = yaml.safe_load(content)
+        if not (
+            isinstance(payload, dict)
+            and payload.get("format") == "rulespec/v1"
+            and isinstance(payload.get("module"), dict)
+            and isinstance(payload["module"].get("deferred_outputs"), list)
+        ):
+            return occurrences
+        for deferred_output in payload["module"]["deferred_outputs"]:
+            if not isinstance(deferred_output, dict):
+                continue
+            reason = deferred_output.get("reason")
+            if not isinstance(reason, str):
+                continue
+            occurrences.update(
+                extract_numeric_occurrences_from_text(
+                    _numeric_occurrence_source_text(reason)
+                )
+            )
+    return occurrences
+
+
 _SECTION_CROSS_REFERENCE_PATTERN = re.compile(
     r"\b(?:sections?|secs?\.?|regs?\.?|regulations?|paragraphs?)\s+"
     r"\d+(?:\.\d+)+(?:\s*(?:through|to|-|and|,)\s*\d+(?:\.\d+)+)*",
@@ -3006,6 +3032,7 @@ def evaluate_artifact(
     )
     named_scalar_occurrences.update(_numeric_concept_name_occurrences(content))
     named_scalar_occurrences.update(_verification_value_numeric_occurrences(content))
+    named_scalar_occurrences.update(_deferred_output_numeric_occurrences(content))
     named_scalar_occurrences.update(
         _imported_named_scalar_occurrences(content, policy_repo_root)
     )

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -4053,6 +4053,85 @@ rules:
         assert metrics.ci_pass
         assert metrics.numeric_occurrence_issues == []
 
+    def test_numeric_occurrence_check_counts_deferred_output_reasons(self, tmp_path):
+        rulespec_file = tmp_path / "example.yaml"
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  deferred_outputs:
+    - output: example:provision#full_deduction_for_aged_households
+      reason: This branch depends on whether the household contains a person aged 60 or older.
+  summary: |-
+    A deduction is 10 dollars unless the household has a person aged 60 or older.
+rules:
+  - name: base_deduction_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2025-01-01'
+        formula: '10'
+"""
+        )
+
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline, "_run_compile_check", return_value=compile_result
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=tmp_path,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text=(
+                    "A deduction is 10 dollars unless the household has a "
+                    "person aged 60 or older."
+                ),
+            )
+
+        assert metrics.ci_pass
+        assert metrics.numeric_occurrence_issues == []
+
+    def test_numeric_occurrence_check_ignores_deferred_reason_section_numbers(
+        self, tmp_path
+    ):
+        rulespec_file = tmp_path / "example.yaml"
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  deferred_outputs:
+    - output: example:provision#separate_branch
+      reason: This branch is deferred until Section 4.000.1 is encoded.
+rules: []
+"""
+        )
+
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline, "_run_compile_check", return_value=compile_result
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=tmp_path,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text="The operative non-citation amount is 4 dollars.",
+            )
+
+        assert not metrics.ci_pass
+        assert metrics.numeric_occurrence_issues == [
+            "Source numeric value 4 appears 1 time(s), but only 0 named scalar "
+            "definition(s) with that value were found."
+        ]
+
     def test_repeated_source_scalar_is_covered_by_one_named_definition(self, tmp_path):
         rulespec_file = tmp_path / "example.yaml"
         rulespec_file.write_text(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.689"
+version = "0.2.690"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- count numeric values in `module.deferred_outputs[].reason` as covered for source numeric coverage
- strip section/citation references from deferred reasons before counting, so `Section 4.000.1` does not satisfy a source amount
- bump package version to `0.2.690`

## CO SNAP manual replay
Re-evaluated the 19-row numeric subset against the scratch RuleSpec files without re-encoding. Compared `/tmp/axiom-co-snap-manual-stress/numeric-subset-0.2.689-verification-values.jsonl` to `/tmp/axiom-co-snap-manual-stress/numeric-subset-0.2.690-deferred-output.jsonl`.

- numeric occurrence issues: 10 -> 8
- rows with numeric occurrence issues: 10 -> 8
- numeric rows cleared: `4.403`, `4.407.3`
- rows newly passing: `4.407.3`

## Tests
- `uv run --with ruff ruff format src/axiom_encode/harness/evals.py tests/test_evals.py`
- `uv run --with ruff ruff check src/axiom_encode/harness/evals.py tests/test_evals.py`
- `uv run --with pytest --with pytest-cov pytest tests/test_evals.py::TestEvaluateArtifact::test_numeric_occurrence_check_counts_deferred_output_reasons tests/test_evals.py::TestEvaluateArtifact::test_numeric_occurrence_check_ignores_deferred_reason_section_numbers tests/test_evals.py::TestEvaluateArtifact::test_numeric_occurrence_check_counts_verification_values`
- `uv run --with pytest --with pytest-cov pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`