### PR TITLE
Guard delegated setting repairs by resolvable targets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.700"
+version = "0.2.701"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.700"
+__version__ = "0.2.701"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -19440,12 +19440,34 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
         relative_output,
         policy_repo_path=policy_repo_path,
     )
+    resolved_setting_targets = _resolved_executable_delegated_setting_targets(
+        _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS,
+        current_payload=payload,
+        current_rules_file=rules_file,
+        policy_repo_path=policy_repo_path,
+    )
+    unresolved_setting_targets = {
+        normalized
+        for setting_target in _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS
+        if (normalized := _normalize_source_relation_target_ref(setting_target.target))
+        not in resolved_setting_targets
+    }
+    repaired: list[str] = []
+    repaired.extend(
+        _drop_unresolved_delegated_setting_sets_relations(
+            payload,
+            rules,
+            unresolved_targets=unresolved_setting_targets,
+        )
+    )
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return repaired
     existing_names = {
         str(rule.get("name") or "").strip() for rule in rules if isinstance(rule, dict)
     }
     source_relation_additions: list[dict[str, Any]] = []
     wrapper_additions: list[dict[str, Any]] = []
-    repaired: list[str] = []
     retargeted_wrappers, retargeted_relations = (
         _repair_delegated_setting_relation_targets(
             rules,
@@ -19454,6 +19476,7 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
             policy_repo_path=policy_repo_path,
             target_anchor=target_anchor,
             existing_names=existing_names,
+            resolvable_targets=set(resolved_setting_targets),
         )
     )
     if retargeted_wrappers:
@@ -19464,12 +19487,12 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
                 existing_names.add(wrapper_name)
     repaired.extend(retargeted_relations)
     for setting_target in _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS:
-        target_rule = _rulespec_rule_for_absolute_ref(
-            setting_target.target,
-            current_payload=payload,
-            current_rules_file=rules_file,
-            policy_repo_path=policy_repo_path,
+        normalized_setting_target = _normalize_source_relation_target_ref(
+            setting_target.target
         )
+        target_rule = resolved_setting_targets.get(normalized_setting_target or "")
+        if target_rule is None:
+            continue
         target_kind = _rulespec_rule_kind(target_rule)
         existing_relation = _generated_source_relation_for_target(
             rules,
@@ -19817,6 +19840,69 @@ def _generated_source_relation_for_target(
     return None
 
 
+def _resolved_executable_delegated_setting_targets(
+    setting_targets: tuple[Any, ...],
+    *,
+    current_payload: dict[str, Any],
+    current_rules_file: Path,
+    policy_repo_path: Path | None,
+) -> dict[str, dict[str, Any]]:
+    resolved: dict[str, dict[str, Any]] = {}
+    for setting_target in setting_targets:
+        normalized_target = _normalize_source_relation_target_ref(setting_target.target)
+        if not normalized_target:
+            continue
+        target_rule = _rulespec_rule_for_absolute_ref(
+            setting_target.target,
+            current_payload=current_payload,
+            current_rules_file=current_rules_file,
+            policy_repo_path=policy_repo_path,
+        )
+        if target_rule is None or not _is_executable_rulespec_rule(target_rule):
+            continue
+        resolved[normalized_target] = target_rule
+    return resolved
+
+
+def _drop_unresolved_delegated_setting_sets_relations(
+    payload: dict[str, Any],
+    rules: list[Any],
+    *,
+    unresolved_targets: set[str],
+) -> list[str]:
+    if not unresolved_targets:
+        return []
+
+    retained_rules: list[Any] = []
+    dropped: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            retained_rules.append(rule)
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "source_relation":
+            retained_rules.append(rule)
+            continue
+        source_relation = rule.get("source_relation")
+        if not isinstance(source_relation, dict):
+            retained_rules.append(rule)
+            continue
+        if str(source_relation.get("type") or "").strip().lower() != "sets":
+            retained_rules.append(rule)
+            continue
+        target_ref = _normalize_source_relation_target_ref(
+            source_relation.get("target")
+        )
+        if target_ref not in unresolved_targets:
+            retained_rules.append(rule)
+            continue
+        dropped.append(str(rule.get("name") or target_ref).strip())
+
+    if not dropped:
+        return []
+    payload["rules"] = retained_rules
+    return dropped
+
+
 def _repair_delegated_setting_relation_targets(
     rules: list[Any],
     *,
@@ -19825,6 +19911,7 @@ def _repair_delegated_setting_relation_targets(
     policy_repo_path: Path | None,
     target_anchor: str,
     existing_names: set[str],
+    resolvable_targets: set[str] | None = None,
 ) -> tuple[list[dict[str, Any]], list[str]]:
     """Retarget generated SNAP utility `sets` relations to canonical hooks."""
     canonical_targets = {
@@ -19863,12 +19950,22 @@ def _repair_delegated_setting_relation_targets(
         setting_target = _delegated_setting_target_for_value_name(value_name)
         if setting_target is None:
             continue
+        normalized_setting_target = _normalize_source_relation_target_ref(
+            setting_target.target
+        )
+        if (
+            resolvable_targets is not None
+            and normalized_setting_target not in resolvable_targets
+        ):
+            continue
         target_rule = _rulespec_rule_for_absolute_ref(
             setting_target.target,
             current_payload=current_payload,
             current_rules_file=current_rules_file,
             policy_repo_path=policy_repo_path,
         )
+        if target_rule is None or not _is_executable_rulespec_rule(target_rule):
+            continue
         target_kind = _rulespec_rule_kind(target_rule)
         target_symbol = setting_target.target.rsplit("#", 1)[-1]
         relation_stem = target_symbol.removesuffix("_state_option")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4885,6 +4885,39 @@ rules:
     ):
         output_root = tmp_path / "out"
         policy_repo = tmp_path / "rulespec-us-nc"
+        federal_file = (
+            tmp_path / "rulespec-us" / "regulations" / "7-cfr" / "273" / "9.yaml"
+        )
+        federal_file.parent.mkdir(parents=True)
+        federal_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: snap_standard_utility_allowance_state_option
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0'
+- name: snap_limited_utility_allowance_state_option
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0'
+- name: snap_individual_utility_allowance_state_option
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0'
+"""
+        )
         rules_file = (
             output_root
             / "runner"
@@ -5285,6 +5318,23 @@ rules:
 
     def test_delegated_policy_setting_repair_skips_existing_sets_edge(self, tmp_path):
         output_root = tmp_path / "out"
+        federal_file = (
+            tmp_path / "rulespec-us" / "regulations" / "7-cfr" / "273" / "9.yaml"
+        )
+        federal_file.parent.mkdir(parents=True)
+        federal_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: snap_standard_utility_allowance_state_option
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0'
+"""
+        )
         rules_file = output_root / "runner" / "state_rule.yaml"
         rules_file.parent.mkdir(parents=True)
         rules_file.write_text(
@@ -5322,6 +5372,55 @@ rules:
         assert repaired == ["import:us:regulations/7-cfr/273/9"]
         payload = yaml.safe_load(rules_file.read_text())
         assert payload["imports"] == ["us:regulations/7-cfr/273/9"]
+
+    def test_delegated_policy_setting_repair_drops_unresolved_sets_edge(self, tmp_path):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us-co"
+        rules_file = (
+            output_root / "runner" / "regulations" / "10-ccr-2506-1" / "4.407.31.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: sets_snap_standard_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+    value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: snap_standard_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '594'
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_delegated_policy_settings_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "RuleSpec source relation `sets_snap_standard_utility_allowance` "
+                "sets target "
+                "`us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option`, "
+                "but the target does not resolve to an executable parameter or "
+                "derived rule in the merged program"
+            ],
+        )
+
+        assert repaired == ["sets_snap_standard_utility_allowance"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert [rule["name"] for rule in payload["rules"]] == [
+            "snap_standard_utility_allowance"
+        ]
 
     def test_delegated_policy_setting_repair_wraps_parameter_values_for_derived_slots(
         self, tmp_path
@@ -10414,6 +10513,39 @@ rules:
         self, capsys, tmp_path
     ):
         repo = tmp_path / "rulespec-us-nc"
+        federal_file = (
+            tmp_path / "rulespec-us" / "regulations" / "7-cfr" / "273" / "9.yaml"
+        )
+        federal_file.parent.mkdir(parents=True)
+        federal_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: snap_standard_utility_allowance_state_option
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0'
+- name: snap_limited_utility_allowance_state_option
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0'
+- name: snap_individual_utility_allowance_state_option
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0'
+"""
+        )
         rules_file = repo / "policies" / "fns" / "utility-allowances.yaml"
         rules_file.parent.mkdir(parents=True)
         rules_file.write_text(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.700"
+version = "0.2.701"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- require delegated SNAP utility setting repairs to resolve executable federal targets before adding canonical `sets` edges
- drop already-generated `sets` edges whose canonical federal targets are not executable in the merged policy repo
- bump axiom-encode to 0.2.701

## Tests
- `uv run pytest tests/test_cli.py -k 'delegated_policy_setting_repair or repair_delegated_policy_settings'`\n- `uv run ruff check src/axiom_encode/cli.py tests/test_cli.py pyproject.toml src/axiom_encode/__init__.py`