### PR TITLE
Repair invalid generated test inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.697"
+version = "0.2.698"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.697"
+__version__ = "0.2.698"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1000,6 +1000,28 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_invalid_test_inputs_parser = subparsers.add_parser(
+        "repair-invalid-test-inputs",
+        help="Apply signed deterministic repairs for invalid generated test inputs",
+    )
+    repair_invalid_test_inputs_parser.add_argument(
+        "file", type=Path, help="RuleSpec YAML file"
+    )
+    repair_invalid_test_inputs_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="Rules repository root used for manifest signing",
+    )
+    repair_invalid_test_inputs_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_judgment_positive_tests_parser = subparsers.add_parser(
         "repair-judgment-positive-tests",
         help="Apply signed deterministic repairs for missing positive Judgment tests",
@@ -2015,6 +2037,8 @@ def main():
         cmd_repair_zero_branch_tests(args)
     elif args.command == "repair-test-input-assignments":
         cmd_repair_test_input_assignments(args)
+    elif args.command == "repair-invalid-test-inputs":
+        cmd_repair_invalid_test_inputs(args)
     elif args.command == "repair-judgment-positive-tests":
         cmd_repair_judgment_positive_tests(args)
     elif args.command == "repair-unused-imports":
@@ -7717,6 +7741,120 @@ def cmd_repair_test_input_assignments(args):
     message = (
         "Applied test input assignment repair to "
         f"{relative_output}: {', '.join(repaired_test_cases)}"
+    )
+    if not validation.all_passed:
+        message += (
+            f" with pending validation issues still remaining: {len(pending_issues)}"
+        )
+    print(message)
+    print(f"manifest={manifest_path}")
+
+
+def cmd_repair_invalid_test_inputs(args):
+    """Apply signed deterministic repairs for invalid generated test inputs."""
+    repo_path = Path(args.repo).resolve()
+    rules_file = Path(args.file)
+    if not rules_file.is_absolute():
+        rules_file = repo_path / rules_file
+    rules_file = rules_file.resolve()
+    if not rules_file.exists():
+        print(f"RuleSpec file not found: {rules_file}")
+        sys.exit(1)
+    try:
+        relative_output = rules_file.relative_to(repo_path)
+    except ValueError:
+        print(f"RuleSpec file {rules_file} is not under repo {repo_path}")
+        sys.exit(1)
+
+    test_file = _rulespec_test_path(rules_file)
+    if not test_file.exists():
+        print(f"Companion test file not found: {test_file}")
+        sys.exit(1)
+
+    original_test_content = test_file.read_text()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+
+    removed_refs: list[str] = []
+    seen_invalid_refs: set[str] = set()
+    while True:
+        validation = ValidatorPipeline(
+            policy_repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+            enable_oracles=False,
+            require_policy_proofs=True,
+        ).validate(rules_file, skip_reviewers=True)
+        pending_issues = [
+            result.error for result in validation.results.values() if result.error
+        ]
+        invalid_refs = {
+            ref
+            for ref in _invalid_input_refs_from_issues(pending_issues)
+            if "#input." in ref
+        }
+        if not invalid_refs:
+            break
+        if invalid_refs <= seen_invalid_refs:
+            test_file.write_text(original_test_content)
+            print("Repair failed validation; restored original test file.")
+            for issue in pending_issues:
+                print(f"- {issue}")
+            sys.exit(1)
+        seen_invalid_refs.update(invalid_refs)
+        removed_now = _remove_invalid_test_input_refs(
+            test_file=test_file,
+            issues=pending_issues,
+        )
+        if not removed_now:
+            test_file.write_text(original_test_content)
+            print("Repair failed validation; restored original test file.")
+            for issue in pending_issues:
+                print(f"- {issue}")
+            sys.exit(1)
+        removed_refs.extend(removed_now)
+
+    if not removed_refs:
+        print("No invalid test input repairs found.")
+        return
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        generated_output = output_root / "deterministic-repair" / relative_output
+        generated_output.parent.mkdir(parents=True, exist_ok=True)
+        generated_output.write_text(rules_file.read_text())
+        result = argparse.Namespace(
+            output_file=str(generated_output),
+            runner="deterministic-repair",
+            backend="deterministic",
+            model="invalid-test-input-v1",
+            tool="axiom-encode repair-invalid-test-inputs",
+            citation=(
+                f"{_repo_jurisdiction_prefix(repo_path)}:"
+                f"{_relative_rulespec_import_target(relative_output)}"
+            ),
+            generation_prompt_sha256=None,
+            trace_file=None,
+            context_manifest_file=None,
+        )
+        manifest_path = _write_applied_encoding_manifest(
+            result,
+            output_root=output_root,
+            policy_repo_path=repo_path,
+            relative_output=relative_output,
+            applied_files=[rules_file, test_file],
+            run_id="deterministic-repair",
+            signing_key=signing_key,
+            axiom_encode_git=axiom_encode_git,
+        )
+
+    unique_removed_refs = list(dict.fromkeys(removed_refs))
+    message = (
+        "Applied invalid test input repair to "
+        f"{relative_output}: {', '.join(unique_removed_refs)}"
     )
     if not validation.all_passed:
         message += (
@@ -15628,7 +15766,10 @@ def _local_factual_input_names_from_rules_content(rules_content: str) -> set[str
             formula = version.get("formula")
             if not isinstance(formula, str):
                 continue
-            identifiers = set(re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*\b", formula))
+            scrubbed_formula = re.sub(r"'[^']*'|\"[^\"]*\"", " ", formula)
+            identifiers = set(
+                re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*\b", scrubbed_formula)
+            )
             factual_inputs.update(identifiers - defined_symbols - dsl_symbols)
     return factual_inputs
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -14990,7 +14990,8 @@ def _rulespec_import_prefix_static(import_path: str) -> str | None:
 
 def _formula_local_identifiers(formula: str) -> set[str]:
     """Return non-builtin identifiers referenced by a RuleSpec formula."""
-    return set(_RULESPEC_IDENTIFIER.findall(formula)) - _RULESPEC_FORMULA_BUILTINS
+    scrubbed = _QUOTED_STRING_PATTERN.sub(" ", formula)
+    return set(_RULESPEC_IDENTIFIER.findall(scrubbed)) - _RULESPEC_FORMULA_BUILTINS
 
 
 def _normalize_identifier(value: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,6 +141,7 @@ from axiom_encode.cli import (
     cmd_repair_current_year_final_amounts,
     cmd_repair_embedded_scalar_literals,
     cmd_repair_imported_test_inputs,
+    cmd_repair_invalid_test_inputs,
     cmd_repair_judgment_positive_tests,
     cmd_repair_missing_source_proofs,
     cmd_repair_nonnegative_floors,
@@ -10173,6 +10174,109 @@ rules:
         payload = json.loads(manifest.read_text())
         assert payload["model"] == "test-input-assignment-v1"
         assert payload["tool"] == "axiom-encode repair-test-input-assignments"
+
+    def test_repair_invalid_test_inputs_keeps_unrelated_issues(self, capsys, tmp_path):
+        repo = tmp_path / "rulespec-us"
+        rules_file = repo / "statutes" / "26" / "153.yaml"
+        test_file = repo / "statutes" / "26" / "153.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: conditional_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: amount
+"""
+        )
+        test_file.write_text(
+            """- name: positive_case
+  period: 2026
+  input:
+    us:statutes/26/153#input.amount: 5
+    us:statutes/26/153#input.annual: false
+  output:
+    us:statutes/26/153#conditional_amount: 5
+"""
+        )
+        args = SimpleNamespace(
+            repo=repo,
+            file=Path("statutes/26/153.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            call_count = 0
+
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == rules_file.resolve()
+                assert skip_reviewers is True
+                self.__class__.call_count += 1
+                if self.__class__.call_count == 1:
+                    return SimpleNamespace(
+                        all_passed=False,
+                        results={
+                            "execution": SimpleNamespace(
+                                error=(
+                                    "Test case `positive_case` execution failed: "
+                                    "dataset input "
+                                    "`us:statutes/26/153#input.annual` must use an "
+                                    "absolute legal RuleSpec reference that resolves "
+                                    "to an input slot, derived rule, or parameter in "
+                                    "the compiled program"
+                                )
+                            ),
+                            "numeric": SimpleNamespace(
+                                error=(
+                                    "Source numeric value `10` is not represented in "
+                                    "a non-test RuleSpec file."
+                                )
+                            ),
+                        },
+                    )
+                return SimpleNamespace(
+                    all_passed=False,
+                    results={
+                        "numeric": SimpleNamespace(
+                            error=(
+                                "Source numeric value `10` is not represented in a "
+                                "non-test RuleSpec file."
+                            )
+                        )
+                    },
+                )
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_invalid_test_inputs(args)
+
+        output = capsys.readouterr().out
+        assert "Applied invalid test input repair to statutes/26/153.yaml" in output
+        assert "with pending validation issues still remaining: 1" in output
+        cases = yaml.safe_load(test_file.read_text())
+        assert cases[0]["input"] == {
+            "us:statutes/26/153#input.amount": 5,
+        }
+        manifest = repo / ".axiom/encoding-manifests/statutes/26/153.json"
+        payload = json.loads(manifest.read_text())
+        assert payload["model"] == "invalid-test-input-v1"
+        assert payload["tool"] == "axiom-encode repair-invalid-test-inputs"
 
     def test_encode_apply_auto_repairs_exception_positive_companion(
         self, capsys, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5789,6 +5789,54 @@ rules:
     assert find_test_input_assignment_issues(content, test_cases) == []
 
 
+def test_test_input_assignment_ignores_quoted_string_literals():
+    content = """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: weekly_factor
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '2026-01-01'
+        value: 52
+  - name: annual_factor
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '2026-01-01'
+        value: 1
+  - name: income_factor
+    kind: derived
+    entity: Household
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if income_pay_frequency == "weekly":
+              weekly_factor
+          elif income_pay_frequency == "annual":
+              annual_factor
+          else:
+              1
+"""
+    test_cases = [
+        {
+            "name": "weekly_income",
+            "input": {
+                "us:statutes/7/2014#input.income_pay_frequency": "weekly",
+            },
+            "output": {
+                "us:statutes/7/2014#income_factor": 52,
+            },
+        },
+    ]
+
+    assert find_test_input_assignment_issues(content, test_cases) == []
+
+
 def test_test_input_assignment_treats_local_indexed_by_selector_as_dependency():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.697"
+version = "0.2.698"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- ignore quoted string literals when deriving local formula identifiers for required test inputs
- add a signed deterministic repair-invalid-test-inputs command for invalid generated test input refs
- bump axiom-encode to 0.2.698

## Tests
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run python -m pytest tests/test_cli.py tests/test_rulespec_validation.py -k 'repair_invalid_test_inputs or quoted_string_literals or package_version_metadata_matches_pyproject'
- uv run python -m pytest tests/test_cli.py -k 'current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject or repair_invalid_test_inputs'
- uv run python -m pytest tests/test_rulespec_validation.py -k 'quoted_string_literals'