### PR TITLE
Repair conditional vacuity companion tests

### DIFF
--- a/changelog.d/conditional-vacuity-test-repair.fixed.md
+++ b/changelog.d/conditional-vacuity-test-repair.fixed.md
@@ -1,0 +1,1 @@
+Repair generated companion tests that expect a target judgment not to hold when the target formula is vacuously true under an explicitly false applicability guard.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.735"
+version = "0.2.736"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.735"
+__version__ = "0.2.736"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -19482,6 +19482,43 @@ def cmd_encode(args):
                 if repaired_output_cases:
                     outcome["auto_repaired_auto_output_tests"] = repaired_output_cases
             if not can_apply:
+                repaired_target_cases = []
+                while not can_apply:
+                    repaired_test_cases = (
+                        _try_repair_generated_conditional_vacuity_tests_for_apply(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            issues=apply_issues,
+                        )
+                    )
+                    if not repaired_test_cases:
+                        break
+                    repaired_target_cases.extend(repaired_test_cases)
+                    outcome["auto_repaired_conditional_vacuity_tests"] = (
+                        repaired_target_cases
+                    )
+                    print(
+                        "  apply=auto_repaired_conditional_vacuity_tests:"
+                        + ",".join(repaired_test_cases)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+                if repaired_target_cases:
+                    outcome["auto_repaired_conditional_vacuity_tests"] = (
+                        repaired_target_cases
+                    )
+            if not can_apply:
                 prior_repairs = outcome.get("auto_repaired_zero_branch_tests")
                 if not isinstance(prior_repairs, list):
                     prior_repairs = []
@@ -27991,6 +28028,35 @@ def _try_repair_generated_auto_output_test_mismatches_for_apply(
     )
 
 
+def _try_repair_generated_conditional_vacuity_tests_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+    issues: list[str],
+) -> list[str]:
+    """Update expectations when a generated formula is vacuously true."""
+    if not issues:
+        return []
+
+    try:
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    test_file = _rulespec_test_path(rules_file)
+    return _repair_conditional_vacuity_test_mismatches(
+        rules_file=rules_file,
+        test_file=test_file,
+        policy_repo_path=policy_repo_path,
+        relative_output=relative_output,
+        issues=issues,
+    )
+
+
 def _repair_imported_output_test_mismatches(
     *,
     test_file: Path,
@@ -28122,6 +28188,152 @@ def _repair_auto_output_test_mismatches(
         yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
     )
     return repaired_cases
+
+
+def _repair_conditional_vacuity_test_mismatches(
+    *,
+    rules_file: Path,
+    test_file: Path,
+    policy_repo_path: Path,
+    relative_output: Path,
+    issues: list[str],
+) -> list[str]:
+    if not rules_file.exists() or not test_file.exists():
+        return []
+
+    try:
+        rules_payload = yaml.safe_load(rules_file.read_text()) or {}
+        test_payload = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, yaml.YAMLError):
+        return []
+    if not isinstance(rules_payload, dict) or not isinstance(test_payload, list):
+        return []
+
+    anchor = _relative_output_to_anchor(
+        relative_output, policy_repo_path=policy_repo_path
+    )
+    output_formula_guards = _rule_negated_or_guards_by_name(rules_payload)
+    if not output_formula_guards:
+        return []
+
+    repairs_by_case: dict[str, dict[str, object]] = {}
+    for issue in issues:
+        parsed = _parse_generated_test_output_mismatch(str(issue))
+        if parsed is None:
+            continue
+        case_name, output_ref, actual_value = parsed
+        if case_name.startswith(("auto_output_", "auto_positive_")):
+            continue
+        if re.search(r"\b(?:threshold|boundary)\b", case_name, flags=re.IGNORECASE):
+            continue
+        if not _rulespec_ref_matches_base(output_ref, anchor):
+            continue
+        if _normalized_generated_test_scalar(actual_value) != "holds":
+            continue
+        rule_name = _rulespec_test_key_fragment(output_ref)
+        if rule_name not in output_formula_guards:
+            continue
+        repairs_by_case.setdefault(case_name, {})[output_ref] = actual_value
+    if not repairs_by_case:
+        return []
+
+    repaired_cases: list[str] = []
+    for test_case in test_payload:
+        if not isinstance(test_case, dict):
+            continue
+        case_name = str(test_case.get("name") or "").strip()
+        replacements = repairs_by_case.get(case_name)
+        if not replacements:
+            continue
+        inputs = test_case.get("input")
+        outputs = test_case.get("output")
+        if not isinstance(inputs, dict) or not isinstance(outputs, dict):
+            return []
+
+        changed = False
+        for output_ref, actual_value in replacements.items():
+            output_key = _matching_mapping_key_by_rulespec_ref(outputs, output_ref)
+            if output_key is None:
+                return []
+            if _normalized_generated_test_scalar(outputs[output_key]) != "not_holds":
+                continue
+            rule_name = _rulespec_test_key_fragment(output_ref)
+            guards = output_formula_guards.get(rule_name, set())
+            if not any(
+                _test_input_sets_guard_false(inputs, anchor=anchor, guard=guard)
+                for guard in guards
+            ):
+                continue
+            outputs[output_key] = actual_value
+            changed = True
+        if changed:
+            repaired_cases.append(case_name)
+
+    if not repaired_cases:
+        return []
+    test_file.write_text(
+        yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
+    )
+    return repaired_cases
+
+
+def _rule_negated_or_guards_by_name(
+    rules_payload: dict[str, object],
+) -> dict[str, set[str]]:
+    rules = rules_payload.get("rules")
+    if not isinstance(rules, list):
+        return {}
+
+    guards_by_rule: dict[str, set[str]] = {}
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        rule_name = str(rule.get("name") or "").strip()
+        if not rule_name:
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        guards: set[str] = set()
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if isinstance(formula, str):
+                guards.update(_formula_negated_or_guards(formula))
+        if guards:
+            guards_by_rule[rule_name] = guards
+    return guards_by_rule
+
+
+def _formula_negated_or_guards(formula: str) -> set[str]:
+    normalized = " ".join(formula.split())
+    match = re.match(
+        r"^\s*(?:\(\s*)*not\s+(?P<guard>[A-Za-z_][A-Za-z0-9_]*)"
+        r"\s*(?:\)\s*)*or\b",
+        normalized,
+    )
+    if not match:
+        return set()
+    return {match["guard"]}
+
+
+def _test_input_sets_guard_false(
+    inputs: dict[object, object],
+    *,
+    anchor: str,
+    guard: str,
+) -> bool:
+    target_fragment = f"input.{guard}"
+    for key, value in inputs.items():
+        key_text = str(key)
+        if "#" in key_text and not _rulespec_ref_matches_base(key_text, anchor):
+            continue
+        if _rulespec_test_key_fragment(key_text) != target_fragment:
+            continue
+        if _is_boolean_test_value(value, False):
+            return True
+    return False
 
 
 def _parse_generated_test_output_mismatch(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,6 +108,7 @@ from axiom_encode.cli import (
     _try_repair_generated_admin_agency_aggregate_entities_for_apply,
     _try_repair_generated_bare_snapunit_entity_for_apply,
     _try_repair_generated_boolean_comparison_predicates_for_apply,
+    _try_repair_generated_conditional_vacuity_tests_for_apply,
     _try_repair_generated_delegated_policy_settings_for_apply,
     _try_repair_generated_embedded_scalar_literals_for_apply,
     _try_repair_generated_empty_test_outputs_for_apply,
@@ -13783,6 +13784,72 @@ rules:
             "auto_output_monthly_reported_tips_below_low_tip_threshold"
         ]
         assert run.outcome["status"] == "apply_applied"
+
+    def test_repairs_conditional_vacuity_test_mismatches(self, tmp_path):
+        output_root = tmp_path / "out"
+        runner = "codex-test-model"
+        output_file = (
+            output_root / runner / "regulations" / "10-ccr-2506-1" / "4.707.3.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: direct_shipment_office_requisition_process_compliant
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          (not issuance_office_receives_ebt_card_shipments_directly_from_usda_fns)
+          or (
+            requisitioning_issuance_office_notified_before_any_requisition_adjustment
+          )
+"""
+        )
+        test_file = output_file.with_name("4.707.3.test.yaml")
+        anchor = "us-co:regulations/10-ccr-2506-1/4.707.3"
+        output_ref = f"{anchor}#direct_shipment_office_requisition_process_compliant"
+        test_file.write_text(
+            f"""- name: missing_security_insurance_or_required_direct_shipment_process_fails
+  input:
+    {anchor}#input.issuance_office_receives_ebt_card_shipments_directly_from_usda_fns: false
+    {anchor}#input.requisitioning_issuance_office_notified_before_any_requisition_adjustment: false
+  output:
+    {output_ref}: not_holds
+- name: direct_shipment_guard_true_not_repaired
+  input:
+    {anchor}#input.issuance_office_receives_ebt_card_shipments_directly_from_usda_fns: true
+    {anchor}#input.requisitioning_issuance_office_notified_before_any_requisition_adjustment: false
+  output:
+    {output_ref}: not_holds
+"""
+        )
+        policy_repo = tmp_path / "rulespec-us-co"
+        policy_repo.mkdir()
+        issues = [
+            "regulations/10-ccr-2506-1/4.707.3.yaml: ci: "
+            "Test case "
+            "`missing_security_insurance_or_required_direct_shipment_process_fails` "
+            f"output `{output_ref}` expected not_holds, got holds.",
+            "regulations/10-ccr-2506-1/4.707.3.yaml: ci: "
+            "Test case `direct_shipment_guard_true_not_repaired` "
+            f"output `{output_ref}` expected not_holds, got holds.",
+        ]
+
+        repaired = _try_repair_generated_conditional_vacuity_tests_for_apply(
+            SimpleNamespace(output_file=str(output_file), runner=runner),
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=issues,
+        )
+
+        assert repaired == [
+            "missing_security_insurance_or_required_direct_shipment_process_fails"
+        ]
+        test_payload = yaml.safe_load(test_file.read_text())
+        assert test_payload[0]["output"][output_ref] == "holds"
+        assert test_payload[1]["output"][output_ref] == "not_holds"
 
     def test_encode_apply_removes_local_import_output_input_placeholders(
         self, capsys, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.735"
+version = "0.2.736"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair generated companion-test expectations when a target judgment formula is vacuously true under an explicitly false applicability guard
- keep the repair formula-aware and scoped to target-anchor judgment mismatches
- bump axiom-encode to 0.2.736 and add a changelog fragment

## Tests
- uv run --with pytest python -m pytest tests/test_cli.py -k 'conditional_vacuity or auto_repairs_auto_output_test_mismatches' -vv
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run --with towncrier python -m towncrier build --draft --version 0.0.0
- git diff --check
- uv run --with pytest python -m pytest tests/test_cli.py -k 'current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject or conditional_vacuity' -vv