### PR TITLE
Fix RuleSpec monorepo placement aliases

### DIFF
--- a/changelog.d/rulespec-monorepo-placement.fixed.md
+++ b/changelog.d/rulespec-monorepo-placement.fixed.md
@@ -1,0 +1,1 @@
+Fix upstream placement validation for country-monorepo target aliases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.752"
+version = "0.2.753"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.752"
+__version__ = "0.2.753"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -6105,6 +6105,8 @@ def _find_duplicate_upstream_executable_issues(
                 continue
             if candidate.target == current_target:
                 continue
+            if _rulespec_targets_are_equivalent(candidate.target, current_target):
+                continue
             if Path(candidate.source_file).resolve() == current_file:
                 continue
             if _rulespec_target_is_descendant_of(current_target, candidate.target):
@@ -6123,9 +6125,40 @@ def _find_duplicate_upstream_executable_issues(
 
 def _rulespec_target_is_descendant_of(target: str, ancestor: str) -> bool:
     """Return whether a RuleSpec target is a more-specific path under ancestor."""
-    target_base = _rulespec_target_base(target)
-    ancestor_base = _rulespec_target_base(ancestor)
+    target_base = _canonical_rulespec_target_identity_base(target)
+    ancestor_base = _canonical_rulespec_target_identity_base(ancestor)
     return target_base.startswith(f"{ancestor_base}/")
+
+
+def _rulespec_targets_are_equivalent(left: str, right: str) -> bool:
+    return _canonical_rulespec_target_identity_base(
+        left
+    ) == _canonical_rulespec_target_identity_base(right) and _target_symbol(
+        left
+    ) == _target_symbol(right)
+
+
+def _canonical_rulespec_target_identity_base(target: str) -> str:
+    """Normalize country-monorepo and per-jurisdiction target prefixes.
+
+    CI validates files in a country monorepo checkout while also loading a
+    second dependency checkout named like ``rulespec-us``. The same physical
+    country file can therefore be represented as either
+    ``us-co:regulations/...`` or ``us:rulespec-us/us-co/regulations/...``.
+    These are the same RuleSpec target for placement purposes.
+    """
+    base = _rulespec_target_base(target)
+    prefix, separator, relative = base.partition(":")
+    if not separator:
+        return base
+    relative = relative.strip("/")
+    parts = tuple(part for part in relative.split("/") if part)
+    if parts and parts[0] == f"rulespec-{prefix}":
+        remainder = parts[1:]
+        if remainder and remainder[0].startswith(f"{prefix}-"):
+            return "/".join(remainder)
+        return "/".join((prefix, *remainder))
+    return "/".join((prefix, *parts))
 
 
 def _rulespec_target_base(target: str) -> str:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -9665,6 +9665,21 @@ rules:
     assert "us:statutes/26/151/d#exemption_amount" in issues[0]
 
 
+def test_upstream_placement_target_identity_matches_country_monorepo_alias():
+    assert validator_pipeline._rulespec_targets_are_equivalent(
+        "us-co:regulations/10-ccr-2506-1/4.130.1#snap_limit",
+        "us:rulespec-us/us-co/regulations/10-ccr-2506-1/4.130.1#snap_limit",
+    )
+    assert validator_pipeline._rulespec_target_is_descendant_of(
+        "us-co:regulations/10-ccr-2506-1/4.130.1/a#snap_limit",
+        "us:rulespec-us/us-co/regulations/10-ccr-2506-1/4.130.1#snap_limit",
+    )
+    assert not validator_pipeline._rulespec_targets_are_equivalent(
+        "us-co:regulations/10-ccr-2506-1/4.130.1#snap_limit",
+        "us:statutes/7/2014#snap_limit",
+    )
+
+
 def test_upstream_placement_allows_distinct_local_rule_with_same_name(tmp_path):
     repo_parent = tmp_path / "repos"
     _write_rulespec_file(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.752"
+version = "0.2.753"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What changed

- Normalizes RuleSpec placement target identities before duplicate-upstream checks.
- Treats country-monorepo aliases like `us-co:regulations/...` and dependency checkout targets like `us:rulespec-us/us-co/regulations/...` as the same target for placement purposes.
- Preserves distinct targets across different legal scopes, such as `us-co:...` versus federal `us:statutes/...`.
- Bumps `axiom-encode` to `0.2.753` with a changelog entry.

## Why

RuleSpec CI for TheAxiomFoundation/rulespec-us#414 failed with false upstream-placement violations. The same files were loaded through two equivalent target spellings in CI, so the validator reported local Colorado and Florida rules as duplicating themselves through the dependency checkout.

## Validation

- `env -u UV_FROZEN uv run pytest tests/test_rulespec_validation.py -k "upstream_placement" -q`
- `env -u UV_FROZEN uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py pyproject.toml src/axiom_encode/__init__.py`
- `env -u UV_FROZEN uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py src/axiom_encode/__init__.py`
- `env -u UV_FROZEN uv run pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject -q`
- `env -u UV_FROZEN uv run towncrier check`
- `git diff --check`
- Locally reproduced the rulespec-us#414 `us-co` CI shard with the patched encoder; all 263 selected files passed validation.
