### PR TITLE
Import federal utility settings in Colorado SNAP repair

### DIFF
--- a/changelog.d/colorado-snap-2051-federal-import.fixed.md
+++ b/changelog.d/colorado-snap-2051-federal-import.fixed.md
@@ -1,0 +1,1 @@
+Import federal SNAP utility settings when repairing Colorado expedited-service shelter thresholds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.746"
+version = "0.2.747"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.746"
+__version__ = "0.2.747"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3867,6 +3867,7 @@ COLORADO_SNAP_PROGRAM_RELATIVE = Path(
 COLORADO_SNAP_CCR_ROOT = Path("regulations/10-ccr-2506-1")
 COLORADO_SNAP_REPAIR_RELATIVE_OUTPUTS = (
     COLORADO_SNAP_PROGRAM_RELATIVE,
+    COLORADO_SNAP_CCR_ROOT / "4.205.1.yaml",
     COLORADO_SNAP_CCR_ROOT / "4.207.2.yaml",
     COLORADO_SNAP_CCR_ROOT / "4.207.3.yaml",
     COLORADO_SNAP_CCR_ROOT / "4.401.yaml",
@@ -3945,6 +3946,7 @@ def cmd_repair_colorado_snap_federal_refs(args):
         _repair_colorado_snap_policy_composition(
             repo_path / COLORADO_SNAP_PROGRAM_RELATIVE
         )
+        _repair_colorado_snap_2051(repo_path / COLORADO_SNAP_CCR_ROOT / "4.205.1.yaml")
         _repair_colorado_snap_2072(repo_path / COLORADO_SNAP_CCR_ROOT / "4.207.2.yaml")
         _repair_colorado_snap_401(repo_path / COLORADO_SNAP_CCR_ROOT / "4.401.yaml")
         _repair_colorado_snap_4073(repo_path / COLORADO_SNAP_CCR_ROOT / "4.407.3.yaml")
@@ -4984,6 +4986,18 @@ def _repair_colorado_snap_policy_composition(path: Path) -> None:
     content = _upsert_rules_text(
         content,
         _colorado_snap_federal_bridge_rules(include_allotment_bridges=False),
+    )
+    path.write_text(content)
+
+
+def _repair_colorado_snap_2051(path: Path) -> None:
+    content = path.read_text()
+    content = _ensure_yaml_import_text(
+        content,
+        "us:regulations/7-cfr/273/9",
+        before_import=(
+            "us-co:regulations/10-ccr-2506-1/4.406#snap_destitute_income_household"
+        ),
     )
     path.write_text(content)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,6 +62,7 @@ from axiom_encode.cli import (
     _repair_california_snap_program_tests,
     _repair_colorado_snap_401,
     _repair_colorado_snap_401_tests,
+    _repair_colorado_snap_2051,
     _repair_colorado_snap_2072,
     _repair_colorado_snap_2072_tests,
     _repair_colorado_snap_policy_composition,
@@ -9946,6 +9947,34 @@ rules:
         assert rule["versions"][0]["formula"] == "false"
         assert rule["entity"] == "Household"
         assert rule["period"] == "Month"
+
+    def test_repair_colorado_snap_2051_imports_federal_utility_settings(self, tmp_path):
+        rules_file = tmp_path / "4.205.1.yaml"
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us-co:regulations/10-ccr-2506-1/4.406#snap_destitute_income_household
+  - us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
+rules:
+  - name: expedited_shelter_cost_threshold
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: snap_standard_utility_allowance
+"""
+        )
+
+        _repair_colorado_snap_2051(rules_file)
+
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["imports"] == [
+            "us:regulations/7-cfr/273/9",
+            "us-co:regulations/10-ccr-2506-1/4.406#snap_destitute_income_household",
+            "us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance",
+        ]
 
     def test_repair_colorado_snap_401_uses_household_scope_for_separate_household(
         self, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.746"
+version = "0.2.747"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- include Colorado SNAP rule 4.205.1 in the federal-reference repair outputs
- add the missing federal 7 CFR 273.9 import for the expedited shelter threshold repair
- bump axiom-encode to 0.2.747 with a regression test

## Validation
- `env -u UV_FROZEN uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py`
- `env -u UV_FROZEN uv run ruff check src/axiom_encode/cli.py tests/test_cli.py`
- `env -u UV_FROZEN uv run pytest tests/test_cli.py -k "colorado_snap_2051 or repair_colorado_snap_federal_refs or delegated_policy_settings" -vv`
- `env -u UV_FROZEN uv run towncrier check`
