### PR TITLE
Synthesize recursive positive Judgment inputs

### DIFF
--- a/changelog.d/recursive-positive-judgment-tests.fixed.md
+++ b/changelog.d/recursive-positive-judgment-tests.fixed.md
@@ -1,0 +1,1 @@
+Synthesize positive Judgment companion tests through local positive Judgment dependencies so required dependency inputs are set to satisfying values instead of later defaulting to false.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.723"
+version = "0.2.724"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.723"
+__version__ = "0.2.724"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -15316,6 +15316,24 @@ def _positive_judgment_formula_input_assignments(
     rules_by_name: dict[str, dict[str, object]],
     imported_outputs: set[str],
 ) -> dict[str, object]:
+    assignments, _protected = _positive_judgment_formula_input_assignments_for_formula(
+        formula=formula,
+        rules_payload=rules_payload,
+        rules_by_name=rules_by_name,
+        imported_outputs=imported_outputs,
+        seen_rules=set(),
+    )
+    return assignments
+
+
+def _positive_judgment_formula_input_assignments_for_formula(
+    *,
+    formula: str,
+    rules_payload: dict[str, object],
+    rules_by_name: dict[str, dict[str, object]],
+    imported_outputs: set[str],
+    seen_rules: set[str],
+) -> tuple[dict[str, object], set[str]]:
     negated_group_spans = _negated_parenthesized_expression_spans(formula)
     positive_context_formula = _formula_with_spans_blank(
         formula,
@@ -15330,7 +15348,26 @@ def _positive_judgment_formula_input_assignments(
     defined_symbols = set(rules_by_name) | imported_outputs
 
     for identifier in sorted(identifiers - negated_identifiers):
-        if identifier in rules_by_name or identifier in imported_outputs:
+        dependency = rules_by_name.get(identifier)
+        if dependency is not None:
+            if _rule_is_derived_judgment(dependency) and identifier not in seen_rules:
+                dependency_formula = _first_rule_formula(dependency)
+                if dependency_formula:
+                    (
+                        dependency_assignments,
+                        dependency_protected_inputs,
+                    ) = _positive_judgment_formula_input_assignments_for_formula(
+                        formula=dependency_formula,
+                        rules_payload=rules_payload,
+                        rules_by_name=rules_by_name,
+                        imported_outputs=imported_outputs,
+                        seen_rules=seen_rules | {identifier},
+                    )
+                    for input_name, value in dependency_assignments.items():
+                        assignments.setdefault(input_name, value)
+                    protected_positive_inputs.update(dependency_protected_inputs)
+            continue
+        if identifier in imported_outputs:
             continue
         assignments[identifier] = _positive_generated_test_input_value(
             identifier,
@@ -15372,7 +15409,14 @@ def _positive_judgment_formula_input_assignments(
             )
         )
 
-    return assignments
+    return assignments, protected_positive_inputs
+
+
+def _rule_is_derived_judgment(rule: dict[str, object]) -> bool:
+    return (
+        str(rule.get("kind") or "").strip().lower() == "derived"
+        and str(rule.get("dtype") or "").strip().lower() == "judgment"
+    )
 
 
 def _negated_parenthesized_expression_spans(
@@ -15560,14 +15604,37 @@ def _positive_generated_test_input_value(
     rules_payload: dict[str, object],
     formula: str,
 ) -> object:
+    comparison_value = _numeric_positive_assignment_for_expression(
+        input_name=input_name,
+        expression=formula,
+    )
+    if comparison_value is not None:
+        return comparison_value
     if not _factual_input_appears_numeric(input_name, rules_payload=rules_payload):
         return True
-    token = re.escape(input_name)
-    if re.search(rf"\b{token}\b\s*(?:<|<=)", formula):
-        return 0
-    if re.search(rf"(?:>|>=)\s*\b{token}\b", formula):
-        return 0
     return 999999
+
+
+def _numeric_positive_assignment_for_expression(
+    *,
+    input_name: str,
+    expression: str,
+) -> int | None:
+    token = re.escape(input_name)
+    value_token = r"-?\d+(?:\.\d+)?|[A-Za-z_][A-Za-z0-9_]*"
+    right_pattern = re.compile(
+        rf"\b{token}\b\s*(?P<op><=|>=|<|>)\s*(?P<threshold>{value_token})"
+    )
+    left_pattern = re.compile(
+        rf"(?P<threshold>{value_token})\s*(?P<op><=|>=|<|>)\s*\b{token}\b"
+    )
+    for match in right_pattern.finditer(expression):
+        return 0 if match["op"] in {"<", "<="} else 999999
+    for match in left_pattern.finditer(expression):
+        if match["threshold"] == input_name:
+            continue
+        return 999999 if match["op"] in {"<", "<="} else 0
+    return None
 
 
 def _preferred_false_breaker_input(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12772,6 +12772,103 @@ rules:
             not in synthesized["input"]
         )
 
+    def test_judgment_positive_test_repair_synthesizes_local_judgment_dependency_inputs(
+        self, tmp_path
+    ):
+        repo_path = tmp_path / "rulespec-us-co"
+        rules_file = repo_path / "regulations" / "10-ccr-2506-1" / "4.802.62.yaml"
+        test_file = repo_path / "regulations" / "10-ccr-2506-1" / "4.802.62.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: failure_to_appear_good_cause_letter_period_calendar_days
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 10
+  - name: appeal_abandoned_for_failure_to_appear
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          appellant_failed_to_appear_at_duly_scheduled_hearing
+          and appellant_was_given_proper_notice
+          and not appellant_gave_timely_advance_notice_of_acceptable_good_cause_for_inability_to_appear
+  - name: initial_decision_confirms_failure_to_appear_dismissal
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          appeal_abandoned_for_failure_to_appear
+          and appellant_submitted_letter_explaining_failure_to_appear
+          and calendar_days_since_order_of_dismissal_was_mailed <= failure_to_appear_good_cause_letter_period_calendar_days
+          and not administrative_adjudicator_finds_acceptable_good_cause_for_appellant_not_appearing
+"""
+        )
+        test_file.write_text("[]\n")
+
+        repaired = _append_generated_judgment_positive_tests_if_missing(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=repo_path,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            relative_output=Path("regulations/10-ccr-2506-1/4.802.62.yaml"),
+            issues=[
+                "Judgment rule missing positive companion output coverage: "
+                "`us-co:regulations/10-ccr-2506-1/4.802.62#initial_decision_confirms_failure_to_appear_dismissal` "
+                "is not asserted as `holds` by the companion `.test.yaml` file."
+            ],
+        )
+
+        assert repaired == [
+            "auto_positive_initial_decision_confirms_failure_to_appear_dismissal"
+        ]
+        test_payload = yaml.safe_load(test_file.read_text())
+        synthesized = test_payload[0]
+        assert (
+            synthesized["input"][
+                "us-co:regulations/10-ccr-2506-1/4.802.62#input.appellant_failed_to_appear_at_duly_scheduled_hearing"
+            ]
+            is True
+        )
+        assert (
+            synthesized["input"][
+                "us-co:regulations/10-ccr-2506-1/4.802.62#input.appellant_was_given_proper_notice"
+            ]
+            is True
+        )
+        assert (
+            synthesized["input"][
+                "us-co:regulations/10-ccr-2506-1/4.802.62#input.appellant_gave_timely_advance_notice_of_acceptable_good_cause_for_inability_to_appear"
+            ]
+            is False
+        )
+        assert (
+            synthesized["input"][
+                "us-co:regulations/10-ccr-2506-1/4.802.62#input.appellant_submitted_letter_explaining_failure_to_appear"
+            ]
+            is True
+        )
+        assert (
+            synthesized["input"][
+                "us-co:regulations/10-ccr-2506-1/4.802.62#input.calendar_days_since_order_of_dismissal_was_mailed"
+            ]
+            == 0
+        )
+        assert (
+            synthesized["input"][
+                "us-co:regulations/10-ccr-2506-1/4.802.62#input.administrative_adjudicator_finds_acceptable_good_cause_for_appellant_not_appearing"
+            ]
+            is False
+        )
+        assert synthesized["output"] == {
+            "us-co:regulations/10-ccr-2506-1/4.802.62#initial_decision_confirms_failure_to_appear_dismissal": "holds"
+        }
+
     def test_judgment_positive_test_repair_breaks_parenthesized_exception(
         self, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.723"
+version = "0.2.724"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Recursively synthesize positive companion-test inputs through local derived Judgment dependencies
- Derive numeric positive test inputs directly from formula comparisons before boolean name heuristics
- Bump encoder version to 0.2.724 and add a changelog fragment

## Tests
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- uv run --with pytest python -m pytest tests/test_cli.py -k 'judgment_positive_test_repair'
- uv run --with pytest python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
- uv run --with towncrier python -m towncrier build --draft --version 0.0.0