### PR TITLE
Rerun invalid input repair after canonical test refs

### DIFF
--- a/changelog.d/rerun-invalid-test-input-repair-after-canonical-refs.fixed.md
+++ b/changelog.d/rerun-invalid-test-input-repair-after-canonical-refs.fixed.md
@@ -1,0 +1,1 @@
+Rerun generated invalid companion-test input repair after canonical test-reference repair.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.728"
+version = "0.2.729"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.728"
+__version__ = "0.2.729"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -19445,25 +19445,104 @@ def cmd_encode(args):
                 print(f"  apply=blocked_validation:{detail}")
             if can_apply:
                 try:
-                    applied = _apply_generated_encoding_result(
-                        result,
-                        output_root=args.output,
+                    output_file = Path(str(getattr(result, "output_file", "") or ""))
+                    relative_output = _relative_generated_output_path(
+                        result, output_root=args.output
+                    )
+                    canonical_repaired_files = _enforce_canonical_concept_registry(
+                        candidate_files=[output_file, _rulespec_test_path(output_file)],
+                        relative_output=relative_output,
                         policy_repo_path=policy_repo_path,
-                        run_id=logged_run.id,
-                        supplemental_files=supplemental_files,
                     )
                 except RuntimeError as exc:
-                    outcome["status"] = "apply_blocked_manifest"
-                    outcome["apply_error"] = str(exc)
-                    outcome["final_success"] = False
-                    print(f"  apply=blocked_manifest:{exc}")
+                    can_apply = False
+                    apply_issues = [str(exc)]
+                    outcome["overlay_validation_success"] = False
                 else:
-                    print("  apply=" + ",".join(str(path) for path in applied))
-                    apply_passed = True
-                    outcome["status"] = "apply_applied"
-                    outcome["apply_success"] = True
-                    outcome["final_success"] = True
-                    outcome["applied_files"] = [str(path) for path in applied]
+                    if canonical_repaired_files:
+                        can_apply, apply_issues, supplemental_files = (
+                            _validate_generated_encoding_in_policy_overlay(
+                                result,
+                                output_root=args.output,
+                                policy_repo_path=policy_repo_path,
+                                axiom_rules_path=axiom_rules_path,
+                                validate_dependents=not bool(
+                                    getattr(args, "apply_target_only", False)
+                                ),
+                            )
+                        )
+                        outcome["overlay_validation_success"] = bool(can_apply)
+                        if not can_apply:
+                            repaired_invalid_input_refs = list(
+                                outcome.get("auto_repaired_invalid_test_inputs") or []
+                            )
+                            while not can_apply:
+                                repaired_refs = (
+                                    _try_repair_generated_invalid_test_inputs_for_apply(
+                                        result,
+                                        output_root=args.output,
+                                        issues=apply_issues,
+                                    )
+                                )
+                                if not repaired_refs:
+                                    break
+                                for repaired_ref in repaired_refs:
+                                    if repaired_ref not in repaired_invalid_input_refs:
+                                        repaired_invalid_input_refs.append(repaired_ref)
+                                outcome["auto_repaired_invalid_test_inputs"] = (
+                                    repaired_invalid_input_refs
+                                )
+                                print(
+                                    "  apply=auto_repaired_invalid_test_inputs:"
+                                    + ",".join(repaired_refs)
+                                )
+                                can_apply, apply_issues, supplemental_files = (
+                                    _validate_generated_encoding_in_policy_overlay(
+                                        result,
+                                        output_root=args.output,
+                                        policy_repo_path=policy_repo_path,
+                                        axiom_rules_path=axiom_rules_path,
+                                        validate_dependents=not bool(
+                                            getattr(args, "apply_target_only", False)
+                                        ),
+                                    )
+                                )
+                                outcome["overlay_validation_success"] = bool(can_apply)
+                            if repaired_invalid_input_refs:
+                                outcome["auto_repaired_invalid_test_inputs"] = (
+                                    repaired_invalid_input_refs
+                                )
+                if not can_apply:
+                    detail = (
+                        apply_issues[0]
+                        if apply_issues
+                        else f"standalone_failed: {result.error or 'validation failed'}"
+                    )
+                    outcome["status"] = "apply_blocked_validation"
+                    outcome["apply_error"] = detail
+                    outcome["final_success"] = False
+                    print(f"  apply=blocked_validation:{detail}")
+                else:
+                    try:
+                        applied = _apply_generated_encoding_result(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            run_id=logged_run.id,
+                            supplemental_files=supplemental_files,
+                        )
+                    except RuntimeError as exc:
+                        outcome["status"] = "apply_blocked_manifest"
+                        outcome["apply_error"] = str(exc)
+                        outcome["final_success"] = False
+                        print(f"  apply=blocked_manifest:{exc}")
+                    else:
+                        print("  apply=" + ",".join(str(path) for path in applied))
+                        apply_passed = True
+                        outcome["status"] = "apply_applied"
+                        outcome["apply_success"] = True
+                        outcome["final_success"] = True
+                        outcome["applied_files"] = [str(path) for path in applied]
     repair_manifest = _record_encode_outcome(
         db_path=db_path,
         result=result,
@@ -28050,12 +28129,12 @@ def _enforce_canonical_concept_registry(
     candidate_files: list[Path],
     relative_output: Path,
     policy_repo_path: Path | None = None,
-) -> None:
+) -> list[Path]:
     """Refuse to apply a generated encoding that violates the concept registry.
 
     Raises RuntimeError listing every violation so the encoder caller can
-    surface them. Run before any file copy so a bad encode never lands in
-    the live rules repo.
+    surface them. Returns repaired test files. Run before any file copy so a
+    bad encode never lands in the live rules repo.
     """
     registry = load_concept_registry()
     apply_anchor = _relative_output_to_anchor(
@@ -28073,7 +28152,7 @@ def _enforce_canonical_concept_registry(
         files, registry, apply_anchor=apply_anchor
     )
     if not violations:
-        return
+        return repaired
     lines = [str(v) for v in violations]
     raise RuntimeError(
         "Canonical concept registry violations — refusing to apply:\n  "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11911,6 +11911,103 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_reruns_invalid_input_repair_after_canonical_repair(
+        self, capsys, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us-co"
+        policy_repo.mkdir()
+        args = self._make_args(
+            tmp_path,
+            backend="codex",
+            citation="10 CCR 2506-1 4.205.32",
+            policy_repo_path=policy_repo,
+            sync=False,
+        )
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path
+            / "out"
+            / "codex-test-model"
+            / "regulations"
+            / "10-ccr-2506-1"
+            / "4.205.32.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: eligible_second_period_retroactive_prorated_benefits_required
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: household_found_eligible
+"""
+        )
+        stale_ref = "us:statutes/7/2014/e/6/A#input.snap_monthly_household_income"
+        invalid_ref = "us:statutes/7/2014/e/6/A#input.snap_total_gross_income"
+        test_file = output_file.with_name("4.205.32.test.yaml")
+        test_file.write_text(
+            f"""- name: eligible_household_in_second_period_gets_retroactive_prorated_benefits
+  period: 2026-01
+  input:
+    us-co:regulations/10-ccr-2506-1/4.205.32#input.household_found_eligible: true
+    {stale_ref}: 0
+  output:
+    us-co:regulations/10-ccr-2506-1/4.205.32#eligible_second_period_retroactive_prorated_benefits_required: holds
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = policy_repo / "regulations/10-ccr-2506-1/4.205.32.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (True, [], {}),
+                    (
+                        False,
+                        [
+                            "regulations/10-ccr-2506-1/4.205.32.yaml: ci: "
+                            "Test case "
+                            "`eligible_household_in_second_period_gets_retroactive_prorated_benefits` "
+                            "input invalid: input "
+                            f"`{invalid_ref}` does not resolve to an input slot in "
+                            "statutes/7/2014/e/6/A.yaml."
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert "apply=auto_repaired_test_yaml_canonical_refs:" in output
+        assert f"apply=auto_repaired_invalid_test_inputs:{invalid_ref}" in output
+        assert mock_overlay.call_count == 3
+        mock_apply.assert_called_once()
+        test_content = test_file.read_text()
+        assert stale_ref not in test_content
+        assert invalid_ref not in test_content
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_invalid_test_inputs"] == [invalid_ref]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_hoist_nested_test_tables_normalizes_entity_rows(self, tmp_path):
         test_file = tmp_path / "3121" / "a" / "2.test.yaml"
         test_file.parent.mkdir(parents=True)

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.728"
+version = "0.2.729"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- rerun generated invalid companion-test input cleanup when canonical test-reference repair changes generated tests before apply
- keep the apply gate blocked unless the follow-up overlay validation passes
- add a regression for the Colorado SNAP 4.205.32 failure mode
- bump axiom-encode to 0.2.729

## Checks
- `uv run ruff check src/axiom_encode/cli.py tests/test_cli.py`
- `uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py`
- `uv run --with pytest python -m pytest tests/test_cli.py -k 'canonical_repair or invalid_input_repair_after_assignment_repair or self_referential_generated_derived_rules'`\n- `uv run --with pytest python -m pytest tests/test_concepts_auto_repair.py`\n- `uv run --with pytest python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`\n- `uv run --with towncrier python -m towncrier build --draft --version 0.0.0`\n- `git diff --check`