### PR TITLE
Allow limited downstream outputs for amount helpers

### DIFF
--- a/changelog.d/aca-component-limitation-validator.fixed.md
+++ b/changelog.d/aca-component-limitation-validator.fixed.md
@@ -1,0 +1,1 @@
+Avoid flagging component amount helpers as uncapped when a downstream derived output applies the same source limitation through that helper.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.763"
+version = "0.2.764"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.763"
+__version__ = "0.2.764"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -12775,6 +12775,12 @@ def find_source_limitation_application_issues(content: str) -> list[str]:
             source_text=scoped_source_text,
         ):
             continue
+        if _formula_is_referenced_by_limited_downstream_formula(
+            name,
+            formula_by_name=formula_by_name,
+            source_text=scoped_source_text,
+        ):
+            continue
         issues.append(
             "Source limitation not applied: "
             f"`{name}` is a final amount-style output, but the same source text "
@@ -13933,6 +13939,28 @@ def _formula_or_referenced_helpers_implement_limitation(
             current_name=identifier,
             source_text=source_text,
             seen=visited,
+        ):
+            return True
+    return False
+
+
+def _formula_is_referenced_by_limited_downstream_formula(
+    name: str,
+    *,
+    formula_by_name: dict[str, str],
+    source_text: str,
+) -> bool:
+    """Return true when `name` is an intermediate used by a limited output."""
+    for downstream_name, downstream_formula in formula_by_name.items():
+        if downstream_name == name:
+            continue
+        if name not in _formula_local_identifiers(downstream_formula):
+            continue
+        if _formula_or_referenced_helpers_implement_limitation(
+            downstream_formula,
+            formula_by_name=formula_by_name,
+            current_name=downstream_name,
+            source_text=source_text,
         ):
             return True
     return False

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -19980,6 +19980,37 @@ rules:
     assert find_source_limitation_application_issues(content) == []
 
 
+def test_source_limitation_application_accepts_component_used_by_limited_output():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    The monthly premium assistance amount is the lesser of qualified health
+    plan monthly premiums or the excess of adjusted monthly premium over 1/12
+    of the applicable percentage times household income.
+rules:
+  - name: monthly_household_income_contribution_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: monthly_fraction * applicable_percentage * household_income
+  - name: premium_assistance_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(qualified_health_plan_monthly_premiums, max(0, adjusted_monthly_premium - monthly_household_income_contribution_amount))
+"""
+
+    assert find_source_limitation_application_issues(content) == []
+
+
 def test_source_limitation_application_scopes_subsection_special_rule():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.763"
+version = "0.2.764"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- allow source-limitation validation to recognize component amount helpers that are referenced by a downstream derived output applying the limitation
- add an ACA-style regression test for monthly contribution helpers feeding a capped premium assistance amount
- add changelog entry

## Tests
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_rulespec_validation.py -k source_limitation_application -q`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_rulespec_validation.py -q`
- `uv run --with pytest --with pytest-cov --with pytest-asyncio python -m pytest -q` (2151 passed, 22 skipped)
