### PR TITLE
Skip positive coverage for false conjunction judgments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.716"
+version = "0.2.717"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.716"
+__version__ = "0.2.717"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -6466,7 +6466,71 @@ def _rule_versions_are_constant_false(versions: list[Any]) -> bool:
         for version in versions
         if isinstance(version, dict) and isinstance(version.get("formula"), str)
     ]
-    return bool(formulas) and all(formula == "false" for formula in formulas)
+    return bool(formulas) and all(
+        _formula_is_syntactically_unsatisfiable_false(formula) for formula in formulas
+    )
+
+
+def _formula_is_syntactically_unsatisfiable_false(formula: str) -> bool:
+    normalized = re.sub(r"\s+", " ", formula.strip().lower())
+    normalized = _strip_balanced_outer_parentheses(normalized)
+    if normalized == "false":
+        return True
+    conjuncts = _split_top_level_boolean_operator(normalized, "and")
+    return len(conjuncts) > 1 and any(
+        _formula_is_syntactically_unsatisfiable_false(conjunct)
+        for conjunct in conjuncts
+    )
+
+
+def _strip_balanced_outer_parentheses(expression: str) -> str:
+    stripped = expression.strip()
+    while stripped.startswith("(") and stripped.endswith(")"):
+        depth = 0
+        encloses_all = True
+        for index, char in enumerate(stripped):
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0 and index != len(stripped) - 1:
+                    encloses_all = False
+                    break
+            if depth < 0:
+                encloses_all = False
+                break
+        if not encloses_all or depth != 0:
+            break
+        stripped = stripped[1:-1].strip()
+    return stripped
+
+
+def _split_top_level_boolean_operator(expression: str, operator: str) -> list[str]:
+    parts: list[str] = []
+    depth = 0
+    start = 0
+    index = 0
+    pattern = re.compile(rf"\b{re.escape(operator)}\b")
+    while index < len(expression):
+        char = expression[index]
+        if char == "(":
+            depth += 1
+            index += 1
+            continue
+        if char == ")":
+            depth = max(depth - 1, 0)
+            index += 1
+            continue
+        if depth == 0:
+            match = pattern.match(expression, index)
+            if match is not None:
+                parts.append(expression[start:index].strip())
+                start = match.end()
+                index = match.end()
+                continue
+        index += 1
+    parts.append(expression[start:].strip())
+    return [part for part in parts if part]
 
 
 def _rulespec_executable_signature(rule: dict[str, Any]) -> str | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12584,7 +12584,9 @@ rules:
         }
         assert test_payload[1]["tables"] == test_payload[0]["tables"]
 
-    def test_judgment_positive_test_repair_skips_constant_false_rule(self, tmp_path):
+    def test_judgment_positive_test_repair_skips_unsatisfiable_false_rule(
+        self, tmp_path
+    ):
         repo_path = tmp_path / "rulespec-us-co"
         rules_file = repo_path / "regulations" / "10-ccr-2506-1" / "4.801.43.yaml"
         test_file = repo_path / "regulations" / "10-ccr-2506-1" / "4.801.43.test.yaml"
@@ -12600,13 +12602,17 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: |-
-          false
+          claim_is_terminated
+          and voluntary_payment_made_on_terminated_claim
+          and false
 """
         )
         test_file.write_text(
             """- name: terminated_claim_nonreactivation
   period: 2026-01
-  input: {}
+  input:
+    us-co:regulations/10-ccr-2506-1/4.801.43#input.claim_is_terminated: true
+    us-co:regulations/10-ccr-2506-1/4.801.43#input.voluntary_payment_made_on_terminated_claim: true
   output:
     us-co:regulations/10-ccr-2506-1/4.801.43#voluntary_payment_reactivates_terminated_claim: not_holds
 """

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -1053,7 +1053,9 @@ rules:
     ]
 
 
-def test_judgment_positive_companion_output_allows_constant_false_rule(tmp_path):
+def test_judgment_positive_companion_output_allows_unsatisfiable_false_rule(
+    tmp_path,
+):
     policy_repo = tmp_path / "rulespec-us-co"
     rules_file = policy_repo / "regulations" / "10-ccr-2506-1" / "4.801.43.yaml"
     rules_file.parent.mkdir(parents=True)
@@ -1068,13 +1070,18 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         formula: |-
-          false
+          claim_is_terminated
+          and voluntary_payment_made_on_terminated_claim
+          and false
 """
     cases = [
         {
             "name": "terminated_claim_nonreactivation",
             "period": "2026-01",
-            "input": {},
+            "input": {
+                "us-co:regulations/10-ccr-2506-1/4.801.43#input.claim_is_terminated": True,
+                "us-co:regulations/10-ccr-2506-1/4.801.43#input.voluntary_payment_made_on_terminated_claim": True,
+            },
             "output": {
                 "us-co:regulations/10-ccr-2506-1/4.801.43#voluntary_payment_reactivates_terminated_claim": "not_holds"
             },
@@ -1089,6 +1096,53 @@ rules:
     )
 
     assert issues == []
+
+
+def test_judgment_positive_companion_output_requires_positive_for_or_false_rule(
+    tmp_path,
+):
+    policy_repo = tmp_path / "rulespec-us-co"
+    rules_file = policy_repo / "regulations" / "10-ccr-2506-1" / "4.801.43.yaml"
+    rules_file.parent.mkdir(parents=True)
+    content = """format: rulespec/v1
+rules:
+  - name: terminated_claim_reactivation_prohibited
+    kind: derived
+    entity: SnapClaim
+    dtype: Judgment
+    period: Month
+    source: 10 CCR 2506-1 4.801.43(A)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          claim_is_terminated
+          or false
+"""
+    cases = [
+        {
+            "name": "not_terminated",
+            "period": "2026-01",
+            "input": {
+                "us-co:regulations/10-ccr-2506-1/4.801.43#input.claim_is_terminated": False,
+            },
+            "output": {
+                "us-co:regulations/10-ccr-2506-1/4.801.43#terminated_claim_reactivation_prohibited": "not_holds"
+            },
+        }
+    ]
+
+    issues = find_judgment_positive_companion_output_issues(
+        content,
+        cases,
+        rules_file=rules_file,
+        policy_repo_path=policy_repo,
+    )
+
+    assert issues == [
+        "Judgment rule missing positive companion output coverage: "
+        "`us-co:regulations/10-ccr-2506-1/4.801.43#terminated_claim_reactivation_prohibited` "
+        "is not asserted as `holds` by the companion `.test.yaml` file."
+    ]
 
 
 def test_judgment_positive_companion_output_allows_holds_case(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.716"
+version = "0.2.717"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- treat Judgment formulas forced false by a top-level `and false` conjunct as unsatisfiable for positive companion coverage
- keep apply-time positive test repair from synthesizing impossible `holds` cases for these legal prohibitions
- add a guard that `x or false` still requires positive coverage
- bump axiom-encode to 0.2.717

## Validation
- `uv run pytest tests/test_rulespec_validation.py -k 'judgment_positive_companion_output'`\n- `uv run pytest tests/test_cli.py -k 'judgment_positive_test_repair'`\n- `uv run ruff check src/ tests/`\n- `uv run ruff format --check src/ tests/`\n- `git diff --check`\n- `uv run pytest tests/test_cli.py -k 'current_encoder_affecting_changes_are_behind_version_bump'`