### PR TITLE
Track encoded TANF surfaces as oracle-mapping work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.757"
+version = "0.2.758"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.757"
+__version__ = "0.2.758"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -175,10 +175,11 @@ surfaces:
   variable: co_tanf
   source_type: state_implementation
   state: CO
-  axiom_status: pending_rulespec_encoding
+  axiom_status: pending_oracle_mapping
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Current RuleSpec repos include tested Colorado Works basic-cash-assistance, earned-income-disregard, grant-standard,
+    and time-limit legal slices. Remaining parity work is an oracle adapter or PE surface alignment for the same monthly legal
+    boundaries, not initial RuleSpec encoding.
 - country: us
   program_id: tanf
   program_name: DC TANF
@@ -315,10 +316,11 @@ surfaces:
   variable: az_tanf
   source_type: state_implementation
   state: AZ
-  axiom_status: pending_rulespec_encoding
+  axiom_status: pending_oracle_mapping
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Current RuleSpec repos include tested Arizona Cash Assistance payment-standard, needy-family, benefit-determination,
+    earned-income-deduction, and resource/income legal slices. Remaining parity work is a direct oracle adapter for PE's Arizona
+    TANF surface and helper boundaries, not initial RuleSpec encoding.
 - country: us
   program_id: tanf
   program_name: Oklahoma TANF

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.757"
+version = "0.2.758"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- relabel Colorado and Arizona TANF program surfaces from `pending_rulespec_encoding` to `pending_oracle_mapping`
- document that current RuleSpec repos already contain tested state-law TANF slices, while PE parity still needs oracle adapters / surface alignment
- bump `axiom-encode` to `0.2.758`

## Related PE issues filed during sweep
- PolicyEngine/policyengine-us#8688: Colorado CCAP SMI eligibility should include income equal to 85% SMI
- PolicyEngine/policyengine-us#8687: Colorado CCAP entry eligibility should include the CCDF asset limit

## Validation
- `uv run ruff check src/axiom_encode/__init__.py src/axiom_encode/oracles/policyengine`
- `uv run python - <<'PY' ... yaml.safe_load(...) ... PY`
- `uv run axiom-encode oracle-coverage --root /tmp/axiom-next-pe-workspace --include-program-surfaces --limit 30`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py tests/test_policyengine_coverage_monorepo.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py -k "oracle_coverage"`

Note: `uv run pytest ...` hits a broken global `/Users/maxghenis/bin/pytest` shim, so targeted tests were run through `python -m pytest` with pytest/pytest-cov supplied by uv.
