### PR TITLE
Require paired exception companion signatures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.710"
+version = "0.2.711"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.710"
+__version__ = "0.2.711"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -14623,6 +14623,8 @@ def _has_exception_positive_companion_case(
     rule_name: str,
     exception_input: str,
 ) -> bool:
+    negative_signatures: set[tuple[tuple[str, str], ...]] = set()
+    positive_signatures: set[tuple[tuple[str, str], ...]] = set()
     for test_case in test_payload:
         if not isinstance(test_case, dict):
             continue
@@ -14630,15 +14632,31 @@ def _has_exception_positive_companion_case(
         outputs = test_case.get("output")
         if not isinstance(inputs, dict) or not isinstance(outputs, dict):
             continue
-        if not _case_sets_exception_input(
+        sets_exception_false = _case_sets_exception_input(
             inputs, exception_input=exception_input, value=False
-        ):
-            continue
-        if _case_asserts_rule_value(
+        )
+        sets_exception_true = _case_sets_exception_input(
+            inputs, exception_input=exception_input, value=True
+        )
+        if sets_exception_false and _case_asserts_rule_value(
             outputs, rule_name=rule_name, normalized_value="holds"
         ):
-            return True
-    return False
+            positive_signatures.add(
+                _case_input_signature_without_exception(
+                    inputs,
+                    exception_input=exception_input,
+                )
+            )
+        if sets_exception_true and _case_asserts_rule_value(
+            outputs, rule_name=rule_name, normalized_value="not_holds"
+        ):
+            negative_signatures.add(
+                _case_input_signature_without_exception(
+                    inputs,
+                    exception_input=exception_input,
+                )
+            )
+    return bool(negative_signatures.intersection(positive_signatures))
 
 
 def _has_exception_negative_companion_case(
@@ -14647,6 +14665,8 @@ def _has_exception_negative_companion_case(
     rule_name: str,
     exception_input: str,
 ) -> bool:
+    positive_signatures: set[tuple[tuple[str, str], ...]] = set()
+    negative_signatures: set[tuple[tuple[str, str], ...]] = set()
     for test_case in test_payload:
         if not isinstance(test_case, dict):
             continue
@@ -14654,15 +14674,56 @@ def _has_exception_negative_companion_case(
         outputs = test_case.get("output")
         if not isinstance(inputs, dict) or not isinstance(outputs, dict):
             continue
-        if not _case_sets_exception_input(
+        sets_exception_true = _case_sets_exception_input(
             inputs, exception_input=exception_input, value=True
-        ):
-            continue
-        if _case_asserts_rule_value(
+        )
+        sets_exception_false = _case_sets_exception_input(
+            inputs, exception_input=exception_input, value=False
+        )
+        if sets_exception_true and _case_asserts_rule_value(
             outputs, rule_name=rule_name, normalized_value="not_holds"
         ):
-            return True
-    return False
+            negative_signatures.add(
+                _case_input_signature_without_exception(
+                    inputs,
+                    exception_input=exception_input,
+                )
+            )
+        if sets_exception_false and _case_asserts_rule_value(
+            outputs, rule_name=rule_name, normalized_value="holds"
+        ):
+            positive_signatures.add(
+                _case_input_signature_without_exception(
+                    inputs,
+                    exception_input=exception_input,
+                )
+            )
+    return bool(positive_signatures.intersection(negative_signatures))
+
+
+def _case_input_signature_without_exception(
+    inputs: dict[object, object],
+    *,
+    exception_input: str,
+) -> tuple[tuple[str, str], ...]:
+    exception_fragment = f"input.{exception_input}"
+    signature: dict[str, str] = {}
+    for key, value in inputs.items():
+        fragment = _rulespec_test_key_fragment(key)
+        if fragment == exception_fragment:
+            continue
+        signature[fragment] = _normalized_test_value_for_signature(value)
+    return tuple(sorted(signature.items()))
+
+
+def _normalized_test_value_for_signature(value: object) -> str:
+    if isinstance(value, dict | list | tuple):
+        return yaml.safe_dump(
+            value,
+            sort_keys=True,
+            allow_unicode=False,
+        ).strip()
+    return _normalized_generated_test_scalar(value)
 
 
 def _case_sets_exception_input(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,7 @@ from axiom_encode import __version__ as AXIOM_ENCODE_TEST_VERSION
 from axiom_encode.cli import (
     APPLIED_ENCODING_MANIFEST_SCHEMA,
     APPLIED_ENCODING_SIGNING_KEY_ENV,
+    _append_exception_positive_companion_tests_if_missing,
     _append_generated_derived_output_tests_if_missing,
     _append_generated_judgment_positive_tests_if_missing,
     _append_generated_zero_branch_tests_if_missing,
@@ -11286,6 +11287,79 @@ rules:
         assert run.outcome["auto_repaired_exception_tests"] == [case_name]
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
+
+    def test_exception_companion_repair_requires_matching_positive_signature(
+        self, tmp_path
+    ):
+        repo_path = tmp_path / "rulespec-us-co"
+        test_file = repo_path / "regulations" / "10-ccr-2506-1" / "4.403.test.yaml"
+        test_file.parent.mkdir(parents=True)
+        test_file.write_text(
+            """- name: vista_payment_excluded_when_client_was_receiving_snap_at_joining
+  period: 2024-06
+  input:
+    us-co:regulations/10-ccr-2506-1/4.403#input.payment_is_vista_payment: true
+    us-co:regulations/10-ccr-2506-1/4.403#input.client_was_receiving_snap_benefits_when_joined_vista_or_initial_vista_exclusion_determined: true
+    us-co:regulations/10-ccr-2506-1/4.403#input.payment_is_rental_or_lease_income_from_self_employment_property: false
+    us-co:regulations/10-ccr-2506-1/4.403#input.household_member_actively_manages_property_average_hours_per_week: 0
+  output:
+    us-co:regulations/10-ccr-2506-1/4.403#payment_considered_earned_income: not_holds
+- name: actively_managed_rental_self_employment_property_income_counted
+  period: 2024-06
+  input:
+    us-co:regulations/10-ccr-2506-1/4.403#input.payment_is_vista_payment: false
+    us-co:regulations/10-ccr-2506-1/4.403#input.client_was_receiving_snap_benefits_when_joined_vista_or_initial_vista_exclusion_determined: false
+    us-co:regulations/10-ccr-2506-1/4.403#input.payment_is_rental_or_lease_income_from_self_employment_property: true
+    us-co:regulations/10-ccr-2506-1/4.403#input.household_member_actively_manages_property_average_hours_per_week: 20
+  output:
+    us-co:regulations/10-ccr-2506-1/4.403#payment_considered_earned_income: holds
+"""
+        )
+
+        repaired = _append_exception_positive_companion_tests_if_missing(
+            test_file=test_file,
+            repo_path=repo_path,
+            relative_output=Path("regulations/10-ccr-2506-1/4.403.yaml"),
+            issues=[
+                "regulations/10-ccr-2506-1/4.403.yaml: ci: "
+                "Exception test coverage missing: "
+                "`payment_considered_earned_income` negates "
+                "`client_was_receiving_snap_benefits_when_joined_vista_or_initial_vista_exclusion_determined`, "
+                "but no companion test sets "
+                "`#input.client_was_receiving_snap_benefits_when_joined_vista_or_initial_vista_exclusion_determined` "
+                "true and expects `payment_considered_earned_income` to be "
+                "not_holds while an otherwise identical positive companion sets "
+                "that exception false and expects holds."
+            ],
+        )
+
+        assert repaired == [
+            "auto_positive_payment_considered_earned_income_"
+            "client_was_receiving_snap_benefits_when_joined_vista_or_initial_vista_exclusion_determined"
+        ]
+        test_payload = yaml.safe_load(test_file.read_text())
+        companion = test_payload[2]
+        assert (
+            companion["input"][
+                "us-co:regulations/10-ccr-2506-1/4.403#input.payment_is_vista_payment"
+            ]
+            is True
+        )
+        assert (
+            companion["input"][
+                "us-co:regulations/10-ccr-2506-1/4.403#input.client_was_receiving_snap_benefits_when_joined_vista_or_initial_vista_exclusion_determined"
+            ]
+            is False
+        )
+        assert (
+            companion["input"][
+                "us-co:regulations/10-ccr-2506-1/4.403#input.payment_is_rental_or_lease_income_from_self_employment_property"
+            ]
+            is False
+        )
+        assert companion["output"] == {
+            "us-co:regulations/10-ccr-2506-1/4.403#payment_considered_earned_income": "holds"
+        }
 
     def test_encode_apply_auto_repairs_exception_negative_after_positive_companion(
         self, capsys, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.710"
+version = "0.2.711"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- require exception companion presence checks to match otherwise-identical input signatures except for the exception input
- avoid treating unrelated positive scenarios as valid exception companions
- add a Colorado SNAP VISTA regression where an unrelated rental positive case previously suppressed repair
- bump axiom-encode to 0.2.711

## Tests
- `uv run pytest tests/test_cli.py -k 'exception_companion or exception_positive_companion or exception_negative_after_positive_companion or judgment_positive_test_repair or positive_judgment or current_encoder_affecting_changes_are_behind_version_bump'`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `git diff --check`