### PR TITLE
Repair source proofs in normalized RuleSpec

### DIFF
--- a/changelog.d/source-proof-unindented-rules.fixed.md
+++ b/changelog.d/source-proof-unindented-rules.fixed.md
@@ -1,0 +1,1 @@
+Repair missing source proof atoms in RuleSpec files whose rules sequence was normalized without item indentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.692"
+version = "0.2.693"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.692"
+__version__ = "0.2.693"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -13102,6 +13102,12 @@ def _repair_missing_source_proof_atoms(content: str) -> tuple[str, list[str]]:
     repaired_lines, repaired_rules = _insert_missing_source_proof_atoms(
         lines, repairs_by_rule
     )
+    if set(repaired_rules) != set(repairs_by_rule):
+        structured_content, structured_rules = (
+            _insert_missing_source_proof_atoms_structured(payload, repairs_by_rule)
+        )
+        if structured_rules:
+            return structured_content, structured_rules
     return "".join(repaired_lines), repaired_rules
 
 
@@ -13255,6 +13261,63 @@ def _insert_missing_source_proof_atoms(
         repaired_rules.append(rule_name)
 
     return output, repaired_rules
+
+
+def _insert_missing_source_proof_atoms_structured(
+    payload: dict[str, object],
+    repairs_by_rule: dict[str, dict[str, str]],
+) -> tuple[str, list[str]]:
+    module = payload.get("module")
+    if not isinstance(module, dict):
+        module = {}
+        payload["module"] = module
+    proof_validation = module.get("proof_validation")
+    if not isinstance(proof_validation, dict):
+        module["proof_validation"] = {"required": True}
+    else:
+        proof_validation["required"] = True
+
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return yaml.safe_dump(payload, sort_keys=False, allow_unicode=False), []
+
+    repaired_rules: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        rule_name = str(rule.get("name") or "").strip()
+        repair = repairs_by_rule.get(rule_name)
+        if repair is None:
+            continue
+        metadata = rule.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+            rule["metadata"] = metadata
+        proof = metadata.get("proof")
+        if not isinstance(proof, dict):
+            proof = {}
+            metadata["proof"] = proof
+        atoms = proof.get("atoms")
+        if isinstance(atoms, list) and atoms:
+            continue
+        source: dict[str, str] = {
+            "corpus_citation_path": repair["corpus_citation_path"],
+        }
+        if repair["span"]:
+            source["span"] = repair["span"]
+        proof["atoms"] = [
+            {
+                "path": "versions[0].formula",
+                "kind": repair["kind"],
+                "source": source,
+            }
+        ]
+        repaired_rules.append(rule_name)
+
+    return (
+        yaml.safe_dump(payload, sort_keys=False, allow_unicode=False),
+        repaired_rules,
+    )
 
 
 def _source_proof_insertion(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19380,6 +19380,35 @@ rules:
         assert "corpus_citation_path: us/regulation/7/273/1" in repaired
         assert "span: '7 CFR 273.1(a)'" in repaired
 
+    def test_repair_missing_source_proofs_handles_unindented_rules_sequence(
+        self,
+    ):
+        content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.403
+rules:
+- name: snap_countable_employee_wage_income
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  unit: USD
+  source: 10 CCR 2506-1 section 4.403(A)
+  versions:
+  - effective_from: '2025-10-01'
+    formula: "if excluded_income:\\n    0\\nelse:\\n    employee_wages_received"
+"""
+
+        repaired, repaired_rules = _repair_missing_source_proof_atoms(content)
+
+        assert repaired_rules == ["snap_countable_employee_wage_income"]
+        assert "proof_validation:\n    required: true" in repaired
+        assert "metadata:\n    proof:\n      atoms:" in repaired
+        assert "kind: formula" in repaired
+        assert "corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.403" in repaired
+        assert "span: 10 CCR 2506-1 section 4.403(A)" in repaired
+
     def test_repair_embedded_scalar_literals_extracts_parameter(self, tmp_path):
         content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.692"
+version = "0.2.693"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a structured fallback for source proof atom insertion when RuleSpec YAML has normalized top-level rule sequence items
- preserve the existing line-oriented path for original formatted files
- bump axiom-encode to 0.2.693

## Tests
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run python -m pytest tests/test_cli.py -k 'repair_missing_source_proofs or package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump'