### PR TITLE
Detect unresolved delegated setting repairs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.701"
+version = "0.2.702"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.701"
+__version__ = "0.2.702"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -8087,10 +8087,16 @@ def cmd_repair_delegated_policy_settings(args):
         original_content,
         rules_file=rules_file,
     )
+    before_unresolved_delegated_issues = _unresolved_delegated_setting_sets_issue_texts(
+        original_content,
+        rules_file=rules_file,
+        policy_repo_path=repo_path,
+    )
     before_delegated_issues = _ordered_unique_strings(
         [
             *(_delegated_policy_setting_issue_texts(before_issues)),
             *before_direct_delegated_issues,
+            *before_unresolved_delegated_issues,
         ]
     )
     if not before_delegated_issues:
@@ -8124,10 +8130,16 @@ def cmd_repair_delegated_policy_settings(args):
         rules_file.read_text(),
         rules_file=rules_file,
     )
+    after_unresolved_delegated_issues = _unresolved_delegated_setting_sets_issue_texts(
+        rules_file.read_text(),
+        rules_file=rules_file,
+        policy_repo_path=repo_path,
+    )
     after_delegated_issues = _ordered_unique_strings(
         [
             *(_delegated_policy_setting_issue_texts(after_issues)),
             *after_direct_delegated_issues,
+            *after_unresolved_delegated_issues,
         ]
     )
     if not set(before_delegated_issues) - set(after_delegated_issues):
@@ -19615,6 +19627,60 @@ def _issue_mentions_delegated_policy_setting(issue: str) -> bool:
         or "us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs"
         in issue
     )
+
+
+def _unresolved_delegated_setting_sets_issue_texts(
+    content: str,
+    *,
+    rules_file: Path,
+    policy_repo_path: Path | None,
+) -> list[str]:
+    try:
+        payload = yaml.safe_load(content) or {}
+    except (OSError, yaml.YAMLError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    resolved_targets = _resolved_executable_delegated_setting_targets(
+        _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS,
+        current_payload=payload,
+        current_rules_file=rules_file,
+        policy_repo_path=policy_repo_path,
+    )
+    unresolved_targets = {
+        normalized
+        for setting_target in _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS
+        if (normalized := _normalize_source_relation_target_ref(setting_target.target))
+        not in resolved_targets
+    }
+    if not unresolved_targets:
+        return []
+
+    issues: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "source_relation":
+            continue
+        source_relation = rule.get("source_relation")
+        if not isinstance(source_relation, dict):
+            continue
+        if str(source_relation.get("type") or "").strip().lower() != "sets":
+            continue
+        target = _normalize_source_relation_target_ref(source_relation.get("target"))
+        if target not in unresolved_targets:
+            continue
+        name = str(rule.get("name") or target).strip()
+        issues.append(
+            "RuleSpec source relation "
+            f"`{name}` sets target `{target}`, but the target does not resolve "
+            "to an executable parameter or derived rule in the merged program"
+        )
+    return issues
 
 
 def _ensure_rulespec_payload_import(payload: dict[str, Any], target: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10661,6 +10661,82 @@ rules:
             manifest_payload["tool"] == "axiom-encode repair-delegated-policy-settings"
         )
 
+    def test_repair_delegated_policy_settings_drops_unresolved_existing_edge(
+        self, capsys, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us-co"
+        rules_file = repo / "regulations" / "10-ccr-2506-1" / "4.407.31.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: Colorado SNAP household utility allowance standards.
+rules:
+- name: sets_snap_standard_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+    value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: snap_standard_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '594'
+"""
+        )
+        args = SimpleNamespace(
+            repo=repo,
+            file=Path("regulations/10-ccr-2506-1/4.407.31.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == rules_file.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_delegated_policy_settings(args)
+
+        output = capsys.readouterr().out
+        assert (
+            "Applied delegated policy setting repair to "
+            "regulations/10-ccr-2506-1/4.407.31.yaml: "
+            "sets_snap_standard_utility_allowance"
+        ) in output
+        payload = yaml.safe_load(rules_file.read_text())
+        assert [rule["name"] for rule in payload["rules"]] == [
+            "snap_standard_utility_allowance"
+        ]
+        manifest = (
+            repo / ".axiom/encoding-manifests/regulations/10-ccr-2506-1/4.407.31.json"
+        )
+        manifest_payload = json.loads(manifest.read_text())
+        assert manifest_payload["model"] == "delegated-policy-setting-v1"
+        assert (
+            manifest_payload["tool"] == "axiom-encode repair-delegated-policy-settings"
+        )
+
     def test_repair_bare_snapunit_entities_uses_module_summary_context(
         self, capsys, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.701"
+version = "0.2.702"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- make repair-delegated-policy-settings detect unresolved generated delegated [96msets[0m edges directly from RuleSpec YAML
- feed those synthetic issues into the existing signed repair flow so stale unresolved delegation edges are removed
- add regression coverage for a clean standalone validation run that still contains an unresolved federal target edge

## Tests
- uv run pytest tests/test_cli.py -k 'repair_delegated_policy_settings or delegated_policy_setting_repair'
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check