### PR TITLE
Tolerate RuleSpec test decimal residue

### DIFF
--- a/changelog.d/rulespec-test-decimal-residue.fixed.md
+++ b/changelog.d/rulespec-test-decimal-residue.fixed.md
@@ -1,0 +1,1 @@
+Tolerate tiny decimal residue in the `axiom-encode test` companion-test runner.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.766"
+version = "0.2.767"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.766"
+__version__ = "0.2.767"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3252,9 +3252,7 @@ def _rulespec_scalar_matches(actual_value: dict, expected) -> bool:
         and isinstance(expected, (int, float))
         and not isinstance(expected, bool)
     ):
-        from decimal import Decimal
-
-        return Decimal(str(value)) == Decimal(str(expected))
+        return abs(Decimal(str(value)) - Decimal(str(expected))) <= Decimal("1e-18")
     if kind == "date" and isinstance(expected, date):
         return value == expected.isoformat()
     if isinstance(expected, date):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -102,6 +102,7 @@ from axiom_encode.cli import (
     _rewrite_import_output_test_input_refs,
     _rewrite_judgment_conditional_formulas,
     _rewrite_judgment_numeric_comparisons,
+    _rulespec_scalar_matches,
     _scoped_source_text_for_encode_source_id,
     _sha256_file,
     _sha256_text,
@@ -2276,6 +2277,20 @@ rules:
         args.json = json_output
         args.axiom_rules_path = self._require_axiom_rules_path()
         return args
+
+    def test_scalar_match_tolerates_decimal_residue(self):
+        assert _rulespec_scalar_matches(
+            {"kind": "decimal", "value": Decimal("19.999999999999999999999999992")},
+            20,
+        )
+        assert _rulespec_scalar_matches(
+            {"kind": "decimal", "value": Decimal("480.00000000000000000000000001")},
+            480,
+        )
+        assert not _rulespec_scalar_matches(
+            {"kind": "decimal", "value": Decimal("19.99")},
+            20,
+        )
 
     def test_executes_companion_tests_success_json(self, capsys, tmp_path):
         repo = self._write_rulespec_with_test(tmp_path, expected_benefit=15)

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.766"
+version = "0.2.767"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- tolerate tiny decimal residue in the `axiom-encode test` numeric comparator
- add a focused CLI regression test
- bump axiom-encode to 0.2.767

## Tests
- uv run --with pytest --with pytest-cov --with pytest-asyncio python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::TestCmdTest::test_scalar_match_tolerates_decimal_residue -q
- uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-health-p1-20260619 /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-health-p1-20260619/us/statutes/26/36B/b.test.yaml
- uv run --with pytest --with pytest-cov --with pytest-asyncio python -m pytest -q