### PR TITLE
Skip source-scope fallback for path-only proofs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.717"
+version = "0.2.718"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.717"
+__version__ = "0.2.718"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -7705,6 +7705,9 @@ def _rule_source_scope(
     fallback_source_text: str,
 ) -> tuple[str, str | None] | None:
     source_texts = _rule_proof_source_excerpts(rule)
+    if not source_texts and _rule_proof_source_contexts(rule):
+        # Path-only proof citations are not rule-specific source text.
+        return None
     if not source_texts and fallback_source_text:
         source_texts = [fallback_source_text]
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -14280,6 +14280,40 @@ rules:
     ]
 
 
+def test_source_scope_consistency_skips_mixed_summary_for_path_only_proof():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.803.41
+  summary: |-
+    Households mailed a waiver request must receive a statement of rights and
+    notice that they have fifteen days to return a completed waiver. Completion
+    is voluntary. If the suspected member signs and timely returns the waiver,
+    that person and the head of household receive a notice of disqualification.
+rules:
+  - name: waiver_completion_voluntary_requirement_satisfied
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Day
+    source: 10 CCR 2506-1, section 4.803.41(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.803.41
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          not local_office_requires_completion_of_waiver
+          and not local_office_actions_appear_to_require_completion_of_waiver
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
 def test_source_scope_consistency_rejects_definite_person_subject_at_unit_scope():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.717"
+version = "0.2.718"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- skip source-scope summary fallback when a rule has proof source references but no excerpt text
- add a Colorado waiver-section regression for mixed procedural summaries
- bump axiom-encode to 0.2.718

## Tests
- uv run pytest tests/test_rulespec_validation.py -k 'source_scope_consistency'
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check
- uv run pytest tests/test_cli.py -k 'current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject'