### PR TITLE
Map 25D residential clean energy PE gap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.780"
+version = "0.2.781"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.780"
+__version__ = "0.2.781"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -15114,6 +15114,74 @@ mappings:
     mapping_type: not_comparable
     rationale: "Source-specific intermediate output (rule `timely_application_for_recertification`, grounded against `Ala. Admin. Code 660-4-7-.08`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
+  - legal_id: us:statutes/26/25D#fuel_cell_credit_per_half_kilowatt_cap_amount
+    country: us
+    program: residential_clean_energy_credit
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.credits.residential_clean_energy.fuel_cell_cap_per_kw
+    rationale: Section 25D(b)(1) states the fuel-cell cap per half kilowatt, while PolicyEngine stores the related amount per kilowatt; compare this after adding transformed parameter comparisons for this surface.
+
+  - legal_id: us:statutes/26/25D#fuel_cell_joint_occupancy_max_expenditures_per_half_kilowatt
+    country: us
+    program: residential_clean_energy_credit
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the section 25D(e) joint-occupancy fuel-cell expenditure limit as a separate parameter or variable.
+
+  - legal_id: us:statutes/26/25D#residential_clean_energy_credit_applicable_percentage_property_placed_after_2016_and_before_2020
+    country: us
+    program: residential_clean_energy_credit
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.credits.residential_clean_energy.applicable_percentage
+    rationale: RuleSpec exposes the statutory placed-in-service percentage branch separately, while PolicyEngine exposes a period-selected percentage schedule.
+
+  - legal_id: us:statutes/26/25D#residential_clean_energy_credit_applicable_percentage_property_placed_after_2019_and_before_2022
+    country: us
+    program: residential_clean_energy_credit
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.credits.residential_clean_energy.applicable_percentage
+    rationale: RuleSpec exposes the statutory placed-in-service percentage branch separately, while PolicyEngine exposes a period-selected percentage schedule.
+
+  - legal_id: us:statutes/26/25D#residential_clean_energy_credit_applicable_percentage_property_placed_after_2021
+    country: us
+    program: residential_clean_energy_credit
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.credits.residential_clean_energy.applicable_percentage
+    rationale: RuleSpec exposes the statutory placed-in-service percentage branch separately, while PolicyEngine exposes a period-selected percentage schedule that is stale after Pub. L. 119-21; see PolicyEngine/policyengine-us#8694.
+
+  - legal_id: us:statutes/26/25D#residential_clean_energy_credit_applicable_percentage
+    country: us
+    program: residential_clean_energy_credit
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.credits.residential_clean_energy.applicable_percentage
+    rationale: PolicyEngine's applicable percentage schedule still includes the pre-Pub. L. 119-21 2033/2034 phase-down and has not yet been updated for the current-law post-2025 termination; see PolicyEngine/policyengine-us#8694.
+
+  - legal_id: us:statutes/26/25D#residential_clean_energy_credit_potential
+    country: us
+    program: residential_clean_energy_credit
+    mapping_type: not_comparable
+    policyengine_variable: residential_clean_energy_credit_potential
+    rationale: PolicyEngine exposes the potential credit, but its applicable percentage schedule is stale after Pub. L. 119-21 and differs for post-2025 positive-expenditure cases; see PolicyEngine/policyengine-us#8694.
+
+  - legal_id: us:statutes/26/25D#residential_clean_energy_credit_current_year_limit_under_section_25D_c
+    country: us
+    program: residential_clean_energy_credit
+    mapping_type: not_comparable
+    policyengine_variable: residential_clean_energy_credit_credit_limit
+    rationale: Same broad section 25D(c) current-year limitation concept, but RuleSpec exposes the section 26(a) limit and other-credit subtraction as legal boundary inputs while PolicyEngine computes them from its full tax stack.
+
+  - legal_id: us:statutes/26/25D#residential_clean_energy_credit
+    country: us
+    program: residential_clean_energy_credit
+    mapping_type: not_comparable
+    policyengine_variable: residential_clean_energy_credit
+    rationale: Same final residential clean energy credit surface, but PolicyEngine is stale after Pub. L. 119-21 and still allows post-2025 credits; see PolicyEngine/policyengine-us#8694.
+
+  - legal_id: us:statutes/26/25D#residential_clean_energy_credit_carryforward_to_succeeding_taxable_year
+    country: us
+    program: residential_clean_energy_credit
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the section 25D(c) carryforward amount as a separate variable.
+
 prefixes:
   - legal_id_prefix: us:statutes/5/5566#
     country: us

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2378,6 +2378,27 @@ def test_policyengine_registry_is_legal_id_keyed():
         section_2014c_net_failure_mapping.policyengine_variable
         == "meets_snap_net_income_test"
     )
+    residential_clean_energy_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/25D#residential_clean_energy_credit",
+        country="us",
+    )
+    assert residential_clean_energy_mapping.mapping_type == "not_comparable"
+    assert (
+        residential_clean_energy_mapping.policyengine_variable
+        == "residential_clean_energy_credit"
+    )
+    assert "PolicyEngine/policyengine-us#8694" in (
+        residential_clean_energy_mapping.rationale or ""
+    )
+    residential_clean_energy_percentage_mapping = registry.mapping_for_legal_id(
+        "us:statutes/26/25D#residential_clean_energy_credit_applicable_percentage",
+        country="us",
+    )
+    assert residential_clean_energy_percentage_mapping.mapping_type == "not_comparable"
+    assert (
+        residential_clean_energy_percentage_mapping.policyengine_parameter
+        == "gov.irs.credits.residential_clean_energy.applicable_percentage"
+    )
     section_2014c_gross_failure_mapping = registry.mapping_for_legal_id(
         "us:statutes/7/2014/c#household_fails_gross_income_standard",
         country="us",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.780"
+version = "0.2.781"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add PolicyEngine oracle mappings for the new 26 USC 25D residential clean energy outputs
- mark the surface known-not-comparable while PolicyEngine-US is stale after Pub. L. 119-21
- reference PolicyEngine/policyengine-us#8694 for the post-2025 termination bug
- bump axiom-encode to 0.2.781

## Validation
- `uv run python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed`
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`