### PR TITLE
Use relative output for child numeric repair

### DIFF
--- a/changelog.d/child-numeric-reencoding-relative-output.fixed.md
+++ b/changelog.d/child-numeric-reencoding-relative-output.fixed.md
@@ -1,0 +1,1 @@
+Use generated relative output paths when repairing child numeric reencoding aliases during apply.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.768"
+version = "0.2.769"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.768"
+__version__ = "0.2.769"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -24365,7 +24365,9 @@ def _try_repair_generated_child_numeric_reencoding_for_apply(
     if not parsed_issues:
         return []
     try:
-        _relative_generated_output_path(result, output_root=output_root)
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
     except RuntimeError:
         return []
 
@@ -24373,6 +24375,7 @@ def _try_repair_generated_child_numeric_reencoding_for_apply(
     return _repair_child_numeric_reencoding_parent_aliases(
         rules_file=rules_file,
         policy_repo_path=policy_repo_path,
+        relative_output=relative_output,
         parsed_issues=parsed_issues,
     )
 
@@ -24396,6 +24399,7 @@ def _repair_child_numeric_reencoding_parent_aliases(
     *,
     rules_file: Path,
     policy_repo_path: Path,
+    relative_output: Path | None = None,
     parsed_issues: list[tuple[tuple[str, ...], str]],
 ) -> list[str]:
     """Remove parent helpers that re-derive child-owned numeric concepts.
@@ -24454,6 +24458,7 @@ def _repair_child_numeric_reencoding_parent_aliases(
     local_ref_prefix = _rulespec_local_ref_prefix_for_generated_file(
         rules_file,
         policy_repo_path=policy_repo_path,
+        relative_output=relative_output,
     )
     child_ref_by_name = {
         child_name: child_ref
@@ -24524,11 +24529,15 @@ def _rulespec_local_ref_prefix_for_generated_file(
     rules_file: Path,
     *,
     policy_repo_path: Path,
+    relative_output: Path | None = None,
 ) -> str:
-    try:
-        relative = rules_file.resolve().relative_to(policy_repo_path.resolve())
-    except ValueError:
-        relative = rules_file
+    if relative_output is not None:
+        relative = relative_output
+    else:
+        try:
+            relative = rules_file.resolve().relative_to(policy_repo_path.resolve())
+        except ValueError:
+            relative = rules_file
     return f"{_repo_jurisdiction_prefix(policy_repo_path)}:{relative.with_suffix('').as_posix()}#"
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2296,9 +2296,10 @@ rules:
 
     def test_repairs_child_numeric_reencoding_parent_aliases(self, tmp_path):
         repo = tmp_path / "rulespec-us"
-        rules_file = repo / "statutes/26/36B.yaml"
+        rules_file = tmp_path / "out" / "codex-test-model" / "statutes/26/36B.yaml"
         child_file = repo / "statutes/26/36B/b.yaml"
         child_file.parent.mkdir(parents=True)
+        rules_file.parent.mkdir(parents=True)
         child_file.write_text(
             """format: rulespec/v1
 rules:
@@ -2364,6 +2365,7 @@ rules:
         repaired = _repair_child_numeric_reencoding_parent_aliases(
             rules_file=rules_file,
             policy_repo_path=repo,
+            relative_output=Path("statutes/26/36B.yaml"),
             parsed_issues=[parsed_issue],
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.768"
+version = "0.2.769"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- pass generated relative output paths into child numeric reencoding repair during apply
- cover generated temp-output paths so parent aliases point at child fragments instead of the parent file

## Tests
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/ tests/
- uv run --with pytest --with pytest-cov --with pytest-asyncio python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::TestCmdTest::test_repairs_child_numeric_reencoding_parent_aliases -q
- uv run --with pytest --with pytest-cov --with pytest-asyncio python -m pytest -q