### PR TITLE
Route state encodings and wire Colorado OAP oracle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.781"
+version = "0.2.782"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.781"
+__version__ = "0.2.782"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -63,6 +63,7 @@ from .harness.evals import (
     _canonical_target_ref_prefix,
     _canonical_uk_legislation_tail,
     _eval_result_from_payload,
+    _looks_like_corpus_citation_path,
     _source_identifier_to_relative_rulespec_path,
     _target_source_scope_for_heuristics,
     evaluate_artifact,
@@ -218,9 +219,9 @@ def _resolve_policy_repo_for_corpus_source(
     corpus_citation_path: str,
     override: Path | None = None,
 ) -> Path:
-    if override is not None:
-        return override
     jurisdiction = corpus_citation_path.strip().split("/", 1)[0] or "us"
+    if override is not None:
+        return jurisdiction_content_dir(override, jurisdiction).resolve()
     return _resolve_policy_repo_for_prefix(jurisdiction)
 
 
@@ -18771,7 +18772,15 @@ def cmd_encode(args):
     axiom_rules_path = args.axiom_rules_path or _resolve_repo_checkout(
         "axiom-rules-engine"
     )
-    policy_repo_path = args.policy_repo_path or _resolve_policy_repo_for_prefix("us")
+    if _looks_like_corpus_citation_path(args.citation):
+        policy_repo_path = _resolve_policy_repo_for_corpus_source(
+            args.citation,
+            args.policy_repo_path,
+        )
+    else:
+        policy_repo_path = args.policy_repo_path or _resolve_policy_repo_for_prefix(
+            "us"
+        )
 
     if not corpus_path.exists():
         print(f"Axiom Corpus repo not found: {corpus_path}")

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -24524,6 +24524,7 @@ print("BENCHMARK:" + json.dumps(result))
                 *adapter.annual_derived_spm_overrides,
             ):
                 aliases.update(source_keys)
+            aliases.update(adapter.unsupported_truthy_input_keys)
             if adapter.state_code_from_boolean_input is not None:
                 aliases.add(adapter.state_code_from_boolean_input[0])
         return {alias.lower() for alias in aliases if alias}
@@ -24697,6 +24698,23 @@ print("BENCHMARK:" + json.dumps(result))
                         "RuleSpec test supplies unsupported PolicyEngine US scenario inputs"
                     )
                     return False, f"{reason}: {', '.join(sorted(unsupported_keys))}"
+            if adapter is not None and adapter.unsupported_truthy_input_keys:
+                unsupported_truthy_keys = []
+                for key in adapter.unsupported_truthy_input_keys:
+                    value = self._rulespec_test_input_value(inputs, key)
+                    if value is None:
+                        continue
+                    if bool(value):
+                        unsupported_truthy_keys.append(key)
+                if unsupported_truthy_keys:
+                    reason = adapter.unsupported_input_reason or (
+                        "RuleSpec test supplies active facts that PolicyEngine US "
+                        "does not model"
+                    )
+                    return (
+                        False,
+                        f"{reason}: {', '.join(sorted(unsupported_truthy_keys))}",
+                    )
         if country == "uk" and isinstance(expected, dict):
             return (
                 False,

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -25,6 +25,7 @@ class PolicyEngineUSVarAdapter:
     annual_derived_spm_overrides: tuple[tuple[str, str, tuple[str, ...]], ...] = ()
     unsupported_input_keys: tuple[str, ...] = ()
     unsupported_input_patterns: tuple[str, ...] = ()
+    unsupported_truthy_input_keys: tuple[str, ...] = ()
     unsupported_input_reason: str | None = None
     default_state_code: str | None = None
     state_code_from_boolean_input: tuple[str, str, str] | None = None
@@ -390,6 +391,28 @@ PE_US_VAR_ADAPTERS = (
         spm=True,
         annual_direct_spm_overrides=(("family_size", "spm_unit_size"),),
         default_state_code="CO",
+    ),
+    PolicyEngineUSVarAdapter(
+        rule_names=("oap_authorized_grant_payment_for_month",),
+        pe_var="co_oap",
+        default_state_code="CO",
+        annualized_person_inputs=(
+            ("client_total_countable_income_for_oap", "ssi_countable_income"),
+        ),
+        boolean_person_inputs=(
+            (
+                "client_is_oap_eligible_under_sections_3_520_6_and_3_520_7",
+                "co_oap_eligible",
+            ),
+        ),
+        unsupported_truthy_input_keys=(
+            "client_is_inmate_in_penal_institution",
+            "client_is_resident_in_unlicensed_or_uncertified_facility",
+        ),
+        unsupported_input_reason=(
+            "PolicyEngine Colorado OAP does not model these 3.532 grant-payment "
+            "exclusion facts"
+        ),
     ),
     PolicyEngineUSVarAdapter(
         rule_names=("snap_excess_shelter_deduction",),

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -671,6 +671,95 @@ mappings:
     candidate_priority: P2
     rationale: PolicyEngine's Colorado CCAP entry income predicate does not include the 3.111(H)(4)(c) one-million-dollar asset cap and uses PE's separate FPG entry-rate predicate.
 
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.530#oap_total_monthly_grant_standard
+    country: us
+    program: co_oap
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.ssa.oap.grant_standard
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Colorado OAP monthly grant standard parameter.
+
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.532#oap_authorized_grant_payment_for_month
+    country: us
+    program: co_oap
+    mapping_type: direct_variable
+    policyengine_variable: co_oap
+    result_multiplier: 0.08333333333333333
+    entity: person
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Colorado OAP grant amount before the OAP payment-floor supplement and first-month proration; PolicyEngine exposes the annual amount, so the oracle scales it to the monthly RuleSpec output.
+
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.532#oap_state_supplementary_payment_for_month
+    country: us
+    program: co_oap
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This is the OAP payment-floor supplement under 9 CCR 2503-5 3.532(B); PolicyEngine's Colorado state-supplement variable models AND-CS, not this OAP floor top-up.
+
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.532#oap_total_grant_payment_including_state_supplement_for_month
+    country: us
+    program: co_oap
+    mapping_type: not_comparable
+    policyengine_variable: co_oap
+    candidate_priority: P4
+    rationale: PolicyEngine's Colorado OAP variable is the grant-standard-minus-income amount before the OAP payment-floor supplement; this RuleSpec output includes the separate 3.532(B) state supplementary payment.
+
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.532#oap_first_month_grant_payment_with_proration
+    country: us
+    program: co_oap
+    mapping_type: not_comparable
+    policyengine_variable: co_oap
+    candidate_priority: P4
+    rationale: PolicyEngine's Colorado OAP variable does not expose the 3.532(B)(1)-(2) first-month proration rule as a one-to-one output.
+
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.520.72#resource_limit_amount_for_unmarried_person_under_3_520_72
+    country: us
+    program: co_oap
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.ssa.oap.resources.single
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado OAP unmarried-person resource limit.
+
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.520.72#resource_limit_amount_for_married_person_under_3_520_72
+    country: us
+    program: co_oap
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.ssa.oap.resources.couple
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Colorado OAP married-person resource limit.
+
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.520.72#person_resource_limit_under_3_520_72
+    country: us
+    program: co_oap
+    mapping_type: not_comparable
+    policyengine_variable: co_oap_eligible
+    candidate_priority: P4
+    rationale: This RuleSpec helper selects between the unmarried and married resource limits with the sponsor/co-sponsor exception in 3.520.72; PolicyEngine exposes the final OAP eligibility predicate rather than this legal resource-limit selector.
+
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.520.72#client_countable_resources_including_deemed_from_sponsors_under_3_520_72
+    country: us
+    program: co_oap
+    mapping_type: not_comparable
+    policyengine_variable: ssi_countable_resources
+    candidate_priority: P4
+    rationale: RuleSpec explicitly adds deemed sponsor resources under 3.520.72; PolicyEngine's SSI countable resources is a broader annual resource abstraction.
+
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.520.72#client_resources_within_limit_under_3_520_72
+    country: us
+    program: co_oap
+    mapping_type: not_comparable
+    policyengine_variable: co_oap_eligible
+    candidate_priority: P4
+    rationale: This is only the 3.520.72 resource-limit predicate; PolicyEngine's Colorado OAP eligibility also includes age, state, and other eligibility conditions.
+
   - legal_id: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
     country: us
     program: snap

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3700,6 +3700,23 @@ class TestCmdEncode:
             == args.axiom_rules_path
         )
 
+    def test_encode_routes_state_corpus_citation_to_monorepo_jurisdiction_dir(
+        self, capsys, tmp_path
+    ):
+        policy_repo_path = tmp_path / "rulespec-us"
+        (policy_repo_path / "us").mkdir(parents=True)
+        (policy_repo_path / "us-co").mkdir()
+        args = self._make_args(
+            tmp_path,
+            citation="us-co/regulation/9-ccr-2503-5/3.530",
+            policy_repo_path=policy_repo_path,
+        )
+
+        mock_run, exit_code = self._run_encode(args, self._make_eval_result(True))
+
+        assert exit_code == 0
+        assert mock_run.call_args.kwargs["policy_path"] == policy_repo_path / "us-co"
+
     def test_encode_passes_skip_reviewers_to_model_eval(self, capsys, tmp_path):
         args = self._make_args(tmp_path, skip_reviewers=True)
         mock_run, exit_code = self._run_encode(args, self._make_eval_result(True))

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -262,6 +262,21 @@ def test_policyengine_program_surface_marks_arizona_ccap_pending_source_ingestio
     assert "official DES/AZSOS sources" in arizona_ccap["rationale"]
 
 
+def test_policyengine_program_surface_marks_colorado_oap_wired():
+    report = build_policyengine_program_surface_report(program="co_oap")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    colorado_oap = items_by_variable["co_oap"]
+
+    assert colorado_oap["axiom_status"] == "wired"
+    assert colorado_oap["mapping_count"] >= 1
+    assert colorado_oap["comparable_mapping_count"] >= 1
+    assert (
+        "us-co:regulations/9-ccr-2503-5/3.532#oap_authorized_grant_payment_for_month"
+        in colorado_oap["legal_ids"]
+    )
+
+
 def test_policyengine_coverage_classifies_nz_outputs_outside_policyengine(tmp_path):
     _write_rulespec_file(
         tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2369,6 +2369,22 @@ def test_policyengine_registry_is_legal_id_keyed():
     assert colorado_ccap_smi_limit_mapping.mapping_type == "direct_variable"
     assert colorado_ccap_smi_limit_mapping.policyengine_variable == "co_ccap_smi"
     assert colorado_ccap_smi_limit_mapping.result_multiplier == 0.85
+    colorado_oap_mapping = registry.mapping_for_legal_id(
+        "us-co:regulations/9-ccr-2503-5/3.532#oap_authorized_grant_payment_for_month",
+        country="us",
+    )
+    assert colorado_oap_mapping.mapping_type == "direct_variable"
+    assert colorado_oap_mapping.policyengine_variable == "co_oap"
+    assert colorado_oap_mapping.result_multiplier == pytest.approx(1 / 12)
+    colorado_oap_grant_standard_mapping = registry.mapping_for_legal_id(
+        "us-co:regulations/9-ccr-2503-5/3.530#oap_total_monthly_grant_standard",
+        country="us",
+    )
+    assert colorado_oap_grant_standard_mapping.mapping_type == "parameter_value"
+    assert (
+        colorado_oap_grant_standard_mapping.policyengine_parameter
+        == "gov.states.co.ssa.oap.grant_standard"
+    )
     section_2014c_net_failure_mapping = registry.mapping_for_legal_id(
         "us:statutes/7/2014/c#snap_net_income_exceeds_poverty_line",
         country="us",
@@ -4136,6 +4152,69 @@ def test_policyengine_mappability_ignores_unrelated_legal_inputs_when_mapped():
     assert list(projected) == [
         "us-co:regulations/8-ccr-1403-1/3.111/h-low-income-eligibility-guidelines#input.family_size"
     ]
+
+
+def test_policyengine_oap_adapter_annualizes_monthly_income_and_sets_eligibility(
+    tmp_path,
+):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    script = pipeline._build_pe_us_scenario_script(
+        "co_oap",
+        {
+            "period": "2026-01",
+            "us-co:regulations/9-ccr-2503-5/3.532#input.client_total_countable_income_for_oap": 32,
+            "us-co:regulations/9-ccr-2503-5/3.532#input.client_is_oap_eligible_under_sections_3_520_6_and_3_520_7": True,
+        },
+        "2026",
+    )
+
+    assert "'state_code_str': {'2026': 'CO'}" in script
+    assert "'ssi_countable_income': {'2026': 384.0}" in script
+    assert "'co_oap_eligible': {'2026': True}" in script
+
+
+def test_policyengine_oap_mappability_blocks_active_unmodeled_exclusions(
+    tmp_path,
+):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    inputs = {
+        "us-co:regulations/9-ccr-2503-5/3.532#input.client_total_countable_income_for_oap": 32,
+        "us-co:regulations/9-ccr-2503-5/3.532#input.client_is_oap_eligible_under_sections_3_520_6_and_3_520_7": True,
+        "us-co:regulations/9-ccr-2503-5/3.532#input.client_is_inmate_in_penal_institution": False,
+        "us-co:regulations/9-ccr-2503-5/3.532#input.client_is_resident_in_unlicensed_or_uncertified_facility": False,
+    }
+
+    mappable, reason = pipeline._is_pe_test_mappable(
+        "us",
+        "oap_authorized_grant_payment_for_month",
+        inputs,
+        pe_var="co_oap",
+    )
+
+    assert mappable is True
+    assert reason is None
+
+    inputs[
+        "us-co:regulations/9-ccr-2503-5/3.532#input.client_is_inmate_in_penal_institution"
+    ] = True
+    mappable, reason = pipeline._is_pe_test_mappable(
+        "us",
+        "oap_authorized_grant_payment_for_month",
+        inputs,
+        pe_var="co_oap",
+    )
+
+    assert mappable is False
+    assert "does not model these 3.532 grant-payment exclusion facts" in (reason or "")
+    assert "client_is_inmate_in_penal_institution" in (reason or "")
 
 
 def test_policyengine_tax_scenario_skips_unmodelled_niit_components(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.781"
+version = "0.2.782"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- route corpus citations like `us-co/regulation/...` into the matching jurisdiction content directory when encoding against the `rulespec-us` monorepo
- add PolicyEngine oracle mappings for Colorado OAP grant/resource outputs and classify adjacent OAP supplement/resource helpers
- add a CO OAP adapter that annualizes monthly OAP income inputs, sets PE eligibility, and blocks active 3.532 exclusion facts

## Tests
- `uv run python -m pytest tests/test_cli.py::TestCmdEncode::test_encode_routes_state_corpus_citation_to_monorepo_jurisdiction_dir tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_rulespec_validation.py::test_policyengine_oap_adapter_annualizes_monthly_income_and_sets_eligibility tests/test_rulespec_validation.py::test_policyengine_oap_mappability_blocks_active_unmodeled_exclusions tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_colorado_oap_wired -q`
- `uv run python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run python -m pytest tests/test_rulespec_validation.py::test_policyengine_mappability_ignores_unrelated_legal_inputs_when_mapped tests/test_rulespec_validation.py::test_policyengine_oracle_rejects_untranslated_legal_facts tests/test_rulespec_validation.py::test_policyengine_oracle_uses_policyengine_only_inputs_for_legal_facts -q`
- `uv run ruff check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py src/axiom_encode/oracles/policyengine/adapters.py src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/registry.py tests/test_cli.py tests/test_policyengine_coverage.py tests/test_rulespec_validation.py`