### PR TITLE
Repair generated target prefix typos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.714"
+version = "0.2.715"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.714"
+__version__ = "0.2.715"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -16350,6 +16350,64 @@ def _invalid_input_refs_from_issues(issues: list[str]) -> set[str]:
     return refs
 
 
+def _unresolved_test_input_refs_from_issues(issues: list[str]) -> set[str]:
+    refs: set[str] = set()
+    pattern = (
+        r"input `(?P<input>[^`]+)` points to a RuleSpec file that could not be "
+        r"resolved"
+    )
+    for issue in issues:
+        for match in re.finditer(pattern, str(issue)):
+            refs.add(match.group("input").strip())
+    return refs
+
+
+def _current_target_replacement_for_near_ref_typo(
+    input_ref: str,
+    *,
+    target_base: str,
+) -> str | None:
+    if "#input." not in input_ref:
+        return None
+    input_base, fragment = input_ref.split("#", 1)
+    if input_base == target_base or not fragment.startswith("input."):
+        return None
+
+    input_jurisdiction = _rulespec_ref_jurisdiction(input_base)
+    target_jurisdiction = _rulespec_ref_jurisdiction(target_base)
+    if input_jurisdiction and input_jurisdiction != target_jurisdiction:
+        return None
+
+    input_tail = _rulespec_ref_without_jurisdiction(input_base).strip("/")
+    target_tail = _rulespec_ref_without_jurisdiction(target_base).strip("/")
+    if not input_tail or not target_tail:
+        return None
+
+    input_parts = Path(input_tail).parts
+    target_parts = Path(target_tail).parts
+    if (
+        len(input_parts) != len(target_parts)
+        or not input_parts
+        or input_parts[0] != target_parts[0]
+        or input_parts[-1] != target_parts[-1]
+    ):
+        return None
+
+    similarity = difflib.SequenceMatcher(None, input_tail, target_tail).ratio()
+    if similarity < 0.97:
+        return None
+    return f"{target_base}#{fragment}"
+
+
+def _rulespec_ref_jurisdiction(ref: str) -> str | None:
+    if ":" not in ref:
+        return None
+    prefix, tail = ref.split(":", 1)
+    if "/" in prefix or "#" in prefix or not tail:
+        return None
+    return prefix
+
+
 def _mixed_derived_output_case_names(issues: list[str]) -> set[str]:
     return {
         match.group("case").strip()
@@ -18858,6 +18916,41 @@ def cmd_encode(args):
                     outcome["overlay_validation_success"] = bool(can_apply)
                 if repaired_input_refs:
                     outcome["auto_repaired_import_output_inputs"] = repaired_input_refs
+            if not can_apply:
+                repaired_target_ref_typos: list[str] = []
+                while not can_apply:
+                    repaired_refs = _try_repair_generated_target_prefix_typos_for_apply(
+                        result,
+                        output_root=args.output,
+                        policy_repo_path=policy_repo_path,
+                        issues=apply_issues,
+                    )
+                    if not repaired_refs:
+                        break
+                    repaired_target_ref_typos.extend(repaired_refs)
+                    outcome["auto_repaired_target_prefix_typos"] = (
+                        repaired_target_ref_typos
+                    )
+                    print(
+                        "  apply=auto_repaired_target_prefix_typos:"
+                        + ",".join(repaired_refs)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+                if repaired_target_ref_typos:
+                    outcome["auto_repaired_target_prefix_typos"] = (
+                        repaired_target_ref_typos
+                    )
             if not can_apply:
                 repaired_invalid_input_refs: list[str] = []
                 while not can_apply:
@@ -26280,6 +26373,58 @@ def _try_repair_generated_invalid_test_inputs_for_apply(
     rules_file = Path(str(getattr(result, "output_file", "") or ""))
     test_file = _rulespec_test_path(rules_file)
     return _remove_invalid_test_input_refs(test_file=test_file, issues=issues)
+
+
+def _try_repair_generated_target_prefix_typos_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+    issues: list[str],
+) -> list[str]:
+    """Normalize generated-test refs that typo the current target's path."""
+    if not issues:
+        return []
+
+    try:
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    test_file = _rulespec_test_path(rules_file)
+    if not test_file.exists():
+        return []
+
+    target_base = (
+        f"{_repo_jurisdiction_prefix(policy_repo_path)}:"
+        f"{_relative_rulespec_import_target(relative_output)}"
+    )
+    replacements: dict[str, str] = {}
+    for input_ref in _unresolved_test_input_refs_from_issues(issues):
+        replacement = _current_target_replacement_for_near_ref_typo(
+            input_ref, target_base=target_base
+        )
+        if replacement is not None:
+            replacements[input_ref] = replacement
+    if not replacements:
+        return []
+
+    try:
+        test_payload = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    if not isinstance(test_payload, list):
+        return []
+
+    if not _replace_mapping_keys_recursive(test_payload, replacements):
+        return []
+    test_file.write_text(
+        yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
+    )
+    return [f"{old}->{new}" for old, new in sorted(replacements.items())]
 
 
 def _try_repair_generated_imported_test_inputs_for_apply(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13195,6 +13195,110 @@ rules: []
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_repairs_near_target_test_input_prefix_typo(
+        self, capsys, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us-co"
+        policy_repo.mkdir()
+        args = self._make_args(
+            tmp_path,
+            backend="codex",
+            citation="10 CCR 2506-1 4.801.4",
+            policy_repo_path=policy_repo,
+            sync=False,
+        )
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path
+            / "out"
+            / "codex-test-model"
+            / "regulations"
+            / "10-ccr-2506-1"
+            / "4.801.4.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: collection_action_required
+    kind: derived
+    entity: SnapClaim
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: not payment_received_in_full
+"""
+        )
+        wrong_ref = (
+            "us-co:regulations/10-cc-2506-1/4.801.4#input.payment_received_in_full"
+        )
+        correct_ref = (
+            "us-co:regulations/10-ccr-2506-1/4.801.4#input.payment_received_in_full"
+        )
+        test_file = output_file.with_name("4.801.4.test.yaml")
+        test_file.write_text(
+            f"""- name: household_collection_suspension_and_nondelinquency_controls
+  period: 2026-01
+  input:
+    {wrong_ref}: false
+    {correct_ref}: false
+  output:
+    us-co:regulations/10-ccr-2506-1/4.801.4#collection_action_required: holds
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "regulations/10-ccr-2506-1/4.801.4.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "regulations/10-ccr-2506-1/4.801.4.yaml: ci: "
+                            "Test case "
+                            "`household_collection_suspension_and_nondelinquency_controls` "
+                            "input invalid: input "
+                            f"`{wrong_ref}` points to a RuleSpec file that "
+                            "could not be resolved: "
+                            "rulespec-us-co/regulations/10-cc-2506-1/4.801.4.yaml."
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert (
+            f"apply=auto_repaired_target_prefix_typos:{wrong_ref}->{correct_ref}"
+        ) in output
+        assert mock_overlay.call_count == 2
+        mock_apply.assert_called_once()
+        test_content = test_file.read_text()
+        assert wrong_ref not in test_content
+        assert test_content.count(correct_ref) == 1
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_target_prefix_typos"] == [
+            f"{wrong_ref}->{correct_ref}"
+        ]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_fills_imported_inputs_after_invalid_input_repair(
         self, capsys, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.714"
+version = "0.2.715"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- normalize generated test input refs that typo the current RuleSpec target path when validation reports an unresolved RuleSpec file
- run the repair before the generic invalid-input removal path so tests keep canonical inputs
- bump axiom-encode to 0.2.715

## Tests
- uv run pytest tests/test_cli.py -k 'repairs_near_target_test_input_prefix_typo'\n- uv run pytest tests/test_cli.py -k 'invalid_imported_test_inputs or fills_imported_inputs_after_invalid_input_repair or repairs_near_target_test_input_prefix_typo'\n- uv run ruff check src/ tests/\n- uv run ruff format --check src/ tests/\n- git diff --check\n- uv run pytest tests/test_cli.py -k 'current_encoder_affecting_changes_are_behind_version_bump'