### PR TITLE
Wire Colorado CCAP PolicyEngine oracle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.753"
+version = "0.2.754"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.753"
+__version__ = "0.2.754"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -22809,6 +22809,16 @@ Output ONLY valid JSON:
                 continue
 
             mappability_inputs = policyengine_inputs or inputs
+            if (
+                country == "us"
+                and not policyengine_inputs
+                and isinstance(mappability_inputs, dict)
+            ):
+                mappability_inputs = self._pe_us_projectable_inputs_for_mappability(
+                    mappability_inputs,
+                    pe_var,
+                    mapping=mapping,
+                )
             mappable, reason = self._is_pe_test_mappable(
                 country,
                 raw_test_rule_name,
@@ -24222,6 +24232,54 @@ print("BENCHMARK:" + json.dumps(result))
                 unprojectable.append(key_text)
         return sorted(unprojectable)
 
+    @classmethod
+    def _pe_us_projectable_inputs_for_mappability(
+        cls,
+        inputs: dict,
+        pe_var: str | None,
+        *,
+        mapping: PolicyEngineMapping | None = None,
+    ) -> dict:
+        """Drop unrelated legal-ID inputs before PE mappability checks.
+
+        RuleSpec tests often assert several legal outputs in one case. A PE
+        oracle comparison for one mapped output should not be blocked merely
+        because the same case also contains legal inputs for non-comparable
+        sibling outputs.
+        """
+        projected: dict = {}
+        saw_projectable_legal_input = False
+        saw_unprojectable_legal_input = False
+        for key, value in inputs.items():
+            key_text = str(key)
+            input_alias = cls._rulespec_legal_input_alias(key_text)
+            if input_alias is not None:
+                if cls._is_projectable_pe_us_input_alias(
+                    input_alias,
+                    pe_var,
+                    mapping=mapping,
+                ):
+                    projected[key] = value
+                    saw_projectable_legal_input = True
+                else:
+                    saw_unprojectable_legal_input = True
+                continue
+
+            relation_name = cls._rulespec_legal_relation_name(key_text)
+            if relation_name is not None:
+                if cls._is_projectable_pe_us_relation_input(relation_name, pe_var):
+                    projected[key] = value
+                    saw_projectable_legal_input = True
+                else:
+                    saw_unprojectable_legal_input = True
+                continue
+
+            projected[key] = value
+
+        if saw_projectable_legal_input and saw_unprojectable_legal_input:
+            return projected
+        return inputs
+
     @staticmethod
     def _rulespec_legal_input_alias(key_text: str) -> str | None:
         if ":" not in key_text or "#" not in key_text:
@@ -25141,7 +25199,7 @@ print(f'RESULT:{{float(value)}}')
 
         if adapter is not None:
             for rule_key, pe_attr in adapter.annualized_person_inputs:
-                value = inputs.get(rule_key)
+                value = self._rulespec_test_input_value(inputs, rule_key)
                 if value is None:
                     continue
                 with contextlib.suppress(TypeError, ValueError):
@@ -25153,23 +25211,23 @@ print(f'RESULT:{{float(value)}}')
                     )
                     attrs.append(f"'{pe_attr}': {{'{year}': {annual_value}}}")
             for rule_key, pe_attr in adapter.boolean_person_inputs:
-                if rule_key in inputs:
+                value = self._rulespec_test_input_value(inputs, rule_key)
+                if value is not None:
                     attrs = (
                         target_person_attrs
                         if target_person_attrs is not None
                         else adult_attrs
                     )
-                    attrs.append(f"'{pe_attr}': {{'{year}': {bool(inputs[rule_key])}}}")
+                    attrs.append(f"'{pe_attr}': {{'{year}': {bool(value)}}}")
             for rule_key, pe_attr in adapter.monthly_boolean_person_inputs:
-                if rule_key in inputs:
+                value = self._rulespec_test_input_value(inputs, rule_key)
+                if value is not None:
                     attrs = (
                         target_person_attrs
                         if target_person_attrs is not None
                         else adult_attrs
                     )
-                    attrs.append(
-                        f"'{pe_attr}': {{'{period}': {bool(inputs[rule_key])}}}"
-                    )
+                    attrs.append(f"'{pe_attr}': {{'{period}': {bool(value)}}}")
 
         snap_eligible_member_proxy = None
         if "snap_household_has_eligible_participating_member" in inputs:
@@ -25309,26 +25367,28 @@ print(f'RESULT:{{float(value)}}')
         }
         override_values: dict[str, Any] = {}
         for rule_key, pe_key in snap_overridable.items():
-            if rule_key in inputs:
-                override_values[pe_key] = normalize_pe_override_value(
-                    pe_key, inputs[rule_key]
-                )
+            value = self._rulespec_test_input_value(inputs, rule_key)
+            if value is None:
+                continue
+            override_values[pe_key] = normalize_pe_override_value(pe_key, value)
 
         if adapter is not None:
             for rule_key, pe_key in adapter.direct_spm_overrides:
-                if rule_key in inputs:
-                    override_values[pe_key] = normalize_pe_override_value(
-                        pe_key, inputs[rule_key]
-                    )
+                value = self._rulespec_test_input_value(inputs, rule_key)
+                if value is None:
+                    continue
+                override_values[pe_key] = normalize_pe_override_value(pe_key, value)
             for target_key, operation, source_keys in adapter.derived_spm_overrides:
                 if target_key in override_values:
                     continue
-                if not all(source_key in inputs for source_key in source_keys):
+                source_values_by_key = [
+                    self._rulespec_test_input_value(inputs, source_key)
+                    for source_key in source_keys
+                ]
+                if not all(value is not None for value in source_values_by_key):
                     continue
                 try:
-                    source_values = [
-                        float(inputs[source_key]) for source_key in source_keys
-                    ]
+                    source_values = [float(value) for value in source_values_by_key]
                 except (TypeError, ValueError):
                     continue
                 derived_value = derive_override_value(operation, source_values)
@@ -25340,10 +25400,13 @@ print(f'RESULT:{{float(value)}}')
         annual_override_values: dict[str, Any] = {}
         if adapter is not None:
             for rule_key, pe_key in adapter.annual_direct_spm_overrides:
-                if rule_key in inputs:
-                    annual_override_values[pe_key] = normalize_pe_override_value(
-                        pe_key, inputs[rule_key]
-                    )
+                value = self._rulespec_test_input_value(inputs, rule_key)
+                if value is None:
+                    continue
+                annual_override_values[pe_key] = normalize_pe_override_value(
+                    pe_key,
+                    value,
+                )
             for (
                 target_key,
                 operation,
@@ -25355,13 +25418,17 @@ print(f'RESULT:{{float(value)}}')
                     target_key == "snap_assets"
                     and source_keys
                     and source_keys[0] == "snap_total_resources_before_exclusions"
-                    and source_keys[0] in inputs
+                    and self._rulespec_test_input_value(inputs, source_keys[0])
+                    is not None
                 )
                 try:
                     source_values = [
-                        float(inputs[source_key]) if source_key in inputs else 0.0
+                        float(value) if value is not None else 0.0
                         for source_key in source_keys
-                        if source_key in inputs or missing_as_zero
+                        for value in [
+                            self._rulespec_test_input_value(inputs, source_key)
+                        ]
+                        if value is not None or missing_as_zero
                     ]
                 except (TypeError, ValueError):
                     continue

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -384,6 +384,14 @@ PE_US_VAR_ADAPTERS = (
         spm=True,
     ),
     PolicyEngineUSVarAdapter(
+        rule_names=("monthly_state_median_income_85_limit",),
+        pe_var="co_ccap_smi",
+        monthly=True,
+        spm=True,
+        annual_direct_spm_overrides=(("family_size", "spm_unit_size"),),
+        default_state_code="CO",
+    ),
+    PolicyEngineUSVarAdapter(
         rule_names=("snap_excess_shelter_deduction",),
         pe_var="snap_excess_shelter_expense_deduction",
         monthly=True,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -643,6 +643,34 @@ mappings:
     candidate_priority: P4
     rationale: Axiom composition helper combining Colorado income, resource, work, student, citizenship, transfer, and application rules; PE eligibility is adjacent but not this composed legal output.
 
+  - legal_id: us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#monthly_state_median_income_85_limit
+    country: us
+    program: ccap
+    mapping_type: direct_variable
+    policyengine_variable: co_ccap_smi
+    result_multiplier: 0.85
+    entity: spm_unit
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Colorado CCAP monthly state median income limit; PolicyEngine exposes the monthly SMI helper and the legal output is 85 percent of it.
+
+  - legal_id: us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#gross_income_within_state_median_income_ceiling
+    country: us
+    program: ccap
+    mapping_type: not_comparable
+    policyengine_variable: co_ccap_smi_eligible
+    candidate_priority: P2
+    rationale: PolicyEngine's Colorado CCAP SMI eligibility predicate uses a strict less-than comparison, while 8 CCR 1403-1 3.111(H)(1) says gross income must not exceed 85 percent of state median income.
+
+  - legal_id: us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#income_and_asset_eligible_for_ccap_low_income_guidelines
+    country: us
+    program: ccap
+    mapping_type: not_comparable
+    policyengine_variable: co_ccap_entry_income_eligible
+    candidate_priority: P2
+    rationale: PolicyEngine's Colorado CCAP entry income predicate does not include the 3.111(H)(4)(c) one-million-dollar asset cap and uses PE's separate FPG entry-rate predicate.
+
   - legal_id: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -5270,6 +5270,80 @@ rules:
     assert tax["test_output_count"] == 1
 
 
+def test_policyengine_coverage_maps_colorado_ccap_smi_limit(tmp_path):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-co"
+        / "regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.yaml",
+        """format: rulespec/v1
+rules:
+  - name: monthly_state_median_income_85_limit
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2025-10-01'
+        formula: state_median_income_85_monthly_by_family_size[family_size]
+  - name: gross_income_within_state_median_income_ceiling
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: household_monthly_gross_income <= monthly_state_median_income_85_limit
+  - name: income_and_asset_eligible_for_ccap_low_income_guidelines
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: gross_income_within_state_median_income_ceiling and assets_within_ccap_limit
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-co"
+        / "regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.test.yaml",
+        """- name: family size four limit
+  period: 2025-10
+  input:
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.family_size: 4
+  output:
+    us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#monthly_state_median_income_85_limit: 9828.83
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="ccap")
+
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 2,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    smi_limit = items_by_id[
+        "us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#monthly_state_median_income_85_limit"
+    ]
+    income_predicate = items_by_id[
+        "us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#gross_income_within_state_median_income_ceiling"
+    ]
+    combined_predicate = items_by_id[
+        "us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#income_and_asset_eligible_for_ccap_low_income_guidelines"
+    ]
+    assert smi_limit["policyengine_variable"] == "co_ccap_smi"
+    assert smi_limit["tested"] is True
+    assert smi_limit["test_output_count"] == 1
+    assert income_predicate["status"] == "known_not_comparable"
+    assert income_predicate["policyengine_variable"] == "co_ccap_smi_eligible"
+    assert combined_predicate["status"] == "known_not_comparable"
+    assert (
+        combined_predicate["policyengine_variable"] == "co_ccap_entry_income_eligible"
+    )
+
+
 def test_policyengine_coverage_maps_colorado_taxable_income_base(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us-co" / "statutes/39/39-22-104/2.yaml",

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2344,6 +2344,13 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
     assert gross_income_limit_mapping.policyengine_variable == "snap_fpg"
     assert gross_income_limit_mapping.result_multiplier == 1.3
+    colorado_ccap_smi_limit_mapping = registry.mapping_for_legal_id(
+        "us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#monthly_state_median_income_85_limit",
+        country="us",
+    )
+    assert colorado_ccap_smi_limit_mapping.mapping_type == "direct_variable"
+    assert colorado_ccap_smi_limit_mapping.policyengine_variable == "co_ccap_smi"
+    assert colorado_ccap_smi_limit_mapping.result_multiplier == 0.85
     section_2014c_net_failure_mapping = registry.mapping_for_legal_id(
         "us:statutes/7/2014/c#snap_net_income_exceeds_poverty_line",
         country="us",
@@ -3987,6 +3994,52 @@ def test_policyengine_tax_scenario_builds_refundable_credit_inputs(tmp_path):
     assert "'refundable_ctc': {'2026': 1200}" in script
     assert "'recovery_rebate_credit': {'2026': 0}" in script
     assert "'refundable_payroll_tax_credit': {'2026': 100}" in script
+
+
+def test_policyengine_scenario_uses_legal_id_adapter_inputs(tmp_path):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    legal_id = (
+        "us-co:regulations/8-ccr-1403-1/3.111/"
+        "h-low-income-eligibility-guidelines#input.family_size"
+    )
+
+    script = pipeline._build_pe_us_scenario_script(
+        "co_ccap_smi",
+        {
+            "period": "2025-10",
+            legal_id: 4,
+        },
+        "2025",
+    )
+
+    assert "'state_code_str': {'2025': 'CO'}" in script
+    assert "'spm_unit_size': {'2025': 4}" in script
+
+
+def test_policyengine_mappability_ignores_unrelated_legal_inputs_when_mapped():
+    registry = load_policyengine_registry()
+    mapping = registry.mapping_for_legal_id(
+        "us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#monthly_state_median_income_85_limit",
+        country="us",
+    )
+    inputs = {
+        "us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.family_size": 4,
+        "us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.household_assets": 1_000_000,
+    }
+
+    projected = ValidatorPipeline._pe_us_projectable_inputs_for_mappability(
+        inputs,
+        "co_ccap_smi",
+        mapping=mapping,
+    )
+
+    assert list(projected) == [
+        "us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.family_size"
+    ]
 
 
 def test_policyengine_tax_scenario_skips_unmodelled_niit_components(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.753"
+version = "0.2.754"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- map Colorado CCAP's 85% state median income monthly limit to PolicyEngine's `co_ccap_smi` helper with a `0.85` result multiplier
- mark adjacent Colorado CCAP PE predicates as not comparable where PE uses strict `<` or omits the RuleSpec asset cap
- let PE scenario adapters consume legal-ID-qualified RuleSpec inputs and ignore unrelated legal inputs when checking mappability for one mapped output

## Validation

- `uv run --with ruff ruff check src/axiom_encode/oracles/policyengine/adapters.py src/axiom_encode/harness/validator_pipeline.py tests/test_policyengine_coverage.py tests/test_rulespec_validation.py`
- `uv run --with ruff ruff format --check src/axiom_encode/oracles/policyengine/adapters.py src/axiom_encode/harness/validator_pipeline.py tests/test_policyengine_coverage.py tests/test_rulespec_validation.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_maps_colorado_ccap_smi_limit tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_rulespec_validation.py::test_policyengine_scenario_uses_legal_id_adapter_inputs tests/test_rulespec_validation.py::test_policyengine_mappability_ignores_unrelated_legal_inputs_when_mapped`
- `uv run axiom-encode validate /Users/maxghenis/_axiom-worktrees/rulespec-us-main-ccap-oracle/us-co/regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines.yaml --skip-reviewers --oracle policyengine --require-oracle-classification --json`

Live RuleSpec validation result: `ci_pass=true`, `oracle_passed=true`, `policyengine=1.0`, `failed=0`, `unmapped=0`.
