### PR TITLE
Repair imported test inputs during apply

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.702"
+version = "0.2.703"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.702"
+__version__ = "0.2.703"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -18489,6 +18489,43 @@ def cmd_encode(args):
                         repaired_invalid_input_refs
                     )
             if not can_apply:
+                repaired_imported_inputs: list[str] = []
+                while not can_apply:
+                    repaired_refs = (
+                        _try_repair_generated_imported_test_inputs_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            issues=apply_issues,
+                        )
+                    )
+                    if not repaired_refs:
+                        break
+                    repaired_imported_inputs.extend(repaired_refs)
+                    outcome["auto_repaired_imported_test_inputs"] = (
+                        repaired_imported_inputs
+                    )
+                    print(
+                        "  apply=auto_repaired_imported_test_inputs:"
+                        + ",".join(repaired_refs)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+                if repaired_imported_inputs:
+                    outcome["auto_repaired_imported_test_inputs"] = (
+                        repaired_imported_inputs
+                    )
+            if not can_apply:
                 repaired_input_cases: list[str] = []
                 while not can_apply:
                     repaired_test_cases = (
@@ -25705,6 +25742,45 @@ def _try_repair_generated_invalid_test_inputs_for_apply(
     rules_file = Path(str(getattr(result, "output_file", "") or ""))
     test_file = _rulespec_test_path(rules_file)
     return _remove_invalid_test_input_refs(test_file=test_file, issues=issues)
+
+
+def _try_repair_generated_imported_test_inputs_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+    issues: list[str],
+) -> list[str]:
+    """Fill deterministic defaults for imported inputs in generated tests."""
+    if not issues:
+        return []
+
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    validation = argparse.Namespace(
+        results={
+            str(index): argparse.Namespace(error=str(issue))
+            for index, issue in enumerate(issues)
+        }
+    )
+    assignments = _missing_input_assignments_from_validation(validation)
+    if not assignments:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    test_file = _rulespec_test_path(rules_file)
+    repaired = _complete_missing_imported_test_inputs(
+        rules_file=rules_file,
+        test_file=test_file,
+        repo_path=policy_repo_path,
+        validation=validation,
+    )
+    if not repaired:
+        return []
+    return sorted({assignment["input"] for assignment in assignments})
 
 
 _SECTION_1401_A_OUTPUT = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12580,6 +12580,113 @@ rules: []
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_fills_imported_inputs_after_invalid_input_repair(
+        self, capsys, tmp_path
+    ):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+
+        imported_file = args.policy_repo_path / "statutes" / "26" / "1" / "h.yaml"
+        imported_file.parent.mkdir(parents=True)
+        imported_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: net_capital_gain
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          max(0, long_term_capital_gains - investment_income_amount)
+"""
+        )
+
+        output_file = (
+            tmp_path / "out" / "codex-test-model" / "statutes" / "26" / "199A.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/1/h#net_capital_gain
+rules: []
+"""
+        )
+        test_file = output_file.with_name("199A.test.yaml")
+        invalid_ref = "us:statutes/26/1#input.long_term_capital_gains"
+        test_file.write_text(
+            f"""- name: qbi_case
+  input:
+    {invalid_ref}: 100
+    us:statutes/26/1/h#input.long_term_capital_gains: 100
+  output:
+    us:statutes/26/199A#qbi_taxable_income_limit: 20000
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/26/199A.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "statutes/26/199A.yaml: ci: Test case "
+                            "`qbi_case` input invalid: input "
+                            f"`{invalid_ref}` does not resolve to an input slot "
+                            "in statutes/26/1.yaml."
+                        ],
+                        {},
+                    ),
+                    (
+                        False,
+                        [
+                            "statutes/26/199A.yaml: ci: Test case "
+                            "`qbi_case` execution failed: missing input "
+                            "`investment_income_amount`"
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert f"apply=auto_repaired_invalid_test_inputs:{invalid_ref}" in output
+        assert (
+            "apply=auto_repaired_imported_test_inputs:investment_income_amount"
+            in output
+        )
+        assert mock_overlay.call_count == 3
+        mock_apply.assert_called_once()
+        test_content = test_file.read_text()
+        assert invalid_ref not in test_content
+        assert "us:statutes/26/1/h#input.long_term_capital_gains: 100" in test_content
+        assert "us:statutes/26/1/h#input.investment_income_amount: 0" in test_content
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_invalid_test_inputs"] == [invalid_ref]
+        assert run.outcome["auto_repaired_imported_test_inputs"] == [
+            "investment_income_amount"
+        ]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_removes_unreferenced_proof_imports(self, capsys, tmp_path):
         args = self._make_args(tmp_path, backend="codex", sync=False)
         args.apply = True

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.702"
+version = "0.2.703"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- run the existing deterministic imported-test-input completion pass from encode --apply when overlay validation reports runtime missing imported inputs
- handle cases where invalid generated input cleanup reveals a second missing imported input error
- add regression coverage for invalid-input repair followed by imported-input repair

## Tests
- env -u UV_FROZEN uv lock
- uv run pytest tests/test_cli.py -k 'imported_test_inputs or invalid_imported_test_inputs or imported_inputs_after_invalid'
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check