### PR TITLE
Repair generated RuleSpec apply blockers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.778"
+version = "0.2.779"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.778"
+__version__ = "0.2.779"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -18968,6 +18968,20 @@ def cmd_encode(args):
                     "  apply=auto_repaired_nested_test_tables:"
                     + ",".join(repaired_nested_test_tables)
                 )
+            repaired_unquoted_source_scalars = (
+                _try_repair_generated_unquoted_source_scalars_for_apply(
+                    result,
+                    output_root=args.output,
+                )
+            )
+            if repaired_unquoted_source_scalars:
+                outcome["auto_repaired_unquoted_source_scalars"] = (
+                    repaired_unquoted_source_scalars
+                )
+                print(
+                    "  apply=auto_repaired_unquoted_source_scalars:"
+                    + ",".join(repaired_unquoted_source_scalars)
+                )
             repaired_deferred_scope = (
                 _try_repair_generated_out_of_scope_deferred_outputs_for_apply(
                     result,
@@ -25544,13 +25558,28 @@ def _try_repair_generated_empty_deferred_source_values_for_apply(
     return _remove_empty_deferred_source_values(rules_file=rules_file)
 
 
+def _try_repair_generated_unquoted_source_scalars_for_apply(
+    result,
+    *,
+    output_root: Path,
+) -> list[str]:
+    """Quote generated source: scalars that contain YAML-significant colons."""
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    return _quote_unquoted_source_scalars(rules_file=rules_file)
+
+
 def _try_repair_generated_invalid_deferred_source_values_for_apply(
     result,
     *,
     output_root: Path,
     issues: list[str],
 ) -> list[str]:
-    """Remove optional invalid source_values from deferred outputs."""
+    """Canonicalize or remove optional invalid source_values from deferred outputs."""
     if not any(
         (
             "module.deferred_outputs[" in str(issue)
@@ -25566,12 +25595,18 @@ def _try_repair_generated_invalid_deferred_source_values_for_apply(
     ):
         return []
     try:
-        _relative_generated_output_path(result, output_root=output_root)
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
     except RuntimeError:
         return []
 
     rules_file = Path(str(getattr(result, "output_file", "") or ""))
-    return _remove_invalid_deferred_source_values(rules_file=rules_file)
+    base_anchor = _relative_output_to_anchor(relative_output)
+    return _canonicalize_or_remove_invalid_deferred_source_values(
+        rules_file=rules_file,
+        base_anchor=base_anchor,
+    )
 
 
 def _try_repair_generated_out_of_scope_deferred_outputs_for_apply(
@@ -25632,7 +25667,55 @@ def _remove_empty_deferred_source_values(*, rules_file: Path) -> list[str]:
     return [f"source_values[{index}]" for index in range(removed)]
 
 
-def _remove_invalid_deferred_source_values(*, rules_file: Path) -> list[str]:
+def _quote_unquoted_source_scalars(*, rules_file: Path) -> list[str]:
+    if not rules_file.exists():
+        return []
+    try:
+        original = rules_file.read_text()
+    except OSError:
+        return []
+    try:
+        yaml.safe_load(original)
+        return []
+    except (yaml.YAMLError, ValueError):
+        pass
+
+    repaired_lines: list[str] = []
+    repaired: list[str] = []
+    for line_number, raw_line in enumerate(
+        original.splitlines(keepends=True),
+        start=1,
+    ):
+        newline = "\n" if raw_line.endswith("\n") else ""
+        line = raw_line[:-1] if newline else raw_line
+        match = re.match(
+            r"^(\s*source:\s+)([^'\"|>{\[].*:\s+.*?)(\s*)$",
+            line,
+        )
+        if match is None:
+            repaired_lines.append(raw_line)
+            continue
+        prefix, value, trailing = match.groups()
+        quoted = value.replace("'", "''")
+        repaired_lines.append(f"{prefix}'{quoted}'{trailing}{newline}")
+        repaired.append(f"source:{line_number}")
+
+    if not repaired:
+        return []
+    repaired_text = "".join(repaired_lines)
+    try:
+        yaml.safe_load(repaired_text)
+    except (yaml.YAMLError, ValueError):
+        return []
+    rules_file.write_text(repaired_text)
+    return repaired
+
+
+def _canonicalize_or_remove_invalid_deferred_source_values(
+    *,
+    rules_file: Path,
+    base_anchor: str,
+) -> list[str]:
     if not rules_file.exists():
         return []
     try:
@@ -25648,6 +25731,12 @@ def _remove_invalid_deferred_source_values(*, rules_file: Path) -> list[str]:
     if not isinstance(deferred_outputs, list):
         return []
 
+    rule_names = {
+        str(rule.get("name") or "").strip()
+        for rule in payload.get("rules") or []
+        if isinstance(rule, dict) and str(rule.get("name") or "").strip()
+    }
+
     repaired: list[str] = []
     for index, record in enumerate(deferred_outputs):
         if not isinstance(record, dict):
@@ -25655,17 +25744,32 @@ def _remove_invalid_deferred_source_values(*, rules_file: Path) -> list[str]:
         source_values = record.get("source_values")
         if source_values is None:
             continue
-        invalid_values = (
-            not isinstance(source_values, list)
-            or not source_values
-            or any(
-                not _looks_like_absolute_rulespec_output_target(value)
-                for value in source_values
-            )
-        )
-        if not invalid_values:
+        if not isinstance(source_values, list) or not source_values:
+            record.pop("source_values", None)
+            repaired.append(f"source_values[{index}]")
             continue
-        record.pop("source_values", None)
+
+        canonical_values: list[str] = []
+        changed = False
+        for value in source_values:
+            if _looks_like_absolute_rulespec_output_target(value):
+                canonical_values.append(str(value).strip())
+                continue
+            value_text = str(value or "").strip() if isinstance(value, str) else ""
+            if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", value_text) and (
+                value_text in rule_names
+            ):
+                canonical_values.append(f"{base_anchor}#{value_text}")
+                changed = True
+                continue
+            changed = True
+
+        if not changed:
+            continue
+        if canonical_values:
+            record["source_values"] = list(dict.fromkeys(canonical_values))
+        else:
+            record.pop("source_values", None)
         repaired.append(f"source_values[{index}]")
 
     if not repaired:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -568,7 +568,8 @@ GROUNDING_FORMULA_NUMBER_PATTERN = re.compile(
     r"(?<![\w./])(-?[\d,]+(?:\.\d+)?)(?![\w./])"
 )
 SOURCE_TEXT_NUMBER_PATTERN = re.compile(
-    r"(?:^|(?<=[\s$£€(\[,+\-−*/]))(-?(?:[\d,]+(?:\.\d+)?|\.\d+))\b"
+    r"(?:^|(?<=[\s$£€(\[,+\-−*/\"'`“”‘’]))"
+    r"(-?(?:[\d,]+(?:\.\d+)?|\.\d+))\b"
 )
 SOURCE_TEXT_RATIO_NUMBER_PATTERN = re.compile(
     r"(?<![\w.])(\d{1,3})\s*/\s*(\d{1,3})(?![\w/])"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4551,6 +4551,83 @@ rules: []
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_canonicalizes_local_deferred_source_values(
+        self, capsys, tmp_path
+    ):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path / "out" / "codex-test-model" / "statutes" / "42" / "426.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/426
+  deferred_outputs:
+    - output: us:statutes/42/426/b#hospital_insurance_entitlement_for_individuals_under_65
+      reason: Requires upstream disability entitlement mechanics.
+      source_values:
+        - disability_hi_waiting_period_months
+rules:
+  - name: disability_hi_waiting_period_months
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '1966-07-01'
+        formula: 24
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/42/426.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "statutes/42/426.yaml: ci: "
+                            "module.deferred_outputs[0].source_values entry "
+                            "`disability_hi_waiting_period_months` must be an "
+                            "absolute RuleSpec target with a rule fragment."
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert "apply=auto_repaired_invalid_deferred_source_values:" in output
+        assert (
+            "us:statutes/42/426#disability_hi_waiting_period_months"
+            in output_file.read_text()
+        )
+        assert "source_values:" in output_file.read_text()
+        assert mock_overlay.call_count == 2
+        mock_apply.assert_called_once()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_invalid_deferred_source_values"] == [
+            "source_values[0]"
+        ]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_rulespec_output_target_check_rejects_dict_source_values(self):
         assert _looks_like_absolute_rulespec_output_target(
             "us:statutes/26/3132/c#modified_section_110_b_aggregate_limit_amount"
@@ -15675,6 +15752,58 @@ rules:
             "encode_result",
             "encode_outcome",
         ]
+
+    def test_encode_apply_repairs_unquoted_source_scalar_colons(self, capsys, tmp_path):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed compile validation"
+        output_file = tmp_path / "out" / "codex-test-model" / "statutes/42/426.yaml"
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/426
+  deferred_outputs:
+    - output: us:statutes/42/426/b#hospital_insurance_entitlement_under_426_b
+      source: 42 USC 426(b): Individuals under 65 years
+      reason: Requires upstream disability entitlement mechanics.
+rules: []
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = args.policy_repo_path / "statutes/42/426.yaml"
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                return_value=(True, [], {}),
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert "apply=auto_repaired_unquoted_source_scalars:source:7" in output
+        repaired = yaml.safe_load(output_file.read_text())
+        assert (
+            repaired["module"]["deferred_outputs"][0]["source"]
+            == "42 USC 426(b): Individuals under 65 years"
+        )
+        assert mock_overlay.call_count == 1
+        mock_apply.assert_called_once()
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert run.outcome["auto_repaired_unquoted_source_scalars"] == ["source:7"]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
 
     def test_encode_apply_blocks_non_validation_generation_failure(
         self, capsys, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5732,6 +5732,31 @@ rules:
     assert 450 in source_values
 
 
+def test_rulespec_grounding_accepts_quoted_statutory_substitution_numbers():
+    content = """format: rulespec/v1
+rules:
+  - name: disability_trial_work_termination_months_substituted_for_36
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '15'
+"""
+
+    source_text = (
+        "the term “36 months” in section 421(m)(1)(A) shall be applied "
+        "as though it read “15 months”."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    source_values = extract_numbers_from_text(source_text)
+    assert 36 in source_values
+    assert 15 in source_values
+    source_occurrences = extract_numeric_occurrences_from_text(source_text)
+    assert 36 in source_occurrences
+    assert 15 in source_occurrences
+
+
 def test_numeric_occurrence_extraction_treats_escaped_newline_as_line_break():
     actual = "Table 1\n1 | 100\n2 | 200"
     escaped = r"Table 1\n1 | 100\n2 | 200"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.778"
+version = "0.2.779"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Accept quoted numeric source values such as statutory substitutions in numeric grounding.
- Canonicalize local deferred source_values references to absolute RuleSpec targets during signed apply repair.
- Quote generated source: scalars with YAML-significant colons before overlay validation.

## Tests
- uv run python -m pytest tests/test_rulespec_validation.py -k "grounding_accepts_quoted_statutory_substitution_numbers" tests/test_cli.py -k "deferred_source_values or unquoted_source_scalar_colons"
- uv run ruff check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_rulespec_validation.py