### PR TITLE
Allow aggregate outputs to sum limited helpers

### DIFF
--- a/changelog.d/aggregate-limited-amount-validator.fixed.md
+++ b/changelog.d/aggregate-limited-amount-validator.fixed.md
@@ -1,0 +1,1 @@
+Allow source-limitation validation for aggregate outputs that sum locally limited amount helpers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.764"
+version = "0.2.765"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.764"
+__version__ = "0.2.765"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -12781,6 +12781,13 @@ def find_source_limitation_application_issues(content: str) -> list[str]:
             source_text=scoped_source_text,
         ):
             continue
+        if _formula_aggregates_limited_local_amount(
+            formula,
+            formula_by_name=formula_by_name,
+            current_name=name,
+            source_text=scoped_source_text,
+        ):
+            continue
         issues.append(
             "Source limitation not applied: "
             f"`{name}` is a final amount-style output, but the same source text "
@@ -13960,6 +13967,35 @@ def _formula_is_referenced_by_limited_downstream_formula(
             downstream_formula,
             formula_by_name=formula_by_name,
             current_name=downstream_name,
+            source_text=source_text,
+        ):
+            return True
+    return False
+
+
+def _formula_aggregates_limited_local_amount(
+    formula: str,
+    *,
+    formula_by_name: dict[str, str],
+    current_name: str,
+    source_text: str,
+) -> bool:
+    """Return true when an aggregate sums local amounts that apply a limit."""
+    if not re.search(r"\bsum(?:_where)?\s*\(", formula):
+        return False
+    normalized_formula = f"_{_normalize_identifier(formula)}_"
+    for helper_name, helper_formula in formula_by_name.items():
+        if helper_name == current_name:
+            continue
+        normalized_helper = _normalize_identifier(helper_name)
+        if not normalized_helper:
+            continue
+        if f"_{normalized_helper}_" not in normalized_formula:
+            continue
+        if _formula_or_referenced_helpers_implement_limitation(
+            helper_formula,
+            formula_by_name=formula_by_name,
+            current_name=helper_name,
             source_text=source_text,
         ):
             return True

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -20011,6 +20011,38 @@ rules:
     assert find_source_limitation_application_issues(content) == []
 
 
+def test_source_limitation_application_accepts_annual_sum_of_limited_monthly_amounts():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    The premium assistance credit amount means the sum of premium assistance
+    amounts determined for all coverage months. The premium assistance amount
+    for a coverage month is the lesser of monthly premiums or the excess of the
+    adjusted monthly premium over the required monthly contribution.
+rules:
+  - name: premium_assistance_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: min(monthly_premiums, max(0, adjusted_monthly_premium - required_monthly_contribution_amount))
+  - name: premium_assistance_credit_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum(coverage_months.premium_assistance_amount_determined_for_coverage_month)
+"""
+
+    assert find_source_limitation_application_issues(content) == []
+
+
 def test_source_limitation_application_scopes_subsection_special_rule():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.764"
+version = "0.2.765"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary\n- allow source-limitation validation for aggregate outputs that sum locally limited amount helpers\n- add ACA-style annual credit regression coverage\n- bump axiom-encode to 0.2.765\n\n## Tests\n- uv run --with pytest --with pytest-cov --with pytest-asyncio python -m pytest -q