### PR TITLE
Loop test input assignment repairs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.696"
+version = "0.2.697"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.696"
+__version__ = "0.2.697"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -7630,60 +7630,59 @@ def cmd_repair_test_input_assignments(args):
         args, "axiom_rules_path", None
     ) or _resolve_runtime_axiom_rules_checkout(repo_path)
 
-    initial_validation = ValidatorPipeline(
-        policy_repo_path=repo_path,
-        axiom_rules_path=axiom_rules_path,
-        enable_oracles=False,
-        require_policy_proofs=True,
-    ).validate(rules_file, skip_reviewers=True)
-    initial_issues = [
-        result.error for result in initial_validation.results.values() if result.error
-    ]
-    assignment_issues = [
-        issue
-        for issue in initial_issues
-        if _parse_test_input_assignment_issue(str(issue)) is not None
-    ]
-    initial_assignment_signatures = _test_input_assignment_issue_signatures(
-        assignment_issues
-    )
-    repaired_test_cases = _fill_missing_test_input_assignments(
-        rules_file=rules_file,
-        test_file=test_file,
-        policy_repo_path=repo_path,
-        relative_output=relative_output,
-        issues=assignment_issues,
-    )
+    repaired_test_cases: list[str] = []
+    seen_assignment_signatures: set[tuple[str, str]] = set()
+    while True:
+        validation = ValidatorPipeline(
+            policy_repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+            enable_oracles=False,
+            require_policy_proofs=True,
+        ).validate(rules_file, skip_reviewers=True)
+        pending_issues = [
+            result.error for result in validation.results.values() if result.error
+        ]
+        assignment_issues = [
+            issue
+            for issue in pending_issues
+            if _parse_test_input_assignment_issue(str(issue)) is not None
+        ]
+        if not assignment_issues:
+            break
+        assignment_signatures = _test_input_assignment_issue_signatures(
+            assignment_issues
+        )
+        if (
+            not assignment_signatures
+            or assignment_signatures <= seen_assignment_signatures
+        ):
+            test_file.write_text(original_test_content)
+            print("Repair failed validation; restored original test file.")
+            for issue in pending_issues:
+                print(f"- {issue}")
+            sys.exit(1)
+        seen_assignment_signatures.update(assignment_signatures)
+        repaired_now = _fill_missing_test_input_assignments(
+            rules_file=rules_file,
+            test_file=test_file,
+            policy_repo_path=repo_path,
+            relative_output=relative_output,
+            issues=assignment_issues,
+        )
+        if not repaired_now:
+            test_file.write_text(original_test_content)
+            print("Repair failed validation; restored original test file.")
+            for issue in pending_issues:
+                print(f"- {issue}")
+            sys.exit(1)
+        repaired_test_cases.extend(repaired_now)
+
     if not repaired_test_cases:
         print("No test input assignment repairs found.")
         return
 
     signing_key = _require_applied_encoding_manifest_signing_key()
     axiom_encode_git = _require_clean_axiom_encode_git_provenance()
-
-    validation = ValidatorPipeline(
-        policy_repo_path=repo_path,
-        axiom_rules_path=axiom_rules_path,
-        enable_oracles=False,
-        require_policy_proofs=True,
-    ).validate(rules_file, skip_reviewers=True)
-    pending_issues = [
-        result.error for result in validation.results.values() if result.error
-    ]
-    if not validation.all_passed:
-        remaining_assignment_signatures = _test_input_assignment_issue_signatures(
-            pending_issues
-        )
-        made_assignment_progress = (
-            bool(initial_assignment_signatures - remaining_assignment_signatures)
-            and remaining_assignment_signatures < initial_assignment_signatures
-        )
-        if not made_assignment_progress:
-            test_file.write_text(original_test_content)
-            print("Repair failed validation; restored original test file.")
-            for issue in pending_issues:
-                print(f"- {issue}")
-            sys.exit(1)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         output_root = Path(tmpdir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10064,6 +10064,12 @@ rules:
     us:statutes/26/153#input.amount: 5
   output:
     us:statutes/26/153#conditional_amount: 5
+- name: second_positive_case
+  period: 2026
+  input:
+    us:statutes/26/153#input.amount: 7
+  output:
+    us:statutes/26/153#conditional_amount: 7
 """
         )
         args = SimpleNamespace(
@@ -10090,6 +10096,28 @@ rules:
                                 error=(
                                     "Test input assignment missing: "
                                     "`positive_case` does not assign "
+                                    "#input.qualifying_condition. Every test for a "
+                                    "proof-required RuleSpec module must set all local "
+                                    "factual inputs, including false facts, so tests "
+                                    "cannot pass through implicit defaults."
+                                )
+                            ),
+                            "numeric": SimpleNamespace(
+                                error=(
+                                    "Source numeric value `10` is not represented in "
+                                    "a non-test RuleSpec file."
+                                )
+                            ),
+                        },
+                    )
+                if self.__class__.call_count == 2:
+                    return SimpleNamespace(
+                        all_passed=False,
+                        results={
+                            "assignments": SimpleNamespace(
+                                error=(
+                                    "Test input assignment missing: "
+                                    "`second_positive_case` does not assign "
                                     "#input.qualifying_condition. Every test for a "
                                     "proof-required RuleSpec module must set all local "
                                     "factual inputs, including false facts, so tests "
@@ -10135,6 +10163,10 @@ rules:
         cases = yaml.safe_load(test_file.read_text())
         assert cases[0]["input"] == {
             "us:statutes/26/153#input.amount": 5,
+            "us:statutes/26/153#input.qualifying_condition": False,
+        }
+        assert cases[1]["input"] == {
+            "us:statutes/26/153#input.amount": 7,
             "us:statutes/26/153#input.qualifying_condition": False,
         }
         manifest = repo / ".axiom/encoding-manifests/statutes/26/153.json"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.696"
+version = "0.2.697"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- make repair-test-input-assignments iterate through cascaded assignment issues surfaced one at a time by validation
- restore and fail if an assignment signature repeats without progress
- extend regression coverage and bump axiom-encode to 0.2.697

## Tests
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run python -m pytest tests/test_cli.py -k 'repair_test_input_assignments_keeps_unrelated_issues or package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump'