### PR TITLE
Route repo-augmented context through content roots

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.762"
+version = "0.2.763"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.762"
+__version__ = "0.2.763"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -33,6 +33,8 @@ from axiom_encode.constants import DEFAULT_OPENAI_MODEL
 from axiom_encode.prompts.encoder import SOURCE_SCOPE_PROTOCOL
 from axiom_encode.repo_routing import (
     canonical_rulespec_repo_name,
+    find_policy_repo_root,
+    jurisdiction_content_dir,
     monorepo_alternative_path,
 )
 from axiom_encode.statute import (
@@ -2937,14 +2939,18 @@ def _repo_augmented_context_root(policy_path: Path) -> Path:
     if resolved.name == "axiom-rules-engine":
         fallback = resolved.parent / "rulespec-us"
         if fallback.exists():
-            return fallback
-    return resolved
+            return jurisdiction_content_dir(fallback, jurisdiction_prefix(fallback))
+    return jurisdiction_content_dir(resolved, jurisdiction_prefix(resolved))
 
 
 def _context_import_relative_target(source_path: Path, policy_path: Path) -> Path:
     """Prefer canonical repo-relative import targets for copied precedent files."""
     repo_parent = policy_path.parent.resolve()
     resolved_source = source_path.resolve()
+    source_policy_root = find_policy_repo_root(resolved_source)
+    if source_policy_root is not None:
+        with contextlib.suppress(ValueError):
+            return resolved_source.relative_to(source_policy_root.resolve())
 
     for candidate in sorted(repo_parent.glob("rulespec-*")):
         if not candidate.is_dir():

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -9021,6 +9021,48 @@ rules:
             copied_sources[str(context_test)]["kind"] == "implementation_test_context"
         )
 
+    def test_prepare_eval_workspace_adds_country_monorepo_child_context(self, tmp_path):
+        policy_repo_root = tmp_path / "rulespec-us"
+        child_root = policy_repo_root / "us" / "statutes" / "26" / "36B" / "b" / "3"
+        child_root.mkdir(parents=True)
+        child_file = child_root / "A.yaml"
+        child_file.write_text(
+            "format: rulespec/v1\n"
+            "rules:\n"
+            "  - name: applicable_percentage_income_tier\n"
+            "    kind: derived\n"
+            "    entity: TaxUnit\n"
+            "    dtype: Integer\n"
+            "    period: Year\n"
+            "    versions:\n"
+            "      - effective_from: '2024-01-01'\n"
+            "        formula: 0\n"
+        )
+
+        runner = parse_runner_spec("codex:gpt-5.4")
+        workspace = prepare_eval_workspace(
+            citation="26 USC 36B",
+            runner=runner,
+            output_root=tmp_path / "out",
+            source_text="Section 36B defines the premium assistance credit amount.",
+            axiom_rules_path=policy_repo_root,
+            mode="repo-augmented",
+            extra_context_paths=[],
+        )
+
+        manifest = json.loads(workspace.manifest_file.read_text())
+        copied_sources = {
+            item["source_path"]: item for item in manifest["context_files"]
+        }
+        assert copied_sources[str(child_file)]["kind"] == "implementation_precedent"
+        assert (
+            copied_sources[str(child_file)]["workspace_path"]
+            == "context/statutes/26/36B/b/3/A.yaml"
+        )
+        assert (
+            copied_sources[str(child_file)]["import_path"] == "us:statutes/26/36B/b/3/A"
+        )
+
     def test_prepare_eval_workspace_adds_plural_same_section_subsection_context(
         self, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.762"
+version = "0.2.763"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- route repo-augmented context selection through the jurisdiction content root, so unified country repos like `rulespec-us/us/...` provide existing child RuleSpecs to parent encodes
- derive copied context import targets relative to the jurisdiction content root, preserving imports such as `us:statutes/...` instead of `us:us/statutes/...`
- bump axiom-encode to 0.2.763

## Tests
- `uv run --with ruff ruff format src/ tests/`
- `uv run --with ruff ruff check src/ tests/`
- `git diff --check`
- `uv run --with pytest --with pytest-cov --with pytest-asyncio python -m pytest`
