### PR TITLE
Classify AZ CCAP as pending source ingestion

### DIFF
--- a/changelog.d/az-ccap-source-ingestion-status.fixed.md
+++ b/changelog.d/az-ccap-source-ingestion-status.fixed.md
@@ -1,0 +1,1 @@
+Classified Arizona CCAP as pending source ingestion in the PolicyEngine program surface report.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.777"
+version = "0.2.778"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.777"
+__version__ = "0.2.778"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3661,6 +3661,7 @@ def cmd_oracle_coverage(args):
             "deferred_jurisdiction",
             "pending_oracle_mapping",
             "pending_rulespec_encoding",
+            "pending_source_ingestion",
         }
     ]
     if pending_surface_items:

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -29,6 +29,7 @@ PROGRAM_SURFACE_STATUSES = {
     "pe_in_progress",
     "pending_oracle_mapping",
     "pending_rulespec_encoding",
+    "pending_source_ingestion",
     "wired",
 }
 _PROGRAM_TOKEN_RE = {
@@ -241,6 +242,7 @@ def build_policyengine_program_surface_report(
         "deferred_jurisdiction",
         "pending_oracle_mapping",
         "pending_rulespec_encoding",
+        "pending_source_ingestion",
     }
     pending_surfaces = [
         surface for surface in surfaces if surface.axiom_status in unwired_statuses

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -921,10 +921,12 @@ surfaces:
   variable: az_ccap
   source_type: state_implementation
   state: AZ
-  axiom_status: pending_rulespec_encoding
+  axiom_status: pending_source_ingestion
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: PolicyEngine models Arizona CCAP from Arizona Administrative Code Title 6, Chapter 5 plus DES income-fee
+    and reimbursement schedules. Those official DES/AZSOS sources are not yet in the Axiom corpus, and live unattended
+    fetches currently return Cloudflare challenge pages. Track the source-ingestion blocker in TheAxiomFoundation/axiom-corpus#110;
+    ingestion must land before RuleSpec encoding/oracle wiring can claim parity.
 - country: us
   program_id: ccdf
   program_name: CalWORKs childcare

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -249,6 +249,19 @@ def test_policyengine_program_surface_marks_colorado_ccap_final_subsidy_known_no
     assert "final modeled subsidy" in colorado_ccap["rationale"]
 
 
+def test_policyengine_program_surface_marks_arizona_ccap_pending_source_ingestion():
+    report = build_policyengine_program_surface_report(program="ccap")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    arizona_ccap = items_by_variable["az_ccap"]
+
+    assert arizona_ccap["program_id"] == "ccdf"
+    assert arizona_ccap["state"] == "AZ"
+    assert arizona_ccap["axiom_status"] == "pending_source_ingestion"
+    assert arizona_ccap["mapping_count"] == 0
+    assert "official DES/AZSOS sources" in arizona_ccap["rationale"]
+
+
 def test_policyengine_coverage_classifies_nz_outputs_outside_policyengine(tmp_path):
     _write_rulespec_file(
         tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.777"
+version = "0.2.778"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add `pending_source_ingestion` to PolicyEngine program surface statuses and pending-surface CLI output
- classify `az_ccap` as blocked on official source ingestion instead of raw RuleSpec encoding
- link the blocker to TheAxiomFoundation/axiom-corpus#110 and add regression coverage

## Why
PE models Arizona CCAP from Arizona Administrative Code Title 6, Chapter 5 plus DES income/fee and reimbursement schedules, but those official DES/AZSOS sources are not yet in the Axiom corpus. Direct unattended requests to the current official URLs return Cloudflare challenge HTML.

## Validation
- `uv run --extra dev pytest tests/test_policyengine_coverage.py -q`
- `uv tool run ruff check src/ tests/`
- `uv tool run ruff format --check src/ tests/`
- `uv run --extra dev pytest tests/ -q`