### PR TITLE
Prefer configured RuleSpec roots for compile validation

### DIFF
--- a/changelog.d/rulespec-compile-configured-roots.fixed.md
+++ b/changelog.d/rulespec-compile-configured-roots.fixed.md
@@ -1,0 +1,1 @@
+Prefer configured RuleSpec roots over incidental sibling checkouts during compile validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.739"
+version = "0.2.740"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.739"
+__version__ = "0.2.740"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -18489,19 +18489,26 @@ class ValidatorPipeline:
     def _rulespec_compile_env(self) -> dict[str, str]:
         """Build an env that can resolve canonical RuleSpec repo imports."""
         env = self._pythonpath_env()
-        roots = [self.policy_repo_path, self.policy_repo_path.parent]
+        roots: list[Path] = []
         if Path(self.policy_repo_path).parent.name.startswith("rulespec-"):
             # A monorepo jurisdiction directory: sibling checkouts live next
             # to the monorepo checkout itself.
-            roots.append(Path(self.policy_repo_path).parent.parent)
+            incidental_roots = [
+                self.policy_repo_path.parent,
+                self.policy_repo_path.parent.parent,
+            ]
+        else:
+            incidental_roots = [self.policy_repo_path.parent]
         alias_parent = _rulespec_repo_alias_parent(self.policy_repo_path)
         if alias_parent is not None:
-            roots.insert(0, alias_parent)
+            roots.append(alias_parent)
+        roots.append(self.policy_repo_path)
         existing_roots = env.get("AXIOM_RULESPEC_REPO_ROOTS", "")
         if existing_roots:
             roots.extend(
                 Path(root) for root in existing_roots.split(os.pathsep) if root
             )
+        roots.extend(incidental_roots)
         deduped_roots: list[str] = []
         seen: set[str] = set()
         for root in roots:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2552,8 +2552,12 @@ rules:
         for env in captured_envs:
             assert env is not None
             roots = env["AXIOM_RULESPEC_REPO_ROOTS"].split(os.pathsep)
-            assert roots[:2] == [str(repo.resolve()), str(repo.resolve().parent)]
+            assert roots[0] == str(repo.resolve())
+            assert str(repo.resolve().parent) in roots
             assert str(stale_repo) in roots
+            assert roots.index(str(stale_repo)) < roots.index(
+                str(repo.resolve().parent)
+            )
 
     def test_executes_companion_tests_from_canonical_alias_checkout(
         self, capsys, monkeypatch, tmp_path
@@ -24672,7 +24676,10 @@ class TestCmdValidateEdgeCases:
         assert call_kwargs["policy_repo_path"] == tmp_path / "rulespec-us-tn"
         assert call_kwargs["axiom_rules_path"] == tmp_path / "axiom-rules-engine"
 
-    def test_validate_fallback_prefers_workspace_repo_roots(self, tmp_path):
+    def test_validate_fallback_prefers_workspace_repo_roots(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.delenv("AXIOM_RULESPEC_REPO_ROOTS", raising=False)
         rulespec_file = tmp_path / "generated" / "test.yaml"
         rulespec_file.parent.mkdir(parents=True)
         rulespec_file.write_text("# test")
@@ -24704,8 +24711,8 @@ class TestCmdValidateEdgeCases:
 
         with (
             patch(
-                "axiom_encode.cli._resolve_repo_checkout",
-                side_effect=lambda name: workspace_root / name,
+                "axiom_encode.cli._resolve_policy_repo_for_prefix",
+                return_value=rules_us_path,
             ),
             patch("axiom_encode.cli.ValidatorPipeline") as mock_pipeline_cls,
         ):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -130,8 +130,38 @@ def test_rulespec_compile_env_exposes_policy_repo_roots(monkeypatch, tmp_path):
     roots = pipeline._rulespec_compile_env()["AXIOM_RULESPEC_REPO_ROOTS"].split(
         os.pathsep
     )
-    assert roots[:2] == [str(policy_repo), str(repo_parent)]
+    assert roots[0] == str(policy_repo)
     assert str(existing_root) in roots
+    assert str(repo_parent) in roots
+    assert roots.index(str(existing_root)) < roots.index(str(repo_parent))
+
+
+def test_rulespec_compile_env_prefers_configured_roots_over_stale_parent(
+    monkeypatch,
+    tmp_path,
+):
+    repo_parent = tmp_path / "worktrees"
+    policy_repo = repo_parent / "rulespec-us-co"
+    policy_repo.mkdir(parents=True)
+    stale_sibling = repo_parent / "rulespec-us"
+    stale_sibling.mkdir()
+    configured_parent = tmp_path / "configured-roots"
+    (configured_parent / "rulespec-us").mkdir(parents=True)
+    monkeypatch.setenv("AXIOM_RULESPEC_REPO_ROOTS", str(configured_parent))
+
+    pipeline = ValidatorPipeline(
+        policy_repo_path=policy_repo,
+        axiom_rules_path=repo_parent / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    roots = pipeline._rulespec_compile_env()["AXIOM_RULESPEC_REPO_ROOTS"].split(
+        os.pathsep
+    )
+    assert roots[0] == str(policy_repo)
+    assert str(configured_parent) in roots
+    assert str(repo_parent) in roots
+    assert roots.index(str(configured_parent)) < roots.index(str(repo_parent))
 
 
 def test_rulespec_validation_run_compiled_uses_current_repo_env(monkeypatch, tmp_path):
@@ -199,8 +229,10 @@ def test_rulespec_validation_run_compiled_uses_current_repo_env(monkeypatch, tmp
     assert outputs["us:statutes/1/1#benefit"]["value"]["value"] == 6
     assert captured_env is not None
     roots = captured_env["AXIOM_RULESPEC_REPO_ROOTS"].split(os.pathsep)
-    assert roots[:2] == [str(policy_repo), str(repo_parent)]
+    assert roots[0] == str(policy_repo)
     assert str(stale_root) in roots
+    assert str(repo_parent) in roots
+    assert roots.index(str(stale_root)) < roots.index(str(repo_parent))
 
 
 def test_rulespec_target_resolution_prefers_configured_roots(monkeypatch, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.739"
+version = "0.2.740"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- keep the current policy checkout first in RuleSpec compile environments
- prefer explicit `AXIOM_RULESPEC_REPO_ROOTS` before incidental sibling/parent roots
- add a regression for stale sibling roots shadowing configured roots
- bump axiom-encode to 0.2.740

## Root Cause
The target resolver already preferred configured RuleSpec roots, but compile validation still searched incidental parent/sibling roots before the configured roots. In apply overlays this let stale sibling checkouts shadow the intended federal RuleSpec root.

## Checks
- `env -u UV_FROZEN uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `env -u UV_FROZEN uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `env -u UV_FROZEN uv run --with pytest python -m pytest tests/test_rulespec_validation.py -vv`