### PR TITLE
Wire Colorado AND-CS PolicyEngine oracle

### DIFF
--- a/changelog.d/colorado-and-cs-oracle-coverage.changed.md
+++ b/changelog.d/colorado-and-cs-oracle-coverage.changed.md
@@ -1,0 +1,1 @@
+Wire Colorado AND-CS RuleSpec outputs to the PolicyEngine state-supplement oracle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.782"
+version = "0.2.783"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.782"
+__version__ = "0.2.783"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -415,6 +415,41 @@ PE_US_VAR_ADAPTERS = (
         ),
     ),
     PolicyEngineUSVarAdapter(
+        rule_names=(
+            "and_cs_authorized_grant_payment_for_month",
+            "and_cs_grant_payment_for_month",
+            "and_cs_monthly_grant_payment",
+        ),
+        pe_var="co_state_supplement",
+        default_state_code="CO",
+        annualized_person_inputs=(
+            ("client_total_countable_income_for_and_cs", "ssi_countable_income"),
+            ("and_cs_total_countable_income", "ssi_countable_income"),
+            ("client_countable_income_for_and_cs", "ssi_countable_income"),
+            ("client_ssi_payment_amount_for_and_cs", "ssi"),
+            ("and_cs_ssi_payment_amount", "ssi"),
+        ),
+        boolean_person_inputs=(
+            (
+                "client_is_and_cs_eligible_under_sections_3_546_and_3_547",
+                "co_state_supplement_eligible",
+            ),
+            (
+                "and_cs_client_eligible_for_grant_payments_under_3_548",
+                "co_state_supplement_eligible",
+            ),
+            ("and_cs_client_eligible", "co_state_supplement_eligible"),
+        ),
+        unsupported_truthy_input_keys=(
+            "client_is_inmate_in_penal_institution",
+            "client_is_resident_in_unlicensed_or_uncertified_facility",
+        ),
+        unsupported_input_reason=(
+            "PolicyEngine Colorado SSP does not model these 3.548 grant-payment "
+            "exclusion facts"
+        ),
+    ),
+    PolicyEngineUSVarAdapter(
         rule_names=("snap_excess_shelter_deduction",),
         pe_var="snap_excess_shelter_expense_deduction",
         monthly=True,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -760,6 +760,52 @@ mappings:
     candidate_priority: P4
     rationale: This is only the 3.520.72 resource-limit predicate; PolicyEngine's Colorado OAP eligibility also includes age, state, and other eligibility conditions.
 
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.546#and_cs_total_monthly_grant_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.ssa.state_supplement.grant_standard
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Colorado AND-CS monthly grant standard parameter for the state-administered SSI supplement.
+
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.548#and_cs_authorized_grant_payment_for_month
+    country: us
+    program: ssi_state_supplement
+    mapping_type: direct_variable
+    policyengine_variable: co_state_supplement
+    result_multiplier: 0.08333333333333333
+    entity: person
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Colorado AND-CS grant-standard-minus-countable-income amount; PolicyEngine exposes the annual amount, so the oracle scales it to the monthly RuleSpec output.
+
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.548#and_cs_grant_payment_for_month
+    country: us
+    program: ssi_state_supplement
+    mapping_type: direct_variable
+    policyengine_variable: co_state_supplement
+    result_multiplier: 0.08333333333333333
+    entity: person
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Colorado AND-CS grant-standard-minus-countable-income amount; PolicyEngine exposes the annual amount, so the oracle scales it to the monthly RuleSpec output.
+
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.548#and_cs_monthly_grant_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: direct_variable
+    policyengine_variable: co_state_supplement
+    result_multiplier: 0.08333333333333333
+    entity: person
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Colorado AND-CS grant-standard-minus-countable-income amount; PolicyEngine exposes the annual amount, so the oracle scales it to the monthly RuleSpec output.
+
   - legal_id: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -277,6 +277,23 @@ def test_policyengine_program_surface_marks_colorado_oap_wired():
     )
 
 
+def test_policyengine_program_surface_marks_colorado_ssp_wired():
+    report = build_policyengine_program_surface_report(program="co_state_supplement")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    colorado_ssp = items_by_variable["co_state_supplement"]
+
+    assert colorado_ssp["program_id"] == "ssi_state_supplement"
+    assert colorado_ssp["state"] == "CO"
+    assert colorado_ssp["axiom_status"] == "wired"
+    assert colorado_ssp["mapping_count"] >= 1
+    assert colorado_ssp["comparable_mapping_count"] >= 1
+    assert (
+        "us-co:regulations/9-ccr-2503-5/3.548#and_cs_authorized_grant_payment_for_month"
+        in colorado_ssp["legal_ids"]
+    )
+
+
 def test_policyengine_coverage_classifies_nz_outputs_outside_policyengine(tmp_path):
     _write_rulespec_file(
         tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2385,6 +2385,22 @@ def test_policyengine_registry_is_legal_id_keyed():
         colorado_oap_grant_standard_mapping.policyengine_parameter
         == "gov.states.co.ssa.oap.grant_standard"
     )
+    colorado_ssp_mapping = registry.mapping_for_legal_id(
+        "us-co:regulations/9-ccr-2503-5/3.548#and_cs_authorized_grant_payment_for_month",
+        country="us",
+    )
+    assert colorado_ssp_mapping.mapping_type == "direct_variable"
+    assert colorado_ssp_mapping.policyengine_variable == "co_state_supplement"
+    assert colorado_ssp_mapping.result_multiplier == pytest.approx(1 / 12)
+    colorado_ssp_grant_standard_mapping = registry.mapping_for_legal_id(
+        "us-co:regulations/9-ccr-2503-5/3.546#and_cs_total_monthly_grant_standard",
+        country="us",
+    )
+    assert colorado_ssp_grant_standard_mapping.mapping_type == "parameter_value"
+    assert (
+        colorado_ssp_grant_standard_mapping.policyengine_parameter
+        == "gov.states.co.ssa.state_supplement.grant_standard"
+    )
     section_2014c_net_failure_mapping = registry.mapping_for_legal_id(
         "us:statutes/7/2014/c#snap_net_income_exceeds_poverty_line",
         country="us",
@@ -4215,6 +4231,69 @@ def test_policyengine_oap_mappability_blocks_active_unmodeled_exclusions(
     assert mappable is False
     assert "does not model these 3.532 grant-payment exclusion facts" in (reason or "")
     assert "client_is_inmate_in_penal_institution" in (reason or "")
+
+
+def test_policyengine_and_cs_adapter_annualizes_income_and_sets_eligibility(
+    tmp_path,
+):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    script = pipeline._build_pe_us_scenario_script(
+        "co_state_supplement",
+        {
+            "period": "2026-01",
+            "us-co:regulations/9-ccr-2503-5/3.548#input.client_total_countable_income_for_and_cs": 32,
+            "us-co:regulations/9-ccr-2503-5/3.548#input.client_is_and_cs_eligible_under_sections_3_546_and_3_547": True,
+        },
+        "2026",
+    )
+
+    assert "'state_code_str': {'2026': 'CO'}" in script
+    assert "'ssi_countable_income': {'2026': 384.0}" in script
+    assert "'co_state_supplement_eligible': {'2026': True}" in script
+
+
+def test_policyengine_and_cs_mappability_blocks_active_unmodeled_exclusions(
+    tmp_path,
+):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    inputs = {
+        "us-co:regulations/9-ccr-2503-5/3.548#input.client_total_countable_income_for_and_cs": 32,
+        "us-co:regulations/9-ccr-2503-5/3.548#input.client_is_and_cs_eligible_under_sections_3_546_and_3_547": True,
+        "us-co:regulations/9-ccr-2503-5/3.548#input.client_is_inmate_in_penal_institution": False,
+        "us-co:regulations/9-ccr-2503-5/3.548#input.client_is_resident_in_unlicensed_or_uncertified_facility": False,
+    }
+
+    mappable, reason = pipeline._is_pe_test_mappable(
+        "us",
+        "and_cs_authorized_grant_payment_for_month",
+        inputs,
+        pe_var="co_state_supplement",
+    )
+
+    assert mappable is True
+    assert reason is None
+
+    inputs[
+        "us-co:regulations/9-ccr-2503-5/3.548#input.client_is_resident_in_unlicensed_or_uncertified_facility"
+    ] = True
+    mappable, reason = pipeline._is_pe_test_mappable(
+        "us",
+        "and_cs_authorized_grant_payment_for_month",
+        inputs,
+        pe_var="co_state_supplement",
+    )
+
+    assert mappable is False
+    assert "does not model these 3.548 grant-payment exclusion facts" in (reason or "")
+    assert "client_is_resident_in_unlicensed_or_uncertified_facility" in (reason or "")
 
 
 def test_policyengine_tax_scenario_skips_unmodelled_niit_components(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.782"
+version = "0.2.783"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map Colorado AND-CS grant-standard and grant-payment RuleSpec outputs to PolicyEngine `co_state_supplement`
- add a PE-US adapter that annualizes monthly AND-CS inputs and supplies Colorado eligibility overrides
- mark the Colorado SSP PE surface as wired once comparable mappings are present
- bump axiom-encode to 0.2.783

## Checks
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_colorado_ssp_wired tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_colorado_oap_wired tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_rulespec_validation.py::test_policyengine_and_cs_adapter_annualizes_income_and_sets_eligibility tests/test_rulespec_validation.py::test_policyengine_and_cs_mappability_blocks_active_unmodeled_exclusions tests/test_rulespec_validation.py::test_policyengine_oap_adapter_annualizes_monthly_income_and_sets_eligibility tests/test_rulespec_validation.py::test_policyengine_oap_mappability_blocks_active_unmodeled_exclusions -q`
- `uv run ruff check src/axiom_encode/oracles/policyengine/adapters.py tests/test_policyengine_coverage.py tests/test_rulespec_validation.py`