### PR TITLE
Repair self-referential generated derived rules

### DIFF
--- a/changelog.d/repair-self-referential-generated-derived-rules.fixed.md
+++ b/changelog.d/repair-self-referential-generated-derived-rules.fixed.md
@@ -1,0 +1,1 @@
+Repair generated self-referential derived rules during signed apply by renaming the same-name local factual input and companion-test assignments.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.727"
+version = "0.2.728"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.727"
+__version__ = "0.2.728"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -18791,6 +18791,43 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_self_references: list[str] = []
+                while not can_apply:
+                    repaired_refs = (
+                        _try_repair_generated_self_referential_derived_rules_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            issues=apply_issues,
+                        )
+                    )
+                    if not repaired_refs:
+                        break
+                    repaired_self_references.extend(repaired_refs)
+                    outcome["auto_repaired_self_referential_derived_rules"] = (
+                        repaired_self_references
+                    )
+                    print(
+                        "  apply=auto_repaired_self_referential_derived_rules:"
+                        + ",".join(repaired_refs)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+                if repaired_self_references:
+                    outcome["auto_repaired_self_referential_derived_rules"] = (
+                        repaired_self_references
+                    )
+            if not can_apply:
                 repaired_test_cases = _try_repair_generated_exception_tests_for_apply(
                     result,
                     output_root=args.output,
@@ -26778,6 +26815,141 @@ def _try_repair_generated_unreferenced_proof_imports_for_apply(
         rules_file=rules_file,
         issues=issues,
     )
+
+
+def _try_repair_generated_self_referential_derived_rules_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+    issues: list[str],
+) -> list[str]:
+    """Rename generated same-name local facts that cause derived cycles."""
+    rule_names = _cyclic_derived_rule_names_from_issues(issues)
+    if not rule_names:
+        return []
+
+    try:
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    test_file = _rulespec_test_path(rules_file)
+    target_anchor = _relative_output_to_anchor(
+        relative_output, policy_repo_path=policy_repo_path
+    )
+    return _rename_self_referential_derived_rule_inputs(
+        rules_file=rules_file,
+        test_file=test_file,
+        target_anchor=target_anchor,
+        rule_names=rule_names,
+    )
+
+
+def _cyclic_derived_rule_names_from_issues(issues: list[str]) -> list[str]:
+    names: list[str] = []
+    seen: set[str] = set()
+    pattern = re.compile(
+        r"cyclic derived dependency detected involving:\s*"
+        r"(?P<name>[A-Za-z_][A-Za-z0-9_]*)"
+    )
+    for issue in issues:
+        for match in pattern.finditer(str(issue)):
+            name = match["name"].strip()
+            if name and name not in seen:
+                seen.add(name)
+                names.append(name)
+    return names
+
+
+def _rename_self_referential_derived_rule_inputs(
+    *,
+    rules_file: Path,
+    test_file: Path,
+    target_anchor: str,
+    rule_names: list[str],
+) -> list[str]:
+    if not rules_file.exists():
+        return []
+    try:
+        rules_payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    if not isinstance(rules_payload, dict):
+        return []
+    rules = rules_payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    existing_rule_names = {
+        str(rule.get("name") or "").strip() for rule in rules if isinstance(rule, dict)
+    }
+    requested = set(rule_names)
+    replacements: dict[str, str] = {}
+    changed_rules = False
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        rule_name = str(rule.get("name") or "").strip()
+        if rule_name not in requested or rule.get("kind") != "derived":
+            continue
+        replacement_name = _self_reference_input_name(
+            rule_name, existing_names=existing_rule_names
+        )
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        rule_changed = False
+        token = re.compile(rf"\b{re.escape(rule_name)}\b")
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            repaired_formula = token.sub(replacement_name, formula)
+            if repaired_formula != formula:
+                version["formula"] = repaired_formula
+                rule_changed = True
+        if rule_changed:
+            replacements[rule_name] = replacement_name
+            changed_rules = True
+
+    if not changed_rules:
+        return []
+    rules_file.write_text(
+        yaml.safe_dump(rules_payload, sort_keys=False, allow_unicode=False)
+    )
+
+    if test_file.exists():
+        try:
+            test_payload = yaml.safe_load(test_file.read_text()) or []
+        except (OSError, ValueError, yaml.YAMLError):
+            test_payload = None
+        if isinstance(test_payload, list):
+            key_replacements = {
+                f"{target_anchor}#input.{old}": f"{target_anchor}#input.{new}"
+                for old, new in replacements.items()
+            }
+            if _replace_mapping_keys_recursive(test_payload, key_replacements):
+                test_file.write_text(
+                    yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
+                )
+
+    return [f"{old}->{new}" for old, new in sorted(replacements.items())]
+
+
+def _self_reference_input_name(rule_name: str, *, existing_names: set[str]) -> str:
+    base = f"{rule_name}_fact"
+    if base not in existing_names:
+        return base
+    suffix = 2
+    while f"{base}_{suffix}" in existing_names:
+        suffix += 1
+    return f"{base}_{suffix}"
 
 
 def _try_repair_generated_invalid_test_inputs_for_apply(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11663,6 +11663,136 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_repairs_self_referential_generated_derived_rules(
+        self, capsys, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us-co"
+        policy_repo.mkdir()
+        args = self._make_args(
+            tmp_path,
+            backend="codex",
+            citation="10 CCR 2506-1 4.203.3",
+            policy_repo_path=policy_repo,
+            sync=False,
+        )
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed compile validation"
+        output_file = (
+            tmp_path
+            / "out"
+            / "codex-test-model"
+            / "regulations"
+            / "10-ccr-2506-1"
+            / "4.203.3.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: emergency_authorized_representative_designation_valid
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          emergency_authorized_representative_designated_in_writing
+  - name: emergency_authorized_representative_obtains_ebt_card_for_household
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          emergency_authorized_representative_designation_valid
+          and emergency_authorized_representative_obtains_ebt_card_for_household
+"""
+        )
+        test_file = output_file.with_name("4.203.3.test.yaml")
+        target_anchor = "us-co:regulations/10-ccr-2506-1/4.203.3"
+        test_file.write_text(
+            f"""- name: emergency_representative_designation_valid
+  period: 2026-01
+  input:
+    {target_anchor}#input.emergency_authorized_representative_designated_in_writing: true
+    {target_anchor}#input.emergency_authorized_representative_obtains_ebt_card_for_household: true
+  output:
+    {target_anchor}#emergency_authorized_representative_obtains_ebt_card_for_household: holds
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = policy_repo / "regulations/10-ccr-2506-1/4.203.3.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "regulations/10-ccr-2506-1/4.203.3.yaml: compile: "
+                            "Axiom rules engine compile failed: cyclic derived "
+                            "dependency detected involving: "
+                            "emergency_authorized_representative_obtains_ebt_card_for_household"
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        repaired = (
+            "emergency_authorized_representative_obtains_ebt_card_for_household"
+            "->emergency_authorized_representative_obtains_ebt_card_for_household_fact"
+        )
+        output = capsys.readouterr().out
+        assert (
+            f"apply=auto_repaired_self_referential_derived_rules:{repaired}" in output
+        )
+        assert mock_overlay.call_count == 2
+        mock_apply.assert_called_once()
+        rules_payload = yaml.safe_load(output_file.read_text())
+        repaired_rule = rules_payload["rules"][1]
+        assert (
+            "emergency_authorized_representative_obtains_ebt_card_for_household_fact"
+            in repaired_rule["versions"][0]["formula"]
+        )
+        assert (
+            "\nand emergency_authorized_representative_obtains_ebt_card_for_household\n"
+            not in f"\n{repaired_rule['versions'][0]['formula']}\n"
+        )
+        test_content = test_file.read_text()
+        assert (
+            f"{target_anchor}#input."
+            "emergency_authorized_representative_obtains_ebt_card_for_household_fact"
+            in test_content
+        )
+        assert (
+            f"{target_anchor}#input."
+            "emergency_authorized_representative_obtains_ebt_card_for_household:"
+            not in test_content
+        )
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_self_referential_derived_rules"] == [repaired]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_reruns_invalid_input_repair_after_assignment_repair(
         self, capsys, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.727"
+version = "0.2.728"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair generated derived rules whose formulas reference their own exported name
- rename the self-reference to a distinct local factual input and update generated companion-test assignments
- record the repair under auto_repaired_self_referential_derived_rules

## Tests
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- uv run --with pytest python -m pytest tests/test_cli.py -k 'self_referential_generated_derived_rules or invalid_input_repair_after_assignment_repair or missing_test_input_assignments or invalid_imported_test_inputs'
- uv run --with pytest python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
- uv run --with towncrier python -m towncrier build --draft --version 0.0.0