### PR TITLE
Repair dependent apply input completion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.708"
+version = "0.2.709"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.707"
+version = "0.2.708"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.707"
+__version__ = "0.2.708"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.708"
+__version__ = "0.2.709"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -27790,8 +27790,9 @@ def _validate_generated_encoding_in_policy_overlay(
             for validator_result in validation.results.values():
                 if validator_result.error:
                     relative_file = validated_file.relative_to(overlay_repo)
+                    validator_name = getattr(validator_result, "validator_name", "ci")
                     issues.append(
-                        f"{relative_file}: {validator_result.validator_name}: {validator_result.error}"
+                        f"{relative_file}: {validator_name}: {validator_result.error}"
                     )
         return False, issues, {}
 
@@ -30326,11 +30327,6 @@ def _default_refs_for_missing_input(
         (reference, value)
         for reference, value in baseline_inputs.items()
         if reference.endswith(suffix)
-        and not (
-            target_input_names is not None
-            and input_name not in target_input_names
-            and _rulespec_ref_matches_base(reference, target_ref)
-        )
     ]
     if matches:
         return matches

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -14426,7 +14426,7 @@ def _append_exception_positive_companion_tests_if_missing(
     relative_output: Path,
     issues: list[str],
 ) -> list[str]:
-    """Clone generated negative exception tests into paired positive companions."""
+    """Clone generated exception tests into missing paired companions."""
     if not issues or not test_file.exists():
         return []
     repair_specs = _exception_test_repair_specs_from_issues(issues)
@@ -14451,30 +14451,48 @@ def _append_exception_positive_companion_tests_if_missing(
         if isinstance(test_case, dict)
     }
     for rule_name, exception_input in repair_specs:
-        case_name = (
-            f"auto_positive_{_safe_test_name(rule_name)}_"
-            f"{_safe_test_name(exception_input)}"
-        )
-        if case_name in existing_case_names:
-            continue
-        if _has_exception_positive_companion_case(
+        if not _has_exception_positive_companion_case(
             test_payload,
             rule_name=rule_name,
             exception_input=exception_input,
         ):
-            continue
-        companion = _build_exception_positive_companion_case(
+            case_name = _unique_generated_test_name(
+                f"auto_positive_{_safe_test_name(rule_name)}_"
+                f"{_safe_test_name(exception_input)}",
+                existing_case_names,
+            )
+            companion = _build_exception_positive_companion_case(
+                test_payload,
+                target_base=target_base,
+                case_name=case_name,
+                rule_name=rule_name,
+                exception_input=exception_input,
+            )
+            if companion is not None:
+                test_payload.append(companion)
+                existing_case_names.add(case_name)
+                repaired.append(case_name)
+        if not _has_exception_negative_companion_case(
             test_payload,
-            target_base=target_base,
-            case_name=case_name,
             rule_name=rule_name,
             exception_input=exception_input,
-        )
-        if companion is None:
-            continue
-        test_payload.append(companion)
-        existing_case_names.add(case_name)
-        repaired.append(case_name)
+        ):
+            case_name = _unique_generated_test_name(
+                f"auto_negative_{_safe_test_name(rule_name)}_"
+                f"{_safe_test_name(exception_input)}",
+                existing_case_names,
+            )
+            companion = _build_exception_negative_companion_case(
+                test_payload,
+                target_base=target_base,
+                case_name=case_name,
+                rule_name=rule_name,
+                exception_input=exception_input,
+            )
+            if companion is not None:
+                test_payload.append(companion)
+                existing_case_names.add(case_name)
+                repaired.append(case_name)
 
     if not repaired:
         return []
@@ -14552,6 +14570,53 @@ def _build_exception_positive_companion_case(
     return None
 
 
+def _build_exception_negative_companion_case(
+    test_payload: list[object],
+    *,
+    target_base: str,
+    case_name: str,
+    rule_name: str,
+    exception_input: str,
+) -> dict[str, object] | None:
+    for test_case in test_payload:
+        if not isinstance(test_case, dict):
+            continue
+        inputs = test_case.get("input")
+        outputs = test_case.get("output")
+        if not isinstance(inputs, dict) or not isinstance(outputs, dict):
+            continue
+        if not _case_sets_exception_input(
+            inputs, exception_input=exception_input, value=False
+        ):
+            continue
+        if not _case_asserts_rule_value(
+            outputs, rule_name=rule_name, normalized_value="holds"
+        ):
+            continue
+        companion = copy.deepcopy(test_case)
+        companion["name"] = case_name
+        companion_inputs = companion.get("input")
+        companion_outputs = companion.get("output")
+        if not isinstance(companion_inputs, dict) or not isinstance(
+            companion_outputs, dict
+        ):
+            return None
+        _set_exception_input_value(
+            companion_inputs,
+            target_base=target_base,
+            exception_input=exception_input,
+            value=True,
+        )
+        _set_rule_output_value(
+            companion_outputs,
+            target_base=target_base,
+            rule_name=rule_name,
+            value="not_holds",
+        )
+        return companion
+    return None
+
+
 def _has_exception_positive_companion_case(
     test_payload: list[object],
     *,
@@ -14571,6 +14636,30 @@ def _has_exception_positive_companion_case(
             continue
         if _case_asserts_rule_value(
             outputs, rule_name=rule_name, normalized_value="holds"
+        ):
+            return True
+    return False
+
+
+def _has_exception_negative_companion_case(
+    test_payload: list[object],
+    *,
+    rule_name: str,
+    exception_input: str,
+) -> bool:
+    for test_case in test_payload:
+        if not isinstance(test_case, dict):
+            continue
+        inputs = test_case.get("input")
+        outputs = test_case.get("output")
+        if not isinstance(inputs, dict) or not isinstance(outputs, dict):
+            continue
+        if not _case_sets_exception_input(
+            inputs, exception_input=exception_input, value=True
+        ):
+            continue
+        if _case_asserts_rule_value(
+            outputs, rule_name=rule_name, normalized_value="not_holds"
         ):
             return True
     return False
@@ -18452,6 +18541,35 @@ def cmd_encode(args):
                         repaired_positive_cases
                     )
             if not can_apply:
+                repaired_exception_cases = list(
+                    outcome.get("auto_repaired_exception_tests") or []
+                )
+                repaired_test_cases = _try_repair_generated_exception_tests_for_apply(
+                    result,
+                    output_root=args.output,
+                    policy_repo_path=policy_repo_path,
+                    issues=apply_issues,
+                )
+                if repaired_test_cases:
+                    repaired_exception_cases.extend(repaired_test_cases)
+                    outcome["auto_repaired_exception_tests"] = repaired_exception_cases
+                    print(
+                        "  apply=auto_repaired_exception_tests:"
+                        + ",".join(repaired_test_cases)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_input_refs: list[str] = []
                 while not can_apply:
                     repaired_refs = (
@@ -18709,6 +18827,35 @@ def cmd_encode(args):
                     ]
                     print(
                         "  apply=auto_repaired_judgment_positive_tests:"
+                        + ",".join(repaired_test_cases)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
+                repaired_exception_cases = list(
+                    outcome.get("auto_repaired_exception_tests") or []
+                )
+                repaired_test_cases = _try_repair_generated_exception_tests_for_apply(
+                    result,
+                    output_root=args.output,
+                    policy_repo_path=policy_repo_path,
+                    issues=apply_issues,
+                )
+                if repaired_test_cases:
+                    repaired_exception_cases.extend(repaired_test_cases)
+                    outcome["auto_repaired_exception_tests"] = repaired_exception_cases
+                    print(
+                        "  apply=auto_repaired_exception_tests:"
                         + ",".join(repaired_test_cases)
                     )
                     can_apply, apply_issues, supplemental_files = (
@@ -29414,6 +29561,17 @@ def _remove_invalid_dependent_test_inputs(
         f"{_repo_jurisdiction_prefix(overlay_repo)}:"
         f"{_relative_rulespec_import_target(relative_output)}"
     )
+    target_input_names: set[str] = set()
+    target_output_names: set[str] = set()
+    target_file = overlay_repo / relative_output
+    if target_file.exists():
+        with contextlib.suppress(OSError, ValueError, yaml.YAMLError):
+            target_content = target_file.read_text()
+            target_input_names = _local_factual_input_names_from_rules_content(
+                target_content
+            )
+            target_payload = yaml.safe_load(target_content) or {}
+            target_output_names = set(_rules_by_name_from_payload(target_payload))
     changed: list[Path] = []
     for validated_file, validation in validations:
         if validated_file == overlay_repo / relative_output:
@@ -29447,15 +29605,121 @@ def _remove_invalid_dependent_test_inputs(
             test_payload = yaml.safe_load(content) or []
         except (OSError, ValueError, yaml.YAMLError):
             continue
+        has_target_invalid_ref = any(
+            _rulespec_ref_matches_base(input_ref, target_ref)
+            for input_ref in invalid_refs
+        )
+        if has_target_invalid_ref:
+            invalid_refs.update(
+                _stale_target_input_refs_in_test_payload(
+                    test_payload,
+                    target_ref=target_ref,
+                    target_input_names=target_input_names,
+                )
+            )
         removable_refs = _expand_refs_with_matching_test_input_keys(
             test_payload,
             invalid_refs,
         )
         updated = _remove_input_refs_from_test_cases(content, removable_refs)
+        if has_target_invalid_ref:
+            try:
+                updated_payload = yaml.safe_load(updated) or []
+            except (OSError, ValueError, yaml.YAMLError):
+                updated_payload = None
+            if isinstance(updated_payload, list) and _remove_stale_target_outputs(
+                updated_payload,
+                target_ref=target_ref,
+                target_output_names=target_output_names,
+                dependent_ref=dependent_ref,
+                local_input_names=_dependent_local_formula_input_names(
+                    validated_file,
+                    repo_path=overlay_repo,
+                ),
+            ):
+                updated = yaml.safe_dump(
+                    updated_payload,
+                    sort_keys=False,
+                    allow_unicode=False,
+                )
         if updated == content:
             continue
         test_path.write_text(updated)
         changed.append(test_path)
+    return changed
+
+
+def _stale_target_input_refs_in_test_payload(
+    test_payload: object,
+    *,
+    target_ref: str,
+    target_input_names: set[str],
+) -> set[str]:
+    if not isinstance(test_payload, list):
+        return set()
+    stale_refs: set[str] = set()
+    for test_case in test_payload:
+        if not isinstance(test_case, dict):
+            continue
+        inputs = test_case.get("input")
+        for input_ref in _rulespec_input_refs_from_value(inputs):
+            if not _rulespec_ref_matches_base(input_ref, target_ref):
+                continue
+            if "#input." not in input_ref:
+                continue
+            input_name = input_ref.split("#input.", 1)[1].strip()
+            if input_name and input_name not in target_input_names:
+                stale_refs.add(input_ref)
+    return stale_refs
+
+
+def _rulespec_input_refs_from_value(value: object) -> set[str]:
+    refs: set[str] = set()
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            key_text = str(key)
+            if "#input." in key_text:
+                refs.add(key_text)
+            refs.update(_rulespec_input_refs_from_value(nested))
+    elif isinstance(value, list):
+        for item in value:
+            refs.update(_rulespec_input_refs_from_value(item))
+    return refs
+
+
+def _remove_stale_target_outputs(
+    test_payload: list[object],
+    *,
+    target_ref: str,
+    target_output_names: set[str],
+    dependent_ref: str,
+    local_input_names: set[str],
+) -> bool:
+    changed = False
+    for test_case in test_payload:
+        if not isinstance(test_case, dict):
+            continue
+        outputs = test_case.get("output")
+        if not isinstance(outputs, dict):
+            continue
+        for output_ref in list(outputs):
+            output_text = str(output_ref)
+            if not _rulespec_ref_matches_base(output_text, target_ref):
+                continue
+            if "#" not in output_text:
+                continue
+            output_name = output_text.rsplit("#", 1)[1].strip()
+            if not output_name or output_name in target_output_names:
+                continue
+            output_value = outputs.pop(output_ref)
+            if output_name in local_input_names:
+                inputs = test_case.setdefault("input", {})
+                if isinstance(inputs, dict):
+                    inputs.setdefault(
+                        f"{dependent_ref}#input.{output_name}",
+                        output_value,
+                    )
+            changed = True
     return changed
 
 
@@ -29675,13 +29939,17 @@ def _complete_missing_dependent_test_inputs(
         f"{_repo_jurisdiction_prefix(overlay_repo)}:"
         f"{_relative_rulespec_import_target(relative_output)}"
     )
-    baseline_inputs = _load_test_input_baseline(
-        _rulespec_test_path(overlay_repo / relative_output)
-    )
-    imported_inputs = _imported_input_refs_by_name(
-        overlay_repo / relative_output,
+    target_file = overlay_repo / relative_output
+    target_baseline_inputs = _load_test_input_baseline(_rulespec_test_path(target_file))
+    target_imported_inputs = _imported_input_refs_by_name(
+        target_file,
         repo_path=overlay_repo,
     )
+    target_input_names: set[str] = set()
+    with contextlib.suppress(OSError, ValueError, yaml.YAMLError):
+        target_input_names = _local_factual_input_names_from_rules_content(
+            target_file.read_text()
+        )
     changed: list[Path] = []
     for validated_file, validation in validations:
         if validated_file == overlay_repo / relative_output:
@@ -29689,6 +29957,14 @@ def _complete_missing_dependent_test_inputs(
         test_path = _rulespec_test_path(validated_file)
         if not test_path.exists():
             continue
+        try:
+            relative_validated = validated_file.relative_to(overlay_repo)
+        except ValueError:
+            continue
+        dependent_ref = (
+            f"{_repo_jurisdiction_prefix(overlay_repo)}:"
+            f"{_relative_rulespec_import_target(relative_validated)}"
+        )
         missing_inputs: set[str] = set()
         for validator_result in validation.results.values():
             error = validator_result.error or ""
@@ -29696,6 +29972,28 @@ def _complete_missing_dependent_test_inputs(
                 missing_inputs.add(match.group("input"))
         if not missing_inputs:
             continue
+        baseline_inputs = dict(target_baseline_inputs)
+        baseline_inputs.update(_load_test_input_baseline(test_path))
+        imported_inputs = _merge_imported_input_refs_by_name(
+            _imported_input_refs_by_name(
+                validated_file,
+                repo_path=overlay_repo,
+            ),
+            target_imported_inputs,
+        )
+        local_input_refs: dict[str, list[str]] = {}
+        for input_name in sorted(
+            _dependent_local_formula_input_names(validated_file, repo_path=overlay_repo)
+        ):
+            _append_unique_input_ref(
+                local_input_refs,
+                input_name,
+                f"{dependent_ref}#input.{input_name}",
+            )
+        imported_inputs = _merge_imported_input_refs_by_name(
+            local_input_refs,
+            imported_inputs,
+        )
         content = test_path.read_text()
         updated = content
         for input_name in sorted(missing_inputs):
@@ -29704,6 +30002,7 @@ def _complete_missing_dependent_test_inputs(
                 target_ref=target_ref,
                 baseline_inputs=baseline_inputs,
                 imported_inputs=imported_inputs,
+                target_input_names=target_input_names,
             ):
                 updated = _insert_input_default_in_test_cases(
                     updated,
@@ -29714,6 +30013,17 @@ def _complete_missing_dependent_test_inputs(
             test_path.write_text(updated)
             changed.append(test_path)
     return changed
+
+
+def _merge_imported_input_refs_by_name(
+    *input_maps: dict[str, list[str]],
+) -> dict[str, list[str]]:
+    merged: dict[str, list[str]] = {}
+    for input_map in input_maps:
+        for input_name, input_refs in input_map.items():
+            for input_ref in input_refs:
+                _append_unique_input_ref(merged, input_name, input_ref)
+    return merged
 
 
 def _complete_missing_imported_test_inputs(
@@ -29979,9 +30289,10 @@ def _import_base_to_repo_file(import_base: str, *, repo_path: Path) -> Path | No
         return None
     if ":" in normalized:
         _, normalized = normalized.split(":", 1)
-    relative = Path(normalized)
-    if relative.suffix not in {".yaml", ".yml"}:
-        relative = relative.with_suffix(".yaml")
+    if normalized.endswith((".yaml", ".yml")):
+        relative = Path(normalized)
+    else:
+        relative = Path(f"{normalized}.yaml")
     return repo_path / relative
 
 
@@ -30008,12 +30319,18 @@ def _default_refs_for_missing_input(
     target_ref: str,
     baseline_inputs: dict[str, object],
     imported_inputs: dict[str, list[str]] | None = None,
+    target_input_names: set[str] | None = None,
 ) -> list[tuple[str, object]]:
     suffix = f"#input.{input_name}"
     matches = [
         (reference, value)
         for reference, value in baseline_inputs.items()
         if reference.endswith(suffix)
+        and not (
+            target_input_names is not None
+            and input_name not in target_input_names
+            and _rulespec_ref_matches_base(reference, target_ref)
+        )
     ]
     if matches:
         return matches
@@ -30023,6 +30340,8 @@ def _default_refs_for_missing_input(
     ]
     if imported_matches:
         return imported_matches
+    if target_input_names is not None and input_name not in target_input_names:
+        return []
     return [
         (f"{target_ref}#input.{input_name}", _infer_missing_input_default(input_name))
     ]
@@ -30037,10 +30356,14 @@ def _infer_missing_input_default(input_name: str) -> object:
         "amount",
         "base",
         "count",
+        "cost",
+        "costs",
         "credit",
         "deduction",
         "expense",
         "gross",
+        "hour",
+        "hours",
         "income",
         "limit",
         "net",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7849,7 +7849,19 @@ rules:
         target_file = repo / "statutes/26/32/c/2.yaml"
         rules_file.parent.mkdir(parents=True)
         target_file.parent.mkdir(parents=True)
-        rules_file.write_text("format: rulespec/v1\nrules: []\n")
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: bridge_output
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2026-01-01'
+    formula: snap_countable_earned_income
+"""
+        )
         target_file.write_text("format: rulespec/v1\nrules: []\n")
         test_file.write_text(
             """- name: mixed_case
@@ -7892,7 +7904,19 @@ rules:
         target_file = repo / "statutes/26/32/c/2.yaml"
         rules_file.parent.mkdir(parents=True)
         target_file.parent.mkdir(parents=True)
-        rules_file.write_text("format: rulespec/v1\nrules: []\n")
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: bridge_output
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2026-01-01'
+    formula: snap_countable_earned_income
+"""
+        )
         target_file.write_text("format: rulespec/v1\nrules: []\n")
         test_file.write_text(
             """- name: stale_cross_module_input
@@ -7937,6 +7961,88 @@ rules:
             "us:statutes/26/32/c/2#input.wages_salaries_tips_and_other_employee_compensation_includible_in_gross_income"
             in repaired
         )
+
+    def test_remove_invalid_dependent_test_inputs_batches_target_stale_refs(
+        self, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us-co"
+        rules_file = repo / "policies/cdhs/snap/fy-2026-benefit-calculation.yaml"
+        test_file = repo / "policies/cdhs/snap/fy-2026-benefit-calculation.test.yaml"
+        target_file = repo / "regulations/10-ccr-2506-1/4.403.yaml"
+        rules_file.parent.mkdir(parents=True)
+        target_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: bridge_output
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2026-01-01'
+    formula: snap_countable_earned_income
+"""
+        )
+        target_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: replacement_output
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2026-01-01'
+    formula: valid_replacement_input
+"""
+        )
+        reported_ref = "us-co:regulations/10-ccr-2506-1/4.403#input.old_rental_hours"
+        stale_ref = "us-co:regulations/10-ccr-2506-1/4.403#input.old_rental_income"
+        valid_ref = (
+            "us-co:regulations/10-ccr-2506-1/4.403#input.valid_replacement_input"
+        )
+        test_file.write_text(
+            f"""- name: ongoing_month
+  period: 2026-01
+  input:
+    {reported_ref}: 0
+    {stale_ref}: 100
+    {valid_ref}: 200
+    us-co:policies/cdhs/snap/fy-2026-benefit-calculation#input.local_bridge: 1
+  output:
+    us-co:regulations/10-ccr-2506-1/4.403#snap_countable_earned_income: 1000
+    us-co:policies/cdhs/snap/fy-2026-benefit-calculation#colorado_snap_allotment: 292
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    error=(
+                        "Test case `ongoing_month` input invalid: input "
+                        f"`{reported_ref}` does not resolve to an input slot "
+                        "in regulations/10-ccr-2506-1/4.403.yaml."
+                    )
+                )
+            }
+        )
+
+        changed = _remove_invalid_dependent_test_inputs(
+            overlay_repo=repo,
+            relative_output=Path("regulations/10-ccr-2506-1/4.403.yaml"),
+            validations=[(rules_file, validation)],
+        )
+
+        assert changed == [test_file]
+        repaired = yaml.safe_load(test_file.read_text())
+        assert repaired[0]["input"] == {
+            valid_ref: 200,
+            "us-co:policies/cdhs/snap/fy-2026-benefit-calculation#input.local_bridge": 1,
+            "us-co:policies/cdhs/snap/fy-2026-benefit-calculation#input.snap_countable_earned_income": 1000,
+        }
+        assert repaired[0]["output"] == {
+            "us-co:policies/cdhs/snap/fy-2026-benefit-calculation#colorado_snap_allotment": 292
+        }
 
     def test_remove_unknown_dependent_test_outputs_drops_stale_ref(self, tmp_path):
         repo = tmp_path / "rulespec-us-co"
@@ -8238,6 +8344,99 @@ rules:
         )
         assert (
             "us:statutes/26/32/c/2#input.individual_is_nonresident_alien"
+            not in repaired
+        )
+
+    def test_complete_missing_dependent_test_inputs_uses_dependent_import_ref(
+        self, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us-co"
+        target_file = repo / "regulations/10-ccr-2506-1/4.403.yaml"
+        dependent_file = repo / "policies/cdhs/snap/fy-2026-benefit-calculation.yaml"
+        sibling_import_file = repo / "regulations/10-ccr-2506-1/4.404.yaml"
+        test_file = repo / "policies/cdhs/snap/fy-2026-benefit-calculation.test.yaml"
+        target_file.parent.mkdir(parents=True)
+        dependent_file.parent.mkdir(parents=True, exist_ok=True)
+        sibling_import_file.parent.mkdir(parents=True, exist_ok=True)
+        target_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: rental_self_employment_property_income_considered_earned_income
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: average_hours_per_week_actively_managing_property >= 20
+"""
+        )
+        sibling_import_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: snap_countable_unearned_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if average_rental_property_management_hours_per_week < 20:
+              rental_property_gross_income
+          else:
+              0
+"""
+        )
+        dependent_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us-co:regulations/10-ccr-2506-1/4.403
+  - us-co:regulations/10-ccr-2506-1/4.404
+rules:
+  - name: snap_total_monthly_unearned_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: snap_countable_unearned_income
+"""
+        )
+        test_file.write_text(
+            """- name: dependent_case
+  input: {}
+  output:
+    us-co:policies/cdhs/snap/fy-2026-benefit-calculation#snap_total_monthly_unearned_income: 100
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    error=(
+                        "Test case `dependent_case` execution failed: missing input "
+                        "`average_rental_property_management_hours_per_week` for "
+                        "entity `case-1` over 2026-01-01..2026-01-31"
+                    )
+                )
+            }
+        )
+
+        changed = _complete_missing_dependent_test_inputs(
+            overlay_repo=repo,
+            relative_output=Path("regulations/10-ccr-2506-1/4.403.yaml"),
+            validations=[(dependent_file, validation)],
+        )
+
+        assert changed == [test_file]
+        repaired = test_file.read_text()
+        assert (
+            "us-co:regulations/10-ccr-2506-1/4.404#input.average_rental_property_management_hours_per_week: 0"
+            in repaired
+        )
+        assert (
+            "us-co:regulations/10-ccr-2506-1/4.403#input.average_rental_property_management_hours_per_week"
             not in repaired
         )
 
@@ -11085,6 +11284,116 @@ rules:
         assert "us:statutes/26/24#ctc_qualifying_child: holds" in test_content
         run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
         assert run.outcome["auto_repaired_exception_tests"] == [case_name]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
+    def test_encode_apply_auto_repairs_exception_negative_after_positive_companion(
+        self, capsys, tmp_path
+    ):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path / "out" / "codex-test-model" / "statutes" / "7" / "2014" / "e.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: title_i_vista_payment_is_earned_income
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          payment_received_under_title_i_vista
+          and not household_specified_for_title_i_exclusion
+"""
+        )
+        test_file = output_file.with_name("e.test.yaml")
+        test_file.write_text("[]\n")
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/7/2014/e.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "statutes/7/2014/e.yaml: ci: "
+                            "Judgment rule missing positive companion output coverage: "
+                            "`us:statutes/7/2014/e#title_i_vista_payment_is_earned_income` "
+                            "is not asserted as `holds` by the companion `.test.yaml` file."
+                        ],
+                        {},
+                    ),
+                    (
+                        False,
+                        [
+                            "statutes/7/2014/e.yaml: ci: "
+                            "Exception test coverage missing: "
+                            "`title_i_vista_payment_is_earned_income` negates "
+                            "`household_specified_for_title_i_exclusion`, "
+                            "but no companion test sets "
+                            "`#input.household_specified_for_title_i_exclusion` "
+                            "true and expects "
+                            "`title_i_vista_payment_is_earned_income` to be not_holds "
+                            "while an otherwise identical positive companion sets that "
+                            "exception false and expects holds."
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        positive_case = "auto_positive_title_i_vista_payment_is_earned_income"
+        negative_case = (
+            "auto_negative_title_i_vista_payment_is_earned_income_"
+            "household_specified_for_title_i_exclusion"
+        )
+        assert f"apply=auto_repaired_judgment_positive_tests:{positive_case}" in output
+        assert f"apply=auto_repaired_exception_tests:{negative_case}" in output
+        assert mock_overlay.call_count == 3
+        mock_apply.assert_called_once()
+        test_payload = yaml.safe_load(test_file.read_text())
+        assert test_payload[0]["name"] == positive_case
+        assert (
+            test_payload[0]["input"][
+                "us:statutes/7/2014/e#input.household_specified_for_title_i_exclusion"
+            ]
+            is False
+        )
+        assert test_payload[1]["name"] == negative_case
+        assert (
+            test_payload[1]["input"][
+                "us:statutes/7/2014/e#input.household_specified_for_title_i_exclusion"
+            ]
+            is True
+        )
+        assert (
+            test_payload[1]["output"][
+                "us:statutes/7/2014/e#title_i_vista_payment_is_earned_income"
+            ]
+            == "not_holds"
+        )
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_judgment_positive_tests"] == [positive_case]
+        assert run.outcome["auto_repaired_exception_tests"] == [negative_case]
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.707"
+version = "0.2.708"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.708"
+version = "0.2.709"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair exception companion generation so apply can add missing negative companions after positive companion repair
- make dependent apply input completion use the dependent module import graph and avoid invalid fallback inputs on replaced targets
- preserve dotted RuleSpec import paths like `4.404` when resolving sibling imports
- bump axiom-encode to 0.2.708

## Validation
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `git diff --check`
- `uv run pytest tests/test_cli.py -k 'complete_missing_dependent_test_inputs or remove_invalid_dependent_test_inputs or exception_positive_companion or exception_negative_after_positive_companion or judgment_positive_test_repair'`\n- 4.403 generated overlay validation: `can True`, supplemental `policies/cdhs/snap/fy-2026-benefit-calculation.test.yaml`\n