### PR TITLE
Detect subrepo changed files in repair manifests

### DIFF
--- a/changelog.d/subrepo-manifest-changed-files.fixed.md
+++ b/changelog.d/subrepo-manifest-changed-files.fixed.md
@@ -1,0 +1,1 @@
+Detect changed companion files when deterministic repairs run from jurisdiction subdirectories.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.747"
+version = "0.2.748"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.747"
+__version__ = "0.2.748"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -4023,14 +4023,49 @@ def _changed_manifest_group_files(
             break
         except RuntimeError:
             continue
+    repo_prefix = _git_worktree_prefix(repo_path)
     return _unique_paths(
         [
             path
             for _relative_output, files in manifest_groups
             for path in files
-            if path.relative_to(repo_path).as_posix() in changed
+            if _manifest_group_file_changed(
+                path=path,
+                repo_path=repo_path,
+                repo_prefix=repo_prefix,
+                changed=changed,
+            )
         ]
     )
+
+
+def _git_worktree_prefix(repo_path: Path) -> str:
+    completed = subprocess.run(
+        ["git", "rev-parse", "--show-prefix"],
+        cwd=repo_path,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return ""
+    return completed.stdout.strip().strip("/")
+
+
+def _manifest_group_file_changed(
+    *,
+    path: Path,
+    repo_path: Path,
+    repo_prefix: str,
+    changed: set[str],
+) -> bool:
+    relative_path = path.relative_to(repo_path).as_posix()
+    if relative_path in changed:
+        return True
+    if repo_prefix and f"{repo_prefix}/{relative_path}" in changed:
+        return True
+    return False
 
 
 def _write_colorado_snap_repair_manifests(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,7 @@ from axiom_encode.cli import (
     _applied_encoding_manifest_signature_issue,
     _apply_generated_encoding_result,
     _california_snap_repair_guard_manifest_groups,
+    _changed_manifest_group_files,
     _collapse_additive_versioned_derived_formulas,
     _complete_missing_dependent_test_inputs,
     _complete_missing_imported_test_inputs,
@@ -22668,6 +22669,47 @@ rules:
             "statutes/26/3101/b/2.yaml",
             "statutes/26/3101/b/2.test.yaml",
         ]
+
+    def test_changed_manifest_group_files_matches_subrepo_git_paths(self, tmp_path):
+        worktree = tmp_path / "rulespec-us"
+        policy_repo = worktree / "us-co"
+        target = policy_repo / "regulations/10-ccr-2506-1/4.402.2.yaml"
+        test_file = policy_repo / "regulations/10-ccr-2506-1/4.402.2.test.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text("format: rulespec/v1\nrules: []\n")
+        test_file.write_text("- name: baseline\n")
+
+        subprocess.run(["git", "init"], cwd=worktree, check=True, capture_output=True)
+        subprocess.run(["git", "add", "."], cwd=worktree, check=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.email=test@example.com",
+                "-c",
+                "user.name=Test User",
+                "commit",
+                "-m",
+                "baseline",
+            ],
+            cwd=worktree,
+            check=True,
+            capture_output=True,
+        )
+
+        test_file.write_text("- name: changed\n")
+
+        changed = _changed_manifest_group_files(
+            policy_repo,
+            [
+                (
+                    Path("regulations/10-ccr-2506-1/4.402.2.yaml"),
+                    [target, test_file],
+                )
+            ],
+        )
+
+        assert changed == [test_file]
 
     def test_repair_missing_source_proofs_keeps_progress_with_pending_issues(
         self, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.747"
+version = "0.2.748"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- normalize changed-file detection for deterministic repair manifests run from jurisdiction subdirectories
- add a Git-backed regression for `us-co` subrepo companion test detection
- bump axiom-encode to 0.2.748

## Root Cause
Git reports changed files relative to the repository root even when commands run from `us-co/`, while deterministic manifest grouping compared those paths to jurisdiction-relative paths like `regulations/...`. That caused changed companion test files to be omitted from refreshed manifests.

## Validation
- `env -u UV_FROZEN uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py`
- `env -u UV_FROZEN uv run ruff check src/axiom_encode/cli.py tests/test_cli.py`
- `env -u UV_FROZEN uv run pytest tests/test_cli.py -k "changed_manifest_group_files or repair_missing_source_proofs_refreshes_changed_companion_manifest or repair_missing_source_proofs_includes_changed_companion_tests" -vv`
- `env -u UV_FROZEN uv run pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject -q`
- `env -u UV_FROZEN uv run towncrier check`
