### PR TITLE
Defer missing unexported import dependencies

### DIFF
--- a/changelog.d/unexported-import-missing-input.fixed.md
+++ b/changelog.d/unexported-import-missing-input.fixed.md
@@ -1,0 +1,1 @@
+Defer generated outputs that depend on same-repo import fragments absent from the referenced RuleSpec file instead of treating the fragment as a local factual input during apply.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.732"
+version = "0.2.733"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.732"
+__version__ = "0.2.733"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -24048,6 +24048,18 @@ def _try_repair_generated_unsafe_formula_outputs_for_apply(
         for rule in rules
         if isinstance(rule, dict) and str(rule.get("name") or "")
     }
+    unresolved_import_symbols = _unexported_import_symbols_for_missing_inputs(
+        rules_file=rules_file,
+        policy_repo_path=policy_repo_path,
+        issues=issues,
+    )
+    if unresolved_import_symbols:
+        for rule_name, rule in rules_by_name.items():
+            identifiers = _generated_rule_formula_identifiers(rule)
+            if not identifiers.intersection(unresolved_import_symbols):
+                continue
+            seed_rules.add(rule_name)
+            issue_reasons[rule_name].append("unresolved_import_symbol")
     for import_item in unrelated_same_section_imports:
         imported_symbols = _imported_symbols_for_unrelated_same_section_issue(
             import_item,
@@ -24168,6 +24180,13 @@ def _try_repair_generated_unsafe_formula_outputs_for_apply(
                 "This output is deferred until the same-section definition can be "
                 "imported or composed without borrowing the unrelated concept."
             )
+        elif "unresolved_import_symbol" in reasons:
+            reason = (
+                "Generated rule depended on an import fragment that the referenced "
+                "RuleSpec file does not export. This output is deferred until the "
+                "referenced source exports the intended concept or the dependency "
+                "can be corrected without inventing a local fact."
+            )
         else:
             reason = (
                 "Generated rule used a thresholded, capped, base-limited, or "
@@ -24198,6 +24217,8 @@ def _try_repair_generated_unsafe_formula_outputs_for_apply(
             isinstance(rule, dict) and str(rule.get("name") or "") in affected_rules
         )
     ]
+    if unresolved_import_symbols:
+        _remove_imports_with_fragments(payload, unresolved_import_symbols)
     if not payload["rules"]:
         module.setdefault("status", "deferred")
     rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
@@ -24208,6 +24229,67 @@ def _try_repair_generated_unsafe_formula_outputs_for_apply(
         rule_names=affected_rules,
     )
     return deferred_targets
+
+
+def _unexported_import_symbols_for_missing_inputs(
+    *,
+    rules_file: Path,
+    policy_repo_path: Path,
+    issues: list[str],
+) -> set[str]:
+    missing_inputs = _missing_input_names_from_issues(issues)
+    if not missing_inputs or not rules_file.exists():
+        return set()
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return set()
+    if not isinstance(payload, dict):
+        return set()
+    imports = payload.get("imports")
+    if not isinstance(imports, list):
+        return set()
+
+    unresolved: set[str] = set()
+    for raw_import in imports:
+        if not isinstance(raw_import, str) or "#" not in raw_import:
+            continue
+        fragment = raw_import.rsplit("#", 1)[1].strip()
+        if fragment not in missing_inputs:
+            continue
+        parsed = _parse_same_repo_rulespec_import_ref(
+            raw_import,
+            repo_path=policy_repo_path,
+        )
+        if parsed is None or parsed.symbol is None:
+            continue
+        exported_symbols = _rulespec_exported_rule_names(parsed.path)
+        exported_symbols.update(_deferred_output_names(parsed.path))
+        if parsed.symbol not in exported_symbols:
+            unresolved.add(parsed.symbol)
+    return unresolved
+
+
+def _remove_imports_with_fragments(
+    payload: dict[str, object],
+    fragments: set[str],
+) -> None:
+    imports = payload.get("imports")
+    if not isinstance(imports, list):
+        return
+    kept_imports: list[object] = []
+    for raw_import in imports:
+        if (
+            isinstance(raw_import, str)
+            and "#" in raw_import
+            and raw_import.rsplit("#", 1)[1].strip() in fragments
+        ):
+            continue
+        kept_imports.append(raw_import)
+    if kept_imports:
+        payload["imports"] = kept_imports
+    else:
+        payload.pop("imports", None)
 
 
 def _imported_symbols_for_unrelated_same_section_issue(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17453,6 +17453,91 @@ rules:
 
         assert inputs == {"adjusted_gross_income"}
 
+    def test_unsafe_formula_repair_defers_missing_unexported_import_symbol(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us-co"
+        imported = policy_repo / "regulations/10-ccr-2506-1/4.206.yaml"
+        generated = (
+            output_root / "codex-test-model" / "regulations/10-ccr-2506-1/4.400.yaml"
+        )
+        imported.parent.mkdir(parents=True)
+        generated.parent.mkdir(parents=True)
+        imported.write_text(
+            """format: rulespec/v1
+rules:
+  - name: standard_income_criteria_met
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: gross_income_standard_met and net_income_standard_met
+"""
+        )
+        generated.write_text(
+            """format: rulespec/v1
+imports:
+  - us-co:regulations/10-ccr-2506-1/4.206#standard_eligibility_household
+rules:
+  - name: issuance_month_prospective_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: reasonably_anticipated_monthly_income
+  - name: standard_eligibility_resource_value_considered
+    kind: derived
+    entity: Household
+    dtype: Boolean
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: standard_eligibility_household and household_resources_value_considered
+"""
+        )
+        generated.with_name("4.400.test.yaml").write_text(
+            """- name: standard_eligibility_household_resources_are_considered
+  period: 2026-01
+  input:
+    us-co:regulations/10-ccr-2506-1/4.400#input.household_resources_value_considered: true
+  output:
+    us-co:regulations/10-ccr-2506-1/4.400#standard_eligibility_resource_value_considered: true
+"""
+        )
+        result = SimpleNamespace(output_file=str(generated), runner="codex-test-model")
+
+        repaired = _try_repair_generated_unsafe_formula_outputs_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "regulations/10-ccr-2506-1/4.400.yaml: ci: Test case "
+                "`standard_eligibility_household_resources_are_considered` "
+                "execution failed: missing input `standard_eligibility_household`"
+            ],
+        )
+
+        assert repaired == [
+            "us-co:regulations/10-ccr-2506-1/4.400#standard_eligibility_resource_value_considered"
+        ]
+        content = generated.read_text()
+        assert "standard_eligibility_household\n" not in content
+        assert "#standard_eligibility_household" not in content
+        assert "issuance_month_prospective_income" in content
+        assert "module:" in content
+        assert "deferred_outputs:" in content
+        assert "referenced RuleSpec" in content
+        assert "file does not export" in content
+        assert (
+            "standard_eligibility_resource_value_considered"
+            not in generated.with_name("4.400.test.yaml").read_text()
+        )
+
     def test_complete_missing_imported_test_inputs_adds_import_defaults(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"
         imported = policy_repo / "statutes/26/1/h.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.732"
+version = "0.2.733"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- detect runtime missing-input failures caused by generated same-repo imports whose fragment is absent from the referenced RuleSpec file
- defer generated outputs that depend on those absent import fragments instead of letting them become local factual inputs
- remove the invalid generated import fragment and add a regression for the Colorado SNAP 4.400 shape

## Tests
- uv run --with pytest python -m pytest tests/test_cli.py -k 'unexported_import or import_symbol_near_miss or local_factual_input_names_ignore_imported_output_fragments' -vv
- uv run --with pytest python -m pytest tests/test_cli.py -k 'current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject or unexported_import' -vv
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run --with towncrier python -m towncrier build --draft --version 0.0.0
- git diff --check