### PR TITLE
Remove stale dependent output refs during apply

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.704"
+version = "0.2.705"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.704"
+__version__ = "0.2.705"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -16027,10 +16027,12 @@ def _ordered_unique_strings(values: list[str]) -> list[str]:
 
 def _unknown_output_refs_from_issues(issues: list[str]) -> set[str]:
     refs: set[str] = set()
-    pattern = r"unknown executable output (?P<output>\S+)"
     for issue in issues:
-        for match in re.finditer(pattern, str(issue)):
+        text = str(issue)
+        for match in re.finditer(r"unknown executable output (?P<output>\S+)", text):
             refs.add(match.group("output").strip())
+        for match in _UNRESOLVED_TEST_OUTPUT_ISSUE_PATTERN.finditer(text):
+            refs.add(match.group(1).strip())
     return refs
 
 
@@ -27454,6 +27456,23 @@ def _validate_generated_encoding_in_policy_overlay(
                     dependents=dependents,
                 )
                 continue
+            removed_unknown_outputs = _remove_unknown_dependent_test_outputs(
+                overlay_repo=overlay_repo,
+                relative_output=relative_output,
+                validations=validations,
+            )
+            if removed_unknown_outputs:
+                for path in removed_unknown_outputs:
+                    supplemental_files[path.relative_to(overlay_repo)] = (
+                        path.read_text()
+                    )
+                validations = _validate_overlay_files(
+                    pipeline,
+                    dependent_pipeline=dependent_pipeline,
+                    overlay_target=overlay_target,
+                    dependents=dependents,
+                )
+                continue
             removed_cross_module_outputs = _remove_cross_module_dependent_test_outputs(
                 overlay_repo=overlay_repo,
                 relative_output=relative_output,
@@ -29324,6 +29343,36 @@ def _invalid_dependent_test_input_ref_is_removable(
         _ABSOLUTE_RULESPEC_REF_RE.match(input_ref)
         and not _rulespec_ref_matches_base(input_ref, dependent_ref)
     )
+
+
+def _remove_unknown_dependent_test_outputs(
+    *,
+    overlay_repo: Path,
+    relative_output: Path,
+    validations: list[tuple[Path, object]],
+) -> list[Path]:
+    """Remove obsolete output assertions from dependent tests."""
+    changed: list[Path] = []
+    target_path = overlay_repo / relative_output
+    for validated_file, validation in validations:
+        if validated_file == target_path:
+            continue
+        test_path = _rulespec_test_path(validated_file)
+        if not test_path.exists():
+            continue
+        issues = [
+            str(result.error)
+            for result in validation.results.values()
+            if getattr(result, "error", None)
+        ]
+        removed = _remove_unknown_test_output_refs(
+            test_file=test_path,
+            issues=issues,
+        )
+        if not removed:
+            continue
+        changed.append(test_path)
+    return changed
 
 
 def _remove_cross_module_dependent_test_outputs(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,7 @@ from axiom_encode.cli import (
     _qualify_deferred_output_subsection_paths,
     _remove_cross_module_dependent_test_outputs,
     _remove_invalid_dependent_test_inputs,
+    _remove_unknown_dependent_test_outputs,
     _remove_unknown_test_output_refs,
     _repair_anaphoric_scope_identifiers,
     _repair_bare_indexed_parameter_references,
@@ -7883,6 +7884,54 @@ rules:
             "us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income"
             in repaired
         )
+
+    def test_remove_unknown_dependent_test_outputs_drops_stale_ref(self, tmp_path):
+        repo = tmp_path / "rulespec-us-co"
+        rules_file = repo / "policies/cdhs/snap/fy-2026-benefit-calculation.yaml"
+        test_file = repo / "policies/cdhs/snap/fy-2026-benefit-calculation.test.yaml"
+        target_file = repo / "regulations/10-ccr-2506-1/4.403.yaml"
+        rules_file.parent.mkdir(parents=True)
+        target_file.parent.mkdir(parents=True)
+        rules_file.write_text("format: rulespec/v1\nrules: []\n")
+        target_file.write_text("format: rulespec/v1\nrules: []\n")
+        test_file.write_text(
+            """- name: ongoing_month_derives_income_eligibility_and_colorado_allotment
+  period:
+    period_kind: month
+    start: '2026-01-01'
+    end: '2026-01-31'
+  input: {}
+  output:
+    us-co:regulations/10-ccr-2506-1/4.403#snap_countable_earned_income: 1200
+    us-co:policies/cdhs/snap/fy-2026-benefit-calculation#colorado_snap_allotment: 292
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    error=(
+                        "Test case "
+                        "`ongoing_month_derives_income_eligibility_and_colorado_allotment` "
+                        "output "
+                        "`us-co:regulations/10-ccr-2506-1/4.403#snap_countable_earned_income` "
+                        "does not resolve to a derived rule, or parameter in "
+                        "regulations/10-ccr-2506-1/4.403.yaml."
+                    )
+                )
+            }
+        )
+
+        changed = _remove_unknown_dependent_test_outputs(
+            overlay_repo=repo,
+            relative_output=Path("regulations/10-ccr-2506-1/4.403.yaml"),
+            validations=[(rules_file, validation)],
+        )
+
+        assert changed == [test_file]
+        repaired = yaml.safe_load(test_file.read_text())
+        assert repaired[0]["output"] == {
+            "us-co:policies/cdhs/snap/fy-2026-benefit-calculation#colorado_snap_allotment": 292
+        }
 
     def test_remove_unknown_test_output_refs_drops_stale_outputs(self, tmp_path):
         test_file = tmp_path / "policy.test.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.704"
+version = "0.2.705"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Parse unresolved test-output validation messages as unknown output refs
- Remove stale output assertions from dependent tests during generated apply overlay repair
- Bump axiom-encode to 0.2.705

## Tests
- uv run pytest tests/test_cli.py -k 'unknown_test_output_refs or unknown_dependent_test_outputs'
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check