### PR TITLE
Support colon-prefixed source id output paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.721"
+version = "0.2.722"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.721"
+__version__ = "0.2.722"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -4006,6 +4006,27 @@ def _source_identifier_to_relative_rulespec_path(source_id: str) -> Path:
     time (issue #71).
     """
     parts = [part for part in source_id.strip().strip("/").split("/") if part]
+    if parts and ":" in parts[0]:
+        jurisdiction, source_root = parts[0].split(":", 1)
+        if source_root in _RULESPEC_SOURCE_ROOT_TOKENS:
+            tail = parts[1:]
+            root = _RULESPEC_OUTPUT_ROOT_BY_SOURCE_TOKEN.get(source_root, source_root)
+            if (
+                tail
+                and jurisdiction == "us"
+                and source_root
+                in {
+                    "regulation",
+                    "regulations",
+                }
+            ):
+                tail = _canonical_us_regulation_tail(tail)
+            if tail and jurisdiction == "uk":
+                tail = _canonical_uk_legislation_tail(tail)
+            if tail:
+                if _preserve_state_statute_dotted_leaf(jurisdiction, root, tail):
+                    return Path(root) / Path(*tail[:-1]) / f"{tail[-1]}.yaml"
+                return Path(root) / _dotted_leaf_to_nested_yaml_path(tail)
     if len(parts) >= 2 and parts[0] in _RULESPEC_SOURCE_ROOT_TOKENS:
         tail = parts[1:]
         if tail:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -123,6 +123,12 @@ def test_source_identifier_maps_corpus_regulation_to_repo_path():
     ) == Path("regulations/18-nycrr/387/12/f/3/v/c.yaml")
 
 
+def test_source_identifier_maps_colon_prefixed_regulation_to_repo_path():
+    assert _source_identifier_to_relative_rulespec_path(
+        "us-co:regulations/10-ccr-2506-1/4.804.1"
+    ) == Path("regulations/10-ccr-2506-1/4.804.1.yaml")
+
+
 def test_source_identifier_maps_state_manual_to_policies_repo_path():
     assert _source_identifier_to_relative_rulespec_path(
         "us-az/manual/des/faa5/na-child-support-expense/block-2"
@@ -515,6 +521,24 @@ def test_resolve_eval_output_path_uses_repo_relative_source_root_directly():
         "policies/otda/snap/fy-2026-benefit-calculation",
         requested_source="us/guidance/usda/fns/snap-fy2026-cola/page-1",
     ) == Path("policies/otda/snap/fy-2026-benefit-calculation.yaml")
+
+
+def test_resolve_eval_output_path_uses_colon_prefixed_rulespec_source_id(tmp_path):
+    repo = tmp_path / "rulespec-us-co"
+    repo.mkdir()
+
+    source_id = "us-co:regulations/10-ccr-2506-1/4.804.1"
+    relative_output = _resolve_eval_output_path(source_id)
+
+    assert relative_output == Path("regulations/10-ccr-2506-1/4.804.1.yaml")
+    assert (
+        _canonical_target_ref_prefix(
+            source_id,
+            relative_output,
+            policy_repo_path=repo,
+        )
+        == "us-co:regulations/10-ccr-2506-1/4.804.1"
+    )
 
 
 def test_resolve_eval_output_path_uses_requested_source_when_citation_is_free_text():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.721"
+version = "0.2.722"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map colon-prefixed RuleSpec source ids like `us-co:regulations/...` to canonical repo-relative output paths
- keep generated tests and apply validation anchored on `regulations/...` instead of `source/...`
- bump axiom-encode to 0.2.722

## Tests
- `uv run pytest tests/test_evals.py -k "source_identifier_maps_colon_prefixed_regulation_to_repo_path or resolve_eval_output_path_uses_colon_prefixed_rulespec_source_id or state_regulation_cross_section_context"`
- `uv run pytest tests/test_cli.py -k "current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject"`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `git diff --check HEAD~1 HEAD`