### PR TITLE
Ground textual fraction numbers across line breaks

### DIFF
--- a/changelog.d/textual-fraction-linebreak-grounding.fixed.md
+++ b/changelog.d/textual-fraction-linebreak-grounding.fixed.md
@@ -1,0 +1,1 @@
+Ground standalone textual fractions across line breaks before numeric grounding validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.730"
+version = "0.2.731"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.730"
+__version__ = "0.2.731"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -712,6 +712,10 @@ _FRACTION_WORD_PATTERN = (
     r"(?:one[-\s]+half|one[-\s]+third|two[-\s]+thirds|"
     r"one[-\s]+quarter|three[-\s]+quarters)"
 )
+_STANDALONE_FRACTION_WORD_PATTERN = re.compile(
+    rf"\b({_FRACTION_WORD_PATTERN})\b",
+    re.IGNORECASE,
+)
 IMPORT_ITEM_PATTERN = re.compile(r"^\s*-\s*(['\"]?)([^'\"]+?)\1\s*$")
 IMPORT_MAPPING_PATTERN = re.compile(r"^\s*[A-Za-z_]\w*:\s*(['\"]?)([^'\"]+?)\1\s*$")
 _EMBEDDED_SCALAR_DIRECT_VALUE = re.compile(r"-?[\d,]+(?:\.\d+)?")
@@ -2510,6 +2514,11 @@ def extract_numbers_from_text(text: str) -> set[float]:
         numbers.add(value)
         occupied_spans.append(span)
     numbers.update(_extract_percentage_context_values(text))
+    for span, value in _iter_standalone_fraction_word_matches(text):
+        if _span_overlaps(span, occupied_spans):
+            continue
+        numbers.add(value)
+        occupied_spans.append(span)
     for span, value in _iter_cardinal_word_number_matches(text):
         if _span_overlaps(span, occupied_spans):
             continue
@@ -2529,17 +2538,11 @@ def extract_numbers_from_text(text: str) -> set[float]:
     for match in _ORDINAL_WORD_PATTERN.finditer(text):
         numbers.add(_ORDINAL_WORD_VALUES[match.group(1).lower()])
 
-    text_lower = text.lower()
-    for phrase, value in _FRACTION_WORD_VALUES.items():
-        if phrase in text_lower:
-            numbers.add(value)
-        if phrase.replace(" ", "-") in text_lower:
-            numbers.add(value)
-
     for glyph, value in _UNICODE_FRACTION_VALUES.items():
         if glyph in text:
             numbers.add(value)
 
+    text_lower = text.lower()
     for match in _CARDINAL_WORD_PATTERN.finditer(text_lower):
         numbers.add(_CARDINAL_WORD_VALUES[match.group(1)])
 
@@ -2723,6 +2726,15 @@ def _parse_fraction_word(text: str) -> float | None:
     return _FRACTION_WORD_VALUES.get(normalized)
 
 
+def _iter_standalone_fraction_word_matches(
+    text: str,
+) -> Iterator[tuple[tuple[int, int], float]]:
+    for match in _STANDALONE_FRACTION_WORD_PATTERN.finditer(text):
+        value = _parse_fraction_word(match.group(1))
+        if value is not None:
+            yield match.span(1), value
+
+
 def _extract_percentage_context_values(text: str) -> set[float]:
     """Return decimal rate equivalents for numbers in percentage table contexts."""
     values: set[float] = set()
@@ -2901,6 +2913,12 @@ def extract_numeric_occurrences_from_text(text: str) -> list[float]:
     spans: list[tuple[int, int]] = []
 
     for span, value in _iter_normalized_special_numeric_matches(cleaned):
+        occurrences.append(value)
+        spans.append(span)
+
+    for span, value in _iter_standalone_fraction_word_matches(cleaned):
+        if _span_overlaps(span, spans):
+            continue
         occurrences.append(value)
         spans.append(span)
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -4272,6 +4272,28 @@ rules:
     )
 
 
+def test_rulespec_grounding_accepts_textual_half_across_line_break():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-co/regulation/example/source
+rules:
+  - name: departing_resident_partial_allotment_fraction
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '0.5'
+"""
+
+    source_text = (
+        "the center shall provide the resident with one\n"
+        "half of his/her monthly allotment"
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
 def test_rulespec_grounding_does_not_trust_module_summary():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.730"
+version = "0.2.731"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- ground standalone textual fractions before cardinal-word extraction
- include textual fractions in source numeric occurrence extraction
- add a regression test for `one\nhalf` backing generated `0.5` formulas
- bump axiom-encode to 0.2.731

## Checks
- `uv run --with pytest python -m pytest tests/test_rulespec_validation.py -k grounding -vv`
- `uv run --with pytest python -m pytest tests/test_cli.py -k version -vv`
- `uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `uv run --with towncrier python -m towncrier build --draft --version 0.0.0`
- `git diff --check`