### PR TITLE
Clarify claim collection caps in encoder prompt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.713"
+version = "0.2.714"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.713"
+__version__ = "0.2.714"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -46,6 +46,13 @@ SOURCE_SCOPE_PROTOCOL = """Source-scope protocol:
   those lower-entity results through an explicit relation; it must not multiply
   a unit-level placeholder or aggregate base by the rate unless the source
   defines the base on that unit.
+- For claim, overpayment, overissuance, repayment, recoupment, restitution, or
+  collection rules, treat phrases such as "may not collect more than the
+  amount of the claim", "cannot collect more than", and "limited to the claim"
+  as collectability caps. Encode the established gross claim, required offsets,
+  and collectible final amount as distinct outputs. The final collectible
+  amount must compose the computed claim and required offsets with the
+  collectability cap, not return a bare placeholder such as `claim_amount`.
 - Imported definitions do not override the current source's legal subject. If
   the current source imposes a rate-applied amount on each/every individual,
   person, employee, member, claimant, child, dependent, or spouse, declare this

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1074,6 +1074,9 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "unit-level placeholder or aggregate base by the rate" in prompt
     assert '"per taxpayer per beneficiary"' in prompt
     assert "Do not apply one\n  per-unit cap to a single aggregate amount" in prompt
+    assert "For claim, overpayment, overissuance, repayment" in prompt
+    assert "as collectability caps" in prompt
+    assert "not return a bare placeholder such as `claim_amount`" in prompt
     assert (
         "Imported definitions do not override the current source's legal subject"
         in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.713"
+version = "0.2.714"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add encoder prompt guidance for claim/overpayment collection caps such as "may not collect more than the amount of the claim"
- pin the prompt text in the eval prompt surface test
- bump axiom-encode to 0.2.714

## Why
CO SNAP 4.801.3 generated an otherwise compiling claim calculation but exported a final maximum_collectible_claim_amount as a bare claim_amount placeholder, ignoring the same-source collectability cap. The deterministic validator caught it; this prompt update makes the required shape explicit before rerun.

## Tests
- uv run pytest tests/test_evals.py -k "test_build_eval_prompt_targets_rulespec_yaml"
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check
- uv run pytest tests/test_cli.py -k "current_encoder_affecting_changes_are_behind_version_bump"