### PR TITLE
Map generated Colorado AND-CS grant standard

### DIFF
--- a/changelog.d/colorado-and-cs-generated-grant-standard.changed.md
+++ b/changelog.d/colorado-and-cs-generated-grant-standard.changed.md
@@ -1,0 +1,1 @@
+Map the generated Colorado AND-CS grant-standard output to the PolicyEngine state-supplement parameter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.783"
+version = "0.2.784"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.783"
+__version__ = "0.2.784"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -770,6 +770,16 @@ mappings:
     comparison: money
     rationale: Same Colorado AND-CS monthly grant standard parameter for the state-administered SSI supplement.
 
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.546#and_cs_total_grant_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.co.ssa.state_supplement.grant_standard
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Colorado AND-CS monthly grant standard parameter for the state-administered SSI supplement.
+
   - legal_id: us-co:regulations/9-ccr-2503-5/3.548#and_cs_authorized_grant_payment_for_month
     country: us
     program: ssi_state_supplement

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2393,7 +2393,7 @@ def test_policyengine_registry_is_legal_id_keyed():
     assert colorado_ssp_mapping.policyengine_variable == "co_state_supplement"
     assert colorado_ssp_mapping.result_multiplier == pytest.approx(1 / 12)
     colorado_ssp_grant_standard_mapping = registry.mapping_for_legal_id(
-        "us-co:regulations/9-ccr-2503-5/3.546#and_cs_total_monthly_grant_standard",
+        "us-co:regulations/9-ccr-2503-5/3.546#and_cs_total_grant_standard",
         country="us",
     )
     assert colorado_ssp_grant_standard_mapping.mapping_type == "parameter_value"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.783"
+version = "0.2.784"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add the generated `and_cs_total_grant_standard` legal ID as the Colorado AND-CS grant-standard PolicyEngine parameter mapping
- keep the prior monthly-name mapping as a harmless alias for future generated variants
- bump axiom-encode to 0.2.784

## Checks
- `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_colorado_ssp_wired -q`