### PR TITLE
Harden delegated policy repair apply path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.758"
+version = "0.2.759"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.758"
+__version__ = "0.2.759"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -8420,6 +8420,9 @@ def cmd_repair_delegated_policy_settings(args):
         print("No delegated policy setting repairs found.")
         return
 
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+
     generated_result = argparse.Namespace(
         output_file=str(rules_file),
         runner=repo_path.name,
@@ -8474,9 +8477,6 @@ def cmd_repair_delegated_policy_settings(args):
         for issue in after_issues:
             print(f"- {issue}")
         sys.exit(1)
-
-    signing_key = _require_applied_encoding_manifest_signing_key()
-    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
 
     with tempfile.TemporaryDirectory() as tmpdir:
         output_root = Path(tmpdir)
@@ -20642,8 +20642,9 @@ def _try_repair_generated_embedded_scalar_literals_for_apply(
     rules_file = Path(str(getattr(result, "output_file", "") or ""))
     if not rules_file.exists():
         return []
+    original_content = rules_file.read_text()
     try:
-        payload = yaml.safe_load(rules_file.read_text()) or {}
+        payload = yaml.safe_load(original_content) or {}
     except (OSError, yaml.YAMLError):
         return []
     if not isinstance(payload, dict):
@@ -21156,8 +21157,9 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
     rules_file = Path(str(getattr(result, "output_file", "") or ""))
     if not rules_file.exists():
         return []
+    original_content = rules_file.read_text()
     try:
-        payload = yaml.safe_load(rules_file.read_text()) or {}
+        payload = yaml.safe_load(original_content) or {}
     except (OSError, yaml.YAMLError):
         return []
     if not isinstance(payload, dict):
@@ -21305,6 +21307,24 @@ def _try_repair_generated_delegated_policy_settings_for_apply(
 
     if not source_relation_additions and not wrapper_additions and not repaired:
         return []
+    import_only_repair = (
+        not source_relation_additions
+        and not wrapper_additions
+        and all(item.startswith("import:") for item in repaired)
+    )
+    if import_only_repair:
+        import_targets = [
+            item.removeprefix("import:")
+            for item in repaired
+            if item.removeprefix("import:").strip()
+        ]
+        preserved_content = _add_rulespec_imports_preserving_content(
+            original_content,
+            import_targets,
+        )
+        if preserved_content is not None:
+            rules_file.write_text(preserved_content)
+            return repaired
 
     insert_at = 0
     while insert_at < len(rules):
@@ -21481,6 +21501,60 @@ def _ensure_rulespec_payload_import(payload: dict[str, Any], target: str) -> boo
         return False
     imports.append(import_target)
     return True
+
+
+def _add_rulespec_imports_preserving_content(
+    content: str,
+    import_targets: list[str],
+) -> str | None:
+    unique_targets = _ordered_unique_strings(
+        [target.strip() for target in import_targets if target.strip()]
+    )
+    if not unique_targets:
+        return content
+    try:
+        payload = yaml.safe_load(content) or {}
+    except yaml.YAMLError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    imports = payload.get("imports")
+    existing_imports = (
+        {
+            str(item).split("#", 1)[0].strip()
+            for item in imports
+            if isinstance(item, str)
+        }
+        if isinstance(imports, list)
+        else set()
+    )
+    missing = [target for target in unique_targets if target not in existing_imports]
+    if not missing:
+        return content
+
+    lines = content.splitlines()
+    import_line = next(
+        (
+            index
+            for index, line in enumerate(lines)
+            if line.strip() == "imports:" and not line.startswith((" ", "\t"))
+        ),
+        None,
+    )
+    rendered = [f"  - {target}" for target in missing]
+    if import_line is None:
+        suffix = "\n" if content.endswith("\n") else "\n"
+        return f"{content}{suffix}imports:\n" + "\n".join(rendered) + "\n"
+
+    insert_at = import_line + 1
+    while insert_at < len(lines):
+        line = lines[insert_at]
+        if line.startswith((" ", "\t")) or not line.strip():
+            insert_at += 1
+            continue
+        break
+    next_lines = [*lines[:insert_at], *rendered, *lines[insert_at:]]
+    return "\n".join(next_lines) + ("\n" if content.endswith("\n") else "")
 
 
 def _rulespec_rule_kind(rule: dict[str, Any] | None) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5532,22 +5532,22 @@ rules:
         rules_file.write_text(
             """format: rulespec/v1
 rules:
-- name: sets_snap_standard_utility_allowance
-  kind: source_relation
-  source_relation:
-    type: sets
-    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
-    value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
-    basis:
-      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
-- name: snap_standard_utility_allowance
-  kind: derived
-  entity: Household
-  dtype: Money
-  period: Month
-  versions:
-  - effective_from: '2025-10-01'
-    formula: '594'
+  - name: sets_snap_standard_utility_allowance
+    kind: source_relation
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  - name: snap_standard_utility_allowance
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: '594'
 """
         )
         result = SimpleNamespace(output_file=rules_file, runner="runner")
@@ -11486,22 +11486,22 @@ rules:
 module:
   summary: Colorado SNAP household utility allowance standards.
 rules:
-- name: sets_snap_standard_utility_allowance
-  kind: source_relation
-  source_relation:
-    type: sets
-    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
-    value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
-    basis:
-      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
-- name: snap_standard_utility_allowance
-  kind: derived
-  entity: Household
-  dtype: Money
-  period: Month
-  versions:
-  - effective_from: '2025-10-01'
-    formula: '594'
+  - name: sets_snap_standard_utility_allowance
+    kind: source_relation
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  - name: snap_standard_utility_allowance
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: '594'
 """
         )
         args = SimpleNamespace(
@@ -11583,22 +11583,22 @@ rules:
 module:
   summary: Colorado SNAP household utility allowance standards.
 rules:
-- name: sets_snap_standard_utility_allowance
-  kind: source_relation
-  source_relation:
-    type: sets
-    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
-    value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
-    basis:
-      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
-- name: snap_standard_utility_allowance
-  kind: derived
-  entity: Household
-  dtype: Money
-  period: Month
-  versions:
-  - effective_from: '2025-10-01'
-    formula: '594'
+  - name: sets_snap_standard_utility_allowance
+    kind: source_relation
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+  - name: snap_standard_utility_allowance
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: '594'
 """
         )
         args = SimpleNamespace(
@@ -11635,6 +11635,9 @@ rules:
             "us-co/regulations/10-ccr-2506-1/4.407.31.yaml: "
             "import:us:regulations/7-cfr/273/9"
         ) in output
+        assert "\nrules:\n  - name: sets_snap_standard_utility_allowance" in (
+            rules_file.read_text()
+        )
         payload = yaml.safe_load(rules_file.read_text())
         assert payload["imports"] == ["us:regulations/7-cfr/273/9"]
         assert [rule["name"] for rule in payload["rules"]] == [
@@ -11653,6 +11656,103 @@ rules:
         assert (
             manifest_payload["tool"] == "axiom-encode repair-delegated-policy-settings"
         )
+
+    def test_repair_delegated_policy_settings_requires_signing_key_before_mutating(
+        self, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us"
+        federal_file = repo / "us" / "regulations" / "7-cfr" / "273" / "9.yaml"
+        federal_file.parent.mkdir(parents=True)
+        federal_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: snap_state_standard_utility_allowance_delegation
+  kind: source_relation
+  source_relation:
+    type: delegates
+    target: us:regulations/7-cfr/273/9#snap_utility_allowance_for_shelter_costs
+    authority: federal
+- name: snap_standard_utility_allowance_state_option
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '0'
+"""
+        )
+        rules_file = repo / "us-ga" / "policies" / "dfcs" / "snap" / "3617.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: Georgia SNAP utility allowances.
+rules:
+- name: sets_snap_standard_utility_allowance
+  kind: source_relation
+  source_relation:
+    type: sets
+    target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+    value: us-ga:policies/dfcs/snap/3617#snap_standard_utility_allowance
+    basis:
+      delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+- name: snap_standard_utility_allowance
+  kind: derived
+  entity: Household
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '2025-10-01'
+    formula: '405'
+"""
+        )
+        original = rules_file.read_text()
+        args = SimpleNamespace(
+            repo=repo,
+            file=Path("us-ga/policies/dfcs/snap/3617.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == rules_file.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(
+                    all_passed=False,
+                    results={
+                        "compile": SimpleNamespace(
+                            error=(
+                                "RuleSpec source relation "
+                                "`sets_snap_standard_utility_allowance` sets target "
+                                "`us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option`, "
+                                "but the target does not resolve to an executable "
+                                "parameter or derived rule in the merged program"
+                            )
+                        )
+                    },
+                )
+
+        provenance = MagicMock()
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                provenance,
+            ),
+            patch.dict(os.environ, {APPLIED_ENCODING_SIGNING_KEY_ENV: ""}),
+            pytest.raises(RuntimeError, match=APPLIED_ENCODING_SIGNING_KEY_ENV),
+        ):
+            cmd_repair_delegated_policy_settings(args)
+
+        provenance.assert_not_called()
+        assert rules_file.read_text() == original
+        assert not (
+            repo / ".axiom/encoding-manifests/us-ga/policies/dfcs/snap/3617.json"
+        ).exists()
 
     def test_repair_bare_snapunit_entities_uses_module_summary_context(
         self, capsys, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.758"
+version = "0.2.759"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- require signing key and clean encoder provenance before delegated policy setting repair mutates RuleSpec files
- preserve existing RuleSpec YAML formatting for import-only delegated repairs
- add regression coverage for missing signing key and monorepo delegated import repairs

## Validation
- `uv run ruff check src/axiom_encode/__init__.py src/axiom_encode/cli.py tests/test_cli.py`
- `uv run ruff format --check src/axiom_encode/__init__.py src/axiom_encode/cli.py tests/test_cli.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py -k delegated_policy_settings`

## Follow-up
This is needed before committing the generated Georgia SNAP repair in `rulespec-us`, whose manifest references encoder commit `259a78c483b9cefb3a4cb43db6913513ffdd700c`.
