### PR TITLE
Prefer configured RuleSpec roots

### DIFF
--- a/changelog.d/rulespec-root-precedence.fixed.md
+++ b/changelog.d/rulespec-root-precedence.fixed.md
@@ -1,0 +1,1 @@
+Prefer explicit `AXIOM_RULESPEC_REPO_ROOTS` when resolving cross-repo RuleSpec targets, avoiding stale sibling checkouts shadowing configured roots during apply repairs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.738"
+version = "0.2.739"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.738"
+__version__ = "0.2.739"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -17665,19 +17665,22 @@ def _candidate_rulespec_repo_roots(
     if policy_repo_path is not None:
         policy_root = Path(policy_repo_path).resolve()
         add(policy_root)
-        add(policy_root.parent)
         add(policy_root / "_axiom")
+
+    env_roots = os.environ.get("AXIOM_RULESPEC_REPO_ROOTS", "")
+    for raw_root in env_roots.split(os.pathsep):
+        if raw_root.strip():
+            add(Path(raw_root.strip()))
+
+    if policy_repo_path is not None:
+        policy_root = Path(policy_repo_path).resolve()
+        add(policy_root.parent)
         add(policy_root.parent / "_axiom")
         if policy_root.parent.name.startswith("rulespec-"):
             # A monorepo jurisdiction directory: sibling checkouts live next
             # to the monorepo itself.
             add(policy_root.parent.parent)
             add(policy_root.parent.parent / "_axiom")
-
-    env_roots = os.environ.get("AXIOM_RULESPEC_REPO_ROOTS", "")
-    for raw_root in env_roots.split(os.pathsep):
-        if raw_root.strip():
-            add(Path(raw_root.strip()))
 
     cwd = Path.cwd()
     add(cwd)

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -203,6 +203,62 @@ def test_rulespec_validation_run_compiled_uses_current_repo_env(monkeypatch, tmp
     assert str(stale_root) in roots
 
 
+def test_rulespec_target_resolution_prefers_configured_roots(monkeypatch, tmp_path):
+    workspace = tmp_path / "worktrees"
+    policy_repo = workspace / "rulespec-us-co"
+    policy_repo.mkdir(parents=True)
+    stale_sibling = workspace / "rulespec-us"
+    stale_file = stale_sibling / "regulations" / "7-cfr" / "273" / "9.yaml"
+    stale_file.parent.mkdir(parents=True)
+    stale_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: stale_snap_income_rule
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: '0'
+"""
+    )
+    configured_parent = tmp_path / "configured"
+    configured_file = (
+        configured_parent
+        / "rulespec-us"
+        / "us"
+        / "regulations"
+        / "7-cfr"
+        / "273"
+        / "9.yaml"
+    )
+    configured_file.parent.mkdir(parents=True)
+    configured_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: snap_standard_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: '0'
+"""
+    )
+    monkeypatch.setenv("AXIOM_RULESPEC_REPO_ROOTS", str(configured_parent))
+    target_ref = validator_pipeline._parse_rulespec_target(
+        "us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option"
+    )
+
+    assert target_ref is not None
+    assert (
+        validator_pipeline._resolve_rulespec_target_file(target_ref, policy_repo)
+        == configured_file
+    )
+
+
 def test_unrelated_same_section_term_import_rejects_other_section_standin(tmp_path):
     repo = tmp_path / "rulespec-us"
     section_root = repo / "statutes/26/3134"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.738"
+version = "0.2.739"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Prefer explicit AXIOM_RULESPEC_REPO_ROOTS before incidental sibling worktrees when resolving cross-repo RuleSpec targets
- Add a regression test for stale sibling rulespec-us shadowing configured roots
- Bump axiom-encode provenance to 0.2.739

## Tests
- env -u UV_FROZEN uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py src/axiom_encode/__init__.py
- env -u UV_FROZEN uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py src/axiom_encode/__init__.py
- env -u UV_FROZEN uv run --with pytest python -m pytest tests/test_rulespec_validation.py -k 'target_resolution_prefers_configured_roots or delegated_policy_setting' -vv
- env -u UV_FROZEN uv run --with pytest python -m pytest tests/test_cli.py -k 'delegated_policy_setting_repair or current_encoder_affecting_changes_are_behind_version_bump or package_version_metadata_matches_pyproject' -vv
- env -u UV_FROZEN uv run towncrier build --draft --version 0.2.739
- git diff --check