### PR TITLE
Handle zero-branch repair edge cases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.694"
+version = "0.2.695"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.694"
+__version__ = "0.2.695"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -7522,14 +7522,15 @@ def cmd_repair_zero_branch_tests(args):
                 )
             )
         )
-        introduced_non_zero_issues = _non_zero_branch_issues(
-            issues
-        ) - _non_zero_branch_issues(initial_issues)
+        repaired_case_issues = _issues_for_repaired_test_cases(
+            issues,
+            repaired_test_cases,
+        )
         made_zero_branch_progress = (
             bool(initial_zero_branch_outputs - remaining_zero_branch_outputs)
             and remaining_zero_branch_outputs < initial_zero_branch_outputs
         )
-        if introduced_non_zero_issues or not made_zero_branch_progress:
+        if repaired_case_issues or not made_zero_branch_progress:
             test_file.write_text(original_test_content)
             print("Repair failed validation; restored original test file.")
             for issue in issues:
@@ -13672,12 +13673,15 @@ def _zero_branch_coverage_issues_for_files(
     return find_zero_branch_test_coverage_issues(content, test_cases)
 
 
-def _non_zero_branch_issues(issues: list[str]) -> set[str]:
-    return {
+def _issues_for_repaired_test_cases(
+    issues: list[str],
+    repaired_test_cases: list[str],
+) -> list[str]:
+    return [
         issue
         for issue in issues
-        if "Zero branch test coverage missing: " not in str(issue)
-    }
+        if any(case_name in str(issue) for case_name in repaired_test_cases)
+    ]
 
 
 def _only_pending_exception_test_coverage_issues(issues: list[str]) -> bool:
@@ -15449,6 +15453,7 @@ def _local_factual_input_names_from_rules_content(rules_content: str) -> set[str
         "ceil",
         "count_where",
         "else",
+        "elif",
         "false",
         "floor",
         "if",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9868,6 +9868,8 @@ rules:
         formula: |-
           if second_condition:
               second_amount
+          elif backup_condition:
+              backup_amount
           else:
               0
 """
@@ -9934,6 +9936,7 @@ rules:
         test_content = test_file.read_text()
         assert "auto_zero_first_zero_branch_amount" in test_content
         assert "auto_zero_second_zero_branch_amount" in test_content
+        assert "#input.elif" not in test_content
         manifest = repo / ".axiom/encoding-manifests/statutes/26/151.json"
         payload = json.loads(manifest.read_text())
         assert payload["model"] == "zero-branch-test-v1"
@@ -9942,6 +9945,92 @@ rules:
             "statutes/26/151.yaml",
             "statutes/26/151.test.yaml",
         ]
+
+    def test_repair_zero_branch_tests_keeps_unmasked_legacy_issues(
+        self, capsys, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us"
+        rules_file = repo / "statutes" / "26" / "152.yaml"
+        test_file = repo / "statutes" / "26" / "152.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: zero_branch_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if condition:
+              amount
+          else:
+              0
+"""
+        )
+        test_file.write_text(
+            """- name: positive_case
+  period: 2026
+  input:
+    us:statutes/26/152#input.condition: true
+    us:statutes/26/152#input.amount: 5
+  output:
+    us:statutes/26/152#zero_branch_amount: 5
+"""
+        )
+        args = SimpleNamespace(
+            repo=repo,
+            file=Path("statutes/26/152.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            call_count = 0
+
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == rules_file.resolve()
+                assert skip_reviewers is True
+                self.__class__.call_count += 1
+                if self.__class__.call_count == 1:
+                    error = (
+                        "Zero branch test coverage missing: "
+                        "`zero_branch_amount` has a formula branch that returns 0."
+                    )
+                else:
+                    error = (
+                        "Test case `legacy_case` mixes derived output entities "
+                        "(Household, Person); put outputs for each entity in "
+                        "separate test cases."
+                    )
+                return SimpleNamespace(
+                    all_passed=False,
+                    results={"ci": SimpleNamespace(error=error)},
+                )
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_zero_branch_tests(args)
+
+        output = capsys.readouterr().out
+        assert "Applied zero-branch test repair to statutes/26/152.yaml" in output
+        assert "with pending validation issues still remaining: 1" in output
+        assert "auto_zero_zero_branch_amount" in test_file.read_text()
+        manifest = repo / ".axiom/encoding-manifests/statutes/26/152.json"
+        assert json.loads(manifest.read_text())["model"] == "zero-branch-test-v1"
 
     def test_encode_apply_auto_repairs_exception_positive_companion(
         self, capsys, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.694"
+version = "0.2.695"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- prevent zero-branch repair from treating DSL keywords such as elif as factual inputs
- allow signed zero-branch repairs when unrelated pre-existing validation issues remain, while still rejecting issues introduced by generated auto-zero cases
- bump package version to 0.2.695

## Tests
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run python -m pytest tests/test_cli.py -k 'zero_branch_tests_derives_hidden_zero_issues or zero_branch_tests_keeps_unmasked_legacy_issues or zero_branch_repair_uses_upper_bound_input_for_band_selector or package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump'