### PR TITLE
Repair scalar relation rows from count_where

### DIFF
--- a/changelog.d/repair-scalar-relation-rows-from-count-where.fixed.md
+++ b/changelog.d/repair-scalar-relation-rows-from-count-where.fixed.md
@@ -1,0 +1,1 @@
+Repair generated scalar relation rows from `count_where(relation, child_fact)` formulas during signed apply.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.729"
+version = "0.2.730"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.729"
+__version__ = "0.2.730"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -22895,7 +22895,8 @@ def _relation_row_replacement_from_generated_rules(
     New generated files can define a relation and immediately test it before any
     companion exists; in that case a scalar row like `- 30000` is unambiguous
     only when the formulas reference exactly one child fact through
-    `relation_name.child_fact`.
+    `relation_name.child_fact` or a boolean aggregate such as
+    `count_where(relation_name, child_fact)`.
     """
     if rules_file is None or not rules_file.exists():
         return None
@@ -22936,6 +22937,10 @@ def _single_relation_child_fact_names(
         rf"(?<![A-Za-z0-9_]){escaped_relation}\."
         r"(?P<child>[A-Za-z_][A-Za-z0-9_]*)\b"
     )
+    aggregate_pattern = re.compile(
+        rf"\b(?:count_where|any_where|all_where)\(\s*{escaped_relation}\s*,\s*"
+        r"(?P<child>[A-Za-z_][A-Za-z0-9_]*)\b(?!\s*\.)"
+    )
     child_names: set[str] = set()
     for rule in rules:
         if not isinstance(rule, dict):
@@ -22951,6 +22956,9 @@ def _single_relation_child_fact_names(
                 continue
             child_names.update(
                 match.group("child") for match in child_pattern.finditer(formula)
+            )
+            child_names.update(
+                match.group("child") for match in aggregate_pattern.finditer(formula)
             )
     return child_names
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18514,6 +18514,85 @@ rules:
             },
         ]
 
+    def test_repair_scalar_relation_rows_from_generated_count_where_formula(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us-co"
+        policy_repo.mkdir()
+        rules_file = (
+            tmp_path / "generated" / "regulations" / "10-ccr-2506-1" / "4.208.1.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: Colorado SNAP certification-period guidelines.
+rules:
+  - name: member_of_certification_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: household_qualifies_for_twenty_four_month_certification_period
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          len(member_of_certification_household) > 0
+          and count_where(member_of_certification_household, member_is_aged_60_or_older_or_has_disability) == len(member_of_certification_household)
+"""
+        )
+        test_file = rules_file.with_name("4.208.1.test.yaml")
+        test_file.write_text(
+            """- name: mixed_age_household_does_not_qualify
+  period: 2026-01
+  input:
+    us-co:regulations/10-ccr-2506-1/4.208.1#relation.member_of_certification_household:
+      - true
+      - false
+  output:
+    us-co:regulations/10-ccr-2506-1/4.208.1#household_qualifies_for_twenty_four_month_certification_period: not_holds
+"""
+        )
+
+        repaired = _repair_scalar_relation_rows(
+            rules_file=rules_file,
+            test_file=test_file,
+            policy_repo_path=policy_repo,
+            parsed_issues=[
+                (
+                    "mixed_age_household_does_not_qualify",
+                    "us-co:regulations/10-ccr-2506-1/4.208.1#relation.member_of_certification_household",
+                    1,
+                ),
+                (
+                    "mixed_age_household_does_not_qualify",
+                    "us-co:regulations/10-ccr-2506-1/4.208.1#relation.member_of_certification_household",
+                    2,
+                ),
+            ],
+        )
+
+        assert repaired == [
+            "mixed_age_household_does_not_qualify:"
+            "us-co:regulations/10-ccr-2506-1/4.208.1#relation.member_of_certification_household[1]",
+            "mixed_age_household_does_not_qualify:"
+            "us-co:regulations/10-ccr-2506-1/4.208.1#relation.member_of_certification_household[2]",
+        ]
+        [case] = yaml.safe_load(test_file.read_text())
+        assert case["input"][
+            "us-co:regulations/10-ccr-2506-1/4.208.1#relation.member_of_certification_household"
+        ] == [
+            {
+                "us-co:regulations/10-ccr-2506-1/4.208.1#input.member_is_aged_60_or_older_or_has_disability": True
+            },
+            {
+                "us-co:regulations/10-ccr-2506-1/4.208.1#input.member_is_aged_60_or_older_or_has_disability": False
+            },
+        ]
+
     def test_apply_overlay_validation_rejects_dropped_source_relation(self, tmp_path):
         output_root = tmp_path / "out"
         policy_repo = tmp_path / "rulespec-us-ny"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.729"
+version = "0.2.730"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- infer generated scalar relation-row test mappings from `count_where(relation, child_fact)` when it is the only child fact for that relation
- add a regression for the Colorado SNAP 4.208.1 blocked apply case
- bump axiom-encode to 0.2.730

## Checks
- `uv run ruff check src/axiom_encode/cli.py tests/test_cli.py`
- `uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py`
- `uv run --with pytest python -m pytest tests/test_cli.py -k 'scalar_relation_rows'`\n- `uv run --with pytest python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`\n- `uv run --with towncrier python -m towncrier build --draft --version 0.0.0`\n- `git diff --check`