### PR TITLE
Repair broad CFR range source relations

### DIFF
--- a/changelog.d/broad-regulation-implements.fixed.md
+++ b/changelog.d/broad-regulation-implements.fixed.md
@@ -1,0 +1,1 @@
+Repair apply-time handling for generated broad federal regulation range `implements` relations without concrete delegation bases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.736"
+version = "0.2.737"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.736"
+__version__ = "0.2.737"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -21211,7 +21211,7 @@ def _may_drop_generated_federal_regulation_implements_relation(
     *,
     payload: dict[str, object],
 ) -> bool:
-    """Return true for unsupported CFR-to-statute implementation provenance edges."""
+    """Return true for unsupported broad CFR implementation provenance edges."""
     source_relation = rule.get("source_relation")
     if not isinstance(source_relation, dict):
         return False
@@ -21221,6 +21221,8 @@ def _may_drop_generated_federal_regulation_implements_relation(
     if isinstance(basis, dict) and str(basis.get("delegation") or "").strip():
         return False
     target = str(source_relation.get("target") or "").strip()
+    if _is_broad_federal_regulation_range_ref(target):
+        return True
     if not target.startswith("us:statutes/"):
         return False
     module = payload.get("module")
@@ -21236,6 +21238,18 @@ def _may_drop_generated_federal_regulation_implements_relation(
         return False
     source = str(rule.get("source") or "").strip().lower()
     return bool(re.search(r"\bc\.?\s*f\.?\s*r\.?\b", source, flags=re.IGNORECASE))
+
+
+def _is_broad_federal_regulation_range_ref(target: str) -> bool:
+    normalized = _normalize_source_relation_target_ref(target)
+    if not normalized or "#" in normalized:
+        return False
+    if not normalized.startswith("us:regulations/"):
+        return False
+    parts = [part.strip().lower() for part in normalized.split("/") if part.strip()]
+    if "7-cfr" not in parts:
+        return False
+    return any(re.fullmatch(r"\d+[a-z]?(?:-|–|—)\d+[a-z]?", part) for part in parts)
 
 
 def _source_relation_delegation_basis_for_target(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6016,6 +6016,61 @@ rules:
             "parent_or_caretaker_relative_medicaid_eligible"
         ]
 
+    def test_source_relation_delegation_repair_drops_broad_federal_regulation_range(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = (
+            output_root / "runner" / "regulations" / "10-ccr-2506-1" / "4.100.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.100
+rules:
+- name: colorado_snap_rules_implement_usda_snap_program_regulations
+  kind: source_relation
+  source: 10 CCR 2506-1 section 4.100
+  source_relation:
+    type: implements
+    target: us:regulations/7-cfr/271-274
+    basis:
+      excerpt: promulgated in accordance with USDA regulations, 7 C.F.R. 271-274
+- name: household_must_meet_snap_eligibility
+  kind: derived
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: 10 CCR 2506-1 section 4.100
+  versions:
+    - effective_from: '2026-01-01'
+      formula: household_applies_for_snap
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_source_relation_delegations_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=tmp_path / "rulespec-us-co",
+            issues=[
+                "RuleSpec source relation "
+                "`colorado_snap_rules_implement_usda_snap_program_regulations` "
+                "with type `implements` must declare "
+                "source_relation.basis.delegation"
+            ],
+        )
+
+        assert repaired == [
+            "colorado_snap_rules_implement_usda_snap_program_regulations"
+        ]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert [rule["name"] for rule in payload["rules"]] == [
+            "household_must_meet_snap_eligibility"
+        ]
+
     def test_source_relation_delegation_repair_keeps_non_cfr_implements_without_basis(
         self, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.736"
+version = "0.2.737"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- drop generated broad federal regulation range `implements` relations when no concrete delegation basis exists
- add a regression matching the Colorado SNAP manual `7-cfr/271-274` blocker
- bump axiom-encode to 0.2.737

## Tests
- `uv run --with pytest python -m pytest tests/test_cli.py -k 'source_relation_delegation_repair' -vv`\n- `uv run --with pytest python -m pytest tests/test_cli.py -k 'current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject or source_relation_delegation_repair_drops_broad_federal_regulation_range' -vv`\n- `uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py`\n- `uv run ruff check src/axiom_encode/cli.py tests/test_cli.py`\n- `uv run --with towncrier python -m towncrier build --draft --version 0.0.0`\n- `git diff --check`