### PR TITLE
Repair semicolon-separated proof excerpts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.712"
+version = "0.2.713"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.712"
+__version__ = "0.2.713"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -8354,7 +8354,73 @@ def _clean_generated_file_content(content: str) -> str:
         stripped,
     )
     stripped = _normalize_backslash_escaped_yaml_apostrophes(stripped)
+    stripped = _normalize_semicolon_separated_yaml_excerpts(stripped)
     return stripped + ("\n" if stripped and not stripped.endswith("\n") else "")
+
+
+def _normalize_semicolon_separated_yaml_excerpts(content: str) -> str:
+    """Repair excerpt lines emitted as multiple adjacent quoted scalars."""
+    if "excerpt:" not in content or not re.search(r"['\"]\s*;\s*['\"]", content):
+        return content
+
+    repaired_lines: list[str] = []
+    for line in content.splitlines(keepends=True):
+        repaired_lines.append(_normalize_semicolon_separated_yaml_excerpt_line(line))
+    return "".join(repaired_lines)
+
+
+def _normalize_semicolon_separated_yaml_excerpt_line(line: str) -> str:
+    body = line.rstrip("\r\n")
+    newline = line[len(body) :]
+    match = re.match(r"^(?P<prefix>\s*excerpt:\s*)(?P<rest>.+?)\s*$", body)
+    if not match:
+        return line
+    parsed = _parse_semicolon_separated_quoted_scalars(match.group("rest").strip())
+    if parsed is None or len(parsed) < 2:
+        return line
+    joined = "; ".join(parsed)
+    escaped = joined.replace("\\", "\\\\").replace('"', '\\"')
+    return f'{match.group("prefix")}"{escaped}"{newline}'
+
+
+def _parse_semicolon_separated_quoted_scalars(text: str) -> list[str] | None:
+    values: list[str] = []
+    index = 0
+    while index < len(text):
+        while index < len(text) and text[index].isspace():
+            index += 1
+        if index >= len(text) or text[index] not in {"'", '"'}:
+            return None
+        quote = text[index]
+        index += 1
+        value: list[str] = []
+        while index < len(text):
+            char = text[index]
+            next_char = text[index + 1] if index + 1 < len(text) else ""
+            if char == "\\" and next_char:
+                value.append(next_char)
+                index += 2
+                continue
+            if quote == "'" and char == "'" and next_char == "'":
+                value.append("'")
+                index += 2
+                continue
+            if char == quote:
+                index += 1
+                break
+            value.append(char)
+            index += 1
+        else:
+            return None
+        values.append("".join(value))
+        while index < len(text) and text[index].isspace():
+            index += 1
+        if index == len(text):
+            return values
+        if text[index] != ";":
+            return None
+        index += 1
+    return values
 
 
 def _normalize_backslash_escaped_yaml_apostrophes(content: str) -> str:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -5149,6 +5149,38 @@ class TestGeneratedBundleCleaning:
         ]
         assert excerpt == "benefits received as a result of the individual's service"
 
+    def test_clean_generated_file_content_repairs_semicolon_excerpts(self):
+        content = (
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  summary: Payment exclusions.\n"
+            "rules:\n"
+            "  - name: excluded_payment_limit\n"
+            "    kind: parameter\n"
+            "    dtype: Money\n"
+            "    unit: USD\n"
+            "    metadata:\n"
+            "      proof:\n"
+            "        atoms:\n"
+            "          - source:\n"
+            '              excerpt: "per capita Payments ... of two thousand dollars ($2,000) or less"; "up to two thousand dollars ($2,000) per year"; "The first two thousand dollars ($2,000) of each payment is excluded"\n'
+            "    versions:\n"
+            "      - effective_from: '0001-01-01'\n"
+            "        formula: 2000\n"
+        )
+
+        cleaned = _clean_generated_file_content(content)
+        payload = yaml.safe_load(cleaned)
+
+        excerpt = payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"][
+            "excerpt"
+        ]
+        assert excerpt == (
+            "per capita Payments ... of two thousand dollars ($2,000) or less; "
+            "up to two thousand dollars ($2,000) per year; "
+            "The first two thousand dollars ($2,000) of each payment is excluded"
+        )
+
     def test_materialize_eval_artifact_rejects_non_rulespec_bundle(self, tmp_path):
         output_file = tmp_path / "source" / "example.yaml"
         response = (

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.712"
+version = "0.2.713"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- normalize generated proof excerpt lines that contain multiple adjacent quoted YAML scalars separated by semicolons
- add a regression for the SNAP payment-exclusion excerpt shape that broke CO 4.405.2
- bump axiom-encode to 0.2.713

## Tests
- uv run pytest tests/test_evals.py -k 'clean_generated_file_content or admin_agency_aggregate'
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check
- uv run pytest tests/test_cli.py -k 'current_encoder_affecting_changes_are_behind_version_bump'