### PR TITLE
Repair generated excerpt and formula syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.779"
+version = "0.2.780"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.779"
+__version__ = "0.2.780"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -79,6 +79,7 @@ from .validator_pipeline import (
     find_unused_modifier_parameter_issues,
     numeric_value_is_grounded,
     repair_copied_cross_reference_summary,
+    repair_formula_let_bindings,
     repair_source_table_band_scalar_parameters,
     repair_source_table_interval_row_alignment,
     repair_source_table_interval_tests,
@@ -8407,6 +8408,7 @@ def _normalize_main_eval_content(
     """Normalize generated main artifacts according to their format."""
     if target_path.suffix not in {".yaml", ".yml"}:
         raise ValueError("RuleSpec artifacts must use .yaml or .yml paths")
+    content = _clean_generated_file_content(content)
     normalized = _normalize_rulespec_content(content)
     normalized, _repaired_rules = repair_source_table_band_scalar_parameters(
         normalized,
@@ -8424,6 +8426,7 @@ def _normalize_main_eval_content(
         normalized,
         rules_file=target_path,
     )
+    normalized, _let_binding_repairs = repair_formula_let_bindings(normalized)
     normalized, _conditional_repairs = repair_unsupported_chained_conditionals(
         normalized
     )
@@ -8567,7 +8570,10 @@ def _clean_generated_file_content(content: str) -> str:
 
 def _normalize_semicolon_separated_yaml_excerpts(content: str) -> str:
     """Repair excerpt lines emitted as multiple adjacent quoted scalars."""
-    if "excerpt:" not in content or not re.search(r"['\"]\s*;\s*['\"]", content):
+    if "excerpt:" not in content or not re.search(
+        r"['\"]\s*(?:;|\b(?:and|or)\b)\s*['\"]",
+        content,
+    ):
         return content
 
     repaired_lines: list[str] = []
@@ -8583,15 +8589,21 @@ def _normalize_semicolon_separated_yaml_excerpt_line(line: str) -> str:
     if not match:
         return line
     parsed = _parse_semicolon_separated_quoted_scalars(match.group("rest").strip())
-    if parsed is None or len(parsed) < 2:
+    if parsed is None or len(parsed[0]) < 2:
         return line
-    joined = "; ".join(parsed)
+    values, separators = parsed
+    joined = values[0] + "".join(
+        separator + value for separator, value in zip(separators, values[1:])
+    )
     escaped = joined.replace("\\", "\\\\").replace('"', '\\"')
     return f'{match.group("prefix")}"{escaped}"{newline}'
 
 
-def _parse_semicolon_separated_quoted_scalars(text: str) -> list[str] | None:
+def _parse_semicolon_separated_quoted_scalars(
+    text: str,
+) -> tuple[list[str], list[str]] | None:
     values: list[str] = []
+    separators: list[str] = []
     index = 0
     while index < len(text):
         while index < len(text) and text[index].isspace():
@@ -8623,11 +8635,17 @@ def _parse_semicolon_separated_quoted_scalars(text: str) -> list[str] | None:
         while index < len(text) and text[index].isspace():
             index += 1
         if index == len(text):
-            return values
-        if text[index] != ";":
+            return values, separators
+        if text[index] == ";":
+            separators.append("; ")
+            index += 1
+            continue
+        separator_match = re.match(r"(and|or)\b", text[index:], flags=re.IGNORECASE)
+        if separator_match is None:
             return None
-        index += 1
-    return values
+        separators.append(f" {separator_match.group(1).lower()} ")
+        index += len(separator_match.group(1))
+    return values, separators
 
 
 def _normalize_backslash_escaped_yaml_apostrophes(content: str) -> str:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -4390,6 +4390,108 @@ def repair_unsupported_chained_conditionals(content: str) -> tuple[str, list[str
     return repaired_content, sorted(changed_rules)
 
 
+def repair_formula_let_bindings(content: str) -> tuple[str, list[str]]:
+    """Inline simple generated formula-local assignments."""
+    payload = _rulespec_payload(content)
+    if payload is None or payload.get("format") != "rulespec/v1":
+        return content, []
+
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return content, []
+
+    changed_rules: set[str] = set()
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        rule_name = str(rule.get("name") or "<unknown>").strip() or "<unknown>"
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            repaired = _repair_formula_let_binding_text(formula)
+            if repaired == formula:
+                continue
+            version["formula"] = repaired
+            changed_rules.add(rule_name)
+
+    if not changed_rules:
+        return content, []
+
+    repaired_content = yaml.safe_dump(payload, sort_keys=False).strip() + "\n"
+    return repaired_content, sorted(changed_rules)
+
+
+_FORMULA_LET_BINDING_PATTERN = re.compile(
+    r"^(?P<indent>\s*)(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*=\s*(?!=)(?P<expr>.*)$"
+)
+
+
+def _repair_formula_let_binding_text(formula: str) -> str:
+    lines = formula.splitlines()
+    if not any(_FORMULA_LET_BINDING_PATTERN.match(line) for line in lines):
+        return formula
+
+    replacements: dict[str, str] = {}
+    repaired_lines: list[str] = []
+    changed = False
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        match = _FORMULA_LET_BINDING_PATTERN.match(line)
+        if match is None:
+            repaired_lines.append(
+                _replace_formula_let_binding_names(line, replacements)
+            )
+            index += 1
+            continue
+
+        name = match.group("name")
+        indent = len(match.group("indent"))
+        expr_parts: list[str] = []
+        inline_expr = match.group("expr").strip()
+        if inline_expr:
+            expr_parts.append(inline_expr)
+            index += 1
+        else:
+            index += 1
+            while index < len(lines):
+                continuation = lines[index]
+                if continuation.strip() == "":
+                    index += 1
+                    continue
+                continuation_indent = len(continuation) - len(continuation.lstrip(" "))
+                if continuation_indent <= indent:
+                    break
+                expr_parts.append(continuation.strip())
+                index += 1
+
+        if not expr_parts:
+            repaired_lines.append(line)
+            continue
+
+        expression = " ".join(expr_parts)
+        expression = _replace_formula_let_binding_names(expression, replacements)
+        replacements[name] = f"({expression})"
+        changed = True
+
+    if not changed:
+        return formula
+    return "\n".join(repaired_lines)
+
+
+def _replace_formula_let_binding_names(line: str, replacements: dict[str, str]) -> str:
+    repaired = line
+    for name, expression in replacements.items():
+        repaired = re.sub(rf"\b{re.escape(name)}\b", expression, repaired)
+    return repaired
+
+
 def repair_source_table_open_ended_bound_sentinels(
     content: str,
     *,

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -5213,6 +5213,35 @@ class TestGeneratedBundleCleaning:
             "The first two thousand dollars ($2,000) of each payment is excluded"
         )
 
+    def test_clean_generated_file_content_repairs_conjoined_quoted_excerpts(self):
+        content = (
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  summary: Fuel cell cap.\n"
+            "rules:\n"
+            "  - name: residential_clean_energy_fuel_cell_credit_component\n"
+            "    kind: derived\n"
+            "    metadata:\n"
+            "      proof:\n"
+            "        atoms:\n"
+            "          - source:\n"
+            '              excerpt: "applicable percentages of qualified fuel cell property expenditures" and "shall not exceed $500 with respect to each half kilowatt of capacity"\n'
+            "    versions:\n"
+            "      - effective_from: '2006-01-01'\n"
+            "        formula: 500\n"
+        )
+
+        cleaned = _clean_generated_file_content(content)
+        payload = yaml.safe_load(cleaned)
+
+        excerpt = payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"][
+            "excerpt"
+        ]
+        assert excerpt == (
+            "applicable percentages of qualified fuel cell property expenditures "
+            "and shall not exceed $500 with respect to each half kilowatt of capacity"
+        )
+
     def test_materialize_eval_artifact_rejects_non_rulespec_bundle(self, tmp_path):
         output_file = tmp_path / "source" / "example.yaml"
         response = (
@@ -5223,6 +5252,54 @@ class TestGeneratedBundleCleaning:
 
         assert wrote is False
         assert not output_file.exists()
+
+    def test_materialize_eval_artifact_repairs_single_file_conjoined_excerpts(
+        self, tmp_path
+    ):
+        output_file = tmp_path / "source" / "section-25d.yaml"
+        response = (
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  summary: Fuel cell cap.\n"
+            "rules:\n"
+            "  - name: residential_clean_energy_fuel_cell_credit_component\n"
+            "    kind: derived\n"
+            "    metadata:\n"
+            "      proof:\n"
+            "        atoms:\n"
+            "          - source:\n"
+            '              excerpt: "applicable percentages of qualified fuel cell property expenditures" and "shall not exceed $500 with respect to each half kilowatt of capacity"\n'
+            "    versions:\n"
+            "      - effective_from: '2006-01-01'\n"
+            "        formula: |-\n"
+            "          if expenditures_after_termination_date:\n"
+            "              0\n"
+            "          else:\n"
+            "              base_expenditures =\n"
+            "                  max(0, qualified_solar_electric_property_expenditures)\n"
+            "                  + max(0, qualified_battery_storage_technology_expenditures)\n"
+            "              credit = residential_clean_energy_applicable_percentage * base_expenditures\n"
+            "              max(0, credit + residential_clean_energy_fuel_cell_credit_component)\n"
+        )
+
+        wrote = _materialize_eval_artifact(response, output_file)
+
+        assert wrote is True
+        payload = yaml.safe_load(output_file.read_text())
+        excerpt = payload["rules"][0]["metadata"]["proof"]["atoms"][0]["source"][
+            "excerpt"
+        ]
+        assert excerpt == (
+            "applicable percentages of qualified fuel cell property expenditures "
+            "and shall not exceed $500 with respect to each half kilowatt of capacity"
+        )
+        formula = payload["rules"][0]["versions"][0]["formula"]
+        assert "base_expenditures =" not in formula
+        assert "credit =" not in formula
+        assert (
+            "residential_clean_energy_applicable_percentage * "
+            "(max(0, qualified_solar_electric_property_expenditures)"
+        ) in formula
 
     def test_materialize_eval_artifact_cleans_bundled_rulespec_fences(self, tmp_path):
         output_file = tmp_path / "source" / "uksi-2006-965-regulation-2.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.779"
+version = "0.2.780"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair generated single-file RuleSpec YAML proof excerpt lines with adjacent quoted scalars joined by `and`/`or`
- run generated-file cleaning before main artifact normalization, not only bundled file materialization
- inline simple generated formula-local let bindings before compile-time conditional repair
- bump axiom-encode to 0.2.780

## Validation
- `uv run python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_evals.py::TestGeneratedBundleCleaning::test_clean_generated_file_content_repairs_conjoined_quoted_excerpts tests/test_evals.py::TestGeneratedBundleCleaning::test_materialize_eval_artifact_repairs_single_file_conjoined_excerpts tests/test_evals.py::TestGeneratedBundleCleaning::test_clean_generated_file_content_repairs_semicolon_excerpts`
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- verified the prior failed generated `26 USC 25D` artifact compiles after normalization