### PR TITLE
Resolve cross-prefix import collisions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.703"
+version = "0.2.704"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.703"
+__version__ = "0.2.704"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -28442,9 +28442,16 @@ def _imported_module_exported_rule_names(
         if not isinstance(raw_import, str):
             continue
         resolved = _same_repo_import_base_and_file(raw_import, repo_path=repo_path)
-        if resolved is None:
+        import_file = (
+            resolved[1]
+            if resolved is not None
+            else _rulespec_file_for_absolute_module_ref(
+                raw_import,
+                policy_repo_path=repo_path,
+            )
+        )
+        if import_file is None:
             continue
-        _, import_file = resolved
         try:
             resolved_file = import_file.resolve()
         except OSError:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13830,6 +13830,74 @@ rules:
             "us:statutes/26/3306/d#pay_period_result": "holds",
         }
 
+    def test_imported_rule_name_collision_repair_resolves_cross_prefix_imports(
+        self, tmp_path
+    ):
+        state_repo = tmp_path / "rulespec-us-co"
+        federal_repo = tmp_path / "rulespec-us"
+        imported_file = federal_repo / "regulations/7-cfr/273/5.yaml"
+        rules_file = state_repo / "regulations/10-ccr-2506-1/4.306.yaml"
+        test_file = state_repo / "regulations/10-ccr-2506-1/4.306.test.yaml"
+        imported_file.parent.mkdir(parents=True)
+        rules_file.parent.mkdir(parents=True)
+        imported_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: snap_student_enrollment_status_active
+    kind: derived
+    versions:
+      - effective_from: '2019-06-14'
+        formula: student_school_term_has_begun
+"""
+        )
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:regulations/7-cfr/273/5
+rules:
+  - name: snap_student_enrollment_status_active
+    kind: derived
+    versions:
+      - effective_from: '2019-06-14'
+        formula: student_started_classes
+  - name: colorado_student_status
+    kind: derived
+    versions:
+      - effective_from: '2019-06-14'
+        formula: snap_student_enrollment_status_active
+"""
+        )
+        test_file.write_text(
+            """- name: active_case
+  output:
+    us-co:regulations/10-ccr-2506-1/4.306#snap_student_enrollment_status_active: holds
+    us-co:regulations/10-ccr-2506-1/4.306#colorado_student_status: holds
+"""
+        )
+
+        repaired = _repair_imported_rule_name_collisions(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=state_repo,
+            relative_output=Path("regulations/10-ccr-2506-1/4.306.yaml"),
+        )
+
+        rules_payload = yaml.safe_load(rules_file.read_text())
+        test_cases = yaml.safe_load(test_file.read_text())
+        assert repaired == ["snap_student_enrollment_status_active"]
+        assert [rule["name"] for rule in rules_payload["rules"]] == [
+            "local_snap_student_enrollment_status_active",
+            "colorado_student_status",
+        ]
+        assert (
+            rules_payload["rules"][1]["versions"][0]["formula"]
+            == "local_snap_student_enrollment_status_active"
+        )
+        assert test_cases[0]["output"] == {
+            "us-co:regulations/10-ccr-2506-1/4.306#local_snap_student_enrollment_status_active": "holds",
+            "us-co:regulations/10-ccr-2506-1/4.306#colorado_student_status": "holds",
+        }
+
     def test_upstream_placement_duplicate_repair_imports_existing_target(
         self, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.703"
+version = "0.2.704"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- let imported rule-name collision repair resolve cross-prefix imports such as us: modules from state RuleSpec repos
- add regression coverage for a rulespec-us-co file importing a sibling rulespec-us federal module
- bump axiom-encode to 0.2.704

## Tests
- env -u UV_FROZEN uv lock
- uv run pytest tests/test_cli.py -k 'imported_rule_name_collision_repair'
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check