### PR TITLE
Repair Colorado SNAP claims deduction bridge

### DIFF
--- a/changelog.d/colorado-snap-claims-deduction.fixed.md
+++ b/changelog.d/colorado-snap-claims-deduction.fixed.md
@@ -1,0 +1,1 @@
+Fix the Colorado SNAP federal reference repair to bridge claim earned income deduction calculations to the federal SNAP earned income deduction rate instead of generating a duplicate executable parameter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.750"
+version = "0.2.751"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.750"
+__version__ = "0.2.751"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3872,6 +3872,7 @@ COLORADO_SNAP_REPAIR_RELATIVE_OUTPUTS = (
     COLORADO_SNAP_CCR_ROOT / "4.207.3.yaml",
     COLORADO_SNAP_CCR_ROOT / "4.401.yaml",
     COLORADO_SNAP_CCR_ROOT / "4.407.3.yaml",
+    COLORADO_SNAP_CCR_ROOT / "4.801.3.yaml",
 )
 
 CALIFORNIA_SNAP_SHELTER_SURFACE_REPAIR_MODEL = "california-snap-shelter-surface-v1"
@@ -3950,6 +3951,7 @@ def cmd_repair_colorado_snap_federal_refs(args):
         _repair_colorado_snap_2072(repo_path / COLORADO_SNAP_CCR_ROOT / "4.207.2.yaml")
         _repair_colorado_snap_401(repo_path / COLORADO_SNAP_CCR_ROOT / "4.401.yaml")
         _repair_colorado_snap_4073(repo_path / COLORADO_SNAP_CCR_ROOT / "4.407.3.yaml")
+        _repair_colorado_snap_8013(repo_path / COLORADO_SNAP_CCR_ROOT / "4.801.3.yaml")
         _repair_colorado_snap_program_tests(
             _rulespec_test_path(repo_path / COLORADO_SNAP_PROGRAM_RELATIVE)
         )
@@ -5181,6 +5183,24 @@ def _repair_colorado_snap_4073(path: Path) -> None:
             ),
             *_colorado_snap_shelter_bridge_rules(),
         ],
+    )
+    path.write_text(content)
+
+
+def _repair_colorado_snap_8013(path: Path) -> None:
+    content = path.read_text()
+    content = _ensure_yaml_import_text(
+        content,
+        "us:statutes/7/2014/e/2/B",
+    )
+    content, _ = _remove_rulespec_rule_by_name(
+        content,
+        "earned_income_deduction_rate",
+    )
+    content = _replace_formula_identifier(
+        content,
+        old="earned_income_deduction_rate",
+        new="snap_earned_income_deduction_rate",
     )
     path.write_text(content)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,6 +66,7 @@ from axiom_encode.cli import (
     _repair_colorado_snap_2051,
     _repair_colorado_snap_2072,
     _repair_colorado_snap_2072_tests,
+    _repair_colorado_snap_8013,
     _repair_colorado_snap_policy_composition,
     _repair_colorado_snap_program_tests,
     _repair_embedded_scalar_literals,
@@ -9977,6 +9978,47 @@ rules:
             "us-co:regulations/10-ccr-2506-1/4.406#snap_destitute_income_household",
             "us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance",
         ]
+
+    def test_repair_colorado_snap_8013_imports_federal_deduction_rate(self, tmp_path):
+        rules_file = tmp_path / "4.801.3.yaml"
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: Claims
+rules:
+  - name: earned_income_deduction_rate
+    kind: parameter
+    dtype: Rate
+    source: 10 CCR 2506-1 4.801.3(C)(4)
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          0.20
+
+  - name: earned_income_deduction_allowed_for_claim_calculation
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 10 CCR 2506-1 4.801.3(C)(4)
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          earned_income_deduction_rate * max(0, earned_income_timely_reported_for_claim_calculation)
+"""
+        )
+
+        _repair_colorado_snap_8013(rules_file)
+
+        content = rules_file.read_text()
+        payload = yaml.safe_load(content)
+        assert payload["imports"] == ["us:statutes/7/2014/e/2/B"]
+        assert [rule["name"] for rule in payload["rules"]] == [
+            "earned_income_deduction_allowed_for_claim_calculation"
+        ]
+        formula = payload["rules"][0]["versions"][0]["formula"]
+        assert formula.startswith("snap_earned_income_deduction_rate * max(0,")
 
     def test_repair_colorado_snap_2072_preserves_indentless_yaml(self, tmp_path):
         rules_file = tmp_path / "4.207.2.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.750"
+version = "0.2.751"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add Colorado SNAP 4.801.3 to the signed federal-reference repair surface
- bridge the claim earned income deduction formula to the federal SNAP earned income deduction rate
- bump axiom-encode to 0.2.751 with a focused regression test

## Tests
- env -u UV_FROZEN uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- env -u UV_FROZEN uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- env -u UV_FROZEN uv run pytest tests/test_cli.py -k "colorado_snap_8013 or colorado_snap_2051" -vv
- env -u UV_FROZEN uv run pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject -q
- env -u UV_FROZEN uv run towncrier check
