### PR TITLE
Retry unsafe deferral after positive test repair

### DIFF
--- a/changelog.d/post-positive-unsafe-deferral.fixed.md
+++ b/changelog.d/post-positive-unsafe-deferral.fixed.md
@@ -1,0 +1,1 @@
+Retry unsafe generated-output deferral after judgment positive-test repair exposes a missing unexported import dependency.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.733"
+version = "0.2.734"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.733"
+__version__ = "0.2.734"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -17551,6 +17551,56 @@ def cmd_encode(args):
             outcome["final_success"] = False
             print(f"  apply=blocked_generation:{detail}")
         else:
+
+            def _retry_generated_unsafe_formula_output_deferrals() -> list[str]:
+                nonlocal can_apply, apply_issues, supplemental_files
+                repaired_deferred_rules: list[str] = []
+                seen_deferred_rules: set[str] = set()
+                for _repair_attempt in range(5):
+                    repaired_batch = (
+                        _try_repair_generated_unsafe_formula_outputs_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            issues=apply_issues,
+                        )
+                    )
+                    if not repaired_batch:
+                        break
+                    new_repairs = [
+                        repair
+                        for repair in repaired_batch
+                        if repair not in seen_deferred_rules
+                    ]
+                    seen_deferred_rules.update(repaired_batch)
+                    repaired_deferred_rules.extend(new_repairs)
+                    prior_repairs = outcome.get("auto_deferred_unsafe_formula_outputs")
+                    if not isinstance(prior_repairs, list):
+                        prior_repairs = []
+                    outcome["auto_deferred_unsafe_formula_outputs"] = [
+                        *prior_repairs,
+                        *new_repairs,
+                    ]
+                    print(
+                        "  apply=auto_deferred_unsafe_formula_outputs:"
+                        + ",".join(repaired_batch)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+                    if can_apply:
+                        break
+                return repaired_deferred_rules
+
             repaired_section_1401_b_1_income = (
                 _try_repair_generated_section_1401_b_1_self_employment_income_for_apply(
                     result,
@@ -18963,6 +19013,8 @@ def cmd_encode(args):
                     outcome["auto_repaired_judgment_positive_tests"] = (
                         repaired_positive_cases
                     )
+                    if not can_apply:
+                        _retry_generated_unsafe_formula_output_deferrals()
             if not can_apply:
                 repaired_exception_cases = list(
                     outcome.get("auto_repaired_exception_tests") or []
@@ -19337,6 +19389,8 @@ def cmd_encode(args):
                         )
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
+                if repaired_positive_cases and not can_apply:
+                    _retry_generated_unsafe_formula_output_deferrals()
             if not can_apply:
                 repaired_exception_cases = list(
                     outcome.get("auto_repaired_exception_tests") or []

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12453,6 +12453,141 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_retries_unsafe_deferral_after_positive_repair(
+        self, capsys, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us-co"
+        policy_repo.mkdir()
+        args = self._make_args(
+            tmp_path,
+            backend="codex",
+            citation="us-co/regulation/10-ccr-2506-1/4.400",
+            policy_repo_path=policy_repo,
+            sync=False,
+        )
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        imported_file = policy_repo / "regulations/10-ccr-2506-1/4.206.yaml"
+        imported_file.parent.mkdir(parents=True)
+        imported_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: standard_eligibility_nonfinancial_criteria_met
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: nonfinancial_criteria_met
+"""
+        )
+        output_file = (
+            tmp_path
+            / "out"
+            / "codex-test-model"
+            / "regulations"
+            / "10-ccr-2506-1"
+            / "4.400.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us-co:regulations/10-ccr-2506-1/4.206#standard_eligibility_household
+rules:
+  - name: standard_eligibility_resources_value_considered
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: standard_eligibility_household and household_resources_value_considered
+"""
+        )
+        test_file = output_file.with_name("4.400.test.yaml")
+        test_file.write_text(
+            """- name: resources_not_considered_when_resources_value_not_considered
+  period: 2026-01
+  input:
+    us-co:regulations/10-ccr-2506-1/4.400#input.household_resources_value_considered: false
+  output:
+    us-co:regulations/10-ccr-2506-1/4.400#standard_eligibility_resources_value_considered: not_holds
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = policy_repo / "regulations/10-ccr-2506-1/4.400.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "regulations/10-ccr-2506-1/4.400.yaml: ci: "
+                            "Judgment rule missing positive companion output coverage: "
+                            "`us-co:regulations/10-ccr-2506-1/4.400#standard_eligibility_resources_value_considered` "
+                            "is not asserted as `holds` by the companion `.test.yaml` file."
+                        ],
+                        {},
+                    ),
+                    (
+                        False,
+                        [
+                            "regulations/10-ccr-2506-1/4.400.yaml: ci: Test case "
+                            "`auto_positive_standard_eligibility_resources_value_considered` "
+                            "execution failed: missing input "
+                            "`standard_eligibility_household` for entity `case-4` "
+                            "over 2026-01-01..2026-01-31"
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        positive_case = "auto_positive_standard_eligibility_resources_value_considered"
+        deferred_target = (
+            "us-co:regulations/10-ccr-2506-1/4.400#"
+            "standard_eligibility_resources_value_considered"
+        )
+        assert f"apply=auto_repaired_judgment_positive_tests:{positive_case}" in output
+        assert f"apply=auto_deferred_unsafe_formula_outputs:{deferred_target}" in output
+        assert mock_overlay.call_count == 3
+        mock_apply.assert_called_once()
+        content = output_file.read_text()
+        assert "#standard_eligibility_household" not in content
+        payload = yaml.safe_load(content)
+        assert all(
+            rule.get("name") != "standard_eligibility_resources_value_considered"
+            for rule in payload.get("rules", [])
+            if isinstance(rule, dict)
+        )
+        assert deferred_target in content
+        assert (
+            "standard_eligibility_resources_value_considered"
+            not in test_file.read_text()
+        )
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_judgment_positive_tests"] == [positive_case]
+        assert run.outcome["auto_deferred_unsafe_formula_outputs"] == [deferred_target]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_repeats_scalar_relation_row_repair(self, capsys, tmp_path):
         policy_repo = tmp_path / "rulespec-us-ny"
         policy_repo.mkdir()

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.733"
+version = "0.2.734"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- retry generated unsafe-output deferral immediately after judgment positive-test repair exposes validation issues
- add a regression for positive-test synthesis surfacing a missing unexported same-repo import fragment
- bump axiom-encode to 0.2.734

## Tests
- uv run --with pytest python -m pytest tests/test_cli.py -k 'retries_unsafe_deferral_after_positive_repair or unsafe_formula_repair_defers_missing_unexported_import_symbol or package_version_metadata_matches_pyproject' -vv\n- uv run --with pytest python -m pytest tests/test_cli.py -k 'judgment_positive or unexported_import or unsafe_formula_output_repair_defers or unsafe_formula_repair_defers_missing_unexported_import_symbol' -vv\n- uv run --with pytest python -m pytest tests/test_cli.py -k 'current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject or retries_unsafe_deferral_after_positive_repair or unsafe_formula_repair_defers_missing_unexported_import_symbol' -vv\n- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py\n- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py\n- uv run --with towncrier python -m towncrier build --draft --version 0.0.0\n- git diff --check