### PR TITLE
Repair generated incorporates source relations

### DIFF
--- a/changelog.d/incorporates-source-relation.fixed.md
+++ b/changelog.d/incorporates-source-relation.fixed.md
@@ -1,0 +1,1 @@
+Repair generated `source_relation.type: incorporates` provenance edges by normalizing them to schema-valid `cites` relations during apply.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.737"
+version = "0.2.738"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.737"
+__version__ = "0.2.738"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -17717,6 +17717,34 @@ def cmd_encode(args):
             )
             outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_source_relation_types = (
+                    _try_repair_generated_invalid_source_relation_types_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_source_relation_types:
+                    outcome["auto_repaired_source_relation_types"] = (
+                        repaired_source_relation_types
+                    )
+                    print(
+                        "  apply=auto_repaired_source_relation_types:"
+                        + ",".join(repaired_source_relation_types)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_delegated_settings = (
                     _try_repair_generated_delegated_policy_settings_for_apply(
                         result,
@@ -21206,6 +21234,59 @@ def _try_repair_generated_source_relation_delegations_for_apply(
     return repaired
 
 
+def _try_repair_generated_invalid_source_relation_types_for_apply(
+    result,
+    *,
+    output_root: Path,
+    issues: list[str],
+) -> list[str]:
+    """Normalize generated source relation synonyms unsupported by RuleSpec."""
+    if not any(_issue_mentions_unknown_source_relation_type(issue) for issue in issues):
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    repaired: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "source_relation":
+            continue
+        source_relation = rule.get("source_relation")
+        if not isinstance(source_relation, dict):
+            continue
+        relation_type = str(source_relation.get("type") or "").strip().lower()
+        if relation_type != "incorporates":
+            continue
+        source_relation["type"] = "cites"
+        for unsupported_key in (
+            "edition",
+            "later_amendments_or_editions_incorporated",
+        ):
+            source_relation.pop(unsupported_key, None)
+        repaired.append(str(rule.get("name") or source_relation.get("target") or ""))
+
+    if not repaired:
+        return []
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repaired
+
+
 def _may_drop_generated_federal_regulation_implements_relation(
     rule: dict[str, object],
     *,
@@ -21406,6 +21487,11 @@ def _issue_mentions_missing_source_relation_delegation(issue: str) -> bool:
         "must declare source_relation.basis.delegation" in unquoted
         and "source relation" in unquoted.lower()
     )
+
+
+def _issue_mentions_unknown_source_relation_type(issue: str) -> bool:
+    normalized = str(issue).lower()
+    return "source_relation.type" in normalized and "unknown variant" in normalized
 
 
 def _issue_mentions_versioned_derived_formula(issue: str) -> bool:

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -846,6 +846,9 @@ _NAMING_PROTOCOL = """- Do not create standalone small-number parameters just to
   `restates`, `sets`, `amends`, `implements`, `delegates`, `defines`, or
   `cites`. It must include `source_relation.type` and
   `source_relation.target`, and it must not include executable `versions`.
+- If a source incorporates another authority by reference, encode that
+  provenance edge as `source_relation.type: cites`; never invent an
+  `incorporates` source relation type.
 - Do not put source graph relationships in executable rule metadata. If a
   source `sets`, `amends`, `implements`, or `restates` another source, encode a
   separate `kind: source_relation` record in the same RuleSpec file.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -112,6 +112,7 @@ from axiom_encode.cli import (
     _try_repair_generated_delegated_policy_settings_for_apply,
     _try_repair_generated_embedded_scalar_literals_for_apply,
     _try_repair_generated_empty_test_outputs_for_apply,
+    _try_repair_generated_invalid_source_relation_types_for_apply,
     _try_repair_generated_judgment_conditionals_for_apply,
     _try_repair_generated_judgment_numeric_comparisons_for_apply,
     _try_repair_generated_missing_deferred_outputs_for_apply,
@@ -4924,6 +4925,50 @@ rules:
 
         assert repaired == []
         assert rules_file.read_text() == original
+
+    def test_invalid_source_relation_type_repair_normalizes_incorporates(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = (
+            output_root / "runner" / "regulations" / "10-ccr-2506-1" / "4.100.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: colorado_snap_rules_incorporate_usda_snap_program_regulations_edition
+  kind: source_relation
+  source: 10 CCR 2506-1 section 4.100
+  source_relation:
+    type: incorporates
+    target: us:regulations/7-cfr/271-274
+    edition: 2021
+    later_amendments_or_editions_incorporated: false
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_invalid_source_relation_types_for_apply(
+            result,
+            output_root=output_root,
+            issues=[
+                "yaml parse error: rules[0].source_relation.type: unknown variant "
+                "`incorporates`, expected one of `defines`, `delegates`, "
+                "`implements`, `sets`, `amends`, `restates`, `cites`"
+            ],
+        )
+
+        assert repaired == [
+            "colorado_snap_rules_incorporate_usda_snap_program_regulations_edition"
+        ]
+        source_relation = yaml.safe_load(rules_file.read_text())["rules"][0][
+            "source_relation"
+        ]
+        assert source_relation == {
+            "type": "cites",
+            "target": "us:regulations/7-cfr/271-274",
+        }
 
     def test_delegated_policy_setting_repair_adds_snap_utility_sets_edges(
         self, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.737"
+version = "0.2.738"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- normalize generated `source_relation.type: incorporates` to schema-valid `cites` during apply
- add prompt guidance to use `cites` for incorporation-by-reference provenance
- add regression coverage for the Colorado SNAP 4.100 shape
- bump axiom-encode to 0.2.738

## Tests
- `uv run --with pytest python -m pytest tests/test_cli.py -k 'invalid_source_relation_type_repair or source_relation_delegation_repair_drops_broad_federal_regulation_range or package_version_metadata_matches_pyproject' -vv`\n- `uv run --with pytest python -m pytest tests/test_cli.py -k 'current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject or invalid_source_relation_type_repair or source_relation_delegation_repair_drops_broad_federal_regulation_range' -vv`\n- `uv run ruff format --check src/axiom_encode/cli.py src/axiom_encode/prompts/encoder.py tests/test_cli.py`\n- `uv run ruff check src/axiom_encode/cli.py src/axiom_encode/prompts/encoder.py tests/test_cli.py`\n- `uv run --with towncrier python -m towncrier build --draft --version 0.0.0`\n- `git diff --check`