### PR TITLE
Skip positive coverage for constant false judgments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.715"
+version = "0.2.716"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.715"
+__version__ = "0.2.716"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -90,6 +90,7 @@ from .harness.validator_pipeline import (
     _matching_delegated_setting_rule_names,
     _parse_rulespec_target,
     _resolve_rulespec_target_file,
+    _rule_versions_are_constant_false,
     _rulespec_executable_index_for_roots,
     _rulespec_executable_signature,
     _rulespec_local_item_prefix,
@@ -15161,6 +15162,10 @@ def _append_generated_judgment_positive_tests_if_missing(
     repaired: list[str] = []
     for target in output_targets:
         rule_name = target.rsplit("#", 1)[-1]
+        rule = derived_rules_by_target.get(target)
+        versions = rule.get("versions") if isinstance(rule, dict) else None
+        if isinstance(versions, list) and _rule_versions_are_constant_false(versions):
+            continue
         if _test_payload_has_rule_output_value(
             test_payload, rule_name=rule_name, normalized_value="holds"
         ):
@@ -15174,7 +15179,7 @@ def _append_generated_judgment_positive_tests_if_missing(
             case_name=case_name,
             target=f"{target_base}#{rule_name}",
             target_base=target_base,
-            rule=derived_rules_by_target.get(target),
+            rule=rule,
             rules_payload=rules_payload,
             rules_by_name=rules_by_name,
             test_payload=test_payload,

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -6439,6 +6439,8 @@ def find_judgment_positive_companion_output_issues(
             for version in versions
         ):
             continue
+        if _rule_versions_are_constant_false(versions):
+            continue
         name = _rulespec_rule_name(rule)
         target = _canonical_rulespec_file_target(
             policy_repo_path=policy_repo_path,
@@ -6456,6 +6458,15 @@ def find_judgment_positive_companion_output_issues(
         )
 
     return issues
+
+
+def _rule_versions_are_constant_false(versions: list[Any]) -> bool:
+    formulas = [
+        str(version.get("formula") or "").strip().lower()
+        for version in versions
+        if isinstance(version, dict) and isinstance(version.get("formula"), str)
+    ]
+    return bool(formulas) and all(formula == "false" for formula in formulas)
 
 
 def _rulespec_executable_signature(rule: dict[str, Any]) -> str | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12584,6 +12584,54 @@ rules:
         }
         assert test_payload[1]["tables"] == test_payload[0]["tables"]
 
+    def test_judgment_positive_test_repair_skips_constant_false_rule(self, tmp_path):
+        repo_path = tmp_path / "rulespec-us-co"
+        rules_file = repo_path / "regulations" / "10-ccr-2506-1" / "4.801.43.yaml"
+        test_file = repo_path / "regulations" / "10-ccr-2506-1" / "4.801.43.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: voluntary_payment_reactivates_terminated_claim
+    kind: derived
+    entity: SnapClaim
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          false
+"""
+        )
+        test_file.write_text(
+            """- name: terminated_claim_nonreactivation
+  period: 2026-01
+  input: {}
+  output:
+    us-co:regulations/10-ccr-2506-1/4.801.43#voluntary_payment_reactivates_terminated_claim: not_holds
+"""
+        )
+
+        repaired = _append_generated_judgment_positive_tests_if_missing(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=repo_path,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            relative_output=Path("regulations/10-ccr-2506-1/4.801.43.yaml"),
+            issues=[
+                "Judgment rule missing positive companion output coverage: "
+                "`us-co:regulations/10-ccr-2506-1/4.801.43#voluntary_payment_reactivates_terminated_claim` "
+                "is not asserted as `holds` by the companion `.test.yaml` file."
+            ],
+        )
+
+        assert repaired == []
+        test_payload = yaml.safe_load(test_file.read_text())
+        assert len(test_payload) == 1
+        assert test_payload[0]["output"] == {
+            "us-co:regulations/10-ccr-2506-1/4.801.43#voluntary_payment_reactivates_terminated_claim": "not_holds"
+        }
+
     def test_judgment_positive_test_repair_synthesizes_formula_inputs(self, tmp_path):
         repo_path = tmp_path / "rulespec-us"
         rules_file = repo_path / "statutes" / "26" / "3303.yaml"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1053,6 +1053,44 @@ rules:
     ]
 
 
+def test_judgment_positive_companion_output_allows_constant_false_rule(tmp_path):
+    policy_repo = tmp_path / "rulespec-us-co"
+    rules_file = policy_repo / "regulations" / "10-ccr-2506-1" / "4.801.43.yaml"
+    rules_file.parent.mkdir(parents=True)
+    content = """format: rulespec/v1
+rules:
+  - name: voluntary_payment_reactivates_terminated_claim
+    kind: derived
+    entity: SnapClaim
+    dtype: Judgment
+    period: Month
+    source: 10 CCR 2506-1 4.801.43(A)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          false
+"""
+    cases = [
+        {
+            "name": "terminated_claim_nonreactivation",
+            "period": "2026-01",
+            "input": {},
+            "output": {
+                "us-co:regulations/10-ccr-2506-1/4.801.43#voluntary_payment_reactivates_terminated_claim": "not_holds"
+            },
+        }
+    ]
+
+    issues = find_judgment_positive_companion_output_issues(
+        content,
+        cases,
+        rules_file=rules_file,
+        policy_repo_path=policy_repo,
+    )
+
+    assert issues == []
+
+
 def test_judgment_positive_companion_output_allows_holds_case(tmp_path):
     policy_repo = tmp_path / "rulespec-us"
     rules_file = policy_repo / "statutes" / "26" / "3102" / "f" / "1.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.715"
+version = "0.2.716"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- skip Judgment positive-companion validation when every effective version is a constant `false` formula
- keep apply-time generated positive test repair from creating impossible `holds` cases for legal prohibitions
- bump axiom-encode to 0.2.716

## Validation
- `uv run pytest tests/test_rulespec_validation.py -k 'judgment_positive_companion_output'`\n- `uv run pytest tests/test_cli.py -k 'judgment_positive_test_repair'`\n- `uv run ruff check src/ tests/`\n- `uv run ruff format --check src/ tests/`\n- `git diff --check`\n- `uv run pytest tests/test_cli.py -k 'current_encoder_affecting_changes_are_behind_version_bump'`