### PR TITLE
Ground half-time phrases as numeric halves

### DIFF
--- a/changelog.d/half-time-fraction-grounding.fixed.md
+++ b/changelog.d/half-time-fraction-grounding.fixed.md
@@ -1,0 +1,1 @@
+Ground half-time source phrases as one-half numeric rates during RuleSpec validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.731"
+version = "0.2.732"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.731"
+__version__ = "0.2.732"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -702,6 +702,7 @@ _UNICODE_FRACTION_VALUES = {
     "⅞": 0.875,
 }
 _FRACTION_WORD_VALUES = {
+    "half time": 0.5,
     "one half": 0.5,
     "one third": 1 / 3,
     "two thirds": 2 / 3,
@@ -709,7 +710,7 @@ _FRACTION_WORD_VALUES = {
     "three quarters": 0.75,
 }
 _FRACTION_WORD_PATTERN = (
-    r"(?:one[-\s]+half|one[-\s]+third|two[-\s]+thirds|"
+    r"(?:half[-\s]+time|one[-\s]+half|one[-\s]+third|two[-\s]+thirds|"
     r"one[-\s]+quarter|three[-\s]+quarters)"
 )
 _STANDALONE_FRACTION_WORD_PATTERN = re.compile(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -4294,6 +4294,25 @@ rules:
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
 
 
+def test_rulespec_grounding_accepts_half_time_as_fraction():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-co/regulation/example/source
+rules:
+  - name: full_time_enrollment_fraction
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '0.5'
+"""
+
+    source_text = "a person enrolled at least half-time in an accredited school"
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
 def test_rulespec_grounding_does_not_trust_module_summary():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.731"
+version = "0.2.732"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- recognize half-time / half time source phrases as grounded one-half rates during RuleSpec numeric validation
- add regression coverage for generated 0.5 formulas sourced from half-time enrollment language
- bump axiom-encode to 0.2.732 with a changelog fragment

## Checks
- uv run --with pytest python -m pytest tests/test_rulespec_validation.py -k 'grounding' -vv
- uv run --with pytest python -m pytest tests/test_cli.py -k 'version' -vv
- uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- uv run --with towncrier python -m towncrier build --draft --version 0.0.0
- git diff --check HEAD~1 HEAD