### PR TITLE
Preserve Colorado SNAP repair YAML layout

### DIFF
--- a/changelog.d/colorado-snap-yaml-layout.fixed.md
+++ b/changelog.d/colorado-snap-yaml-layout.fixed.md
@@ -1,0 +1,1 @@
+Preserve parseable YAML when Colorado SNAP deterministic repairs update indentless RuleSpec files and utility test anchors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.748"
+version = "0.2.749"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.748"
+__version__ = "0.2.749"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -5376,17 +5376,24 @@ def _ensure_yaml_import_text(
     *,
     before_import: str | None = None,
 ) -> str:
-    import_line = f"  - {import_target}\n"
-    if import_line in content:
+    import_indent = _yaml_sequence_item_indent(content, "imports")
+    import_line = f"{import_indent}- {import_target}\n"
+    if re.search(rf"(?m)^\s*-\s+{re.escape(import_target)}$", content):
         return content
     if before_import is not None:
-        before_line = f"  - {before_import}\n"
-        if before_line in content:
-            return content.replace(before_line, import_line + before_line, 1)
+        before_match = re.search(
+            rf"(?m)^(\s*)-\s+{re.escape(before_import)}$",
+            content,
+        )
+        if before_match is not None:
+            line_start = before_match.start()
+            return f"{content[:line_start]}{import_line}{content[line_start:]}"
     rules_marker = "rules:\n"
     if rules_marker not in content:
         raise RuntimeError("RuleSpec payload missing rules section")
-    return content.replace(rules_marker, import_line + rules_marker, 1)
+    if re.search(r"(?m)^imports:\s*$", content):
+        return content.replace(rules_marker, import_line + rules_marker, 1)
+    return content.replace(rules_marker, f"imports:\n{import_line}{rules_marker}", 1)
 
 
 def _append_rules_text_if_missing(
@@ -5414,13 +5421,18 @@ def _upsert_rule_text(
     before_rule: str | None = None,
 ) -> str:
     name = str(rule.get("name") or "")
-    marker = f"  - name: {name}\n"
+    rule_indent = _yaml_sequence_item_indent(content, "rules")
+    marker = f"{rule_indent}- name: {name}\n"
     start = content.find(marker)
     if start == -1:
         return _insert_rule_text_if_missing(content, rule, before_rule=before_rule)
-    next_start = content.find("\n  - name: ", start + len(marker))
+    next_start = content.find(f"\n{rule_indent}- name: ", start + len(marker))
     end = len(content) if next_start == -1 else next_start + 1
-    return f"{content[:start]}{_render_generated_rule_yaml(rule)}{content[end:]}"
+    return (
+        f"{content[:start]}"
+        f"{_render_generated_rule_yaml(rule, item_indent=rule_indent)}"
+        f"{content[end:]}"
+    )
 
 
 def _insert_rule_text_if_missing(
@@ -5430,24 +5442,48 @@ def _insert_rule_text_if_missing(
     before_rule: str | None = None,
 ) -> str:
     name = str(rule.get("name") or "")
-    if f"\n  - name: {name}\n" in f"\n{content}":
+    rule_indent = _yaml_sequence_item_indent(content, "rules")
+    if re.search(rf"(?m)^\s*-\s+name:\s+{re.escape(name)}$", content):
         return content
-    rendered = _render_generated_rule_yaml(rule)
+    rendered = _render_generated_rule_yaml(rule, item_indent=rule_indent)
     if before_rule is not None:
-        marker = f"\n  - name: {before_rule}\n"
-        if marker in content:
-            return content.replace(marker, f"\n{rendered}{marker}", 1)
+        marker = re.search(
+            rf"(?m)^{re.escape(rule_indent)}-\s+name:\s+{re.escape(before_rule)}$",
+            content,
+        )
+        if marker is not None:
+            return f"{content[: marker.start()]}{rendered}{content[marker.start() :]}"
     if not content.endswith("\n"):
         content += "\n"
     return f"{content}{rendered}"
 
 
-def _render_generated_rule_yaml(rule: dict[str, object]) -> str:
-    lines = [f"  - name: {rule['name']}"]
+def _yaml_sequence_item_indent(content: str, section: str) -> str:
+    match = re.search(
+        rf"(?ms)^{re.escape(section)}:\s*\n(?P<body>.*?)(?=^[A-Za-z_][^:\n]*:\s*$|\Z)",
+        content,
+    )
+    if match is None:
+        return "  "
+    for line in match.group("body").splitlines():
+        item = re.match(r"^(\s*)-\s+", line)
+        if item is not None:
+            return item.group(1)
+    return "  "
+
+
+def _render_generated_rule_yaml(
+    rule: dict[str, object], *, item_indent: str = "  "
+) -> str:
+    body_indent = f"{item_indent}  "
+    nested_sequence_indent = body_indent if item_indent == "" else f"{body_indent}  "
+    nested_mapping_indent = f"{nested_sequence_indent}  "
+    formula_indent = f"{nested_mapping_indent}  "
+    lines = [f"{item_indent}- name: {rule['name']}"]
     for key in ("kind", "entity", "dtype", "period", "unit", "source"):
         value = rule.get(key)
         if value is not None:
-            lines.append(f"    {key}: {value}")
+            lines.append(f"{body_indent}{key}: {value}")
     versions = rule.get("versions")
     if not isinstance(versions, list) or not versions:
         raise RuntimeError("Generated rule missing versions")
@@ -5456,13 +5492,13 @@ def _render_generated_rule_yaml(rule: dict[str, object]) -> str:
         raise RuntimeError("Generated rule missing formula")
     lines.extend(
         [
-            "    versions:",
-            f"      - effective_from: '{version.get('effective_from', '2025-10-01')}'",
-            "        formula: |-",
+            f"{body_indent}versions:",
+            f"{nested_sequence_indent}- effective_from: '{version.get('effective_from', '2025-10-01')}'",
+            f"{nested_mapping_indent}formula: |-",
         ]
     )
     formula_lines = str(version["formula"]).splitlines() or [""]
-    lines.extend(f"          {line}" for line in formula_lines)
+    lines.extend(f"{formula_indent}{line}" for line in formula_lines)
     return "\n".join(lines) + "\n"
 
 
@@ -5595,6 +5631,8 @@ def _split_colorado_snap_program_utility_outputs(content: str) -> str:
             "us-co:policies/cdhs/snap/fy-2026-benefit-calculation#snap_eligible"
         ),
     )
+    if "&base_snap_case" not in content:
+        content = content.replace("  input:\n", "  input: &base_snap_case\n", 1)
     utility_case = """- name: ongoing_month_derives_standard_utility_allowance
   period: 2026-01
   input:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,6 +105,7 @@ from axiom_encode.cli import (
     _sha256_text,
     _sign_applied_encoding_manifest,
     _source_relation_preservation_issues,
+    _split_colorado_snap_program_utility_outputs,
     _split_table_row_relation_test_cases,
     _stage_apply_overlay_dependency_root,
     _suppress_rulespec_ancestor_targets_for_subsection_overlay,
@@ -9976,6 +9977,60 @@ rules:
             "us-co:regulations/10-ccr-2506-1/4.406#snap_destitute_income_household",
             "us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance",
         ]
+
+    def test_repair_colorado_snap_2072_preserves_indentless_yaml(self, tmp_path):
+        rules_file = tmp_path / "4.207.2.yaml"
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+- us:regulations/7-cfr/273/10
+- us:statutes/7/2017/a
+rules:
+- name: state_agency_rounds_thirty_percent_net_income_up
+  kind: parameter
+  entity: Household
+  dtype: Judgment
+  period: Month
+  source: Colorado SNAP federal surface bridge
+  versions:
+  - effective_from: '2025-10-01'
+    formula: 'false'
+"""
+        )
+
+        _repair_colorado_snap_2072(rules_file)
+
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["imports"] == [
+            "us:regulations/7-cfr/273/10",
+            "us:statutes/7/2014/e/6/A",
+            "us:statutes/7/2017/a",
+        ]
+        names = [rule["name"] for rule in payload["rules"]]
+        assert names.count("state_agency_rounds_thirty_percent_net_income_up") == 1
+        assert "snap_initial_month_prorated_allotment" in names
+
+    def test_split_colorado_snap_program_utility_outputs_anchors_base_case(self):
+        content = """- name: ongoing_month_derives_income_eligibility_and_colorado_allotment
+  period: 2026-01
+  input:
+    us-co:policies/cdhs/snap/fy-2026-benefit-calculation#input.household_shelter_costs_incurred: 500
+  output:
+    us-co:policies/cdhs/snap/fy-2026-benefit-calculation#snap_eligible: holds
+    us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance: 594
+- name: additional_household_member_uses_usda_additional_member_amount
+  period: 2026-01
+  input:
+    us-co:regulations/10-ccr-2506-1/4.207.3#input.household_size: 9
+  output:
+    us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment: 2190
+"""
+
+        repaired = _split_colorado_snap_program_utility_outputs(content)
+
+        assert "input: &base_snap_case" in repaired
+        assert "<<: *base_snap_case" in repaired
+        yaml.safe_load(repaired)
 
     def test_repair_colorado_snap_401_uses_household_scope_for_separate_household(
         self, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.748"
+version = "0.2.749"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- preserve existing YAML sequence indentation when deterministic Colorado SNAP repairs add imports and generated bridge rules
- anchor the base SNAP program test case before inserting a merge-based utility-output test
- bump axiom-encode to 0.2.749

## Root cause
The repair helpers assumed two-space-indented top-level YAML sequences, but some RuleSpec files use indentless top-level lists. That made generated bridge rules nest under the previous rule instead of remaining top-level. The SNAP program utility split also inserted `<<: *base_snap_case` without first creating `&base_snap_case` when the target test file did not already have one.

## Validation
- `env -u UV_FROZEN uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py`
- `env -u UV_FROZEN uv run ruff check src/axiom_encode/cli.py tests/test_cli.py`
- `env -u UV_FROZEN uv run pytest tests/test_cli.py -k "colorado_snap_2072_preserves_indentless_yaml or split_colorado_snap_program_utility_outputs_anchors_base_case or colorado_snap_2051" -vv`
- `env -u UV_FROZEN uv run pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject -q`
- `env -u UV_FROZEN uv run towncrier check`
