### PR TITLE
Repair hidden zero-branch test gaps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.693"
+version = "0.2.694"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.693"
+__version__ = "0.2.694"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -105,6 +105,7 @@ from .harness.validator_pipeline import (
     find_tax_filing_status_local_input_issues,
     find_tax_status_component_local_input_issues,
     find_unused_import_issues,
+    find_zero_branch_test_coverage_issues,
     repair_current_year_final_amount_tables,
     repair_nonnegative_amount_reductions,
     repair_source_table_band_scalar_parameters,
@@ -7476,12 +7477,25 @@ def cmd_repair_zero_branch_tests(args):
     initial_issues = [
         result.error for result in initial_validation.results.values() if result.error
     ]
+    zero_branch_issues = _zero_branch_coverage_issues_for_files(
+        rules_file=rules_file,
+        test_file=test_file,
+    )
+    if not zero_branch_issues:
+        zero_branch_issues = [
+            issue
+            for issue in initial_issues
+            if "Zero branch test coverage missing: " in issue
+        ]
+    initial_zero_branch_outputs = set(
+        _zero_branch_output_names_from_issues(zero_branch_issues)
+    )
     repaired_test_cases = _append_generated_zero_branch_tests_if_missing(
         rules_file=rules_file,
         test_file=test_file,
         repo_path=repo_path,
         relative_output=relative_output,
-        issues=initial_issues,
+        issues=zero_branch_issues,
     )
     if not repaired_test_cases:
         print("No zero-branch test repairs found.")
@@ -7497,14 +7511,30 @@ def cmd_repair_zero_branch_tests(args):
         require_policy_proofs=True,
     ).validate(rules_file, skip_reviewers=True)
     if not validation.all_passed:
-        test_file.write_text(original_test_content)
         issues = [
             result.error for result in validation.results.values() if result.error
         ]
-        print("Repair failed validation; restored original test file.")
-        for issue in issues:
-            print(f"- {issue}")
-        sys.exit(1)
+        remaining_zero_branch_outputs = set(
+            _zero_branch_output_names_from_issues(
+                _zero_branch_coverage_issues_for_files(
+                    rules_file=rules_file,
+                    test_file=test_file,
+                )
+            )
+        )
+        introduced_non_zero_issues = _non_zero_branch_issues(
+            issues
+        ) - _non_zero_branch_issues(initial_issues)
+        made_zero_branch_progress = (
+            bool(initial_zero_branch_outputs - remaining_zero_branch_outputs)
+            and remaining_zero_branch_outputs < initial_zero_branch_outputs
+        )
+        if introduced_non_zero_issues or not made_zero_branch_progress:
+            test_file.write_text(original_test_content)
+            print("Repair failed validation; restored original test file.")
+            for issue in issues:
+                print(f"- {issue}")
+            sys.exit(1)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         output_root = Path(tmpdir)
@@ -7536,10 +7566,16 @@ def cmd_repair_zero_branch_tests(args):
             axiom_encode_git=axiom_encode_git,
         )
 
-    print(
+    message = (
         "Applied zero-branch test repair to "
         f"{relative_output}: {', '.join(repaired_test_cases)}"
     )
+    if not validation.all_passed:
+        pending_count = len(
+            [result.error for result in validation.results.values() if result.error]
+        )
+        message += f" with pending validation issues still remaining: {pending_count}"
+    print(message)
     print(f"manifest={manifest_path}")
 
 
@@ -13617,6 +13653,31 @@ def _only_pending_zero_branch_coverage_issues(issues: list[str]) -> bool:
     return bool(issues) and all(
         "Zero branch test coverage missing: " in issue for issue in issues
     )
+
+
+def _zero_branch_coverage_issues_for_files(
+    *, rules_file: Path, test_file: Path
+) -> list[str]:
+    """Compute zero-branch issues directly, even when earlier validators mask them."""
+    if not rules_file.exists() or not test_file.exists():
+        return []
+    try:
+        test_cases = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    try:
+        content = rules_file.read_text()
+    except OSError:
+        return []
+    return find_zero_branch_test_coverage_issues(content, test_cases)
+
+
+def _non_zero_branch_issues(issues: list[str]) -> set[str]:
+    return {
+        issue
+        for issue in issues
+        if "Zero branch test coverage missing: " not in str(issue)
+    }
 
 
 def _only_pending_exception_test_coverage_issues(issues: list[str]) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -154,6 +154,7 @@ from axiom_encode.cli import (
     cmd_repair_tax_filing_status_branches,
     cmd_repair_tax_status_components,
     cmd_repair_unreferenced_proof_imports,
+    cmd_repair_zero_branch_tests,
     cmd_retire,
     cmd_runs,
     cmd_session_end,
@@ -9834,6 +9835,113 @@ rules:
         assert cases[0]["output"] == {
             "us:statutes/26/36B/b/3/A#applicable_percentage": 0
         }
+
+    def test_repair_zero_branch_tests_derives_hidden_zero_issues(
+        self, capsys, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us"
+        rules_file = repo / "statutes" / "26" / "151.yaml"
+        test_file = repo / "statutes" / "26" / "151.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: first_zero_branch_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if first_condition:
+              first_amount
+          else:
+              0
+  - name: second_zero_branch_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if second_condition:
+              second_amount
+          else:
+              0
+"""
+        )
+        test_file.write_text(
+            """- name: positive_first
+  period: 2026
+  input:
+    us:statutes/26/151#input.first_condition: true
+    us:statutes/26/151#input.first_amount: 5
+  output:
+    us:statutes/26/151#first_zero_branch_amount: 5
+- name: positive_second
+  period: 2026
+  input:
+    us:statutes/26/151#input.second_condition: true
+    us:statutes/26/151#input.second_amount: 7
+  output:
+    us:statutes/26/151#second_zero_branch_amount: 7
+"""
+        )
+        args = SimpleNamespace(
+            repo=repo,
+            file=Path("statutes/26/151.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == rules_file.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(
+                    all_passed=False,
+                    results={
+                        "scope": SimpleNamespace(
+                            error=(
+                                "Source scope mismatch: `some_rule` is declared "
+                                "on `TaxUnit`, but the embedded source states a "
+                                "person-scoped rule."
+                            )
+                        )
+                    },
+                )
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_zero_branch_tests(args)
+
+        output = capsys.readouterr().out
+        assert "Applied zero-branch test repair to statutes/26/151.yaml" in output
+        assert "with pending validation issues still remaining: 1" in output
+        test_content = test_file.read_text()
+        assert "auto_zero_first_zero_branch_amount" in test_content
+        assert "auto_zero_second_zero_branch_amount" in test_content
+        manifest = repo / ".axiom/encoding-manifests/statutes/26/151.json"
+        payload = json.loads(manifest.read_text())
+        assert payload["model"] == "zero-branch-test-v1"
+        assert payload["tool"] == "axiom-encode repair-zero-branch-tests"
+        assert [item["path"] for item in payload["applied_files"]] == [
+            "statutes/26/151.yaml",
+            "statutes/26/151.test.yaml",
+        ]
 
     def test_encode_apply_auto_repairs_exception_positive_companion(
         self, capsys, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.693"
+version = "0.2.694"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary\n- derive zero-branch repair issues directly from the RuleSpec/test pair when direct validation masks later zero-branch gaps\n- allow signed zero-branch repair manifests when the zero-branch bucket shrinks/clears and unrelated pre-existing validation issues remain\n- bump axiom-encode to 0.2.694\n\n## Tests\n- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py\n- uv run python -m pytest tests/test_cli.py -k 'zero_branch_tests_derives_hidden_zero_issues or zero_branch_repair_uses_upper_bound_input_for_band_selector or package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump'