### PR TITLE
Tolerate tiny RuleSpec decimal residue

### DIFF
--- a/changelog.d/rulespec-decimal-residue.fixed.md
+++ b/changelog.d/rulespec-decimal-residue.fixed.md
@@ -1,0 +1,1 @@
+Tolerate tiny decimal residue when comparing RuleSpec numeric test outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.765"
+version = "0.2.766"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.765"
+__version__ = "0.2.766"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -19502,9 +19502,9 @@ class ValidatorPipeline:
         expected_kind = expected.get("kind")
         numeric = {"integer", "decimal"}
         if actual_kind in numeric and expected_kind in numeric:
-            return self._rulespec_decimal(
-                actual.get("value")
-            ) == self._rulespec_decimal(expected.get("value"))
+            actual_decimal = self._rulespec_decimal(actual.get("value"))
+            expected_decimal = self._rulespec_decimal(expected.get("value"))
+            return abs(actual_decimal - expected_decimal) <= Decimal("1e-18")
         if actual_kind == "bool" and expected_kind == "bool":
             return bool(actual.get("value")) == bool(expected.get("value"))
         if actual_kind != expected_kind:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -3,6 +3,7 @@ import json
 import math
 import os
 import subprocess
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -112,6 +113,23 @@ from axiom_encode.oracles.policyengine.registry import (
 
 AXIOM_RULES_PATH = Path("/Users/maxghenis/TheAxiomFoundation/axiom-rules-engine")
 AXIOM_RULES_ENGINE_BINARY = AXIOM_RULES_PATH / "target" / "debug" / "axiom-rules-engine"
+
+
+def test_rulespec_numeric_output_comparison_tolerates_decimal_residue(tmp_path):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path / "rulespec-us",
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    assert pipeline._rulespec_scalar_values_equal(
+        {"kind": "decimal", "value": Decimal("19.999999999999999999999999992")},
+        {"kind": "integer", "value": 20},
+    )
+    assert not pipeline._rulespec_scalar_values_equal(
+        {"kind": "decimal", "value": Decimal("19.99")},
+        {"kind": "integer", "value": 20},
+    )
 
 
 def test_rulespec_compile_env_exposes_policy_repo_roots(monkeypatch, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.765"
+version = "0.2.766"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- tolerate tiny decimal residue when comparing RuleSpec numeric test outputs
- add a focused regression test for decimal-vs-integer output comparison
- bump axiom-encode to 0.2.766

## Tests
- uv run --with pytest --with pytest-cov --with pytest-asyncio python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_rulespec_validation.py::test_rulespec_numeric_output_comparison_tolerates_decimal_residue -q
- uv run --with pytest --with pytest-cov --with pytest-asyncio python -m pytest -q