### PR TITLE
Allow source proof repair progress

### DIFF
--- a/changelog.d/source-proof-progress-repair.fixed.md
+++ b/changelog.d/source-proof-progress-repair.fixed.md
@@ -1,0 +1,1 @@
+Allow signed source proof repair to keep deterministic progress when later validation issues remain.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.691"
+version = "0.2.692"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.691"
+__version__ = "0.2.692"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -11080,6 +11080,17 @@ def cmd_repair_missing_source_proofs(args):
         args, "axiom_rules_path", None
     ) or _resolve_runtime_axiom_rules_checkout(repo_path)
 
+    before_validation = ValidatorPipeline(
+        policy_repo_path=repo_path,
+        axiom_rules_path=axiom_rules_path,
+        enable_oracles=False,
+        require_policy_proofs=True,
+    ).validate(rules_file, skip_reviewers=True)
+    before_issues = [
+        result.error for result in before_validation.results.values() if result.error
+    ]
+    before_missing_proof_rules = _missing_source_proof_issue_rule_names(before_issues)
+
     rules_file.write_text(repaired_content)
     validation = ValidatorPipeline(
         policy_repo_path=repo_path,
@@ -11091,7 +11102,16 @@ def cmd_repair_missing_source_proofs(args):
         issues = [
             result.error for result in validation.results.values() if result.error
         ]
-        if _only_pending_tax_filing_status_branch_issues(
+        after_missing_proof_rules = _missing_source_proof_issue_rule_names(issues)
+        repaired_missing_proof_rules = (
+            before_missing_proof_rules - after_missing_proof_rules
+        )
+        if repaired_missing_proof_rules:
+            print(
+                "Applied missing source proof repair with pending validation "
+                f"issues still remaining: {len(issues)}"
+            )
+        elif _only_pending_tax_filing_status_branch_issues(
             issues
         ) or _only_pending_nonnegative_amount_reduction_issues(issues):
             print(
@@ -13099,6 +13119,15 @@ def _only_pending_nonnegative_amount_reduction_issues(issues: list[str]) -> bool
         or "Nonnegative taxable income missing floor:" in issue
         for issue in issues
     )
+
+
+def _missing_source_proof_issue_rule_names(issues: list[str]) -> set[str]:
+    names: set[str] = set()
+    for issue in issues:
+        match = re.match(r"Proof missing: rule `([^`]+)` ", issue)
+        if match is not None:
+            names.add(match.group(1))
+    return names
 
 
 def _rulespec_module_source_paths(payload: dict[str, object]) -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19247,6 +19247,109 @@ rules:
             "statutes/26/3101/b/2.yaml",
         ]
 
+    def test_repair_missing_source_proofs_keeps_progress_with_pending_issues(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "statutes/26/3101/b/2.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3101
+  summary: Medicare tax threshold source text.
+rules:
+  - name: additional_medicare_tax_rate
+    kind: parameter
+    dtype: Rate
+    source: 26 USC 3101(b)(2)(A)
+    versions:
+      - effective_from: '2013-01-01'
+        formula: '0.009'
+  - name: additional_medicare_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3101(b)(2)
+    versions:
+      - effective_from: '2013-01-01'
+        formula: wages * additional_medicare_tax_rate
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("statutes/26/3101/b/2.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            calls = 0
+
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                FakePipeline.calls += 1
+                if FakePipeline.calls == 1:
+                    return SimpleNamespace(
+                        all_passed=False,
+                        results={
+                            "rate": SimpleNamespace(
+                                error=(
+                                    "Proof missing: rule "
+                                    "`additional_medicare_tax_rate` is "
+                                    "policy-bearing and must declare "
+                                    "`metadata.proof.atoms`."
+                                )
+                            ),
+                            "tax": SimpleNamespace(
+                                error=(
+                                    "Proof missing: rule "
+                                    "`additional_medicare_tax` is "
+                                    "policy-bearing and must declare "
+                                    "`metadata.proof.atoms`."
+                                )
+                            ),
+                        },
+                    )
+                return SimpleNamespace(
+                    all_passed=False,
+                    results={
+                        "tax": SimpleNamespace(
+                            error=(
+                                "Proof missing: rule `additional_medicare_tax` "
+                                "is policy-bearing and must declare "
+                                "`metadata.proof.atoms`."
+                            )
+                        )
+                    },
+                )
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_missing_source_proofs(args)
+
+        content = target.read_text()
+        assert "proof_validation:\n    required: true" in content
+        assert content.count("metadata:\n      proof:\n        atoms:") == 2
+        manifest = policy_repo / ".axiom/encoding-manifests/statutes/26/3101/b/2.json"
+        assert manifest.exists()
+        assert FakePipeline.calls == 2
+
     def test_repair_missing_source_proofs_treats_derived_relation_as_executable(
         self,
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.691"
+version = "0.2.692"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- allow signed source proof repair to keep deterministic progress when unrelated validation issues remain
- compare before/after missing-proof rule names before deciding whether to restore the original file
- bump axiom-encode to 0.2.692

## Tests
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run python -m pytest tests/test_cli.py -k 'repair_missing_source_proofs or package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump'