### PR TITLE
Track PolicyEngine program surface coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.754"
+version = "0.2.755"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.754"
+__version__ = "0.2.755"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -690,6 +690,19 @@ def main():
         help="Exit non-zero when a comparable output is absent from companion tests",
     )
     oracle_coverage_parser.add_argument(
+        "--include-program-surfaces",
+        action="store_true",
+        help="Include PolicyEngine program-variable surface wiring coverage",
+    )
+    oracle_coverage_parser.add_argument(
+        "--fail-on-pending-program-surfaces",
+        action="store_true",
+        help=(
+            "Exit non-zero when an included PolicyEngine program variable is "
+            "pending RuleSpec encoding, pending oracle mapping, or deferred"
+        ),
+    )
+    oracle_coverage_parser.add_argument(
         "--json", action="store_true", help="Output as JSON"
     )
 
@@ -3517,12 +3530,29 @@ def cmd_oracle_coverage(args):
         sys.exit(2)
 
     root = (args.root or _default_rulespec_inventory_root()).resolve()
-    report = build_policyengine_coverage_report(root, program=args.program)
+    include_program_surfaces = getattr(args, "include_program_surfaces", False) is True
+    fail_on_pending_program_surfaces = (
+        getattr(args, "fail_on_pending_program_surfaces", False) is True
+    )
+    report = build_policyengine_coverage_report(
+        root,
+        program=args.program,
+        include_program_surfaces=include_program_surfaces,
+    )
 
     unmapped = int(report["status_counts"].get("unmapped", 0))
     untested_comparable = int(report.get("untested_comparable", 0))
-    should_fail = (args.fail_on_unmapped and unmapped) or (
-        args.fail_on_untested_comparable and untested_comparable
+    pending_program_surfaces = int(
+        (report.get("program_surfaces") or {}).get("pending_surfaces", 0)
+    )
+    should_fail = (
+        (args.fail_on_unmapped and unmapped)
+        or (args.fail_on_untested_comparable and untested_comparable)
+        or (
+            fail_on_pending_program_surfaces
+            and include_program_surfaces
+            and pending_program_surfaces
+        )
     )
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
@@ -3536,6 +3566,18 @@ def cmd_oracle_coverage(args):
     print(f"Status: {_format_counter(report['status_counts'])}")
     print(f"Untested comparable outputs: {untested_comparable}")
     print(f"Programs: {_format_counter(report['program_counts'])}")
+    if report.get("program_surfaces"):
+        surfaces = report["program_surfaces"]
+        print(
+            "PolicyEngine program surfaces: "
+            f"{surfaces['total_surfaces']} "
+            f"status={_format_counter(surfaces['status_counts'])} "
+            f"pending={surfaces['pending_surfaces']}"
+        )
+        print(
+            "PolicyEngine surface priorities: "
+            f"{_format_counter(surfaces['priority_counts'])}"
+        )
     print()
 
     for repo in report["repos"]:
@@ -3568,6 +3610,29 @@ def cmd_oracle_coverage(args):
             print(f"  - {item['legal_id']}")
         if len(untested_items) > args.limit:
             print(f"  - ... {len(untested_items) - args.limit} more")
+
+    program_surfaces = report.get("program_surfaces") or {}
+    pending_surface_items = [
+        item
+        for item in program_surfaces.get("items", [])
+        if item.get("axiom_status")
+        in {
+            "deferred_jurisdiction",
+            "pending_oracle_mapping",
+            "pending_rulespec_encoding",
+        }
+    ]
+    if pending_surface_items:
+        print()
+        print(f"Pending PolicyEngine program surfaces (first {args.limit}):")
+        for item in pending_surface_items[: args.limit]:
+            state = f" [{item['state']}]" if item.get("state") else ""
+            print(
+                f"  - {item['variable']}{state}: "
+                f"{item['axiom_status']} ({item['program_id']})"
+            )
+        if len(pending_surface_items) > args.limit:
+            print(f"  - ... {len(pending_surface_items) - args.limit} more")
 
     sys.exit(1 if should_fail else 0)
 

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -21,6 +21,15 @@ from .registry import PolicyEngineMapping, load_policyengine_registry
 
 EXECUTABLE_RULE_KINDS = {"parameter", "derived", "derived_relation"}
 ORACLE_COVERAGE_STATUSES = {"comparable", "known_not_comparable", "unmapped"}
+PROGRAM_SURFACE_STATUSES = {
+    "deferred_jurisdiction",
+    "input_only",
+    "out_of_scope",
+    "pe_in_progress",
+    "pending_oracle_mapping",
+    "pending_rulespec_encoding",
+    "wired",
+}
 _PROGRAM_TOKEN_RE = {
     token: re.compile(rf"(^|[^a-z0-9]){token}([^a-z0-9]|$)")
     for token in ("medicaid", "chip", "aca")
@@ -107,10 +116,53 @@ class PolicyEngineCandidateItem:
         }
 
 
+@dataclass(frozen=True)
+class PolicyEngineProgramSurfaceItem:
+    """One PolicyEngine program variable classified against Axiom wiring."""
+
+    country: str
+    program_id: str
+    program_name: str
+    category: str
+    policyengine_status: str
+    coverage: str
+    variable: str
+    axiom_status: str
+    source_type: str = "program"
+    agency: str | None = None
+    state: str | None = None
+    priority: str | None = None
+    rationale: str | None = None
+    mapping_count: int = 0
+    comparable_mapping_count: int = 0
+    legal_ids: tuple[str, ...] = ()
+
+    def as_dict(self) -> dict[str, str | int | list[str] | None]:
+        return {
+            "country": self.country,
+            "program_id": self.program_id,
+            "program_name": self.program_name,
+            "category": self.category,
+            "policyengine_status": self.policyengine_status,
+            "coverage": self.coverage,
+            "variable": self.variable,
+            "axiom_status": self.axiom_status,
+            "source_type": self.source_type,
+            "agency": self.agency,
+            "state": self.state,
+            "priority": self.priority,
+            "rationale": self.rationale,
+            "mapping_count": self.mapping_count,
+            "comparable_mapping_count": self.comparable_mapping_count,
+            "legal_ids": list(self.legal_ids),
+        }
+
+
 def build_policyengine_coverage_report(
     root: Path,
     *,
     program: str | None = None,
+    include_program_surfaces: bool = False,
 ) -> dict[str, Any]:
     """Classify executable RuleSpec outputs against the PolicyEngine registry."""
     registry = load_policyengine_registry()
@@ -132,7 +184,7 @@ def build_policyengine_coverage_report(
     for item in items:
         repo_counts.setdefault(item.repo, Counter())[item.status] += 1
 
-    return {
+    report = {
         "oracle": "policyengine",
         "root": str(root),
         "total_outputs": len(items),
@@ -148,6 +200,60 @@ def build_policyengine_coverage_report(
             for repo, counter in sorted(repo_counts.items())
         ],
         "items": [item.as_dict() for item in items],
+    }
+    if include_program_surfaces:
+        report["program_surfaces"] = build_policyengine_program_surface_report(
+            program=program,
+            registry=registry,
+        )
+    return report
+
+
+def build_policyengine_program_surface_report(
+    *,
+    country: str = "us",
+    program: str | None = None,
+    manifest_path: Path | None = None,
+    registry=None,
+) -> dict[str, Any]:
+    """Classify PolicyEngine program variables against the Axiom registry."""
+    registry = registry or load_policyengine_registry()
+    payload = _load_policyengine_program_surface_manifest(
+        country=country,
+        manifest_path=manifest_path,
+    )
+    surfaces = [
+        _program_surface_item_from_payload(raw_surface, registry=registry)
+        for raw_surface in payload["surfaces"]
+    ]
+    if program:
+        surfaces = [
+            surface
+            for surface in surfaces
+            if _program_surface_matches_filter(surface, program)
+        ]
+    status_counts = Counter(surface.axiom_status for surface in surfaces)
+    priority_counts = Counter(
+        surface.priority for surface in surfaces if surface.priority
+    )
+    unwired_statuses = {
+        "deferred_jurisdiction",
+        "pending_oracle_mapping",
+        "pending_rulespec_encoding",
+    }
+    pending_surfaces = [
+        surface for surface in surfaces if surface.axiom_status in unwired_statuses
+    ]
+    return {
+        "oracle": "policyengine",
+        "country": country,
+        "program": program,
+        "source": payload.get("source", {}),
+        "total_surfaces": len(surfaces),
+        "status_counts": dict(sorted(status_counts.items())),
+        "priority_counts": dict(sorted(priority_counts.items())),
+        "pending_surfaces": len(pending_surfaces),
+        "items": [surface.as_dict() for surface in surfaces],
     }
 
 
@@ -450,6 +556,111 @@ def _load_policyengine_variable_names() -> set[str] | None:
         return set(CountryTaxBenefitSystem().variables)
     except Exception:
         return None
+
+
+def _load_policyengine_program_surface_manifest(
+    *,
+    country: str,
+    manifest_path: Path | None,
+) -> dict[str, Any]:
+    path = (
+        manifest_path
+        if manifest_path is not None
+        else Path(__file__).with_name("program_surfaces") / f"{country}.yaml"
+    )
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError, ValueError) as exc:
+        raise ValueError(
+            f"Unable to load PolicyEngine surface manifest {path}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"PolicyEngine surface manifest must be an object: {path}")
+    raw_surfaces = payload.get("surfaces")
+    if not isinstance(raw_surfaces, list):
+        raise ValueError(
+            f"PolicyEngine surface manifest surfaces must be a list: {path}"
+        )
+    for index, raw_surface in enumerate(raw_surfaces):
+        if not isinstance(raw_surface, dict):
+            raise ValueError(
+                f"PolicyEngine surface manifest entry {index} must be an object: {path}"
+            )
+        missing = [
+            key
+            for key in (
+                "country",
+                "program_id",
+                "program_name",
+                "category",
+                "policyengine_status",
+                "coverage",
+                "variable",
+                "axiom_status",
+            )
+            if not raw_surface.get(key)
+        ]
+        if missing:
+            raise ValueError(
+                f"PolicyEngine surface manifest entry {index} missing "
+                f"{', '.join(missing)}: {path}"
+            )
+        status = str(raw_surface.get("axiom_status"))
+        if status not in PROGRAM_SURFACE_STATUSES - {"wired"}:
+            raise ValueError(
+                f"Unsupported PolicyEngine surface status for "
+                f"{raw_surface.get('variable')}: {status}"
+            )
+    return payload
+
+
+def _program_surface_item_from_payload(
+    payload: dict[str, Any],
+    *,
+    registry,
+) -> PolicyEngineProgramSurfaceItem:
+    variable = str(payload["variable"])
+    country = str(payload.get("country") or "us")
+    mappings = registry.mappings_for_policyengine_variable(variable, country=country)
+    axiom_status = "wired" if mappings else str(payload["axiom_status"])
+    return PolicyEngineProgramSurfaceItem(
+        country=country,
+        program_id=str(payload["program_id"]),
+        program_name=str(payload["program_name"]),
+        category=str(payload["category"]),
+        policyengine_status=str(payload["policyengine_status"]),
+        coverage=str(payload["coverage"]),
+        variable=variable,
+        axiom_status=axiom_status,
+        source_type=str(payload.get("source_type") or "program"),
+        agency=payload.get("agency"),
+        state=payload.get("state"),
+        priority=payload.get("priority"),
+        rationale=payload.get("rationale"),
+        mapping_count=len(mappings),
+        comparable_mapping_count=sum(1 for mapping in mappings if mapping.comparable),
+        legal_ids=tuple(mapping.legal_id for mapping in mappings),
+    )
+
+
+def _program_surface_matches_filter(
+    surface: PolicyEngineProgramSurfaceItem,
+    program: str,
+) -> bool:
+    programs = _program_filter_values(program)
+    normalized = program.lower()
+    if surface.program_id in programs or surface.variable in programs:
+        return True
+    if normalized == "tax" and surface.category.lower() == "taxes":
+        return True
+    if normalized == "health" and surface.category.lower() == "healthcare":
+        return True
+    if normalized in {"ccap", "ccdf", "child_care"}:
+        return surface.program_id in {"ccdf", "ne_childcare"} or any(
+            token in surface.variable
+            for token in ("ccap", "ccdf", "child_care", "childcare", "caps")
+        )
+    return False
 
 
 def _load_rulespec_payload(path: Path) -> dict[str, Any] | None:

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1,0 +1,2497 @@
+source:
+  repository: PolicyEngine/policyengine-us
+  ref: upstream/main
+  commit: 9656d3d9f99f07b259559496edb35c204a7abe3a
+  path: policyengine_us/programs.yaml
+  generated_by: axiom-encode policyengine program surface wiring
+surfaces:
+- country: us
+  program_id: federal_income_tax
+  program_name: Federal income taxes
+  category: Taxes
+  agency: IRS
+  policyengine_status: complete
+  coverage: US
+  variable: income_tax
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: state_income_tax
+  program_name: State income taxes
+  category: Taxes
+  agency: IRS
+  policyengine_status: complete
+  coverage: US
+  variable: state_income_tax
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: payroll_taxes
+  program_name: Payroll taxes
+  category: Taxes
+  agency: IRS
+  policyengine_status: complete
+  coverage: US
+  variable: employee_payroll_tax
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: snap
+  program_name: SNAP
+  category: Benefits
+  agency: USDA
+  policyengine_status: complete
+  coverage: US
+  variable: snap
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: wic
+  program_name: WIC
+  category: Benefits
+  agency: USDA
+  policyengine_status: complete
+  coverage: US
+  variable: wic
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: school_meals
+  program_name: Free and reduced school meals
+  category: Benefits
+  agency: USDA
+  policyengine_status: complete
+  coverage: US
+  variable: free_school_meals
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: csfp
+  program_name: Commodity Supplemental Food Program
+  category: Benefits
+  agency: USDA
+  policyengine_status: complete
+  coverage: US
+  variable: csfp
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: fdpir
+  program_name: FDPIR
+  category: Benefits
+  agency: USDA
+  policyengine_status: partial
+  coverage: US
+  variable: fdpir
+  source_type: program
+  axiom_status: input_only
+  priority: P1
+  rationale: PolicyEngine exposes this as an exogenous or input-only program amount rather than a computed law oracle target.
+- country: us
+  program_id: medicaid
+  program_name: Medicaid
+  category: Healthcare
+  agency: HHS
+  policyengine_status: complete
+  coverage: US
+  variable: medicaid
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: chip
+  program_name: CHIP
+  category: Healthcare
+  agency: HHS
+  policyengine_status: complete
+  coverage: US
+  variable: chip
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: aca_subsidies
+  program_name: ACA subsidies
+  category: Healthcare
+  agency: ACA
+  policyengine_status: complete
+  coverage: US
+  variable: aca_ptc
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: CalWORKs cash benefit
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: CA
+  variable: ca_tanf
+  source_type: state_implementation
+  state: CA
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Colorado TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: CO
+  variable: co_tanf
+  source_type: state_implementation
+  state: CO
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: DC TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: DC
+  variable: dc_tanf
+  source_type: state_implementation
+  state: DC
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Illinois TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: IL
+  variable: il_tanf
+  source_type: state_implementation
+  state: IL
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: NY TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: NY
+  variable: ny_tanf
+  source_type: state_implementation
+  state: NY
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Massachusetts TAFDC
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: MA
+  variable: ma_tafdc
+  source_type: state_implementation
+  state: MA
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Montana TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: MT
+  variable: mt_tanf
+  source_type: state_implementation
+  state: MT
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: North Carolina TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: NC
+  variable: nc_tanf
+  source_type: state_implementation
+  state: NC
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: New Jersey WFNJ
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: NJ
+  variable: nj_wfnj
+  source_type: state_implementation
+  state: NJ
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Texas TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: TX
+  variable: tx_tanf
+  source_type: state_implementation
+  state: TX
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Washington TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: WA
+  variable: wa_tanf
+  source_type: state_implementation
+  state: WA
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Arizona TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: AZ
+  variable: az_tanf
+  source_type: state_implementation
+  state: AZ
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Oklahoma TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: OK
+  variable: ok_tanf
+  source_type: state_implementation
+  state: OK
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Missouri TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: MO
+  variable: mo_tanf
+  source_type: state_implementation
+  state: MO
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Pennsylvania TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: PA
+  variable: pa_tanf
+  source_type: state_implementation
+  state: PA
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Maryland TCA
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: MD
+  variable: md_tca
+  source_type: state_implementation
+  state: MD
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: South Dakota TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: SD
+  variable: sd_tanf
+  source_type: state_implementation
+  state: SD
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Georgia TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: GA
+  variable: ga_tanf
+  source_type: state_implementation
+  state: GA
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Mississippi TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: MS
+  variable: ms_tanf
+  source_type: state_implementation
+  state: MS
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Indiana TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: IN
+  variable: in_tanf
+  source_type: state_implementation
+  state: IN
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Florida TCA
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: FL
+  variable: fl_tca
+  source_type: state_implementation
+  state: FL
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Maine TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: ME
+  variable: me_tanf
+  source_type: state_implementation
+  state: ME
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Nevada TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: NV
+  variable: nv_tanf
+  source_type: state_implementation
+  state: NV
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Kansas TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: KS
+  variable: ks_tanf
+  source_type: state_implementation
+  state: KS
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Hawaii TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: HI
+  variable: hi_tanf
+  source_type: state_implementation
+  state: HI
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Delaware TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: DE
+  variable: de_tanf
+  source_type: state_implementation
+  state: DE
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Oregon TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: OR
+  variable: or_tanf
+  source_type: state_implementation
+  state: OR
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Minnesota MFIP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: MN
+  variable: mn_mfip
+  source_type: state_implementation
+  state: MN
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Tennessee Families First
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: TN
+  variable: tn_ff
+  source_type: state_implementation
+  state: TN
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: West Virginia WORKS
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: WV
+  variable: wv_works
+  source_type: state_implementation
+  state: WV
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Rhode Island WORKS
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: RI
+  variable: ri_works
+  source_type: state_implementation
+  state: RI
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: New Hampshire FANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: NH
+  variable: nh_fanf
+  source_type: state_implementation
+  state: NH
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Connecticut TFA
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: CT
+  variable: ct_tfa
+  source_type: state_implementation
+  state: CT
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Ohio Works First
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: OH
+  variable: oh_owf
+  source_type: state_implementation
+  state: OH
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Michigan FIP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: MI
+  variable: mi_fip
+  source_type: state_implementation
+  state: MI
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Wisconsin Works
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: WI
+  variable: wi_works
+  source_type: state_implementation
+  state: WI
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Idaho TAFI
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: ID
+  variable: id_tafi
+  source_type: state_implementation
+  state: ID
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Nebraska ADC
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: NE
+  variable: ne_adc
+  source_type: state_implementation
+  state: NE
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Arkansas TEA
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: AR
+  variable: ar_tea
+  source_type: state_implementation
+  state: AR
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Utah FEP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: UT
+  variable: ut_fep
+  source_type: state_implementation
+  state: UT
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Kentucky K-TAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: KY
+  variable: ky_ktap
+  source_type: state_implementation
+  state: KY
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Alabama TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: AL
+  variable: al_tanf
+  source_type: state_implementation
+  state: AL
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Alaska ATAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: AK
+  variable: ak_atap
+  source_type: state_implementation
+  state: AK
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Iowa FIP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: IA
+  variable: ia_fip
+  source_type: state_implementation
+  state: IA
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Louisiana FITAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: LA
+  variable: la_fitap
+  source_type: state_implementation
+  state: LA
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: New Mexico Works
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: NM
+  variable: nm_works
+  source_type: state_implementation
+  state: NM
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: North Dakota TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: ND
+  variable: nd_tanf
+  source_type: state_implementation
+  state: ND
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: South Carolina TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: SC
+  variable: sc_tanf
+  source_type: state_implementation
+  state: SC
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Vermont Reach Up
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: VT
+  variable: vt_reach_up
+  source_type: state_implementation
+  state: VT
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Virginia TANF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: VA
+  variable: va_tanf
+  source_type: state_implementation
+  state: VA
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: tanf
+  program_name: Wyoming POWER
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: WY
+  variable: wy_power
+  source_type: state_implementation
+  state: WY
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: ccdf
+  program_name: CCAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: AK
+  variable: ak_ccap
+  source_type: state_implementation
+  state: AK
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Arkansas SRA
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: AR
+  variable: ar_sra
+  source_type: state_implementation
+  state: AR
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Alabama CCSP
+  category: Benefits
+  agency: HHS
+  policyengine_status: partial
+  coverage: AL
+  variable: al_ccsp
+  source_type: state_implementation
+  state: AL
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: CCAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: AZ
+  variable: az_ccap
+  source_type: state_implementation
+  state: AZ
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: ccdf
+  program_name: CalWORKs childcare
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: CA
+  variable: ca_calworks_child_care
+  source_type: state_implementation
+  state: CA
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: CCAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: CO
+  variable: co_ccap_subsidy
+  source_type: state_implementation
+  state: CO
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: ccdf
+  program_name: Care 4 Kids
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: CT
+  variable: ct_c4k
+  source_type: state_implementation
+  state: CT
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: School Readiness
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: FL
+  variable: fl_sr
+  source_type: state_implementation
+  state: FL
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Hawaii Child Care Subsidy
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: HI
+  variable: hi_ccap
+  source_type: state_implementation
+  state: HI
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: CCAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: IL
+  variable: il_ccap_eligible
+  source_type: state_implementation
+  state: IL
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: ICCP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: ID
+  variable: id_iccp
+  source_type: state_implementation
+  state: ID
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Indiana CCDF
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: IN
+  variable: in_ccdf
+  source_type: state_implementation
+  state: IN
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Kansas CCAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: KS
+  variable: ks_child_care_subsidies
+  source_type: state_implementation
+  state: KS
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: CCAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: KY
+  variable: ky_ccap
+  source_type: state_implementation
+  state: KY
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Louisiana CCAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: LA
+  variable: la_ccap
+  source_type: state_implementation
+  state: LA
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Massachusetts CCFA
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: MA
+  variable: ma_ccfa
+  source_type: state_implementation
+  state: MA
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Maryland CCS
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: MD
+  variable: md_child_care_subsidies
+  source_type: state_implementation
+  state: MD
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Maine CCAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: ME
+  variable: me_ccap
+  source_type: state_implementation
+  state: ME
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: CCPP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: MS
+  variable: ms_ccpp
+  source_type: state_implementation
+  state: MS
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Iowa CCA
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: IA
+  variable: ia_cca
+  source_type: state_implementation
+  state: IA
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: New Hampshire CCAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: NH
+  variable: nh_ccap
+  source_type: state_implementation
+  state: NH
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: DC CCSP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: DC
+  variable: dc_ccsp
+  source_type: state_implementation
+  state: DC
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: North Carolina SCCA
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: NC
+  variable: nc_scca
+  source_type: state_implementation
+  state: NC
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Delaware POC
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: DE
+  variable: de_poc
+  source_type: state_implementation
+  state: DE
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Pennsylvania CCW
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: PA
+  variable: pa_ccw
+  source_type: state_implementation
+  state: PA
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Rhode Island CCAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: RI
+  variable: ri_ccap
+  source_type: state_implementation
+  state: RI
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Texas CCS
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: TX
+  variable: tx_ccs
+  source_type: state_implementation
+  state: TX
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Vermont CCFAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: VT
+  variable: vt_ccfap
+  source_type: state_implementation
+  state: VT
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Washington WCCC
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: WA
+  variable: wa_wccc
+  source_type: state_implementation
+  state: WA
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: West Virginia CCAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: WV
+  variable: wv_ccap
+  source_type: state_implementation
+  state: WV
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
+  program_name: Georgia CAPS
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: GA
+  variable: ga_caps
+  source_type: state_implementation
+  state: GA
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: head_start
+  program_name: Head Start
+  category: Benefits
+  agency: HHS
+  policyengine_status: partial
+  coverage: US, WA
+  variable: head_start
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: head_start
+  program_name: ECEAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: WA
+  variable: wa_eceap
+  source_type: state_implementation
+  state: WA
+  axiom_status: deferred_jurisdiction
+  priority: P1
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: head_start
+  program_name: Birth to Three ECEAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: WA
+  variable: wa_birth_to_three_eceap
+  source_type: state_implementation
+  state: WA
+  axiom_status: deferred_jurisdiction
+  priority: P1
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: liheap
+  program_name: DC LIHEAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: DC
+  variable: dc_liheap
+  source_type: state_implementation
+  state: DC
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: liheap
+  program_name: Massachusetts LIHEAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: MA
+  variable: ma_liheap
+  source_type: state_implementation
+  state: MA
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: liheap
+  program_name: Illinois LIHEAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: IL
+  variable: il_liheap
+  source_type: state_implementation
+  state: IL
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi
+  program_name: SSI
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: US
+  variable: ssi
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Alaska SSP
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: AK
+  variable: ak_ssp
+  source_type: state_implementation
+  state: AK
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Alabama SSP
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: AL
+  variable: al_ssp
+  source_type: state_implementation
+  state: AL
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: California SSP
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: CA
+  variable: ca_state_supplement
+  source_type: state_implementation
+  state: CA
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Connecticut SSP
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: CT
+  variable: ct_ssp
+  source_type: state_implementation
+  state: CT
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Colorado SSP
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: CO
+  variable: co_state_supplement
+  source_type: state_implementation
+  state: CO
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: DC OSSP
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: DC
+  variable: dc_ossp
+  source_type: state_implementation
+  state: DC
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Delaware SSP
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: DE
+  variable: de_ssp
+  source_type: state_implementation
+  state: DE
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Florida OSS
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: FL
+  variable: fl_oss
+  source_type: state_implementation
+  state: FL
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Georgia SSP
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: GA
+  variable: ga_ssp
+  source_type: state_implementation
+  state: GA
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Idaho AABD
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: ID
+  variable: id_aabd
+  source_type: state_implementation
+  state: ID
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Indiana SSP
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: IN
+  variable: in_ssp
+  source_type: state_implementation
+  state: IN
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Massachusetts SSP
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: MA
+  variable: ma_state_supplement
+  source_type: state_implementation
+  state: MA
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Maryland PAA
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: MD
+  variable: md_paa
+  source_type: state_implementation
+  state: MD
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Michigan SSP
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: MI
+  variable: mi_ssp
+  source_type: state_implementation
+  state: MI
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Maine SSP
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: ME
+  variable: me_ssp
+  source_type: state_implementation
+  state: ME
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Missouri SSP
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: MO
+  variable: mo_ssp
+  source_type: state_implementation
+  state: MO
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Minnesota MSA
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: MN
+  variable: mn_msa
+  source_type: state_implementation
+  state: MN
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Nebraska AABD
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: NE
+  variable: ne_aabd
+  source_type: state_implementation
+  state: NE
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Kansas SSPP
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: KS
+  variable: ks_sspp
+  source_type: state_implementation
+  state: KS
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Louisiana OSS
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: LA
+  variable: la_oss
+  source_type: state_implementation
+  state: LA
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Kentucky SSP
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: KY
+  variable: ky_ssp
+  source_type: state_implementation
+  state: KY
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Illinois AABD
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: IL
+  variable: il_aabd
+  source_type: state_implementation
+  state: IL
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: New Mexico SSI supplement
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: NM
+  variable: nm_ssi_state_supplement
+  source_type: state_implementation
+  state: NM
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: South Carolina SSI supplement
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: SC
+  variable: sc_ssi_state_supplement
+  source_type: state_implementation
+  state: SC
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Texas SSI supplement
+  category: Benefits
+  agency: SSA
+  policyengine_status: complete
+  coverage: TX
+  variable: tx_ssi_state_supplement
+  source_type: state_implementation
+  state: TX
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ssi_state_supplement
+  program_name: Washington SSP
+  category: Benefits
+  agency: SSA
+  policyengine_status: partial
+  coverage: WA
+  variable: wa_ssp
+  source_type: state_implementation
+  state: WA
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: social_security
+  program_name: Social Security
+  category: Benefits
+  agency: SSA
+  policyengine_status: partial
+  coverage: US
+  variable: social_security
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: medicare
+  program_name: Medicare
+  category: Healthcare
+  agency: HHS
+  policyengine_status: complete
+  coverage: US
+  variable: is_medicare_eligible
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: section_8
+  program_name: Section 8
+  category: Housing
+  agency: HUD
+  policyengine_status: in_progress
+  coverage: unspecified
+  variable: hud_hap
+  source_type: program
+  axiom_status: pe_in_progress
+  priority: P3
+  rationale: PolicyEngine marks this surface in progress, so Axiom tracks it but does not require full oracle wiring yet.
+- country: us
+  program_id: lifeline
+  program_name: Lifeline
+  category: Benefits
+  agency: FCC
+  policyengine_status: complete
+  coverage: US
+  variable: lifeline
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: acp
+  program_name: Affordable Connectivity Program
+  category: Benefits
+  agency: FCC
+  policyengine_status: complete
+  coverage: US
+  variable: acp
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: pell_grant
+  program_name: Pell Grant
+  category: Education
+  agency: ED
+  policyengine_status: complete
+  coverage: US
+  variable: pell_grant
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: education_tax_credits
+  program_name: Education tax credits
+  category: Education
+  agency: IRS
+  policyengine_status: complete
+  coverage: US
+  variable: american_opportunity_credit
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: clean_vehicle_credits
+  program_name: Clean vehicle credits
+  category: Energy
+  agency: IRS
+  policyengine_status: complete
+  coverage: US
+  variable: clean_vehicle_credit
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: residential_clean_energy_credit
+  program_name: Residential clean energy credit
+  category: Energy
+  agency: IRS
+  policyengine_status: complete
+  coverage: US
+  variable: residential_clean_energy_credit
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: ira_tax_credits
+  program_name: IRA tax credits
+  category: Energy
+  agency: IRS
+  policyengine_status: complete
+  coverage: US
+  variable: energy_efficient_home_improvement_credit
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: doe_high_efficiency_rebate
+  program_name: DOE high efficiency rebate
+  category: Energy
+  agency: DOE
+  policyengine_status: complete
+  coverage: US
+  variable: high_efficiency_electric_home_rebate
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: doe_efficiency_rebate
+  program_name: DOE efficiency rebate
+  category: Energy
+  agency: DOE
+  policyengine_status: complete
+  coverage: US
+  variable: residential_efficiency_electrification_rebate
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: co_oap
+  program_name: Colorado OAP
+  category: Benefits
+  agency: State
+  policyengine_status: complete
+  coverage: CO
+  variable: co_oap
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: co_chp
+  program_name: Colorado CHP
+  category: Healthcare
+  agency: State
+  policyengine_status: complete
+  coverage: CO
+  variable: co_chp
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: co_omnisalud
+  program_name: Colorado OmniSalud
+  category: Healthcare
+  agency: State
+  policyengine_status: complete
+  coverage: CO
+  variable: co_omnisalud
+  source_type: program
+  axiom_status: pending_rulespec_encoding
+  priority: P1
+  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
+    before claiming parity.
+- country: us
+  program_id: dc_power
+  program_name: DC Power
+  category: Benefits
+  agency: State
+  policyengine_status: complete
+  coverage: DC
+  variable: dc_power
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: dc_gac
+  program_name: DC GAC
+  category: Benefits
+  agency: State
+  policyengine_status: complete
+  coverage: DC
+  variable: dc_gac
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ca_cvrp
+  program_name: California CVRP
+  category: Energy
+  agency: State
+  policyengine_status: complete
+  coverage: CA
+  variable: ca_cvrp
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P3
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ca_capi
+  program_name: California CAPI
+  category: Benefits
+  agency: State
+  policyengine_status: complete
+  coverage: CA
+  variable: ca_capi
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: care
+  program_name: California CARE
+  category: Energy
+  agency: State
+  policyengine_status: complete
+  coverage: CA
+  variable: ca_care
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P3
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: fera
+  program_name: California FERA
+  category: Energy
+  agency: State
+  policyengine_status: complete
+  coverage: CA
+  variable: ca_fera
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P3
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: il_fpp
+  program_name: Illinois Family Planning Program
+  category: Healthcare
+  agency: State
+  policyengine_status: complete
+  coverage: IL
+  variable: il_fpp_eligible
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: il_ibccp
+  program_name: Illinois IBCCP
+  category: Healthcare
+  agency: State
+  policyengine_status: complete
+  coverage: IL
+  variable: il_bcc_eligible
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: il_hbwd
+  program_name: Illinois HBWD
+  category: Healthcare
+  agency: State
+  policyengine_status: complete
+  coverage: IL
+  variable: il_hbwd
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ms_wd
+  program_name: Mississippi WD
+  category: Healthcare
+  agency: State
+  policyengine_status: complete
+  coverage: MS
+  variable: ms_wd_eligible
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: il_ihwap
+  program_name: Illinois IHWAP
+  category: Energy
+  agency: State
+  policyengine_status: complete
+  coverage: IL
+  variable: il_ihwap_eligible
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P3
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: il_scretd
+  program_name: Illinois SCRETD
+  category: Taxes
+  agency: State
+  policyengine_status: complete
+  coverage: IL
+  variable: il_scretd_deferral_amount
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: il_ipass_assist
+  program_name: Illinois I-PASS Assist
+  category: Benefits
+  agency: State
+  policyengine_status: complete
+  coverage: IL
+  variable: il_ipass_assist_eligible
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: il_bap
+  program_name: Illinois BAP
+  category: Benefits
+  agency: Local
+  policyengine_status: complete
+  coverage: Chicago
+  variable: il_bap_eligible
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: il_cta_benefit
+  program_name: Illinois CTA benefit
+  category: Benefits
+  agency: Local
+  policyengine_status: complete
+  coverage: Chicago
+  variable: il_cta_benefit
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ne_aabd
+  program_name: Nebraska AABD
+  category: Benefits
+  agency: DHHS
+  policyengine_status: complete
+  coverage: NE
+  variable: ne_aabd
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ne_childcare
+  program_name: Nebraska child care subsidy
+  category: Benefits
+  agency: State
+  policyengine_status: complete
+  coverage: NE
+  variable: ne_child_care_subsidy
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: mbta_reduced_fare
+  program_name: MBTA reduced fare
+  category: Benefits
+  agency: State
+  policyengine_status: complete
+  coverage: MA
+  variable: ma_mbta_income_eligible_reduced_fare_eligible
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ma_eaedc
+  program_name: Massachusetts EAEDC
+  category: Benefits
+  agency: State
+  policyengine_status: complete
+  coverage: MA
+  variable: ma_eaedc
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: nj_unemployment_insurance
+  program_name: New Jersey Unemployment Insurance
+  category: Benefits
+  agency: NJ Department of Labor and Workforce Development
+  policyengine_status: complete
+  coverage: NJ
+  variable: nj_unemployment_insurance
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ny_drive_clean_rebate
+  program_name: NY Drive Clean Rebate
+  category: Energy
+  agency: State
+  policyengine_status: complete
+  coverage: NY
+  variable: ny_drive_clean_rebate
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P3
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: tx_fpp_benefit
+  program_name: Texas FPP
+  category: Healthcare
+  agency: State
+  policyengine_status: complete
+  coverage: TX
+  variable: tx_fpp_benefit
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: pa_uc
+  program_name: Pennsylvania Unemployment Compensation
+  category: Benefits
+  agency: PA Department of Labor & Industry
+  policyengine_status: complete
+  coverage: PA
+  variable: pa_uc
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: tx_dart_benefit
+  program_name: Texas DART
+  category: Benefits
+  agency: Local
+  policyengine_status: complete
+  coverage: Dallas County, TX
+  variable: tx_dart_benefit_person
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: tx_harris_rides_subsidy
+  program_name: Harris County Rides Subsidy
+  category: Benefits
+  agency: Local
+  policyengine_status: complete
+  coverage: Harris County, TX
+  variable: tx_harris_rides_subsidy
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ez_save
+  program_name: Los Angeles County EZ Save
+  category: Energy
+  agency: Local
+  policyengine_status: complete
+  coverage: Los Angeles County
+  variable: ca_la_ez_save
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P3
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: la_infant_supplement
+  program_name: Los Angeles County infant supplement
+  category: Benefits
+  agency: Local
+  policyengine_status: complete
+  coverage: Los Angeles County
+  variable: ca_la_infant_supplement
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: la_expectant_parent
+  program_name: Los Angeles County expectant parent payment
+  category: Benefits
+  agency: Local
+  policyengine_status: complete
+  coverage: Los Angeles County
+  variable: ca_la_expectant_parent_payment
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: la_general_relief
+  program_name: Los Angeles County General Relief
+  category: Benefits
+  agency: Local
+  policyengine_status: complete
+  coverage: Los Angeles County
+  variable: la_general_relief
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ca_marin_general_relief
+  program_name: Marin County General Relief
+  category: Benefits
+  agency: Local
+  policyengine_status: complete
+  coverage: Marin County
+  variable: ca_marin_general_relief
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ca_oc_general_relief
+  program_name: Orange County General Relief
+  category: Benefits
+  agency: Local
+  policyengine_status: partial
+  coverage: Orange County
+  variable: ca_oc_general_relief
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ca_riv_general_relief
+  program_name: Riverside County General Relief
+  category: Benefits
+  agency: Local
+  policyengine_status: complete
+  coverage: Riverside County
+  variable: ca_riv_general_relief
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ca_riv_liheap
+  program_name: Riverside County LIHEAP
+  category: Energy
+  agency: Local
+  policyengine_status: complete
+  coverage: Riverside County
+  variable: ca_riv_liheap_eligible
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P3
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: share
+  program_name: Riverside County SHARE
+  category: Energy
+  agency: Local
+  policyengine_status: complete
+  coverage: Riverside County
+  variable: ca_riv_share_payment
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P3
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ca_ala_general_assistance
+  program_name: Alameda County General Assistance
+  category: Benefits
+  agency: Local
+  policyengine_status: complete
+  coverage: Alameda County
+  variable: ca_ala_general_assistance
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ca_smc_general_assistance
+  program_name: San Mateo County General Assistance
+  category: Benefits
+  agency: Local
+  policyengine_status: complete
+  coverage: San Mateo County
+  variable: ca_smc_general_assistance
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ca_scc_general_assistance
+  program_name: Santa Clara County General Assistance
+  category: Benefits
+  agency: Local
+  policyengine_status: complete
+  coverage: Santa Clara County
+  variable: ca_scc_general_assistance
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ca_cc_general_assistance
+  program_name: Contra Costa County General Assistance
+  category: Benefits
+  agency: Local
+  policyengine_status: complete
+  coverage: Contra Costa County
+  variable: ca_cc_general_assistance
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ca_sf_caap
+  program_name: San Francisco County Adult Assistance Programs
+  category: Benefits
+  agency: Local
+  policyengine_status: partial
+  coverage: San Francisco County
+  variable: ca_sf_caap
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: nyc_income_tax
+  program_name: NYC income tax
+  category: Taxes
+  agency: Local
+  policyengine_status: complete
+  coverage: New York City
+  variable: nyc_income_tax
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: sf_wftc
+  program_name: San Francisco WFTC
+  category: Taxes
+  agency: Local
+  policyengine_status: complete
+  coverage: San Francisco
+  variable: sf_wftc
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: montgomery_county_eitc
+  program_name: Montgomery County EITC
+  category: Taxes
+  agency: Local
+  policyengine_status: complete
+  coverage: Montgomery County, MD
+  variable: md_montgomery_eitc_refundable
+  source_type: program
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.

--- a/src/axiom_encode/oracles/policyengine/registry.py
+++ b/src/axiom_encode/oracles/policyengine/registry.py
@@ -122,6 +122,24 @@ class PolicyEngineOracleRegistry:
             and (country is None or mapping.country == country)
         ]
 
+    def mappings_for_policyengine_variable(
+        self, policyengine_variable: str, *, country: str | None = None
+    ) -> list[PolicyEngineMapping]:
+        """Return exact and prefix mappings that reference a PE variable."""
+        mappings = [
+            mapping
+            for mapping in self.mappings_by_legal_id.values()
+            if mapping.policyengine_variable == policyengine_variable
+            and (country is None or mapping.country == country)
+        ]
+        mappings.extend(
+            mapping
+            for mapping in self.prefix_mappings
+            if mapping.policyengine_variable == policyengine_variable
+            and (country is None or mapping.country == country)
+        )
+        return sorted(mappings, key=lambda mapping: mapping.legal_id)
+
     def validate(self) -> list[str]:
         issues: list[str] = []
         seen: set[str] = set()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1764,6 +1764,55 @@ class TestCmdValidate:
         assert "Untested comparable outputs: 1" in output
         assert "us:statutes/26/3101/a#oasdi_wage_tax_rate" in output
 
+    def test_oracle_coverage_fail_on_pending_program_surfaces_exits_nonzero(
+        self, capsys, tmp_path
+    ):
+        args = MagicMock()
+        args.root = tmp_path
+        args.oracle = "policyengine"
+        args.program = None
+        args.limit = 25
+        args.fail_on_unmapped = False
+        args.fail_on_untested_comparable = False
+        args.include_program_surfaces = True
+        args.fail_on_pending_program_surfaces = True
+        args.json = False
+
+        with patch(
+            "axiom_encode.cli.build_policyengine_coverage_report",
+            return_value={
+                "oracle": "policyengine",
+                "root": str(tmp_path),
+                "total_outputs": 0,
+                "status_counts": {},
+                "untested_comparable": 0,
+                "program_counts": {},
+                "repos": [],
+                "items": [],
+                "program_surfaces": {
+                    "total_surfaces": 1,
+                    "status_counts": {"pending_rulespec_encoding": 1},
+                    "priority_counts": {"P1": 1},
+                    "pending_surfaces": 1,
+                    "items": [
+                        {
+                            "variable": "wic",
+                            "axiom_status": "pending_rulespec_encoding",
+                            "program_id": "wic",
+                            "state": None,
+                        }
+                    ],
+                },
+            },
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_oracle_coverage(args)
+
+        assert exc_info.value.code == 1
+        output = capsys.readouterr().out
+        assert "PolicyEngine program surfaces: 1" in output
+        assert "wic: pending_rulespec_encoding" in output
+
     def test_oracle_candidates_prints_priority_queue(self, capsys, tmp_path):
         args = MagicMock()
         args.root = tmp_path

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -5,6 +5,7 @@ import pytest
 from axiom_encode.oracles.policyengine.coverage import (
     build_policyengine_candidate_report,
     build_policyengine_coverage_report,
+    build_policyengine_program_surface_report,
 )
 
 
@@ -89,6 +90,64 @@ rules:
     assert (
         statuses_by_id["us:statutes/7/9999#snap_unclassified_new_output"] == "unmapped"
     )
+
+
+def test_policyengine_program_surface_report_overlays_legal_registry(tmp_path):
+    manifest = tmp_path / "program_surfaces.yaml"
+    manifest.write_text(
+        """source:
+  repository: PolicyEngine/policyengine-us
+  ref: test
+  path: policyengine_us/programs.yaml
+surfaces:
+  - country: us
+    program_id: federal_income_tax
+    program_name: Federal income taxes
+    category: Taxes
+    policyengine_status: complete
+    coverage: US
+    variable: income_tax
+    axiom_status: pending_rulespec_encoding
+    priority: P1
+    rationale: Should be overridden by the legal-ID registry.
+  - country: us
+    program_id: wic
+    program_name: WIC
+    category: Benefits
+    policyengine_status: complete
+    coverage: US
+    variable: wic
+    axiom_status: pending_rulespec_encoding
+    priority: P1
+    rationale: Needs RuleSpec encoding.
+  - country: us
+    program_id: fdpir
+    program_name: FDPIR
+    category: Benefits
+    policyengine_status: partial
+    coverage: US
+    variable: fdpir
+    axiom_status: input_only
+    priority: P1
+    rationale: PE treats this as input-only.
+""",
+        encoding="utf-8",
+    )
+
+    report = build_policyengine_program_surface_report(manifest_path=manifest)
+
+    assert report["total_surfaces"] == 3
+    assert report["status_counts"] == {
+        "input_only": 1,
+        "pending_rulespec_encoding": 1,
+        "wired": 1,
+    }
+    assert report["pending_surfaces"] == 1
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    assert items_by_variable["income_tax"]["axiom_status"] == "wired"
+    assert items_by_variable["income_tax"]["mapping_count"] >= 1
+    assert items_by_variable["wic"]["axiom_status"] == "pending_rulespec_encoding"
+    assert items_by_variable["fdpir"]["axiom_status"] == "input_only"
 
 
 def test_policyengine_coverage_classifies_nz_outputs_outside_policyengine(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.754"
+version = "0.2.755"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- Adds a bundled PolicyEngine-US program-surface manifest generated from `PolicyEngine/policyengine-us` `upstream/main` commit `9656d3d9f99f07b259559496edb35c204a7abe3a`.
- Extends the PolicyEngine oracle coverage report to overlay legal-ID registry mappings onto those program surfaces, so only actual registry mappings can classify a surface as `wired`.
- Adds `oracle-coverage --include-program-surfaces` and `--fail-on-pending-program-surfaces` so PE program parity gaps are visible and optionally gateable.
- Bumps `axiom-encode` to `0.2.755`.

## Current live surface report

Against `/Users/maxghenis/TheAxiomFoundation`:

- 183 PolicyEngine program surfaces tracked
- 4 wired by current legal-ID mappings
- 78 pending RuleSpec encoding
- 99 deferred to jurisdictions outside current priority wiring
- 1 input-only
- 1 PolicyEngine in-progress
- 177 pending/deferred surfaces for the new fail gate

The first pending national surfaces are `state_income_tax`, `wic`, `free_school_meals`, `csfp`, `medicaid`, `chip`, and `aca_ptc`.

## Validation

- `uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::TestCmdValidate::test_oracle_coverage_fail_on_pending_program_surfaces_exits_nonzero tests/test_policyengine_coverage.py`
- `uv run --with ruff ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/registry.py src/axiom_encode/cli.py tests/test_policyengine_coverage.py tests/test_cli.py`
- `uv run --with ruff ruff format --check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/registry.py src/axiom_encode/cli.py tests/test_policyengine_coverage.py tests/test_cli.py`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --include-program-surfaces --limit 8`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --include-program-surfaces --fail-on-pending-program-surfaces --limit 5` exits 1 as expected while pending surfaces remain.
