### PR TITLE
Repair scalar relation rows from missing input issues

### DIFF
--- a/changelog.d/scalar-relation-row-missing-input-repair.fixed.md
+++ b/changelog.d/scalar-relation-row-missing-input-repair.fixed.md
@@ -1,0 +1,1 @@
+Repair generated scalar relation rows when validation reports the resulting missing child input assignment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.769"
+version = "0.2.770"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.769"
+__version__ = "0.2.770"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -24306,6 +24306,10 @@ _SCALAR_RELATION_ROW_ISSUE_PATTERN = re.compile(
     r"`(?P<relation>[^`]+)` item #(?P<index>\d+) must be a mapping"
 )
 
+_TEST_INPUT_ASSIGNMENT_MISSING_CASE_PATTERN = re.compile(
+    r"Test input assignment missing:\s*`(?P<case>[^`]+)`"
+)
+
 
 def _try_repair_generated_scalar_relation_rows_for_apply(
     result,
@@ -24316,18 +24320,16 @@ def _try_repair_generated_scalar_relation_rows_for_apply(
 ) -> list[str]:
     """Replace scalar relation rows with companion-test row mappings.
 
-    Generated tests occasionally write relation inputs as `- true`. The engine
-    needs each relation row to be a mapping of child facts. This repair is only
-    applied when validation has identified the exact bad row, and it derives the
-    replacement row from an existing companion test for the same relation target.
+    Generated tests occasionally write relation inputs as `- true` or `- 300`.
+    The engine needs each relation row to be a mapping of child facts. Prefer
+    exact row-shape validator issues, and fall back to missing-input-assignment
+    issues only when the named generated test case still contains scalar rows.
     """
     parsed_issues = [
         parsed
         for issue in issues
         if (parsed := _parse_scalar_relation_row_issue(str(issue))) is not None
     ]
-    if not parsed_issues:
-        return []
     try:
         _relative_generated_output_path(result, output_root=output_root)
     except RuntimeError:
@@ -24335,6 +24337,13 @@ def _try_repair_generated_scalar_relation_rows_for_apply(
 
     rules_file = Path(str(getattr(result, "output_file", "") or ""))
     test_file = _rulespec_test_path(rules_file)
+    if not parsed_issues:
+        parsed_issues = _scalar_relation_row_issues_from_missing_input_assignment(
+            test_file,
+            issues=issues,
+        )
+    if not parsed_issues:
+        return []
     return _repair_scalar_relation_rows(
         rules_file=rules_file,
         test_file=test_file,
@@ -24589,6 +24598,49 @@ def _parse_scalar_relation_row_issue(
         match.group("relation"),
         int(match.group("index")),
     )
+
+
+def _scalar_relation_row_issues_from_missing_input_assignment(
+    test_file: Path,
+    *,
+    issues: list[str],
+) -> list[tuple[str, str, int]]:
+    case_names = {
+        match.group("case").strip()
+        for issue in issues
+        if (match := _TEST_INPUT_ASSIGNMENT_MISSING_CASE_PATTERN.search(str(issue)))
+    }
+    if not case_names or not test_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    if isinstance(payload, dict) and isinstance(payload.get("cases"), list):
+        cases = payload["cases"]
+    elif isinstance(payload, list):
+        cases = payload
+    else:
+        return []
+
+    parsed_issues: list[tuple[str, str, int]] = []
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        case_name = str(case.get("name") or "").strip()
+        if case_name not in case_names:
+            continue
+        inputs = case.get("input")
+        if not isinstance(inputs, dict):
+            continue
+        for relation_ref, rows in inputs.items():
+            relation_key = str(relation_ref)
+            if "#relation." not in relation_key or not isinstance(rows, list):
+                continue
+            for index, row in enumerate(rows, start=1):
+                if not isinstance(row, dict):
+                    parsed_issues.append((case_name, relation_key, index))
+    return parsed_issues
 
 
 def _repair_scalar_relation_rows(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -130,6 +130,7 @@ from axiom_encode.cli import (
     _try_repair_generated_nonoperative_source_coverage_for_apply,
     _try_repair_generated_parameter_only_companion_tests_for_apply,
     _try_repair_generated_policyengine_oracle_inputs_for_apply,
+    _try_repair_generated_scalar_relation_rows_for_apply,
     _try_repair_generated_section_1401_b_1_self_employment_income_for_apply,
     _try_repair_generated_source_relation_delegations_for_apply,
     _try_repair_generated_source_table_band_scalars_for_apply,
@@ -19752,6 +19753,87 @@ rules:
             },
             {
                 "uk:statutes/ukpga/2007/3/23#input.amount_charged_to_income_tax_for_tax_year": 5000
+            },
+        ]
+
+    def test_try_repair_scalar_relation_rows_from_missing_input_assignment(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        policy_repo.mkdir()
+        output_root = tmp_path / "out"
+        rules_file = (
+            output_root / "codex-test-model" / "statutes" / "26" / "36B" / "b.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: Section 36B(b) computes premium assistance amounts.
+rules:
+  - name: coverage_months
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: premium_assistance_credit_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum(coverage_months.premium_assistance_amount_determined_for_coverage_month)
+"""
+        )
+        test_file = rules_file.with_name("b.test.yaml")
+        test_file.write_text(
+            """- name: annual_credit_sums_coverage_month_amounts
+  period: 2026
+  input:
+    us:statutes/26/36B/b#relation.coverage_months:
+      - 300
+      - 480
+      - 0
+  output:
+    us:statutes/26/36B/b#premium_assistance_credit_amount: 780
+"""
+        )
+        result = SimpleNamespace(
+            runner="codex-test-model",
+            output_file=str(rules_file),
+        )
+
+        repaired = _try_repair_generated_scalar_relation_rows_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "statutes/26/36B/b.yaml: ci: Test input assignment missing: "
+                "`annual_credit_sums_coverage_month_amounts` must provide "
+                "`input` facts or `tables` rows assigning every local factual "
+                "`#input.premium_assistance_amount_determined_for_coverage_month` "
+                "referenced by this module's formulas."
+            ],
+        )
+
+        assert repaired == [
+            "annual_credit_sums_coverage_month_amounts:"
+            "us:statutes/26/36B/b#relation.coverage_months[1]",
+            "annual_credit_sums_coverage_month_amounts:"
+            "us:statutes/26/36B/b#relation.coverage_months[2]",
+            "annual_credit_sums_coverage_month_amounts:"
+            "us:statutes/26/36B/b#relation.coverage_months[3]",
+        ]
+        [case] = yaml.safe_load(test_file.read_text())
+        assert case["input"]["us:statutes/26/36B/b#relation.coverage_months"] == [
+            {
+                "us:statutes/26/36B/b#input.premium_assistance_amount_determined_for_coverage_month": 300
+            },
+            {
+                "us:statutes/26/36B/b#input.premium_assistance_amount_determined_for_coverage_month": 480
+            },
+            {
+                "us:statutes/26/36B/b#input.premium_assistance_amount_determined_for_coverage_month": 0
             },
         ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.769"
+version = "0.2.770"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair generated scalar relation rows when validation reports the downstream missing child input assignment
- add a regression test using the ACA 36B-style relation row shape
- bump axiom-encode to 0.2.770

## Tests
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run --with pytest --with pytest-cov --with pytest-asyncio python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::TestApplyDependencyValidation::test_try_repair_scalar_relation_rows_from_missing_input_assignment -q
- uv run --with pytest --with pytest-cov --with pytest-asyncio python -m pytest -q