### PR TITLE
Tighten admin aggregate source matching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.711"
+version = "0.2.712"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.711"
+__version__ = "0.2.712"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -148,6 +148,7 @@ _ADMIN_AGENCY_BONUS_USE_RESTRICTION_PATTERN = re.compile(
     r"SNAP-related\s+expenses?)\b",
     flags=re.IGNORECASE,
 )
+_ADMIN_AGENCY_AGGREGATE_CONTEXT_WINDOW = 500
 _CONDITIONAL_AMOUNT_SLICE_PATTERN = re.compile(
     r"\b(?:if|where|unless|except|subject to|treated as paid)\b",
     re.IGNORECASE,
@@ -6856,10 +6857,7 @@ def find_admin_agency_aggregate_entity_issues(
     source_text: str,
 ) -> list[str]:
     """Reject executable entity rules for State-agency/FNS aggregate measures."""
-    is_admin_agency_aggregate = (
-        _ADMIN_AGENCY_AGGREGATE_SUBJECT_PATTERN.search(source_text)
-        and _ADMIN_AGENCY_AGGREGATE_MEASURE_PATTERN.search(source_text)
-    ) or _ADMIN_AGENCY_BONUS_USE_RESTRICTION_PATTERN.search(source_text)
+    is_admin_agency_aggregate = _has_admin_agency_aggregate_source_context(source_text)
     if not is_admin_agency_aggregate:
         return []
     try:
@@ -6901,6 +6899,34 @@ def find_admin_agency_aggregate_entity_issues(
             "administrative surface still cannot be represented faithfully."
         )
     return issues
+
+
+def _has_admin_agency_aggregate_source_context(source_text: str) -> bool:
+    """Return true only when administrative subjects and measures are local."""
+    if _ADMIN_AGENCY_BONUS_USE_RESTRICTION_PATTERN.search(source_text):
+        return True
+
+    subject_matches = list(
+        _ADMIN_AGENCY_AGGREGATE_SUBJECT_PATTERN.finditer(source_text)
+    )
+    if not subject_matches:
+        return False
+    measure_matches = list(
+        _ADMIN_AGENCY_AGGREGATE_MEASURE_PATTERN.finditer(source_text)
+    )
+    if not measure_matches:
+        return False
+
+    for subject_match in subject_matches:
+        subject_center = (subject_match.start() + subject_match.end()) // 2
+        for measure_match in measure_matches:
+            measure_center = (measure_match.start() + measure_match.end()) // 2
+            if (
+                abs(subject_center - measure_center)
+                <= _ADMIN_AGENCY_AGGREGATE_CONTEXT_WINDOW
+            ):
+                return True
+    return False
 
 
 def _context_file_export_detail(item: EvalContextFile) -> str:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -248,6 +248,37 @@ rules:
     assert find_admin_agency_aggregate_entity_issues(content, source_text) == []
 
 
+def test_admin_agency_aggregate_allows_long_income_exclusion_list():
+    source_text = (
+        "P.L. No. 100-175, Section 166, Older Americans Act. Funds received by "
+        "persons fifty-five (55) years of age and older under the Senior "
+        "Community Service Employment Program under Title V of the Older "
+        "Americans Act are excluded from income. State agencies and eight "
+        "organizations receive funding under Title V. "
+        + ("Separate income exclusion text. " * 40)
+        + "P.L. No. 101-508 amended Section 402(i) of the Social Security Act. "
+        "At-risk block grant child care payments are excluded from being "
+        "counted as income for SNAP purposes."
+    )
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.405.2
+rules:
+  - name: payment_excluded_as_income
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Month
+    source: 10 CCR 2506-1, 4.405.2
+    versions:
+      - effective_from: '0001-01-01'
+        formula: senior_community_service_payment or at_risk_child_care_payment
+"""
+
+    assert find_admin_agency_aggregate_entity_issues(content, source_text) == []
+
+
 def test_source_identifier_maps_federal_regulation_to_cfr_repo_path():
     assert _source_identifier_to_relative_rulespec_path(
         "us/regulation/7/273/10"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.711"
+version = "0.2.712"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- require State-agency/FNS administrative subject terms and aggregate/liability measure terms to appear in the same local source window before rejecting standard entities
- keep the existing bonus-use restriction detector
- add a Colorado SNAP 4.405.2 income-exclusion regression so long exclusion lists do not cross-match unrelated phrases
- bump axiom-encode to 0.2.712

## Tests
- uv run pytest tests/test_evals.py -k admin_agency_aggregate
- uv run pytest tests/test_cli.py -k current_encoder_affecting_changes_are_behind_version_bump
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check