### PR TITLE
Cache RuleSpec validation reference lookups

### DIFF
--- a/changelog.d/cache-rulespec-reference-summary.fixed.md
+++ b/changelog.d/cache-rulespec-reference-summary.fixed.md
@@ -1,0 +1,1 @@
+Cache RuleSpec reference summaries and sibling rule-name inventories during validation so large changed-file batches do not repeatedly reparse the same target modules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.743"
+version = "0.2.744"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.743"
+__version__ = "0.2.744"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -14947,6 +14947,24 @@ def _formula_references_symbol(formula_text: str, symbol: str) -> bool:
 
 
 def _rulespec_rule_names_from_file(path: Path) -> set[str]:
+    try:
+        stat = path.stat()
+        cache_path = path.resolve()
+    except OSError:
+        return set()
+    return _rulespec_rule_names_from_file_cached(
+        cache_path,
+        stat.st_mtime_ns,
+        stat.st_size,
+    )
+
+
+@functools.lru_cache(maxsize=8192)
+def _rulespec_rule_names_from_file_cached(
+    path: Path,
+    _mtime_ns: int,
+    _size: int,
+) -> set[str]:
     with contextlib.suppress(OSError):
         return _rulespec_rule_names_from_content(path.read_text())
     return set()
@@ -18200,6 +18218,29 @@ def _rulespec_formula_identifiers(payload: Any) -> set[str]:
 
 
 def _rulespec_reference_summary(target_file: Path) -> _RuleSpecReferenceSummary:
+    try:
+        stat = target_file.stat()
+        cache_path = target_file.resolve()
+    except OSError:
+        return _RuleSpecReferenceSummary(
+            derived=frozenset(),
+            parameters=frozenset(),
+            relations=frozenset(),
+            input_slots=frozenset(),
+        )
+    return _rulespec_reference_summary_cached(
+        cache_path,
+        stat.st_mtime_ns,
+        stat.st_size,
+    )
+
+
+@functools.lru_cache(maxsize=8192)
+def _rulespec_reference_summary_cached(
+    target_file: Path,
+    _mtime_ns: int,
+    _size: int,
+) -> _RuleSpecReferenceSummary:
     try:
         payload = yaml.safe_load(target_file.read_text()) or {}
     except (OSError, yaml.YAMLError, ValueError):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -8062,6 +8062,58 @@ rules:
     assert find_sibling_rule_name_collision_issues(content, rules_file) == []
 
 
+def test_sibling_rule_name_collision_caches_sibling_names(
+    monkeypatch,
+    tmp_path,
+):
+    rules_file = (
+        tmp_path / "rulespec-us" / "statutes" / "7" / "2015" / "d" / "2" / "A.yaml"
+    )
+    sibling = rules_file.with_name("B.yaml")
+    rules_file.parent.mkdir(parents=True)
+    sibling.write_text(
+        """format: rulespec/v1
+rules:
+  - name: care_responsibility_exemption_applies
+    kind: derived
+"""
+    )
+    content = """format: rulespec/v1
+rules:
+  - name: title_iv_or_unemployment_work_registration_exemption_applies
+    kind: derived
+"""
+
+    validator_pipeline._rulespec_rule_names_from_file_cached.cache_clear()
+    original_safe_load = validator_pipeline.yaml.safe_load
+    load_count = 0
+
+    def counting_safe_load(stream):
+        nonlocal load_count
+        load_count += 1
+        return original_safe_load(stream)
+
+    monkeypatch.setattr(
+        validator_pipeline.yaml,
+        "safe_load",
+        counting_safe_load,
+    )
+
+    for _ in range(2):
+        assert find_sibling_rule_name_collision_issues(content, rules_file) == []
+
+    assert load_count == 3
+
+    sibling.write_text(
+        sibling.read_text().replace(
+            "care_responsibility_exemption_applies",
+            "care_responsibility_exemption_for_dependent_applies",
+        )
+    )
+    assert find_sibling_rule_name_collision_issues(content, rules_file) == []
+    assert load_count == 5
+
+
 def test_child_fragment_reencoding_rejects_parent_copying_child_inputs(tmp_path):
     repo = tmp_path / "rulespec-us"
     rules_file = repo / "statutes" / "26" / "63" / "c.yaml"
@@ -10962,6 +11014,77 @@ rules:
     )
 
     assert issue is None
+
+
+def test_rulespec_reference_summary_cache_reuses_unchanged_file(
+    monkeypatch,
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "regulations" / "7-cfr" / "273" / "10.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: snap_monthly_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: household_size + snap_net_income
+"""
+    )
+
+    validator_pipeline._rulespec_reference_summary_cached.cache_clear()
+    original_safe_load = validator_pipeline.yaml.safe_load
+    load_count = 0
+
+    def counting_safe_load(stream):
+        nonlocal load_count
+        load_count += 1
+        return original_safe_load(stream)
+
+    monkeypatch.setattr(
+        validator_pipeline.yaml,
+        "safe_load",
+        counting_safe_load,
+    )
+
+    for reference in (
+        "us:regulations/7-cfr/273/10#input.household_size",
+        "us:regulations/7-cfr/273/10#input.snap_net_income",
+    ):
+        issue = validator_pipeline._rulespec_absolute_test_reference_issue(
+            reference,
+            label="input",
+            policy_repo_path=repo,
+            allow_input_slots=True,
+            allow_relations=False,
+            allow_outputs=False,
+        )
+        assert issue is None
+
+    assert load_count == 1
+
+    rules_file.write_text(
+        rules_file.read_text().replace(
+            "household_size + snap_net_income",
+            "household_size + snap_net_income + shelter_deduction",
+        )
+    )
+    issue = validator_pipeline._rulespec_absolute_test_reference_issue(
+        "us:regulations/7-cfr/273/10#input.shelter_deduction",
+        label="input",
+        policy_repo_path=repo,
+        allow_input_slots=True,
+        allow_relations=False,
+        allow_outputs=False,
+    )
+
+    assert issue is None
+    assert load_count == 2
 
 
 def test_rulespec_ci_rejects_scale_tables_encoded_as_match_literals(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.743"
+version = "0.2.744"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- cache RuleSpec reference summaries by resolved path, mtime, and size
- cache sibling RuleSpec rule-name inventories by resolved path, mtime, and size
- bump axiom-encode to 0.2.744

## Why
Large RuleSpec validation runs repeatedly resolve the same target files and sibling files. The CO SNAP manual PR exposed this as minutes of repeated YAML parsing before reaching real validation failures.

## Tests
- `env -u UV_FROZEN uv run pytest tests/test_rulespec_validation.py -vv`
- `env -u UV_FROZEN uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `env -u UV_FROZEN uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
