### PR TITLE
Classify CO CCAP final surface as non-comparable

### DIFF
--- a/changelog.d/co-ccap-surface-known-not-comparable.fixed.md
+++ b/changelog.d/co-ccap-surface-known-not-comparable.fixed.md
@@ -1,0 +1,1 @@
+Classify the Colorado CCAP final PolicyEngine subsidy surface as known non-comparable to the encoded legal helper slices.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.776"
+version = "0.2.777"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.776"
+__version__ = "0.2.777"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -949,10 +949,12 @@ surfaces:
   variable: co_ccap_subsidy
   source_type: state_implementation
   state: CO
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Current RuleSpec repos include tested Colorado CCAP low-income eligibility, SMI, FPG, and asset-limit legal slices,
+    with comparable mapping for the SMI helper. PolicyEngine's co_ccap_subsidy is a final modeled subsidy equal to childcare
+    expenses minus a parent fee and is defined for PE's composed eligibility predicate, so it is not a direct one-to-one legal
+    output until Axiom has an equivalent final subsidy composition or PE exposes compatible legal helper boundaries.
 - country: us
   program_id: ccdf
   program_name: Care 4 Kids

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -236,6 +236,19 @@ surfaces:
     assert items_by_variable["fdpir"]["axiom_status"] == "input_only"
 
 
+def test_policyengine_program_surface_marks_colorado_ccap_final_subsidy_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="ccap")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    colorado_ccap = items_by_variable["co_ccap_subsidy"]
+
+    assert colorado_ccap["program_id"] == "ccdf"
+    assert colorado_ccap["state"] == "CO"
+    assert colorado_ccap["axiom_status"] == "known_not_comparable"
+    assert colorado_ccap["mapping_count"] == 0
+    assert "final modeled subsidy" in colorado_ccap["rationale"]
+
+
 def test_policyengine_coverage_classifies_nz_outputs_outside_policyengine(tmp_path):
     _write_rulespec_file(
         tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.776"
+version = "0.2.777"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Classify the Colorado CCAP final PolicyEngine subsidy surface as known non-comparable to the encoded legal helper slices.
- Keep the existing comparable SMI helper mapping and document why co_ccap_subsidy is not a one-to-one legal output.
- Bump axiom-encode to 0.2.777 and add a coverage regression test.

## Validation
- uv run --extra dev pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev pytest tests/
- uv tool run ruff check src/ tests/
- uv tool run ruff format --check src/ tests/

## Coverage impact
Using merged rulespec-us main:
- executable outputs: 12,337; comparable: 339; known_not_comparable: 11,998; untested comparable: 0
- program surfaces: pending_rulespec_encoding 68 -> 67; known_not_comparable 3 -> 4
