### PR TITLE
Fix monorepo delegated setting imports

### DIFF
--- a/changelog.d/monorepo-delegated-setting-import.fixed.md
+++ b/changelog.d/monorepo-delegated-setting-import.fixed.md
@@ -1,0 +1,1 @@
+Fix delegated policy setting validation and repair for existing state `sets` relations in unified RuleSpec monorepos.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.744"
+version = "0.2.745"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.744"
+__version__ = "0.2.745"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -8086,11 +8086,19 @@ def cmd_repair_delegated_policy_settings(args):
         rules_file=rules_file,
         policy_repo_path=repo_path,
     )
+    before_missing_import_delegated_issues = (
+        _missing_delegated_setting_import_issue_texts(
+            original_content,
+            rules_file=rules_file,
+            policy_repo_path=repo_path,
+        )
+    )
     before_delegated_issues = _ordered_unique_strings(
         [
             *(_delegated_policy_setting_issue_texts(before_issues)),
             *before_direct_delegated_issues,
             *before_unresolved_delegated_issues,
+            *before_missing_import_delegated_issues,
         ]
     )
     if not before_delegated_issues:
@@ -8129,11 +8137,19 @@ def cmd_repair_delegated_policy_settings(args):
         rules_file=rules_file,
         policy_repo_path=repo_path,
     )
+    after_missing_import_delegated_issues = (
+        _missing_delegated_setting_import_issue_texts(
+            rules_file.read_text(),
+            rules_file=rules_file,
+            policy_repo_path=repo_path,
+        )
+    )
     after_delegated_issues = _ordered_unique_strings(
         [
             *(_delegated_policy_setting_issue_texts(after_issues)),
             *after_direct_delegated_issues,
             *after_unresolved_delegated_issues,
+            *after_missing_import_delegated_issues,
         ]
     )
     if not set(before_delegated_issues) - set(after_delegated_issues):
@@ -8158,9 +8174,9 @@ def cmd_repair_delegated_policy_settings(args):
             backend="deterministic",
             model="delegated-policy-setting-v1",
             tool="axiom-encode repair-delegated-policy-settings",
-            citation=(
-                f"{_repo_jurisdiction_prefix(repo_path)}:"
-                f"{_relative_rulespec_import_target(relative_output)}"
+            citation=_relative_output_to_anchor(
+                relative_output,
+                policy_repo_path=repo_path,
             ),
             generation_prompt_sha256=None,
             trace_file=None,
@@ -20902,6 +20918,69 @@ def _unresolved_delegated_setting_sets_issue_texts(
     return issues
 
 
+def _missing_delegated_setting_import_issue_texts(
+    content: str,
+    *,
+    rules_file: Path,
+    policy_repo_path: Path | None,
+) -> list[str]:
+    try:
+        payload = yaml.safe_load(content) or {}
+    except (OSError, yaml.YAMLError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    resolved_targets = _resolved_executable_delegated_setting_targets(
+        _SNAP_UTILITY_ALLOWANCE_SETTING_TARGETS,
+        current_payload=payload,
+        current_rules_file=rules_file,
+        policy_repo_path=policy_repo_path,
+    )
+    if not resolved_targets:
+        return []
+
+    issues: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "source_relation":
+            continue
+        source_relation = rule.get("source_relation")
+        if not isinstance(source_relation, dict):
+            continue
+        if str(source_relation.get("type") or "").strip().lower() != "sets":
+            continue
+        target = _normalize_source_relation_target_ref(source_relation.get("target"))
+        if target not in resolved_targets:
+            continue
+        if _rulespec_payload_imports_target(payload, target):
+            continue
+        import_target = target.split("#", 1)[0].strip()
+        name = str(rule.get("name") or target).strip()
+        issues.append(
+            "RuleSpec source relation "
+            f"`{name}` sets target `{target}`, but this module does not import "
+            f"`{import_target}`"
+        )
+    return issues
+
+
+def _rulespec_payload_imports_target(payload: dict[str, Any], target: str) -> bool:
+    import_target = target.split("#", 1)[0].strip()
+    if not import_target:
+        return False
+    imports = payload.get("imports")
+    if not isinstance(imports, list):
+        return False
+    return import_target in {
+        str(item).split("#", 1)[0].strip() for item in imports if isinstance(item, str)
+    }
+
+
 def _ensure_rulespec_payload_import(payload: dict[str, Any], target: str) -> bool:
     import_target = target.split("#", 1)[0].strip()
     if not import_target:
@@ -28969,8 +29048,15 @@ def _relative_generated_output_path(
 def _relative_output_to_anchor(
     relative_output: Path, *, policy_repo_path: Path | None = None
 ) -> str:
-    """Convert a generated file's relative path to its `us:...` anchor."""
+    """Convert a generated file's relative path to its RuleSpec anchor."""
     rel = relative_output.with_suffix("")
+    parts = rel.parts
+    if (
+        len(parts) >= 2
+        and parts[1] in {"policies", "regulations", "statutes"}
+        and re.fullmatch(r"[a-z]{2}(?:-[a-z0-9_]+)*", parts[0])
+    ):
+        return f"{parts[0]}:{Path(*parts[1:]).as_posix()}"
     jurisdiction = (
         _repo_jurisdiction_prefix(policy_repo_path) if policy_repo_path else "us"
     )

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -17718,10 +17718,35 @@ def _candidate_rulespec_repo_roots(
 def _rulespec_repo_alias_parent(policy_repo_path: Path) -> Path | None:
     """Expose a temp checkout under its canonical `rulespec-*` repo name."""
     canonical_name = canonical_rulespec_repo_name(policy_repo_path)
-    if not canonical_name or policy_repo_path.name == canonical_name:
+    return _rulespec_repo_alias_parent_for_root(policy_repo_path, canonical_name)
+
+
+def _monorepo_rulespec_repo_alias(
+    policy_repo_path: Path,
+) -> tuple[Path, str] | None:
+    """Expose a country monorepo root when validating one jurisdiction subdir."""
+    policy_root = Path(policy_repo_path).resolve()
+    monorepo_root = policy_root.parent
+    if not monorepo_root.name.startswith("rulespec-"):
+        return None
+    if policy_root.name not in jurisdiction_subdir_names(monorepo_root):
+        return None
+    canonical_name = canonical_rulespec_repo_name(monorepo_root)
+    alias_parent = _rulespec_repo_alias_parent_for_root(monorepo_root, canonical_name)
+    if alias_parent is None or canonical_name is None:
+        return None
+    return alias_parent, canonical_name
+
+
+def _rulespec_repo_alias_parent_for_root(
+    rulespec_root: Path,
+    canonical_name: str | None,
+) -> Path | None:
+    """Expose a checkout root under a canonical `rulespec-*` repo name."""
+    if not canonical_name or Path(rulespec_root).name == canonical_name:
         return None
 
-    resolved_repo = policy_repo_path.resolve()
+    resolved_repo = Path(rulespec_root).resolve()
     digest = hashlib.sha256(str(resolved_repo).encode()).hexdigest()[:16]
     alias_parent = Path(tempfile.gettempdir()) / "axiom-rulespec-repo-aliases" / digest
     alias_parent.mkdir(parents=True, exist_ok=True)
@@ -17743,6 +17768,17 @@ def _canonical_rulespec_compile_path(
     policy_repo_path: Path,
 ) -> Path:
     """Return a compile path under the canonical repo alias when needed."""
+    monorepo_alias = _monorepo_rulespec_repo_alias(policy_repo_path)
+    if monorepo_alias is not None:
+        monorepo_alias_parent, monorepo_canonical_name = monorepo_alias
+        try:
+            relative = rules_file.resolve().relative_to(
+                Path(policy_repo_path).resolve().parent
+            )
+        except ValueError:
+            return rules_file
+        return monorepo_alias_parent / monorepo_canonical_name / relative
+
     alias_parent = _rulespec_repo_alias_parent(policy_repo_path)
     canonical_name = canonical_rulespec_repo_name(policy_repo_path)
     if alias_parent is None or canonical_name is None:
@@ -18529,6 +18565,10 @@ class ValidatorPipeline:
             ]
         else:
             incidental_roots = [self.policy_repo_path.parent]
+        monorepo_alias = _monorepo_rulespec_repo_alias(self.policy_repo_path)
+        if monorepo_alias is not None:
+            monorepo_alias_parent, _monorepo_canonical_name = monorepo_alias
+            roots.append(monorepo_alias_parent)
         alias_parent = _rulespec_repo_alias_parent(self.policy_repo_path)
         if alias_parent is not None:
             roots.append(alias_parent)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11337,6 +11337,109 @@ rules:
             manifest_payload["tool"] == "axiom-encode repair-delegated-policy-settings"
         )
 
+    def test_repair_delegated_policy_settings_imports_resolved_monorepo_edge(
+        self, capsys, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us"
+        federal_file = repo / "us" / "regulations" / "7-cfr" / "273" / "9.yaml"
+        federal_file.parent.mkdir(parents=True)
+        federal_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: snap_state_standard_utility_allowance_delegation
+  kind: source_relation
+  source_relation:
+    type: delegates
+    target: us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs
+    authority: federal
+- name: snap_standard_utility_allowance_state_option
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0'
+"""
+        )
+        rules_file = repo / "us-co" / "regulations" / "10-ccr-2506-1" / "4.407.31.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: Colorado SNAP household utility allowance standards.
+rules:
+- name: sets_snap_standard_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+    value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: snap_standard_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '594'
+"""
+        )
+        args = SimpleNamespace(
+            repo=repo,
+            file=Path("us-co/regulations/10-ccr-2506-1/4.407.31.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == rules_file.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_delegated_policy_settings(args)
+
+        output = capsys.readouterr().out
+        assert (
+            "Applied delegated policy setting repair to "
+            "us-co/regulations/10-ccr-2506-1/4.407.31.yaml: "
+            "import:us:regulations/7-cfr/273/9"
+        ) in output
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["imports"] == ["us:regulations/7-cfr/273/9"]
+        assert [rule["name"] for rule in payload["rules"]] == [
+            "sets_snap_standard_utility_allowance",
+            "snap_standard_utility_allowance",
+        ]
+        manifest = (
+            repo
+            / ".axiom/encoding-manifests/us-co/regulations/10-ccr-2506-1/4.407.31.json"
+        )
+        manifest_payload = json.loads(manifest.read_text())
+        assert manifest_payload["citation"] == (
+            "us-co:regulations/10-ccr-2506-1/4.407.31"
+        )
+        assert manifest_payload["model"] == "delegated-policy-setting-v1"
+        assert (
+            manifest_payload["tool"] == "axiom-encode repair-delegated-policy-settings"
+        )
+
     def test_repair_bare_snapunit_entities_uses_module_summary_context(
         self, capsys, tmp_path
     ):

--- a/tests/test_repo_routing.py
+++ b/tests/test_repo_routing.py
@@ -73,6 +73,48 @@ def test_canonical_compile_path_exposes_temp_checkout_file_under_origin_name(tmp
     assert compile_path.resolve() == rules_file.resolve()
 
 
+def test_canonical_compile_path_keeps_monorepo_jurisdiction_under_country_alias(
+    tmp_path,
+):
+    checkout = tmp_path / "rulespec-us-clean.abcd"
+    _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")
+    policy_root = checkout / "us-co"
+    rules_file = policy_root / "regulations" / "10-ccr-2506-1" / "4.407.31.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text("format: rulespec/v1\nrules: []\n")
+
+    compile_path = _canonical_rulespec_compile_path(rules_file, policy_root)
+
+    assert "rulespec-us" in compile_path.parts
+    assert "rulespec-us-co" not in compile_path.parts
+    assert compile_path.parts[-5:] == (
+        "rulespec-us",
+        "us-co",
+        "regulations",
+        "10-ccr-2506-1",
+        "4.407.31.yaml",
+    )
+    assert compile_path.resolve() == rules_file.resolve()
+
+
+def test_compile_env_exposes_monorepo_for_jurisdiction_subdir(tmp_path):
+    checkout = tmp_path / "rulespec-us-clean.abcd"
+    _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")
+    policy_root = checkout / "us-co"
+    policy_root.mkdir()
+
+    pipeline = ValidatorPipeline(
+        policy_repo_path=policy_root,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+    env = pipeline._rulespec_compile_env()
+    roots = [Path(root) for root in env["AXIOM_RULESPEC_REPO_ROOTS"].split(os.pathsep)]
+
+    alias_parent = next(root for root in roots if (root / "rulespec-us").is_symlink())
+    assert (alias_parent / "rulespec-us").resolve() == checkout.resolve()
+
+
 def test_compiled_program_maps_alias_temp_prefix_to_canonical_legal_id(tmp_path):
     checkout = tmp_path / "rulespec-us-clean.abcd"
     _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.744"
+version = "0.2.745"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Fixes validation and deterministic repair for existing delegated state setting relations in unified RuleSpec monorepos.\n\nChanges:\n- compile jurisdiction subdir files through the country monorepo alias so imports like us:regulations/... resolve\n- let repair-delegated-policy-settings recognize missing imports for already-canonical sets edges\n- normalize root-level monorepo anchors for repair manifests\n- add regression tests for monorepo compile routing and delegated setting repair\n\nValidation:\n- env -u UV_FROZEN uv run ruff format --check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_repo_routing.py\n- env -u UV_FROZEN uv run ruff check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_repo_routing.py\n- env -u UV_FROZEN uv run pytest tests/test_repo_routing.py tests/test_cli.py -k 'delegated_policy_settings or repo' -vv\n- env -u UV_FROZEN uv run towncrier check\n- axiom-encode validate --skip-reviewers us-co/regulations/10-ccr-2506-1/4.407.31.yaml us-co/regulations/10-ccr-2506-1/4.205.1.yaml