### PR TITLE
Map generated Colorado AND-CS payment oracle

### DIFF
--- a/changelog.d/colorado-and-cs-generated-payment.changed.md
+++ b/changelog.d/colorado-and-cs-generated-payment.changed.md
@@ -1,0 +1,1 @@
+Map the generated Colorado AND-CS authorized grant payment output to the PolicyEngine state supplement oracle.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.784"
+version = "0.2.785"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.784"
+__version__ = "0.2.785"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -24515,6 +24515,7 @@ print("BENCHMARK:" + json.dumps(result))
                 *adapter.direct_spm_overrides,
                 *adapter.annual_direct_spm_overrides,
                 *adapter.annualized_person_inputs,
+                *adapter.monthly_person_inputs,
                 *adapter.boolean_person_inputs,
                 *adapter.monthly_boolean_person_inputs,
             ):
@@ -25395,6 +25396,18 @@ print(f'RESULT:{{float(value)}}')
                         else adult_attrs
                     )
                     attrs.append(f"'{pe_attr}': {{'{year}': {annual_value}}}")
+            for rule_key, pe_attr in adapter.monthly_person_inputs:
+                value = self._rulespec_test_input_value(inputs, rule_key)
+                if value is None:
+                    continue
+                with contextlib.suppress(TypeError, ValueError):
+                    month_value = float(value)
+                    attrs = (
+                        target_person_attrs
+                        if target_person_attrs is not None
+                        else adult_attrs
+                    )
+                    attrs.append(f"'{pe_attr}': {{'{period}': {month_value}}}")
             for rule_key, pe_attr in adapter.boolean_person_inputs:
                 value = self._rulespec_test_input_value(inputs, rule_key)
                 if value is not None:

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -17,6 +17,7 @@ class PolicyEngineUSVarAdapter:
     monthly: bool = False
     spm: bool = False
     annualized_person_inputs: tuple[tuple[str, str], ...] = ()
+    monthly_person_inputs: tuple[tuple[str, str], ...] = ()
     boolean_person_inputs: tuple[tuple[str, str], ...] = ()
     monthly_boolean_person_inputs: tuple[tuple[str, str], ...] = ()
     direct_spm_overrides: tuple[tuple[str, str], ...] = ()
@@ -416,29 +417,75 @@ PE_US_VAR_ADAPTERS = (
     ),
     PolicyEngineUSVarAdapter(
         rule_names=(
+            "and_cs_authorized_grant_payment",
             "and_cs_authorized_grant_payment_for_month",
             "and_cs_grant_payment_for_month",
             "and_cs_monthly_grant_payment",
         ),
         pe_var="co_state_supplement",
+        monthly=True,
         default_state_code="CO",
         annualized_person_inputs=(
+            (
+                "client_countable_income_other_than_ssi_for_and_cs",
+                "ssi_countable_income",
+            ),
             ("client_total_countable_income_for_and_cs", "ssi_countable_income"),
             ("and_cs_total_countable_income", "ssi_countable_income"),
             ("client_countable_income_for_and_cs", "ssi_countable_income"),
+        ),
+        monthly_person_inputs=(
+            ("ssi_payment_received_amount", "ssi"),
+            ("gross_ssi_payment_amount", "ssi"),
             ("client_ssi_payment_amount_for_and_cs", "ssi"),
             ("and_cs_ssi_payment_amount", "ssi"),
         ),
         boolean_person_inputs=(
             (
+                "client_has_been_found_eligible_for_and_cs",
+                "is_ssi_eligible_individual",
+            ),
+            ("client_has_been_found_eligible_for_and_cs", "is_ssi_disabled"),
+            (
+                "and_cs_client_eligible_for_grant_payment",
+                "is_ssi_eligible_individual",
+            ),
+            ("and_cs_client_eligible_for_grant_payment", "is_ssi_disabled"),
+            (
+                "client_has_been_found_eligible_for_and_cs",
+                "co_state_supplement_eligible",
+            ),
+            (
+                "and_cs_client_eligible_for_grant_payment",
+                "co_state_supplement_eligible",
+            ),
+            (
                 "client_is_and_cs_eligible_under_sections_3_546_and_3_547",
                 "co_state_supplement_eligible",
+            ),
+            (
+                "client_is_and_cs_eligible_under_sections_3_546_and_3_547",
+                "is_ssi_eligible_individual",
+            ),
+            (
+                "client_is_and_cs_eligible_under_sections_3_546_and_3_547",
+                "is_ssi_disabled",
             ),
             (
                 "and_cs_client_eligible_for_grant_payments_under_3_548",
                 "co_state_supplement_eligible",
             ),
+            (
+                "and_cs_client_eligible_for_grant_payments_under_3_548",
+                "is_ssi_eligible_individual",
+            ),
+            (
+                "and_cs_client_eligible_for_grant_payments_under_3_548",
+                "is_ssi_disabled",
+            ),
             ("and_cs_client_eligible", "co_state_supplement_eligible"),
+            ("and_cs_client_eligible", "is_ssi_eligible_individual"),
+            ("and_cs_client_eligible", "is_ssi_disabled"),
         ),
         unsupported_truthy_input_keys=(
             "client_is_inmate_in_penal_institution",

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -780,41 +780,49 @@ mappings:
     comparison: money
     rationale: Same Colorado AND-CS monthly grant standard parameter for the state-administered SSI supplement.
 
+  - legal_id: us-co:regulations/9-ccr-2503-5/3.548#and_cs_authorized_grant_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: direct_variable
+    policyengine_variable: co_state_supplement
+    entity: person
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Colorado AND-CS monthly grant-standard-minus-countable-income amount.
+
   - legal_id: us-co:regulations/9-ccr-2503-5/3.548#and_cs_authorized_grant_payment_for_month
     country: us
     program: ssi_state_supplement
     mapping_type: direct_variable
     policyengine_variable: co_state_supplement
-    result_multiplier: 0.08333333333333333
     entity: person
     period: month
     unit: USD
     comparison: money
-    rationale: Same Colorado AND-CS grant-standard-minus-countable-income amount; PolicyEngine exposes the annual amount, so the oracle scales it to the monthly RuleSpec output.
+    rationale: Same Colorado AND-CS monthly grant-standard-minus-countable-income amount.
 
   - legal_id: us-co:regulations/9-ccr-2503-5/3.548#and_cs_grant_payment_for_month
     country: us
     program: ssi_state_supplement
     mapping_type: direct_variable
     policyengine_variable: co_state_supplement
-    result_multiplier: 0.08333333333333333
     entity: person
     period: month
     unit: USD
     comparison: money
-    rationale: Same Colorado AND-CS grant-standard-minus-countable-income amount; PolicyEngine exposes the annual amount, so the oracle scales it to the monthly RuleSpec output.
+    rationale: Same Colorado AND-CS monthly grant-standard-minus-countable-income amount.
 
   - legal_id: us-co:regulations/9-ccr-2503-5/3.548#and_cs_monthly_grant_payment
     country: us
     program: ssi_state_supplement
     mapping_type: direct_variable
     policyengine_variable: co_state_supplement
-    result_multiplier: 0.08333333333333333
     entity: person
     period: month
     unit: USD
     comparison: money
-    rationale: Same Colorado AND-CS grant-standard-minus-countable-income amount; PolicyEngine exposes the annual amount, so the oracle scales it to the monthly RuleSpec output.
+    rationale: Same Colorado AND-CS monthly grant-standard-minus-countable-income amount.
 
   - legal_id: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -289,6 +289,10 @@ def test_policyengine_program_surface_marks_colorado_ssp_wired():
     assert colorado_ssp["mapping_count"] >= 1
     assert colorado_ssp["comparable_mapping_count"] >= 1
     assert (
+        "us-co:regulations/9-ccr-2503-5/3.548#and_cs_authorized_grant_payment"
+        in colorado_ssp["legal_ids"]
+    )
+    assert (
         "us-co:regulations/9-ccr-2503-5/3.548#and_cs_authorized_grant_payment_for_month"
         in colorado_ssp["legal_ids"]
     )

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2386,12 +2386,21 @@ def test_policyengine_registry_is_legal_id_keyed():
         == "gov.states.co.ssa.oap.grant_standard"
     )
     colorado_ssp_mapping = registry.mapping_for_legal_id(
-        "us-co:regulations/9-ccr-2503-5/3.548#and_cs_authorized_grant_payment_for_month",
+        "us-co:regulations/9-ccr-2503-5/3.548#and_cs_authorized_grant_payment",
         country="us",
     )
     assert colorado_ssp_mapping.mapping_type == "direct_variable"
     assert colorado_ssp_mapping.policyengine_variable == "co_state_supplement"
-    assert colorado_ssp_mapping.result_multiplier == pytest.approx(1 / 12)
+    assert colorado_ssp_mapping.result_multiplier is None
+    colorado_ssp_legacy_name_mapping = registry.mapping_for_legal_id(
+        "us-co:regulations/9-ccr-2503-5/3.548#and_cs_authorized_grant_payment_for_month",
+        country="us",
+    )
+    assert colorado_ssp_legacy_name_mapping.mapping_type == "direct_variable"
+    assert (
+        colorado_ssp_legacy_name_mapping.policyengine_variable == "co_state_supplement"
+    )
+    assert colorado_ssp_legacy_name_mapping.result_multiplier is None
     colorado_ssp_grant_standard_mapping = registry.mapping_for_legal_id(
         "us-co:regulations/9-ccr-2503-5/3.546#and_cs_total_grant_standard",
         country="us",
@@ -4245,14 +4254,18 @@ def test_policyengine_and_cs_adapter_annualizes_income_and_sets_eligibility(
         "co_state_supplement",
         {
             "period": "2026-01",
-            "us-co:regulations/9-ccr-2503-5/3.548#input.client_total_countable_income_for_and_cs": 32,
-            "us-co:regulations/9-ccr-2503-5/3.548#input.client_is_and_cs_eligible_under_sections_3_546_and_3_547": True,
+            "us-co:regulations/9-ccr-2503-5/3.548#input.client_countable_income_other_than_ssi_for_and_cs": 32,
+            "us-co:regulations/9-ccr-2503-5/3.548#input.gross_ssi_payment_amount": 40,
+            "us-co:regulations/9-ccr-2503-5/3.548#input.client_has_been_found_eligible_for_and_cs": True,
         },
         "2026",
     )
 
     assert "'state_code_str': {'2026': 'CO'}" in script
     assert "'ssi_countable_income': {'2026': 384.0}" in script
+    assert "'ssi': {'2026-01': 40.0}" in script
+    assert "'is_ssi_eligible_individual': {'2026': True}" in script
+    assert "'is_ssi_disabled': {'2026': True}" in script
     assert "'co_state_supplement_eligible': {'2026': True}" in script
 
 
@@ -4265,15 +4278,16 @@ def test_policyengine_and_cs_mappability_blocks_active_unmodeled_exclusions(
         enable_oracles=False,
     )
     inputs = {
-        "us-co:regulations/9-ccr-2503-5/3.548#input.client_total_countable_income_for_and_cs": 32,
-        "us-co:regulations/9-ccr-2503-5/3.548#input.client_is_and_cs_eligible_under_sections_3_546_and_3_547": True,
+        "us-co:regulations/9-ccr-2503-5/3.548#input.client_countable_income_other_than_ssi_for_and_cs": 32,
+        "us-co:regulations/9-ccr-2503-5/3.548#input.gross_ssi_payment_amount": 40,
+        "us-co:regulations/9-ccr-2503-5/3.548#input.client_has_been_found_eligible_for_and_cs": True,
         "us-co:regulations/9-ccr-2503-5/3.548#input.client_is_inmate_in_penal_institution": False,
         "us-co:regulations/9-ccr-2503-5/3.548#input.client_is_resident_in_unlicensed_or_uncertified_facility": False,
     }
 
     mappable, reason = pipeline._is_pe_test_mappable(
         "us",
-        "and_cs_authorized_grant_payment_for_month",
+        "and_cs_authorized_grant_payment",
         inputs,
         pe_var="co_state_supplement",
     )
@@ -4286,7 +4300,7 @@ def test_policyengine_and_cs_mappability_blocks_active_unmodeled_exclusions(
     ] = True
     mappable, reason = pipeline._is_pe_test_mappable(
         "us",
-        "and_cs_authorized_grant_payment_for_month",
+        "and_cs_authorized_grant_payment",
         inputs,
         pe_var="co_state_supplement",
     )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.784"
+version = "0.2.785"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map generated Colorado AND-CS authorized grant payment outputs to PolicyEngine
- run the CO SSP PE oracle monthly and project SSI/countable-income inputs correctly
- add regression coverage for generated legal IDs and scenario projection

## Tests
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run --with pytest --with pytest-cov python -m pytest tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_rulespec_validation.py::test_policyengine_and_cs_adapter_annualizes_income_and_sets_eligibility tests/test_rulespec_validation.py::test_policyengine_and_cs_mappability_blocks_active_unmodeled_exclusions tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_colorado_ssp_wired