### PR TITLE
Repair unit-scoped generated person definitions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.706"
+version = "0.2.707"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.706"
+__version__ = "0.2.707"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -18014,6 +18014,34 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_unit_scoped_definitions = (
+                    _try_repair_generated_unit_scoped_person_definition_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_unit_scoped_definitions:
+                    outcome["auto_repaired_unit_scoped_person_definition"] = (
+                        repaired_unit_scoped_definitions
+                    )
+                    print(
+                        "  apply=auto_repaired_unit_scoped_person_definition:"
+                        + ",".join(repaired_unit_scoped_definitions)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_person_scoped_definitions = (
                     _try_repair_generated_person_scoped_definition_for_apply(
                         result,
@@ -25297,6 +25325,111 @@ def _remove_test_outputs_for_rule_names(test_file: Path, rule_names: set[str]) -
         test_file.write_text(
             yaml.safe_dump(repaired_cases, sort_keys=False, allow_unicode=False)
         )
+
+
+def _try_repair_generated_unit_scoped_person_definition_for_apply(
+    result,
+    *,
+    output_root: Path,
+    issues: list[str],
+) -> list[str]:
+    """Move generated Person definitions to the source-stated unit scope."""
+    target_names = _unit_scoped_person_definition_issue_names(issues)
+    if not target_names:
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    return _repair_unit_scoped_person_definition_entities(
+        rules_file=rules_file,
+        target_names=target_names,
+    )
+
+
+def _unit_scoped_person_definition_issue_names(issues: list[str]) -> list[str]:
+    names: list[str] = []
+    for issue in issues:
+        match = _SOURCE_SCOPE_UNIT_MISMATCH_PERSON_ISSUE_PATTERN.search(str(issue))
+        if match is not None:
+            names.append(match.group(1))
+    return names
+
+
+def _repair_unit_scoped_person_definition_entities(
+    *,
+    rules_file: Path,
+    target_names: list[str],
+) -> list[str]:
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    unit_entity = _dominant_unit_entity_name(rules)
+    by_name = {
+        str(rule.get("name")).strip(): rule
+        for rule in rules
+        if isinstance(rule, dict)
+        and isinstance(rule.get("name"), str)
+        and str(rule.get("name")).strip()
+    }
+    repaired: list[str] = []
+    for target_name in dict.fromkeys(target_names):
+        target_rule = by_name.get(target_name)
+        if not isinstance(target_rule, dict):
+            continue
+        if _set_rule_entity_to_unit(target_rule, unit_entity=unit_entity):
+            repaired.append(target_name)
+
+    if not repaired:
+        return []
+
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repaired
+
+
+def _dominant_unit_entity_name(rules: list[object]) -> str:
+    canonical = {
+        "family": "Family",
+        "household": "Household",
+        "snapunit": "SnapUnit",
+        "spmunit": "SPMUnit",
+        "taxunit": "TaxUnit",
+    }
+    counts: dict[str, int] = {}
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        normalized = str(rule.get("entity") or "").replace("_", "").lower()
+        if normalized not in _UNIT_ENTITY_NAMES:
+            continue
+        counts[normalized] = counts.get(normalized, 0) + 1
+    if not counts:
+        return "Household"
+    dominant = max(counts, key=lambda name: (counts[name], name))
+    return canonical.get(dominant, "Household")
+
+
+def _set_rule_entity_to_unit(
+    rule: dict[str, object],
+    *,
+    unit_entity: str,
+) -> bool:
+    entity = str(rule.get("entity") or "").strip()
+    if entity != "Person":
+        return False
+    rule["entity"] = unit_entity
+    return True
 
 
 def _try_repair_generated_person_scoped_definition_for_apply(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,6 +89,7 @@ from axiom_encode.cli import (
     _repair_shared_statutory_rate_names,
     _repair_snap_2014c_income_standard_test_inputs,
     _repair_tax_filing_status_branches,
+    _repair_unit_scoped_person_definition_entities,
     _repair_upstream_placement_duplicate_imports,
     _require_axiom_encode_version_provenance,
     _rewrite_gpt_runner_backend,
@@ -121,6 +122,7 @@ from axiom_encode.cli import (
     _try_repair_generated_source_table_band_scalars_for_apply,
     _try_repair_generated_unresolved_local_test_outputs_for_apply,
     _try_repair_generated_unsafe_formula_outputs_for_apply,
+    _unit_scoped_person_definition_issue_names,
     _validate_generated_encoding_in_policy_overlay,
     _write_applied_encoding_manifest,
     _write_overlay_eval_source_metadata_for_generated_output,
@@ -7493,6 +7495,57 @@ rules:
 
         assert _medicaid_magi_income_helper_issue_names(issues) == [
             "household_income_at_or_below_state_section_1931_income_standard"
+        ]
+
+    def test_unit_scoped_person_definition_issue_names(self):
+        issues = [
+            "Source scope mismatch: `llc_or_s_corporation_owner_earned_income` "
+            "is declared on `Person`, but the embedded source states a "
+            "household/unit-scoped test. Encode the rule at the source-stated "
+            "unit scope or cite source text that states the person-level test."
+        ]
+
+        assert _unit_scoped_person_definition_issue_names(issues) == [
+            "llc_or_s_corporation_owner_earned_income"
+        ]
+
+    def test_repair_unit_scoped_person_definition_entities_uses_dominant_unit(
+        self, tmp_path
+    ):
+        rules_file = tmp_path / "regulations/10-ccr-2506-1/4.403.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: llc_or_s_corporation_owner_earned_income
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2026-01-01'
+    formula: salary_payments_for_services_as_employee
+- name: boarder_income_to_household
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2026-01-01'
+    formula: direct_boarder_payments_to_household
+"""
+        )
+
+        repaired = _repair_unit_scoped_person_definition_entities(
+            rules_file=rules_file,
+            target_names=["llc_or_s_corporation_owner_earned_income"],
+        )
+
+        assert repaired == ["llc_or_s_corporation_owner_earned_income"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert [rule["entity"] for rule in payload["rules"]] == [
+            "Household",
+            "Household",
         ]
 
     def test_inline_medicaid_magi_income_helpers_removes_one_use_income_helper(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.706"
+version = "0.2.707"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Add an apply repair for generated Person definitions when source verification says the rule is unit-scoped
- Use the dominant unit entity already present in the generated file, defaulting to Household
- Bump axiom-encode to 0.2.707

## Tests
- uv run pytest tests/test_cli.py -k 'unit_scoped_person_definition or medicaid_magi_income_helper_issue_names'
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check