### PR TITLE
Classify SSI income exclusions for PolicyEngine oracle

### DIFF
--- a/changelog.d/ssi-income-oracle-coverage.fixed.md
+++ b/changelog.d/ssi-income-oracle-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify federal SSI income-exclusion RuleSpec outputs against PolicyEngine oracle coverage, including exact mappings for the general and earned-income exclusion parameters, and repair oracle parameter tests for simple source-backed fraction formulas.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.787"
+version = "0.2.789"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.787"
+__version__ = "0.2.789"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -15411,7 +15411,14 @@ def _scalar_formula_value(formula: object) -> int | float | str | bool | None:
         return None
     stripped = formula.strip()
     if not re.fullmatch(r"-?\d+(?:\.\d+)?", stripped):
-        return None
+        fraction_match = re.fullmatch(r"\(?\s*(-?\d+)\s*/\s*(-?\d+)\s*\)?", stripped)
+        if not fraction_match:
+            return None
+        numerator = int(fraction_match.group(1))
+        denominator = int(fraction_match.group(2))
+        if denominator == 0:
+            return None
+        return numerator / denominator
     parsed = yaml.safe_load(stripped)
     return parsed if isinstance(parsed, (int, float)) else None
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -102,6 +102,114 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec encodes the original 1974 statutory annual SSI couple base rate in 42 USC 1382(b); PolicyEngine stores final monthly federal benefit-rate parameters after later statutory increases and COLA uprating, not this base amount as a comparable parameter cell.
 
+  - legal_id: us:statutes/42/1382a/b/2#annual_general_income_exclusion_limit
+    country: us
+    program: ssi
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ssa.ssi.income.exclusions.general
+    period: year
+    unit: USD
+    comparison: money
+    result_multiplier: 12
+    rationale: Same federal SSI general income exclusion amount, with PolicyEngine storing the monthly parameter and RuleSpec encoding the annual statutory limit.
+
+  - legal_id: us:statutes/42/1382a/b/2#annual_general_income_excluded
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: ssi_countable_income
+    candidate_priority: P4
+    rationale: RuleSpec exposes the section 1382a(b)(2) annual general income exclusion as a source-level helper before later earned-income and deeming mechanics. PolicyEngine applies the monthly general exclusion inside the broader ssi_countable_income calculation and does not expose this helper one-to-one.
+
+  - legal_id: us:statutes/42/1382a/b/2#default_state_age_payment_age
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec encodes the source-level age threshold for the special pre-1973 state age-and-residency payment exclusion. PolicyEngine-US does not expose this transitional state-payment threshold as a one-to-one SSI parameter.
+
+  - legal_id: us:statutes/42/1382a/b/2#state_age_payment_residency_year_requirement
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec encodes the source-level residency duration threshold for the special pre-1973 state age-and-residency payment exclusion. PolicyEngine-US does not expose this transitional state-payment threshold as a one-to-one SSI parameter.
+
+  - legal_id: us:statutes/42/1382a/b/2#state_age_residency_payment_excluded
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the special section 1382a(b)(2)(B) exclusion for qualifying state age-and-residency payments under programs established before July 1, 1973. PolicyEngine-US does not model this transitional state-payment exclusion as a one-to-one SSI variable.
+
+  - legal_id: us:statutes/42/1382a/b/4#annual_earned_income_initial_exclusion_limit
+    country: us
+    program: ssi
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ssa.ssi.income.exclusions.earned
+    period: year
+    unit: USD
+    comparison: money
+    result_multiplier: 12
+    rationale: Same federal SSI earned income flat exclusion amount, with PolicyEngine storing the monthly parameter and RuleSpec encoding the annual statutory limit.
+
+  - legal_id: us:statutes/42/1382a/b/4#earned_income_remainder_exclusion_rate
+    country: us
+    program: ssi
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ssa.ssi.income.exclusions.earned_share
+    period: month
+    comparison: rate
+    rationale: Same federal SSI share of earned income excluded after the flat earned-income exclusion.
+
+  - legal_id: us:statutes/42/1382a/b/4#blind_branch_earned_income_excluded
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: ssi_countable_income
+    candidate_priority: P4
+    rationale: RuleSpec exposes the blind-recipient branch of section 1382a(b)(4), including source-specific ordering against expenses and self-support-plan exclusions. PolicyEngine applies standard SSI income exclusions inside ssi_countable_income and does not expose this branch helper one-to-one.
+
+  - legal_id: us:statutes/42/1382a/b/4#blind_branch_earning_expenses_excluded
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: ssi_countable_income
+    candidate_priority: P4
+    rationale: RuleSpec exposes the blind-recipient earning-expense exclusion in section 1382a(b)(4)(A)(ii). PolicyEngine-US does not expose this blind-work-expense helper as a one-to-one SSI variable.
+
+  - legal_id: us:statutes/42/1382a/b/4#blind_branch_self_support_plan_other_income_excluded
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: ssi_countable_income
+    candidate_priority: P4
+    rationale: RuleSpec exposes the blind-recipient plan-to-achieve-self-support income exclusion in section 1382a(b)(4)(A)(iii). PolicyEngine-US does not expose this PASS helper as a one-to-one SSI variable.
+
+  - legal_id: us:statutes/42/1382a/b/4#disabled_branch_earned_income_excluded
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: ssi_countable_income
+    candidate_priority: P4
+    rationale: RuleSpec exposes the disabled-not-blind branch of section 1382a(b)(4), including source-specific ordering for impairment-related work expenses and the earned-income remainder exclusion. PolicyEngine applies standard SSI income exclusions inside ssi_countable_income and does not expose this branch helper one-to-one.
+
+  - legal_id: us:statutes/42/1382a/b/4#disabled_branch_self_support_plan_other_income_excluded
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: ssi_countable_income
+    candidate_priority: P4
+    rationale: RuleSpec exposes the disabled-recipient plan-to-achieve-self-support income exclusion in section 1382a(b)(4)(B)(iv). PolicyEngine-US does not expose this PASS helper as a one-to-one SSI variable.
+
+  - legal_id: us:statutes/42/1382a/b/4#age_sixty_five_branch_earned_income_excluded
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: ssi_countable_income
+    candidate_priority: P4
+    rationale: RuleSpec exposes the age-65 branch of section 1382a(b)(4)(C) for individuals not covered by the blind or disabled branches. PolicyEngine applies standard SSI income exclusions inside ssi_countable_income and does not expose this branch helper one-to-one.
+
   - legal_id: us:statutes/42/1382f/a#annual_rounding_multiple
     country: us
     program: ssi

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25064,6 +25064,12 @@ rules:
     versions:
       - effective_from: '2019-01-01'
         formula: '4500'
+  - name: earned_income_remainder_exclusion_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '1974-01-01'
+        formula: '1 / 2'
 """
         )
         test_file.write_text(
@@ -25084,6 +25090,8 @@ rules:
                 if (
                     legal_id
                     == "us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_initial_phase"
+                    or legal_id
+                    == "us-co:statutes/39/39-22-104/4/y#earned_income_remainder_exclusion_rate"
                 ):
                     return SimpleNamespace(mapping_type="parameter_value")
                 return None
@@ -25118,7 +25126,7 @@ rules:
             cmd_repair_oracle_parameter_tests(args)
 
         payload = yaml.safe_load(test_file.read_text())
-        added = payload[-1]
+        added = payload[-2]
         assert (
             added["name"]
             == "oracle_parameter_military_retirement_benefits_cap_initial_phase"
@@ -25126,6 +25134,15 @@ rules:
         assert added["input"] == {}
         assert added["output"] == {
             "us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_initial_phase": 4500
+        }
+        fraction_added = payload[-1]
+        assert (
+            fraction_added["name"]
+            == "oracle_parameter_earned_income_remainder_exclusion_rate"
+        )
+        assert fraction_added["input"] == {}
+        assert fraction_added["output"] == {
+            "us-co:statutes/39/39-22-104/4/y#earned_income_remainder_exclusion_rate": 0.5
         }
 
     def test_repair_oracle_parameter_tests_does_not_mutate_without_signing_key(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2346,6 +2346,41 @@ def test_policyengine_registry_is_legal_id_keyed():
         earned_income_rate_mapping.policyengine_parameter
         == "gov.usda.snap.income.deductions.earned_income"
     )
+    ssi_general_exclusion_mapping = registry.mapping_for_legal_id(
+        "us:statutes/42/1382a/b/2#annual_general_income_exclusion_limit",
+        country="us",
+    )
+    assert ssi_general_exclusion_mapping.mapping_type == "parameter_value"
+    assert (
+        ssi_general_exclusion_mapping.policyengine_parameter
+        == "gov.ssa.ssi.income.exclusions.general"
+    )
+    assert ssi_general_exclusion_mapping.result_multiplier == 12
+    ssi_earned_exclusion_mapping = registry.mapping_for_legal_id(
+        "us:statutes/42/1382a/b/4#annual_earned_income_initial_exclusion_limit",
+        country="us",
+    )
+    assert ssi_earned_exclusion_mapping.mapping_type == "parameter_value"
+    assert (
+        ssi_earned_exclusion_mapping.policyengine_parameter
+        == "gov.ssa.ssi.income.exclusions.earned"
+    )
+    assert ssi_earned_exclusion_mapping.result_multiplier == 12
+    ssi_earned_share_mapping = registry.mapping_for_legal_id(
+        "us:statutes/42/1382a/b/4#earned_income_remainder_exclusion_rate",
+        country="us",
+    )
+    assert ssi_earned_share_mapping.mapping_type == "parameter_value"
+    assert (
+        ssi_earned_share_mapping.policyengine_parameter
+        == "gov.ssa.ssi.income.exclusions.earned_share"
+    )
+    ssi_blind_expense_mapping = registry.mapping_for_legal_id(
+        "us:statutes/42/1382a/b/4#blind_branch_earning_expenses_excluded",
+        country="us",
+    )
+    assert ssi_blind_expense_mapping.mapping_type == "not_comparable"
+    assert ssi_blind_expense_mapping.policyengine_variable == "ssi_countable_income"
     maximum_allotment_mapping = registry.mapping_for_legal_id(
         "us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_table",
         country="us",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.787"
+version = "0.2.789"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated federal SSI income-exclusion outputs against PolicyEngine oracle coverage
- map the general and earned-income exclusion amounts to PolicyEngine parameters with monthly-to-annual multipliers
- support deterministic oracle test repair for simple source-backed fraction formulas such as the SSI earned-income exclusion rate

## Checks
- uv run ruff check src tests
- uv run ruff format --check src tests
- uv run --with towncrier python -m towncrier build --draft --version 0.0.0
- uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::TestApplyDependencyValidation::test_repair_oracle_parameter_tests_appends_scalar_parameter_case tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_rulespec_validation.py::test_policyengine_oracle_applies_result_multiplier -q