### PR TITLE
Support state regulation cited context

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.720"
+version = "0.2.721"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.720"
+__version__ = "0.2.721"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2355,6 +2355,10 @@ def _candidate_corpus_citation_paths(identifier: str) -> tuple[str, ...]:
 
 def _looks_like_corpus_citation_path(identifier: str) -> bool:
     parts = [part for part in identifier.strip().strip("/").split("/") if part]
+    if parts and ":" in parts[0]:
+        _jurisdiction, source_root = parts[0].split(":", 1)
+        if source_root in _RULESPEC_SOURCE_ROOT_TOKENS:
+            return True
     if len(parts) >= 2 and parts[0] in _RULESPEC_SOURCE_ROOT_TOKENS:
         return True
     return len(parts) >= 3 and parts[1] in {
@@ -2673,22 +2677,23 @@ def _select_cross_section_context_files(
     source_text: str,
     policy_root: Path,
 ) -> list[Path]:
-    """Select existing RuleSpecs for cited USC sections outside this section."""
-    try:
-        parts = parse_usc_citation(citation)
-    except Exception:
+    """Select existing RuleSpecs for cited sections outside this section."""
+    current_section = _section_for_eval_identifier(citation)
+    if current_section is None:
         return []
 
-    target_rel = citation_to_relative_rulespec_path(parts)
+    target_rel = _target_rel_for_eval_identifier(citation)
+    if target_rel is None:
+        return []
     selected: list[Path] = []
     seen: set[Path] = set()
     for cited_parts, _start, _end in _iter_cited_usc_sections(source_text):
-        if cited_parts.section == parts.section:
+        if cited_parts.section == current_section:
             continue
-        cited_parts = CitationParts(
-            parts.title, cited_parts.section, cited_parts.fragments
-        )
-        for candidate_rel in _cited_context_candidate_paths(cited_parts):
+        for candidate_rel in _cited_context_candidate_paths_for_eval_identifier(
+            citation,
+            cited_parts,
+        ):
             if candidate_rel == target_rel:
                 continue
             candidates = _cited_context_candidates(
@@ -2707,6 +2712,102 @@ def _select_cross_section_context_files(
                     seen.add(resolved)
             break
     return selected
+
+
+def _section_for_eval_identifier(citation: str) -> str | None:
+    """Return the current legal section for USC or corpus-backed identifiers."""
+    if _looks_like_corpus_citation_path(citation):
+        target_rel = _target_rel_for_eval_identifier(citation)
+        if target_rel is None:
+            return None
+        parts = list(target_rel.parts)
+        if len(parts) >= 3 and parts[0] in {"regulations", "statutes"}:
+            return Path(parts[2]).stem
+        return None
+
+    try:
+        return parse_usc_citation(citation).section
+    except Exception:
+        return None
+
+
+def _cited_context_candidate_paths_for_eval_identifier(
+    citation: str,
+    cited_parts: CitationParts,
+) -> list[Path]:
+    """Return candidate RuleSpec paths for a source-text section citation."""
+    if not _looks_like_corpus_citation_path(citation):
+        try:
+            current_parts = parse_usc_citation(citation)
+        except Exception:
+            current_parts = None
+        if current_parts is None:
+            return []
+        return _cited_context_candidate_paths(
+            CitationParts(
+                current_parts.title,
+                cited_parts.section,
+                cited_parts.fragments,
+            )
+        )
+
+    target_rel = _target_rel_for_eval_identifier(citation)
+    if target_rel is None:
+        return []
+    return _same_source_cited_context_candidate_paths(target_rel, cited_parts)
+
+
+def _same_source_cited_context_candidate_paths(
+    target_rel: Path,
+    cited_parts: CitationParts,
+) -> list[Path]:
+    """Return same-instrument candidates for non-USC corpus-backed citations."""
+    parts = list(target_rel.parts)
+    if len(parts) >= 3 and parts[0] == "regulations":
+        base = Path(parts[0]) / parts[1]
+        return _dotted_section_context_candidate_paths(base, cited_parts)
+    if len(parts) >= 3 and parts[0] == "statutes":
+        return _cited_context_candidate_paths(
+            CitationParts(parts[1], cited_parts.section, cited_parts.fragments)
+        )
+    return []
+
+
+def _dotted_section_context_candidate_paths(
+    base: Path,
+    cited_parts: CitationParts,
+) -> list[Path]:
+    """Return exact and dotted-ancestor candidates for state regulation sections."""
+    paths: list[Path] = []
+    section = cited_parts.section
+    for length in range(len(cited_parts.fragments), -1, -1):
+        paths.append(
+            _dotted_section_context_path(
+                base,
+                section,
+                cited_parts.fragments[:length],
+            )
+        )
+    if re.fullmatch(r"\d+(?:\.\d+)+", section):
+        segments = section.split(".")
+        for length in range(len(segments) - 1, 0, -1):
+            paths.append(base / f"{'.'.join(segments[:length])}.yaml")
+
+    unique: list[Path] = []
+    for path in paths:
+        if path not in unique:
+            unique.append(path)
+    return unique
+
+
+def _dotted_section_context_path(
+    base: Path,
+    section: str,
+    fragments: tuple[str, ...],
+) -> Path:
+    if not fragments:
+        return base / f"{section}.yaml"
+    return base / section / Path(*fragments[:-1]) / f"{fragments[-1]}.yaml"
 
 
 def _source_text_requests_cited_subsection_rates(source_text: str) -> bool:
@@ -2883,8 +2984,15 @@ def _relative_rulespec_path_to_import_target(
 
 def _target_rel_for_eval_identifier(citation: str) -> Path | None:
     """Return the canonical RuleSpec target path for corpus or USC citations."""
-    if _looks_like_corpus_citation_path(citation.strip().strip("/")):
-        return _source_identifier_to_relative_rulespec_path(citation)
+    normalized = citation.strip().strip("/")
+    first_part = normalized.split("/", 1)[0]
+    if ":" in first_part:
+        _jurisdiction, source_root = first_part.split(":", 1)
+        if source_root in _RULESPEC_SOURCE_ROOT_TOKENS:
+            rest = normalized.split(":", 1)[1]
+            return _source_identifier_to_relative_rulespec_path(rest)
+    if _looks_like_corpus_citation_path(normalized):
+        return _source_identifier_to_relative_rulespec_path(normalized)
     try:
         return citation_to_relative_rulespec_path(citation)
     except Exception:
@@ -6507,10 +6615,10 @@ def _missing_cited_statute_targets(
     context_files: list[EvalContextFile],
 ) -> list[tuple[str, str]]:
     """Return cited statute targets that are not available as copied context."""
-    try:
-        parts = parse_usc_citation(citation)
-    except Exception:
+    current_section = _section_for_eval_identifier(citation)
+    if current_section is None:
         return []
+    import_prefix = _import_prefix_for_eval_identifier(citation)
 
     available = {
         _normalize_prompt_import_target(item.import_path) for item in context_files
@@ -6519,19 +6627,29 @@ def _missing_cited_statute_targets(
     seen: set[str] = set()
     for cited_parts, _start, _end in _iter_cited_usc_sections(source_text):
         section = cited_parts.section
-        if section == parts.section:
+        if section == current_section:
             continue
-        target_parts = CitationParts(parts.title, section, cited_parts.fragments)
-        target = _relative_rulespec_path_to_import_target(
-            citation_to_relative_rulespec_path(target_parts).with_suffix(""),
-            prefix="us",
+        candidate_paths = _cited_context_candidate_paths_for_eval_identifier(
+            citation,
+            cited_parts,
         )
-        normalized = _normalize_prompt_import_target(target)
+        if not candidate_paths:
+            continue
+        candidate_targets = [
+            _relative_rulespec_path_to_import_target(path, prefix=import_prefix)
+            for path in candidate_paths
+        ]
+        normalized_candidates = [
+            _normalize_prompt_import_target(target) for target in candidate_targets
+        ]
         if any(
             _prompt_import_covers(available_target, normalized)
             for available_target in available
+            for normalized in normalized_candidates
         ):
             continue
+        target = candidate_targets[0]
+        normalized = normalized_candidates[0]
         if normalized in seen:
             continue
         seen.add(normalized)
@@ -6542,6 +6660,23 @@ def _missing_cited_statute_targets(
         )
         missing.append((label, target))
     return missing
+
+
+def _import_prefix_for_eval_identifier(citation: str) -> str | None:
+    """Return the canonical import prefix implied by an eval identifier."""
+    normalized = citation.strip().strip("/")
+    first_part = normalized.split("/", 1)[0]
+    if ":" in first_part:
+        prefix, _rest = first_part.split(":", 1)
+        return prefix or None
+    parts = [part for part in normalized.split("/") if part]
+    if len(parts) >= 3 and parts[0] not in _RULESPEC_SOURCE_ROOT_TOKENS:
+        return parts[0]
+    try:
+        parse_usc_citation(citation)
+    except Exception:
+        return None
+    return "us"
 
 
 def _normalize_prompt_import_target(import_target: str) -> str:
@@ -6555,10 +6690,18 @@ def _normalize_prompt_import_target(import_target: str) -> str:
 
 def _prompt_import_covers(available: str, expected: str) -> bool:
     """Return whether an available prompt import covers an expected target."""
-    return (
+    if (
         available == expected
         or available.startswith(expected + "/")
         or expected.startswith(available + "/")
+    ):
+        return True
+    available_parts = available.split("/")
+    expected_parts = expected.split("/")
+    return (
+        len(available_parts) == len(expected_parts)
+        and available_parts[:-1] == expected_parts[:-1]
+        and expected_parts[-1].startswith(available_parts[-1] + ".")
     )
 
 
@@ -6640,11 +6783,31 @@ def _import_target_to_statute_citation(import_path: str) -> _StatuteCitation | N
     try:
         statutes_index = parts.index("statutes")
     except ValueError:
-        return None
-    if len(parts) <= statutes_index + 2:
-        return None
-    section = parts[statutes_index + 2]
-    fragments = tuple(parts[statutes_index + 3 :])
+        statutes_index = None
+    if statutes_index is not None:
+        if len(parts) <= statutes_index + 2:
+            return None
+        section = parts[statutes_index + 2]
+        fragments = tuple(parts[statutes_index + 3 :])
+    else:
+        try:
+            regulations_index = parts.index("regulations")
+        except ValueError:
+            return None
+        if len(parts) <= regulations_index + 2:
+            return None
+        regulation_root = parts[regulations_index + 1]
+        if re.fullmatch(r"\d+-ccr-\d+-\d+", regulation_root, flags=re.IGNORECASE):
+            section = parts[regulations_index + 2]
+            fragments = tuple(parts[regulations_index + 3 :])
+        elif (
+            re.fullmatch(r"\d+-cfr", regulation_root, flags=re.IGNORECASE)
+            and len(parts) > regulations_index + 3
+        ):
+            section = f"{parts[regulations_index + 2]}.{parts[regulations_index + 3]}"
+            fragments = tuple(parts[regulations_index + 4 :])
+        else:
+            return None
     if not re.fullmatch(r"[0-9][A-Za-z0-9.-]*", section):
         return None
     if not all(_is_citation_fragment(fragment) for fragment in fragments):

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -9240,6 +9240,96 @@ rules:
             copied_sources[str(context_test)]["kind"] == "implementation_test_context"
         )
 
+    def test_prepare_eval_workspace_adds_state_regulation_cross_section_context(
+        self, tmp_path
+    ):
+        repo_root = tmp_path / "repos"
+        policy_repo_root = repo_root / "rulespec-us-co"
+        regulations_root = policy_repo_root / "regulations" / "10-ccr-2506-1"
+        regulations_root.mkdir(parents=True)
+        disqualification_period = regulations_root / "4.803.2.yaml"
+        disqualification_period.write_text(
+            "format: rulespec/v1\n"
+            "rules:\n"
+            "  - name: consent_agreement_disqualification_start_deadline_calendar_days\n"
+            "    kind: parameter\n"
+            "    dtype: Integer\n"
+            "    period: Year\n"
+            "    versions:\n"
+            "      - effective_from: '2026-01-01'\n"
+            "        formula: '30'\n"
+        )
+        fair_hearing_parent = regulations_root / "4.411.yaml"
+        fair_hearing_parent.write_text(
+            "format: rulespec/v1\n"
+            "rules:\n"
+            "  - name: fair_hearing_request_deadline_days\n"
+            "    kind: parameter\n"
+            "    dtype: Integer\n"
+            "    period: Year\n"
+            "    versions:\n"
+            "      - effective_from: '2026-01-01'\n"
+            "        formula: '90'\n"
+        )
+        source_text = (
+            "Disqualification shall continue uninterrupted until completed, "
+            "regardless of household eligibility, and shall be imposed in "
+            "accordance with Section 4.803.2, F unless contrary to the court "
+            "order. The household may also request a hearing under Section "
+            "4.411.1."
+        )
+
+        selected = _select_cross_section_context_files(
+            "us-co/regulation/10-ccr-2506-1/4.804.1",
+            source_text,
+            policy_repo_root,
+        )
+
+        assert selected == [disqualification_period, fair_hearing_parent]
+
+        workspace = prepare_eval_workspace(
+            citation="us-co/regulation/10-ccr-2506-1/4.804.1",
+            runner=parse_runner_spec("openai:gpt-5.5"),
+            output_root=tmp_path / "out",
+            source_text=source_text,
+            axiom_rules_path=policy_repo_root,
+            mode="repo-augmented",
+            source_metadata_payload={
+                "corpus_citation_path": "us-co/regulation/10-ccr-2506-1/4.804.1",
+            },
+            extra_context_paths=[],
+        )
+
+        manifest = json.loads(workspace.manifest_file.read_text())
+        copied_sources = {
+            item["source_path"]: item for item in manifest["context_files"]
+        }
+        assert (
+            copied_sources[str(disqualification_period)]["import_path"]
+            == "us-co:regulations/10-ccr-2506-1/4.803.2"
+        )
+        assert (
+            copied_sources[str(fair_hearing_parent)]["import_path"]
+            == "us-co:regulations/10-ccr-2506-1/4.411"
+        )
+
+        prompt = _build_eval_prompt(
+            "us-co/regulation/10-ccr-2506-1/4.804.1",
+            "repo-augmented",
+            workspace,
+            workspace.context_files,
+            target_file_name="4.804.1.yaml",
+            target_ref_prefix="us-co:regulations/10-ccr-2506-1/4.804.1",
+            include_tests=True,
+            runner_backend="openai",
+        )
+
+        assert "Mandatory cited RuleSpec imports detected" in prompt
+        assert "`us-co:regulations/10-ccr-2506-1/4.803.2`" in prompt
+        assert "`us-co:regulations/10-ccr-2506-1/4.411`" in prompt
+        assert "Missing cited RuleSpec sources detected" not in prompt
+        assert "us:statutes/us-co:regulations" not in prompt
+
     def test_prepare_eval_workspace_adds_child_context_for_unavailable_cited_parent(
         self, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.720"
+version = "0.2.721"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- resolve corpus-backed regulation section citations against the same regulation manual instead of USC paths
- recognize copied regulation context in cited-import prompt guidance
- add a CO SNAP regression for Section 4.803.2 and dotted ancestor fallback to Section 4.411

## Tests
- uv run pytest tests/test_evals.py -k "state_regulation_cross_section_context or cross_section_context or missing_cross_reference_exception_requires_defer or missing_definition_dependency_requires_defer"
- uv run pytest tests/test_cli.py -k "current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject"
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- git diff --check HEAD~1 HEAD