### PR TITLE
Expose signed SnapUnit repair

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.699"
+version = "0.2.700"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.699"
+__version__ = "0.2.700"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -99,6 +99,7 @@ from .harness.validator_pipeline import (
     _rulespec_rule_formula_rule_records,
     _rulespec_target_is_descendant_of,
     extract_embedded_source_text,
+    find_delegated_policy_setting_issues,
     find_interval_table_reencoding_candidates,
     find_proof_import_reference_issues,
     find_structured_scale_parameter_issue_records,
@@ -1061,6 +1062,28 @@ def main():
         help="Rules repository root used for manifest signing",
     )
     repair_delegated_policy_settings_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
+    repair_bare_snapunit_parser = subparsers.add_parser(
+        "repair-bare-snapunit-entities",
+        help="Apply signed deterministic repairs for undeclared generated SnapUnit rules",
+    )
+    repair_bare_snapunit_parser.add_argument(
+        "file", type=Path, help="RuleSpec YAML file"
+    )
+    repair_bare_snapunit_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="Rules repository root used for manifest signing",
+    )
+    repair_bare_snapunit_parser.add_argument(
         "--axiom-rules-engine-path",
         dest="axiom_rules_path",
         metavar="AXIOM_RULES_ENGINE_PATH",
@@ -2090,6 +2113,8 @@ def main():
         cmd_repair_mixed_derived_entity_output_tests(args)
     elif args.command == "repair-delegated-policy-settings":
         cmd_repair_delegated_policy_settings(args)
+    elif args.command == "repair-bare-snapunit-entities":
+        cmd_repair_bare_snapunit_entities(args)
     elif args.command == "repair-judgment-positive-tests":
         cmd_repair_judgment_positive_tests(args)
     elif args.command == "repair-unused-imports":
@@ -8058,7 +8083,16 @@ def cmd_repair_delegated_policy_settings(args):
     before_issues = [
         result.error for result in before_validation.results.values() if result.error
     ]
-    before_delegated_issues = _delegated_policy_setting_issue_texts(before_issues)
+    before_direct_delegated_issues = find_delegated_policy_setting_issues(
+        original_content,
+        rules_file=rules_file,
+    )
+    before_delegated_issues = _ordered_unique_strings(
+        [
+            *(_delegated_policy_setting_issue_texts(before_issues)),
+            *before_direct_delegated_issues,
+        ]
+    )
     if not before_delegated_issues:
         print("No delegated policy setting repairs found.")
         return
@@ -8071,7 +8105,7 @@ def cmd_repair_delegated_policy_settings(args):
         generated_result,
         output_root=repo_path.parent,
         policy_repo_path=repo_path,
-        issues=before_issues,
+        issues=_ordered_unique_strings([*before_issues, *before_delegated_issues]),
     )
     if not repaired:
         print("No delegated policy setting repairs found.")
@@ -8086,7 +8120,16 @@ def cmd_repair_delegated_policy_settings(args):
     after_issues = [
         result.error for result in after_validation.results.values() if result.error
     ]
-    after_delegated_issues = _delegated_policy_setting_issue_texts(after_issues)
+    after_direct_delegated_issues = find_delegated_policy_setting_issues(
+        rules_file.read_text(),
+        rules_file=rules_file,
+    )
+    after_delegated_issues = _ordered_unique_strings(
+        [
+            *(_delegated_policy_setting_issue_texts(after_issues)),
+            *after_direct_delegated_issues,
+        ]
+    )
     if not set(before_delegated_issues) - set(after_delegated_issues):
         rules_file.write_text(original_content)
         print("Repair failed validation; restored original file.")
@@ -8133,6 +8176,120 @@ def cmd_repair_delegated_policy_settings(args):
         f"{relative_output}: {', '.join(repaired)}"
     )
     if not after_validation.all_passed:
+        message += (
+            f" with pending validation issues still remaining: {len(after_issues)}"
+        )
+    print(message)
+    print(f"manifest={manifest_path}")
+
+
+def cmd_repair_bare_snapunit_entities(args):
+    """Apply signed repairs for generated SnapUnit rules with no relation."""
+    repo_path = Path(args.repo).resolve()
+    rules_file = Path(args.file)
+    if not rules_file.is_absolute():
+        rules_file = repo_path / rules_file
+    rules_file = rules_file.resolve()
+    if not rules_file.exists():
+        print(f"RuleSpec file not found: {rules_file}")
+        sys.exit(1)
+    try:
+        relative_output = rules_file.relative_to(repo_path)
+    except ValueError:
+        print(f"RuleSpec file {rules_file} is not under repo {repo_path}")
+        sys.exit(1)
+
+    original_content = rules_file.read_text()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+
+    def validate_issues() -> list[str]:
+        validation = ValidatorPipeline(
+            policy_repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+            enable_oracles=False,
+            require_policy_proofs=True,
+        ).validate(rules_file, skip_reviewers=True)
+        return [result.error for result in validation.results.values() if result.error]
+
+    before_issues = validate_issues()
+    before_snapunit_names = {
+        record["rule"] for record in _bare_snapunit_entity_issue_records(before_issues)
+    }
+    if not before_snapunit_names:
+        print("No bare SnapUnit entity repairs found.")
+        return
+
+    generated_result = argparse.Namespace(
+        output_file=str(rules_file),
+        runner=repo_path.name,
+    )
+    repaired: list[str] = []
+    current_issues = before_issues
+    while True:
+        repaired_pass = _try_repair_generated_bare_snapunit_entity_for_apply(
+            generated_result,
+            output_root=repo_path.parent,
+            issues=current_issues,
+        )
+        if not repaired_pass:
+            break
+        repaired.extend(repaired_pass)
+        current_issues = validate_issues()
+        if not _bare_snapunit_entity_issue_records(current_issues):
+            break
+
+    after_issues = validate_issues()
+    after_snapunit_names = {
+        record["rule"] for record in _bare_snapunit_entity_issue_records(after_issues)
+    }
+    if not before_snapunit_names - after_snapunit_names:
+        rules_file.write_text(original_content)
+        print("Repair failed validation; restored original file.")
+        print("- Bare SnapUnit entity repair did not clear any reported rules.")
+        for issue in after_issues:
+            print(f"- {issue}")
+        sys.exit(1)
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        generated_output = output_root / "deterministic-repair" / relative_output
+        generated_output.parent.mkdir(parents=True, exist_ok=True)
+        generated_output.write_text(rules_file.read_text())
+        result = argparse.Namespace(
+            output_file=str(generated_output),
+            runner="deterministic-repair",
+            backend="deterministic",
+            model="bare-snapunit-entity-v1",
+            tool="axiom-encode repair-bare-snapunit-entities",
+            citation=(
+                f"{_repo_jurisdiction_prefix(repo_path)}:"
+                f"{_relative_rulespec_import_target(relative_output)}"
+            ),
+            generation_prompt_sha256=None,
+            trace_file=None,
+            context_manifest_file=None,
+        )
+        manifest_path = _write_applied_encoding_manifest(
+            result,
+            output_root=output_root,
+            policy_repo_path=repo_path,
+            relative_output=relative_output,
+            applied_files=[rules_file],
+            run_id="deterministic-repair",
+            signing_key=signing_key,
+            axiom_encode_git=axiom_encode_git,
+        )
+
+    message = (
+        "Applied bare SnapUnit entity repair to "
+        f"{relative_output}: {', '.join(_ordered_unique_strings(repaired))}"
+    )
+    if after_issues:
         message += (
             f" with pending validation issues still remaining: {len(after_issues)}"
         )
@@ -15852,6 +16009,10 @@ def _delegated_policy_setting_issue_texts(issues: list[str]) -> list[str]:
     ]
 
 
+def _ordered_unique_strings(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(str(value) for value in values if str(value)))
+
+
 def _unknown_output_refs_from_issues(issues: list[str]) -> set[str]:
     refs: set[str] = set()
     pattern = r"unknown executable output (?P<output>\S+)"
@@ -18900,6 +19061,10 @@ def _try_repair_generated_bare_snapunit_entity_for_apply(
             fallback_source_text = module.get("source_text")
             if isinstance(fallback_source_text, str):
                 source_text_value = fallback_source_text
+            if not source_text_value:
+                fallback_summary = module.get("summary")
+                if isinstance(fallback_summary, str):
+                    source_text_value = fallback_summary
     source_text = (source_text_value or "").lower()
     if "snapunit" in source_text or "snap unit" in source_text:
         return []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -138,6 +138,7 @@ from axiom_encode.cli import (
     cmd_oracle_candidates,
     cmd_oracle_coverage,
     cmd_repair_arizona_snap_composition,
+    cmd_repair_bare_snapunit_entities,
     cmd_repair_current_year_final_amounts,
     cmd_repair_delegated_policy_settings,
     cmd_repair_embedded_scalar_literals,
@@ -10469,15 +10470,6 @@ rules:
                     return SimpleNamespace(
                         all_passed=False,
                         results={
-                            "delegated": SimpleNamespace(
-                                error=(
-                                    "Delegated policy setting missing "
-                                    "source_relation: "
-                                    "`heating_cooling_standard_utility_allowance` "
-                                    "encodes a state-set SNAP standard utility "
-                                    "allowance."
-                                )
-                            ),
                             "numeric": SimpleNamespace(
                                 error=(
                                     "Source numeric value `10` is not represented in "
@@ -10536,6 +10528,110 @@ rules:
         assert (
             manifest_payload["tool"] == "axiom-encode repair-delegated-policy-settings"
         )
+
+    def test_repair_bare_snapunit_entities_uses_module_summary_context(
+        self, capsys, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us-co"
+        rules_file = repo / "regulations" / "10-ccr-2506-1" / "4.407.31.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: Colorado SNAP household utility allowance standards.
+rules:
+- name: snap_standard_utility_allowance
+  kind: derived
+  entity: SnapUnit
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 594
+- name: snap_limited_utility_allowance
+  kind: derived
+  entity: SnapUnit
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 377
+"""
+        )
+        args = SimpleNamespace(
+            repo=repo,
+            file=Path("regulations/10-ccr-2506-1/4.407.31.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == rules_file.resolve()
+                assert skip_reviewers is True
+                payload = yaml.safe_load(rules_file.read_text())
+                entities = {
+                    rule["name"]: rule.get("entity")
+                    for rule in payload["rules"]
+                    if isinstance(rule, dict)
+                }
+                if entities["snap_standard_utility_allowance"] == "SnapUnit":
+                    error = (
+                        "Filtered entity dependency missing: "
+                        "`snap_standard_utility_allowance` uses "
+                        "`entity: SnapUnit`, but this RuleSpec file does not "
+                        "declare `SnapUnit` with a `kind: derived_relation` rule "
+                        "or import its declaring relation (`snap_unit`)."
+                    )
+                elif entities["snap_limited_utility_allowance"] == "SnapUnit":
+                    error = (
+                        "Filtered entity dependency missing: "
+                        "`snap_limited_utility_allowance` uses "
+                        "`entity: SnapUnit`, but this RuleSpec file does not "
+                        "declare `SnapUnit` with a `kind: derived_relation` rule "
+                        "or import its declaring relation (`snap_unit`)."
+                    )
+                else:
+                    error = (
+                        "Source numeric value `10` is not represented in a "
+                        "non-test RuleSpec file."
+                    )
+                return SimpleNamespace(
+                    all_passed=False,
+                    results={"issue": SimpleNamespace(error=error)},
+                )
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_bare_snapunit_entities(args)
+
+        output = capsys.readouterr().out
+        assert (
+            "Applied bare SnapUnit entity repair to "
+            "regulations/10-ccr-2506-1/4.407.31.yaml"
+        ) in output
+        payload = yaml.safe_load(rules_file.read_text())
+        assert [rule["entity"] for rule in payload["rules"]] == [
+            "Household",
+            "Household",
+        ]
+        manifest = (
+            repo / ".axiom/encoding-manifests/regulations/10-ccr-2506-1/4.407.31.json"
+        )
+        manifest_payload = json.loads(manifest.read_text())
+        assert manifest_payload["model"] == "bare-snapunit-entity-v1"
+        assert manifest_payload["tool"] == "axiom-encode repair-bare-snapunit-entities"
 
     def test_encode_apply_auto_repairs_exception_positive_companion(
         self, capsys, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.699"
+version = "0.2.700"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- expose signed repair-bare-snapunit-entities for generated rules that used SnapUnit without declaring/importing the relation
- let the standalone delegated policy setting repair use direct delegated-setting validation, not only the first aggregate validation error
- allow the SnapUnit rescope repair to use module summaries as context when generated files do not embed full source text

## Tests
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run python -m pytest tests/test_cli.py -k 'repair_bare_snapunit_entities or repair_delegated_policy_settings or package_version_metadata_matches_pyproject'
- uv run python -m pytest tests/test_cli.py -k 'current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject or repair_bare_snapunit_entities or repair_delegated_policy_settings'