### PR TITLE
Classify SSI PolicyEngine oracle coverage

### DIFF
--- a/changelog.d/ssi-policyengine-coverage.changed.md
+++ b/changelog.d/ssi-policyengine-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify federal SSI benefit-rate intermediates in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.785"
+version = "0.2.786"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.785"
+__version__ = "0.2.786"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -723,17 +723,54 @@ PE_US_HEALTH_VAR_ADAPTERS = (
     *PE_US_ACA_PTC_VAR_ADAPTERS,
 )
 
+PE_US_SSI_VAR_ADAPTERS = (
+    PolicyEngineUSVarAdapter(
+        rule_names=("ssi", "ssi_payment", "ssi_payment_amount"),
+        pe_var="ssi",
+        entity="person",
+        period="month",
+        unit="USD",
+        comparison="money",
+        monthly=True,
+    ),
+    PolicyEngineUSVarAdapter(
+        rule_names=("ssi_countable_income",),
+        pe_var="ssi_countable_income",
+        entity="person",
+        period="year",
+        unit="USD",
+        comparison="money",
+    ),
+    PolicyEngineUSVarAdapter(
+        rule_names=("ssi_countable_resources",),
+        pe_var="ssi_countable_resources",
+        entity="person",
+        period="year",
+        unit="USD",
+        comparison="money",
+    ),
+    PolicyEngineUSVarAdapter(
+        rule_names=("is_ssi_eligible_individual",),
+        pe_var="is_ssi_eligible_individual",
+        entity="person",
+        period="year",
+        comparison="decision",
+    ),
+)
+
 PE_US_PROGRAM_VAR_ADAPTERS = {
     "snap": PE_US_VAR_ADAPTERS,
     "medicaid": PE_US_MEDICAID_VAR_ADAPTERS,
     "chip": PE_US_CHIP_VAR_ADAPTERS,
     "aca_ptc": PE_US_ACA_PTC_VAR_ADAPTERS,
     "health": PE_US_HEALTH_VAR_ADAPTERS,
+    "ssi": PE_US_SSI_VAR_ADAPTERS,
 }
 
 PE_US_ALL_VAR_ADAPTERS = (
     *PE_US_VAR_ADAPTERS,
     *PE_US_HEALTH_VAR_ADAPTERS,
+    *PE_US_SSI_VAR_ADAPTERS,
 )
 
 PE_US_VAR_ADAPTERS_BY_NAME = {

--- a/src/axiom_encode/oracles/policyengine/classifier.py
+++ b/src/axiom_encode/oracles/policyengine/classifier.py
@@ -236,6 +236,8 @@ def _infer_program_from_legal_id(legal_id: str, *, rule_name: str = "") -> str:
         return "health"
     if "snap" in lowered:
         return "snap"
+    if lowered.startswith(("us:statutes/42/1382", "us:statutes/42/1382f")):
+        return "ssi"
     if lowered.startswith("us:statutes/26/") or lowered.startswith(
         "us-co:statutes/39/"
     ):

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -883,6 +883,8 @@ def _infer_program_from_legal_id(legal_id: str, *, rule_name: str = "") -> str:
         return "aca_ptc"
     if "snap" in lowered:
         return "snap"
+    if lowered.startswith(("us:statutes/42/1382", "us:statutes/42/1382f")):
+        return "ssi"
     if (
         lowered.startswith("us:statutes/26/")
         or lowered.startswith("us-co:statutes/39/")

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -86,6 +86,86 @@ mappings:
     comparison: rate
     rationale: Same federal SNAP earned-income deduction rate.
 
+  - legal_id: us:statutes/42/1382/b#statutory_base_annual_rate_without_eligible_spouse
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.individual
+    candidate_priority: P4
+    rationale: RuleSpec encodes the original 1974 statutory annual SSI base rate in 42 USC 1382(b); PolicyEngine stores final monthly federal benefit-rate parameters after later statutory increases and COLA uprating, not this base amount as a comparable parameter cell.
+
+  - legal_id: us:statutes/42/1382/b#statutory_base_annual_rate_with_eligible_spouse
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.couple
+    candidate_priority: P4
+    rationale: RuleSpec encodes the original 1974 statutory annual SSI couple base rate in 42 USC 1382(b); PolicyEngine stores final monthly federal benefit-rate parameters after later statutory increases and COLA uprating, not this base amount as a comparable parameter cell.
+
+  - legal_id: us:statutes/42/1382f/a#annual_rounding_multiple
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.individual
+    candidate_priority: P4
+    rationale: RuleSpec exposes the statutory annual rounding multiple used by 42 USC 1382f(a); PolicyEngine materializes final monthly SSI federal benefit-rate parameters and does not expose the intermediate annual rounding rule as a comparable target.
+
+  - legal_id: us:statutes/42/1382f/a#prior_rounding_carryover_increase
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.individual
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 42 USC 1382f(a) carryover amount from prior annual rounding; PolicyEngine materializes final monthly SSI federal benefit-rate parameters and does not expose this intermediate COLA calculation step.
+
+  - legal_id: us:statutes/42/1382f/a#amount_after_paragraph_1_increase
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.individual
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 42 USC 1382f(a)(1) intermediate amount before annual rounding; PolicyEngine materializes final monthly SSI federal benefit-rate parameters and does not expose this intermediate COLA calculation step.
+
+  - legal_id: us:statutes/42/1382f/a#subsection_a_applicable_increase_percentage
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.individual
+    candidate_priority: P4
+    rationale: RuleSpec exposes the statutory COLA percentage selected by 42 USC 1382f(a); PolicyEngine stores already-uprated monthly SSI federal benefit-rate parameters and does not expose the percentage selection as a comparable output.
+
+  - legal_id: us:statutes/42/1382f/a#amount_after_subsection_a_increase
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.individual
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 42 USC 1382f(a) post-COLA amount before it is folded into final monthly SSI benefit-rate parameters; PolicyEngine does not expose this statutory intermediate as a comparable target.
+
+  - legal_id: us:statutes/42/1382f/c#dollar_amount_increase_for_section_1382_a_1_a_and_b_1
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.individual
+    candidate_priority: P4
+    rationale: RuleSpec encodes the one-time 1983 statutory dollar increase for individual SSI rates; PolicyEngine stores final monthly federal benefit-rate parameters rather than this source-specific transitional increase.
+
+  - legal_id: us:statutes/42/1382f/c#dollar_amount_increase_for_public_law_93_66_section_211_a_1_a
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.individual
+    candidate_priority: P4
+    rationale: RuleSpec encodes the one-time 1983 statutory increase to the Public Law 93-66 amount; PolicyEngine stores final monthly federal benefit-rate parameters rather than this source-specific transitional increase.
+
+  - legal_id: us:statutes/42/1382f/c#dollar_amount_increase_for_section_1382_a_2_a_and_b_2
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.couple
+    candidate_priority: P4
+    rationale: RuleSpec encodes the one-time 1983 statutory dollar increase for couple SSI rates; PolicyEngine stores final monthly federal benefit-rate parameters rather than this source-specific transitional increase.
+
   - legal_id: us:statutes/7/2014/e/6/A#snap_net_income_pre_shelter
     country: us
     program: snap

--- a/tests/test_policyengine_classifier.py
+++ b/tests/test_policyengine_classifier.py
@@ -372,6 +372,63 @@ def test_classify_splits_combined_medicaid_chip_sources_by_rule_name(
     }
 
 
+def test_classify_rulespec_repo_filters_federal_ssi_sources(tmp_path: Path) -> None:
+    repo = tmp_path / "rulespec-us"
+    ssi_dir = repo / "statutes" / "42" / "1382a" / "b"
+    ssi_dir.mkdir(parents=True)
+    (ssi_dir / "2.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "format": "rulespec/v1",
+                "module": {},
+                "rules": [
+                    {
+                        "name": "ssi_general_income_exclusion_annual_amount",
+                        "kind": "parameter",
+                        "dtype": "Money",
+                        "source": "The first $240 per year is excluded.",
+                        "versions": [
+                            {"effective_from": "1974-01-01", "formula": "240"}
+                        ],
+                    }
+                ],
+            }
+        )
+    )
+    snap_dir = repo / "statutes" / "7" / "2014" / "e"
+    snap_dir.mkdir(parents=True)
+    (snap_dir / "2.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "format": "rulespec/v1",
+                "module": {},
+                "rules": [
+                    {
+                        "name": "snap_earned_income_deduction_rate",
+                        "kind": "parameter",
+                        "dtype": "Rate",
+                        "source": "SNAP earned income deduction.",
+                        "versions": [
+                            {"effective_from": "2025-01-01", "formula": "0.2"}
+                        ],
+                    }
+                ],
+            }
+        )
+    )
+
+    classifications = classify_rulespec_repo(
+        repo_root=repo,
+        jurisdiction="us",
+        program="ssi",
+    )
+
+    assert [c.legal_id.split("#")[1] for c in classifications] == [
+        "ssi_general_income_exclusion_annual_amount"
+    ]
+    assert classifications[0].mapping_type == "not_comparable"
+
+
 def test_iter_rules_skips_non_executable_kinds(tmp_path: Path) -> None:
     """`source_relation` and missing-kind rules are not executable outputs."""
     path = tmp_path / "block-1.yaml"

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -298,6 +298,140 @@ def test_policyengine_program_surface_marks_colorado_ssp_wired():
     )
 
 
+def test_policyengine_coverage_classifies_federal_ssi_benefit_rate_intermediates(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/42/1382/b.yaml",
+        """format: rulespec/v1
+rules:
+  - name: statutory_base_annual_rate_without_eligible_spouse
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '1974-01-01'
+        formula: 1752
+  - name: statutory_base_annual_rate_with_eligible_spouse
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '1974-01-01'
+        formula: 2628
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/42/1382f/a.yaml",
+        """format: rulespec/v1
+rules:
+  - name: annual_rounding_multiple
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '1975-01-01'
+        formula: 12
+  - name: prior_rounding_carryover_increase
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '1975-01-01'
+        formula: 0
+  - name: amount_after_paragraph_1_increase
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '1975-01-01'
+        formula: 1
+  - name: subsection_a_applicable_increase_percentage
+    kind: derived
+    dtype: Rate
+    versions:
+      - effective_from: '1975-01-01'
+        formula: 0
+  - name: amount_after_subsection_a_increase
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '1975-01-01'
+        formula: 1
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/42/1382f/c.yaml",
+        """format: rulespec/v1
+rules:
+  - name: dollar_amount_increase_for_section_1382_a_1_a_and_b_1
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '1983-07-01'
+        formula: 240
+  - name: dollar_amount_increase_for_public_law_93_66_section_211_a_1_a
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '1983-07-01'
+        formula: 120
+  - name: dollar_amount_increase_for_section_1382_a_2_a_and_b_2
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '1983-07-01'
+        formula: 360
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/42/1382a/b.yaml",
+        """format: rulespec/v1
+rules:
+  - name: future_unmapped_ssi_income_exclusion
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '1974-01-01'
+        formula: 240
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="ssi")
+
+    assert report["total_outputs"] == 11
+    assert report["status_counts"] == {
+        "known_not_comparable": 10,
+        "unmapped": 1,
+    }
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id["us:statutes/42/1382a/b#future_unmapped_ssi_income_exclusion"][
+            "program"
+        ]
+        == "ssi"
+    )
+    assert (
+        items_by_id["us:statutes/42/1382a/b#future_unmapped_ssi_income_exclusion"][
+            "status"
+        ]
+        == "unmapped"
+    )
+    classified_items = [
+        item for item in report["items"] if item["status"] == "known_not_comparable"
+    ]
+    assert {item["program"] for item in classified_items} == {"ssi"}
+    assert {item["mapping_type"] for item in classified_items} == {"not_comparable"}
+    assert {item["candidate_priority"] for item in classified_items} == {"P4"}
+    assert (
+        items_by_id[
+            "us:statutes/42/1382/b#statutory_base_annual_rate_without_eligible_spouse"
+        ]["policyengine_parameter"]
+        == "gov.ssa.ssi.amount.individual"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/42/1382/b#statutory_base_annual_rate_with_eligible_spouse"
+        ]["policyengine_parameter"]
+        == "gov.ssa.ssi.amount.couple"
+    )
+
+
 def test_policyengine_coverage_classifies_nz_outputs_outside_policyengine(tmp_path):
     _write_rulespec_file(
         tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.785"
+version = "0.2.786"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify federal SSI benefit-rate statutory intermediates as reviewed PolicyEngine non-comparables
- add an SSI PolicyEngine adapter catalog and SSI program inference for coverage/classifier filtering
- bump axiom-encode to 0.2.786

## Validation
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py tests/test_policyengine_classifier.py -q --no-cov`
- `uv run ruff check src/axiom_encode/oracles/policyengine/adapters.py src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/oracles/policyengine/classifier.py tests/test_policyengine_coverage.py tests/test_policyengine_classifier.py`
- `uv run python - <<'PY' ... load_policyengine_registry().validate() ... PY`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees --program ssi --fail-on-unmapped --fail-on-untested-comparable`

SSI local coverage result: 10 executable outputs, all `known_not_comparable`, 0 untested comparables.
