### PR TITLE
Classify aggregate PE program surfaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.756"
+version = "0.2.757"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.756"
+__version__ = "0.2.757"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -27,10 +27,11 @@ surfaces:
   coverage: US
   variable: state_income_tax
   source_type: program
-  axiom_status: pending_rulespec_encoding
-  priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  axiom_status: out_of_scope
+  priority: P2
+  rationale: PolicyEngine's state_income_tax is a cross-jurisdiction aggregation over state-specific income tax laws, refundable credits,
+    and reported-state-tax simulation fallback. It is not itself a single legal provision for RuleSpec legal-ID wiring; compare Axiom
+    against individually encoded state tax variables and component legal outputs instead.
 - country: us
   program_id: payroll_taxes
   program_name: Payroll taxes
@@ -40,10 +41,11 @@ surfaces:
   coverage: US
   variable: employee_payroll_tax
   source_type: program
-  axiom_status: pending_rulespec_encoding
-  priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  axiom_status: out_of_scope
+  priority: P2
+  rationale: PolicyEngine's employee_payroll_tax aggregates federal employee Social Security, Medicare, additional Medicare, and state
+    employee payroll tax components. Axiom should compare the encoded federal and state components separately rather than claiming a
+    one-to-one RuleSpec legal ID for this aggregate.
 - country: us
   program_id: snap
   program_name: SNAP
@@ -53,10 +55,11 @@ surfaces:
   coverage: US
   variable: snap
   source_type: program
-  axiom_status: pending_rulespec_encoding
-  priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  axiom_status: out_of_scope
+  priority: P2
+  rationale: PolicyEngine's snap variable is a final simulation benefit surface that can apply reported SNAP, take-up, emergency
+    allotments, and local add-ons. RuleSpec should wire exact SNAP legal outputs such as eligibility, normal allotment, deductions,
+    and state-set parameters instead of this simulation aggregate.
 - country: us
   program_id: wic
   program_name: WIC
@@ -66,10 +69,10 @@ surfaces:
   coverage: US
   variable: wic
   source_type: program
-  axiom_status: pending_rulespec_encoding
-  priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  axiom_status: out_of_scope
+  priority: P2
+  rationale: PolicyEngine's wic variable combines eligibility, take-up, and modeled package values. RuleSpec should encode and compare
+    the governing WIC eligibility and benefit-value parameters separately when those sources are ingested.
 - country: us
   program_id: school_meals
   program_name: Free and reduced school meals
@@ -79,10 +82,10 @@ surfaces:
   coverage: US
   variable: free_school_meals
   source_type: program
-  axiom_status: pending_rulespec_encoding
-  priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  axiom_status: out_of_scope
+  priority: P2
+  rationale: PolicyEngine's free_school_meals variable is a modeled annual value from school meal tier and net subsidy assumptions,
+    not a single legal provision. RuleSpec should compare eligibility tiers and subsidy parameters separately.
 - country: us
   program_id: csfp
   program_name: Commodity Supplemental Food Program
@@ -92,10 +95,10 @@ surfaces:
   coverage: US
   variable: csfp
   source_type: program
-  axiom_status: pending_rulespec_encoding
-  priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  axiom_status: out_of_scope
+  priority: P2
+  rationale: PolicyEngine's CSFP program variable combines eligibility with a modeled annual food-package value parameter. RuleSpec
+    should encode and compare CSFP eligibility and amount parameters separately when source text is available.
 - country: us
   program_id: fdpir
   program_name: FDPIR
@@ -117,10 +120,11 @@ surfaces:
   coverage: US
   variable: medicaid
   source_type: program
-  axiom_status: pending_rulespec_encoding
-  priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  axiom_status: out_of_scope
+  priority: P2
+  rationale: PolicyEngine's medicaid variable reports modeled coverage value through medicaid_cost, not a direct statutory cash
+    benefit or eligibility output. RuleSpec should compare Medicaid eligibility categories, income limits, and state-set parameters
+    separately.
 - country: us
   program_id: chip
   program_name: CHIP
@@ -130,10 +134,10 @@ surfaces:
   coverage: US
   variable: chip
   source_type: program
-  axiom_status: pending_rulespec_encoding
-  priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  axiom_status: out_of_scope
+  priority: P2
+  rationale: PolicyEngine's chip variable reports modeled per-capita CHIP value for eligible people, not a one-to-one legal provision.
+    RuleSpec should compare CHIP eligibility categories, income limits, and state-set parameters separately.
 - country: us
   program_id: aca_subsidies
   program_name: ACA subsidies

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -127,9 +127,9 @@ surfaces:
     policyengine_status: complete
     coverage: US
     variable: employee_payroll_tax
-    axiom_status: pending_rulespec_encoding
+    axiom_status: out_of_scope
     priority: P1
-    rationale: Non-comparable registry mappings should not mark this wired.
+    rationale: Aggregate surface should not be treated as direct RuleSpec work.
   - country: us
     program_id: fdpir
     program_name: FDPIR
@@ -149,18 +149,16 @@ surfaces:
     assert report["total_surfaces"] == 4
     assert report["status_counts"] == {
         "input_only": 1,
-        "pending_rulespec_encoding": 2,
+        "out_of_scope": 1,
+        "pending_rulespec_encoding": 1,
         "wired": 1,
     }
-    assert report["pending_surfaces"] == 2
+    assert report["pending_surfaces"] == 1
     items_by_variable = {item["variable"]: item for item in report["items"]}
     assert items_by_variable["income_tax"]["axiom_status"] == "wired"
     assert items_by_variable["income_tax"]["mapping_count"] >= 1
     assert items_by_variable["wic"]["axiom_status"] == "pending_rulespec_encoding"
-    assert (
-        items_by_variable["employee_payroll_tax"]["axiom_status"]
-        == "pending_rulespec_encoding"
-    )
+    assert items_by_variable["employee_payroll_tax"]["axiom_status"] == "out_of_scope"
     assert items_by_variable["employee_payroll_tax"]["mapping_count"] >= 1
     assert items_by_variable["employee_payroll_tax"]["comparable_mapping_count"] == 0
     assert items_by_variable["fdpir"]["axiom_status"] == "input_only"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.756"
+version = "0.2.757"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- classify PE aggregate/value surfaces as `out_of_scope` for direct RuleSpec legal-ID wiring:
  - `state_income_tax`
  - `employee_payroll_tax`
  - `snap`
  - `wic`
  - `free_school_meals`
  - `csfp`
  - `medicaid`
  - `chip`
- keep ACA PTC pending because it is a real direct policy surface, but current corpus evidence is missing IRC section 36B
- update the coverage overlay regression test for out-of-scope surfaces with non-comparable mappings

## Why

These PE variables are final simulation aggregates, modeled values, costs, take-up/reported-data surfaces, or cross-jurisdiction aggregates. Axiom should compare the underlying statutory/legal outputs and state-set parameters instead of pretending these aggregate PE variables have a single RuleSpec legal ID.

Filed the ACA PTC corpus blocker separately: TheAxiomFoundation/axiom-corpus#108.

## Validation

- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py::test_policyengine_program_surface_report_overlays_legal_registry`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py -k 'oracle_coverage_fail_on_pending_program_surfaces_exits_nonzero or current_encoder_affecting_changes_are_behind_version_bump'`
- `uv run --with ruff ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/registry.py`
- `uv run --with ruff ruff format --check tests/test_policyengine_coverage.py`
- `uv run axiom-encode oracle-coverage --root /tmp/axiom-pe-workspace --include-program-surfaces --limit 20`

Latest isolated coverage report after this change:

- executable outputs: 12,317
- comparable: 334
- known_not_comparable: 11,983
- untested comparable outputs: 0
- PE program surfaces: 183
- statuses: deferred_jurisdiction=99, input_only=1, out_of_scope=8, pe_in_progress=1, pending_rulespec_encoding=72, wired=2
