### PR TITLE
Prevent self-referential derived rules

### DIFF
--- a/changelog.d/prevent-self-referential-derived-rules.fixed.md
+++ b/changelog.d/prevent-self-referential-derived-rules.fixed.md
@@ -1,0 +1,1 @@
+Prevent encoder generations from naming derived rules after facts that their formulas also require, avoiding self-referential derived dependency cycles.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.725"
+version = "0.2.726"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.725"
+__version__ = "0.2.726"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -4804,6 +4804,13 @@ RuleSpec requirements:
   eligibility predicates: if importing a rate-bearing source would complete a
   cycle with a foundational base definition, keep the rate as a source-named
   boundary input and continue encoding the non-cyclic base formula.
+- Never create a derived rule whose formula references that same rule's name.
+  The derived rule name must be the legal conclusion or compliance output, while
+  required facts inside the formula must use distinct source-named local inputs.
+  For example, do not define `x_has_bona_fide_need` as
+  `x_has_bona_fide_need and other_conditions`; instead name the derived output
+  `x_arrangement_valid` and reference a separate factual input such as
+  `bona_fide_need_for_x_arrangement`.
 - When the requested source defines a base, net amount, includable amount, wage
   base, income base, deduction base, or similar amount that a tax, contribution,
   credit, or deduction section will consume, do not import that consumer section
@@ -5187,6 +5194,10 @@ RuleSpec requirements:
      indexed numeric concepts; formulas may use structural integer keys only to
      select from those concepts. If an exact same-path child scalar is available
      in context, import it instead of duplicating it locally.
+  1a. Dependency inventory: no local derived rule formula references its own
+      rule name. If a legal phrase is both a required fact and a desired output,
+      rename the output to the conclusion and keep the required fact as a
+      distinct local input.
   2. Test input inventory: for every local factual identifier referenced by a
      local derived formula, every companion test case assigns the corresponding
      `#input.<fact>` explicitly, including false facts. Do not rely on implicit

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -717,6 +717,13 @@ _NAMING_PROTOCOL = """- Do not create standalone small-number parameters just to
   eligibility predicates: if importing a rate-bearing source would complete a
   cycle with a foundational base definition, keep the rate as a source-named
   boundary input and continue encoding the non-cyclic base formula.
+- Never create a derived rule whose formula references that same rule's name.
+  The derived rule name must be the legal conclusion or compliance output, while
+  required facts inside the formula must use distinct source-named local inputs.
+  For example, do not define `x_has_bona_fide_need` as
+  `x_has_bona_fide_need and other_conditions`; instead name the derived output
+  `x_arrangement_valid` and reference a separate factual input such as
+  `bona_fide_need_for_x_arrangement`.
 - When the requested source defines a base, net amount, includable amount, wage
   base, income base, deduction base, or similar amount that a tax, contribution,
   credit, or deduction section will consume, do not import that consumer section
@@ -1226,6 +1233,10 @@ _SELF_CHECK = """- Before finalizing, do this self-check:
      indexed numeric concepts; formulas may use structural integer keys only to
      select from those concepts. If an exact same-path child scalar is available
      in context, import it instead of duplicating it locally.
+  1a. Dependency inventory: no local derived rule formula references its own
+      rule name. If a legal phrase is both a required fact and a desired output,
+      rename the output to the conclusion and keep the required fact as a
+      distinct local input.
   2. Test input inventory: for every local factual identifier referenced by a
      local derived formula, every companion test case assigns the corresponding
      `#input.<fact>` explicitly, including false facts. Do not rely on implicit

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -137,6 +137,11 @@ def test_generic_encoder_prompt_includes_statutory_base_naming_guidance():
     assert "unused/proof-only import" in ENCODER_PROMPT
     assert "directly or transitively" in ENCODER_PROMPT
     assert "numeric boundary input" in ENCODER_PROMPT
+    assert (
+        "Never create a derived rule whose formula references that same rule's name"
+        in ENCODER_PROMPT
+    )
+    assert "bona_fide_need_for_x_arrangement" in ENCODER_PROMPT
     assert "rate-bearing source" in ENCODER_PROMPT
     assert "cycle with a foundational base definition" in ENCODER_PROMPT
     assert "defines a base, net amount" in ENCODER_PROMPT

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1150,6 +1150,11 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "Never use `post_YYYY`, `pre_YYYY`, `after_YYYY`, `before_YYYY`" in prompt
     assert "overrides preservation of existing local input names" in prompt
     assert "Never introduce an import cycle" in prompt
+    assert (
+        "Never create a derived rule whose formula references that same rule's name"
+        in prompt
+    )
+    assert "no local derived rule formula references its own\n      rule name" in prompt
     assert "directly or transitively" in prompt
     assert "numeric boundary input" in prompt
     assert "do not import that consumer section" in prompt
@@ -5899,6 +5904,7 @@ class TestEvalPrompt:
         assert "Hard requirement for IRC sections 2, 6013, and 7703" not in prompt
         assert "section 151 deduction is `allowed` or `allowable`" not in prompt
         assert "Never introduce an import cycle" in prompt
+        assert "same rule's name" in prompt
         assert "rate-bearing source" in prompt
         assert "cycle with a foundational base definition" in prompt
         assert "rate or rate" in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.725"
+version = "0.2.726"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- tell the encoder never to create derived rules whose formulas reference the same rule name
- apply the same guard to the eval prompt surface and self-check
- add prompt regression assertions and bump the encoder version

This was exposed by Colorado SNAP manual 4.203.2, where the generated rule `multi_household_authorized_representative_arrangement_has_bona_fide_need` referenced itself and failed compile validation with a cyclic dependency.

## Tests
- `uv run ruff check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_encoder_backend.py tests/test_evals.py`
- `uv run ruff format --check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_encoder_backend.py tests/test_evals.py`
- `uv run --with pytest python -m pytest tests/test_encoder_backend.py tests/test_evals.py -k 'prompt or rate_only or build_eval_prompt'`
- `uv run --with pytest python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `uv run --with towncrier python -m towncrier build --draft --version 0.0.0`