### PR TITLE
Reject mixed-case rule name tokens

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.718"
+version = "0.2.719"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.718"
+__version__ = "0.2.719"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -14086,6 +14086,34 @@ def find_rule_name_path_suffix_issues(
     return []
 
 
+def find_mixed_case_rule_name_token_issues(content: str) -> list[str]:
+    """Reject accidental mixed-case word tokens in exported rule names."""
+    payload = _rulespec_payload(content)
+    if payload is None:
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    issues: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        name = str(rule.get("name") or "").strip()
+        if not name:
+            continue
+        for token in name.split("_"):
+            if any(ch.islower() for ch in token) and any(ch.isupper() for ch in token):
+                issues.append(
+                    "Rule name token uses accidental mixed case: "
+                    f"rule `{name}` contains token `{token}`. Use lowercase "
+                    "semantic acronyms such as `ipv`; reserve uppercase for "
+                    "source-stated legal fragments like `D`, `7C`, or `7527A`."
+                )
+                break
+    return issues
+
+
 def _path_suffix_tokens_for_rule_name(
     section: str,
     fragments: tuple[str, ...],
@@ -19778,6 +19806,7 @@ class ValidatorPipeline:
         )
         issues.extend(find_helper_only_definition_issues(content))
         issues.extend(find_deferred_output_issues(content))
+        issues.extend(find_mixed_case_rule_name_token_issues(content))
         # Read the requested-source target from the nearby eval workspace or
         # the durable apply manifest so subparagraph-coverage scoping respects
         # encoder intent even when the corpus served a parent-fallback source

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -59,6 +59,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_missing_child_exception_import_issues,
     find_missing_derived_companion_output_issues,
     find_missing_same_section_subsection_import_issues,
+    find_mixed_case_rule_name_token_issues,
     find_nonnegative_amount_reduction_issues,
     find_out_of_scope_rule_source_issues,
     find_partial_extent_zeroing_issues,
@@ -7818,6 +7819,41 @@ rules:
         )
         == []
     )
+
+
+def test_mixed_case_rule_name_token_rejects_accidental_acronym_case():
+    content = """format: rulespec/v1
+rules:
+  - name: first_ipV_disqualification_months
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 12
+"""
+
+    issues = find_mixed_case_rule_name_token_issues(content)
+
+    assert issues == [
+        "Rule name token uses accidental mixed case: rule "
+        "`first_ipV_disqualification_months` contains token `ipV`. Use "
+        "lowercase semantic acronyms such as `ipv`; reserve uppercase for "
+        "source-stated legal fragments like `D`, `7C`, or `7527A`."
+    ]
+
+
+def test_mixed_case_rule_name_token_allows_legal_fragments():
+    content = """format: rulespec/v1
+rules:
+  - name: aggregate_advance_payments_under_section_7527A
+    kind: derived
+  - name: paragraph_7C_or_10_cash_remuneration_deduction_threshold
+    kind: parameter
+  - name: subsection_a_1_D_applies_to_readily_tradable_instrument_payment
+    kind: derived
+"""
+
+    assert find_mixed_case_rule_name_token_issues(content) == []
 
 
 def test_sibling_rule_name_collision_rejects_duplicate_exports(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.718"
+version = "0.2.719"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- reject accidental mixed-case tokens in exported RuleSpec rule names
- allow source-stated legal fragments like `D`, `7C`, and `7527A`
- bump axiom-encode to 0.2.719

## Tests
- `uv run pytest tests/test_rulespec_validation.py -k 'mixed_case_rule_name_token or rule_name_path_suffix or sibling_rule_name_collision'`\n- `uv run pytest tests/test_cli.py -k 'current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject'`\n- `uv run ruff check src/ tests/`\n- `uv run ruff format --check src/ tests/`\n- `git diff --check`