### PR TITLE
Synthesize count-helper positive tests

### DIFF
--- a/changelog.d/count-helper-positive-tests.fixed.md
+++ b/changelog.d/count-helper-positive-tests.fixed.md
@@ -1,0 +1,1 @@
+Synthesize positive Judgment companion tests for local boolean-sum count helpers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.740"
+version = "0.2.741"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.740"
+__version__ = "0.2.741"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -15366,6 +15366,23 @@ def _positive_judgment_formula_input_assignments_for_formula(
                     for input_name, value in dependency_assignments.items():
                         assignments.setdefault(input_name, value)
                     protected_positive_inputs.update(dependency_protected_inputs)
+            elif dependency_formula := _first_rule_formula(dependency):
+                (
+                    helper_assignments,
+                    helper_protected_inputs,
+                ) = _positive_count_helper_input_assignments(
+                    helper_name=identifier,
+                    parent_formula=formula,
+                    helper_formula=dependency_formula,
+                    rules_payload=rules_payload,
+                    rules_by_name=rules_by_name,
+                    imported_outputs=imported_outputs,
+                    excluded_true_inputs=negated_identifiers,
+                    protected_positive_inputs=protected_positive_inputs,
+                )
+                for input_name, value in helper_assignments.items():
+                    assignments.setdefault(input_name, value)
+                protected_positive_inputs.update(helper_protected_inputs)
             continue
         if identifier in imported_outputs:
             continue
@@ -15410,6 +15427,97 @@ def _positive_judgment_formula_input_assignments_for_formula(
         )
 
     return assignments, protected_positive_inputs
+
+
+def _positive_count_helper_input_assignments(
+    *,
+    helper_name: str,
+    parent_formula: str,
+    helper_formula: str,
+    rules_payload: dict[str, object],
+    rules_by_name: dict[str, dict[str, object]],
+    imported_outputs: set[str],
+    excluded_true_inputs: set[str],
+    protected_positive_inputs: set[str],
+) -> tuple[dict[str, object], set[str]]:
+    required_count = _integer_equality_count_for_helper(
+        formula=parent_formula,
+        helper_name=helper_name,
+    )
+    if required_count is None:
+        return {}, set()
+    helper_inputs = _boolean_sum_count_helper_inputs(
+        formula=helper_formula,
+        rules_payload=rules_payload,
+        rules_by_name=rules_by_name,
+        imported_outputs=imported_outputs,
+    )
+    if not helper_inputs or required_count > len(helper_inputs):
+        return {}, set()
+
+    already_selected = [
+        input_name
+        for input_name in helper_inputs
+        if input_name in protected_positive_inputs
+    ]
+    if len(already_selected) > required_count:
+        return {}, set()
+
+    remaining_needed = required_count - len(already_selected)
+    selectable = [
+        input_name
+        for input_name in helper_inputs
+        if input_name not in protected_positive_inputs
+        and input_name not in excluded_true_inputs
+    ]
+    if remaining_needed > len(selectable):
+        return {}, set()
+
+    selected = set(already_selected)
+    selected.update(selectable[:remaining_needed])
+    assignments: dict[str, object] = {}
+    for input_name in helper_inputs:
+        if input_name in protected_positive_inputs and input_name not in selected:
+            return {}, set()
+        assignments[input_name] = input_name in selected
+    return assignments, selected
+
+
+def _integer_equality_count_for_helper(*, formula: str, helper_name: str) -> int | None:
+    token = re.escape(helper_name)
+    patterns = (
+        re.compile(rf"\b{token}\b\s*==\s*(?P<count>\d+)\b"),
+        re.compile(rf"\b(?P<count>\d+)\b\s*==\s*\b{token}\b"),
+    )
+    for pattern in patterns:
+        match = pattern.search(formula)
+        if match is not None:
+            return int(match["count"])
+    return None
+
+
+def _boolean_sum_count_helper_inputs(
+    *,
+    formula: str,
+    rules_payload: dict[str, object],
+    rules_by_name: dict[str, dict[str, object]],
+    imported_outputs: set[str],
+) -> list[str]:
+    defined_symbols = set(rules_by_name) | imported_outputs
+    inputs: list[str] = []
+    seen: set[str] = set()
+    pattern = re.compile(
+        r"\bif\s+(?P<input>[A-Za-z_][A-Za-z0-9_]*)\s*:\s*1\s+else\s*:\s*0\b"
+    )
+    for match in pattern.finditer(formula):
+        input_name = match["input"]
+        if input_name in seen or input_name in defined_symbols:
+            continue
+        if _factual_input_appears_numeric(input_name, rules_payload=rules_payload):
+            continue
+        seen.add(input_name)
+        inputs.append(input_name)
+    return inputs
 
 
 def _rule_is_derived_judgment(rule: dict[str, object]) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13449,6 +13449,75 @@ rules:
             not in synthesized["input"]
         )
 
+    def test_judgment_positive_test_repair_synthesizes_count_helper_inputs(
+        self, tmp_path
+    ):
+        repo_path = tmp_path / "rulespec-us-co"
+        rules_file = repo_path / "regulations" / "10-ccr-2506-1" / "4.407.31.yaml"
+        test_file = repo_path / "regulations" / "10-ccr-2506-1" / "4.407.31.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: snap_non_heating_cooling_utility_expense_count
+    kind: derived
+    dtype: Integer
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          (if household_pays_electricity_utility_cost: 1 else: 0)
+          + (if household_pays_water_utility_cost: 1 else: 0)
+          + (if household_pays_telephone_service_cost: 1 else: 0)
+  - name: snap_one_utility_allowance_eligible
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          snap_non_heating_cooling_utility_expense_count == 1
+          and not household_pays_telephone_service_cost
+"""
+        )
+        test_file.write_text("[]\n")
+
+        repaired = _append_generated_judgment_positive_tests_if_missing(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=repo_path,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            relative_output=Path("regulations/10-ccr-2506-1/4.407.31.yaml"),
+            issues=[
+                "Judgment rule missing positive companion output coverage: "
+                "`us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance_eligible` "
+                "is not asserted as `holds` by the companion `.test.yaml` file."
+            ],
+        )
+
+        assert repaired == ["auto_positive_snap_one_utility_allowance_eligible"]
+        test_payload = yaml.safe_load(test_file.read_text())
+        synthesized = test_payload[0]
+        assert synthesized["output"] == {
+            "us-co:regulations/10-ccr-2506-1/4.407.31#snap_one_utility_allowance_eligible": "holds"
+        }
+        assert (
+            synthesized["input"][
+                "us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_electricity_utility_cost"
+            ]
+            is True
+        )
+        assert (
+            synthesized["input"][
+                "us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_water_utility_cost"
+            ]
+            is False
+        )
+        assert (
+            synthesized["input"][
+                "us-co:regulations/10-ccr-2506-1/4.407.31#input.household_pays_telephone_service_cost"
+            ]
+            is False
+        )
+
     def test_judgment_positive_test_repair_synthesizes_local_judgment_dependency_inputs(
         self, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.740"
+version = "0.2.741"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- synthesize positive Judgment companion tests for local boolean-sum count helpers used in equality comparisons
- exclude negated inputs from the selected true count-helper assignments
- bump axiom-encode to 0.2.741 and add a regression covering SNAP one-utility allowance eligibility

## Tests
- env -u UV_FROZEN uv run --with pytest python -m pytest tests/test_cli.py -vv
- env -u UV_FROZEN uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- env -u UV_FROZEN uv run ruff check src/axiom_encode/cli.py tests/test_cli.py