### PR TITLE
Repair Colorado tax validation drift

### DIFF
--- a/changelog.d/colorado-tax-validation.fixed.md
+++ b/changelog.d/colorado-tax-validation.fixed.md
@@ -1,0 +1,1 @@
+Fix Colorado tax validation drift by recognizing individual credit allowance language as person-scoped and adding a deterministic repair for subsection 39-22-104(2) imports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.751"
+version = "0.2.752"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.751"
+__version__ = "0.2.752"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1234,6 +1234,25 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_colorado_tax_validation_parser = subparsers.add_parser(
+        "repair-colorado-tax-validation",
+        help="Apply signed deterministic repairs for Colorado tax validation drift",
+    )
+    repair_colorado_tax_validation_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="Rules repository root used for manifest signing",
+    )
+    repair_colorado_tax_validation_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_imported_test_inputs_parser = subparsers.add_parser(
         "repair-imported-test-inputs",
         help="Apply signed deterministic repairs for missing imported test inputs",
@@ -2128,6 +2147,8 @@ def main():
         cmd_repair_section_911_a_1_exclusion(args)
     elif args.command == "repair-section-63-f-stale-test-inputs":
         cmd_repair_section_63_f_stale_test_inputs(args)
+    elif args.command == "repair-colorado-tax-validation":
+        cmd_repair_colorado_tax_validation(args)
     elif args.command == "repair-imported-test-inputs":
         cmd_repair_imported_test_inputs(args)
     elif args.command == "repair-companion-test-references":
@@ -9866,6 +9887,105 @@ def _write_grouped_deterministic_repair_manifests(
                 )
             )
     return manifest_paths
+
+
+COLORADO_TAX_VALIDATION_REPAIR_MODEL = "colorado-tax-validation-v1"
+COLORADO_TAX_SUBSECTION_2_IMPORT = "us-co:statutes/39/39-22-104/2"
+COLORADO_TAX_VALIDATION_REPAIR_RELATIVE_OUTPUTS = (
+    Path("statutes/39/39-22-104/1.7/a.yaml"),
+    Path("statutes/39/39-22-104/1.7/b.yaml"),
+    Path("statutes/39/39-22-104/1.7/c.yaml"),
+)
+
+
+def cmd_repair_colorado_tax_validation(args):
+    """Apply signed deterministic repairs for Colorado tax validation drift."""
+    repo_path = Path(args.repo).resolve()
+    if _repo_jurisdiction_prefix(repo_path) != "us-co":
+        print(
+            "repair-colorado-tax-validation must run against rulespec-us-co; "
+            f"got {repo_path}"
+        )
+        sys.exit(1)
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+
+    manifest_groups = [
+        (relative_output, [repo_path / relative_output])
+        for relative_output in COLORADO_TAX_VALIDATION_REPAIR_RELATIVE_OUTPUTS
+    ]
+    _ensure_no_unmanifested_preexisting_rulespec_changes(repo_path, manifest_groups)
+
+    touched = [path for _relative_output, files in manifest_groups for path in files]
+    originals = {path: path.read_text() if path.exists() else None for path in touched}
+
+    try:
+        changed: list[Path] = []
+        for rules_file in touched:
+            changed.extend(_repair_colorado_tax_subsection_2_import(rules_file))
+        changed = _unique_paths(changed)
+        if not changed:
+            print("No Colorado tax validation repairs found.")
+            return
+
+        pipeline = ValidatorPipeline(
+            policy_repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+            enable_oracles=False,
+            require_policy_proofs=True,
+        )
+        validation_issues: list[str] = []
+        for rules_file in touched:
+            validation = pipeline.validate(rules_file, skip_reviewers=True)
+            if validation.all_passed:
+                continue
+            validation_issues.extend(
+                result.error for result in validation.results.values() if result.error
+            )
+        if validation_issues:
+            raise RuntimeError("\n".join(validation_issues))
+    except Exception:
+        _restore_original_files(originals)
+        raise
+
+    changed_by_command = _unique_paths(
+        [
+            path
+            for path in changed
+            if _path_differs_from_original(path, originals.get(path))
+        ]
+    )
+    if not changed_by_command:
+        print("No Colorado tax validation repairs found.")
+        return
+
+    manifest_paths = _write_grouped_deterministic_repair_manifests(
+        repo_path=repo_path,
+        signing_key=signing_key,
+        axiom_encode_git=axiom_encode_git,
+        manifest_groups=manifest_groups,
+        changed_files=changed_by_command,
+        model=COLORADO_TAX_VALIDATION_REPAIR_MODEL,
+        tool="axiom-encode repair-colorado-tax-validation",
+    )
+    print("Applied Colorado tax validation repair")
+    for path in changed_by_command:
+        print(f"changed={path.relative_to(repo_path)}")
+    for manifest_path in manifest_paths:
+        print(f"manifest={manifest_path}")
+
+
+def _repair_colorado_tax_subsection_2_import(rules_file: Path) -> list[Path]:
+    content = rules_file.read_text()
+    repaired = _ensure_yaml_import_text(content, COLORADO_TAX_SUBSECTION_2_IMPORT)
+    if repaired == content:
+        return []
+    rules_file.write_text(repaired)
+    return [rules_file]
 
 
 _SECTION_911_A_1_IMPORT = (

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -7376,10 +7376,12 @@ _TAXPAYER_TAX_UNIT_SOURCE_PATTERN = re.compile(
 )
 _PERSON_SCOPE_SOURCE_PATTERN = re.compile(
     r"\b(?:no|any|each|every|all|a|an|the|that|such)\s+"
+    r"(?:(?:resident|nonresident|qualifying|qualified|eligible)\s+)?"
     r"(?:individual|person|(?:household\s+|family\s+)?member|claimant|child|"
     r"(?:sponsored\s+)?alien|qualified\s+alien|applicant|recipient|"
     r"participant|client|case\s+member)\b"
-    r"[\s\S]{0,180}\b(?:eligible|ineligible|disqualif|excluded?|participat)",
+    r"[\s\S]{0,180}\b(?:eligible|ineligible|disqualif|excluded?|participat|"
+    r"allowed\s+(?:a\s+)?credit)",
     flags=re.IGNORECASE,
 )
 _UNIT_SCOPE_SOURCE_PATTERN = re.compile(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,6 +69,7 @@ from axiom_encode.cli import (
     _repair_colorado_snap_8013,
     _repair_colorado_snap_policy_composition,
     _repair_colorado_snap_program_tests,
+    _repair_colorado_tax_subsection_2_import,
     _repair_embedded_scalar_literals,
     _repair_employer_scoped_entities,
     _repair_float_keyed_indexed_parameter_values,
@@ -10019,6 +10020,31 @@ rules:
         ]
         formula = payload["rules"][0]["versions"][0]["formula"]
         assert formula.startswith("snap_earned_income_deduction_rate * max(0,")
+
+    def test_repair_colorado_tax_subsection_2_import(self, tmp_path):
+        rules_file = tmp_path / "a.yaml"
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: subject to subsection (2) of this section
+rules:
+- name: individual_estate_trust_income_tax_rate_before_2020
+  kind: parameter
+  dtype: Rate
+  source: C.R.S. 39-22-104(1.7)(a)
+  versions:
+  - effective_from: '2000-01-01'
+    formula: '0.0463'
+"""
+        )
+
+        assert _repair_colorado_tax_subsection_2_import(rules_file) == [rules_file]
+
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["imports"] == ["us-co:statutes/39/39-22-104/2"]
+        assert payload["rules"][0]["name"] == (
+            "individual_estate_trust_income_tax_rate_before_2020"
+        )
 
     def test_repair_colorado_snap_2072_preserves_indentless_yaml(self, tmp_path):
         rules_file = tmp_path / "4.207.2.yaml"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -14417,6 +14417,41 @@ rules:
     ]
 
 
+def test_source_scope_consistency_accepts_resident_individual_allowed_credit():
+    content = """format: rulespec/v1
+rules:
+  - name: low_income_child_care_expenses_credit_allowed
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    source: C.R.S. 39-22-119.5(3)(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: condition
+            source:
+              excerpt: a resident individual is allowed a credit
+          - path: versions[0].formula
+            kind: condition
+            source:
+              excerpt: insufficient tax liability to claim any credit under section 39-22-119
+          - path: versions[0].formula
+            kind: condition
+            source:
+              excerpt: would be allowed a credit for the expenses under section 21 if sufficient tax liability existed
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          resident_individual
+          and insufficient_tax_liability_for_section_119_credit
+          and expenses_would_be_allowed_under_section_21
+"""
+
+    assert find_source_scope_consistency_issues(content) == []
+
+
 def test_source_scope_consistency_does_not_treat_taxpayer_alone_as_person_scope():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.751"
+version = "0.2.752"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- recognize resident individual credit allowance language as person-scoped in source-scope validation
- add `repair-colorado-tax-validation` to deterministically add missing C.R.S. 39-22-104(2) same-section imports for Colorado tax rate provisions
- bump axiom-encode to 0.2.752

## Validation
- `env -u UV_FROZEN uv run ruff format --check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_rulespec_validation.py`
- `env -u UV_FROZEN uv run ruff check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_rulespec_validation.py`
- `env -u UV_FROZEN uv run pytest tests/test_cli.py -k "colorado_tax_subsection_2_import or colorado_snap_8013" -vv`
- `env -u UV_FROZEN uv run pytest tests/test_rulespec_validation.py -k "resident_individual_allowed_credit or federal_tax_taxpayer_as_person_rule" -vv`
- `env -u UV_FROZEN uv run pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject -q`
- `env -u UV_FROZEN uv run towncrier check`
