### PR TITLE
Add Georgia CMS Medicaid availability repair

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.759"
+version = "0.2.760"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.759"
+__version__ = "0.2.760"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1513,6 +1513,25 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_ga_cms_parser = subparsers.add_parser(
+        "repair-georgia-cms-medicaid-availability",
+        help="Apply signed deterministic Georgia CMS Medicaid availability repairs",
+    )
+    repair_ga_cms_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="rulespec-us repository root used for manifest signing",
+    )
+    repair_ga_cms_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_ny_snap_categorical_parser = subparsers.add_parser(
         "repair-new-york-snap-categorical-eligibility",
         help="Apply signed deterministic repairs for New York SNAP categorical eligibility",
@@ -2186,6 +2205,8 @@ def main():
         cmd_repair_snap_273_10_allotment(args)
     elif args.command == "repair-snap-273-9-income-eligibility":
         cmd_repair_snap_273_9_income_eligibility(args)
+    elif args.command == "repair-georgia-cms-medicaid-availability":
+        cmd_repair_georgia_cms_medicaid_availability(args)
     elif args.command == "repair-new-york-snap-categorical-eligibility":
         cmd_repair_new_york_snap_categorical_eligibility(args)
     elif args.command == "repair-new-york-snap-benefit-tests":
@@ -6772,6 +6793,273 @@ def cmd_repair_snap_273_9_income_eligibility(args):
         )
 
     print("Applied 7 CFR 273.9 income-eligibility repair")
+    print(f"changed={relative_output}")
+    print(f"changed={_rulespec_test_path(relative_output)}")
+    print(f"manifest={manifest_path}")
+
+
+GEORGIA_CMS_MEDICAID_RELATIVE = Path(
+    "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml"
+)
+GEORGIA_CMS_MEDICAID_CITATION = (
+    "us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels"
+)
+
+
+GEORGIA_CMS_MEDICAID_AVAILABILITY_RULES = (
+    {
+        "name": "georgia_parent_caretaker_standard_uses_dollar_amounts",
+        "source": (
+            "CMS Medicaid, CHIP and BHP Eligibility Levels table, "
+            "Georgia row and dollar-amount footnote"
+        ),
+        "column": "Adults (Medicaid) Parent/Caretaker",
+        "excerpt": "28%($)",
+        "formula": "true",
+        "test_value": "true",
+    },
+    {
+        "name": "georgia_pregnant_women_chip_available",
+        "source": "CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row",
+        "column": "Pregnant Women CHIP",
+        "excerpt": "N/A",
+        "formula": "false",
+        "test_value": "false",
+    },
+    {
+        "name": "georgia_adult_medicaid_expansion_available",
+        "source": "CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row",
+        "column": "Adults (Medicaid) Expansion to Adults",
+        "excerpt": "No",
+        "formula": "false",
+        "test_value": "false",
+    },
+)
+
+
+def _rulespec_rule_names(content: str) -> set[str]:
+    try:
+        payload = yaml.safe_load(content) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return set()
+    if not isinstance(payload, dict):
+        return set()
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return set()
+    return {
+        str(rule.get("name") or "").strip()
+        for rule in rules
+        if isinstance(rule, dict) and str(rule.get("name") or "").strip()
+    }
+
+
+def _georgia_cms_medicaid_availability_rule_block(rule: dict[str, str]) -> str:
+    return f"""  - name: {rule["name"]}
+    kind: parameter
+    dtype: Boolean
+    source: {rule["source"]}
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "{rule["excerpt"]}"
+              table:
+                header: State Medicaid, CHIP and BHP Income Eligibility Standards
+                row: Georgia
+                column: {rule["column"]}
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          {rule["formula"]}
+"""
+
+
+def _repair_georgia_cms_medicaid_availability_rules(
+    content: str,
+) -> tuple[str, list[str]]:
+    existing = _rulespec_rule_names(content)
+    missing = [
+        rule
+        for rule in GEORGIA_CMS_MEDICAID_AVAILABILITY_RULES
+        if rule["name"] not in existing
+    ]
+    if not missing:
+        return content, []
+
+    repaired = content.rstrip() + "\n\n"
+    repaired += "\n".join(
+        _georgia_cms_medicaid_availability_rule_block(rule).rstrip() for rule in missing
+    )
+    repaired += "\n"
+    return repaired, [rule["name"] for rule in missing]
+
+
+def _repair_georgia_cms_medicaid_availability_tests(
+    content: str,
+) -> tuple[str, list[str]]:
+    missing = [
+        rule
+        for rule in GEORGIA_CMS_MEDICAID_AVAILABILITY_RULES
+        if f"{GEORGIA_CMS_MEDICAID_CITATION}#{rule['name']}" not in content
+    ]
+    if not missing:
+        return content, []
+
+    repaired = content.rstrip() + "\n"
+    for rule in missing:
+        repaired += (
+            f"    {GEORGIA_CMS_MEDICAID_CITATION}#{rule['name']}: "
+            f"{rule['test_value']}\n"
+        )
+    return repaired, [rule["name"] for rule in missing]
+
+
+def cmd_repair_georgia_cms_medicaid_availability(args):
+    """Apply signed deterministic Georgia CMS availability marker repairs."""
+    repo_path = Path(args.repo).resolve()
+    if _repo_jurisdiction_prefix(repo_path) != "us":
+        print(
+            "repair-georgia-cms-medicaid-availability must run against "
+            f"rulespec-us; got {repo_path}"
+        )
+        sys.exit(1)
+
+    relative_output = GEORGIA_CMS_MEDICAID_RELATIVE
+    rules_file = repo_path / relative_output
+    test_file = _rulespec_test_path(rules_file)
+    if not rules_file.exists():
+        print(f"RuleSpec file not found: {rules_file}")
+        sys.exit(1)
+    if not test_file.exists():
+        print(f"RuleSpec companion test file not found: {test_file}")
+        sys.exit(1)
+
+    original_content = rules_file.read_text()
+    original_test_content = test_file.read_text()
+    repaired_content, repaired_rules = _repair_georgia_cms_medicaid_availability_rules(
+        original_content
+    )
+    repaired_test_content, repaired_tests = (
+        _repair_georgia_cms_medicaid_availability_tests(original_test_content)
+    )
+    applied_files = [rules_file, test_file]
+    axiom_encode_git = None
+
+    if (
+        repaired_content == original_content
+        and repaired_test_content == original_test_content
+    ):
+        manifest_path = repo_path / _applied_encoding_manifest_path(relative_output)
+        if manifest_path.exists():
+            current_hashes = {
+                file.relative_to(repo_path).as_posix(): _sha256_file(file)
+                for file in applied_files
+            }
+            payload = json.loads(manifest_path.read_text())
+            manifest_hashes = {
+                item.get("path"): item.get("sha256")
+                for item in payload.get("applied_files", [])
+                if isinstance(item, dict)
+            }
+            if all(
+                manifest_hashes.get(path) == sha for path, sha in current_hashes.items()
+            ):
+                axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+                if (
+                    payload.get("axiom_encode_version") == __version__
+                    and payload.get("axiom_encode_git") == axiom_encode_git
+                ):
+                    print("No Georgia CMS Medicaid availability repairs found.")
+                    return
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    if axiom_encode_git is None:
+        axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+    _ensure_no_unmanifested_preexisting_rulespec_changes(
+        repo_path,
+        [(relative_output, applied_files)],
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        generated_output = output_root / "deterministic-repair" / relative_output
+        generated_output.parent.mkdir(parents=True, exist_ok=True)
+        generated_output.write_text(repaired_content)
+        generated_test = _rulespec_test_path(generated_output)
+        generated_test.write_text(repaired_test_content)
+
+        rules_file.write_text(repaired_content)
+        test_file.write_text(repaired_test_content)
+
+        try:
+            validation = ValidatorPipeline(
+                policy_repo_path=repo_path,
+                axiom_rules_path=axiom_rules_path,
+                enable_oracles=False,
+                require_policy_proofs=True,
+            ).validate(rules_file, skip_reviewers=True)
+            if not validation.all_passed:
+                issues = [
+                    result.error
+                    for result in validation.results.values()
+                    if result.error
+                ]
+                print("Repair failed validation; restored original files.")
+                for issue in issues:
+                    print(f"- {issue}")
+                sys.exit(1)
+
+            test_failures = _rulespec_companion_test_failures(
+                test_file,
+                root=repo_path,
+                axiom_rules_path=axiom_rules_path,
+            )
+            if test_failures:
+                print("Repair failed companion tests; restored original files.")
+                for failure in test_failures[:20]:
+                    case_name = failure.get("case") or "<unknown case>"
+                    print(f"- {case_name}: {failure.get('message')}")
+                sys.exit(1)
+        finally:
+            validation_passed = "validation" in locals() and validation.all_passed
+            tests_passed = "test_failures" in locals() and not test_failures
+            if not validation_passed or not tests_passed:
+                rules_file.write_text(original_content)
+                test_file.write_text(original_test_content)
+
+        result = argparse.Namespace(
+            output_file=str(generated_output),
+            runner="deterministic-repair",
+            backend="deterministic",
+            model="georgia-cms-medicaid-availability-v1",
+            tool="axiom-encode repair-georgia-cms-medicaid-availability",
+            citation=GEORGIA_CMS_MEDICAID_CITATION,
+            generation_prompt_sha256=None,
+            trace_file=None,
+            context_manifest_file=None,
+        )
+        manifest_path = _write_applied_encoding_manifest(
+            result,
+            output_root=output_root,
+            policy_repo_path=repo_path,
+            relative_output=relative_output,
+            applied_files=applied_files,
+            run_id="deterministic-repair",
+            signing_key=signing_key,
+            axiom_encode_git=axiom_encode_git,
+        )
+
+    changed_names = sorted(set(repaired_rules) | set(repaired_tests))
+    print("Applied Georgia CMS Medicaid availability repair")
+    if changed_names:
+        print(f"changed_rules={', '.join(changed_names)}")
     print(f"changed={relative_output}")
     print(f"changed={_rulespec_test_path(relative_output)}")
     print(f"manifest={manifest_path}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -155,6 +155,7 @@ from axiom_encode.cli import (
     cmd_repair_current_year_final_amounts,
     cmd_repair_delegated_policy_settings,
     cmd_repair_embedded_scalar_literals,
+    cmd_repair_georgia_cms_medicaid_availability,
     cmd_repair_imported_test_inputs,
     cmd_repair_invalid_test_inputs,
     cmd_repair_judgment_positive_tests,
@@ -20238,6 +20239,191 @@ rules:
         assert payload["axiom_encode_version"] == AXIOM_ENCODE_TEST_VERSION
         assert payload["axiom_encode_git"] == current_git
         assert payload["tool"] == "axiom-encode repair-snap-273-9-income-eligibility"
+
+    def test_repair_georgia_cms_medicaid_availability_writes_signed_manifest(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = (
+            policy_repo
+            / "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml"
+        )
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+  summary: |-
+    Georgia row: Pregnant Women CHIP N/A; Adults (Medicaid) Parent/Caretaker 28%($); Adults (Medicaid) Expansion to Adults No.
+rules:
+  - name: georgia_parent_caretaker_adults_medicaid_fpl_limit
+    kind: parameter
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: table_cell
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              table:
+                header: State Medicaid, CHIP and BHP Income Eligibility Standards
+                row: Georgia
+                column: Adults (Medicaid) Parent/Caretaker
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          0.28
+"""
+        )
+        test_file = (
+            policy_repo
+            / "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml"
+        )
+        test_file.write_text(
+            """- name: georgia_magi_eligibility_level_parameters_as_of_december_2023
+  period:
+    period_kind: custom
+    name: day
+    start: '2023-12-01'
+    end: '2023-12-01'
+  input: {}
+  output:
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_parent_caretaker_adults_medicaid_fpl_limit: 0.28
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures",
+                return_value=[],
+            ),
+            patch(
+                "axiom_encode.cli._ensure_no_unmanifested_preexisting_rulespec_changes"
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_georgia_cms_medicaid_availability(args)
+
+        rules_payload = yaml.safe_load(target.read_text())
+        rule_names = [rule["name"] for rule in rules_payload["rules"]]
+        assert "georgia_parent_caretaker_standard_uses_dollar_amounts" in rule_names
+        assert "georgia_pregnant_women_chip_available" in rule_names
+        assert "georgia_adult_medicaid_expansion_available" in rule_names
+        content = target.read_text()
+        assert 'excerpt: "28%($)"' in content
+        assert 'excerpt: "N/A"' in content
+        assert 'excerpt: "No"' in content
+        test_content = test_file.read_text()
+        assert (
+            "us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels"
+            "#georgia_parent_caretaker_standard_uses_dollar_amounts: true"
+        ) in test_content
+        assert (
+            "us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels"
+            "#georgia_pregnant_women_chip_available: false"
+        ) in test_content
+        assert (
+            "us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels"
+            "#georgia_adult_medicaid_expansion_available: false"
+        ) in test_content
+        manifest = (
+            policy_repo / ".axiom/encoding-manifests/us-ga/policies/cms/"
+            "georgia-medicaid-chip-bhp-eligibility-levels.json"
+        )
+        payload = json.loads(manifest.read_text())
+        assert payload["schema_version"] == APPLIED_ENCODING_MANIFEST_SCHEMA
+        assert payload["model"] == "georgia-cms-medicaid-availability-v1"
+        assert (
+            payload["tool"] == "axiom-encode repair-georgia-cms-medicaid-availability"
+        )
+        assert [applied_file["path"] for applied_file in payload["applied_files"]] == [
+            "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml",
+            "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml",
+        ]
+
+    def test_repair_georgia_cms_medicaid_availability_does_not_mutate_without_signing_key(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = (
+            policy_repo
+            / "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml"
+        )
+        target.parent.mkdir(parents=True)
+        original_rules = """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+rules:
+  - name: georgia_parent_caretaker_adults_medicaid_fpl_limit
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          0.28
+"""
+        target.write_text(original_rules)
+        test_file = (
+            policy_repo
+            / "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml"
+        )
+        original_tests = """- name: existing
+  output:
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_parent_caretaker_adults_medicaid_fpl_limit: 0.28
+"""
+        test_file.write_text(original_tests)
+        args = SimpleNamespace(
+            repo=policy_repo,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+        provenance = MagicMock()
+
+        with (
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                provenance,
+            ),
+            patch.dict(os.environ, {APPLIED_ENCODING_SIGNING_KEY_ENV: ""}),
+            pytest.raises(RuntimeError, match=APPLIED_ENCODING_SIGNING_KEY_ENV),
+        ):
+            cmd_repair_georgia_cms_medicaid_availability(args)
+
+        provenance.assert_not_called()
+        assert target.read_text() == original_rules
+        assert test_file.read_text() == original_tests
+        assert not (
+            policy_repo / ".axiom/encoding-manifests/us-ga/policies/cms/"
+            "georgia-medicaid-chip-bhp-eligibility-levels.json"
+        ).exists()
 
     def test_repair_snap_273_10_allotment_restores_files_when_validation_raises(
         self, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.759"
+version = "0.2.760"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a deterministic `repair-georgia-cms-medicaid-availability` command
- append the three missing Georgia CMS source-table marker outputs and companion tests through the signed encoder repair path
- bump axiom-encode to 0.2.760

## Tests
- `uv run ruff check src/axiom_encode/__init__.py src/axiom_encode/cli.py tests/test_cli.py`
- `uv run ruff format --check src/axiom_encode/__init__.py src/axiom_encode/cli.py tests/test_cli.py`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py -k georgia_cms_medicaid`
