### PR TITLE
Require comparable mappings for PE surface wiring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.755"
+version = "0.2.756"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.755"
+__version__ = "0.2.756"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -622,7 +622,8 @@ def _program_surface_item_from_payload(
     variable = str(payload["variable"])
     country = str(payload.get("country") or "us")
     mappings = registry.mappings_for_policyengine_variable(variable, country=country)
-    axiom_status = "wired" if mappings else str(payload["axiom_status"])
+    comparable_mapping_count = sum(1 for mapping in mappings if mapping.comparable)
+    axiom_status = "wired" if comparable_mapping_count else str(payload["axiom_status"])
     return PolicyEngineProgramSurfaceItem(
         country=country,
         program_id=str(payload["program_id"]),
@@ -638,7 +639,7 @@ def _program_surface_item_from_payload(
         priority=payload.get("priority"),
         rationale=payload.get("rationale"),
         mapping_count=len(mappings),
-        comparable_mapping_count=sum(1 for mapping in mappings if mapping.comparable),
+        comparable_mapping_count=comparable_mapping_count,
         legal_ids=tuple(mapping.legal_id for mapping in mappings),
     )
 

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -121,6 +121,16 @@ surfaces:
     priority: P1
     rationale: Needs RuleSpec encoding.
   - country: us
+    program_id: payroll_taxes
+    program_name: Payroll taxes
+    category: Taxes
+    policyengine_status: complete
+    coverage: US
+    variable: employee_payroll_tax
+    axiom_status: pending_rulespec_encoding
+    priority: P1
+    rationale: Non-comparable registry mappings should not mark this wired.
+  - country: us
     program_id: fdpir
     program_name: FDPIR
     category: Benefits
@@ -136,17 +146,23 @@ surfaces:
 
     report = build_policyengine_program_surface_report(manifest_path=manifest)
 
-    assert report["total_surfaces"] == 3
+    assert report["total_surfaces"] == 4
     assert report["status_counts"] == {
         "input_only": 1,
-        "pending_rulespec_encoding": 1,
+        "pending_rulespec_encoding": 2,
         "wired": 1,
     }
-    assert report["pending_surfaces"] == 1
+    assert report["pending_surfaces"] == 2
     items_by_variable = {item["variable"]: item for item in report["items"]}
     assert items_by_variable["income_tax"]["axiom_status"] == "wired"
     assert items_by_variable["income_tax"]["mapping_count"] >= 1
     assert items_by_variable["wic"]["axiom_status"] == "pending_rulespec_encoding"
+    assert (
+        items_by_variable["employee_payroll_tax"]["axiom_status"]
+        == "pending_rulespec_encoding"
+    )
+    assert items_by_variable["employee_payroll_tax"]["mapping_count"] >= 1
+    assert items_by_variable["employee_payroll_tax"]["comparable_mapping_count"] == 0
     assert items_by_variable["fdpir"]["axiom_status"] == "input_only"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.755"
+version = "0.2.756"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- Requires at least one comparable PolicyEngine registry mapping before a PE program surface is classified as `wired`.
- Keeps adjacent/non-comparable registry mentions visible through `mapping_count`, but no longer treats them as parity wiring.
- Adds a regression case using `employee_payroll_tax`, which currently has only non-comparable registry mappings.
- Bumps `axiom-encode` to `0.2.756`.

## Effect

The live PE-US program-surface report changes from:

- `wired=4`, `pending_rulespec_encoding=78`, `pending=177`

to:

- `wired=2`, `pending_rulespec_encoding=80`, `pending=179`

`employee_payroll_tax` and `snap` correctly move back to pending because their current PE-variable mentions are non-comparable mappings.

## Validation

- `uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py::test_policyengine_program_surface_report_overlays_legal_registry`
- `uv run --with ruff ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/oracles/policyengine/coverage.py tests/test_policyengine_coverage.py`
- `uv run --with ruff ruff format --check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/oracles/policyengine/coverage.py tests/test_policyengine_coverage.py`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --include-program-surfaces --limit 8`
