### PR TITLE
Allow context-relative source labels

### DIFF
--- a/changelog.d/context-relative-source-labels.fixed.md
+++ b/changelog.d/context-relative-source-labels.fixed.md
@@ -1,0 +1,1 @@
+Allow out-of-scope source validation to resolve compact sibling labels like `(B)(i)` and `(C)` relative to a requested source subtree such as `42 USC 1382a(b)(4)`, while still rejecting true sibling multicites outside the requested subtree.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.786"
+version = "0.2.787"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.786"
+__version__ = "0.2.787"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1417,12 +1417,20 @@ def _source_citation_to_normalized_targets(
     seen: set[tuple[str, ...]] = set()
     previous_fragment_had_target = False
     previous_raw_fragment: str | None = None
+    previous_target: tuple[str, ...] | None = None
     for raw_fragment in _SOURCE_CITATION_SEPARATOR_RE.split(source):
         fragment_targets = _source_citation_fragment_to_normalized_targets(
             raw_fragment,
             default_title=current_title,
             default_section=current_section,
         )
+        context_relative_target = _source_citation_fragment_to_context_relative_target(
+            raw_fragment,
+            context_target=context_target,
+            previous_target=previous_target,
+        )
+        if context_relative_target is not None:
+            fragment_targets = (context_relative_target,)
         if (
             fragment_targets
             and not previous_fragment_had_target
@@ -1441,6 +1449,7 @@ def _source_citation_to_normalized_targets(
             if len(target) >= 3:
                 current_title = target[1]
                 current_section = target[2]
+            previous_target = target
             if target in seen:
                 continue
             seen.add(target)
@@ -1472,6 +1481,49 @@ def _source_citation_fragment_is_bare_relative_table_label_tail(
             flags=re.IGNORECASE,
         )
     )
+
+
+def _source_citation_fragment_to_context_relative_target(
+    fragment: str,
+    *,
+    context_target: tuple[str, ...] | None,
+    previous_target: tuple[str, ...] | None,
+) -> tuple[str, ...] | None:
+    if context_target is None or previous_target is None or len(context_target) <= 3:
+        return None
+    if not _normalized_target_within(previous_target, context_target):
+        return None
+    previous_tail_length = len(previous_target) - len(context_target)
+    if previous_tail_length <= 0:
+        return None
+    cleaned = _clean_source_citation_fragment(fragment)
+    match = re.fullmatch(r"(?:\([A-Za-z0-9]+\))+", cleaned)
+    if match is None:
+        return None
+    tail = tuple(part.lower() for part in re.findall(r"\(([^)]+)\)", cleaned))
+    if not tail or len(tail) > previous_tail_length:
+        return None
+    previous_relative_tail = previous_target[len(context_target) :]
+    if not _same_citation_label_class(tail[0], previous_relative_tail[0]):
+        return None
+    return context_target + tail
+
+
+def _same_citation_label_class(left: str, right: str) -> bool:
+    return _citation_label_class(left) == _citation_label_class(right)
+
+
+def _citation_label_class(label: str) -> str:
+    cleaned = label.strip().lower()
+    if cleaned.isdigit():
+        return "numeric"
+    if re.fullmatch(r"[ivxlcdm]+", cleaned) and (
+        len(cleaned) > 1 or cleaned in {"i", "v", "x"}
+    ):
+        return "roman"
+    if cleaned.isalpha():
+        return "alpha"
+    return "other"
 
 
 def _source_citation_fragment_to_normalized_targets(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -16240,6 +16240,73 @@ rules:
     assert "`ctc_threshold` source `26 USC 24(b)(2), 24(h)(3)`" in issues[0]
 
 
+def test_out_of_scope_rule_source_allows_context_relative_sibling_labels():
+    content = """format: rulespec/v1
+rules:
+  - name: annual_earned_income_exclusion_limit
+    kind: parameter
+    dtype: Money
+    source: 42 USC 1382a(b)(4)(A)(i), (B)(i), (C)
+    versions:
+      - effective_from: '1974-01-01'
+        formula: 780
+"""
+
+    assert (
+        find_out_of_scope_rule_source_issues(
+            content,
+            requested_source="42 USC 1382a(b)(4)",
+        )
+        == []
+    )
+
+
+def test_out_of_scope_rule_source_allows_context_relative_and_joined_label():
+    content = """format: rulespec/v1
+rules:
+  - name: earned_income_remainder_exclusion_rate
+    kind: parameter
+    dtype: Rate
+    source: 42 USC 1382a(b)(4)(A)(i), (B)(iii), and (C)
+    versions:
+      - effective_from: '1974-01-01'
+        formula: 1 / 2
+"""
+
+    assert (
+        find_out_of_scope_rule_source_issues(
+            content,
+            requested_source="us/statute/42/1382a/b/4",
+        )
+        == []
+    )
+
+
+def test_out_of_scope_rule_source_still_rejects_bare_sibling_label():
+    content = """format: rulespec/v1
+rules:
+  - name: mixed_agricultural_and_vessel_rule
+    kind: derived
+    entity: Asset
+    dtype: Judgment
+    period: Year
+    source: 26 USC 3306(k), (m)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: farm_service or vessel_documented
+"""
+
+    issues = find_out_of_scope_rule_source_issues(
+        content,
+        requested_source="26 USC 3306(k)",
+    )
+
+    assert len(issues) == 1
+    assert (
+        "`mixed_agricultural_and_vessel_rule` source `26 USC 3306(k), (m)`" in issues[0]
+    )
+
+
 def test_out_of_scope_rule_source_rejects_bare_sibling_after_non_table_label():
     content = """format: rulespec/v1
 rules:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.786"
+version = "0.2.787"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- resolve compact sibling source labels like `(B)(i)` and `(C)` relative to requested source subtrees such as `42 USC 1382a(b)(4)`
- preserve rejection for true sibling multicites outside the requested subtree
- bump axiom-encode to `0.2.787`

## Validation
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run --with towncrier python -m towncrier build --draft --version 0.0.0`
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_rulespec_validation.py -q`