### PR TITLE
Classify non-comparable program surfaces

### DIFF
--- a/changelog.d/ecps-tax-person-tax-unit-id-fallback.fixed.md
+++ b/changelog.d/ecps-tax-person-tax-unit-id-fallback.fixed.md
@@ -1,0 +1,1 @@
+Accept PolicyEngine-shaped `tax_unit_id` person columns when grouping ECPS tax request inputs by tax unit.

--- a/changelog.d/program-surface-known-not-comparable.fixed.md
+++ b/changelog.d/program-surface-known-not-comparable.fixed.md
@@ -1,0 +1,1 @@
+Classify PolicyEngine program surfaces with non-comparable legal-ID mappings as known not comparable instead of still pending RuleSpec encoding.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.772"
+version = "0.2.773"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.772"
+__version__ = "0.2.773"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -24,6 +24,7 @@ ORACLE_COVERAGE_STATUSES = {"comparable", "known_not_comparable", "unmapped"}
 PROGRAM_SURFACE_STATUSES = {
     "deferred_jurisdiction",
     "input_only",
+    "known_not_comparable",
     "out_of_scope",
     "pe_in_progress",
     "pending_oracle_mapping",
@@ -623,7 +624,16 @@ def _program_surface_item_from_payload(
     country = str(payload.get("country") or "us")
     mappings = registry.mappings_for_policyengine_variable(variable, country=country)
     comparable_mapping_count = sum(1 for mapping in mappings if mapping.comparable)
-    axiom_status = "wired" if comparable_mapping_count else str(payload["axiom_status"])
+    manifest_status = str(payload["axiom_status"])
+    if comparable_mapping_count:
+        axiom_status = "wired"
+    elif mappings and manifest_status in {
+        "pending_oracle_mapping",
+        "pending_rulespec_encoding",
+    }:
+        axiom_status = "known_not_comparable"
+    else:
+        axiom_status = manifest_status
     return PolicyEngineProgramSurfaceItem(
         country=country,
         program_id=str(payload["program_id"]),

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -76,6 +76,10 @@ FICA_PRE_TAX_CONTRIBUTION_COLUMNS = (
 )
 CAPITAL_GAINS_PROGRAM_PATH = Path("statutes/26/1/h.yaml")
 CAPITAL_GAINS_BASE = "us:statutes/26/1/h"
+LONG_TERM_CAPITAL_GAINS_COLUMNS = (
+    "long_term_capital_gains_before_response",
+    "long_term_capital_gains",
+)
 TAX_BEFORE_CREDITS_PROGRAM_PATH = Path("statutes/26/1/j.yaml")
 TAX_BEFORE_CREDITS_BASE = "us:statutes/26/1/j"
 EITC_PROGRAM_PATH = Path("statutes/26/32.yaml")
@@ -1849,7 +1853,7 @@ def project_capital_gain_definition_inputs(
 ) -> dict[str, Any]:
     long_term_capital_gains = person_money_sum(
         persons,
-        "long_term_capital_gains_before_response",
+        LONG_TERM_CAPITAL_GAINS_COLUMNS,
     )
     short_term_capital_gains = person_money_sum(persons, "short_term_capital_gains")
     qualified_dividend_income = person_money_sum(
@@ -2189,7 +2193,7 @@ def project_section_1401_tax_unit_inputs(
 def project_eitc_relevant_investment_income(row: Any, persons: list[Any]) -> float:
     net_capital_gains = person_money_sum(
         persons,
-        "long_term_capital_gains_before_response",
+        LONG_TERM_CAPITAL_GAINS_COLUMNS,
     ) + person_money_sum(persons, "short_term_capital_gains")
     return (
         person_money_sum(persons, "taxable_interest_income")
@@ -2766,12 +2770,14 @@ def print_report(
 def group_person_rows_by_tax_unit(persons: Any) -> dict[int, list[Any]]:
     grouped: dict[int, list[Any]] = {}
     for _idx, person in persons.iterrows():
-        grouped.setdefault(int(person["person_tax_unit_id"]), []).append(person)
+        tax_unit_id = person.get("person_tax_unit_id", person.get("tax_unit_id"))
+        grouped.setdefault(int(tax_unit_id), []).append(person)
     return grouped
 
 
-def person_money_sum(persons: list[Any], column: str) -> float:
-    return sum(money(person.get(column, 0)) for person in persons)
+def person_money_sum(persons: list[Any], column: str | tuple[str, ...]) -> float:
+    columns = (column,) if isinstance(column, str) else column
+    return sum(first_available_money(person, columns) for person in persons)
 
 
 def input_record(

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -7,6 +7,21 @@ from axiom_encode.oracles.policyengine.coverage import (
     build_policyengine_coverage_report,
     build_policyengine_program_surface_report,
 )
+from axiom_encode.oracles.policyengine.registry import PolicyEngineMapping
+
+
+class _ProgramSurfaceRegistry:
+    def __init__(self, mappings_by_variable):
+        self.mappings_by_variable = mappings_by_variable
+
+    def mappings_for_policyengine_variable(
+        self, policyengine_variable, *, country=None
+    ):
+        return [
+            mapping
+            for mapping in self.mappings_by_variable.get(policyengine_variable, [])
+            if country is None or mapping.country == country
+        ]
 
 
 def _write_rulespec_file(path: Path, content: str) -> Path:
@@ -121,6 +136,16 @@ surfaces:
     priority: P1
     rationale: Needs RuleSpec encoding.
   - country: us
+    program_id: aca_subsidies
+    program_name: ACA subsidies
+    category: Healthcare
+    policyengine_status: complete
+    coverage: US
+    variable: aca_ptc
+    axiom_status: pending_rulespec_encoding
+    priority: P1
+    rationale: Encoded but not comparable to PE's aggregate legal boundary.
+  - country: us
     program_id: payroll_taxes
     program_name: Payroll taxes
     category: Taxes
@@ -143,12 +168,44 @@ surfaces:
 """,
         encoding="utf-8",
     )
+    registry = _ProgramSurfaceRegistry(
+        {
+            "income_tax": [
+                PolicyEngineMapping(
+                    legal_id="us:statutes/26/6401#income_tax",
+                    country="us",
+                    mapping_type="direct_variable",
+                    policyengine_variable="income_tax",
+                )
+            ],
+            "aca_ptc": [
+                PolicyEngineMapping(
+                    legal_id="us:statutes/26/36B/b#premium_assistance_credit_amount",
+                    country="us",
+                    mapping_type="not_comparable",
+                    policyengine_variable="aca_ptc",
+                )
+            ],
+            "employee_payroll_tax": [
+                PolicyEngineMapping(
+                    legal_id="us:statutes/26/3102/a#employee_payroll_tax",
+                    country="us",
+                    mapping_type="not_comparable",
+                    policyengine_variable="employee_payroll_tax",
+                )
+            ],
+        }
+    )
 
-    report = build_policyengine_program_surface_report(manifest_path=manifest)
+    report = build_policyengine_program_surface_report(
+        manifest_path=manifest,
+        registry=registry,
+    )
 
-    assert report["total_surfaces"] == 4
+    assert report["total_surfaces"] == 5
     assert report["status_counts"] == {
         "input_only": 1,
+        "known_not_comparable": 1,
         "out_of_scope": 1,
         "pending_rulespec_encoding": 1,
         "wired": 1,
@@ -156,10 +213,13 @@ surfaces:
     assert report["pending_surfaces"] == 1
     items_by_variable = {item["variable"]: item for item in report["items"]}
     assert items_by_variable["income_tax"]["axiom_status"] == "wired"
-    assert items_by_variable["income_tax"]["mapping_count"] >= 1
+    assert items_by_variable["income_tax"]["mapping_count"] == 1
     assert items_by_variable["wic"]["axiom_status"] == "pending_rulespec_encoding"
+    assert items_by_variable["aca_ptc"]["axiom_status"] == "known_not_comparable"
+    assert items_by_variable["aca_ptc"]["mapping_count"] == 1
+    assert items_by_variable["aca_ptc"]["comparable_mapping_count"] == 0
     assert items_by_variable["employee_payroll_tax"]["axiom_status"] == "out_of_scope"
-    assert items_by_variable["employee_payroll_tax"]["mapping_count"] >= 1
+    assert items_by_variable["employee_payroll_tax"]["mapping_count"] == 1
     assert items_by_variable["employee_payroll_tax"]["comparable_mapping_count"] == 0
     assert items_by_variable["fdpir"]["axiom_status"] == "input_only"
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.772"
+version = "0.2.773"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a `known_not_comparable` program surface status when legal-ID mappings exist but all mapped oracle surfaces are explicitly non-comparable
- keep manifest statuses such as `out_of_scope` intact when non-comparable mappings are intentionally excluded
- make ECPS tax request projection accept PolicyEngine-shaped `tax_unit_id` person rows and the `long_term_capital_gains` alias
- bump axiom-encode to 0.2.773

## Tests
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run --extra dev python -m pytest -q`

Full pytest result: 2178 passed, 1 skipped.