### PR TITLE
Repair scalar conditional Judgment comparisons

### DIFF
--- a/changelog.d/judgment-scalar-conditional-repair.fixed.md
+++ b/changelog.d/judgment-scalar-conditional-repair.fixed.md
@@ -1,0 +1,1 @@
+Repair generated Judgment comparisons that embed scalar `if ... else ...` conditionals by expanding them into boolean branches during signed apply.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.724"
+version = "0.2.725"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.724"
+__version__ = "0.2.725"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -21122,6 +21122,8 @@ def _issue_mentions_judgment_conditional_shape(issue: str) -> bool:
     return (
         "expression shape not supported in judgment position" in text
         and "discriminant" in text
+    ) or (
+        "judgment conditional formula unsupported" in text and "if ... else ..." in text
     )
 
 
@@ -21896,6 +21898,10 @@ def _rewrite_judgment_conditional_expression(expression: str) -> str:
         if branch_formula is not None:
             return branch_formula
 
+    comparison_formula = _rewrite_scalar_conditional_comparison_in_judgment(stripped)
+    if comparison_formula != stripped:
+        return _rewrite_judgment_conditional_expression(comparison_formula)
+
     split = _split_inline_if_expression_span(stripped)
     if split is None:
         return stripped
@@ -21907,6 +21913,113 @@ def _rewrite_judgment_conditional_expression(expression: str) -> str:
         f"  or (not ({condition}) and {false_formula}))"
     )
     return f"{stripped[:start].rstrip()}{replacement}{stripped[end:].lstrip()}"
+
+
+def _rewrite_scalar_conditional_comparison_in_judgment(expression: str) -> str:
+    split = _split_inline_if_expression_span(expression)
+    if split is None:
+        return expression
+    start, end, condition, true_branch, false_branch = split
+    term_start, term_end = _top_level_boolean_term_span_containing(
+        expression,
+        start,
+    )
+    raw_term = expression[term_start:term_end]
+    leading = len(raw_term) - len(raw_term.lstrip())
+    trailing = len(raw_term) - len(raw_term.rstrip())
+    trimmed_start = term_start + leading
+    trimmed_end = term_end - trailing
+    term = expression[trimmed_start:trimmed_end]
+    if _top_level_comparison_operator(term) is None:
+        return expression
+    relative_start = start - trimmed_start
+    relative_end = end - trimmed_start
+    if relative_start < 0 or relative_end > len(term):
+        return expression
+
+    true_term = f"{term[:relative_start]}{true_branch}{term[relative_end:]}".strip()
+    false_term = f"{term[:relative_start]}{false_branch}{term[relative_end:]}".strip()
+    if not true_term or not false_term:
+        return expression
+    replacement = (
+        f"((({condition}) and {true_term})\n  or (not ({condition}) and {false_term}))"
+    )
+    return f"{expression[:trimmed_start]}{replacement}{expression[trimmed_end:]}"
+
+
+def _top_level_boolean_term_span_containing(
+    text: str,
+    position: int,
+) -> tuple[int, int]:
+    depth = 0
+    quote: str | None = None
+    start = 0
+    end = len(text)
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if quote:
+            if char == quote and (index == 0 or text[index - 1] != "\\"):
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            continue
+        if char in "([{":
+            depth += 1
+            index += 1
+            continue
+        if char in ")]}":
+            if depth:
+                depth -= 1
+            index += 1
+            continue
+        if depth == 0 and (
+            _formula_word_at(text, index, "and") or _formula_word_at(text, index, "or")
+        ):
+            if index < position:
+                start = index + (3 if text[index : index + 3].lower() == "and" else 2)
+                index = start
+                continue
+            end = index
+            break
+        index += 1
+    return start, end
+
+
+def _top_level_comparison_operator(text: str) -> tuple[int, str] | None:
+    depth = 0
+    quote: str | None = None
+    operators = ("<=", ">=", "==", "!=", "<", ">")
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if quote:
+            if char == quote and (index == 0 or text[index - 1] != "\\"):
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            continue
+        if char in "([{":
+            depth += 1
+            index += 1
+            continue
+        if char in ")]}":
+            if depth:
+                depth -= 1
+            index += 1
+            continue
+        if depth == 0:
+            for operator in operators:
+                if text.startswith(operator, index):
+                    return index, operator
+        index += 1
+    return None
 
 
 def _rewrite_top_level_judgment_conditional(expression: str) -> str | None:

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1142,6 +1142,10 @@ _FORMULA_PROTOCOL = """- Put formulas under `versions: - effective_from: 'YYYY-M
   boolean expressions using `and`, `or`, `not`, comparisons, and parentheses.
   For example, encode `if exempt: net_ok else: net_ok and gross_ok` as
   `net_ok and (exempt or gross_ok)`.
+  If a Judgment compares against a scalar that varies by condition, do not embed
+  `(if condition: extra else: 0)` inside the comparison. Either create a scalar
+  helper for the allowed amount or branch the Judgment directly, for example
+  `(condition and days <= base + extra) or (not condition and days <= base)`.
 - When using negated conjuncts, write them as a multiline formula with each
   `not <predicate>` term on its own line joined by `and`, rather than one
   compact `not A and not B` line.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6671,6 +6671,58 @@ rules:
             ")"
         )
 
+    def test_judgment_conditional_repair_rewrites_scalar_comparison_branch(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "hearings.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: exceptions_filing_timely
+  kind: derived
+  entity: SnapAppeal
+  dtype: Judgment
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: |-
+      notice_of_intent_to_file_exceptions_timely
+      and calendar_days_from_initial_decision_mailing_to_exceptions
+      <= exceptions_due_calendar_days
+         + mailing_extension_calendar_days
+         + (if ooa_granted_good_cause_extension_for_exceptions: exceptions_extension_max_calendar_days else: 0)
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_judgment_conditionals_for_apply(
+            result,
+            output_root=output_root,
+            issues=[
+                "regulations/10-ccr-2506-1/4.802.63.yaml: ci: "
+                "Judgment conditional formula unsupported: "
+                "`exceptions_filing_timely` uses `if ... else ...` in a Judgment formula. "
+                "Judgment formulas must be boolean expressions using `and`, `or`, `not`, "
+                "comparisons, and parentheses; rewrite branch logic as equivalent boolean "
+                "logic instead of returning one judgment expression or another."
+            ],
+        )
+
+        assert repaired == ["exceptions_filing_timely"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["rules"][0]["versions"][0]["formula"] == (
+            "notice_of_intent_to_file_exceptions_timely and ("
+            "((ooa_granted_good_cause_extension_for_exceptions) "
+            "and calendar_days_from_initial_decision_mailing_to_exceptions "
+            "<= exceptions_due_calendar_days + mailing_extension_calendar_days "
+            "+ (exceptions_extension_max_calendar_days))\n"
+            "  or (not (ooa_granted_good_cause_extension_for_exceptions) "
+            "and calendar_days_from_initial_decision_mailing_to_exceptions "
+            "<= exceptions_due_calendar_days + mailing_extension_calendar_days + (0)))"
+        )
+
     def test_judgment_numeric_comparison_repair_skips_non_truth_decimals(
         self, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.724"
+version = "0.2.725"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair generated Judgment formulas that compare against scalar `if ... else ...` conditionals by expanding the comparison into boolean branches
- recognize the newer validator wording for unsupported Judgment conditionals
- add encoder prompt guidance and regression coverage for the Colorado SNAP 4.802.63 failure

## Tests
- `uv run ruff check src/axiom_encode/cli.py src/axiom_encode/prompts/encoder.py tests/test_cli.py`
- `uv run ruff format --check src/axiom_encode/cli.py src/axiom_encode/prompts/encoder.py tests/test_cli.py`
- `uv run --with pytest python -m pytest tests/test_cli.py -k 'judgment_conditional_repair or judgment_numeric_comparison_repair'`
- `uv run --with pytest python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `uv run --with towncrier python -m towncrier build --draft --version 0.0.0`