### PR TITLE
Refresh PolicyEngine US program surfaces

### DIFF
--- a/changelog.d/program-surface-mn-ccap.changed.md
+++ b/changelog.d/program-surface-mn-ccap.changed.md
@@ -1,0 +1,1 @@
+Refresh the PolicyEngine US program-surface manifest to current upstream main and include Minnesota CCAP.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.774"
+version = "0.2.775"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.774"
+__version__ = "0.2.775"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1,7 +1,7 @@
 source:
   repository: PolicyEngine/policyengine-us
   ref: upstream/main
-  commit: 9656d3d9f99f07b259559496edb35c204a7abe3a
+  commit: 392a91f0019131497418872dc95de4da9aa3fe9b
   path: policyengine_us/programs.yaml
   generated_by: axiom-encode policyengine program surface wiring
 surfaces:
@@ -1151,6 +1151,20 @@ surfaces:
     and Georgia law before other jurisdictions.
 - country: us
   program_id: ccdf
+  program_name: Minnesota CCAP
+  category: Benefits
+  agency: HHS
+  policyengine_status: complete
+  coverage: MN
+  variable: mn_ccap
+  source_type: state_implementation
+  state: MN
+  axiom_status: deferred_jurisdiction
+  priority: P2
+  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
+    and Georgia law before other jurisdictions.
+- country: us
+  program_id: ccdf
   program_name: New Hampshire CCAP
   category: Benefits
   agency: HHS
@@ -1772,10 +1786,11 @@ surfaces:
   coverage: US
   variable: social_security
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: input_only
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: PolicyEngine's social_security program variable aggregates Social Security dependents, disability, retirement, and
+    survivors benefit amounts that are uprated input variables rather than computed benefit-law outputs. RuleSpec should encode and
+    compare source-backed SSA benefit formulas and parameters separately when PE exposes a comparable computed surface.
 - country: us
   program_id: medicare
   program_name: Medicare

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.774"
+version = "0.2.775"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- refresh the PolicyEngine US program-surface manifest source commit to current upstream/main
- add Minnesota CCAP as a deferred P2 CCDF surface

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q