### PR TITLE
Add Georgia CMS effective MAGI repair

### DIFF
--- a/changelog.d/georgia-cms-effective-magi-limits.added.md
+++ b/changelog.d/georgia-cms-effective-magi-limits.added.md
@@ -1,0 +1,1 @@
+Add a signed Georgia CMS repair for effective MAGI limits and PolicyEngine oracle mappings for the comparable Medicaid and CHIP thresholds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.775"
+version = "0.2.776"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.775"
+__version__ = "0.2.776"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1533,6 +1533,25 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_ga_cms_effective_parser = subparsers.add_parser(
+        "repair-georgia-cms-effective-magi-limits",
+        help="Apply signed deterministic Georgia CMS effective MAGI limit repairs",
+    )
+    repair_ga_cms_effective_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="rulespec-us repository root used for manifest signing",
+    )
+    repair_ga_cms_effective_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_ny_snap_categorical_parser = subparsers.add_parser(
         "repair-new-york-snap-categorical-eligibility",
         help="Apply signed deterministic repairs for New York SNAP categorical eligibility",
@@ -2208,6 +2227,8 @@ def main():
         cmd_repair_snap_273_9_income_eligibility(args)
     elif args.command == "repair-georgia-cms-medicaid-availability":
         cmd_repair_georgia_cms_medicaid_availability(args)
+    elif args.command == "repair-georgia-cms-effective-magi-limits":
+        cmd_repair_georgia_cms_effective_magi_limits(args)
     elif args.command == "repair-new-york-snap-categorical-eligibility":
         cmd_repair_new_york_snap_categorical_eligibility(args)
     elif args.command == "repair-new-york-snap-benefit-tests":
@@ -6836,6 +6857,55 @@ GEORGIA_CMS_MEDICAID_AVAILABILITY_RULES = (
 )
 
 
+GEORGIA_CMS_EFFECTIVE_MAGI_LIMIT_RULES = (
+    {
+        "name": "georgia_children_medicaid_ages_0_to_1_effective_fpl_limit",
+        "raw_limit": "georgia_children_medicaid_ages_0_to_1_fpl_limit",
+        "source": (
+            "CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row, "
+            "including the MAGI 5% FPL disregard"
+        ),
+        "test_value": "2.10",
+    },
+    {
+        "name": "georgia_children_medicaid_ages_1_to_5_effective_fpl_limit",
+        "raw_limit": "georgia_children_medicaid_ages_1_to_5_fpl_limit",
+        "source": (
+            "CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row, "
+            "including the MAGI 5% FPL disregard"
+        ),
+        "test_value": "1.54",
+    },
+    {
+        "name": "georgia_children_medicaid_ages_6_to_18_effective_fpl_limit",
+        "raw_limit": "georgia_children_medicaid_ages_6_to_18_fpl_limit",
+        "source": (
+            "CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row, "
+            "including the MAGI 5% FPL disregard"
+        ),
+        "test_value": "1.38",
+    },
+    {
+        "name": "georgia_children_separate_chip_effective_fpl_limit",
+        "raw_limit": "georgia_children_separate_chip_fpl_limit",
+        "source": (
+            "CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row, "
+            "including the MAGI 5% FPL disregard"
+        ),
+        "test_value": "2.52",
+    },
+    {
+        "name": "georgia_pregnant_women_medicaid_effective_fpl_limit",
+        "raw_limit": "georgia_pregnant_women_medicaid_fpl_limit",
+        "source": (
+            "CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row, "
+            "including the MAGI 5% FPL disregard"
+        ),
+        "test_value": "2.25",
+    },
+)
+
+
 def _rulespec_rule_names(content: str) -> set[str]:
     try:
         payload = yaml.safe_load(content) or {}
@@ -6915,6 +6985,213 @@ def _repair_georgia_cms_medicaid_availability_tests(
             f"{rule['test_value']}\n"
         )
     return repaired, [rule["name"] for rule in missing]
+
+
+def _georgia_cms_effective_magi_limit_rule_block(rule: dict[str, str]) -> str:
+    return f"""  - name: {rule["name"]}
+    kind: derived
+    dtype: Rate
+    source: {rule["source"]}
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+              excerpt: "5% FPL disregard"
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          {rule["raw_limit"]} + magi_fpl_disregard_rate
+"""
+
+
+def _repair_georgia_cms_effective_magi_limit_rules(
+    content: str,
+) -> tuple[str, list[str]]:
+    existing = _rulespec_rule_names(content)
+    missing = [
+        rule
+        for rule in GEORGIA_CMS_EFFECTIVE_MAGI_LIMIT_RULES
+        if rule["name"] not in existing
+    ]
+    if not missing:
+        return content, []
+
+    repaired = content.rstrip() + "\n\n"
+    repaired += "\n".join(
+        _georgia_cms_effective_magi_limit_rule_block(rule).rstrip() for rule in missing
+    )
+    repaired += "\n"
+    return repaired, [rule["name"] for rule in missing]
+
+
+def _repair_georgia_cms_effective_magi_limit_tests(
+    content: str,
+) -> tuple[str, list[str]]:
+    missing = [
+        rule
+        for rule in GEORGIA_CMS_EFFECTIVE_MAGI_LIMIT_RULES
+        if f"{GEORGIA_CMS_MEDICAID_CITATION}#{rule['name']}" not in content
+    ]
+    if not missing:
+        return content, []
+
+    repaired = content.rstrip() + "\n"
+    for rule in missing:
+        repaired += (
+            f"    {GEORGIA_CMS_MEDICAID_CITATION}#{rule['name']}: "
+            f"{rule['test_value']}\n"
+        )
+    return repaired, [rule["name"] for rule in missing]
+
+
+def cmd_repair_georgia_cms_effective_magi_limits(args):
+    """Apply signed deterministic Georgia CMS effective MAGI limit repairs."""
+    repo_path = Path(args.repo).resolve()
+    if _repo_jurisdiction_prefix(repo_path) != "us":
+        print(
+            "repair-georgia-cms-effective-magi-limits must run against "
+            f"rulespec-us; got {repo_path}"
+        )
+        sys.exit(1)
+
+    relative_output = GEORGIA_CMS_MEDICAID_RELATIVE
+    rules_file = repo_path / relative_output
+    test_file = _rulespec_test_path(rules_file)
+    if not rules_file.exists():
+        print(f"RuleSpec file not found: {rules_file}")
+        sys.exit(1)
+    if not test_file.exists():
+        print(f"RuleSpec companion test file not found: {test_file}")
+        sys.exit(1)
+
+    original_content = rules_file.read_text()
+    original_test_content = test_file.read_text()
+    repaired_content, repaired_rules = _repair_georgia_cms_effective_magi_limit_rules(
+        original_content
+    )
+    repaired_test_content, repaired_tests = (
+        _repair_georgia_cms_effective_magi_limit_tests(original_test_content)
+    )
+    applied_files = [rules_file, test_file]
+    axiom_encode_git = None
+
+    if (
+        repaired_content == original_content
+        and repaired_test_content == original_test_content
+    ):
+        manifest_path = repo_path / _applied_encoding_manifest_path(relative_output)
+        if manifest_path.exists():
+            current_hashes = {
+                file.relative_to(repo_path).as_posix(): _sha256_file(file)
+                for file in applied_files
+            }
+            payload = json.loads(manifest_path.read_text())
+            manifest_hashes = {
+                item.get("path"): item.get("sha256")
+                for item in payload.get("applied_files", [])
+                if isinstance(item, dict)
+            }
+            if all(
+                manifest_hashes.get(path) == sha for path, sha in current_hashes.items()
+            ):
+                axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+                if (
+                    payload.get("axiom_encode_version") == __version__
+                    and payload.get("axiom_encode_git") == axiom_encode_git
+                ):
+                    print("No Georgia CMS effective MAGI limit repairs found.")
+                    return
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    if axiom_encode_git is None:
+        axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+    _ensure_no_unmanifested_preexisting_rulespec_changes(
+        repo_path,
+        [(relative_output, applied_files)],
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        generated_output = output_root / "deterministic-repair" / relative_output
+        generated_output.parent.mkdir(parents=True, exist_ok=True)
+        generated_output.write_text(repaired_content)
+        generated_test = _rulespec_test_path(generated_output)
+        generated_test.write_text(repaired_test_content)
+
+        rules_file.write_text(repaired_content)
+        test_file.write_text(repaired_test_content)
+
+        try:
+            validation = ValidatorPipeline(
+                policy_repo_path=repo_path,
+                axiom_rules_path=axiom_rules_path,
+                enable_oracles=False,
+                require_policy_proofs=True,
+            ).validate(rules_file, skip_reviewers=True)
+            if not validation.all_passed:
+                issues = [
+                    result.error
+                    for result in validation.results.values()
+                    if result.error
+                ]
+                print("Repair failed validation; restored original files.")
+                for issue in issues:
+                    print(f"- {issue}")
+                sys.exit(1)
+
+            test_failures = _rulespec_companion_test_failures(
+                test_file,
+                root=repo_path,
+                axiom_rules_path=axiom_rules_path,
+            )
+            if test_failures:
+                print("Repair failed companion tests; restored original files.")
+                for failure in test_failures[:20]:
+                    case_name = failure.get("case") or "<unknown case>"
+                    print(f"- {case_name}: {failure.get('message')}")
+                sys.exit(1)
+        finally:
+            validation_passed = "validation" in locals() and validation.all_passed
+            tests_passed = "test_failures" in locals() and not test_failures
+            if not validation_passed or not tests_passed:
+                rules_file.write_text(original_content)
+                test_file.write_text(original_test_content)
+
+        result = argparse.Namespace(
+            output_file=str(generated_output),
+            runner="deterministic-repair",
+            backend="deterministic",
+            model="georgia-cms-effective-magi-limits-v1",
+            tool="axiom-encode repair-georgia-cms-effective-magi-limits",
+            citation=GEORGIA_CMS_MEDICAID_CITATION,
+            generation_prompt_sha256=None,
+            trace_file=None,
+            context_manifest_file=None,
+        )
+        manifest_path = _write_applied_encoding_manifest(
+            result,
+            output_root=output_root,
+            policy_repo_path=repo_path,
+            relative_output=relative_output,
+            applied_files=applied_files,
+            run_id="deterministic-repair",
+            signing_key=signing_key,
+            axiom_encode_git=axiom_encode_git,
+        )
+
+    changed_names = sorted(set(repaired_rules) | set(repaired_tests))
+    print("Applied Georgia CMS effective MAGI limit repair")
+    if changed_names:
+        print(f"changed_rules={', '.join(changed_names)}")
+    print(f"changed={relative_output}")
+    print(f"changed={_rulespec_test_path(relative_output)}")
+    print(f"manifest={manifest_path}")
 
 
 def cmd_repair_georgia_cms_medicaid_availability(args):

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -3137,6 +3137,56 @@ mappings:
     candidate_priority: P4
     rationale: Axiom exposes the raw Georgia CMS table value before the 5% MAGI FPL disregard. PolicyEngine-US stores the effective pregnant-person Medicaid income limit including that disregard.
 
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_medicaid_ages_0_to_1_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.infant.income_limit
+    parameter_key: GA
+    period: year
+    comparison: rate
+    rationale: Same effective Georgia infant Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_medicaid_ages_1_to_5_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.young_child.income_limit
+    parameter_key: GA
+    period: year
+    comparison: rate
+    rationale: Same effective Georgia young-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_medicaid_ages_6_to_18_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.older_child.income_limit
+    parameter_key: GA
+    period: year
+    comparison: rate
+    rationale: Same effective Georgia older-child Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_separate_chip_effective_fpl_limit
+    country: us
+    program: chip
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.chip.child.income_limit
+    parameter_key: GA
+    period: year
+    comparison: rate
+    rationale: Same effective Georgia child CHIP income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
+  - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_pregnant_women_medicaid_effective_fpl_limit
+    country: us
+    program: medicaid
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicaid.eligibility.categories.pregnant.income_limit
+    parameter_key: GA
+    period: year
+    comparison: rate
+    rationale: Same effective Georgia pregnant-person Medicaid income limit, computed from the CMS raw table value plus the MAGI 5% FPL disregard.
+
   - legal_id: us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_parent_caretaker_adults_medicaid_fpl_limit
     country: us
     program: medicaid

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,6 +160,7 @@ from axiom_encode.cli import (
     cmd_repair_current_year_final_amounts,
     cmd_repair_delegated_policy_settings,
     cmd_repair_embedded_scalar_literals,
+    cmd_repair_georgia_cms_effective_magi_limits,
     cmd_repair_georgia_cms_medicaid_availability,
     cmd_repair_imported_test_inputs,
     cmd_repair_invalid_test_inputs,
@@ -20913,6 +20914,159 @@ rules:
             policy_repo / ".axiom/encoding-manifests/us-ga/policies/cms/"
             "georgia-medicaid-chip-bhp-eligibility-levels.json"
         ).exists()
+
+    def test_repair_georgia_cms_effective_magi_limits_writes_signed_manifest(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = (
+            policy_repo
+            / "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml"
+        )
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+  summary: |-
+    Georgia row: Children Medicaid Ages 0-1 205%; Ages 1-5 149%; Ages 6-18 133%; Children Separate CHIP 247%; Pregnant Women Medicaid 220%. The MAGI-based rules generally include a 5% FPL disregard.
+rules:
+  - name: magi_fpl_disregard_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          0.05
+  - name: georgia_children_medicaid_ages_0_to_1_fpl_limit
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          2.05
+  - name: georgia_children_medicaid_ages_1_to_5_fpl_limit
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          1.49
+  - name: georgia_children_medicaid_ages_6_to_18_fpl_limit
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          1.33
+  - name: georgia_children_separate_chip_fpl_limit
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          2.47
+  - name: georgia_pregnant_women_medicaid_fpl_limit
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2023-12-01'
+        formula: |-
+          2.20
+"""
+        )
+        test_file = (
+            policy_repo
+            / "us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml"
+        )
+        test_file.write_text(
+            """- name: georgia_magi_eligibility_level_parameters_as_of_december_2023
+  period:
+    period_kind: custom
+    name: day
+    start: '2023-12-01'
+    end: '2023-12-01'
+  input: {}
+  output:
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#magi_fpl_disregard_rate: 0.05
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_medicaid_ages_0_to_1_fpl_limit: 2.05
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures",
+                return_value=[],
+            ),
+            patch(
+                "axiom_encode.cli._ensure_no_unmanifested_preexisting_rulespec_changes"
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_georgia_cms_effective_magi_limits(args)
+
+        rules_payload = yaml.safe_load(target.read_text())
+        rules_by_name = {rule["name"]: rule for rule in rules_payload["rules"]}
+        infant_rule = rules_by_name[
+            "georgia_children_medicaid_ages_0_to_1_effective_fpl_limit"
+        ]
+        assert infant_rule["kind"] == "derived"
+        assert (
+            infant_rule["versions"][0]["formula"]
+            == "georgia_children_medicaid_ages_0_to_1_fpl_limit + magi_fpl_disregard_rate"
+        )
+        assert (
+            "georgia_children_medicaid_ages_1_to_5_effective_fpl_limit" in rules_by_name
+        )
+        assert (
+            "georgia_children_medicaid_ages_6_to_18_effective_fpl_limit"
+            in rules_by_name
+        )
+        assert "georgia_children_separate_chip_effective_fpl_limit" in rules_by_name
+        assert "georgia_pregnant_women_medicaid_effective_fpl_limit" in rules_by_name
+        test_content = test_file.read_text()
+        assert (
+            "us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels"
+            "#georgia_children_medicaid_ages_0_to_1_effective_fpl_limit: 2.10"
+        ) in test_content
+        assert (
+            "us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels"
+            "#georgia_pregnant_women_medicaid_effective_fpl_limit: 2.25"
+        ) in test_content
+        manifest = (
+            policy_repo / ".axiom/encoding-manifests/us-ga/policies/cms/"
+            "georgia-medicaid-chip-bhp-eligibility-levels.json"
+        )
+        payload = json.loads(manifest.read_text())
+        assert payload["schema_version"] == APPLIED_ENCODING_MANIFEST_SCHEMA
+        assert payload["model"] == "georgia-cms-effective-magi-limits-v1"
+        assert (
+            payload["tool"] == "axiom-encode repair-georgia-cms-effective-magi-limits"
+        )
 
     def test_repair_snap_273_10_allotment_restores_files_when_validation_raises(
         self, tmp_path

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -910,6 +910,31 @@ rules:
     versions:
       - effective_from: '2025-01-01'
         formula: 2.20
+  - name: georgia_children_medicaid_ages_0_to_1_effective_fpl_limit
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: georgia_children_medicaid_ages_0_to_1_fpl_limit + magi_fpl_disregard_rate
+  - name: georgia_children_medicaid_ages_1_to_5_effective_fpl_limit
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: georgia_children_medicaid_ages_1_to_5_fpl_limit + magi_fpl_disregard_rate
+  - name: georgia_children_medicaid_ages_6_to_18_effective_fpl_limit
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: georgia_children_medicaid_ages_6_to_18_fpl_limit + magi_fpl_disregard_rate
+  - name: georgia_children_separate_chip_effective_fpl_limit
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: georgia_children_separate_chip_fpl_limit + magi_fpl_disregard_rate
+  - name: georgia_pregnant_women_medicaid_effective_fpl_limit
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: georgia_pregnant_women_medicaid_fpl_limit + magi_fpl_disregard_rate
   - name: georgia_parent_caretaker_adults_medicaid_fpl_limit
     kind: parameter
     versions:
@@ -933,6 +958,19 @@ rules:
 """,
     )
     _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-ga"
+        / "policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.test.yaml",
+        """- name: georgia_effective_magi_limits
+  output:
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_medicaid_ages_0_to_1_effective_fpl_limit: 2.10
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_medicaid_ages_1_to_5_effective_fpl_limit: 1.54
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_medicaid_ages_6_to_18_effective_fpl_limit: 1.38
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_children_separate_chip_effective_fpl_limit: 2.52
+    us-ga:policies/cms/georgia-medicaid-chip-bhp-eligibility-levels#georgia_pregnant_women_medicaid_effective_fpl_limit: 2.25
+""",
+    )
+    _write_rulespec_file(
         tmp_path / "rulespec-us-ga" / "policies/dfcs/snap/3210/block-2.yaml",
         """format: rulespec/v1
 rules:
@@ -951,16 +989,18 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path)
 
-    assert report["total_outputs"] == 12
-    assert report["status_counts"] == {"known_not_comparable": 12}
+    assert report["total_outputs"] == 17
+    assert report["status_counts"] == {
+        "comparable": 5,
+        "known_not_comparable": 12,
+    }
     assert report["untested_comparable"] == 0
     assert report["program_counts"] == {
-        "chip": 2,
+        "chip": 3,
         "health": 1,
-        "medicaid": 7,
+        "medicaid": 11,
         "snap": 2,
     }
-    assert {item["candidate_priority"] for item in report["items"]} == {"P4"}
 
     items_by_name = {item["rule_name"]: item for item in report["items"]}
     assert (
@@ -975,9 +1015,28 @@ rules:
         ]
         == "gov.hhs.chip.child.income_limit"
     )
+    effective_infant = items_by_name[
+        "georgia_children_medicaid_ages_0_to_1_effective_fpl_limit"
+    ]
+    assert effective_infant["status"] == "comparable"
+    assert effective_infant["mapping_type"] == "parameter_value"
+    assert effective_infant["policyengine_parameter"] == (
+        "gov.hhs.medicaid.eligibility.categories.infant.income_limit"
+    )
+    assert effective_infant["tested"] is True
+    assert (
+        items_by_name["georgia_pregnant_women_medicaid_effective_fpl_limit"][
+            "policyengine_parameter"
+        ]
+        == "gov.hhs.medicaid.eligibility.categories.pregnant.income_limit"
+    )
     assert (
         items_by_name["georgia_pregnant_women_chip_available"]["policyengine_parameter"]
         == "gov.hhs.chip.pregnant.income_limit"
+    )
+    assert (
+        items_by_name["georgia_pregnant_women_chip_available"]["status"]
+        == "known_not_comparable"
     )
     assert items_by_name["categorically_eligible_for_snap"]["program"] == "snap"
     assert (

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.775"
+version = "0.2.776"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a signed deterministic repair command for Georgia CMS effective MAGI FPL limits
- map the five comparable effective Georgia Medicaid/CHIP limits to PolicyEngine parameters
- keep raw CMS table values and availability footnotes as known non-comparable surfaces

## Tests
- uv run --extra dev ruff check .
- uv run --extra dev pytest tests/
