### PR TITLE
Convert stale dependent outputs into local inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.705"
+version = "0.2.706"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.705"
+__version__ = "0.2.706"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -29354,6 +29354,7 @@ def _remove_unknown_dependent_test_outputs(
     """Remove obsolete output assertions from dependent tests."""
     changed: list[Path] = []
     target_path = overlay_repo / relative_output
+    jurisdiction = _repo_jurisdiction_prefix(overlay_repo)
     for validated_file, validation in validations:
         if validated_file == target_path:
             continue
@@ -29365,14 +29366,77 @@ def _remove_unknown_dependent_test_outputs(
             for result in validation.results.values()
             if getattr(result, "error", None)
         ]
-        removed = _remove_unknown_test_output_refs(
-            test_file=test_path,
-            issues=issues,
-        )
-        if not removed:
+        unknown_refs = _unknown_output_refs_from_issues(issues)
+        if not unknown_refs:
             continue
+        try:
+            relative_validated = validated_file.relative_to(overlay_repo)
+            test_cases = yaml.safe_load(test_path.read_text()) or []
+        except (OSError, ValueError, yaml.YAMLError):
+            continue
+        if not isinstance(test_cases, list):
+            continue
+
+        dependent_base = (
+            f"{jurisdiction}:{_relative_rulespec_import_target(relative_validated)}"
+        )
+        local_input_names = _dependent_local_formula_input_names(
+            validated_file,
+            repo_path=overlay_repo,
+        )
+        removable_refs = _expand_refs_with_matching_test_output_keys(
+            test_cases,
+            unknown_refs,
+        )
+        if not removable_refs:
+            continue
+
+        file_changed = False
+        for test_case in test_cases:
+            if not isinstance(test_case, dict):
+                continue
+            outputs = test_case.get("output")
+            if not isinstance(outputs, dict):
+                continue
+            for output_ref in list(outputs):
+                output_text = str(output_ref)
+                if output_text not in removable_refs:
+                    continue
+                output_name = output_text.rsplit("#", 1)[-1].strip()
+                output_value = outputs.pop(output_ref)
+                if output_name in local_input_names:
+                    inputs = test_case.setdefault("input", {})
+                    if isinstance(inputs, dict):
+                        input_ref = f"{dependent_base}#input.{output_name}"
+                        inputs.setdefault(input_ref, output_value)
+                file_changed = True
+        if not file_changed:
+            continue
+        test_path.write_text(
+            yaml.safe_dump(test_cases, sort_keys=False, allow_unicode=False)
+        )
         changed.append(test_path)
     return changed
+
+
+def _dependent_local_formula_input_names(
+    rules_file: Path,
+    *,
+    repo_path: Path,
+) -> set[str]:
+    try:
+        rules_content = rules_file.read_text()
+        payload = yaml.safe_load(rules_content) or {}
+    except (OSError, ValueError, yaml.YAMLError):
+        return set()
+    input_names = _local_factual_input_names_from_rules_content(rules_content)
+    imports = payload.get("imports") if isinstance(payload, dict) else []
+    if isinstance(imports, list):
+        input_names -= _imported_module_exported_rule_names(
+            imports,
+            repo_path=repo_path,
+        )
+    return input_names
 
 
 def _remove_cross_module_dependent_test_outputs(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7933,6 +7933,68 @@ rules:
             "us-co:policies/cdhs/snap/fy-2026-benefit-calculation#colorado_snap_allotment": 292
         }
 
+    def test_remove_unknown_dependent_test_outputs_moves_local_input_value(
+        self, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us-co"
+        rules_file = repo / "policies/cdhs/snap/fy-2026-benefit-calculation.yaml"
+        test_file = repo / "policies/cdhs/snap/fy-2026-benefit-calculation.test.yaml"
+        target_file = repo / "regulations/10-ccr-2506-1/4.403.yaml"
+        rules_file.parent.mkdir(parents=True)
+        target_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+- us-co:regulations/10-ccr-2506-1/4.403
+rules:
+- name: snap_gross_monthly_earned_income
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2026-01-01'
+    formula: snap_countable_earned_income
+"""
+        )
+        target_file.write_text("format: rulespec/v1\nrules: []\n")
+        test_file.write_text(
+            """- name: ongoing_month
+  period: 2026-01
+  input: {}
+  output:
+    us-co:regulations/10-ccr-2506-1/4.403#snap_countable_earned_income: 1000
+    us-co:policies/cdhs/snap/fy-2026-benefit-calculation#snap_gross_monthly_earned_income: 1000
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    error=(
+                        "Test case `ongoing_month` output "
+                        "`us-co:regulations/10-ccr-2506-1/4.403#snap_countable_earned_income` "
+                        "does not resolve to a derived rule, or parameter in "
+                        "regulations/10-ccr-2506-1/4.403.yaml."
+                    )
+                )
+            }
+        )
+
+        changed = _remove_unknown_dependent_test_outputs(
+            overlay_repo=repo,
+            relative_output=Path("regulations/10-ccr-2506-1/4.403.yaml"),
+            validations=[(rules_file, validation)],
+        )
+
+        assert changed == [test_file]
+        repaired = yaml.safe_load(test_file.read_text())
+        assert repaired[0]["input"] == {
+            "us-co:policies/cdhs/snap/fy-2026-benefit-calculation#input.snap_countable_earned_income": 1000
+        }
+        assert repaired[0]["output"] == {
+            "us-co:policies/cdhs/snap/fy-2026-benefit-calculation#snap_gross_monthly_earned_income": 1000
+        }
+
     def test_remove_unknown_test_output_refs_drops_stale_outputs(self, tmp_path):
         test_file = tmp_path / "policy.test.yaml"
         test_file.write_text(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.705"
+version = "0.2.706"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Preserve stale dependent output assertion values as local inputs when a dependent policy now consumes the same symbol as an implicit input
- Keep removing stale dependent output assertions when they are not consumed locally
- Bump axiom-encode to 0.2.706

## Tests
- uv run pytest tests/test_cli.py -k 'unknown_dependent_test_outputs or unknown_test_output_refs'
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check