### PR TITLE
Include companion tests in missing proof manifests

### DIFF
--- a/changelog.d/missing-source-proof-companion-manifest.fixed.md
+++ b/changelog.d/missing-source-proof-companion-manifest.fixed.md
@@ -1,0 +1,1 @@
+Include changed companion tests in signed missing-source-proof repair manifests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.745"
+version = "0.2.746"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.745"
+__version__ = "0.2.746"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -11835,6 +11835,69 @@ def cmd_repair_tax_status_components(args):
     print(f"manifest={manifest_path}")
 
 
+MISSING_SOURCE_PROOF_REPAIR_MODEL = "source-proof-atom-v1"
+MISSING_SOURCE_PROOF_REPAIR_TOOL = "axiom-encode repair-missing-source-proofs"
+
+
+def _missing_source_proof_repair_applied_files(
+    repo_path: Path,
+    relative_output: Path,
+    rules_file: Path,
+) -> list[Path]:
+    applied_files = [rules_file]
+    test_file = _rulespec_test_path(rules_file)
+    if test_file.exists():
+        try:
+            changed_files = _changed_manifest_group_files(
+                repo_path, [(relative_output, [rules_file, test_file])]
+            )
+        except RuntimeError:
+            changed_files = []
+        if any(path.resolve() == test_file.resolve() for path in changed_files):
+            applied_files.append(test_file)
+    return applied_files
+
+
+def _write_missing_source_proof_repair_manifest(
+    *,
+    repo_path: Path,
+    relative_output: Path,
+    content: str,
+    applied_files: list[Path],
+    signing_key: str,
+    axiom_encode_git: dict[str, object],
+) -> Path:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        generated_output = output_root / "deterministic-repair" / relative_output
+        generated_output.parent.mkdir(parents=True, exist_ok=True)
+        generated_output.write_text(content)
+        result = argparse.Namespace(
+            output_file=str(generated_output),
+            runner="deterministic-repair",
+            backend="deterministic",
+            model=MISSING_SOURCE_PROOF_REPAIR_MODEL,
+            tool=MISSING_SOURCE_PROOF_REPAIR_TOOL,
+            citation=(
+                f"{_repo_jurisdiction_prefix(repo_path)}:"
+                f"{_relative_rulespec_import_target(relative_output)}"
+            ),
+            generation_prompt_sha256=None,
+            trace_file=None,
+            context_manifest_file=None,
+        )
+        return _write_applied_encoding_manifest(
+            result,
+            output_root=output_root,
+            policy_repo_path=repo_path,
+            relative_output=relative_output,
+            applied_files=applied_files,
+            run_id="deterministic-repair",
+            signing_key=signing_key,
+            axiom_encode_git=axiom_encode_git,
+        )
+
+
 def cmd_repair_missing_source_proofs(args):
     """Apply signed deterministic repairs for missing source proof atoms."""
     repo_path = Path(args.repo).resolve()
@@ -11855,7 +11918,34 @@ def cmd_repair_missing_source_proofs(args):
     repaired_content, repaired_rules = _repair_missing_source_proof_atoms(
         original_content
     )
+    applied_files = _missing_source_proof_repair_applied_files(
+        repo_path,
+        relative_output,
+        rules_file,
+    )
     if repaired_content == original_content:
+        if len(applied_files) > 1:
+            signing_key = _require_applied_encoding_manifest_signing_key()
+            axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+            if not _applied_manifest_matches_current_deterministic_repair(
+                repo_path=repo_path,
+                relative_output=relative_output,
+                applied_files=applied_files,
+                model=MISSING_SOURCE_PROOF_REPAIR_MODEL,
+                axiom_encode_git=axiom_encode_git,
+                signing_key=signing_key,
+            ):
+                manifest_path = _write_missing_source_proof_repair_manifest(
+                    repo_path=repo_path,
+                    relative_output=relative_output,
+                    content=original_content,
+                    applied_files=applied_files,
+                    signing_key=signing_key,
+                    axiom_encode_git=axiom_encode_git,
+                )
+                print("Refreshed missing source proof repair manifest")
+                print(f"manifest={manifest_path}")
+                return
         print("No missing source proof repairs found.")
         return
 
@@ -11910,35 +12000,14 @@ def cmd_repair_missing_source_proofs(args):
                 print(f"- {issue}")
             sys.exit(1)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        output_root = Path(tmpdir)
-        generated_output = output_root / "deterministic-repair" / relative_output
-        generated_output.parent.mkdir(parents=True, exist_ok=True)
-        generated_output.write_text(repaired_content)
-        result = argparse.Namespace(
-            output_file=str(generated_output),
-            runner="deterministic-repair",
-            backend="deterministic",
-            model="source-proof-atom-v1",
-            tool="axiom-encode repair-missing-source-proofs",
-            citation=(
-                f"{_repo_jurisdiction_prefix(repo_path)}:"
-                f"{_relative_rulespec_import_target(relative_output)}"
-            ),
-            generation_prompt_sha256=None,
-            trace_file=None,
-            context_manifest_file=None,
-        )
-        manifest_path = _write_applied_encoding_manifest(
-            result,
-            output_root=output_root,
-            policy_repo_path=repo_path,
-            relative_output=relative_output,
-            applied_files=[rules_file],
-            run_id="deterministic-repair",
-            signing_key=signing_key,
-            axiom_encode_git=axiom_encode_git,
-        )
+    manifest_path = _write_missing_source_proof_repair_manifest(
+        repo_path=repo_path,
+        relative_output=relative_output,
+        content=repaired_content,
+        applied_files=applied_files,
+        signing_key=signing_key,
+        axiom_encode_git=axiom_encode_git,
+    )
 
     print(
         "Applied missing source proof repair to "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22483,6 +22483,163 @@ rules:
             "statutes/26/3101/b/2.yaml",
         ]
 
+    def test_repair_missing_source_proofs_signs_changed_companion_test(self, tmp_path):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "statutes/26/3101/b/2.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3101
+  summary: Medicare tax threshold source text.
+rules:
+  - name: additional_medicare_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3101(b)(2)
+    versions:
+      - effective_from: '2013-01-01'
+        formula: wages * additional_medicare_tax_rate
+"""
+        )
+        test_file = policy_repo / "statutes/26/3101/b/2.test.yaml"
+        test_file.write_text(
+            """- name: additional_medicare_tax_example
+  period: 2026
+  input:
+    us:statutes/26/3101/b/2#input.wages: 250000
+  output:
+    us:statutes/26/3101/b/2#additional_medicare_tax: 450
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("statutes/26/3101/b/2.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._changed_manifest_group_files",
+                return_value=[target, test_file],
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_missing_source_proofs(args)
+
+        manifest = policy_repo / ".axiom/encoding-manifests/statutes/26/3101/b/2.json"
+        payload = json.loads(manifest.read_text())
+        assert [applied_file["path"] for applied_file in payload["applied_files"]] == [
+            "statutes/26/3101/b/2.yaml",
+            "statutes/26/3101/b/2.test.yaml",
+        ]
+
+    def test_repair_missing_source_proofs_refreshes_changed_companion_manifest(
+        self, tmp_path, capsys
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "statutes/26/3101/b/2.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/26/3101
+  summary: Medicare tax threshold source text.
+rules:
+  - name: additional_medicare_tax
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    source: 26 USC 3101(b)(2)
+    metadata:
+      proof:
+        atoms:
+          - kind: formula
+            corpus_citation_path: us/statute/26/3101
+            span: '26 USC 3101(b)(2)'
+    versions:
+      - effective_from: '2013-01-01'
+        formula: wages * additional_medicare_tax_rate
+"""
+        )
+        original_content = target.read_text()
+        test_file = policy_repo / "statutes/26/3101/b/2.test.yaml"
+        test_file.write_text(
+            """- name: additional_medicare_tax_example
+  period: 2026
+  input:
+    us:statutes/26/3101/b/2#input.wages: 250000
+  output:
+    us:statutes/26/3101/b/2#additional_medicare_tax: 450
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("statutes/26/3101/b/2.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        with (
+            patch(
+                "axiom_encode.cli.ValidatorPipeline",
+                side_effect=AssertionError("refresh should not validate"),
+            ),
+            patch(
+                "axiom_encode.cli._changed_manifest_group_files",
+                return_value=[test_file],
+            ),
+            patch(
+                "axiom_encode.cli._applied_manifest_matches_current_deterministic_repair",
+                return_value=False,
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_missing_source_proofs(args)
+
+        output = capsys.readouterr().out
+        assert "Refreshed missing source proof repair manifest" in output
+        assert target.read_text() == original_content
+        manifest = policy_repo / ".axiom/encoding-manifests/statutes/26/3101/b/2.json"
+        payload = json.loads(manifest.read_text())
+        assert payload["model"] == "source-proof-atom-v1"
+        assert [applied_file["path"] for applied_file in payload["applied_files"]] == [
+            "statutes/26/3101/b/2.yaml",
+            "statutes/26/3101/b/2.test.yaml",
+        ]
+
     def test_repair_missing_source_proofs_keeps_progress_with_pending_issues(
         self, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.745"
+version = "0.2.746"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- include changed RuleSpec companion tests in missing-source-proof repair manifests
- refresh stale source-proof manifests when the RuleSpec body is already repaired but a changed companion test is not covered
- bump axiom-encode to 0.2.746

## Tests
- env -u UV_FROZEN uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- env -u UV_FROZEN uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- env -u UV_FROZEN uv run pytest tests/test_cli.py -k "repair_missing_source_proofs" -vv
- env -u UV_FROZEN uv run towncrier check