### PR TITLE
Classify TANF final surfaces as known non-comparable

### DIFF
--- a/changelog.d/tanf-final-surface-known-not-comparable.fixed.md
+++ b/changelog.d/tanf-final-surface-known-not-comparable.fixed.md
@@ -1,0 +1,1 @@
+Classify Arizona and Colorado TANF final PolicyEngine program surfaces as known-not-comparable until Axiom exposes equivalent final benefit boundaries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.773"
+version = "0.2.774"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.773"
+__version__ = "0.2.774"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -175,11 +175,12 @@ surfaces:
   variable: co_tanf
   source_type: state_implementation
   state: CO
-  axiom_status: pending_oracle_mapping
+  axiom_status: known_not_comparable
   priority: P1
   rationale: Current RuleSpec repos include tested Colorado Works basic-cash-assistance, earned-income-disregard, grant-standard,
-    and time-limit legal slices. Remaining parity work is an oracle adapter or PE surface alignment for the same monthly legal
-    boundaries, not initial RuleSpec encoding.
+    and time-limit legal slices. Those outputs are source-specific legal boundaries, while PolicyEngine's co_tanf is a final monthly
+    benefit variable built from PE's own TANF graph and parameter table; do not treat it as a direct one-to-one oracle target until
+    Axiom has an equivalent final Colorado Works benefit surface or PE exposes compatible helper boundaries.
 - country: us
   program_id: tanf
   program_name: DC TANF
@@ -316,11 +317,12 @@ surfaces:
   variable: az_tanf
   source_type: state_implementation
   state: AZ
-  axiom_status: pending_oracle_mapping
+  axiom_status: known_not_comparable
   priority: P1
   rationale: Current RuleSpec repos include tested Arizona Cash Assistance payment-standard, needy-family, benefit-determination,
-    earned-income-deduction, and resource/income legal slices. Remaining parity work is a direct oracle adapter for PE's Arizona
-    TANF surface and helper boundaries, not initial RuleSpec encoding.
+    earned-income-deduction, and resource/income legal slices. Those outputs are DES FAA5 source slices, while PolicyEngine's az_tanf
+    is a final annualized TANF benefit variable built from PE's own TANF graph; do not treat it as a direct one-to-one oracle target
+    until Axiom has an equivalent final Arizona Cash Assistance benefit surface or PE exposes compatible helper boundaries.
 - country: us
   program_id: tanf
   program_name: Oklahoma TANF

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -146,6 +146,16 @@ surfaces:
     priority: P1
     rationale: Encoded but not comparable to PE's aggregate legal boundary.
   - country: us
+    program_id: tanf
+    program_name: Colorado TANF
+    category: Benefits
+    policyengine_status: complete
+    coverage: CO
+    variable: co_tanf
+    axiom_status: known_not_comparable
+    priority: P1
+    rationale: Encoded legal slices are not the same boundary as PE's final program variable.
+  - country: us
     program_id: payroll_taxes
     program_name: Payroll taxes
     category: Taxes
@@ -202,10 +212,10 @@ surfaces:
         registry=registry,
     )
 
-    assert report["total_surfaces"] == 5
+    assert report["total_surfaces"] == 6
     assert report["status_counts"] == {
         "input_only": 1,
-        "known_not_comparable": 1,
+        "known_not_comparable": 2,
         "out_of_scope": 1,
         "pending_rulespec_encoding": 1,
         "wired": 1,
@@ -218,6 +228,8 @@ surfaces:
     assert items_by_variable["aca_ptc"]["axiom_status"] == "known_not_comparable"
     assert items_by_variable["aca_ptc"]["mapping_count"] == 1
     assert items_by_variable["aca_ptc"]["comparable_mapping_count"] == 0
+    assert items_by_variable["co_tanf"]["axiom_status"] == "known_not_comparable"
+    assert items_by_variable["co_tanf"]["mapping_count"] == 0
     assert items_by_variable["employee_payroll_tax"]["axiom_status"] == "out_of_scope"
     assert items_by_variable["employee_payroll_tax"]["mapping_count"] == 1
     assert items_by_variable["employee_payroll_tax"]["comparable_mapping_count"] == 0

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.773"
+version = "0.2.774"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark Arizona and Colorado final TANF PolicyEngine program surfaces as `known_not_comparable` instead of `pending_oracle_mapping`
- document that current RuleSpec outputs are source-specific legal slices, not the same boundary as PE final TANF benefit variables
- add a program surface coverage regression for manifest-declared known-not-comparable surfaces
- bump axiom-encode to 0.2.774

## Report impact
- AZ `az_tanf`: `pending_oracle_mapping` -> `known_not_comparable`
- CO `co_tanf`: `pending_oracle_mapping` -> `known_not_comparable`
- real workspace pending program surfaces: 170 -> 168

## Tests
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev python -m pytest -q`

Full pytest result: 2178 passed, 1 skipped.