### PR TITLE
Rerun invalid test input repair after assignment repair

### DIFF
--- a/changelog.d/rerun-invalid-test-input-repair-after-assignment.fixed.md
+++ b/changelog.d/rerun-invalid-test-input-repair-after-assignment.fixed.md
@@ -1,0 +1,1 @@
+Rerun generated invalid companion-test input cleanup after test-input assignment repairs so newly exposed stale imported inputs do not block signed apply.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.726"
+version = "0.2.727"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.726"
+__version__ = "0.2.727"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -19132,6 +19132,44 @@ def cmd_encode(args):
                         repaired_input_cases
                     )
             if not can_apply:
+                repaired_invalid_input_refs = list(
+                    outcome.get("auto_repaired_invalid_test_inputs") or []
+                )
+                while not can_apply:
+                    repaired_refs = _try_repair_generated_invalid_test_inputs_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                    if not repaired_refs:
+                        break
+                    for repaired_ref in repaired_refs:
+                        if repaired_ref not in repaired_invalid_input_refs:
+                            repaired_invalid_input_refs.append(repaired_ref)
+                    outcome["auto_repaired_invalid_test_inputs"] = (
+                        repaired_invalid_input_refs
+                    )
+                    print(
+                        "  apply=auto_repaired_invalid_test_inputs:"
+                        + ",".join(repaired_refs)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+                if repaired_invalid_input_refs:
+                    outcome["auto_repaired_invalid_test_inputs"] = (
+                        repaired_invalid_input_refs
+                    )
+            if not can_apply:
                 repaired_scalar_rows = list(
                     outcome.get("auto_repaired_scalar_relation_rows") or []
                 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11663,6 +11663,124 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_reruns_invalid_input_repair_after_assignment_repair(
+        self, capsys, tmp_path
+    ):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path / "out" / "codex-test-model" / "statutes" / "26" / "151.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: section_151_deduction
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if dependent_under_section_152 and tin_included_on_return:
+              adjusted_gross_income
+          else:
+              0
+"""
+        )
+        invalid_ref = "us:statutes/26/151#input.stale_imported_eligibility_flag"
+        test_file = output_file.with_name("151.test.yaml")
+        test_file.write_text(
+            f"""- name: dependent_exemption_denied_without_required_facts
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/26/151#input.filing_status: 0
+    {invalid_ref}: false
+  output:
+    us:statutes/26/151#section_151_deduction: 0
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/26/151.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "statutes/26/151.yaml: ci: "
+                            "Test input assignment missing: "
+                            "`dependent_exemption_denied_without_required_facts` "
+                            "does not assign #input.adjusted_gross_income, "
+                            "#input.dependent_under_section_152, "
+                            "#input.tin_included_on_return. Every test for a "
+                            "proof-required RuleSpec module must set all local "
+                            "factual inputs, including false facts, so tests "
+                            "cannot pass through implicit defaults."
+                        ],
+                        {},
+                    ),
+                    (
+                        False,
+                        [
+                            "statutes/26/151.yaml: ci: Test case "
+                            "`dependent_exemption_denied_without_required_facts` "
+                            "execution failed: dataset input "
+                            f"`{invalid_ref}` must use an absolute legal RuleSpec "
+                            "reference that resolves to an input slot, derived "
+                            "rule, or parameter in the compiled program"
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert (
+            "apply=auto_repaired_test_input_assignments:"
+            "dependent_exemption_denied_without_required_facts"
+        ) in output
+        assert f"apply=auto_repaired_invalid_test_inputs:{invalid_ref}" in output
+        assert mock_overlay.call_count == 3
+        mock_apply.assert_called_once()
+        test_content = test_file.read_text()
+        assert invalid_ref not in test_content
+        assert "us:statutes/26/151#input.adjusted_gross_income: 0" in test_content
+        assert (
+            "us:statutes/26/151#input.dependent_under_section_152: false"
+            in test_content
+        )
+        assert "us:statutes/26/151#input.tin_included_on_return: false" in test_content
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_test_input_assignments"] == [
+            "dependent_exemption_denied_without_required_facts"
+        ]
+        assert run.outcome["auto_repaired_invalid_test_inputs"] == [invalid_ref]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_hoist_nested_test_tables_normalizes_entity_rows(self, tmp_path):
         test_file = tmp_path / "3121" / "a" / "2.test.yaml"
         test_file.parent.mkdir(parents=True)

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.726"
+version = "0.2.727"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- rerun generated invalid companion-test input cleanup after test-input assignment repair
- preserve the existing auto_repaired_invalid_test_inputs outcome field across both passes
- add a regression covering stale generated inputs surfaced after assignment repair

## Tests
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- uv run --with pytest python -m pytest tests/test_cli.py -k 'invalid_imported_test_inputs or invalid_input_repair_after_assignment_repair or missing_test_input_assignments or fills_imported_inputs_after_invalid_input_repair or scalar_relation_rows'
- uv run --with pytest python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
- uv run --with towncrier python -m towncrier build --draft --version 0.0.0