### PR TITLE
Reject synthetic source-authorized test inputs

### DIFF
--- a/changelog.d/source-authorized-prohibition-inputs.fixed.md
+++ b/changelog.d/source-authorized-prohibition-inputs.fixed.md
@@ -1,0 +1,1 @@
+Reject synthetic `source_authorized` local inputs that make source-stated prohibitions or non-entitlements pass positive Judgment companion tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.722"
+version = "0.2.723"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.722"
+__version__ = "0.2.723"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -4857,6 +4857,12 @@ RuleSpec requirements:
   amount but depends on externally determined classifications, official
   designations, statuses, event facts, or source-document categories, encode
   the amount with boundary inputs for those facts instead of deferring.
+- If the source says an actor may not request something, is not entitled to
+  something, or is otherwise categorically prohibited, do not create a local
+  authorization escape-hatch input such as
+  `*_has_source_authorized_*_entitlement` to make the positive entitlement
+  hold. Encode the entitlement as a constant false Judgment or encode the
+  source-stated prohibition/not-entitled rule directly.
 - This includes exclusions conditioned on a reasonable belief that an item can
   be excluded from income under another section. Do not defer solely because
   the cited exclusion section is not encoded; model the source-stated

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -6460,6 +6460,68 @@ def find_judgment_positive_companion_output_issues(
     return issues
 
 
+_SYNTHETIC_SOURCE_AUTHORIZED_INPUT_PATTERN = re.compile(
+    r"(?:^|_)source_authorized(?:_|$)"
+)
+
+
+def find_synthetic_source_authorized_input_issues(content: str) -> list[str]:
+    """Reject local inputs that let tests invent source authorization.
+
+    These inputs usually appear when a source-stated prohibition is encoded as a
+    positive entitlement gated by a caller-supplied escape hatch, e.g. a source
+    says a county is not entitled to a postponement but the formula depends on
+    ``county_has_source_authorized_postponement_entitlement``.
+    """
+    try:
+        payload = yaml.safe_load(content)
+    except (yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict) or payload.get("format") != "rulespec/v1":
+        return []
+
+    local_symbols = _rulespec_executable_names_from_payload(payload)
+    local_symbols.update(_rulespec_data_relation_names(payload))
+    local_symbols.update(_rulespec_import_symbol_names(payload))
+
+    issues: list[str] = []
+    seen: set[tuple[str, str]] = set()
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return issues
+    for rule in rules:
+        if not isinstance(rule, dict) or rule.get("kind") != "derived":
+            continue
+        rule_name = _rulespec_rule_name(rule)
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            for identifier in sorted(_formula_local_identifiers(formula)):
+                if identifier in local_symbols:
+                    continue
+                if not _SYNTHETIC_SOURCE_AUTHORIZED_INPUT_PATTERN.search(identifier):
+                    continue
+                key = (rule_name, identifier)
+                if key in seen:
+                    continue
+                seen.add(key)
+                issues.append(
+                    "Synthetic source-authorized local input: "
+                    f"`{rule_name}` depends on local input `{identifier}`. "
+                    "Encode the source-stated authorization, prohibition, or "
+                    "entitlement directly, or import a source-backed upstream "
+                    "authorization rule; do not let tests supply a "
+                    "`source_authorized` escape hatch."
+                )
+    return issues
+
+
 def _rule_versions_are_constant_false(versions: list[Any]) -> bool:
     formulas = [
         str(version.get("formula") or "").strip().lower()
@@ -19919,6 +19981,7 @@ class ValidatorPipeline:
             )
         )
         issues.extend(find_sibling_rule_name_collision_issues(content, rules_file))
+        issues.extend(find_synthetic_source_authorized_input_issues(content))
         issues.extend(
             find_child_fragment_reencoding_issues(
                 content,

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -786,6 +786,12 @@ _NAMING_PROTOCOL = """- Do not create standalone small-number parameters just to
   amount but depends on externally determined classifications, official
   designations, statuses, event facts, or source-document categories, encode
   the amount with boundary inputs for those facts instead of deferring.
+- If the source says an actor may not request something, is not entitled to
+  something, or is otherwise categorically prohibited, do not create a local
+  authorization escape-hatch input such as
+  `*_has_source_authorized_*_entitlement` to make the positive entitlement
+  hold. Encode the entitlement as a constant false Judgment or encode the
+  source-stated prohibition/not-entitled rule directly.
 - This includes exclusions conditioned on a reasonable belief that an item can
   be excluded from income under another section. Do not defer solely because
   the cited exclusion section is not encoded; model the source-stated

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -82,6 +82,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_source_subparagraph_coverage_issues,
     find_source_table_row_scalar_parameter_issues,
     find_source_verification_issues,
+    find_synthetic_source_authorized_input_issues,
     find_tax_filing_status_enum_representation_issues,
     find_tax_filing_status_local_input_issues,
     find_tax_filing_status_surviving_spouse_issues,
@@ -1097,6 +1098,34 @@ rules:
     )
 
     assert issues == []
+
+
+def test_synthetic_source_authorized_input_rejected_for_prohibition():
+    content = """format: rulespec/v1
+rules:
+  - name: county_postponement_entitled
+    kind: derived
+    entity: SnapFairHearing
+    dtype: Judgment
+    period: Day
+    source: 10 CCR 2506-1 section 4.802.61(A)(3)
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          county_requested_postponement
+          and county_has_source_authorized_postponement_entitlement
+"""
+
+    issues = find_synthetic_source_authorized_input_issues(content)
+
+    assert issues == [
+        "Synthetic source-authorized local input: "
+        "`county_postponement_entitled` depends on local input "
+        "`county_has_source_authorized_postponement_entitlement`. "
+        "Encode the source-stated authorization, prohibition, or entitlement "
+        "directly, or import a source-backed upstream authorization rule; do "
+        "not let tests supply a `source_authorized` escape hatch."
+    ]
 
 
 def test_judgment_positive_companion_output_requires_positive_for_or_false_rule(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.722"
+version = "0.2.723"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Reject local formula inputs containing `source_authorized` when they are not declared or imported source-backed symbols
- Add encoder prompt guidance for source-stated prohibitions and non-entitlements
- Bump axiom-encode to 0.2.723 with a changelog fragment

## Why
While stress-testing Colorado SNAP hearing rules, the encoder generated a positive entitlement rule for a county postponement even though the source says the county may not request and is not entitled to postponement. The generated formula depended on `county_has_source_authorized_postponement_entitlement`, and the companion test simply set that input true. This PR makes that pattern fail validation instead of letting tests invent source authority.

## Tests
- `uv run --with pytest python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `uv run --with pytest python -m pytest tests/test_rulespec_validation.py::test_synthetic_source_authorized_input_rejected_for_prohibition tests/test_rulespec_validation.py::test_judgment_positive_companion_output_allows_unsatisfiable_false_rule tests/test_rulespec_validation.py::test_judgment_positive_companion_output_rejects_never_holds`
- `uv run --with pytest python -m pytest tests/test_cli.py -k 'judgment_positive_test_repair_skips_unsatisfiable_false_rule or judgment_positive_test_repair_synthesizes_formula_inputs'`\n- `uv run ruff check src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_rulespec_validation.py`\n- `uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_rulespec_validation.py`\n- `uv run --with towncrier python -m towncrier build --draft --version 0.0.0`