### PR TITLE
Classify ACA 36B PolicyEngine oracle coverage

### DIFF
--- a/changelog.d/aca-36b-policyengine-oracle-coverage.fixed.md
+++ b/changelog.d/aca-36b-policyengine-oracle-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify ACA 36B and 36B(b) PolicyEngine oracle coverage mappings for RuleSpec CI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.771"
+version = "0.2.772"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.771"
+__version__ = "0.2.772"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2830,6 +2830,99 @@ mappings:
     comparison: money
     rationale: Same statutory other-case additional Medicare wage threshold, stored in PE as parameter data.
 
+  - legal_id: us:statutes/26/36B#applicable_taxpayer_minimum_household_income_poverty_line_ratio
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.ptc_income_eligibility
+    candidate_priority: P4
+    rationale: PolicyEngine stores ACA PTC income eligibility as a thresholded boolean parameter used inside final person-level eligibility. This RuleSpec output is the standalone statutory lower household-income-to-poverty-line ratio.
+
+  - legal_id: us:statutes/26/36B#applicable_taxpayer_maximum_household_income_poverty_line_ratio
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.ptc_income_eligibility
+    candidate_priority: P4
+    rationale: PolicyEngine stores ACA PTC income eligibility as a time-varying thresholded boolean parameter, including the 2021-2025 upper-limit disregard. This RuleSpec output is the standalone statutory general upper household-income-to-poverty-line ratio.
+
+  - legal_id: us:statutes/26/36B#applicable_taxpayer_income_percentage_test_met
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.ptc_income_eligibility
+    candidate_priority: P4
+    rationale: PolicyEngine applies the ACA PTC income range through gov.aca.ptc_income_eligibility inside is_aca_ptc_eligible, which also includes filing status, immigration, coverage, and premium-payment conditions. This RuleSpec output is only the section 36B(c)(1) income-percentage predicate.
+
+  - legal_id: us:statutes/26/36B#employer_sponsored_coverage_affordability_ratio
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_variable: offered_aca_disqualifying_esi
+    candidate_priority: P4
+    rationale: PolicyEngine exposes employer-sponsored coverage disqualification as an input boolean rather than the statutory 9.5 percent affordability ratio as a separate parameter.
+
+  - legal_id: us:statutes/26/36B#employer_sponsored_plan_minimum_value_share
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_variable: offered_aca_disqualifying_esi
+    candidate_priority: P4
+    rationale: PolicyEngine exposes employer-sponsored coverage disqualification as an input boolean rather than the section 36B minimum-value percentage as a separate parameter.
+
+  - legal_id: us:statutes/26/36B#qualified_small_employer_hra_affordability_ratio
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: PolicyEngine-US does not expose qualified small employer HRA affordability mechanics for ACA PTC as separate variables or parameters.
+
+  - legal_id: us:statutes/26/36B#qualified_small_employer_hra_permitted_benefit_month_count
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: PolicyEngine-US does not expose the qualified small employer HRA monthly permitted-benefit divisor as a separate ACA PTC parameter.
+
+  - legal_id: us:statutes/26/36B#qualified_small_employer_hra_monthly_permitted_benefit_fraction
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: PolicyEngine-US does not expose the qualified small employer HRA monthly permitted-benefit fraction as a separate ACA PTC variable or parameter.
+
+  - legal_id: us:statutes/26/36B/b#required_contribution_annual_to_monthly_divisor
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_variable: aca_ptc
+    candidate_priority: P4
+    rationale: PolicyEngine computes the ACA PTC with annual MAGI and annual contribution percentage, while this RuleSpec output is the explicit section 36B(b)(2)(B)(ii) 1/12 divisor used in the statutory monthly formula.
+
+  - legal_id: us:statutes/26/36B/b#required_monthly_contribution
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_variable: aca_ptc
+    candidate_priority: P4
+    rationale: PolicyEngine's ACA PTC formula subtracts the annual required contribution inside aca_ptc and does not expose the section 36B(b)(2)(B)(ii) required monthly contribution as a separate oracle target.
+
+  - legal_id: us:statutes/26/36B/b#premium_assistance_amount
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_variable: premium_tax_credit
+    candidate_priority: P4
+    rationale: PolicyEngine exposes premium_tax_credit and aca_ptc as ACA credit outputs, but not the section 36B(b)(2) coverage-month amount with the statutory actual-premium cap and adjusted benchmark-premium excess as a standalone monthly output.
+
+  - legal_id: us:statutes/26/36B/b#premium_assistance_credit_amount
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_variable: aca_ptc
+    candidate_priority: P4
+    rationale: PolicyEngine's aca_ptc is the annual ACA premium tax credit after eligibility and take-up gates and does not expose the section 36B(b)(1) sum of subsection (b)(2) premium assistance amounts as a one-to-one output.
+
   - legal_id: us:statutes/26/36B/b/3/A#applicable_percentage_income_tier
     country: us
     program: aca_ptc

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2652,6 +2652,63 @@ def test_policyengine_registry_is_legal_id_keyed():
         ).policyengine_variable
         == "employer_medicare_tax"
     )
+    aca_36b_mappings = {
+        "us:statutes/26/36B#applicable_taxpayer_minimum_household_income_poverty_line_ratio": (
+            "policyengine_parameter",
+            "gov.aca.ptc_income_eligibility",
+        ),
+        "us:statutes/26/36B#applicable_taxpayer_maximum_household_income_poverty_line_ratio": (
+            "policyengine_parameter",
+            "gov.aca.ptc_income_eligibility",
+        ),
+        "us:statutes/26/36B#applicable_taxpayer_income_percentage_test_met": (
+            "policyengine_parameter",
+            "gov.aca.ptc_income_eligibility",
+        ),
+        "us:statutes/26/36B#employer_sponsored_coverage_affordability_ratio": (
+            "policyengine_variable",
+            "offered_aca_disqualifying_esi",
+        ),
+        "us:statutes/26/36B#employer_sponsored_plan_minimum_value_share": (
+            "policyengine_variable",
+            "offered_aca_disqualifying_esi",
+        ),
+        "us:statutes/26/36B#qualified_small_employer_hra_affordability_ratio": (
+            None,
+            None,
+        ),
+        "us:statutes/26/36B#qualified_small_employer_hra_permitted_benefit_month_count": (
+            None,
+            None,
+        ),
+        "us:statutes/26/36B#qualified_small_employer_hra_monthly_permitted_benefit_fraction": (
+            None,
+            None,
+        ),
+        "us:statutes/26/36B/b#required_contribution_annual_to_monthly_divisor": (
+            "policyengine_variable",
+            "aca_ptc",
+        ),
+        "us:statutes/26/36B/b#required_monthly_contribution": (
+            "policyengine_variable",
+            "aca_ptc",
+        ),
+        "us:statutes/26/36B/b#premium_assistance_amount": (
+            "policyengine_variable",
+            "premium_tax_credit",
+        ),
+        "us:statutes/26/36B/b#premium_assistance_credit_amount": (
+            "policyengine_variable",
+            "aca_ptc",
+        ),
+    }
+    for legal_id, (target_attr, target_value) in aca_36b_mappings.items():
+        mapping = registry.mapping_for_legal_id(legal_id, country="us")
+        assert mapping.mapping_type == "not_comparable"
+        assert mapping.program == "aca_ptc"
+        assert mapping.candidate_priority == "P4"
+        if target_attr is not None:
+            assert getattr(mapping, target_attr) == target_value
     qualified_veteran_credit_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/3111/e#veteran_employment_credit_against_subsection_a_tax",
         country="us",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.771"
+version = "0.2.772"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify ACA 36B and 36B(b) RuleSpec outputs in the PolicyEngine oracle registry
- record adjacent PE targets where they exist while keeping subsection-level statutory outputs marked not comparable
- add registry regression coverage for the 12 legal IDs that blocked rulespec-us CI
- bump axiom-encode to 0.2.772

## Verification
- uv run ruff check src tests
- uv run ruff format --check src tests
- uv run --extra dev python -m pytest tests/
- CI-shaped oracle coverage over the rulespec-us ACA branch: 12 changed outputs classified as known_not_comparable, 0 coverage failures