### PR TITLE
Preserve canonical RuleSpec test references

### DIFF
--- a/changelog.d/preserve-canonical-test-refs.fixed.md
+++ b/changelog.d/preserve-canonical-test-refs.fixed.md
@@ -1,0 +1,1 @@
+Preserve canonical absolute RuleSpec references when executing companion tests from temporary or aliased checkouts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.741"
+version = "0.2.742"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.741"
+__version__ = "0.2.742"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -82,7 +82,6 @@ from .harness.validator_pipeline import (
     _candidate_upstream_rulespec_roots,
     _canonical_rulespec_compile_path,
     _canonical_rulespec_target,
-    _engine_rulespec_item_path_for_policy_root,
     _extract_source_verification_text,
     _filing_status_rule_source_context,
     _is_executable_rulespec_rule,
@@ -93,7 +92,6 @@ from .harness.validator_pipeline import (
     _rule_versions_are_constant_false,
     _rulespec_executable_index_for_roots,
     _rulespec_executable_signature,
-    _rulespec_local_item_prefix,
     _rulespec_payload_from_file,
     _rulespec_public_item_keys,
     _rulespec_repo_prefix,
@@ -3060,21 +3058,6 @@ def _rulespec_test_relation_request_name(
     *,
     policy_repo_path: Path,
 ) -> str:
-    if ":" in key:
-        prefix, relative = key.split(":", 1)
-        canonical_prefix = _repo_jurisdiction_prefix(policy_repo_path)
-        local_prefix = _rulespec_local_item_prefix(policy_repo_path)
-        if (
-            prefix == canonical_prefix
-            and local_prefix
-            and local_prefix != canonical_prefix
-        ):
-            item_path = _engine_rulespec_item_path_for_policy_root(
-                relative,
-                policy_repo_path=policy_repo_path,
-                canonical_prefix=canonical_prefix,
-            )
-            return f"{local_prefix}:{item_path}"
     return key
 
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -18404,20 +18404,9 @@ def _rulespec_engine_request_name_for_test_key(
     require_legal_input_keys: bool,
     policy_repo_path: Path,
 ) -> str:
-    if not require_legal_input_keys or not _RULESPEC_ABSOLUTE_REFERENCE.match(test_key):
-        return runtime_name
-    local_prefix = _rulespec_local_item_prefix(policy_repo_path)
-    canonical_prefix = jurisdiction_prefix(policy_repo_path)
-    if local_prefix and local_prefix != canonical_prefix:
-        canonical_head = f"{canonical_prefix}:"
-        if test_key.startswith(canonical_head):
-            item_path = _engine_rulespec_item_path_for_policy_root(
-                test_key.split(":", 1)[1],
-                policy_repo_path=policy_repo_path,
-                canonical_prefix=canonical_prefix,
-            )
-            return f"{local_prefix}:{item_path}"
-    return test_key
+    if require_legal_input_keys and _RULESPEC_ABSOLUTE_REFERENCE.match(test_key):
+        return test_key
+    return runtime_name
 
 
 def _rulespec_declared_relation_names(compiled_payload: dict[str, Any]) -> set[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2608,7 +2608,7 @@ rules:
             if "compile" in cmd:
                 program_path = Path(cmd[cmd.index("--program") + 1])
                 compile_programs.append(program_path)
-                item_id = "us-clean.abcd:statutes/1/alias#benefit"
+                item_id = "us:statutes/1/alias#benefit"
                 compiled_ids.append(item_id)
                 output_path = Path(cmd[cmd.index("--output") + 1])
                 output_path.write_text(
@@ -2667,7 +2667,7 @@ rules:
 
         assert exc_info.value.code == 0
         assert json.loads(capsys.readouterr().out)["success"] is True
-        assert compiled_ids == ["us-clean.abcd:statutes/1/alias#benefit"]
+        assert compiled_ids == ["us:statutes/1/alias#benefit"]
         assert len(compile_programs) == 1
         assert "rulespec-us" in compile_programs[0].parts
         assert "rulespec-us-clean.abcd" not in str(compile_programs[0])
@@ -2754,7 +2754,7 @@ rules:
                             "results": [
                                 {
                                     "outputs": {
-                                        "us-clean.abcd:statutes/1/relation#benefit": {
+                                        "us:statutes/1/relation#benefit": {
                                             "kind": "scalar",
                                             "value": {"kind": "integer", "value": 5},
                                         }
@@ -2784,7 +2784,7 @@ rules:
 
         assert exc_info.value.code == 0
         assert json.loads(capsys.readouterr().out)["success"] is True
-        assert relation_names == ["us-clean.abcd:statutes/1/relation#relation.members"]
+        assert relation_names == ["us:statutes/1/relation#relation.members"]
 
     def test_discovery_skips_axiom_dependency_tree(self, tmp_path):
         root = tmp_path / "workspace"

--- a/tests/test_repo_routing.py
+++ b/tests/test_repo_routing.py
@@ -161,7 +161,7 @@ rules:
     }
 
 
-def test_dataset_rewrites_canonical_same_repo_refs_to_engine_temp_prefix(tmp_path):
+def test_dataset_preserves_canonical_same_repo_refs_for_alias_checkout(tmp_path):
     checkout = tmp_path / "rulespec-us-clean.abcd"
     _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")
     rules_file = checkout / "statutes" / "26" / "63" / "f.yaml"
@@ -227,17 +227,17 @@ rules:
     )
 
     assert dataset["relations"][0]["name"] == (
-        "us-clean.abcd:statutes/26/63/f#relation.spouse_of_taxpayer_for_subsection_f"
+        "us:statutes/26/63/f#relation.spouse_of_taxpayer_for_subsection_f"
     )
     assert dataset["inputs"][0]["name"] == (
-        "us-clean.abcd:statutes/26/151#input.tin_included_on_return_claiming_exemption"
+        "us:statutes/26/151#input.tin_included_on_return_claiming_exemption"
     )
     assert dataset["inputs"][1]["name"] == (
-        "us-clean.abcd:statutes/26/63/f#input.taxpayer_is_blind_at_close_of_taxable_year"
+        "us:statutes/26/63/f#input.taxpayer_is_blind_at_close_of_taxable_year"
     )
 
 
-def test_dataset_rewrites_country_subdir_canonical_refs_to_engine_temp_prefix(
+def test_dataset_preserves_country_subdir_canonical_refs_for_alias_checkout(
     tmp_path,
 ):
     checkout = tmp_path / "rulespec-us-clean.abcd"
@@ -276,11 +276,11 @@ rules:
     )
 
     assert dataset["inputs"][0]["name"] == (
-        "us-clean.abcd:us/regulations/7-cfr/275/23/d/2#input.payment_error_rate"
+        "us:regulations/7-cfr/275/23/d/2#input.payment_error_rate"
     )
 
 
-def test_cli_relation_request_rewrites_country_subdir_canonical_refs(tmp_path):
+def test_cli_relation_request_preserves_country_subdir_canonical_refs(tmp_path):
     checkout = tmp_path / "rulespec-us-clean.abcd"
     _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")
     policy_root = checkout / "us"
@@ -292,6 +292,6 @@ def test_cli_relation_request_rewrites_country_subdir_canonical_refs(tmp_path):
     )
 
     assert relation_name == (
-        "us-clean.abcd:us/regulations/7-cfr/275/23/d/1"
+        "us:regulations/7-cfr/275/23/d/1"
         "#relation.state_agencies_for_quality_control_fiscal_year"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.741"
+version = "0.2.742"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- preserve canonical absolute RuleSpec references when building validation datasets from alias/temp checkouts
- stop rewriting companion-test relation names to physical checkout prefixes
- update alias-checkout regressions for canonical IDs

## Verification
- ruff format --check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_repo_routing.py
- ruff check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_repo_routing.py
- pytest tests/test_repo_routing.py -vv
- pytest tests/test_cli.py -vv
- Colorado SNAP 4.208.2 validation passes locally with canonical relation refs