### PR TITLE
Add test input assignment repair command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.695"
+version = "0.2.696"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.695"
+__version__ = "0.2.696"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -978,6 +978,28 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_test_input_assignments_parser = subparsers.add_parser(
+        "repair-test-input-assignments",
+        help="Apply signed deterministic repairs for missing generated test inputs",
+    )
+    repair_test_input_assignments_parser.add_argument(
+        "file", type=Path, help="RuleSpec YAML file"
+    )
+    repair_test_input_assignments_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="Rules repository root used for manifest signing",
+    )
+    repair_test_input_assignments_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_judgment_positive_tests_parser = subparsers.add_parser(
         "repair-judgment-positive-tests",
         help="Apply signed deterministic repairs for missing positive Judgment tests",
@@ -1991,6 +2013,8 @@ def main():
         cmd_repair_current_year_final_amounts(args)
     elif args.command == "repair-zero-branch-tests":
         cmd_repair_zero_branch_tests(args)
+    elif args.command == "repair-test-input-assignments":
+        cmd_repair_test_input_assignments(args)
     elif args.command == "repair-judgment-positive-tests":
         cmd_repair_judgment_positive_tests(args)
     elif args.command == "repair-unused-imports":
@@ -7576,6 +7600,129 @@ def cmd_repair_zero_branch_tests(args):
             [result.error for result in validation.results.values() if result.error]
         )
         message += f" with pending validation issues still remaining: {pending_count}"
+    print(message)
+    print(f"manifest={manifest_path}")
+
+
+def cmd_repair_test_input_assignments(args):
+    """Apply signed deterministic repairs for missing generated test inputs."""
+    repo_path = Path(args.repo).resolve()
+    rules_file = Path(args.file)
+    if not rules_file.is_absolute():
+        rules_file = repo_path / rules_file
+    rules_file = rules_file.resolve()
+    if not rules_file.exists():
+        print(f"RuleSpec file not found: {rules_file}")
+        sys.exit(1)
+    try:
+        relative_output = rules_file.relative_to(repo_path)
+    except ValueError:
+        print(f"RuleSpec file {rules_file} is not under repo {repo_path}")
+        sys.exit(1)
+
+    test_file = _rulespec_test_path(rules_file)
+    if not test_file.exists():
+        print(f"Companion test file not found: {test_file}")
+        sys.exit(1)
+
+    original_test_content = test_file.read_text()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+
+    initial_validation = ValidatorPipeline(
+        policy_repo_path=repo_path,
+        axiom_rules_path=axiom_rules_path,
+        enable_oracles=False,
+        require_policy_proofs=True,
+    ).validate(rules_file, skip_reviewers=True)
+    initial_issues = [
+        result.error for result in initial_validation.results.values() if result.error
+    ]
+    assignment_issues = [
+        issue
+        for issue in initial_issues
+        if _parse_test_input_assignment_issue(str(issue)) is not None
+    ]
+    initial_assignment_signatures = _test_input_assignment_issue_signatures(
+        assignment_issues
+    )
+    repaired_test_cases = _fill_missing_test_input_assignments(
+        rules_file=rules_file,
+        test_file=test_file,
+        policy_repo_path=repo_path,
+        relative_output=relative_output,
+        issues=assignment_issues,
+    )
+    if not repaired_test_cases:
+        print("No test input assignment repairs found.")
+        return
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+
+    validation = ValidatorPipeline(
+        policy_repo_path=repo_path,
+        axiom_rules_path=axiom_rules_path,
+        enable_oracles=False,
+        require_policy_proofs=True,
+    ).validate(rules_file, skip_reviewers=True)
+    pending_issues = [
+        result.error for result in validation.results.values() if result.error
+    ]
+    if not validation.all_passed:
+        remaining_assignment_signatures = _test_input_assignment_issue_signatures(
+            pending_issues
+        )
+        made_assignment_progress = (
+            bool(initial_assignment_signatures - remaining_assignment_signatures)
+            and remaining_assignment_signatures < initial_assignment_signatures
+        )
+        if not made_assignment_progress:
+            test_file.write_text(original_test_content)
+            print("Repair failed validation; restored original test file.")
+            for issue in pending_issues:
+                print(f"- {issue}")
+            sys.exit(1)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        generated_output = output_root / "deterministic-repair" / relative_output
+        generated_output.parent.mkdir(parents=True, exist_ok=True)
+        generated_output.write_text(rules_file.read_text())
+        result = argparse.Namespace(
+            output_file=str(generated_output),
+            runner="deterministic-repair",
+            backend="deterministic",
+            model="test-input-assignment-v1",
+            tool="axiom-encode repair-test-input-assignments",
+            citation=(
+                f"{_repo_jurisdiction_prefix(repo_path)}:"
+                f"{_relative_rulespec_import_target(relative_output)}"
+            ),
+            generation_prompt_sha256=None,
+            trace_file=None,
+            context_manifest_file=None,
+        )
+        manifest_path = _write_applied_encoding_manifest(
+            result,
+            output_root=output_root,
+            policy_repo_path=repo_path,
+            relative_output=relative_output,
+            applied_files=[rules_file, test_file],
+            run_id="deterministic-repair",
+            signing_key=signing_key,
+            axiom_encode_git=axiom_encode_git,
+        )
+
+    message = (
+        "Applied test input assignment repair to "
+        f"{relative_output}: {', '.join(repaired_test_cases)}"
+    )
+    if not validation.all_passed:
+        message += (
+            f" with pending validation issues still remaining: {len(pending_issues)}"
+        )
     print(message)
     print(f"manifest={manifest_path}")
 
@@ -25578,6 +25725,19 @@ def _test_case_has_imported_inputs(inputs: object, *, target_anchor: str) -> boo
         if not _rulespec_ref_matches_base(key_text, target_anchor):
             return True
     return False
+
+
+def _test_input_assignment_issue_signatures(
+    issues: list[str],
+) -> set[tuple[str, str]]:
+    signatures: set[tuple[str, str]] = set()
+    for issue in issues:
+        parsed = _parse_test_input_assignment_issue(str(issue))
+        if parsed is None:
+            continue
+        case_name, missing_inputs = parsed
+        signatures.update((case_name, input_name) for input_name in missing_inputs)
+    return signatures
 
 
 def _parse_test_input_assignment_issue(issue: str) -> tuple[str, set[str]] | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -153,6 +153,7 @@ from axiom_encode.cli import (
     cmd_repair_snap_273_10_allotment,
     cmd_repair_tax_filing_status_branches,
     cmd_repair_tax_status_components,
+    cmd_repair_test_input_assignments,
     cmd_repair_unreferenced_proof_imports,
     cmd_repair_zero_branch_tests,
     cmd_retire,
@@ -10031,6 +10032,115 @@ rules:
         assert "auto_zero_zero_branch_amount" in test_file.read_text()
         manifest = repo / ".axiom/encoding-manifests/statutes/26/152.json"
         assert json.loads(manifest.read_text())["model"] == "zero-branch-test-v1"
+
+    def test_repair_test_input_assignments_keeps_unrelated_issues(
+        self, capsys, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us"
+        rules_file = repo / "statutes" / "26" / "153.yaml"
+        test_file = repo / "statutes" / "26" / "153.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: conditional_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if qualifying_condition:
+              amount
+          else:
+              0
+"""
+        )
+        test_file.write_text(
+            """- name: positive_case
+  period: 2026
+  input:
+    us:statutes/26/153#input.amount: 5
+  output:
+    us:statutes/26/153#conditional_amount: 5
+"""
+        )
+        args = SimpleNamespace(
+            repo=repo,
+            file=Path("statutes/26/153.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            call_count = 0
+
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == rules_file.resolve()
+                assert skip_reviewers is True
+                self.__class__.call_count += 1
+                if self.__class__.call_count == 1:
+                    return SimpleNamespace(
+                        all_passed=False,
+                        results={
+                            "assignments": SimpleNamespace(
+                                error=(
+                                    "Test input assignment missing: "
+                                    "`positive_case` does not assign "
+                                    "#input.qualifying_condition. Every test for a "
+                                    "proof-required RuleSpec module must set all local "
+                                    "factual inputs, including false facts, so tests "
+                                    "cannot pass through implicit defaults."
+                                )
+                            ),
+                            "numeric": SimpleNamespace(
+                                error=(
+                                    "Source numeric value `10` is not represented in "
+                                    "a non-test RuleSpec file."
+                                )
+                            ),
+                        },
+                    )
+                return SimpleNamespace(
+                    all_passed=False,
+                    results={
+                        "numeric": SimpleNamespace(
+                            error=(
+                                "Source numeric value `10` is not represented in a "
+                                "non-test RuleSpec file."
+                            )
+                        )
+                    },
+                )
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_test_input_assignments(args)
+
+        output = capsys.readouterr().out
+        assert "Applied test input assignment repair to statutes/26/153.yaml" in output
+        assert "with pending validation issues still remaining: 1" in output
+        cases = yaml.safe_load(test_file.read_text())
+        assert cases[0]["input"] == {
+            "us:statutes/26/153#input.amount": 5,
+            "us:statutes/26/153#input.qualifying_condition": False,
+        }
+        manifest = repo / ".axiom/encoding-manifests/statutes/26/153.json"
+        payload = json.loads(manifest.read_text())
+        assert payload["model"] == "test-input-assignment-v1"
+        assert payload["tool"] == "axiom-encode repair-test-input-assignments"
 
     def test_encode_apply_auto_repairs_exception_positive_companion(
         self, capsys, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.695"
+version = "0.2.696"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- expose a signed deterministic repair command for missing generated test input assignments
- allow assignment repairs to be signed when unrelated validation issues remain, as long as assignment issues make progress
- add regression coverage for mixed assignment/source issue repair and bump axiom-encode to 0.2.696

## Tests
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run python -m pytest tests/test_cli.py -k 'repair_test_input_assignments_keeps_unrelated_issues or zero_branch_tests_derives_hidden_zero_issues or zero_branch_tests_keeps_unmasked_legacy_issues or package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump'