### PR TITLE
Use Populace for PolicyEngine validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,18 +160,19 @@ appends a record to `artifacts/eval-suites/index.jsonl`.
 
 ## PolicyEngine population oracles
 
-Use `snap-ecps-compare` to compare a SNAP composition module against
-PolicyEngine ECPS (enhanced CPS) records:
+Use `snap-populace-compare` to compare a SNAP composition module against
+PolicyEngine over Populace records:
 
 ```bash
-uv run --with policyengine-us --with numpy \
-  axiom-encode snap-ecps-compare \
+uv run --with "$HOME/PolicyEngine/populace/packages/populace-data[us]" \
+  --with numpy \
+  axiom-encode snap-populace-compare \
   --jurisdiction us-ny \
   --utility-projection policyengine-type \
   --positive-snap-only
 ```
 
-The command runs `axiom-rules-engine` once over projected ECPS records and
+The command runs `axiom-rules-engine` once over projected Populace records and
 compares `us:statutes/7/2017/a#snap_regular_month_allotment` to PolicyEngine
 `snap_normal_allotment`. Use `--jurisdiction us-co` or `--jurisdiction us-ny`;
 add `--fail-on-mismatch` in CI when exact parity is expected, or

--- a/changelog.d/populace-validation.changed.md
+++ b/changelog.d/populace-validation.changed.md
@@ -1,0 +1,1 @@
+Replace ECPS/EFRS validation commands and readiness reporting with Populace-backed PolicyEngine population validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.789"
+version = "0.2.790"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.789"
+__version__ = "0.2.790"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -116,34 +116,34 @@ from .oracles.policyengine.coverage import (
     build_policyengine_coverage_report,
 )
 from .oracles.policyengine.ecps_snap import (
-    configure_parser as configure_snap_ecps_compare_parser,
+    configure_parser as configure_snap_populace_compare_parser,
 )
 from .oracles.policyengine.ecps_snap import (
-    main as run_snap_ecps_compare,
+    main as run_snap_populace_compare,
 )
 from .oracles.policyengine.ecps_tax import (
-    configure_parser as configure_tax_ecps_compare_parser,
+    configure_parser as configure_tax_populace_compare_parser,
 )
 from .oracles.policyengine.ecps_tax import (
-    main as run_tax_ecps_compare,
+    main as run_tax_populace_compare,
 )
 from .oracles.policyengine.efrs_uk import (
-    configure_coverage_parser as configure_uk_efrs_coverage_parser,
+    configure_coverage_parser as configure_uk_populace_coverage_parser,
 )
 from .oracles.policyengine.efrs_uk import (
-    configure_hbai_coverage_parser as configure_uk_efrs_hbai_coverage_parser,
+    configure_hbai_coverage_parser as configure_uk_populace_hbai_coverage_parser,
 )
 from .oracles.policyengine.efrs_uk import (
-    configure_parser as configure_uk_efrs_compare_parser,
+    configure_parser as configure_uk_populace_compare_parser,
 )
 from .oracles.policyengine.efrs_uk import (
-    main as run_uk_efrs_compare,
+    main as run_uk_populace_compare,
 )
 from .oracles.policyengine.efrs_uk import (
-    main_coverage as run_uk_efrs_coverage,
+    main_coverage as run_uk_populace_coverage,
 )
 from .oracles.policyengine.efrs_uk import (
-    main_hbai_coverage as run_uk_efrs_hbai_coverage,
+    main_hbai_coverage as run_uk_populace_hbai_coverage,
 )
 from .oracles.policyengine.registry import load_policyengine_registry
 from .oracles.policyengine.snap_readiness import build_snap_readiness_report
@@ -779,39 +779,69 @@ def main():
         "--json", action="store_true", help="Output as JSON"
     )
 
+    snap_populace_compare_parser = subparsers.add_parser(
+        "snap-populace-compare",
+        help="Compare SNAP RuleSpec output against PolicyEngine over Populace",
+    )
+    configure_snap_populace_compare_parser(snap_populace_compare_parser)
+
+    tax_populace_compare_parser = subparsers.add_parser(
+        "tax-populace-compare",
+        help="Compare federal tax RuleSpec output against PolicyEngine over Populace",
+    )
+    configure_tax_populace_compare_parser(tax_populace_compare_parser)
+
+    uk_populace_compare_parser = subparsers.add_parser(
+        "uk-populace-compare",
+        help="Compare UK RuleSpec output against PolicyEngine over Populace",
+    )
+    configure_uk_populace_compare_parser(uk_populace_compare_parser)
+
+    uk_populace_coverage_parser = subparsers.add_parser(
+        "uk-populace-coverage",
+        help="Report PE-UK Populace computed-variable coverage and backlog",
+    )
+    configure_uk_populace_coverage_parser(uk_populace_coverage_parser)
+
+    uk_populace_hbai_coverage_parser = subparsers.add_parser(
+        "uk-populace-hbai-coverage",
+        help="Report HBAI net-income policy-component coverage",
+    )
+    configure_uk_populace_hbai_coverage_parser(uk_populace_hbai_coverage_parser)
+
     snap_ecps_compare_parser = subparsers.add_parser(
         "snap-ecps-compare",
-        help="Compare SNAP RuleSpec output against PolicyEngine ECPS",
+        help=argparse.SUPPRESS,
     )
-    configure_snap_ecps_compare_parser(snap_ecps_compare_parser)
+    configure_snap_populace_compare_parser(snap_ecps_compare_parser)
 
     tax_ecps_compare_parser = subparsers.add_parser(
         "tax-ecps-compare",
-        help="Compare federal tax RuleSpec output against PolicyEngine ECPS",
+        help=argparse.SUPPRESS,
     )
-    configure_tax_ecps_compare_parser(tax_ecps_compare_parser)
+    configure_tax_populace_compare_parser(tax_ecps_compare_parser)
 
     uk_efrs_compare_parser = subparsers.add_parser(
         "uk-efrs-compare",
-        help="Compare UK RuleSpec output against PolicyEngine Enhanced FRS",
+        help=argparse.SUPPRESS,
     )
-    configure_uk_efrs_compare_parser(uk_efrs_compare_parser)
+    configure_uk_populace_compare_parser(uk_efrs_compare_parser)
 
     uk_efrs_coverage_parser = subparsers.add_parser(
         "uk-efrs-coverage",
-        help="Report PE-UK EFRS computed-variable coverage and backlog",
+        help=argparse.SUPPRESS,
     )
-    configure_uk_efrs_coverage_parser(uk_efrs_coverage_parser)
+    configure_uk_populace_coverage_parser(uk_efrs_coverage_parser)
 
     uk_efrs_hbai_coverage_parser = subparsers.add_parser(
         "uk-efrs-hbai-coverage",
-        help="Report HBAI net-income policy-component coverage",
+        help=argparse.SUPPRESS,
     )
-    configure_uk_efrs_hbai_coverage_parser(uk_efrs_hbai_coverage_parser)
+    configure_uk_populace_hbai_coverage_parser(uk_efrs_hbai_coverage_parser)
 
     snap_readiness_parser = subparsers.add_parser(
         "snap-readiness",
-        help="Report SNAP corpus, RuleSpec, and ECPS oracle readiness by state repo",
+        help="Report SNAP corpus, RuleSpec, and Populace oracle readiness by state repo",
     )
     snap_readiness_parser.add_argument(
         "--root",
@@ -2148,16 +2178,19 @@ def main():
         cmd_oracle_candidates(args)
     elif args.command == "classify":
         cmd_classify(args)
-    elif args.command == "snap-ecps-compare":
-        sys.exit(run_snap_ecps_compare(args))
-    elif args.command == "tax-ecps-compare":
-        sys.exit(run_tax_ecps_compare(args))
-    elif args.command == "uk-efrs-compare":
-        sys.exit(run_uk_efrs_compare(args))
-    elif args.command == "uk-efrs-coverage":
-        sys.exit(run_uk_efrs_coverage(args))
-    elif args.command == "uk-efrs-hbai-coverage":
-        sys.exit(run_uk_efrs_hbai_coverage(args))
+    elif args.command in {"snap-populace-compare", "snap-ecps-compare"}:
+        sys.exit(run_snap_populace_compare(args))
+    elif args.command in {"tax-populace-compare", "tax-ecps-compare"}:
+        sys.exit(run_tax_populace_compare(args))
+    elif args.command in {"uk-populace-compare", "uk-efrs-compare"}:
+        sys.exit(run_uk_populace_compare(args))
+    elif args.command in {"uk-populace-coverage", "uk-efrs-coverage"}:
+        sys.exit(run_uk_populace_coverage(args))
+    elif args.command in {
+        "uk-populace-hbai-coverage",
+        "uk-efrs-hbai-coverage",
+    }:
+        sys.exit(run_uk_populace_hbai_coverage(args))
     elif args.command == "snap-readiness":
         cmd_snap_readiness(args)
     elif args.command == "calibration":
@@ -3787,7 +3820,7 @@ def cmd_classify(args):
 
 
 def cmd_snap_readiness(args):
-    """Report SNAP corpus, RuleSpec, and ECPS oracle readiness."""
+    """Report SNAP corpus, RuleSpec, and Populace oracle readiness."""
     root = (args.root or _default_rulespec_inventory_root()).resolve()
     corpus_root = (
         args.corpus_root.resolve() if args.corpus_root else root / "axiom-corpus"
@@ -3815,7 +3848,7 @@ def cmd_snap_readiness(args):
             f"files={item['rulespec_files']} "
             f"outputs={item['executable_outputs']} "
             f"tests={item['companion_test_files']} "
-            f"ecps_config={str(item['policyengine_ecps_configured']).lower()} "
+            f"populace_config={str(item['policyengine_populace_configured']).lower()} "
             f"program_module={str(item['program_module_exists']).lower()}"
             f"{blocker_suffix}"
         )

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -23363,9 +23363,9 @@ Output ONLY valid JSON:
         year: int = 2024,
         sample_size: int | None = None,
     ) -> ValidationResult:
-        """Benchmark RuleSpec encoding against PolicyEngine using CPS microdata.
+        """Benchmark RuleSpec encoding against PolicyEngine using Populace.
 
-        Runs PE Microsimulation on ECPS, extracts the target
+        Runs PE Microsimulation on Populace, extracts the target
         variable for all tax units, and reports the benchmark. This establishes
         the PE baseline that RuleSpec must match as inputs get wired up.
 

--- a/src/axiom_encode/oracles/policyengine/classifier.py
+++ b/src/axiom_encode/oracles/policyengine/classifier.py
@@ -80,7 +80,7 @@ def _build_rule_name_index(
     """Build a {rule_name: adapter} lookup from the adapter catalog.
 
     When multiple adapters declare the same rule_name (rare), the first one
-    in iteration order wins, matching ECPS comparison precedence.
+    in iteration order wins, matching Populace comparison precedence.
     """
     index: dict[str, PolicyEngineUSVarAdapter] = {}
     for adapter in adapters:

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -1,10 +1,10 @@
-"""Compare SNAP RuleSpec output against PolicyEngine ECPS.
+"""Compare SNAP RuleSpec output against PolicyEngine over Populace.
 
-The comparator projects PolicyEngine ECPS (enhanced CPS) SPM-unit records into a
+The comparator projects PolicyEngine Populace SPM-unit records into a
 jurisdiction's SNAP composition input surface, including related member facts,
 runs the Axiom rules engine over the projected records, and compares regular monthly SNAP
 allotments against PolicyEngine's normal allotment. It uses these targets
-because ECPS records do not include application dates for initial-month
+because population records do not include application dates for initial-month
 proration, and PolicyEngine's top-level ``snap`` microsimulation value includes
 take-up adjustments.
 
@@ -32,6 +32,11 @@ from typing import Any
 import yaml
 
 from axiom_encode.oracles import snapscreener
+from axiom_encode.oracles.policyengine.population import (
+    DEFAULT_US_POPULACE_YEAR,
+    load_populace_dataset,
+    populace_data_requirement,
+)
 
 try:
     import numpy as np
@@ -112,7 +117,7 @@ JURISDICTION_CONFIGS = {
         ),
         relation_id=AXIOM_RELATION_ID_BY_LABEL["member_of_household"],
         member_entity_type="Person",
-        temp_prefix="co-snap-pe-ecps-",
+        temp_prefix="co-snap-pe-populace-",
         display_name="Colorado SNAP",
     ),
     "us-ca": JurisdictionConfig(
@@ -161,7 +166,7 @@ JURISDICTION_CONFIGS = {
             "us-ca:policies/cdss/snap/fy-2026-benefit-calculation#relation.member_of_household"
         ),
         member_entity_type="Person",
-        temp_prefix="ca-snap-pe-ecps-",
+        temp_prefix="ca-snap-pe-populace-",
         display_name="California SNAP",
         additional_relation_ids=(AXIOM_RELATION_ID_BY_LABEL["member_of_household"],),
     ),
@@ -202,7 +207,7 @@ JURISDICTION_CONFIGS = {
         utility_allowance_labels=(),
         relation_id=AXIOM_RELATION_ID_BY_LABEL["member_of_household"],
         member_entity_type="Person",
-        temp_prefix="az-snap-pe-ecps-",
+        temp_prefix="az-snap-pe-populace-",
         display_name="Arizona SNAP",
     ),
     "us-ny": JurisdictionConfig(
@@ -279,7 +284,7 @@ JURISDICTION_CONFIGS = {
             "#relation.member_of_household"
         ),
         member_entity_type="Person",
-        temp_prefix="ny-snap-pe-ecps-",
+        temp_prefix="ny-snap-pe-populace-",
         display_name="New York SNAP",
         additional_relation_ids=(
             AXIOM_RELATION_ID_BY_LABEL["member_of_household"],
@@ -579,13 +584,15 @@ def configure_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         "--sample-size",
         type=int,
         default=None,
-        help="Limit after state filtering. Omit to run all matching ECPS SPM units.",
+        help=(
+            "Limit after state filtering. Omit to run all matching Populace SPM units."
+        ),
     )
     parser.add_argument(
         "--positive-snap-only",
         action="store_true",
         help=(
-            "Only compare ECPS SPM units where PolicyEngine normal allotment "
+            "Only compare Populace SPM units where PolicyEngine normal allotment "
             "is positive."
         ),
     )
@@ -594,11 +601,17 @@ def configure_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         choices=("raw-expenses", "policyengine-type"),
         default="raw-expenses",
         help=(
-            "How to project ECPS utility facts. raw-expenses uses itemized "
-            "utility expenses from ECPS. policyengine-type maps "
+            "How to project Populace utility facts. raw-expenses uses itemized "
+            "utility expenses from Populace. policyengine-type maps "
             "PolicyEngine's utility-allowance type into jurisdiction utility "
             "facts for oracle parity."
         ),
+    )
+    parser.add_argument(
+        "--populace-year",
+        type=int,
+        default=DEFAULT_US_POPULACE_YEAR,
+        help="Published US Populace dataset year to load.",
     )
     parser.add_argument(
         "--tolerance",
@@ -998,13 +1011,14 @@ def require_numpy() -> None:
     if np is None:
         raise SystemExit(
             "numpy is required. Run with: "
-            "uv run --with numpy --with policyengine-us axiom-encode "
-            "snap-ecps-compare"
+            "uv run --with numpy --with "
+            f"{populace_data_requirement('us')} axiom-encode "
+            "snap-populace-compare"
         )
 
 
 def calculate(sim: Any, name: str, period: str | int) -> np.ndarray:
-    return array(sim.calculate(name, period))
+    return array(sim.calculate(name, period=period))
 
 
 def calculate_or_default(
@@ -1090,18 +1104,24 @@ def load_policyengine_cases(
     sample_size: int | None,
     positive_snap_only: bool,
     utility_projection: str,
+    populace_year: int,
 ) -> list[ProjectedCase]:
     try:
         from policyengine_us import Microsimulation
     except ImportError as exc:
         raise SystemExit(
             "policyengine-us is required. Run with: "
-            "uv run --with policyengine-us --with numpy axiom-encode "
-            "snap-ecps-compare"
+            f"uv run --with {populace_data_requirement('us')} --with numpy axiom-encode "
+            "snap-populace-compare"
         ) from exc
 
-    print("Loading PolicyEngine ECPS...")
-    sim = Microsimulation()
+    print(f"Loading PolicyEngine Populace US {populace_year} dataset...")
+    dataset = load_populace_dataset(
+        "us",
+        year=populace_year,
+        command="snap-populace-compare",
+    )
+    sim = Microsimulation(dataset=dataset)
 
     period_label = period.label
     year = period.year
@@ -1129,10 +1149,10 @@ def load_policyengine_cases(
     if sample_size is not None:
         indices = indices[:sample_size]
 
-    print(f"Projecting {len(indices):,} {state} ECPS SPM units...")
+    print(f"Projecting {len(indices):,} {state} Populace SPM units...")
     if skipped_empty_units:
         print(
-            f"Skipped {skipped_empty_units:,} {state} ECPS SPM units "
+            f"Skipped {skipped_empty_units:,} {state} Populace SPM units "
             "with SNAP unit size < 1."
         )
 
@@ -1799,7 +1819,7 @@ def print_summary(
     diffs = sorted(rows, key=lambda row: row["absolute_difference"], reverse=True)
     mean_abs = sum(row["absolute_difference"] for row in rows) / total if total else 0.0
     print()
-    print(f"Compared {total:,} PolicyEngine ECPS SPM units")
+    print(f"Compared {total:,} PolicyEngine Populace SPM units")
     print(f"Tolerance: ${tolerance:,.2f}")
     print(
         f"Matches: {matches:,}/{total:,} ({matches / total:.1%})"
@@ -1929,16 +1949,17 @@ def main(args: argparse.Namespace | None = None) -> int:
         sample_size=args.sample_size,
         positive_snap_only=args.positive_snap_only,
         utility_projection=args.utility_projection,
+        populace_year=args.populace_year,
     )
     if not cases:
-        print("No matching ECPS SPM units.")
+        print("No matching Populace SPM units.")
         return 1
 
     with tempfile.TemporaryDirectory(prefix=config.temp_prefix) as temp_dir:
         artifact = Path(temp_dir) / "program.compiled.json"
         print(f"Compiling {config.display_name} RuleSpec composition...")
         compile_program(axiom_binary, program, artifact, env=env)
-        print("Running the Axiom rules engine over projected ECPS records...")
+        print("Running the Axiom rules engine over projected Populace records...")
         results = run_axiom_cases(
             binary=axiom_binary,
             artifact=artifact,

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -1,7 +1,7 @@
-"""Compare federal tax RuleSpec output against PolicyEngine ECPS.
+"""Compare federal tax RuleSpec output against PolicyEngine over Populace.
 
-This is the federal-tax counterpart to ``snap-ecps-compare``. Each comparison
-surface has an explicit projection from ECPS fields into Axiom inputs. The
+This is the federal-tax counterpart to ``snap-populace-compare``. Each comparison
+surface has an explicit projection from Populace fields into Axiom inputs. The
 projection is intentionally conservative: it does not use PE outputs for the
 surface under test as Axiom inputs.
 """
@@ -30,6 +30,12 @@ from axiom_encode.harness.validator_pipeline import (
     _rulespec_public_item_keys,
     _rulespec_repo_alias_parent,
 )
+from axiom_encode.oracles.policyengine.population import (
+    DEFAULT_US_POPULACE_YEAR,
+    load_populace_dataset,
+    populace_data_requirement,
+    population_table,
+)
 
 try:
     import numpy as np
@@ -37,11 +43,7 @@ except ImportError:  # pragma: no cover - exercised only without optional oracle
     np = None
 
 
-POLICYENGINE_VERSION = "4.11.0"
-POLICYENGINE_CORE_VERSION = "3.26.11"
-POLICYENGINE_DATA_MANIFEST_US_VERSION = "1.700.0"
-POLICYENGINE_US_VERSION = "1.705.16"
-DATASET = "hf://policyengine/policyengine-us-data/enhanced_cps_2024.h5"
+MIN_POLICYENGINE_US_VERSION = "1.723"
 
 CTC_PROGRAM_PATH = Path("statutes/26/24.yaml")
 CTC_TEST_PATH = Path("statutes/26/24.test.yaml")
@@ -537,7 +539,7 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         type=int,
         default=100,
         help=(
-            "Number of positive-weight ECPS tax units to compare; "
+            "Number of positive-weight Populace tax units to compare; "
             "0 compares all eligible tax units"
         ),
     )
@@ -548,14 +550,14 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         default=None,
         dest="tax_unit_ids",
         help=(
-            "Compare a specific ECPS tax_unit_id. Repeat to compare multiple "
+            "Compare a specific Populace tax_unit_id. Repeat to compare multiple "
             "known residual cases; when provided this bypasses --sample-size."
         ),
     )
     parser.add_argument(
         "--positive-ctc-only",
         action="store_true",
-        help="Restrict to ECPS tax units with positive PolicyEngine CTC",
+        help="Restrict to Populace tax units with positive PolicyEngine CTC",
     )
     parser.add_argument(
         "--surface",
@@ -567,7 +569,13 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         "--data-folder",
         type=Path,
         default=Path(".axiom") / "policyengine-data",
-        help="PolicyEngine dataset cache folder",
+        help="Deprecated; Populace uses the Hugging Face cache.",
+    )
+    parser.add_argument(
+        "--populace-year",
+        type=int,
+        default=DEFAULT_US_POPULACE_YEAR,
+        help="Published US Populace dataset year to load.",
     )
     parser.add_argument(
         "--tolerance",
@@ -598,9 +606,7 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         "--allow-uncertified-policyengine-data",
         action="store_true",
         help=(
-            "Allow policyengine.py ECPS data to load against an overridden "
-            "local policyengine-us version. Intended only with "
-            "--allow-policyengine-us-version for validating local oracle fixes."
+            "Deprecated; Populace validation no longer loads policyengine.py microdata."
         ),
     )
     parser.add_argument(
@@ -620,6 +626,7 @@ def main(args: argparse.Namespace) -> int:
         positive_ctc_only=args.positive_ctc_only,
         surface=args.surface,
         data_folder=args.data_folder,
+        populace_year=args.populace_year,
         tolerance=args.tolerance,
         relative_tolerance=args.relative_tolerance,
         tax_unit_ids=tuple(args.tax_unit_ids or ()),
@@ -649,17 +656,13 @@ def compare_tax_ecps(
     positive_ctc_only: bool,
     surface: str,
     data_folder: Path,
+    populace_year: int,
     tolerance: float,
     relative_tolerance: float,
     tax_unit_ids: tuple[int, ...] = (),
     allow_policyengine_us_version: bool = False,
     allow_uncertified_policyengine_data: bool = False,
 ) -> TaxComparisonReport:
-    if allow_uncertified_policyengine_data and not allow_policyengine_us_version:
-        raise SystemExit(
-            "--allow-uncertified-policyengine-data requires "
-            "--allow-policyengine-us-version"
-        )
     require_numpy()
     require_policyengine_versions(
         allow_policyengine_us_version=allow_policyengine_us_version,
@@ -679,6 +682,7 @@ def compare_tax_ecps(
         positive_ctc_only=positive_ctc_only,
         tax_unit_ids=tax_unit_ids,
         data_folder=data_folder,
+        populace_year=populace_year,
         allow_uncertified_policyengine_data=allow_uncertified_policyengine_data,
         tax_unit_variables=tax_unit_variables,
         person_variables=person_variables,
@@ -767,56 +771,58 @@ def compare_tax_ecps(
     )
 
 
+def array(values: Any) -> np.ndarray:
+    require_numpy()
+    if hasattr(values, "to_numpy"):
+        return values.to_numpy()
+    if hasattr(values, "values"):
+        return np.asarray(values.values)
+    return np.asarray(values)
+
+
+def calculate(sim: Any, name: str, period: str | int) -> np.ndarray:
+    return array(sim.calculate(name, period=period))
+
+
 def load_policyengine_tax_data(
     *,
     year: int,
     sample_size: int,
     positive_ctc_only: bool,
     data_folder: Path,
+    populace_year: int,
     tax_unit_ids: tuple[int, ...] = (),
     allow_uncertified_policyengine_data: bool = False,
     tax_unit_variables: tuple[str, ...] = PE_TAX_UNIT_VARIABLES,
     person_variables: tuple[str, ...] = PE_PERSON_VARIABLES,
 ) -> dict[str, Any]:
-    if (
-        allow_uncertified_policyengine_data
-        or policyengine_data_certification_override_required()
-    ):
-        _install_policyengine_data_certification_override()
     try:
-        from policyengine.core import Simulation
-        from policyengine.tax_benefit_models.us import ensure_datasets, us_latest
+        from policyengine_us import Microsimulation
     except ImportError as exc:  # pragma: no cover - optional runtime dependency
         raise SystemExit(policyengine_install_message()) from exc
 
-    log("Loading PolicyEngine ECPS...")
-    datasets = ensure_datasets(
-        datasets=[DATASET],
-        years=[year],
-        data_folder=str(data_folder),
+    _ = data_folder
+    _ = allow_uncertified_policyengine_data
+    log(f"Loading PolicyEngine Populace US {populace_year} dataset...")
+    dataset = load_populace_dataset(
+        "us",
+        year=populace_year,
+        command="tax-populace-compare",
     )
-    dataset = datasets[f"enhanced_cps_2024_{year}"]
-    sim = Simulation(
-        dataset=dataset,
-        tax_benefit_model_version=us_latest,
-        extra_variables={
-            "person": list(person_variables),
-            "tax_unit": list(tax_unit_variables),
-        },
-    )
+    sim = Microsimulation(dataset=dataset)
     log("Running PolicyEngine tax outputs...")
-    sim.run()
 
-    tax_units = sim.output_dataset.data.tax_unit
-    raw_tax_units = dataset.data.tax_unit
-    tax_unit_outputs = tax_units[["tax_unit_id", *tax_unit_variables]].copy()
-    raw_persons = dataset.data.person
-    person_outputs = sim.output_dataset.data.person[
-        ["person_id", *person_variables]
-    ].copy()
+    raw_tax_units = population_table(dataset, "tax_unit")
+    raw_persons = population_table(dataset, "person")
+    tax_unit_outputs = raw_tax_units[["tax_unit_id"]].copy()
+    for variable in tax_unit_variables:
+        tax_unit_outputs[variable] = calculate(sim, variable, year)
+    person_outputs = raw_persons[["person_id"]].copy()
+    for variable in person_variables:
+        person_outputs[variable] = calculate(sim, variable, year)
     indices = select_tax_unit_indices(
         raw_tax_units=raw_tax_units,
-        tax_units=tax_units,
+        tax_units=tax_unit_outputs,
         sample_size=sample_size,
         positive_ctc_only=positive_ctc_only,
         tax_unit_ids=tax_unit_ids,
@@ -859,8 +865,8 @@ def load_policyengine_tax_data(
 def remove_output_columns_already_in_raw(*, raw: Any, outputs: Any, key: str) -> Any:
     """Avoid pandas suffixing when dataset inputs already contain a PE variable.
 
-    Newer ECPS data releases can store source variables that the harness also
-    requests through `extra_variables`. Those columns are already present in the
+    Newer Populace data releases can store source variables that the harness
+    also requests from PolicyEngine. Those columns are already present in the
     raw table, so keep the raw copy and merge only genuinely new outputs.
     """
 
@@ -903,7 +909,7 @@ def select_tax_unit_indices(
     positive_ctc_only: bool,
     tax_unit_ids: tuple[int, ...] = (),
 ) -> Any:
-    """Select ECPS tax-unit row indices for oracle comparison."""
+    """Select Populace tax-unit row indices for oracle comparison."""
     mask = np.asarray(raw_tax_units["tax_unit_weight"]) > 0
     if positive_ctc_only:
         mask &= np.asarray(tax_units["ctc"]) > 0
@@ -929,56 +935,25 @@ def select_tax_unit_indices(
             selected.append(index)
     if missing:
         raise SystemExit(
-            "Requested ECPS tax_unit_id not found: "
+            "Requested Populace tax_unit_id not found: "
             + ", ".join(str(value) for value in missing)
         )
     if filtered:
         raise SystemExit(
-            "Requested ECPS tax_unit_id is not eligible for this comparison: "
+            "Requested Populace tax_unit_id is not eligible for this comparison: "
             + ", ".join(str(value) for value in filtered)
         )
     return np.asarray(selected, dtype=int)
 
 
 def _install_policyengine_data_certification_override() -> None:
-    """Allow ECPS oracle runs against a local policyengine-us fix branch.
-
-    policyengine.py 4.11.0 currently certifies the bundled ECPS data against
-    its manifest-pinned policyengine-us release. When validating a local
-    policyengine-us PR, the installed model version can intentionally differ
-    while the ECPS data is still the desired oracle input. This override is
-    also used when Axiom deliberately pins the oracle to a newer policyengine-us
-    release than policyengine.py's bundled manifest.
-    """
-    os.environ.setdefault("POLICYENGINE_SKIP_COUNTRY_IMPORTS", "1")
-    try:
-        import policyengine.provenance.manifest as manifest
-    except ImportError:  # pragma: no cover - optional runtime dependency
-        return
-
-    def _allow_local_oracle_data(
-        country_id: str,
-        runtime_model_version: str,
-        runtime_data_build_fingerprint: str | None = None,
-    ):
-        return manifest.DataCertification(
-            compatibility_basis="axiom_oracle_local_policyengine_us_override",
-            certified_for_model_version=runtime_model_version,
-            data_build_fingerprint=runtime_data_build_fingerprint,
-            certified_by="axiom-encode tax-ecps-compare",
-        )
-
-    manifest.certify_data_release_compatibility = _allow_local_oracle_data
-    try:
-        import policyengine.tax_benefit_models.common.model_version as model_version
-    except ImportError:  # pragma: no cover - optional runtime dependency
-        return
-    model_version.certify_data_release_compatibility = _allow_local_oracle_data
+    """Deprecated no-op kept for old tests/imports."""
+    return None
 
 
 def policyengine_data_certification_override_required() -> bool:
-    """Return whether the pinned PE-US oracle intentionally exceeds the manifest."""
-    return POLICYENGINE_US_VERSION != POLICYENGINE_DATA_MANIFEST_US_VERSION
+    """Return whether Populace validation needs a PE.py data override."""
+    return False
 
 
 def build_axiom_request(
@@ -1783,11 +1758,12 @@ def taxable_oasdi_wages_by_person_id(
 
 
 def project_fica_wages(person: Any) -> float:
-    """Project IRC 3121(a) FICA wages from ECPS leaf inputs.
+    """Project IRC 3121(a) FICA wages from Populace leaf inputs.
 
     PolicyEngine's payroll tax gross wages are the output being tested here, so
-    use them only as a compatibility fallback for hand-built unit fixtures. ECPS
-    rows should supply gross employment income plus Section 125 deduction leaves.
+    use them only as a compatibility fallback for hand-built unit fixtures.
+    Populace rows should supply gross employment income plus Section 125
+    deduction leaves.
     Traditional 401(k) and 403(b) deferrals reduce income-tax wages, but not
     FICA wages.
     """
@@ -2455,7 +2431,7 @@ def run_axiom_program(
             deduped_roots.append(raw)
     env["AXIOM_RULESPEC_REPO_ROOTS"] = os.pathsep.join(deduped_roots)
     compile_program = _canonical_rulespec_compile_path(program, rulespec_root)
-    with tempfile.TemporaryDirectory(prefix="axiom-tax-ecps-") as tmpdir:
+    with tempfile.TemporaryDirectory(prefix="axiom-tax-populace-") as tmpdir:
         artifact = Path(tmpdir) / f"{program.stem}.json"
         compile_result = subprocess.run(
             [
@@ -2677,10 +2653,10 @@ def compare_outputs(
         mismatches=mismatches,
         output_summary=list(summary.values()),
         projection_notes=[
-            "Current CTC projection uses ECPS raw tax-unit membership, age, "
+            "Current CTC projection uses Populace raw tax-unit membership, age, "
             "student status, separation status, and SSN-card type to reconstruct "
             "the structural Section 152 facts needed by 26 USC 24.",
-            "Standard deduction projection uses ECPS raw ages, blindness, and "
+            "Standard deduction projection uses Populace raw ages, blindness, and "
             "tax-unit membership to reconstruct aged-or-blind counts under "
             "26 USC 63(f).",
             "AGI remains a boundary input until upstream AGI rules are encoded "
@@ -2689,24 +2665,24 @@ def compare_outputs(
             "filing-status rule.",
             "The standard deduction comparison currently treats dependency by "
             "another taxpayer and earned income as boundary-false/zero because "
-            "those upstream facts are not yet encoded from ECPS leaf inputs.",
+            "those upstream facts are not yet encoded from Populace leaf inputs.",
             "OASDI payroll projections run Axiom 3121(a)(1) before sections "
             "3101(a) and 3111(a), so taxable OASDI wages are no longer taken "
             "from PolicyEngine. The section 230 contribution-and-benefit base "
             "is resolved by running the encoded SSA automatic-determination "
             "RuleSpec before section 3121(a)(1).",
-            "Payroll projections derive FICA wages from ECPS employment-income "
+            "Payroll projections derive FICA wages from Populace employment-income "
             "and Section 125 health/HSA payroll-deduction leaves instead of "
             "feeding Axiom from PolicyEngine payroll_tax_gross_wages. "
             "Traditional 401(k) and 403(b) elective deferrals are deliberately "
             "not subtracted from the FICA wage base.",
             "Capital-gain-definition projections compare Section 1(h) net and "
-            "adjusted net capital gain from ECPS raw capital-gain, dividend, "
+            "adjusted net capital gain from Populace raw capital-gain, dividend, "
             "investment-income-election, and unrecaptured-section-1250 fields. "
             "The full capital-gains-tax surface waits on encoded upstream "
             "taxable income rather than using PolicyEngine taxable income as "
             "an Axiom input.",
-            "EITC projections supply ECPS wage and self-employment leaf facts "
+            "EITC projections supply Populace wage and self-employment leaf facts "
             "including farm operations and partnership self-employment income "
             "to Sections 32(c)(2) and 1402(a); Section 32 earned income is "
             "computed by Axiom and compared as an output rather than passed in "
@@ -2717,7 +2693,7 @@ def compare_outputs(
             "the available nonrefundable-credit limit remain explicit upstream "
             "boundary inputs until those federal tax chains are encoded "
             "end-to-end.",
-            "AOTC projections run encoded 26 USC 25A math from ECPS tuition, "
+            "AOTC projections run encoded 26 USC 25A math from Populace tuition, "
             "educational-assistance, enrollment, credential, institution, "
             "prior-claim, and SSN-card facts. Income tax before credits, CDCC, "
             "and foreign tax credit remain explicit upstream boundary inputs "
@@ -2735,7 +2711,7 @@ def compare_outputs(
 def print_report(
     report: TaxComparisonReport, *, tolerance: float, relative_tolerance: float
 ) -> None:
-    print("PolicyEngine tax ECPS comparison")
+    print("PolicyEngine tax Populace comparison")
     print(f"Compared tax units: {report.compared_tax_units:,}")
     print(f"Compared persons: {report.compared_persons:,}")
     print(f"Compared values: {report.compared_values:,}")
@@ -2963,38 +2939,38 @@ def require_policyengine_versions(
     *, allow_policyengine_us_version: bool = False
 ) -> None:
     try:
-        policyengine_version = version("policyengine")
-        policyengine_core_version = version("policyengine-core")
         policyengine_us_version = version("policyengine-us")
     except PackageNotFoundError as exc:
         raise SystemExit(policyengine_install_message()) from exc
-    if policyengine_version != POLICYENGINE_VERSION:
+    if not allow_policyengine_us_version and _version_tuple(
+        policyengine_us_version
+    ) < _version_tuple(MIN_POLICYENGINE_US_VERSION):
         raise SystemExit(
-            f"policyengine=={POLICYENGINE_VERSION} required; found "
-            f"{policyengine_version}. {policyengine_install_message()}"
-        )
-    if policyengine_core_version != POLICYENGINE_CORE_VERSION:
-        raise SystemExit(
-            f"policyengine-core=={POLICYENGINE_CORE_VERSION} required; found "
-            f"{policyengine_core_version}. {policyengine_install_message()}"
-        )
-    if (
-        policyengine_us_version != POLICYENGINE_US_VERSION
-        and not allow_policyengine_us_version
-    ):
-        raise SystemExit(
-            f"policyengine-us=={POLICYENGINE_US_VERSION} required; found "
+            f"policyengine-us>={MIN_POLICYENGINE_US_VERSION} required; found "
             f"{policyengine_us_version}. {policyengine_install_message()}"
         )
 
 
 def policyengine_install_message() -> str:
     return (
-        f"Run with: uv run --with policyengine=={POLICYENGINE_VERSION} "
-        f"--with policyengine-core=={POLICYENGINE_CORE_VERSION} "
-        f"--with policyengine-us=={POLICYENGINE_US_VERSION} "
-        "axiom-encode tax-ecps-compare"
+        "Run with: uv run --with numpy "
+        f"--with {populace_data_requirement('us')} "
+        "axiom-encode tax-populace-compare"
     )
+
+
+def _version_tuple(value: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for raw_part in value.split("."):
+        digits = ""
+        for char in raw_part:
+            if not char.isdigit():
+                break
+            digits += char
+        if digits == "":
+            break
+        parts.append(int(digits))
+    return tuple(parts)
 
 
 def log(message: str) -> None:

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -1,7 +1,7 @@
-"""Compare UK RuleSpec output against PolicyEngine Enhanced FRS.
+"""Compare UK RuleSpec output against PolicyEngine over Populace.
 
-The UK counterpart to the ECPS tax comparators covers mapped surfaces whose
-RuleSpec inputs can be projected from PolicyEngine's Enhanced FRS, plus scalar
+The UK counterpart to the US Populace comparators covers mapped surfaces whose
+RuleSpec inputs can be projected from PolicyEngine over Populace, plus scalar
 parameter surfaces whose generated RuleSpec values can be compared against
 PolicyEngine component outputs.
 """
@@ -22,7 +22,7 @@ from typing import Any, Callable
 import yaml
 
 from .ecps_tax import (
-    POLICYENGINE_CORE_VERSION,
+    _version_tuple,
     input_record,
     money,
     output_number,
@@ -30,11 +30,18 @@ from .ecps_tax import (
     run_axiom_program,
     within_tolerance,
 )
+from .population import (
+    DEFAULT_UK_POPULACE_YEAR,
+    load_populace_dataset,
+    local_dataset_path,
+    populace_data_requirement,
+    population_table,
+)
 
-DEFAULT_DATASET = "enhanced_frs_2023_24"
+DEFAULT_DATASET = ""
 WEEKS_IN_YEAR = 52
 MONTHS_IN_YEAR = 12
-POLICYENGINE_UK_VERSION = "2.88.56"
+MIN_POLICYENGINE_UK_VERSION = "2.88"
 CATEGORY_THRESHOLD_WEEKLY_TOLERANCE = 1.0
 
 NATIONAL_INSURANCE_SECTION_1_PROGRAM_PATH = Path("statutes/ukpga/1992/4/1.yaml")
@@ -1495,7 +1502,7 @@ HBAI_COMPONENT_COVERAGE = {
         "status": "partial",
         "surfaces": ("student-loan-repayment",),
         "covered_outputs": ("student_loan_repayment",),
-        "rationale": "Axiom covers PolicyEngine UK's modelled student_loan_repayment formula by plan-specific threshold and repayment rate. The HBAI student_loan_repayments component remains partial because local EFRS supplies it as reported input data even when student_loan_plan is NONE, overriding PolicyEngine UK's wrapper formula.",
+        "rationale": "Axiom covers PolicyEngine UK's modelled student_loan_repayment formula by plan-specific threshold and repayment rate. The HBAI student_loan_repayments component remains partial because the validation population can supply it as reported input data even when student_loan_plan is NONE, overriding PolicyEngine UK's wrapper formula.",
     },
     "working_tax_credit": {
         "status": "partial",
@@ -1954,7 +1961,7 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         type=int,
         default=100,
         help=(
-            "Number of positive-weight EFRS people to compare; "
+            "Number of positive-weight Populace people to compare; "
             "0 compares all eligible people"
         ),
     )
@@ -1965,7 +1972,7 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         default=None,
         dest="person_ids",
         help=(
-            "Compare a specific EFRS person_id. Repeat to compare multiple "
+            "Compare a specific Populace person_id. Repeat to compare multiple "
             "known residual cases; when provided this bypasses --sample-size."
         ),
     )
@@ -1973,22 +1980,27 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         "--surface",
         choices=["all", *SURFACE_SPECS],
         default="all",
-        help="UK EFRS surface to compare; defaults to all implemented surfaces",
+        help="UK Populace surface to compare; defaults to all implemented surfaces",
     )
     parser.add_argument(
         "--dataset",
         default=DEFAULT_DATASET,
         help=(
-            "PolicyEngine UK dataset logical name, HuggingFace URI, or local .h5 "
-            "path. Defaults to enhanced_frs_2023_24 and prefers local managed "
-            "mirrors when available."
+            "Deprecated local .h5 override for debugging. Omit to load the "
+            "published Populace UK dataset."
         ),
     )
     parser.add_argument(
         "--data-folder",
         type=Path,
         default=Path(".axiom") / "policyengine-data",
-        help="PolicyEngine dataset cache folder",
+        help="Deprecated; Populace uses the Hugging Face cache.",
+    )
+    parser.add_argument(
+        "--populace-year",
+        type=int,
+        default=DEFAULT_UK_POPULACE_YEAR,
+        help="Published UK Populace dataset year to load.",
     )
     parser.add_argument(
         "--universal-credit-program",
@@ -2033,6 +2045,7 @@ def main(args: argparse.Namespace) -> int:
         surface=args.surface,
         dataset=args.dataset,
         data_folder=args.data_folder,
+        populace_year=args.populace_year,
         tolerance=args.tolerance,
         relative_tolerance=args.relative_tolerance,
         universal_credit_program=getattr(args, "universal_credit_program", None),
@@ -2071,15 +2084,21 @@ def configure_coverage_parser(parser: argparse.ArgumentParser) -> None:
         "--dataset",
         default=DEFAULT_DATASET,
         help=(
-            "PolicyEngine UK dataset logical name, HuggingFace URI, or local .h5 "
-            "path for --with-efrs-activity"
+            "Deprecated local .h5 override for --with-populace-activity. "
+            "Omit to load the published Populace UK dataset."
         ),
     )
     parser.add_argument(
         "--data-folder",
         type=Path,
         default=Path(".axiom") / "policyengine-data",
-        help="PolicyEngine dataset cache folder",
+        help="Deprecated; Populace uses the Hugging Face cache.",
+    )
+    parser.add_argument(
+        "--populace-year",
+        type=int,
+        default=DEFAULT_UK_POPULACE_YEAR,
+        help="Published UK Populace dataset year to load.",
     )
     parser.add_argument(
         "--top",
@@ -2088,10 +2107,12 @@ def configure_coverage_parser(parser: argparse.ArgumentParser) -> None:
         help="Maximum missing variables to print in text mode",
     )
     parser.add_argument(
+        "--with-populace-activity",
         "--with-efrs-activity",
         action="store_true",
+        dest="with_populace_activity",
         help=(
-            "Run PolicyEngine over EFRS for missing variables and rank by "
+            "Run PolicyEngine over Populace for missing variables and rank by "
             "observed activity"
         ),
     )
@@ -2104,15 +2125,21 @@ def configure_hbai_coverage_parser(parser: argparse.ArgumentParser) -> None:
         "--dataset",
         default=DEFAULT_DATASET,
         help=(
-            "PolicyEngine UK dataset logical name, HuggingFace URI, or local .h5 "
-            "path for --with-efrs-activity"
+            "Deprecated local .h5 override for --with-populace-activity. "
+            "Omit to load the published Populace UK dataset."
         ),
     )
     parser.add_argument(
         "--data-folder",
         type=Path,
         default=Path(".axiom") / "policyengine-data",
-        help="PolicyEngine dataset cache folder",
+        help="Deprecated; Populace uses the Hugging Face cache.",
+    )
+    parser.add_argument(
+        "--populace-year",
+        type=int,
+        default=DEFAULT_UK_POPULACE_YEAR,
+        help="Published UK Populace dataset year to load.",
     )
     parser.add_argument(
         "--source-root",
@@ -2130,10 +2157,12 @@ def configure_hbai_coverage_parser(parser: argparse.ArgumentParser) -> None:
         help="Maximum components to print in text mode",
     )
     parser.add_argument(
+        "--with-populace-activity",
         "--with-efrs-activity",
         action="store_true",
+        dest="with_populace_activity",
         help=(
-            "Run PolicyEngine over EFRS and add weighted household-level "
+            "Run PolicyEngine over Populace and add weighted household-level "
             "activity for each HBAI component"
         ),
     )
@@ -2147,7 +2176,8 @@ def main_coverage(args: argparse.Namespace) -> int:
         data_folder=args.data_folder,
         domain_filter=args.domain,
         entity_filter=args.entity,
-        include_efrs_activity=args.with_efrs_activity,
+        populace_year=args.populace_year,
+        include_efrs_activity=args.with_populace_activity,
     )
     if args.json:
         print(json.dumps(report.to_json(), indent=2, sort_keys=True))
@@ -2161,7 +2191,8 @@ def main_hbai_coverage(args: argparse.Namespace) -> int:
         year=args.year,
         dataset=args.dataset,
         data_folder=args.data_folder,
-        include_efrs_activity=args.with_efrs_activity,
+        populace_year=args.populace_year,
+        include_efrs_activity=args.with_populace_activity,
         source_root=args.source_root,
     )
     if args.json:
@@ -2181,6 +2212,7 @@ def compare_uk_efrs(
     surface: str,
     dataset: str,
     data_folder: Path,
+    populace_year: int,
     tolerance: float,
     relative_tolerance: float,
     universal_credit_program: Path | None = None,
@@ -2196,6 +2228,7 @@ def compare_uk_efrs(
         sample_size=sample_size,
         dataset=dataset,
         data_folder=data_folder,
+        populace_year=populace_year,
         person_ids=person_ids,
         person_variables=policyengine_person_variables_for_surfaces(surfaces),
         benunit_variables=policyengine_benunit_variables_for_surfaces(surfaces),
@@ -2353,13 +2386,15 @@ def load_policyengine_uk_data(
     sample_size: int,
     dataset: str,
     data_folder: Path,
+    populace_year: int,
     person_ids: tuple[int, ...] = (),
     person_variables: tuple[str, ...] = SURFACE_SPECS[
         "personal-allowance"
     ].pe_variables,
     benunit_variables: tuple[str, ...] = (),
 ) -> dict[str, Any]:
-    local_dataset = local_policyengine_uk_dataset_path(dataset)
+    _ = data_folder
+    local_dataset = local_dataset_path(dataset)
     if local_dataset is not None:
         return load_local_policyengine_uk_data(
             local_path=local_dataset,
@@ -2370,9 +2405,20 @@ def load_policyengine_uk_data(
             benunit_variables=benunit_variables,
         )
 
-    raise SystemExit(
-        "uk-efrs-compare with current PolicyEngine UK requires a local .h5 "
-        f"--dataset path. {policyengine_uk_install_message()}"
+    require_policyengine_uk_versions(command="uk-populace-compare")
+    pe_dataset = load_populace_dataset(
+        "uk",
+        year=populace_year,
+        command="uk-populace-compare",
+    )
+    log(f"Loading PolicyEngine Populace UK {populace_year} dataset...")
+    return load_policyengine_uk_dataset(
+        pe_dataset=pe_dataset,
+        year=year,
+        sample_size=sample_size,
+        person_ids=person_ids,
+        person_variables=person_variables,
+        benunit_variables=benunit_variables,
     )
 
 
@@ -2387,14 +2433,36 @@ def load_local_policyengine_uk_data(
 ) -> dict[str, Any]:
     require_policyengine_uk_versions()
     try:
-        import pandas as pd
-        from policyengine_uk import Microsimulation
         from policyengine_uk.data import UKSingleYearDataset
     except ImportError as exc:  # pragma: no cover - optional runtime dependency
         raise SystemExit(policyengine_uk_install_message()) from exc
 
-    log("Loading local PolicyEngine UK EFRS...")
+    log("Loading local PolicyEngine UK dataset...")
     pe_dataset = UKSingleYearDataset(file_path=str(local_path))
+    return load_policyengine_uk_dataset(
+        pe_dataset=pe_dataset,
+        year=year,
+        sample_size=sample_size,
+        person_ids=person_ids,
+        person_variables=person_variables,
+        benunit_variables=benunit_variables,
+    )
+
+
+def load_policyengine_uk_dataset(
+    *,
+    pe_dataset: Any,
+    year: int,
+    sample_size: int,
+    person_ids: tuple[int, ...],
+    person_variables: tuple[str, ...],
+    benunit_variables: tuple[str, ...],
+) -> dict[str, Any]:
+    try:
+        from policyengine_uk import Microsimulation
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(policyengine_uk_install_message()) from exc
+
     added_disability_categories = (
         add_policyengine_uk_disability_categories_from_reported_amounts(
             pe_dataset,
@@ -2403,16 +2471,15 @@ def load_local_policyengine_uk_data(
     )
     if added_disability_categories:
         log(
-            "Derived local EFRS disability category inputs from reported amounts: "
+            "Derived UK disability category inputs from reported amounts: "
             + ", ".join(added_disability_categories)
         )
     sim = Microsimulation(dataset=pe_dataset)
     data_year = min(sim.dataset.years)
 
-    with pd.HDFStore(local_path, mode="r") as store:
-        raw_person = store["person"].copy()
-        raw_benunit = store["benunit"].copy()
-        household = store["household"].copy()
+    raw_person = population_table(pe_dataset, "person")
+    raw_benunit = population_table(pe_dataset, "benunit")
+    household = population_table(pe_dataset, "household")
 
     person = add_policyengine_uk_person_weights(raw_person, household)
     person_columns = ["person_id", "person_weight"]
@@ -2842,6 +2909,7 @@ def build_uk_efrs_coverage_report(
     year: int = 2026,
     dataset: str = DEFAULT_DATASET,
     data_folder: Path = Path(".axiom") / "policyengine-data",
+    populace_year: int = DEFAULT_UK_POPULACE_YEAR,
     domain_filter: str | None = None,
     entity_filter: str | None = None,
     include_efrs_activity: bool = False,
@@ -2882,6 +2950,7 @@ def build_uk_efrs_coverage_report(
             year=year,
             dataset=dataset,
             data_folder=data_folder,
+            populace_year=populace_year,
         )
 
     source_root_label = None
@@ -2936,6 +3005,7 @@ def build_uk_hbai_policy_coverage_report(
     year: int = 2026,
     dataset: str = DEFAULT_DATASET,
     data_folder: Path = Path(".axiom") / "policyengine-data",
+    populace_year: int = DEFAULT_UK_POPULACE_YEAR,
     include_efrs_activity: bool = False,
     source_root: Path | None = None,
 ) -> UKEFRSHBAICoverageReport:
@@ -2966,6 +3036,7 @@ def build_uk_hbai_policy_coverage_report(
                 year=year,
                 dataset=dataset,
                 data_folder=data_folder,
+                populace_year=populace_year,
             )
         )
 
@@ -3057,30 +3128,34 @@ def policyengine_uk_hbai_activity(
     year: int,
     dataset: str,
     data_folder: Path,
+    populace_year: int,
 ) -> tuple[
     dict[str, UKEFRSHBAIComponentActivity],
     UKEFRSHBAIComponentActivity | None,
     list[dict[str, str]],
 ]:
-    require_policyengine_uk_versions(command="uk-efrs-hbai-coverage")
+    _ = data_folder
+    require_policyengine_uk_versions(command="uk-populace-hbai-coverage")
     try:
         from policyengine_uk import Microsimulation
-        from policyengine_uk.data import UKSingleYearDataset
     except ImportError as exc:  # pragma: no cover - optional runtime dependency
         raise SystemExit(
-            policyengine_uk_install_message("uk-efrs-hbai-coverage")
+            policyengine_uk_install_message("uk-populace-hbai-coverage")
         ) from exc
 
-    local_dataset = local_policyengine_uk_dataset_path(dataset)
-    if local_dataset is None:
-        raise SystemExit(
-            "uk-efrs-hbai-coverage --with-efrs-activity with current "
-            "PolicyEngine UK requires a local .h5 --dataset path. "
-            f"{policyengine_uk_install_message('uk-efrs-hbai-coverage')}"
-        )
+    local_dataset = local_dataset_path(dataset)
+    if local_dataset is not None:
+        from policyengine_uk.data import UKSingleYearDataset
 
-    log("Loading local PolicyEngine UK EFRS for HBAI activity...")
-    pe_dataset = UKSingleYearDataset(file_path=str(local_dataset))
+        log("Loading local PolicyEngine UK dataset for HBAI activity...")
+        pe_dataset = UKSingleYearDataset(file_path=str(local_dataset))
+    else:
+        log("Loading PolicyEngine UK Populace for HBAI activity...")
+        pe_dataset = load_populace_dataset(
+            "uk",
+            year=populace_year,
+            command="uk-populace-hbai-coverage",
+        )
     added_disability_categories = (
         add_policyengine_uk_disability_categories_from_reported_amounts(
             pe_dataset,
@@ -3089,7 +3164,7 @@ def policyengine_uk_hbai_activity(
     )
     if added_disability_categories:
         log(
-            "Derived local EFRS disability category inputs from reported amounts: "
+            "Derived UK disability category inputs from reported amounts: "
             + ", ".join(added_disability_categories)
         )
     sim = Microsimulation(dataset=pe_dataset)
@@ -3179,11 +3254,13 @@ def discover_policyengine_uk_variables(
 
 
 def load_policyengine_uk_variables() -> list[Any]:
-    require_policyengine_uk_versions(command="uk-efrs-coverage")
+    require_policyengine_uk_versions(command="uk-populace-coverage")
     try:
         from policyengine_uk import CountryTaxBenefitSystem
     except ImportError as exc:  # pragma: no cover - optional runtime dependency
-        raise SystemExit(policyengine_uk_install_message("uk-efrs-coverage")) from exc
+        raise SystemExit(
+            policyengine_uk_install_message("uk-populace-coverage")
+        ) from exc
     return list(CountryTaxBenefitSystem().variables.values())
 
 
@@ -3394,7 +3471,7 @@ def policyengine_uk_variables_source_root(*, required: bool = True) -> Path | No
     except ImportError as exc:  # pragma: no cover - optional runtime dependency
         if required:
             raise SystemExit(
-                policyengine_uk_install_message("uk-efrs-coverage")
+                policyengine_uk_install_message("uk-populace-coverage")
             ) from exc
         return None
     source_root = Path(policyengine_uk.__file__).resolve().parent / "variables"
@@ -3424,26 +3501,32 @@ def policyengine_uk_efrs_activity(
     year: int,
     dataset: str,
     data_folder: Path,
+    populace_year: int,
 ) -> tuple[list[UKEFRSVariableActivity], list[dict[str, str]]]:
-    require_policyengine_uk_versions(command="uk-efrs-coverage")
+    _ = data_folder
+    require_policyengine_uk_versions(command="uk-populace-coverage")
     try:
         import numpy as np
         import pandas as pd
         from policyengine_uk import Microsimulation
-        from policyengine_uk.data import UKSingleYearDataset
     except ImportError as exc:  # pragma: no cover - optional runtime dependency
-        raise SystemExit(policyengine_uk_install_message("uk-efrs-coverage")) from exc
-
-    local_dataset = local_policyengine_uk_dataset_path(dataset)
-    if local_dataset is None:
         raise SystemExit(
-            "uk-efrs-coverage --with-efrs-activity with current PolicyEngine UK "
-            f"requires a local .h5 --dataset path. "
-            f"{policyengine_uk_install_message('uk-efrs-coverage')}"
-        )
+            policyengine_uk_install_message("uk-populace-coverage")
+        ) from exc
 
-    log("Loading local PolicyEngine UK EFRS for coverage activity...")
-    pe_dataset = UKSingleYearDataset(file_path=str(local_dataset))
+    local_dataset = local_dataset_path(dataset)
+    if local_dataset is not None:
+        from policyengine_uk.data import UKSingleYearDataset
+
+        log("Loading local PolicyEngine UK dataset for coverage activity...")
+        pe_dataset = UKSingleYearDataset(file_path=str(local_dataset))
+    else:
+        log("Loading PolicyEngine UK Populace for coverage activity...")
+        pe_dataset = load_populace_dataset(
+            "uk",
+            year=populace_year,
+            command="uk-populace-coverage",
+        )
     added_disability_categories = (
         add_policyengine_uk_disability_categories_from_reported_amounts(
             pe_dataset,
@@ -3452,14 +3535,13 @@ def policyengine_uk_efrs_activity(
     )
     if added_disability_categories:
         log(
-            "Derived local EFRS disability category inputs from reported amounts: "
+            "Derived UK disability category inputs from reported amounts: "
             + ", ".join(added_disability_categories)
         )
     sim = Microsimulation(dataset=pe_dataset)
-    with pd.HDFStore(local_dataset, mode="r") as store:
-        raw_person = store["person"].copy()
-        raw_benunit = store["benunit"].copy()
-        household = store["household"].copy()
+    raw_person = population_table(pe_dataset, "person")
+    raw_benunit = population_table(pe_dataset, "benunit")
+    household = population_table(pe_dataset, "household")
     raw_tables = {
         "person": add_policyengine_uk_person_weights(raw_person, household),
         "benunit": add_policyengine_uk_benunit_weights(
@@ -3569,7 +3651,7 @@ def print_uk_efrs_coverage_report(
     *,
     top: int,
 ) -> None:
-    print("PolicyEngine UK EFRS coverage")
+    print("PolicyEngine UK Populace coverage")
     print(
         "PolicyEngine versions: "
         + ", ".join(
@@ -3611,7 +3693,7 @@ def print_uk_efrs_coverage_report(
             print(f"  - {name}")
     if report.activity:
         print()
-        print(f"Top missing EFRS-active PE variables (first {top:,}):")
+        print(f"Top missing Populace-active PE variables (first {top:,}):")
         activity_by_name = {item.name: item for item in report.activity}
         missing_by_name = {item.name: item for item in report.missing_variables}
         for activity in report.activity[:top]:
@@ -3625,7 +3707,7 @@ def print_uk_efrs_coverage_report(
                 f"nonfinite={activity.nonfinite_count:,}"
             )
         inactive_count = sum(1 for item in report.activity if item.nonzero_count == 0)
-        print(f"Missing variables with zero nonzero EFRS rows: {inactive_count:,}")
+        print(f"Missing variables with zero nonzero Populace rows: {inactive_count:,}")
         if activity_by_name:
             print()
     print(f"Missing computed PE variables (first {top:,}):")
@@ -3730,7 +3812,7 @@ def select_person_indices(
         requested_ids=person_ids,
         id_column="person_id",
         weight_column="person_weight",
-        entity_label="EFRS person_id",
+        entity_label="Populace person_id",
     )
 
 
@@ -3746,7 +3828,7 @@ def select_benunit_indices(
         requested_ids=benunit_ids,
         id_column="benunit_id",
         weight_column="benunit_weight",
-        entity_label="EFRS benunit_id",
+        entity_label="Populace benunit_id",
     )
 
 
@@ -4094,7 +4176,7 @@ def build_axiom_request(
             year=year,
             surface=surface,
         )
-    raise ValueError(f"unsupported UK EFRS surface: {surface}")
+    raise ValueError(f"unsupported UK Populace surface: {surface}")
 
 
 def build_national_insurance_class_1_request(
@@ -6643,13 +6725,13 @@ def compare_outputs(
         output_summary=list(summary.values()),
         skipped_surfaces=SKIPPED_SURFACES,
         projection_notes=[
-            "Personal allowance projection supplies EFRS adjusted net income "
+            "Personal allowance projection supplies validation-population adjusted net income "
             "net of PolicyEngine's gift_aid_grossed_up taper adjustment, because "
             "PolicyEngine UK applies that subtraction inside its personal "
             "allowance formula.",
-            "The current projection treats EFRS people as making a claim and "
+            "The current projection treats validation-population people as making a claim and "
             "meeting the Section 56 residence/citizenship-condition boundary "
-            "facts, matching the usual PolicyEngine UK EFRS personal allowance "
+            "facts, matching the usual PolicyEngine UK personal allowance "
             "surface until those upstream legal predicates are encoded.",
             "National Insurance Class 1 comparison projects annual PolicyEngine "
             "NI Class 1 income into a representative tax week, supplies the "
@@ -6687,10 +6769,10 @@ def compare_outputs(
             "and projects claimant_has_partner from PolicyEngine's relation_type "
             "or is_couple. Prisoner and fully-maintained religious-order branches "
             "are projected false because those legal predicates are not exposed "
-            "in the EFRS oracle data.",
+            "in the validation population.",
             "Pension Credit carer additions compare RuleSpec's per-partner "
             "amount against PolicyEngine's annual aggregate carer addition "
-            "divided by num_carers and 52. The EFRS oracle has no positive "
+            "divided by num_carers and 52. The validation population has no positive "
             "severe-disability addition rows, so that branch is currently a "
             "zero-row guard rather than a positive-eligibility validation.",
             "Pension Credit Schedule IIA child-addition comparison projects "
@@ -6704,7 +6786,7 @@ def compare_outputs(
             "day and supplies PolicyEngine's annual state_pension_age for both "
             "the pensionable-age leaf and the woman-born-same-day leaf. The "
             "same projection compares the attained-age judgment against "
-            "PolicyEngine's is_SP_age boolean. Current PolicyEngine UK EFRS "
+            "PolicyEngine's is_SP_age boolean. Current PolicyEngine UK "
             "data exposes the modern equalized-age surface rather than "
             "historical sex-specific age transitions.",
             "State Pension Credit Act section 2 guarantee-credit comparison "
@@ -6720,7 +6802,7 @@ def compare_outputs(
             "minimum_guarantee for the amount B reduction.",
             "Universal Credit Regulation 36 comparisons treat the generated "
             "RuleSpec outputs as component table amounts. PolicyEngine annual "
-            "EFRS component outputs are divided by 12, and EFRS category "
+            "Populace component outputs are divided by 12, and Populace category "
             "variables select the matching standard-allowance, child-element, "
             "carer, LCWRA, and childcare-cap rows.",
             "Welfare Reform Act 2012 section 8 Universal Credit award "
@@ -6741,7 +6823,7 @@ def compare_outputs(
             "PolicyEngine-aligned Carer's Allowance final comparison projects "
             "PolicyEngine UK's country and reported Carer's Allowance receipt "
             "into a final annual wrapper that uses the RuleSpec weekly rate, "
-            "age gate, and 35-hour care threshold. Current EFRS care_hours "
+            "age gate, and 35-hour care threshold. Current Populace care_hours "
             "is zero on reported-receipt rows, so positive PolicyEngine or "
             "reported receipt is projected to the statutory minimum care "
             "hours and qualifying-disability-benefit fact; source age "
@@ -6750,7 +6832,7 @@ def compare_outputs(
             "Payment final comparisons project PolicyEngine final-award or "
             "reported-receipt gates into source-shaped runtime facts because "
             "PolicyEngine does not expose every underlying eligibility and "
-            "take-up predicate separately in the EFRS oracle data.",
+            "take-up predicate separately in the Populace oracle data.",
             "PolicyEngine-aligned Disability Living Allowance final comparison "
             "projects PolicyEngine UK's DLA self-care and mobility category "
             "enums into boolean category leaves for under-16 rows, then "
@@ -6758,7 +6840,7 @@ def compare_outputs(
             "aggregate. Adult legacy DLA rows are outside this GOV.UK child "
             "DLA wrapper and are treated as missing coverage rather than "
             "included in the final comparison.",
-            "When a local EFRS .h5 predates the PolicyEngine UK disability "
+            "When a local UK .h5 predates the PolicyEngine UK disability "
             "category-input migration, the oracle derives PIP, DLA, and "
             "Attendance Allowance category inputs in memory from reported "
             "amount columns using the policyengine-uk-data category threshold "
@@ -6837,7 +6919,7 @@ def compare_outputs(
             "PolicyEngine's uc_childcare_work_condition.",
             "The protected LCWRA Regulation 36 table amount is compared only "
             "when PolicyEngine exposes the raw protected amount. Current "
-            "PolicyEngine UK EFRS outputs apply the July 2025 UC rebalancing "
+            "PolicyEngine UK Populace outputs apply the July 2025 UC rebalancing "
             "scenario for existing claimants, so those rebalanced health-element "
             "values are not treated as the same surface.",
             "Income Tax Act 2007 section 23 net-income comparison projects "
@@ -6860,7 +6942,7 @@ def compare_outputs(
             "It uses UK income-tax thresholds and savings rates from "
             "PolicyEngine parameters to compare the section 11D band amounts "
             "and aggregate savings income tax, with a 25p output tolerance for "
-            "EFRS float precision in PolicyEngine's savings-income arrays.",
+            "Populace float precision in PolicyEngine's savings-income arrays.",
             "Income Tax Act 2007 section 13 dividend-income comparison projects "
             "PolicyEngine's dividend tax formula directly: savings after income "
             "allowances occupies rate-band capacity before dividends, the used "
@@ -7114,7 +7196,7 @@ def print_report(
     tolerance: float,
     relative_tolerance: float,
 ) -> None:
-    print("PolicyEngine UK EFRS comparison")
+    print("PolicyEngine UK Populace comparison")
     print(f"Compared persons: {report.compared_persons:,}")
     print(f"Compared benefit units: {report.compared_benunits:,}")
     print(f"Compared values: {report.compared_values:,}")
@@ -7283,20 +7365,16 @@ def resolve_workspace_root(root: Path | None) -> Path:
     return cwd
 
 
-def require_policyengine_uk_versions(command: str = "uk-efrs-compare") -> None:
+def require_policyengine_uk_versions(command: str = "uk-populace-compare") -> None:
     try:
-        policyengine_core_version = version("policyengine-core")
         policyengine_uk_version = version("policyengine-uk")
     except PackageNotFoundError as exc:
         raise SystemExit(policyengine_uk_install_message(command)) from exc
-    if policyengine_core_version != POLICYENGINE_CORE_VERSION:
+    if _version_tuple(policyengine_uk_version) < _version_tuple(
+        MIN_POLICYENGINE_UK_VERSION
+    ):
         raise SystemExit(
-            f"policyengine-core=={POLICYENGINE_CORE_VERSION} required; found "
-            f"{policyengine_core_version}. {policyengine_uk_install_message(command)}"
-        )
-    if policyengine_uk_version != POLICYENGINE_UK_VERSION:
-        raise SystemExit(
-            f"policyengine-uk=={POLICYENGINE_UK_VERSION} required; found "
+            f"policyengine-uk>={MIN_POLICYENGINE_UK_VERSION} required; found "
             f"{policyengine_uk_version}. {policyengine_uk_install_message(command)}"
         )
 
@@ -7445,11 +7523,10 @@ def policyengine_uk_savings_credit_parameters(year: int) -> dict[str, float]:
     }
 
 
-def policyengine_uk_install_message(command: str = "uk-efrs-compare") -> str:
+def policyengine_uk_install_message(command: str = "uk-populace-compare") -> str:
     return (
-        "Run with: uv run "
-        f"--with policyengine-core=={POLICYENGINE_CORE_VERSION} "
-        f"--with policyengine-uk=={POLICYENGINE_UK_VERSION} "
+        "Run with: "
+        f"uv run --with {populace_data_requirement('uk')} "
         f"axiom-encode {command}"
     )
 

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -19,7 +19,7 @@ mappings:
     period: year
     unit: GBP
     comparison: money
-    rationale: Same UK income tax earned-income amount charged at the basic rate under section 10, with the EFRS oracle comparing only the ordinary non-Scottish UK-rate branch.
+    rationale: Same UK income tax earned-income amount charged at the basic rate under section 10, with the Populace oracle comparing only the ordinary non-Scottish UK-rate branch.
 
   - legal_id: uk:statutes/ukpga/2007/3/10#income_charged_at_higher_rate
     country: uk
@@ -30,7 +30,7 @@ mappings:
     period: year
     unit: GBP
     comparison: money
-    rationale: Same UK income tax earned-income amount charged at the higher rate under section 10, with the EFRS oracle comparing only the ordinary non-Scottish UK-rate branch.
+    rationale: Same UK income tax earned-income amount charged at the higher rate under section 10, with the Populace oracle comparing only the ordinary non-Scottish UK-rate branch.
 
   - legal_id: uk:statutes/ukpga/2007/3/10#income_charged_at_additional_rate
     country: uk
@@ -41,7 +41,7 @@ mappings:
     period: year
     unit: GBP
     comparison: money
-    rationale: Same UK income tax earned-income amount charged at the additional rate under section 10, with the EFRS oracle comparing only the ordinary non-Scottish UK-rate branch.
+    rationale: Same UK income tax earned-income amount charged at the additional rate under section 10, with the Populace oracle comparing only the ordinary non-Scottish UK-rate branch.
 
   - legal_id: uk:statutes/ukpga/2007/3/10#tax_on_income_charged_at_basic_rate
     country: uk
@@ -52,7 +52,7 @@ mappings:
     period: year
     unit: GBP
     comparison: money
-    rationale: Same UK income tax on earned income charged at the basic rate under section 10, with the EFRS oracle comparing only the ordinary non-Scottish UK-rate branch.
+    rationale: Same UK income tax on earned income charged at the basic rate under section 10, with the Populace oracle comparing only the ordinary non-Scottish UK-rate branch.
 
   - legal_id: uk:statutes/ukpga/2007/3/10#tax_on_income_charged_at_higher_rate
     country: uk
@@ -63,7 +63,7 @@ mappings:
     period: year
     unit: GBP
     comparison: money
-    rationale: Same UK income tax on earned income charged at the higher rate under section 10, with the EFRS oracle comparing only the ordinary non-Scottish UK-rate branch.
+    rationale: Same UK income tax on earned income charged at the higher rate under section 10, with the Populace oracle comparing only the ordinary non-Scottish UK-rate branch.
 
   - legal_id: uk:statutes/ukpga/2007/3/10#tax_on_income_charged_at_additional_rate
     country: uk
@@ -74,7 +74,7 @@ mappings:
     period: year
     unit: GBP
     comparison: money
-    rationale: Same UK income tax on earned income charged at the additional rate under section 10, with the EFRS oracle comparing only the ordinary non-Scottish UK-rate branch.
+    rationale: Same UK income tax on earned income charged at the additional rate under section 10, with the Populace oracle comparing only the ordinary non-Scottish UK-rate branch.
 
   - legal_id: uk:statutes/ukpga/2007/3/10#income_tax_on_section_10_income
     country: uk
@@ -336,7 +336,7 @@ mappings:
     period: year
     unit: GBP
     comparison: money
-    rationale: Same final annual person-level National Insurance contribution aggregate after the UK EFRS adapter supplies PolicyEngine UK's Class 1, Class 2, Class 3, and final Class 4 contribution amounts.
+    rationale: Same final annual person-level National Insurance contribution aggregate after the UK Populace adapter supplies PolicyEngine UK's Class 1, Class 2, Class 3, and final Class 4 contribution amounts.
 
   - legal_id: uk:statutes/ukpga/1992/4/8#primary_class_1_contribution
     country: uk
@@ -347,7 +347,7 @@ mappings:
     period: week
     unit: GBP
     comparison: money
-    rationale: Same employee Class 1 NI aggregate after the UK EFRS adapter projects weekly section 8 inputs, PolicyEngine ni_liable, and converts PolicyEngine's annual output to a weekly value.
+    rationale: Same employee Class 1 NI aggregate after the UK Populace adapter projects weekly section 8 inputs, PolicyEngine ni_liable, and converts PolicyEngine's annual output to a weekly value.
 
   - legal_id: uk:statutes/ukpga/1992/4/8#main_primary_class_1_contribution
     country: uk
@@ -358,7 +358,7 @@ mappings:
     period: week
     unit: GBP
     comparison: money
-    rationale: Same main-band employee Class 1 NI component after the UK EFRS adapter projects weekly section 8 inputs and compares on PolicyEngine ni_liable rows.
+    rationale: Same main-band employee Class 1 NI component after the UK Populace adapter projects weekly section 8 inputs and compares on PolicyEngine ni_liable rows.
 
   - legal_id: uk:statutes/ukpga/1992/4/8#additional_primary_class_1_contribution
     country: uk
@@ -369,7 +369,7 @@ mappings:
     period: week
     unit: GBP
     comparison: money
-    rationale: Same additional-band employee Class 1 NI component after the UK EFRS adapter projects weekly section 8 inputs and compares on PolicyEngine ni_liable rows.
+    rationale: Same additional-band employee Class 1 NI component after the UK Populace adapter projects weekly section 8 inputs and compares on PolicyEngine ni_liable rows.
 
   - legal_id: uk:statutes/ukpga/1992/4/15#lower_profits_limit
     country: uk
@@ -418,7 +418,7 @@ mappings:
     period: year
     unit: GBP
     comparison: money
-    rationale: Same main-band Class 4 NI component after the UK EFRS adapter projects annual section 15 profits and compares on PolicyEngine ni_liable rows.
+    rationale: Same main-band Class 4 NI component after the UK Populace adapter projects annual section 15 profits and compares on PolicyEngine ni_liable rows.
 
   - legal_id: uk:statutes/ukpga/1992/4/15#additional_class_4_contribution
     country: uk
@@ -513,7 +513,7 @@ mappings:
     period: year
     unit: GBP
     comparison: money
-    rationale: Same Regulation 100 Class 4 annual maximum after the UK EFRS adapter projects annual primary Class 1, Class 4 main-rate, and profits inputs.
+    rationale: Same Regulation 100 Class 4 annual maximum after the UK Populace adapter projects annual primary Class 1, Class 4 main-rate, and profits inputs.
 
   - legal_id: uk:regulations/uksi/2001/1004/100#class_4_contribution_after_annual_maximum
     country: uk
@@ -624,7 +624,7 @@ mappings:
     period: year
     unit: GBP
     comparison: money
-    rationale: Same wrapper variable for annual student-loan repayments; in local EFRS this may be supplied as reported input data, but the PolicyEngine formula delegates to student_loan_repayment.
+    rationale: Same wrapper variable for annual student-loan repayments; in local Populace this may be supplied as reported input data, but the PolicyEngine formula delegates to student_loan_repayment.
 
   - legal_id: uk:policies/govuk/student-loan-repayments#listed_student_loan_plan_applies
     country: uk
@@ -870,7 +870,7 @@ mappings:
     unit: GBP
     comparison: money
     candidate_priority: P2
-    rationale: Same Pension Credit child-related addition after the UK EFRS adapter projects PolicyEngine's child count, pre-2017 eldest-child flag, and disability buckets into Schedule IIA inputs and converts PolicyEngine's annual output to a weekly amount.
+    rationale: Same Pension Credit child-related addition after the UK Populace adapter projects PolicyEngine's child count, pre-2017 eldest-child flag, and disability buckets into Schedule IIA inputs and converts PolicyEngine's annual output to a weekly amount.
 
   - legal_id: uk:regulations/uksi/2002/2005/schedule/2#wtc_basic_element_amount
     country: uk
@@ -1738,7 +1738,7 @@ mappings:
     period: week
     unit: GBP
     comparison: money
-    rationale: Same Pension Credit deemed income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit pension_credit_assessable_capital into the Regulation 15 claimant-capital leaf and converts PolicyEngine's annual output to a weekly amount.
+    rationale: Same Pension Credit deemed income from capital after the UK Populace adapter projects PolicyEngine's benefit-unit pension_credit_assessable_capital into the Regulation 15 claimant-capital leaf and converts PolicyEngine's annual output to a weekly amount.
 
   - legal_id: uk:regulations/uksi/2008/794/118#capital_tariff_weekly_income
     country: uk
@@ -1749,7 +1749,7 @@ mappings:
     period: week
     unit: GBP
     comparison: money
-    rationale: Same income-related ESA tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit esa_income_assessable_capital into the Regulation 118 claimant-capital leaf, sets the prescribed-accommodation branch false because PolicyEngine does not expose that legal predicate, limits comparison to capital at or below GBP 16,000, and converts PolicyEngine's annual output to a weekly amount.
+    rationale: Same income-related ESA tariff income from capital after the UK Populace adapter projects PolicyEngine's benefit-unit esa_income_assessable_capital into the Regulation 118 claimant-capital leaf, sets the prescribed-accommodation branch false because PolicyEngine does not expose that legal predicate, limits comparison to capital at or below GBP 16,000, and converts PolicyEngine's annual output to a weekly amount.
 
   - legal_id: uk:policies/govuk/esa-income#income_related_esa_annual_amount
     country: uk
@@ -1771,7 +1771,7 @@ mappings:
     period: week
     unit: GBP
     comparison: money
-    rationale: Same income-based JSA tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit jsa_income_assessable_capital into the Regulation 116 claimant-capital leaf, sets the prescribed-accommodation branch false because PolicyEngine does not expose that legal predicate, limits comparison to capital at or below GBP 16,000, and converts PolicyEngine's annual output to a weekly amount.
+    rationale: Same income-based JSA tariff income from capital after the UK Populace adapter projects PolicyEngine's benefit-unit jsa_income_assessable_capital into the Regulation 116 claimant-capital leaf, sets the prescribed-accommodation branch false because PolicyEngine does not expose that legal predicate, limits comparison to capital at or below GBP 16,000, and converts PolicyEngine's annual output to a weekly amount.
 
   - legal_id: uk:regulations/uksi/1987/1967/53#capital_tariff_weekly_income
     country: uk
@@ -1782,7 +1782,7 @@ mappings:
     period: week
     unit: GBP
     comparison: money
-    rationale: Same Income Support tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit income_support_assessable_capital into the Regulation 53 claimant-capital leaf, sets the prescribed-accommodation branch false because PolicyEngine does not expose that legal predicate, limits comparison to capital at or below GBP 16,000, and converts PolicyEngine's annual output to a weekly amount.
+    rationale: Same Income Support tariff income from capital after the UK Populace adapter projects PolicyEngine's benefit-unit income_support_assessable_capital into the Regulation 53 claimant-capital leaf, sets the prescribed-accommodation branch false because PolicyEngine does not expose that legal predicate, limits comparison to capital at or below GBP 16,000, and converts PolicyEngine's annual output to a weekly amount.
 
   - legal_id: uk:regulations/uksi/2006/213/52#capital_tariff_weekly_income
     country: uk
@@ -1793,7 +1793,7 @@ mappings:
     period: week
     unit: GBP
     comparison: money
-    rationale: Same working-age Housing Benefit tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit housing_benefit_assessable_capital into the Regulation 52 claimant-capital leaf, sets the prescribed-circumstances branch false because PolicyEngine does not expose that legal predicate, limits comparison to non-pension-age rows with capital at or below GBP 16,000, and converts PolicyEngine's annual output to a weekly amount.
+    rationale: Same working-age Housing Benefit tariff income from capital after the UK Populace adapter projects PolicyEngine's benefit-unit housing_benefit_assessable_capital into the Regulation 52 claimant-capital leaf, sets the prescribed-circumstances branch false because PolicyEngine does not expose that legal predicate, limits comparison to non-pension-age rows with capital at or below GBP 16,000, and converts PolicyEngine's annual output to a weekly amount.
 
   - legal_id: uk:regulations/uksi/2006/214/29#capital_tariff_weekly_income
     country: uk
@@ -1804,7 +1804,7 @@ mappings:
     period: week
     unit: GBP
     comparison: money
-    rationale: Same pension-age Housing Benefit tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit housing_benefit_assessable_capital into the Regulation 29 claimant-capital leaf, projects the regulation 44(2) capital-disregard exception false because PolicyEngine applies capital exclusions upstream, limits comparison to pension-age rows without guarantee credit, and converts PolicyEngine's annual output to a weekly amount.
+    rationale: Same pension-age Housing Benefit tariff income from capital after the UK Populace adapter projects PolicyEngine's benefit-unit housing_benefit_assessable_capital into the Regulation 29 claimant-capital leaf, projects the regulation 44(2) capital-disregard exception false because PolicyEngine applies capital exclusions upstream, limits comparison to pension-age rows without guarantee credit, and converts PolicyEngine's annual output to a weekly amount.
 
   - legal_id: uk:policies/govuk/housing-benefit#housing_benefit_annual_amount
     country: uk
@@ -1827,7 +1827,7 @@ mappings:
     unit: year
     comparison: count
     candidate_priority: P3
-    rationale: State Pension Credit Act section 1 defines a source-level qualifying age at day granularity. The UK EFRS oracle supplies PolicyEngine UK's state_pension_age to both statutory pensionable-age leaves on a representative day, matching the modern equalized-age surface exposed by PolicyEngine.
+    rationale: State Pension Credit Act section 1 defines a source-level qualifying age at day granularity. The UK Populace oracle supplies PolicyEngine UK's state_pension_age to both statutory pensionable-age leaves on a representative day, matching the modern equalized-age surface exposed by PolicyEngine.
 
   - legal_id: uk:statutes/ukpga/2002/16/1#claimant_has_attained_qualifying_age
     country: uk
@@ -1838,7 +1838,7 @@ mappings:
     period: day
     comparison: boolean
     candidate_priority: P3
-    rationale: State Pension Credit Act section 1 tests whether the claimant has attained the statutory qualifying age at day granularity. The UK EFRS oracle compares RuleSpec's judgment output to PolicyEngine UK's annual is_SP_age predicate after supplying the same age and state_pension_age projection used for qualifying_age.
+    rationale: State Pension Credit Act section 1 tests whether the claimant has attained the statutory qualifying age at day granularity. The UK Populace oracle compares RuleSpec's judgment output to PolicyEngine UK's annual is_SP_age predicate after supplying the same age and state_pension_age projection used for qualifying_age.
 
   - legal_id: uk:statutes/ukpga/2002/16/2#guarantee_credit
     country: uk
@@ -1850,7 +1850,7 @@ mappings:
     unit: GBP
     comparison: money
     candidate_priority: P2
-    rationale: Same annual State Pension Credit guarantee credit amount. The EFRS oracle projects claimant income from PolicyEngine's pension_credit_income, appropriate minimum guarantee from minimum_guarantee, and entitlement from is_guarantee_credit_eligible.
+    rationale: Same annual State Pension Credit guarantee credit amount. The Populace oracle projects claimant income from PolicyEngine's pension_credit_income, appropriate minimum guarantee from minimum_guarantee, and entitlement from is_guarantee_credit_eligible.
 
   - legal_id: uk:statutes/ukpga/2002/16/2#appropriate_minimum_guarantee
     country: uk
@@ -1862,7 +1862,7 @@ mappings:
     unit: GBP
     comparison: money
     candidate_priority: P3
-    rationale: Same annual State Pension Credit appropriate minimum guarantee, after the EFRS oracle projects PolicyEngine's standard_minimum_guarantee and positive additional amount decomposition into the section 2 formula.
+    rationale: Same annual State Pension Credit appropriate minimum guarantee, after the Populace oracle projects PolicyEngine's standard_minimum_guarantee and positive additional amount decomposition into the section 2 formula.
 
   - legal_id: uk:statutes/ukpga/2002/16/2#guarantee_credit_condition_satisfied
     country: uk
@@ -1880,7 +1880,7 @@ mappings:
     unit: GBP
     comparison: money
     candidate_priority: P2
-    rationale: Same annual Pension Credit savings credit amount. The EFRS oracle projects section 3 inputs from PolicyEngine's savings-credit income, claimant income, minimum-guarantee, standard-minimum-guarantee, and prescribed threshold/rate parameters.
+    rationale: Same annual Pension Credit savings credit amount. The Populace oracle projects section 3 inputs from PolicyEngine's savings-credit income, claimant income, minimum-guarantee, standard-minimum-guarantee, and prescribed threshold/rate parameters.
 
   - legal_id: uk:statutes/ukpga/2002/16/3#maximum_savings_credit
     country: uk
@@ -1915,7 +1915,7 @@ mappings:
     period: month
     unit: GBP
     comparison: money
-    rationale: Welfare Reform Act 2012 section 8 computes the award as the positive difference between the maximum amount and prescribed income deductions. PolicyEngine UK's universal_credit_pre_benefit_cap also applies the stochastic would_claim_uc take-up gate, so the EFRS oracle compares the equivalent pre-take-up expression from uc_maximum_amount and uc_income_reduction.
+    rationale: Welfare Reform Act 2012 section 8 computes the award as the positive difference between the maximum amount and prescribed income deductions. PolicyEngine UK's universal_credit_pre_benefit_cap also applies the stochastic would_claim_uc take-up gate, so the Populace oracle compares the equivalent pre-take-up expression from uc_maximum_amount and uc_income_reduction.
 
   - legal_id: uk:regulations/uksi/2013/376/36#standard_allowance_single_under_25_amount
     country: uk
@@ -2070,7 +2070,7 @@ mappings:
     period: month
     unit: GBP
     comparison: money
-    rationale: Same Universal Credit tariff income from capital after the UK EFRS adapter projects PolicyEngine's benefit-unit assessed capital to the Regulation 72 capital leaf and converts PolicyEngine's annual output to a monthly amount.
+    rationale: Same Universal Credit tariff income from capital after the UK Populace adapter projects PolicyEngine's benefit-unit assessed capital to the Regulation 72 capital leaf and converts PolicyEngine's annual output to a monthly amount.
 
   - legal_id: uk:regulations/uksi/2013/376/18#claimant_capital_for_prescribed_capital_limit
     country: uk
@@ -2081,7 +2081,7 @@ mappings:
     period: day
     unit: GBP
     comparison: money
-    rationale: Same Universal Credit assessable capital stock after the UK EFRS adapter projects PolicyEngine's benefit-unit uc_assessable_capital into the Regulation 18 claimant-capital leaf, with other-member inclusion set to zero because PolicyEngine already resolves household capital allocation, reported-capital overrides, and exclusions upstream.
+    rationale: Same Universal Credit assessable capital stock after the UK Populace adapter projects PolicyEngine's benefit-unit uc_assessable_capital into the Regulation 18 claimant-capital leaf, with other-member inclusion set to zero because PolicyEngine already resolves household capital allocation, reported-capital overrides, and exclusions upstream.
 
   - legal_id: uk:regulations/uksi/2013/376/32#work_condition_met_for_assessment_period
     country: uk
@@ -2092,7 +2092,7 @@ mappings:
     period: month
     unit: bool
     comparison: bool
-    rationale: Same Universal Credit childcare work-condition predicate, with the EFRS oracle projecting person-level adult work status into the Regulation 32 claimant and other-member work leaves.
+    rationale: Same Universal Credit childcare work-condition predicate, with the Populace oracle projecting person-level adult work status into the Regulation 32 claimant and other-member work leaves.
 
 prefixes:
   - legal_id_prefix: uk:policies/govuk/council-tax-reduction#

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1086,7 +1086,7 @@ mappings:
     period: month
     unit: USD
     comparison: money
-    rationale: California standard utility allowance, with state and utility eligibility inputs supplied by the ECPS SNAP adapter.
+    rationale: California standard utility allowance, with state and utility eligibility inputs supplied by the Populace SNAP adapter.
 
   - legal_id: us-ca:policies/cdss/snap/fy-2026-benefit-calculation#snap_total_allowable_shelter_expenses
     country: us
@@ -1599,7 +1599,7 @@ mappings:
     mapping_type: not_comparable
     policyengine_variable: snap_gross_income
     candidate_priority: P4
-    rationale: Arizona FY 2026 composition sums Axiom boundary earned and unearned inputs for the ECPS surface; PolicyEngine's SNAP gross income is adjacent but computed from PE's own income source graph.
+    rationale: Arizona FY 2026 composition sums Axiom boundary earned and unearned inputs for the Populace surface; PolicyEngine's SNAP gross income is adjacent but computed from PE's own income source graph.
 
   - legal_id: us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_net_income
     country: us
@@ -1607,7 +1607,7 @@ mappings:
     mapping_type: not_comparable
     policyengine_variable: snap_net_income
     candidate_priority: P4
-    rationale: Arizona FY 2026 composition passes the Axiom net-income boundary into the ECPS surface; PolicyEngine's SNAP net income is adjacent but computed from PE's deduction graph.
+    rationale: Arizona FY 2026 composition passes the Axiom net-income boundary into the Populace surface; PolicyEngine's SNAP net income is adjacent but computed from PE's deduction graph.
 
   - legal_id: us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_eligible
     country: us
@@ -1631,7 +1631,7 @@ mappings:
     mapping_type: not_comparable
     policyengine_variable: snap_excess_shelter_expense_deduction
     candidate_priority: P4
-    rationale: Arizona FY 2026 composition passes the Axiom shelter-deduction boundary into the ECPS surface; PolicyEngine's shelter deduction is adjacent but uses PE housing and utility inputs.
+    rationale: Arizona FY 2026 composition passes the Axiom shelter-deduction boundary into the Populace surface; PolicyEngine's shelter deduction is adjacent but uses PE housing and utility inputs.
 
   - legal_id: us-az:policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation#snap_regular_month_allotment
     country: us
@@ -4538,7 +4538,7 @@ mappings:
     mapping_type: not_comparable
     policyengine_variable: taxable_earnings_for_social_security
     candidate_priority: P4
-    rationale: PolicyEngine exposes taxable Social Security earnings after this exclusion, not the excluded-remuneration amount separately. The ECPS tax harness uses this Axiom output to stage OASDI wage inputs before comparing sections 3101(a) and 3111(a).
+    rationale: PolicyEngine exposes taxable Social Security earnings after this exclusion, not the excluded-remuneration amount separately. The Populace tax harness uses this Axiom output to stage OASDI wage inputs before comparing sections 3101(a) and 3111(a).
 
   - legal_id: us:policies/ssa/contribution-and-benefit-base/2024#contribution_and_benefit_base
     country: us
@@ -12393,2563 +12393,2563 @@ mappings:
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `max_days_temporary_accommodation_in_other_residence`, grounded against `106 CMR 360.030 (Homeless Individual)(3)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `max_days_temporary_accommodation_in_other_residence`, grounded against `106 CMR 360.030 (Homeless Individual)(3)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/360/030/block-1#individual_is_homeless
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `individual_is_homeless`, grounded against `106 CMR 360.030 (Homeless Individual)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `individual_is_homeless`, grounded against `106 CMR 360.030 (Homeless Individual)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/360/030/block-1#event_is_household_disaster
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `event_is_household_disaster`, grounded against `106 CMR 360.030 (Household Disaster)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `event_is_household_disaster`, grounded against `106 CMR 360.030 (Household Disaster)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/360/030/block-1#event_is_household_misfortune
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `event_is_household_misfortune`, grounded against `106 CMR 360.030 (Household Misfortune)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `event_is_household_misfortune`, grounded against `106 CMR 360.030 (Household Misfortune)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/360/030/block-1#program_is_means_tested
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `program_is_means_tested`, grounded against `106 CMR 360.030 (Means-tested Program)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `program_is_means_tested`, grounded against `106 CMR 360.030 (Means-tested Program)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/360/100/block-1#cooking_facilities_required_for_snap
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `cooking_facilities_required_for_snap`, grounded against `106 CMR 360.100`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `cooking_facilities_required_for_snap`, grounded against `106 CMR 360.100`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/360/250/block-1#condition_qualifies_as_disability
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `condition_qualifies_as_disability`, grounded against `106 CMR 360.250 (block 1) - Disability exclusion`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `condition_qualifies_as_disability`, grounded against `106 CMR 360.250 (block 1) - Disability exclusion`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/360/250/block-1#is_qualified_individual
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `is_qualified_individual`, grounded against `106 CMR 360.250 (block 1) - Qualified individual exclusions`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `is_qualified_individual`, grounded against `106 CMR 360.250 (block 1) - Qualified individual exclusions`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/360/600/block-1#household_ineligible_for_snap_due_to_quality_control_noncooperation
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_ineligible_for_snap_due_to_quality_control_noncooperation`, grounded against `106 CMR 360.600`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_ineligible_for_snap_due_to_quality_control_noncooperation`, grounded against `106 CMR 360.600`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/360/950/block-1#voter_registration_transmittal_deadline_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `voter_registration_transmittal_deadline_days`, grounded against `106 CMR 360.950`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `voter_registration_transmittal_deadline_days`, grounded against `106 CMR 360.950`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/360/950/block-1#voter_registration_minimum_age
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `voter_registration_minimum_age`, grounded against `106 CMR 360.950`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `voter_registration_minimum_age`, grounded against `106 CMR 360.950`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/360/950/block-1#voter_registration_form_available_to_person
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `voter_registration_form_available_to_person`, grounded against `106 CMR 360.950`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `voter_registration_form_available_to_person`, grounded against `106 CMR 360.950`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/080/block-1#snap_application_processing_standard_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_application_processing_standard_days`, grounded against `106 CMR 361.080`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_application_processing_standard_days`, grounded against `106 CMR 361.080`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/080/block-1#snap_opportunity_to_participate_timely
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_opportunity_to_participate_timely`, grounded against `106 CMR 361.080`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_opportunity_to_participate_timely`, grounded against `106 CMR 361.080`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/080/block-1#snap_benefits_retroactive_to_application_date
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_benefits_retroactive_to_application_date`, grounded against `106 CMR 361.080`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_benefits_retroactive_to_application_date`, grounded against `106 CMR 361.080`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/100/block-1#snap_application_is_identifiable
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_application_is_identifiable`, grounded against `106 CMR 361.100 (block-1)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_application_is_identifiable`, grounded against `106 CMR 361.100 (block-1)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/120/block-1#ssi_only_household_applying_at_ssa_office
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ssi_only_household_applying_at_ssa_office`, grounded against `106 CMR 361.120 (first paragraph)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ssi_only_household_applying_at_ssa_office`, grounded against `106 CMR 361.120 (first paragraph)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/120/block-1#application_date_is_ssa_receipt_date
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `application_date_is_ssa_receipt_date`, grounded against `106 CMR 361.120 (first paragraph)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `application_date_is_ssa_receipt_date`, grounded against `106 CMR 361.120 (first paragraph)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/120/block-1#application_date_advances_to_next_business_day
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `application_date_advances_to_next_business_day`, grounded against `106 CMR 361.120 (second paragraph)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `application_date_advances_to_next_business_day`, grounded against `106 CMR 361.120 (second paragraph)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/120/block-1#application_date_is_department_receipt_date
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `application_date_is_department_receipt_date`, grounded against `106 CMR 361.120 (second paragraph)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `application_date_is_department_receipt_date`, grounded against `106 CMR 361.120 (second paragraph)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/160/block-1#simultaneous_snap_application_allowed
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `simultaneous_snap_application_allowed`, grounded against `106 CMR 361.160`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `simultaneous_snap_application_allowed`, grounded against `106 CMR 361.160`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/160/block-1#snap_eligibility_based_solely_on_snap_criteria
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_eligibility_based_solely_on_snap_criteria`, grounded against `106 CMR 361.160`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_eligibility_based_solely_on_snap_criteria`, grounded against `106 CMR 361.160`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/160/block-1#snap_certified_under_snap_processing_standards
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_certified_under_snap_processing_standards`, grounded against `106 CMR 361.160`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_certified_under_snap_processing_standards`, grounded against `106 CMR 361.160`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/190/block-1#ssi_household_categorically_eligible_for_snap
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ssi_household_categorically_eligible_for_snap`, grounded against `106 CMR 361.190`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ssi_household_categorically_eligible_for_snap`, grounded against `106 CMR 361.190`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/190/block-1#ssi_household_not_subject_to_additional_interview_at_department
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ssi_household_not_subject_to_additional_interview_at_department`, grounded against `106 CMR 361.190`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ssi_household_not_subject_to_additional_interview_at_department`, grounded against `106 CMR 361.190`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/200/block-1#parental_control_age_limit
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `parental_control_age_limit`, grounded against `106 CMR 361.200 - Parental control definition`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `parental_control_age_limit`, grounded against `106 CMR 361.200 - Parental control definition`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/200/block-1#child_age_limit_for_same_household
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `child_age_limit_for_same_household`, grounded against `106 CMR 361.200 - same household rule for elderly/disabled`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `child_age_limit_for_same_household`, grounded against `106 CMR 361.200 - same household rule for elderly/disabled`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/200/block-1#parental_control_child_age_limit
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `parental_control_child_age_limit`, grounded against `106 CMR 361.200 - children under parental control`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `parental_control_child_age_limit`, grounded against `106 CMR 361.200 - children under parental control`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/200/block-1#is_spouse
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `is_spouse`, grounded against `106 CMR 361.200 - Spouse definition`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `is_spouse`, grounded against `106 CMR 361.200 - Spouse definition`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/200/block-1#has_parental_control_over_individual
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `has_parental_control_over_individual`, grounded against `106 CMR 361.200 - Parental control definition`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `has_parental_control_over_individual`, grounded against `106 CMR 361.200 - Parental control definition`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/200/block-1#disability_verification_required
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `disability_verification_required`, grounded against `106 CMR 361.200 - Disability verification requirement`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `disability_verification_required`, grounded against `106 CMR 361.200 - Disability verification requirement`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/200/block-1#disability_verification_is_sufficient
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `disability_verification_is_sufficient`, grounded against `106 CMR 361.200 - Physician statement requirement`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `disability_verification_is_sufficient`, grounded against `106 CMR 361.200 - Physician statement requirement`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/200/block-1#person_is_unable_to_purchase_food_and_prepare_meals
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_is_unable_to_purchase_food_and_prepare_meals`, grounded against `106 CMR 361.200 - Disabled individuals meeting definition deemed unable`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_is_unable_to_purchase_food_and_prepare_meals`, grounded against `106 CMR 361.200 - Disabled individuals meeting definition deemed unable`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/200/block-1#elderly_and_disabled_individual_must_be_in_same_household
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `elderly_and_disabled_individual_must_be_in_same_household`, grounded against `106 CMR 361.200(A) - Same household requirement for elderly/disabled`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `elderly_and_disabled_individual_must_be_in_same_household`, grounded against `106 CMR 361.200(A) - Same household requirement for elderly/disabled`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/210/block-1#special_treatment_maximum_asset_limit
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `special_treatment_maximum_asset_limit`, grounded against `106 CMR 361.210`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `special_treatment_maximum_asset_limit`, grounded against `106 CMR 361.210`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/210/block-1#special_treatment_entitled
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `special_treatment_entitled`, grounded against `106 CMR 361.210`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `special_treatment_entitled`, grounded against `106 CMR 361.210`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/220/block-1#person_eligible_as_head_of_household
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_eligible_as_head_of_household`, grounded against `106 CMR 361.220 - \"head of household may be any adult member of the household, except that if there is a minor child, the head of household must be an adult who`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_eligible_as_head_of_household`, grounded against `106 CMR 361.220 - \"head of household may be any adult member of the household, except that if there is a minor child, the head of household must be an adult who`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/220/block-1#head_of_household_change_allowed_during_certification_period
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `head_of_household_change_allowed_during_certification_period`, grounded against `106 CMR 361.220 - \"It may not change the designation during a certification period unless there is a change in the household composition, including a change due`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `head_of_household_change_allowed_during_certification_period`, grounded against `106 CMR 361.220 - \"It may not change the designation during a certification period unless there is a change in the household composition, including a change due`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/220/block-1#household_may_select_head_of_household
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_may_select_head_of_household`, grounded against `106 CMR 361.220 - \"The household may select its head of household at initial certification and at each subsequent recertification.\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_may_select_head_of_household`, grounded against `106 CMR 361.220 - \"The household may select its head of household at initial certification and at each subsequent recertification.\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/240/block-1#individual_paying_less_than_reasonable_compensation_not_boarder_and_household_member
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `individual_paying_less_than_reasonable_compensation_not_boarder_and_household_member`, grounded against `106 CMR 361.240, less-than-reasonable-compensation individuals`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `individual_paying_less_than_reasonable_compensation_not_boarder_and_household_member`, grounded against `106 CMR 361.240, less-than-reasonable-compensation individuals`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/240/block-1#boarder_separate_participation_ineligible
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `boarder_separate_participation_ineligible`, grounded against `106 CMR 361.240, boarder separate participation`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `boarder_separate_participation_ineligible`, grounded against `106 CMR 361.240, boarder separate participation`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/240/block-1#boarder_member_participation_allowed_at_providing_household_request
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `boarder_member_participation_allowed_at_providing_household_request`, grounded against `106 CMR 361.240, boarder participation as household member`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `boarder_member_participation_allowed_at_providing_household_request`, grounded against `106 CMR 361.240, boarder participation as household member`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/240/block-1#unrequested_boarder_income_and_resources_unavailable_to_providing_household
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `unrequested_boarder_income_and_resources_unavailable_to_providing_household`, grounded against `106 CMR 361.240, unrequested boarder income and resources`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `unrequested_boarder_income_and_resources_unavailable_to_providing_household`, grounded against `106 CMR 361.240, unrequested boarder income and resources`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/240/block-1#unrequested_boarder_payment_treatment_under_365_200_applies
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `unrequested_boarder_payment_treatment_under_365_200_applies`, grounded against `106 CMR 361.240, boarder payment cross-reference`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `unrequested_boarder_payment_treatment_under_365_200_applies`, grounded against `106 CMR 361.240, boarder payment cross-reference`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/240/block-1#foster_care_person_included_in_snap_household_by_household_option
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `foster_care_person_included_in_snap_household_by_household_option`, grounded against `106 CMR 361.240, foster care household option`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `foster_care_person_included_in_snap_household_by_household_option`, grounded against `106 CMR 361.240, foster care household option`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/240/block-1#included_foster_care_payments_counted_as_unearned_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `included_foster_care_payments_counted_as_unearned_income`, grounded against `106 CMR 361.240, foster care payments as unearned income`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `included_foster_care_payments_counted_as_unearned_income`, grounded against `106 CMR 361.240, foster care payments as unearned income`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/310/block-1#non_household_member_adult_may_be_authorized_representative_for_minors
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `non_household_member_adult_may_be_authorized_representative_for_minors`, grounded against `106 CMR 361.310 (block 1, exception)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `non_household_member_adult_may_be_authorized_representative_for_minors`, grounded against `106 CMR 361.310 (block 1, exception)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/330/block-1#authorized_representative_may_purchase_food
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `authorized_representative_may_purchase_food`, grounded against `106 CMR 361.330 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `authorized_representative_may_purchase_food`, grounded against `106 CMR 361.330 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/350/block-1#designated_employee_may_act_as_authorized_representative
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `designated_employee_may_act_as_authorized_representative`, grounded against `106 CMR 361.350`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `designated_employee_may_act_as_authorized_representative`, grounded against `106 CMR 361.350`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/400/block-1#household_refuses_to_cooperate
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_refuses_to_cooperate`, grounded against `106 CMR 361.400 - refusal determination`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_refuses_to_cooperate`, grounded against `106 CMR 361.400 - refusal determination`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/400/block-1#application_denied_for_refusal_to_cooperate
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `application_denied_for_refusal_to_cooperate`, grounded against `106 CMR 361.400 - denial at time of refusal`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `application_denied_for_refusal_to_cooperate`, grounded against `106 CMR 361.400 - denial at time of refusal`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/400/block-1#household_ineligible_for_refusal_in_subsequent_review
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_ineligible_for_refusal_in_subsequent_review`, grounded against `106 CMR 361.400 - subsequent review refusal`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_ineligible_for_refusal_in_subsequent_review`, grounded against `106 CMR 361.400 - subsequent review refusal`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/400/block-1#reapplication_ineligible_until_cooperates
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `reapplication_ineligible_until_cooperates`, grounded against `106 CMR 361.400 - reapplication after denial or termination for refusal`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `reapplication_ineligible_until_cooperates`, grounded against `106 CMR 361.400 - reapplication after denial or termination for refusal`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/500/block-1#interview_required
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `interview_required`, grounded against `106 CMR 361.500`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `interview_required`, grounded against `106 CMR 361.500`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/500/block-1#face_to_face_interview_required
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `face_to_face_interview_required`, grounded against `106 CMR 361.500`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `face_to_face_interview_required`, grounded against `106 CMR 361.500`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/520/block-1#household_subject_to_verification_requirements_despite_office_interview_waiver
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_subject_to_verification_requirements_despite_office_interview_waiver`, grounded against `106 CMR 361.520 (block 1)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_subject_to_verification_requirements_despite_office_interview_waiver`, grounded against `106 CMR 361.520 (block 1)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/520/block-1#collateral_contact_may_be_substituted_for_documentary_evidence
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `collateral_contact_may_be_substituted_for_documentary_evidence`, grounded against `106 CMR 361.520 (block 1)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `collateral_contact_may_be_substituted_for_documentary_evidence`, grounded against `106 CMR 361.520 (block 1)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/540/block-1#snap_application_processing_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_application_processing_days`, grounded against `106 CMR 361.540`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_application_processing_days`, grounded against `106 CMR 361.540`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/540/block-1#household_may_reschedule_missed_first_interview_without_good_cause
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_may_reschedule_missed_first_interview_without_good_cause`, grounded against `106 CMR 361.540`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_may_reschedule_missed_first_interview_without_good_cause`, grounded against `106 CMR 361.540`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/610/block-1#member_disqualified_for_ssn_noncompliance
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `member_disqualified_for_ssn_noncompliance`, grounded against `106 CMR 361.610`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `member_disqualified_for_ssn_noncompliance`, grounded against `106 CMR 361.610`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/610/block-1#document_accepted_as_actual_child_support_payment_verification
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `document_accepted_as_actual_child_support_payment_verification`, grounded against `106 CMR 361.610`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `document_accepted_as_actual_child_support_payment_verification`, grounded against `106 CMR 361.610`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/620/block-1#information_is_questionable
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `information_is_questionable`, grounded against `106 CMR 361.620 block 1 (definition of questionable information)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `information_is_questionable`, grounded against `106 CMR 361.620 block 1 (definition of questionable information)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/620/block-1#more_intensive_verification_requirement_based_on_protected_characteristics_permitted
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `more_intensive_verification_requirement_based_on_protected_characteristics_permitted`, grounded against `106 CMR 361.620 block 1 (anti-discrimination in verification)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `more_intensive_verification_requirement_based_on_protected_characteristics_permitted`, grounded against `106 CMR 361.620 block 1 (anti-discrimination in verification)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/630/block-1#household_must_be_given_opportunity_to_resolve_discrepancy
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_must_be_given_opportunity_to_resolve_discrepancy`, grounded against `106 CMR 361.630`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_must_be_given_opportunity_to_resolve_discrepancy`, grounded against `106 CMR 361.630`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/700/block-1#compliance_lower_day_threshold
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `compliance_lower_day_threshold`, grounded against `106 CMR 361.700`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `compliance_lower_day_threshold`, grounded against `106 CMR 361.700`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/700/block-1#compliance_upper_day_threshold
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `compliance_upper_day_threshold`, grounded against `106 CMR 361.700`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `compliance_upper_day_threshold`, grounded against `106 CMR 361.700`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/700/block-1#benefits_paid_back_to_application_date
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `benefits_paid_back_to_application_date`, grounded against `106 CMR 361.700`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `benefits_paid_back_to_application_date`, grounded against `106 CMR 361.700`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/900/block-1#processing_period_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `processing_period_days`, grounded against `106 CMR 361.900`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `processing_period_days`, grounded against `106 CMR 361.900`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/900/block-1#worker_must_determine_cause_of_delay
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `worker_must_determine_cause_of_delay`, grounded against `106 CMR 361.900`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `worker_must_determine_cause_of_delay`, grounded against `106 CMR 361.900`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/910/block-1#delay_is_fault_of_household
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `delay_is_fault_of_household`, grounded against `106 CMR 361.910`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `delay_is_fault_of_household`, grounded against `106 CMR 361.910`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/930/block-1#eligibility_determination_period_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `eligibility_determination_period_days`, grounded against `106 CMR 361.930 - \"within 30 calendar days\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `eligibility_determination_period_days`, grounded against `106 CMR 361.930 - \"within 30 calendar days\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/930/block-1#pending_status_application_deadline_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `pending_status_application_deadline_days`, grounded against `106 CMR 361.930 - \"within 60 calendar days following the date the application was filed\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `pending_status_application_deadline_days`, grounded against `106 CMR 361.930 - \"within 60 calendar days following the date the application was filed\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/930/block-1#notice_of_pending_status_required
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `notice_of_pending_status_required`, grounded against `106 CMR 361.930 - \"he or she shall send the household a Notice of Pending Status on the 30th day\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `notice_of_pending_status_required`, grounded against `106 CMR 361.930 - \"he or she shall send the household a Notice of Pending Status on the 30th day\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/930/block-1#worker_must_take_immediate_corrective_action
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `worker_must_take_immediate_corrective_action`, grounded against `106 CMR 361.930 - \"If some action by the worker is needed ... he or she shall take immediate corrective action\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `worker_must_take_immediate_corrective_action`, grounded against `106 CMR 361.930 - \"If some action by the worker is needed ... he or she shall take immediate corrective action\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/930/block-1#notice_must_explain_household_action_and_denial
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `notice_must_explain_household_action_and_denial`, grounded against `106 CMR 361.930 - \"the notice shall also explain what action the household must take and that its application will be denied if the required action is not taken`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `notice_must_explain_household_action_and_denial`, grounded against `106 CMR 361.930 - \"the notice shall also explain what action the household must take and that its application will be denied if the required action is not taken`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/930/block-1#notice_must_advise_of_missing_verifications
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `notice_must_advise_of_missing_verifications`, grounded against `106 CMR 361.930 - \"If the pending status is the result of lack of verifications ... the written notice must also contain a statement advising the household of t`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `notice_must_advise_of_missing_verifications`, grounded against `106 CMR 361.930 - \"If the pending status is the result of lack of verifications ... the written notice must also contain a statement advising the household of t`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/930/block-1#no_further_worker_action_required
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `no_further_worker_action_required`, grounded against `106 CMR 361.930 - \"No further action is required by the worker after the Notice of Pending Status is sent if the household fails to take the required action wit`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `no_further_worker_action_required`, grounded against `106 CMR 361.930 - \"No further action is required by the worker after the Notice of Pending Status is sent if the household fails to take the required action wit`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/940/block-1#snap_benefits_retroactive_to_application_date
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_benefits_retroactive_to_application_date`, grounded against `106 CMR 361.940`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_benefits_retroactive_to_application_date`, grounded against `106 CMR 361.940`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/940/block-1#snap_benefits_begin_month_application_completed
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_benefits_begin_month_application_completed`, grounded against `106 CMR 361.940`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_benefits_begin_month_application_completed`, grounded against `106 CMR 361.940`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/950/block-1#notice_of_denial_required
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `notice_of_denial_required`, grounded against `106 CMR 361.950 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `notice_of_denial_required`, grounded against `106 CMR 361.950 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/950/block-1#notice_must_inform_of_right_to_reapply
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `notice_must_inform_of_right_to_reapply`, grounded against `106 CMR 361.950 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `notice_must_inform_of_right_to_reapply`, grounded against `106 CMR 361.950 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/950/block-1#notice_must_state_missing_verifications_and_department_help_option
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `notice_must_state_missing_verifications_and_department_help_option`, grounded against `106 CMR 361.950 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `notice_must_state_missing_verifications_and_department_help_option`, grounded against `106 CMR 361.950 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/960/block-1#application_processing_deadline_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `application_processing_deadline_days`, grounded against `106 CMR 361.960 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `application_processing_deadline_days`, grounded against `106 CMR 361.960 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/361/960/block-1#worker_must_ensure_application_process_completed
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `worker_must_ensure_application_process_completed`, grounded against `106 CMR 361.960 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `worker_must_ensure_application_process_completed`, grounded against `106 CMR 361.960 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/100/block-1#household_meets_residency_requirement
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_meets_residency_requirement`, grounded against `106 CMR 362.100`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_meets_residency_requirement`, grounded against `106 CMR 362.100`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/100/block-1#individual_meets_dual_participation_restriction
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `individual_meets_dual_participation_restriction`, grounded against `106 CMR 362.100`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `individual_meets_dual_participation_restriction`, grounded against `106 CMR 362.100`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/120/block-1#household_is_unusual_case_for_residency_verification
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_is_unusual_case_for_residency_verification`, grounded against `106 CMR 362.120 (unusual cases clause)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_is_unusual_case_for_residency_verification`, grounded against `106 CMR 362.120 (unusual cases clause)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/120/block-1#residency_verification_required_before_initial_certification
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `residency_verification_required_before_initial_certification`, grounded against `106 CMR 362.120 (residency verification rule)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `residency_verification_required_before_initial_certification`, grounded against `106 CMR 362.120 (residency verification rule)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/210/block-1#snap_citizenship_verified_by_tafdc_or_eaedc
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_citizenship_verified_by_tafdc_or_eaedc`, grounded against `106 CMR 362.210 block 1 (TAFDC/EAEDC proof acceptable)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_citizenship_verified_by_tafdc_or_eaedc`, grounded against `106 CMR 362.210 block 1 (TAFDC/EAEDC proof acceptable)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/210/block-1#snap_citizenship_signed_statement_accepted
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_citizenship_signed_statement_accepted`, grounded against `106 CMR 362.210 block 1 (signed statement fallback)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_citizenship_signed_statement_accepted`, grounded against `106 CMR 362.210 block 1 (signed statement fallback)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/210/block-1#snap_citizenship_verification_accepted
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_citizenship_verification_accepted`, grounded against `106 CMR 362.210 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_citizenship_verification_accepted`, grounded against `106 CMR 362.210 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/220/block-1#temporary_certification_max_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `temporary_certification_max_months`, grounded against `106 CMR 362.220 block 1 \u2014 \"certify the individual for up to six months from the date of the original request for verification\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `temporary_certification_max_months`, grounded against `106 CMR 362.220 block 1 \u2014 \"certify the individual for up to six months from the date of the original request for verification\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/220/block-1#noncitizen_member_ineligible_due_to_verification
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `noncitizen_member_ineligible_due_to_verification`, grounded against `106 CMR 362.220 block 1 \u2014 inability or unwillingness to provide verification of eligible noncitizen status, or to provide or apply for an SSN due to immigration`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `noncitizen_member_ineligible_due_to_verification`, grounded against `106 CMR 362.220 block 1 \u2014 inability or unwillingness to provide verification of eligible noncitizen status, or to provide or apply for an SSN due to immigration`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/220/block-1#noncitizen_eligible_for_temporary_certification
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `noncitizen_eligible_for_temporary_certification`, grounded against `106 CMR 362.220 block 1 \u2014 lost or missing documentation paired with verified formal federal verification request`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `noncitizen_eligible_for_temporary_certification`, grounded against `106 CMR 362.220 block 1 \u2014 lost or missing documentation paired with verified formal federal verification request`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/220/block-1#noncitizen_temporary_certification_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `noncitizen_temporary_certification_months`, grounded against `106 CMR 362.220 block 1 \u2014 up to six months certification from the date of the original verification request`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `noncitizen_temporary_certification_months`, grounded against `106 CMR 362.220 block 1 \u2014 up to six months certification from the date of the original verification request`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/220/block-1#quarter_not_claimable
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `quarter_not_claimable`, grounded against `106 CMR 362.220 block 1 \u2014 no quarter claimable after December 31, 1996 if federal means-tested program benefits were received during that same quarter`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `quarter_not_claimable`, grounded against `106 CMR 362.220 block 1 \u2014 no quarter claimable after December 31, 1996 if federal means-tested program benefits were received during that same quarter`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/220/block-1#commissioner_must_report_to_uscis
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `commissioner_must_report_to_uscis`, grounded against `106 CMR 362.220 block 1 \u2014 Commissioner or designee required to report noncitizens \"known to be in the U.S. unlawfully\" to USCIS`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `commissioner_must_report_to_uscis`, grounded against `106 CMR 362.220 block 1 \u2014 Commissioner or designee required to report noncitizens \"known to be in the U.S. unlawfully\" to USCIS`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/270/block-1#indigency_determination_period_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `indigency_determination_period_months`, grounded against `106 CMR 362.270 (\"Each indigence determination is effective for 12 months and may be renewed for additional 12-month periods.\")`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `indigency_determination_period_months`, grounded against `106 CMR 362.270 (\"Each indigence determination is effective for 12 months and may be renewed for additional 12-month periods.\")`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/270/block-1#sponsor_deeming_applies
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `sponsor_deeming_applies`, grounded against `106 CMR 362.270 (deeming rules application and categorical eligibility exemption)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `sponsor_deeming_applies`, grounded against `106 CMR 362.270 (deeming rules application and categorical eligibility exemption)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/270/block-1#sponsored_noncitizen_ineligible
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `sponsored_noncitizen_ineligible`, grounded against `106 CMR 362.270 (\"The sponsored noncitizen shall be ineligible.\")`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `sponsored_noncitizen_ineligible`, grounded against `106 CMR 362.270 (\"The sponsored noncitizen shall be ineligible.\")`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/270/block-1#indigency_determination_active
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `indigency_determination_active`, grounded against `106 CMR 362.270 (12-month indigence determination effectiveness)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `indigency_determination_active`, grounded against `106 CMR 362.270 (12-month indigence determination effectiveness)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/270/block-1#battery_or_cruelty_exception_renewable
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `battery_or_cruelty_exception_renewable`, grounded against `106 CMR 362.270 (battery or cruelty exception review after 12-month period)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `battery_or_cruelty_exception_renewable`, grounded against `106 CMR 362.270 (battery or cruelty exception review after 12-month period)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/270/block-1#quarter_excluded_from_count
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `quarter_excluded_from_count`, grounded against `106 CMR 362.270 (quarter exclusion when means-tested benefits received)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `quarter_excluded_from_count`, grounded against `106 CMR 362.270 (quarter exclusion when means-tested benefits received)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/300/block-1#mandatory_work_minimum_age
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `mandatory_work_minimum_age`, grounded against `106 CMR 362.300`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `mandatory_work_minimum_age`, grounded against `106 CMR 362.300`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/300/block-1#mandatory_work_maximum_age
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `mandatory_work_maximum_age`, grounded against `106 CMR 362.300`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `mandatory_work_maximum_age`, grounded against `106 CMR 362.300`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/300/block-1#abawd_minimum_age
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `abawd_minimum_age`, grounded against `106 CMR 362.300`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `abawd_minimum_age`, grounded against `106 CMR 362.300`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/300/block-1#abawd_maximum_age
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `abawd_maximum_age`, grounded against `106 CMR 362.300`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `abawd_maximum_age`, grounded against `106 CMR 362.300`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/300/block-1#abawd_noncompliance_month_limit
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `abawd_noncompliance_month_limit`, grounded against `106 CMR 362.300`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `abawd_noncompliance_month_limit`, grounded against `106 CMR 362.300`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/300/block-1#person_subject_to_mandatory_snap_work_requirements
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_subject_to_mandatory_snap_work_requirements`, grounded against `106 CMR 362.300`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_subject_to_mandatory_snap_work_requirements`, grounded against `106 CMR 362.300`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/300/block-1#person_disqualified_for_mandatory_snap_work_noncompliance
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_disqualified_for_mandatory_snap_work_noncompliance`, grounded against `106 CMR 362.300; 106 CMR 367.800`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_disqualified_for_mandatory_snap_work_noncompliance`, grounded against `106 CMR 362.300; 106 CMR 367.800`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/300/block-1#person_subject_to_abawd_work_requirements
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_subject_to_abawd_work_requirements`, grounded against `106 CMR 362.300`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_subject_to_abawd_work_requirements`, grounded against `106 CMR 362.300`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/300/block-1#person_ineligible_for_abawd_noncompliance
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_ineligible_for_abawd_noncompliance`, grounded against `106 CMR 362.300; 106 CMR 362.320`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_ineligible_for_abawd_noncompliance`, grounded against `106 CMR 362.300; 106 CMR 362.320`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/310/block-1#voluntary_et_participant_disqualified_for_noncompliance
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `voluntary_et_participant_disqualified_for_noncompliance`, grounded against `106 CMR 362.310 - voluntary E&T participants not disqualified`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `voluntary_et_participant_disqualified_for_noncompliance`, grounded against `106 CMR 362.310 - voluntary E&T participants not disqualified`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/310/block-1#temporarily_unfit_person_must_meet_work_requirements
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `temporarily_unfit_person_must_meet_work_requirements`, grounded against `106 CMR 362.310 - temporary unfitness exemption ends when fit`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `temporarily_unfit_person_must_meet_work_requirements`, grounded against `106 CMR 362.310 - temporary unfitness exemption ends when fit`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/310/block-1#caregiver_must_fulfill_work_requirements_at_next_recertification_due_to_child_age_six
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `caregiver_must_fulfill_work_requirements_at_next_recertification_due_to_child_age_six`, grounded against `106 CMR 362.310 - child sixth birthday within certification period`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `caregiver_must_fulfill_work_requirements_at_next_recertification_due_to_child_age_six`, grounded against `106 CMR 362.310 - child sixth birthday within certification period`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/310/block-1#teen_must_fulfill_work_registration_at_next_recertification_due_to_age_eighteen
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `teen_must_fulfill_work_registration_at_next_recertification_due_to_age_eighteen`, grounded against `106 CMR 362.310 - exempt teen turning 18 within certification period`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `teen_must_fulfill_work_registration_at_next_recertification_due_to_age_eighteen`, grounded against `106 CMR 362.310 - exempt teen turning 18 within certification period`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/310/block-1#person_must_register_for_work_after_loss_of_exemption
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_must_register_for_work_after_loss_of_exemption`, grounded against `106 CMR 362.310 - loss of exemption due to change in circumstances`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_must_register_for_work_after_loss_of_exemption`, grounded against `106 CMR 362.310 - loss of exemption due to change in circumstances`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/310/block-1#student_qualifies_for_student_exemption
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `student_qualifies_for_student_exemption`, grounded against `106 CMR 362.310 - student exemption disqualifying conditions`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `student_qualifies_for_student_exemption`, grounded against `106 CMR 362.310 - student exemption disqualifying conditions`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/330/block-1#crisis_or_emergency_situation_applies
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `crisis_or_emergency_situation_applies`, grounded against `106 CMR 362.330(B) - crisis or emergency situations (death, health emergency, domestic violence, child's school problem)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `crisis_or_emergency_situation_applies`, grounded against `106 CMR 362.330(B) - crisis or emergency situations (death, health emergency, domestic violence, child's school problem)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/330/block-1#childcare_breakdown_good_cause_applies
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `childcare_breakdown_good_cause_applies`, grounded against `106 CMR 362.330(B) - breakdown of suitable, state-standard childcare with appropriate verification`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `childcare_breakdown_good_cause_applies`, grounded against `106 CMR 362.330(B) - breakdown of suitable, state-standard childcare with appropriate verification`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/330/block-1#special_needs_childcare_unavailable_good_cause_applies
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `special_needs_childcare_unavailable_good_cause_applies`, grounded against `106 CMR 362.330(B) - unavailability of suitable childcare for children with identified special needs, verified`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `special_needs_childcare_unavailable_good_cause_applies`, grounded against `106 CMR 362.330(B) - unavailability of suitable childcare for children with identified special needs, verified`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/330/block-1#snap_work_requirement_good_cause_applies
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_work_requirement_good_cause_applies`, grounded against `106 CMR 362.330(B) - good cause criteria applies to SNAP work requirements only; not to ABA WD work program requirements`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_work_requirement_good_cause_applies`, grounded against `106 CMR 362.330(B) - good cause criteria applies to SNAP work requirements only; not to ABA WD work program requirements`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/340/block-1#same_application_remaining_disqualification_days_threshold
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `same_application_remaining_disqualification_days_threshold`, grounded against `106 CMR 362.340`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `same_application_remaining_disqualification_days_threshold`, grounded against `106 CMR 362.340`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/340/block-1#sanction_carries_to_new_household
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `sanction_carries_to_new_household`, grounded against `106 CMR 362.340`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `sanction_carries_to_new_household`, grounded against `106 CMR 362.340`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/340/block-1#strike_dismissal_treated_as_voluntary_quit_without_good_cause
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `strike_dismissal_treated_as_voluntary_quit_without_good_cause`, grounded against `106 CMR 362.340 Exception`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `strike_dismissal_treated_as_voluntary_quit_without_good_cause`, grounded against `106 CMR 362.340 Exception`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/340/block-1#same_application_used_for_remaining_disqualification_and_subsequent_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `same_application_used_for_remaining_disqualification_and_subsequent_months`, grounded against `106 CMR 362.340`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `same_application_used_for_remaining_disqualification_and_subsequent_months`, grounded against `106 CMR 362.340`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/400/block-1#person_attends_institution_of_post_secondary_education
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_attends_institution_of_post_secondary_education`, grounded against `106 CMR 362.400 (definition of institution of post-secondary education)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_attends_institution_of_post_secondary_education`, grounded against `106 CMR 362.400 (definition of institution of post-secondary education)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/420/block-1#student_enrollment_status_continues
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `student_enrollment_status_continues`, grounded against `106 CMR 362.420 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `student_enrollment_status_continues`, grounded against `106 CMR 362.420 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/362/500/block-1#good_cause_monthly_verification_required
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `good_cause_monthly_verification_required`, grounded against `106 CMR 362.500 - \"Good cause must be verified monthly until the SSN is provided and verified by computer match with SSA\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `good_cause_monthly_verification_required`, grounded against `106 CMR 362.500 - \"Good cause must be verified monthly until the SSN is provided and verified by computer match with SSA\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/100/block-1#nonliquid_asset_countable_equity_value
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `nonliquid_asset_countable_equity_value`, grounded against `106 CMR 363.100 - \"The countable value of a nonliquid asset shall be its equity value which is determined by fair market value less any encumbrances.\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `nonliquid_asset_countable_equity_value`, grounded against `106 CMR 363.100 - \"The countable value of a nonliquid asset shall be its equity value which is determined by fair market value less any encumbrances.\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/100/block-1#asset_is_counted_in_eligibility
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `asset_is_counted_in_eligibility`, grounded against `106 CMR 363.100 - \"All of the household's assets shall be counted in determining eligibility unless specifically exempted by 106 CMR 363.140.\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `asset_is_counted_in_eligibility`, grounded against `106 CMR 363.100 - \"All of the household's assets shall be counted in determining eligibility unless specifically exempted by 106 CMR 363.140.\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/110/block-1#household_subject_to_asset_limits
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_subject_to_asset_limits`, grounded against `106 CMR 363.110`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_subject_to_asset_limits`, grounded against `106 CMR 363.110`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/130/block-1#recertification_low_balance_verification_threshold
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `recertification_low_balance_verification_threshold`, grounded against `106 CMR 363.130 - \"If at recertification the household member declares a balance of $25 or less in an account, other than a checking account, verification shall`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `recertification_low_balance_verification_threshold`, grounded against `106 CMR 363.130 - \"If at recertification the household member declares a balance of $25 or less in an account, other than a checking account, verification shall`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/130/block-1#bank_account_funds_are_available_asset
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `bank_account_funds_are_available_asset`, grounded against `106 CMR 363.130 - \"Funds in a bank account are considered available when a member of the household has both ownership of, and access to, the balance of funds in`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `bank_account_funds_are_available_asset`, grounded against `106 CMR 363.130 - \"Funds in a bank account are considered available when a member of the household has both ownership of, and access to, the balance of funds in`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/130/block-1#crowdfunding_account_is_liquid_resource
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `crowdfunding_account_is_liquid_resource`, grounded against `106 CMR 363.130 - \"Crowdfunding accounts (e.g., GoFundMe and Kickstarter) shall also be considered liquid resources if funds are accessible to the household.\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `crowdfunding_account_is_liquid_resource`, grounded against `106 CMR 363.130 - \"Crowdfunding accounts (e.g., GoFundMe and Kickstarter) shall also be considered liquid resources if funds are accessible to the household.\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/130/block-1#recertification_account_balance_verification_waived
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `recertification_account_balance_verification_waived`, grounded against `106 CMR 363.130 - \"If at recertification the household member declares a balance of $25 or less in an account, other than a checking account, verification shall`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `recertification_account_balance_verification_waived`, grounded against `106 CMR 363.130 - \"If at recertification the household member declares a balance of $25 or less in an account, other than a checking account, verification shall`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/140/block-1#asset_is_noncountable
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `asset_is_noncountable`, grounded against `106 CMR 363.140`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `asset_is_noncountable`, grounded against `106 CMR 363.140`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/200/block-1#household_must_meet_income_eligibility_standards
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_must_meet_income_eligibility_standards`, grounded against `106 CMR 363.200`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_must_meet_income_eligibility_standards`, grounded against `106 CMR 363.200`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/210/block-1#loan_income_verification_sufficient
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `loan_income_verification_sufficient`, grounded against `106 CMR 363.210`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `loan_income_verification_sufficient`, grounded against `106 CMR 363.210`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/210/block-1#self_employment_income_verification_sufficient
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `self_employment_income_verification_sufficient`, grounded against `106 CMR 363.210`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `self_employment_income_verification_sufficient`, grounded against `106 CMR 363.210`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/220/block-1#tafdc_related_support_alimony_unearned_income_cap
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `tafdc_related_support_alimony_unearned_income_cap`, grounded against `106 CMR 363.220`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `tafdc_related_support_alimony_unearned_income_cap`, grounded against `106 CMR 363.220`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/220/block-1#tafdc_related_support_alimony_unearned_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `tafdc_related_support_alimony_unearned_income`, grounded against `106 CMR 363.220`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `tafdc_related_support_alimony_unearned_income`, grounded against `106 CMR 363.220`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/230/block-1#cash_contribution_from_non_legally_responsible_person_is_excluded
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `cash_contribution_from_non_legally_responsible_person_is_excluded`, grounded against `106 CMR 363.230 (cash contributions from non-legally responsible persons)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `cash_contribution_from_non_legally_responsible_person_is_excluded`, grounded against `106 CMR 363.230 (cash contributions from non-legally responsible persons)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/230/block-1#vendor_payment_is_excluded
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `vendor_payment_is_excluded`, grounded against `106 CMR 363.230 (vendor payments)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `vendor_payment_is_excluded`, grounded against `106 CMR 363.230 (vendor payments)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/230/block-1#employer_provided_housing_is_excluded_vendor_payment
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `employer_provided_housing_is_excluded_vendor_payment`, grounded against `106 CMR 363.230 (employer-provided housing as vendor payment)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `employer_provided_housing_is_excluded_vendor_payment`, grounded against `106 CMR 363.230 (employer-provided housing as vendor payment)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/230/block-1#pass_funds_are_excluded_from_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `pass_funds_are_excluded_from_income`, grounded against `106 CMR 363.230 (PASS funds exclusion)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `pass_funds_are_excluded_from_income`, grounded against `106 CMR 363.230 (PASS funds exclusion)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/230/block-1#pass_funds_exclusion_is_verified
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `pass_funds_exclusion_is_verified`, grounded against `106 CMR 363.230 (PASS verification)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `pass_funds_exclusion_is_verified`, grounded against `106 CMR 363.230 (PASS verification)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/363/230/block-1#ssi_benefits_are_countable_income_for_snap
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ssi_benefits_are_countable_income_for_snap`, grounded against `106 CMR 363.230 (SSI treatment for SNAP)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ssi_benefits_are_countable_income_for_snap`, grounded against `106 CMR 363.230 (SSI treatment for SNAP)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/120/block-1#minimum_verification_response_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `minimum_verification_response_days`, grounded against `106 CMR 364.120`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `minimum_verification_response_days`, grounded against `106 CMR 364.120`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/120/block-1#first_month_of_new_certification_period_is_initial_month
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `first_month_of_new_certification_period_is_initial_month`, grounded against `106 CMR 364.120`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `first_month_of_new_certification_period_is_initial_month`, grounded against `106 CMR 364.120`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/120/block-1#notice_of_expiration_proration_exception_applies
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `notice_of_expiration_proration_exception_applies`, grounded against `106 CMR 364.120`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `notice_of_expiration_proration_exception_applies`, grounded against `106 CMR 364.120`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/120/block-1#verification_request_proration_exception_applies
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `verification_request_proration_exception_applies`, grounded against `106 CMR 364.120`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `verification_request_proration_exception_applies`, grounded against `106 CMR 364.120`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/120/block-1#first_month_subject_to_proration
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `first_month_subject_to_proration`, grounded against `106 CMR 364.120`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `first_month_subject_to_proration`, grounded against `106 CMR 364.120`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/200/block-1#assets_used_for_eligibility
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `assets_used_for_eligibility`, grounded against `106 CMR 364.200`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `assets_used_for_eligibility`, grounded against `106 CMR 364.200`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/310/block-1#anticipated_income_is_reasonably_certain
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `anticipated_income_is_reasonably_certain`, grounded against `106 CMR 364.310 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `anticipated_income_is_reasonably_certain`, grounded against `106 CMR 364.310 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/310/block-1#countable_anticipated_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `countable_anticipated_income`, grounded against `106 CMR 364.310 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `countable_anticipated_income`, grounded against `106 CMR 364.310 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/310/block-1#household_may_elect_income_averaging
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_may_elect_income_averaging`, grounded against `106 CMR 364.310 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_may_elect_income_averaging`, grounded against `106 CMR 364.310 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/320/block-1#default_anticipated_income_lookback_weeks
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `default_anticipated_income_lookback_weeks`, grounded against `106 CMR 364.320`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `default_anticipated_income_lookback_weeks`, grounded against `106 CMR 364.320`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/320/block-1#anticipated_income_lookback_weeks
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `anticipated_income_lookback_weeks`, grounded against `106 CMR 364.320`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `anticipated_income_lookback_weeks`, grounded against `106 CMR 364.320`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/320/block-1#past_income_used_as_anticipated_income_indicator
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `past_income_used_as_anticipated_income_indicator`, grounded against `106 CMR 364.320`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `past_income_used_as_anticipated_income_indicator`, grounded against `106 CMR 364.320`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/330/block-1#payment_counted_as_income_in_month
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `payment_counted_as_income_in_month`, grounded against `106 CMR 364.330`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `payment_counted_as_income_in_month`, grounded against `106 CMR 364.330`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/330/block-1#nonrecurring_lump_sum_counted_as_asset_in_month
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `nonrecurring_lump_sum_counted_as_asset_in_month`, grounded against `106 CMR 364.330`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `nonrecurring_lump_sum_counted_as_asset_in_month`, grounded against `106 CMR 364.330`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/340/block-1#weekly_to_monthly_conversion_factor
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `weekly_to_monthly_conversion_factor`, grounded against `106 CMR 364.340 (weekly amounts multiplied by 4.333)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `weekly_to_monthly_conversion_factor`, grounded against `106 CMR 364.340 (weekly amounts multiplied by 4.333)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/340/block-1#biweekly_to_monthly_conversion_factor
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `biweekly_to_monthly_conversion_factor`, grounded against `106 CMR 364.340 (biweekly amounts multiplied by 2.167)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `biweekly_to_monthly_conversion_factor`, grounded against `106 CMR 364.340 (biweekly amounts multiplied by 2.167)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/340/block-1#converted_monthly_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `converted_monthly_income`, grounded against `106 CMR 364.340 (conversion of weekly/biweekly income to monthly)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `converted_monthly_income`, grounded against `106 CMR 364.340 (conversion of weekly/biweekly income to monthly)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/360/block-1#maximum_tafdc_related_child_support_payment
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `maximum_tafdc_related_child_support_payment`, grounded against `106 CMR 364.360`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `maximum_tafdc_related_child_support_payment`, grounded against `106 CMR 364.360`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/360/block-1#countable_tafdc_related_child_support_payment
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `countable_tafdc_related_child_support_payment`, grounded against `106 CMR 364.360`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `countable_tafdc_related_child_support_payment`, grounded against `106 CMR 364.360`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/370/block-1#countable_gross_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `countable_gross_income`, grounded against `106 CMR 364.370 (\"gross income minus the exclusions listed in 106 CMR 363.230\")`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `countable_gross_income`, grounded against `106 CMR 364.370 (\"gross income minus the exclusions listed in 106 CMR 363.230\")`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/370/block-1#applicable_gross_income_standard
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `applicable_gross_income_standard`, grounded against `106 CMR 364.370 (chooses between 364.976 and 364.950 standards)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `applicable_gross_income_standard`, grounded against `106 CMR 364.370 (chooses between 364.976 and 364.950 standards)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/370/block-1#exempt_from_gross_income_test
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `exempt_from_gross_income_test`, grounded against `106 CMR 364.370 (exception for elderly/disabled meeting 361.210 or public assistance categorically eligible per 365.180; not extended to SNAP-only TANF Services`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `exempt_from_gross_income_test`, grounded against `106 CMR 364.370 (exception for elderly/disabled meeting 361.210 or public assistance categorically eligible per 365.180; not extended to SNAP-only TANF Services`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/370/block-1#meets_gross_income_standard
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `meets_gross_income_standard`, grounded against `106 CMR 364.370 (countable gross income equal to or less than the applicable standard)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `meets_gross_income_standard`, grounded against `106 CMR 364.370 (countable gross income equal to or less than the applicable standard)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/370/block-1#net_income_sole_basis_of_eligibility
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `net_income_sole_basis_of_eligibility`, grounded against `106 CMR 364.370 (net income at 364.550 is the sole basis for elderly/disabled households not categorically eligible per 365.180)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `net_income_sole_basis_of_eligibility`, grounded against `106 CMR 364.370 (net income at 364.550 is the sole basis for elderly/disabled households not categorically eligible per 365.180)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/370/block-1#household_meets_income_eligibility
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_meets_income_eligibility`, grounded against `106 CMR 364.370 (gross income test, except when exempt; net income test always determined when not ineligible on gross)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_meets_income_eligibility`, grounded against `106 CMR 364.370 (gross income test, except when exempt; net income test always determined when not ineligible on gross)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/400/block-1#medical_expense_lower_threshold
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `medical_expense_lower_threshold`, grounded against `106 CMR 364.400 medical expense table, \"$35/month or under $0\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `medical_expense_lower_threshold`, grounded against `106 CMR 364.400 medical expense table, \"$35/month or under $0\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/400/block-1#medical_expense_standard_upper_threshold
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `medical_expense_standard_upper_threshold`, grounded against `106 CMR 364.400 medical expense table, \"Over $35.00 to $190/month $155\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `medical_expense_standard_upper_threshold`, grounded against `106 CMR 364.400 medical expense table, \"Over $35.00 to $190/month $155\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/400/block-1#medical_expense_standard_deduction_amount
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `medical_expense_standard_deduction_amount`, grounded against `106 CMR 364.400 medical expense table, \"Over $35.00 to $190/month $155\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `medical_expense_standard_deduction_amount`, grounded against `106 CMR 364.400 medical expense table, \"Over $35.00 to $190/month $155\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/400/block-1#medical_expense_deduction
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `medical_expense_deduction`, grounded against `106 CMR 364.400 medical expense deduction table`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `medical_expense_deduction`, grounded against `106 CMR 364.400 medical expense deduction table`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/400/block-1#earned_income_deduction_allowed_for_overissuance
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `earned_income_deduction_allowed_for_overissuance`, grounded against `106 CMR 364.400, \"This deduction shall not be allowed in determining an overissuance if the household fails to report earned income in a timely manner and the f`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `earned_income_deduction_allowed_for_overissuance`, grounded against `106 CMR 364.400, \"This deduction shall not be allowed in determining an overissuance if the household fails to report earned income in a timely manner and the f`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/400/block-1#vacated_home_shelter_deduction_allowed
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `vacated_home_shelter_deduction_allowed`, grounded against `106 CMR 364.400, vacated home shelter deduction conditions`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `vacated_home_shelter_deduction_allowed`, grounded against `106 CMR 364.400, vacated home shelter deduction conditions`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/400/block-1#child_support_deduction_includes_third_party_payment
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `child_support_deduction_includes_third_party_payment`, grounded against `106 CMR 364.400, child support deduction inclusion of third-party payments`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `child_support_deduction_includes_third_party_payment`, grounded against `106 CMR 364.400, child support deduction inclusion of third-party payments`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/400/block-1#child_support_deduction_includes_children_health_insurance
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `child_support_deduction_includes_children_health_insurance`, grounded against `106 CMR 364.400, \"Payments that are made by the household to obtain health insurance for their children shall also be included as part of the child support dedu`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `child_support_deduction_includes_children_health_insurance`, grounded against `106 CMR 364.400, \"Payments that are made by the household to obtain health insurance for their children shall also be included as part of the child support dedu`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/400/block-1#arrearage_payments_allowed_in_child_support_deduction
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `arrearage_payments_allowed_in_child_support_deduction`, grounded against `106 CMR 364.400, \"The Department shall allow a deduction for amounts paid toward arrearages, even for households without a payment history.\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `arrearage_payments_allowed_in_child_support_deduction`, grounded against `106 CMR 364.400, \"The Department shall allow a deduction for amounts paid toward arrearages, even for households without a payment history.\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/400/block-1#alimony_excluded_from_child_support_deduction
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `alimony_excluded_from_child_support_deduction`, grounded against `106 CMR 364.400, \"Alimony payments made to or for a non-household member shall not be included in the child support deduction.\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `alimony_excluded_from_child_support_deduction`, grounded against `106 CMR 364.400, \"Alimony payments made to or for a non-household member shall not be included in the child support deduction.\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/400/block-1#public_housing_central_meter_sua_allowed
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `public_housing_central_meter_sua_allowed`, grounded against `106 CMR 364.400(G), public housing central meter SUA`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `public_housing_central_meter_sua_allowed`, grounded against `106 CMR 364.400(G), public housing central meter SUA`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/400/block-1#electric_blower_sua_not_allowed
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `electric_blower_sua_not_allowed`, grounded against `106 CMR 364.400(G), electric blower exclusion`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `electric_blower_sua_not_allowed`, grounded against `106 CMR 364.400(G), electric blower exclusion`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/400/block-1#liheaa_recipient_entitled_to_heating_cooling_sua
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `liheaa_recipient_entitled_to_heating_cooling_sua`, grounded against `106 CMR 364.400(G), LIHEAA recipients`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `liheaa_recipient_entitled_to_heating_cooling_sua`, grounded against `106 CMR 364.400(G), LIHEAA recipients`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/400/block-1#non_liheaa_household_eligible_for_heating_sua
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `non_liheaa_household_eligible_for_heating_sua`, grounded against `106 CMR 364.400(G), non-LIHEAA indirect energy assistance with continuing out-of-pocket heating expenses`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `non_liheaa_household_eligible_for_heating_sua`, grounded against `106 CMR 364.400(G), non-LIHEAA indirect energy assistance with continuing out-of-pocket heating expenses`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/410/block-1#child_support_history_minimum_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `child_support_history_minimum_months`, grounded against `106 CMR 364.410`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `child_support_history_minimum_months`, grounded against `106 CMR 364.410`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/410/block-1#child_support_deduction
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `child_support_deduction`, grounded against `106 CMR 364.410`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `child_support_deduction`, grounded against `106 CMR 364.410`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/420/block-1#verification_required_before_acting_on_reported_medical_expense_change
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `verification_required_before_acting_on_reported_medical_expense_change`, grounded against `106 CMR 364.420`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `verification_required_before_acting_on_reported_medical_expense_change`, grounded against `106 CMR 364.420`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/420/block-1#department_acts_on_reported_medical_expense_change_without_verification
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `department_acts_on_reported_medical_expense_change_without_verification`, grounded against `106 CMR 364.420`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `department_acts_on_reported_medical_expense_change_without_verification`, grounded against `106 CMR 364.420`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/420/block-1#household_required_to_report_medical_expenses_during_certification_period
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_required_to_report_medical_expenses_during_certification_period`, grounded against `106 CMR 364.420`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_required_to_report_medical_expenses_during_certification_period`, grounded against `106 CMR 364.420`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/430/block-1#expense_is_deductible_this_month
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `expense_is_deductible_this_month`, grounded against `106 CMR 364.430 (block 1)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `expense_is_deductible_this_month`, grounded against `106 CMR 364.430 (block 1)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/450/block-1#application_processing_standard_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `application_processing_standard_days`, grounded against `106 CMR 364.450`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `application_processing_standard_days`, grounded against `106 CMR 364.450`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/450/block-1#minimum_verification_request_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `minimum_verification_request_days`, grounded against `106 CMR 364.450`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `minimum_verification_request_days`, grounded against `106 CMR 364.450`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/450/block-1#notice_of_pending_denial_day
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `notice_of_pending_denial_day`, grounded against `106 CMR 364.450`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `notice_of_pending_denial_day`, grounded against `106 CMR 364.450`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/450/block-1#household_may_elect_certification_without_deduction
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_may_elect_certification_without_deduction`, grounded against `106 CMR 364.450`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_may_elect_certification_without_deduction`, grounded against `106 CMR 364.450`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/450/block-1#later_verification_treated_as_reported_change
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `later_verification_treated_as_reported_change`, grounded against `106 CMR 364.450`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `later_verification_treated_as_reported_change`, grounded against `106 CMR 364.450`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/450/block-1#household_entitled_to_lost_benefits
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_entitled_to_lost_benefits`, grounded against `106 CMR 364.450`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_entitled_to_lost_benefits`, grounded against `106 CMR 364.450`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/450/block-1#notice_of_pending_denial_required
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `notice_of_pending_denial_required`, grounded against `106 CMR 364.450`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `notice_of_pending_denial_required`, grounded against `106 CMR 364.450`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/500/block-1#cost_threshold
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `cost_threshold`, grounded against `106 CMR 364.500 block-1 (\"If these costs exceed $35 per month\")`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `cost_threshold`, grounded against `106 CMR 364.500 block-1 (\"If these costs exceed $35 per month\")`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/500/block-1#costs_exceed_threshold
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `costs_exceed_threshold`, grounded against `106 CMR 364.500 block-1 (\"If these costs exceed $35 per month, go to the next step.\")`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `costs_exceed_threshold`, grounded against `106 CMR 364.500 block-1 (\"If these costs exceed $35 per month, go to the next step.\")`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/500/block-1#route_to_section_g
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `route_to_section_g`, grounded against `106 CMR 364.500 block-1 (\"If these costs are $35 or less, go to 106 CMR 364.500 (G).\")`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `route_to_section_g`, grounded against `106 CMR 364.500 block-1 (\"If these costs are $35 or less, go to 106 CMR 364.500 (G).\")`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/550/block-1#household_meets_net_income_standard
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_meets_net_income_standard`, grounded against `106 CMR 364.550`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_meets_net_income_standard`, grounded against `106 CMR 364.550`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/600/block-1#minimum_household_size_for_categorical_suspension
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `minimum_household_size_for_categorical_suspension`, grounded against `106 CMR 364.600`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `minimum_household_size_for_categorical_suspension`, grounded against `106 CMR 364.600`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/600/block-1#calculated_allotment_is_zero_or_less
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `calculated_allotment_is_zero_or_less`, grounded against `106 CMR 364.600`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `calculated_allotment_is_zero_or_less`, grounded against `106 CMR 364.600`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/600/block-1#household_must_be_suspended
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_must_be_suspended`, grounded against `106 CMR 364.600`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_must_be_suspended`, grounded against `106 CMR 364.600`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/600/block-1#household_ineligible_due_to_zero_allotment
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_ineligible_due_to_zero_allotment`, grounded against `106 CMR 364.600`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_ineligible_due_to_zero_allotment`, grounded against `106 CMR 364.600`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/600/block-1#monthly_allotment
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `monthly_allotment`, grounded against `106 CMR 364.600`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `monthly_allotment`, grounded against `106 CMR 364.600`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/650/block-1#monthly_allotment_proration_threshold
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `monthly_allotment_proration_threshold`, grounded against `106 CMR 364.650`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `monthly_allotment_proration_threshold`, grounded against `106 CMR 364.650`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/650/block-1#proration_denominator
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `proration_denominator`, grounded against `106 CMR 364.650`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `proration_denominator`, grounded against `106 CMR 364.650`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/650/block-1#mid_month_application_day_threshold
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `mid_month_application_day_threshold`, grounded against `106 CMR 364.650`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `mid_month_application_day_threshold`, grounded against `106 CMR 364.650`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/650/block-1#initial_month_prorated_allotment
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `initial_month_prorated_allotment`, grounded against `106 CMR 364.650`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `initial_month_prorated_allotment`, grounded against `106 CMR 364.650`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/650/block-1#combined_allotment_applies
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `combined_allotment_applies`, grounded against `106 CMR 364.650`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `combined_allotment_applies`, grounded against `106 CMR 364.650`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/650/block-1#combined_allotment_amount
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `combined_allotment_amount`, grounded against `106 CMR 364.650`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `combined_allotment_amount`, grounded against `106 CMR 364.650`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/700/block-1#benefits_terminated_without_pretermination_hearing
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `benefits_terminated_without_pretermination_hearing`, grounded against `106 CMR 364.700 block-1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `benefits_terminated_without_pretermination_hearing`, grounded against `106 CMR 364.700 block-1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/870/block-1#minimum_claim_amount
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `minimum_claim_amount`, grounded against `106 CMR 364.870`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `minimum_claim_amount`, grounded against `106 CMR 364.870`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/870/block-1#applicable_claim_threshold
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `applicable_claim_threshold`, grounded against `106 CMR 364.870`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `applicable_claim_threshold`, grounded against `106 CMR 364.870`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/870/block-1#unintentional_program_violation_claim_demand_letter_required
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `unintentional_program_violation_claim_demand_letter_required`, grounded against `106 CMR 364.870`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `unintentional_program_violation_claim_demand_letter_required`, grounded against `106 CMR 364.870`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/900/block-1#statement_deadline_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `statement_deadline_days`, grounded against `106 CMR 364.900 (statement received within ten days of the date of the report)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `statement_deadline_days`, grounded against `106 CMR 364.900 (statement received within ten days of the date of the report)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/900/block-1#expungement_notice_minimum_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `expungement_notice_minimum_days`, grounded against `106 CMR 364.900 (notice must be mailed no later than 30 days before the date of expungement)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `expungement_notice_minimum_days`, grounded against `106 CMR 364.900 (notice must be mailed no later than 30 days before the date of expungement)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/900/block-1#statement_timely_received
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `statement_timely_received`, grounded against `106 CMR 364.900 (statement timely if within ten days, or weekend/holiday extension)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `statement_timely_received`, grounded against `106 CMR 364.900 (statement timely if within ten days, or weekend/holiday extension)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/900/block-1#expungement_notice_timely_mailed
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `expungement_notice_timely_mailed`, grounded against `106 CMR 364.900 (notice mailed no later than 30 days before expungement)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `expungement_notice_timely_mailed`, grounded against `106 CMR 364.900 (notice mailed no later than 30 days before expungement)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/980/block-1#snap_allotment_percentage
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_allotment_percentage`, grounded against `106 CMR 364.980`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_allotment_percentage`, grounded against `106 CMR 364.980`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/980/block-1#snap_benefit_allotment
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_benefit_allotment`, grounded against `106 CMR 364.980`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_benefit_allotment`, grounded against `106 CMR 364.980`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/110/block-1#is_pa_household
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `is_pa_household`, grounded against `106 CMR 365.110 (PA household definition)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `is_pa_household`, grounded against `106 CMR 365.110 (PA household definition)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/120/block-1#snap_initial_processing_period_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_initial_processing_period_days`, grounded against `106 CMR 365.120 (initial 30-day period)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_initial_processing_period_days`, grounded against `106 CMR 365.120 (initial 30-day period)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/120/block-1#snap_maximum_processing_period_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_maximum_processing_period_days`, grounded against `106 CMR 365.120 (more than 60 days reapplication threshold)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_maximum_processing_period_days`, grounded against `106 CMR 365.120 (more than 60 days reapplication threshold)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/120/block-1#snap_benefits_start_from_application_date
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_benefits_start_from_application_date`, grounded against `106 CMR 365.120 (benefits from date of application if verification within initial 30 days)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_benefits_start_from_application_date`, grounded against `106 CMR 365.120 (benefits from date of application if verification within initial 30 days)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/120/block-1#snap_benefits_start_from_completion_date
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_benefits_start_from_completion_date`, grounded against `106 CMR 365.120 (benefits from completion/verification date if completed in second 30 days)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_benefits_start_from_completion_date`, grounded against `106 CMR 365.120 (benefits from completion/verification date if completed in second 30 days)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/120/block-1#snap_reapplication_required
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_reapplication_required`, grounded against `106 CMR 365.120 (reapplication required after 60 days)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_reapplication_required`, grounded against `106 CMR 365.120 (reapplication required after 60 days)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/130/block-1#person_exempt_from_snap_work_requirements
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_exempt_from_snap_work_requirements`, grounded against `106 CMR 365.130`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_exempt_from_snap_work_requirements`, grounded against `106 CMR 365.130`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/130/block-1#snap_benefit_increase_blocked_for_pa_household
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_benefit_increase_blocked_for_pa_household`, grounded against `106 CMR 365.130`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_benefit_increase_blocked_for_pa_household`, grounded against `106 CMR 365.130`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/140/block-1#pa_household_certification_period_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `pa_household_certification_period_months`, grounded against `106 CMR 365.140`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `pa_household_certification_period_months`, grounded against `106 CMR 365.140`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/140/block-1#pa_household_certification_period_end_month
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `pa_household_certification_period_end_month`, grounded against `106 CMR 365.140`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `pa_household_certification_period_end_month`, grounded against `106 CMR 365.140`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/150/block-1#months_without_pa_review_triggering_snap_termination_notice
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `months_without_pa_review_triggering_snap_termination_notice`, grounded against `106 CMR 365.150`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `months_without_pa_review_triggering_snap_termination_notice`, grounded against `106 CMR 365.150`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/150/block-1#snap_termination_notice_required
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_termination_notice_required`, grounded against `106 CMR 365.150`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_termination_notice_required`, grounded against `106 CMR 365.150`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/170/block-1#uninterrupted_benefits_reapplication_deadline_day_of_month
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `uninterrupted_benefits_reapplication_deadline_day_of_month`, grounded against `106 CMR 365.170 - \"files an application by the 15th day of the last month of its certification period\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `uninterrupted_benefits_reapplication_deadline_day_of_month`, grounded against `106 CMR 365.170 - \"files an application by the 15th day of the last month of its certification period\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/170/block-1#household_entitled_to_uninterrupted_snap_benefits
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_entitled_to_uninterrupted_snap_benefits`, grounded against `106 CMR 365.170 - \"shall be entitled to uninterrupted benefits if it files an application by the 15 th day of the last month of its certification period and com`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_entitled_to_uninterrupted_snap_benefits`, grounded against `106 CMR 365.170 - \"shall be entitled to uninterrupted benefits if it files an application by the 15 th day of the last month of its certification period and com`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/170/block-1#snap_benefits_continue_at_previous_level_pending_appeal
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_benefits_continue_at_previous_level_pending_appeal`, grounded against `106 CMR 365.170 - \"If the household decides to appeal and its PA benefits are continued, the household's SNAP benefits shall continue at the previous level.\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_benefits_continue_at_previous_level_pending_appeal`, grounded against `106 CMR 365.170 - \"If the household decides to appeal and its PA benefits are continued, the household's SNAP benefits shall continue at the previous level.\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/170/block-1#snap_termination_notice_required_for_pa_change
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_termination_notice_required_for_pa_change`, grounded against `106 CMR 365.170 - \"If there is insufficient information to determine the effect on the household's SNAP eligibility and benefit level, a Notice of SNAP Terminat`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_termination_notice_required_for_pa_change`, grounded against `106 CMR 365.170 - \"If there is insufficient information to determine the effect on the household's SNAP eligibility and benefit level, a Notice of SNAP Terminat`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/180/block-1#categorical_eligibility_minimum_monthly_benefit
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `categorical_eligibility_minimum_monthly_benefit`, grounded against `106 CMR 365.180`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `categorical_eligibility_minimum_monthly_benefit`, grounded against `106 CMR 365.180`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/180/block-1#small_household_categorical_minimum_snap_benefit
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `small_household_categorical_minimum_snap_benefit`, grounded against `106 CMR 365.180`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `small_household_categorical_minimum_snap_benefit`, grounded against `106 CMR 365.180`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/180/block-1#large_household_snap_benefits_must_be_suspended_for_excess_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `large_household_snap_benefits_must_be_suspended_for_excess_income`, grounded against `106 CMR 365.180`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `large_household_snap_benefits_must_be_suspended_for_excess_income`, grounded against `106 CMR 365.180`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/190/block-1#tba_snap_benefit_period_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `tba_snap_benefit_period_months`, grounded against `106 CMR 365.190 - TBA five-month period`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `tba_snap_benefit_period_months`, grounded against `106 CMR 365.190 - TBA five-month period`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/190/block-1#tss_income_excluded_in_tba_snap_calculation
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `tss_income_excluded_in_tba_snap_calculation`, grounded against `106 CMR 365.190 - TSS income exclusion for TBA NPA SNAP`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `tss_income_excluded_in_tba_snap_calculation`, grounded against `106 CMR 365.190 - TSS income exclusion for TBA NPA SNAP`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/190/block-1#snap_benefits_recalculated_at_tafdc_closing
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_benefits_recalculated_at_tafdc_closing`, grounded against `106 CMR 365.190 - recalculation on reported change at TAFDC closing`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_benefits_recalculated_at_tafdc_closing`, grounded against `106 CMR 365.190 - recalculation on reported change at TAFDC closing`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/190/block-1#tba_case_closes_for_over_income_during_tba_period
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `tba_case_closes_for_over_income_during_tba_period`, grounded against `106 CMR 365.190 - TBA closure for over income on recalculation`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `tba_case_closes_for_over_income_during_tba_period`, grounded against `106 CMR 365.190 - TBA closure for over income on recalculation`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/200/block-1#boarder_payment_is_self_employment_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `boarder_payment_is_self_employment_income`, grounded against `106 CMR 365.200`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `boarder_payment_is_self_employment_income`, grounded against `106 CMR 365.200`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/200/block-1#non_member_boarder_income_and_resources_excluded
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `non_member_boarder_income_and_resources_excluded`, grounded against `106 CMR 365.200`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `non_member_boarder_income_and_resources_excluded`, grounded against `106 CMR 365.200`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/200/block-1#boarder_cost_of_doing_business_allowed
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `boarder_cost_of_doing_business_allowed`, grounded against `106 CMR 365.200`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `boarder_cost_of_doing_business_allowed`, grounded against `106 CMR 365.200`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/200/block-1#boarder_shelter_costs_paid_to_third_party_excluded
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `boarder_shelter_costs_paid_to_third_party_excluded`, grounded against `106 CMR 365.200`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `boarder_shelter_costs_paid_to_third_party_excluded`, grounded against `106 CMR 365.200`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/430/block-1#person_receives_compensation_for_entire_year
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_receives_compensation_for_entire_year`, grounded against `106 CMR 365.430 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_receives_compensation_for_entire_year`, grounded against `106 CMR 365.430 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/510/block-1#nondisqualified_nonhousehold_member_may_be_separate_snap_household
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `nondisqualified_nonhousehold_member_may_be_separate_snap_household`, grounded against `106 CMR 365.510 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `nondisqualified_nonhousehold_member_may_be_separate_snap_household`, grounded against `106 CMR 365.510 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/600/block-1#drug_or_alcohol_treatment_center_resident_may_participate
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `drug_or_alcohol_treatment_center_resident_may_participate`, grounded against `106 CMR 365.600`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `drug_or_alcohol_treatment_center_resident_may_participate`, grounded against `106 CMR 365.600`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/605/block-1#group_living_arrangement_resident_snap_eligibility_not_precluded
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `group_living_arrangement_resident_snap_eligibility_not_precluded`, grounded against `106 CMR 365.605`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `group_living_arrangement_resident_snap_eligibility_not_precluded`, grounded against `106 CMR 365.605`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/610/block-1#qualifying_drug_or_alcohol_treatment_program
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `qualifying_drug_or_alcohol_treatment_program`, grounded against `106 CMR 365.610 block 1, sentence 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `qualifying_drug_or_alcohol_treatment_program`, grounded against `106 CMR 365.610 block 1, sentence 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/610/block-1#resident_applies_for_snap_on_own_behalf
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `resident_applies_for_snap_on_own_behalf`, grounded against `106 CMR 365.610 block 1, sentence 3`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `resident_applies_for_snap_on_own_behalf`, grounded against `106 CMR 365.610 block 1, sentence 3`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/610/block-1#resident_authorized_allotment_transfer_to_center
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `resident_authorized_allotment_transfer_to_center`, grounded against `106 CMR 365.610 block 1, sentence 4`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `resident_authorized_allotment_transfer_to_center`, grounded against `106 CMR 365.610 block 1, sentence 4`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/620/block-1#maximum_residents_for_group_living_arrangement
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `maximum_residents_for_group_living_arrangement`, grounded against `106 CMR 365.620`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `maximum_residents_for_group_living_arrangement`, grounded against `106 CMR 365.620`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/620/block-1#facility_is_certified_group_living_arrangement
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `facility_is_certified_group_living_arrangement`, grounded against `106 CMR 365.620`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `facility_is_certified_group_living_arrangement`, grounded against `106 CMR 365.620`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/620/block-1#resident_eligible_for_snap_in_group_living_arrangement
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `resident_eligible_for_snap_in_group_living_arrangement`, grounded against `106 CMR 365.620`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `resident_eligible_for_snap_in_group_living_arrangement`, grounded against `106 CMR 365.620`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/620/block-1#worker_verified_group_living_arrangement_before_certification
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `worker_verified_group_living_arrangement_before_certification`, grounded against `106 CMR 365.620`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `worker_verified_group_living_arrangement_before_certification`, grounded against `106 CMR 365.620`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/670/block-1#authorized_representative_status_suspended
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `authorized_representative_status_suspended`, grounded against `106 CMR 365.670 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `authorized_representative_status_suspended`, grounded against `106 CMR 365.670 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/700/block-1#person_is_enrolled_in_qualifying_institution
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_is_enrolled_in_qualifying_institution`, grounded against `106 CMR 365.700 (definition of student, first sentence)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_is_enrolled_in_qualifying_institution`, grounded against `106 CMR 365.700 (definition of student, first sentence)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/700/block-1#person_enrolled_at_least_half_time
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_enrolled_at_least_half_time`, grounded against `106 CMR 365.700 (definition of student, first sentence)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_enrolled_at_least_half_time`, grounded against `106 CMR 365.700 (definition of student, first sentence)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/700/block-1#person_status_preserved_during_temporary_break
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_status_preserved_during_temporary_break`, grounded against `106 CMR 365.700 (definition of student, second sentence)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_status_preserved_during_temporary_break`, grounded against `106 CMR 365.700 (definition of student, second sentence)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/700/block-1#student
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `student`, grounded against `106 CMR 365.700 (definition of student)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `student`, grounded against `106 CMR 365.700 (definition of student)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/730/block-1#student_household_asset_exclusion_for_income_averaged_monies
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `student_household_asset_exclusion_for_income_averaged_monies`, grounded against `106 CMR 365.730`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `student_household_asset_exclusion_for_income_averaged_monies`, grounded against `106 CMR 365.730`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/810/block-1#member_income_source_unchanged_after_job_change
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `member_income_source_unchanged_after_job_change`, grounded against `106 CMR 365.810 (continuity of income source for same-employer job change)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `member_income_source_unchanged_after_job_change`, grounded against `106 CMR 365.810 (continuity of income source for same-employer job change)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/810/block-1#member_income_source_terminated_by_grower_change
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `member_income_source_terminated_by_grower_change`, grounded against `106 CMR 365.810 (grower-not-crew-chief attribution; new grower terminates prior source)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `member_income_source_terminated_by_grower_change`, grounded against `106 CMR 365.810 (grower-not-crew-chief attribution; new grower terminates prior source)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/810/block-1#travel_advance_disregarded_for_expedited_service
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `travel_advance_disregarded_for_expedited_service`, grounded against `106 CMR 365.810 (travel advances disregarded for expedited service)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `travel_advance_disregarded_for_expedited_service`, grounded against `106 CMR 365.810 (travel advances disregarded for expedited service)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/830/block-1#household_identity_verified
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_identity_verified`, grounded against `106 CMR 365.830 - \"The household's identity is the only eligibility factor that must be verified before expedited service is provided.\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_identity_verified`, grounded against `106 CMR 365.830 - \"The household's identity is the only eligibility factor that must be verified before expedited service is provided.\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/830/block-1#all_required_members_registered_for_work
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `all_required_members_registered_for_work`, grounded against `106 CMR 365.830 - \"Every household member required to meet SNAP Work Requirements must register for work before expedited service is provided\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `all_required_members_registered_for_work`, grounded against `106 CMR 365.830 - \"Every household member required to meet SNAP Work Requirements must register for work before expedited service is provided\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/830/block-1#expedited_service_pre_certification_requirements_met
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `expedited_service_pre_certification_requirements_met`, grounded against `106 CMR 365.830 - identity must always be verified and required members must register for work before expedited service is provided`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `expedited_service_pre_certification_requirements_met`, grounded against `106 CMR 365.830 - identity must always be verified and required members must register for work before expedited service is provided`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/830/block-1#ssn_requirements_required_before_expedited_service
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ssn_requirements_required_before_expedited_service`, grounded against `106 CMR 365.830 - \"The Social Security number requirements of 106 CMR 362.500 ... do not have to be met before expedited service is provided.\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ssn_requirements_required_before_expedited_service`, grounded against `106 CMR 365.830 - \"The Social Security number requirements of 106 CMR 362.500 ... do not have to be met before expedited service is provided.\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/840/block-1#anticipated_income_in_month_of_application_disregarded
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `anticipated_income_in_month_of_application_disregarded`, grounded against `106 CMR 365.840`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `anticipated_income_in_month_of_application_disregarded`, grounded against `106 CMR 365.840`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/840/block-1#travel_advance_disregarded_as_reimbursement
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `travel_advance_disregarded_as_reimbursement`, grounded against `106 CMR 365.840`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `travel_advance_disregarded_as_reimbursement`, grounded against `106 CMR 365.840`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/840/block-1#travel_advance_counted_as_income_under_written_contract
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `travel_advance_counted_as_income_under_written_contract`, grounded against `106 CMR 365.840`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `travel_advance_counted_as_income_under_written_contract`, grounded against `106 CMR 365.840`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/840/block-1#proration_of_initial_month_benefits_applies
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `proration_of_initial_month_benefits_applies`, grounded against `106 CMR 365.840`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `proration_of_initial_month_benefits_applies`, grounded against `106 CMR 365.840`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/850/block-1#third_month_benefits_processing_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `third_month_benefits_processing_days`, grounded against `106 CMR 365.850`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `third_month_benefits_processing_days`, grounded against `106 CMR 365.850`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/850/block-1#destitute_migrant_household_third_month_verification_required
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `destitute_migrant_household_third_month_verification_required`, grounded against `106 CMR 365.850 (destitute migrant verification requirement)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `destitute_migrant_household_third_month_verification_required`, grounded against `106 CMR 365.850 (destitute migrant verification requirement)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/850/block-1#destitute_migrant_household_third_month_benefits_issuable
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `destitute_migrant_household_third_month_benefits_issuable`, grounded against `106 CMR 365.850 (third month issuance condition)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `destitute_migrant_household_third_month_benefits_issuable`, grounded against `106 CMR 365.850 (third month issuance condition)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/910/block-1#commercial_boarding_house_income_is_self_employment
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `commercial_boarding_house_income_is_self_employment`, grounded against `106 CMR 365.910 block 1 (roomers, rental property, and boarders of a commercial boarding house)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `commercial_boarding_house_income_is_self_employment`, grounded against `106 CMR 365.910 block 1 (roomers, rental property, and boarders of a commercial boarding house)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/910/block-1#non_commercial_boarder_income_is_self_employment
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `non_commercial_boarder_income_is_self_employment`, grounded against `106 CMR 365.910 block 1 (boarder income other than commercial boarding house)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `non_commercial_boarder_income_is_self_employment`, grounded against `106 CMR 365.910 block 1 (boarder income other than commercial boarding house)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/920/block-1#self_employed_household_member_must_comply_with_work_requirements
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `self_employed_household_member_must_comply_with_work_requirements`, grounded against `106 CMR 365.920`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `self_employed_household_member_must_comply_with_work_requirements`, grounded against `106 CMR 365.920`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/940/block-1#allowable_self_employment_cost
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `allowable_self_employment_cost`, grounded against `106 CMR 365.940`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `allowable_self_employment_cost`, grounded against `106 CMR 365.940`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/970/block-1#farm_self_employment_minimum_annual_gross_proceeds
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `farm_self_employment_minimum_annual_gross_proceeds`, grounded against `106 CMR 365.970`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `farm_self_employment_minimum_annual_gross_proceeds`, grounded against `106 CMR 365.970`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/365/970/block-1#farm_self_employment_loss_offsets_other_countable_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `farm_self_employment_loss_offsets_other_countable_income`, grounded against `106 CMR 365.970`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `farm_self_employment_loss_offsets_other_countable_income`, grounded against `106 CMR 365.970`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/110/block-1#edsap_elderly_age_threshold
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `edsap_elderly_age_threshold`, grounded against `106 CMR 366.110(A) - \"elderly (age 60 or more)\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `edsap_elderly_age_threshold`, grounded against `106 CMR 366.110(A) - \"elderly (age 60 or more)\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/110/block-1#edsap_child_age_threshold
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `edsap_child_age_threshold`, grounded against `106 CMR 366.110(A) - \"Children (less than 18 years old)\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `edsap_child_age_threshold`, grounded against `106 CMR 366.110(A) - \"Children (less than 18 years old)\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/110/block-1#edsap_certification_period_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `edsap_certification_period_months`, grounded against `106 CMR 366.110(A) - \"EDSAP households are certified for 36 months\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `edsap_certification_period_months`, grounded against `106 CMR 366.110(A) - \"EDSAP households are certified for 36 months\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/110/block-1#person_qualifies_for_edsap_household
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_qualifies_for_edsap_household`, grounded against `106 CMR 366.110(A) - EDSAP households include elderly or disabled members; children may also be included`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_qualifies_for_edsap_household`, grounded against `106 CMR 366.110(A) - EDSAP households include elderly or disabled members; children may also be included`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/110/block-1#household_is_edsap
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_is_edsap`, grounded against `106 CMR 366.110(A) - EDSAP households include elderly or disabled members`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_is_edsap`, grounded against `106 CMR 366.110(A) - EDSAP households include elderly or disabled members`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/110/block-1#edsap_household_must_report_change
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `edsap_household_must_report_change`, grounded against `106 CMR 366.110(A) - During the certification period, EDSAP households must report changes in household composition and whenever any household member begins to `). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `edsap_household_must_report_change`, grounded against `106 CMR 366.110(A) - During the certification period, EDSAP households must report changes in household composition and whenever any household member begins to `). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/110/block-1#edsap_household_required_to_complete_interim_report
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `edsap_household_required_to_complete_interim_report`, grounded against `106 CMR 366.110(A) - \"EDSAP households are not required to complete an Interim Report.\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `edsap_household_required_to_complete_interim_report`, grounded against `106 CMR 366.110(A) - \"EDSAP households are not required to complete an Interim Report.\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/110/block-1#information_is_verified_upon_receipt
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `information_is_verified_upon_receipt`, grounded against `106 CMR 366.110(A) - The Department considers information to be verified upon receipt when the information is not questionable and the provider is the primary s`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `information_is_verified_upon_receipt`, grounded against `106 CMR 366.110(A) - The Department considers information to be verified upon receipt when the information is not questionable and the provider is the primary s`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/130/block-1#mass_change_advance_notice_days_threshold
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `mass_change_advance_notice_days_threshold`, grounded against `106 CMR 366.130 (block 1)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `mass_change_advance_notice_days_threshold`, grounded against `106 CMR 366.130 (block 1)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/130/block-1#snap_mass_change_effective_same_month_as_pa_change
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_mass_change_effective_same_month_as_pa_change`, grounded against `106 CMR 366.130 (block 1)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_mass_change_effective_same_month_as_pa_change`, grounded against `106 CMR 366.130 (block 1)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/130/block-1#snap_mass_change_effective_month_following_pa_change
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_mass_change_effective_month_following_pa_change`, grounded against `106 CMR 366.130 (block 1)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_mass_change_effective_month_following_pa_change`, grounded against `106 CMR 366.130 (block 1)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/140/block-1#pa_household_change_reported_for_snap
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `pa_household_change_reported_for_snap`, grounded against `106 CMR 366.140`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `pa_household_change_reported_for_snap`, grounded against `106 CMR 366.140`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/200/block-1#minimum_advance_notice_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `minimum_advance_notice_days`, grounded against `106 CMR 366.200 (\"at least ten days before the effective date of the proposed action\")`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `minimum_advance_notice_days`, grounded against `106 CMR 366.200 (\"at least ten days before the effective date of the proposed action\")`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/200/block-1#notice_of_adverse_action_is_timely
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `notice_of_adverse_action_is_timely`, grounded against `106 CMR 366.200 (\"The notice of adverse action shall be considered timely if it is mailed to the household at least ten days before the effective date of the pr`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `notice_of_adverse_action_is_timely`, grounded against `106 CMR 366.200 (\"The notice of adverse action shall be considered timely if it is mailed to the household at least ten days before the effective date of the pr`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/200/block-1#advance_notice_of_adverse_action_required
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `advance_notice_of_adverse_action_required`, grounded against `106 CMR 366.200 (\"Before taking action to reduce or terminate a household's benefits during the certification period, the worker shall, except as specified in 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `advance_notice_of_adverse_action_required`, grounded against `106 CMR 366.200 (\"Before taking action to reduce or terminate a household's benefits during the certification period, the worker shall, except as specified in 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/215/block-1#notice_of_reduction_or_termination_is_timely
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `notice_of_reduction_or_termination_is_timely`, grounded against `106 CMR 366.215 (block 1)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `notice_of_reduction_or_termination_is_timely`, grounded against `106 CMR 366.215 (block 1)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/220/block-1#benefits_continued_at_prior_level
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `benefits_continued_at_prior_level`, grounded against `106 CMR 366.220`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `benefits_continued_at_prior_level`, grounded against `106 CMR 366.220`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/220/block-1#benefits_reinstated_to_prior_level
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `benefits_reinstated_to_prior_level`, grounded against `106 CMR 366.220`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `benefits_reinstated_to_prior_level`, grounded against `106 CMR 366.220`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/220/block-1#benefits_reduced_or_terminated_as_proposed
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `benefits_reduced_or_terminated_as_proposed`, grounded against `106 CMR 366.220`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `benefits_reduced_or_terminated_as_proposed`, grounded against `106 CMR 366.220`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/300/block-1#household_entitled_to_uninterrupted_benefits
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_entitled_to_uninterrupted_benefits`, grounded against `106 CMR 366.300`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_entitled_to_uninterrupted_benefits`, grounded against `106 CMR 366.300`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/300/block-1#household_snap_benefits_continue
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_snap_benefits_continue`, grounded against `106 CMR 366.300`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_snap_benefits_continue`, grounded against `106 CMR 366.300`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/300/block-1#household_recertification_complete
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_recertification_complete`, grounded against `106 CMR 366.300`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_recertification_complete`, grounded against `106 CMR 366.300`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/320/block-1#timely_reapplication_day_of_month
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `timely_reapplication_day_of_month`, grounded against `106 CMR 366.320 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `timely_reapplication_day_of_month`, grounded against `106 CMR 366.320 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/320/block-1#household_timely_reapplied
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_timely_reapplied`, grounded against `106 CMR 366.320 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_timely_reapplied`, grounded against `106 CMR 366.320 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/320/block-1#pure_ssi_household_timely_recertification_at_ssa
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `pure_ssi_household_timely_recertification_at_ssa`, grounded against `106 CMR 366.320 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `pure_ssi_household_timely_recertification_at_ssa`, grounded against `106 CMR 366.320 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/320/block-1#pure_ssi_household_exempt_from_second_interview
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `pure_ssi_household_exempt_from_second_interview`, grounded against `106 CMR 366.320 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `pure_ssi_household_exempt_from_second_interview`, grounded against `106 CMR 366.320 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/320/block-1#verification_response_timeframe_is_valid
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `verification_response_timeframe_is_valid`, grounded against `106 CMR 366.320 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `verification_response_timeframe_is_valid`, grounded against `106 CMR 366.320 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/320/block-1#noncountable_income_must_be_verified
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `noncountable_income_must_be_verified`, grounded against `106 CMR 366.320 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `noncountable_income_must_be_verified`, grounded against `106 CMR 366.320 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/330/block-1#department_must_issue_recertification_determination_by_end_of_current_certification_period
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `department_must_issue_recertification_determination_by_end_of_current_certification_period`, grounded against `106 CMR 366.330`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `department_must_issue_recertification_determination_by_end_of_current_certification_period`, grounded against `106 CMR 366.330`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/340/block-1#post_termination_notice_filing_window_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `post_termination_notice_filing_window_days`, grounded against `106 CMR 366.340`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `post_termination_notice_filing_window_days`, grounded against `106 CMR 366.340`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/340/block-1#untimely_recertification_treated_as_initial_application
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `untimely_recertification_treated_as_initial_application`, grounded against `106 CMR 366.340`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `untimely_recertification_treated_as_initial_application`, grounded against `106 CMR 366.340`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/340/block-1#household_loses_right_to_uninterrupted_benefits
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_loses_right_to_uninterrupted_benefits`, grounded against `106 CMR 366.340`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_loses_right_to_uninterrupted_benefits`, grounded against `106 CMR 366.340`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/340/block-1#recertification_benefits_not_prorated_for_first_month
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `recertification_benefits_not_prorated_for_first_month`, grounded against `106 CMR 366.340`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `recertification_benefits_not_prorated_for_first_month`, grounded against `106 CMR 366.340`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/340/block-1#recertification_application_denied_for_refusal_to_complete_process
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `recertification_application_denied_for_refusal_to_complete_process`, grounded against `106 CMR 366.340`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `recertification_application_denied_for_refusal_to_complete_process`, grounded against `106 CMR 366.340`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/550/block-1#restoration_offset_applies
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `restoration_offset_applies`, grounded against `106 CMR 366.550`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `restoration_offset_applies`, grounded against `106 CMR 366.550`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/550/block-1#restoration_amount_offset_against_claim
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `restoration_amount_offset_against_claim`, grounded against `106 CMR 366.550`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `restoration_amount_offset_against_claim`, grounded against `106 CMR 366.550`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/550/block-1#restoration_balance_to_household
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `restoration_balance_to_household`, grounded against `106 CMR 366.550`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `restoration_balance_to_household`, grounded against `106 CMR 366.550`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/560/block-1#ipv_disqualification_reversed
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ipv_disqualification_reversed`, grounded against `106 CMR 366.560`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ipv_disqualification_reversed`, grounded against `106 CMR 366.560`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/560/block-1#ipv_restoration_entitlement
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ipv_restoration_entitlement`, grounded against `106 CMR 366.560`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ipv_restoration_entitlement`, grounded against `106 CMR 366.560`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/560/block-1#ipv_restoration_amount
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ipv_restoration_amount`, grounded against `106 CMR 366.560`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ipv_restoration_amount`, grounded against `106 CMR 366.560`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/570/block-1#restored_lost_benefits_allotment
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `restored_lost_benefits_allotment`, grounded against `106 CMR 366.570`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `restored_lost_benefits_allotment`, grounded against `106 CMR 366.570`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/580/block-1#household_receives_restored_lost_benefits
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_receives_restored_lost_benefits`, grounded against `106 CMR 366.580`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_receives_restored_lost_benefits`, grounded against `106 CMR 366.580`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/366/610/block-1#disaster_snap_benefit
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `disaster_snap_benefit`, grounded against `106 CMR 366.610`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `disaster_snap_benefit`, grounded against `106 CMR 366.610`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/025/block-1#snap_fair_hearing_available
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_fair_hearing_available`, grounded against `106 CMR 367.025`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_fair_hearing_available`, grounded against `106 CMR 367.025`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/100/block-1#prior_loss_hearing_request_window_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `prior_loss_hearing_request_window_days`, grounded against `106 CMR 367.100, block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `prior_loss_hearing_request_window_days`, grounded against `106 CMR 367.100, block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/100/block-1#restoration_denial_prior_loss_lower_bound_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `restoration_denial_prior_loss_lower_bound_days`, grounded against `106 CMR 367.100, block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `restoration_denial_prior_loss_lower_bound_days`, grounded against `106 CMR 367.100, block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/100/block-1#restoration_denial_prior_loss_upper_bound_years
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `restoration_denial_prior_loss_upper_bound_years`, grounded against `106 CMR 367.100, block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `restoration_denial_prior_loss_upper_bound_years`, grounded against `106 CMR 367.100, block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/100/block-1#restoration_denial_included_as_department_action
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `restoration_denial_included_as_department_action`, grounded against `106 CMR 367.100, block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `restoration_denial_included_as_department_action`, grounded against `106 CMR 367.100, block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/100/block-1#department_action_for_hearing_request
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `department_action_for_hearing_request`, grounded against `106 CMR 367.100, block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `department_action_for_hearing_request`, grounded against `106 CMR 367.100, block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/100/block-1#household_allowed_to_request_fair_hearing
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_allowed_to_request_fair_hearing`, grounded against `106 CMR 367.100, block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_allowed_to_request_fair_hearing`, grounded against `106 CMR 367.100, block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/125/block-1#request_for_hearing
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `request_for_hearing`, grounded against `106 CMR 367.125`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `request_for_hearing`, grounded against `106 CMR 367.125`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/200/block-1#maximum_hearing_postponement_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `maximum_hearing_postponement_days`, grounded against `106 CMR 367.200`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `maximum_hearing_postponement_days`, grounded against `106 CMR 367.200`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/200/block-1#hearing_decision_time_limit_extension_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `hearing_decision_time_limit_extension_days`, grounded against `106 CMR 367.200`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `hearing_decision_time_limit_extension_days`, grounded against `106 CMR 367.200`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/275/block-1#continuation_of_benefits_pending_appeal_applies
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `continuation_of_benefits_pending_appeal_applies`, grounded against `106 CMR 367.275`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `continuation_of_benefits_pending_appeal_applies`, grounded against `106 CMR 367.275`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/275/block-1#benefits_reinstated_to_prior_level_for_untimely_request
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `benefits_reinstated_to_prior_level_for_untimely_request`, grounded against `106 CMR 367.275`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `benefits_reinstated_to_prior_level_for_untimely_request`, grounded against `106 CMR 367.275`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/275/block-1#mass_change_prior_level_reinstatement_applies
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `mass_change_prior_level_reinstatement_applies`, grounded against `106 CMR 367.275`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `mass_change_prior_level_reinstatement_applies`, grounded against `106 CMR 367.275`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/325/block-1#minimum_hearing_notice_weeks
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `minimum_hearing_notice_weeks`, grounded against `106 CMR 367.325`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `minimum_hearing_notice_weeks`, grounded against `106 CMR 367.325`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/325/block-1#hearing_notice_satisfies_advance_notice_requirement
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `hearing_notice_satisfies_advance_notice_requirement`, grounded against `106 CMR 367.325`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `hearing_notice_satisfies_advance_notice_requirement`, grounded against `106 CMR 367.325`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/325/block-1#hearing_arrangement_is_accessible_to_household
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `hearing_arrangement_is_accessible_to_household`, grounded against `106 CMR 367.325`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `hearing_arrangement_is_accessible_to_household`, grounded against `106 CMR 367.325`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/490/block-1#claim_for_overissuance_must_be_established
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `claim_for_overissuance_must_be_established`, grounded against `106 CMR 367.490`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `claim_for_overissuance_must_be_established`, grounded against `106 CMR 367.490`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/490/block-1#adult_members_jointly_and_severally_liable_for_overissuance
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `adult_members_jointly_and_severally_liable_for_overissuance`, grounded against `106 CMR 367.490`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `adult_members_jointly_and_severally_liable_for_overissuance`, grounded against `106 CMR 367.490`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/495/block-1#unintentional_claim_max_lookback_years
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `unintentional_claim_max_lookback_years`, grounded against `106 CMR 367.495`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `unintentional_claim_max_lookback_years`, grounded against `106 CMR 367.495`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/495/block-1#agency_error_max_effective_lookback_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `agency_error_max_effective_lookback_months`, grounded against `106 CMR 367.495`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `agency_error_max_effective_lookback_months`, grounded against `106 CMR 367.495`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/495/block-1#repayment_agreement_response_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `repayment_agreement_response_days`, grounded against `106 CMR 367.495`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `repayment_agreement_response_days`, grounded against `106 CMR 367.495`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/495/block-1#unintentional_claim_within_lookback
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `unintentional_claim_within_lookback`, grounded against `106 CMR 367.495`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `unintentional_claim_within_lookback`, grounded against `106 CMR 367.495`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/495/block-1#agency_error_effective_month_within_cap
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `agency_error_effective_month_within_cap`, grounded against `106 CMR 367.495`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `agency_error_effective_month_within_cap`, grounded against `106 CMR 367.495`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/495/block-1#automatic_benefit_reduction_triggered
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `automatic_benefit_reduction_triggered`, grounded against `106 CMR 367.495`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `automatic_benefit_reduction_triggered`, grounded against `106 CMR 367.495`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/500/block-1#overissuance_claim_pursued_as_ipv
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `overissuance_claim_pursued_as_ipv`, grounded against `106 CMR 367.500`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `overissuance_claim_pursued_as_ipv`, grounded against `106 CMR 367.500`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/500/block-1#first_month_of_overissuance_for_unreported_change
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `first_month_of_overissuance_for_unreported_change`, grounded against `106 CMR 367.500`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `first_month_of_overissuance_for_unreported_change`, grounded against `106 CMR 367.500`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/510/block-1#unintentional_violation_benefit_reduction_rate
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `unintentional_violation_benefit_reduction_rate`, grounded against `106 CMR 367.510 (unintentional program violation - 10%)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `unintentional_violation_benefit_reduction_rate`, grounded against `106 CMR 367.510 (unintentional program violation - 10%)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/510/block-1#unintentional_violation_benefit_reduction_minimum
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `unintentional_violation_benefit_reduction_minimum`, grounded against `106 CMR 367.510 (unintentional program violation - $10 minimum)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `unintentional_violation_benefit_reduction_minimum`, grounded against `106 CMR 367.510 (unintentional program violation - $10 minimum)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/510/block-1#intentional_violation_benefit_reduction_rate
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `intentional_violation_benefit_reduction_rate`, grounded against `106 CMR 367.510 (intentional program violation - 20%)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `intentional_violation_benefit_reduction_rate`, grounded against `106 CMR 367.510 (intentional program violation - 20%)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/510/block-1#intentional_violation_benefit_reduction_minimum
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `intentional_violation_benefit_reduction_minimum`, grounded against `106 CMR 367.510 (intentional program violation - $20 minimum)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `intentional_violation_benefit_reduction_minimum`, grounded against `106 CMR 367.510 (intentional program violation - $20 minimum)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/510/block-1#claim_adjustment_payoff_period_years
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `claim_adjustment_payoff_period_years`, grounded against `106 CMR 367.510 (three-year claim adjustment period)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `claim_adjustment_payoff_period_years`, grounded against `106 CMR 367.510 (three-year claim adjustment period)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/510/block-1#repayment_start_days_from_agreement
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `repayment_start_days_from_agreement`, grounded against `106 CMR 367.510 (repayment begins no later than 30 days from mailing)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `repayment_start_days_from_agreement`, grounded against `106 CMR 367.510 (repayment begins no later than 30 days from mailing)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/510/block-1#minimum_installment_or_wage_assignment_payment
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `minimum_installment_or_wage_assignment_payment`, grounded against `106 CMR 367.510 (installment/wage assignment floor equals automatic benefit reduction)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `minimum_installment_or_wage_assignment_payment`, grounded against `106 CMR 367.510 (installment/wage assignment floor equals automatic benefit reduction)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/510/block-1#claim_compromise_floor
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `claim_compromise_floor`, grounded against `106 CMR 367.510 (compromise floor)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `claim_compromise_floor`, grounded against `106 CMR 367.510 (compromise floor)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/510/block-1#benefit_reduction_is_collection_method
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `benefit_reduction_is_collection_method`, grounded against `106 CMR 367.510 (benefit reduction when no agreement)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `benefit_reduction_is_collection_method`, grounded against `106 CMR 367.510 (benefit reduction when no agreement)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/510/block-1#wage_assignment_is_collection_method
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `wage_assignment_is_collection_method`, grounded against `106 CMR 367.510 (wage assignment for employed delinquent former clients)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `wage_assignment_is_collection_method`, grounded against `106 CMR 367.510 (wage assignment for employed delinquent former clients)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_advance_notice_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ipv_hearing_advance_notice_days`, grounded against `106 CMR 367.625 - advance notice of hearing`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_advance_notice_days`, grounded against `106 CMR 367.625 - advance notice of hearing`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_maximum_postponement_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ipv_hearing_maximum_postponement_days`, grounded against `106 CMR 367.625 - postponement of up to 30 days`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_maximum_postponement_days`, grounded against `106 CMR 367.625 - postponement of up to 30 days`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_postponement_request_advance_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ipv_hearing_postponement_request_advance_days`, grounded against `106 CMR 367.625 - postponement request advance days`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_postponement_request_advance_days`, grounded against `106 CMR 367.625 - postponement request advance days`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_decision_time_limit_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ipv_hearing_decision_time_limit_days`, grounded against `106 CMR 367.625 - 90-day hearing/decision time limit`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_decision_time_limit_days`, grounded against `106 CMR 367.625 - 90-day hearing/decision time limit`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_advance_notice_satisfied
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ipv_hearing_advance_notice_satisfied`, grounded against `106 CMR 367.625 - written notice at least 30 days in advance`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_advance_notice_satisfied`, grounded against `106 CMR 367.625 - written notice at least 30 days in advance`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_postponement_request_timely
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ipv_hearing_postponement_request_timely`, grounded against `106 CMR 367.625 - postponement request timeliness`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_postponement_request_timely`, grounded against `106 CMR 367.625 - postponement request timeliness`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_postponement_entitlement
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ipv_hearing_postponement_entitlement`, grounded against `106 CMR 367.625 - entitlement to one postponement of up to 30 days`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_postponement_entitlement`, grounded against `106 CMR 367.625 - entitlement to one postponement of up to 30 days`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_decision_deadline_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ipv_hearing_decision_deadline_days`, grounded against `106 CMR 367.625 - 90-day limit extended by postponement days`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_decision_deadline_days`, grounded against `106 CMR 367.625 - 90-day limit extended by postponement days`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/625/block-1#ipv_hearing_decision_timely
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ipv_hearing_decision_timely`, grounded against `106 CMR 367.625 - hearing held and decision rendered within deadline`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ipv_hearing_decision_timely`, grounded against `106 CMR 367.625 - hearing held and decision rendered within deadline`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/675/block-1#adh_advance_notice_may_be_sent
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `adh_advance_notice_may_be_sent`, grounded against `106 CMR 367.675`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `adh_advance_notice_may_be_sent`, grounded against `106 CMR 367.675`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/700/block-1#good_cause_presentation_period_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `good_cause_presentation_period_days`, grounded against `106 CMR 367.700`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `good_cause_presentation_period_days`, grounded against `106 CMR 367.700`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/700/block-1#adh_conducted_without_household_member
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `adh_conducted_without_household_member`, grounded against `106 CMR 367.700`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `adh_conducted_without_household_member`, grounded against `106 CMR 367.700`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/700/block-1#ipv_determined_by_clear_and_convincing_evidence
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ipv_determined_by_clear_and_convincing_evidence`, grounded against `106 CMR 367.700`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ipv_determined_by_clear_and_convincing_evidence`, grounded against `106 CMR 367.700`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/700/block-1#previous_ipv_decision_invalidated
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `previous_ipv_decision_invalidated`, grounded against `106 CMR 367.700`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `previous_ipv_decision_invalidated`, grounded against `106 CMR 367.700`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/700/block-1#new_hearing_required
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `new_hearing_required`, grounded against `106 CMR 367.700`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `new_hearing_required`, grounded against `106 CMR 367.700`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/700/block-1#good_cause_presentation_timely
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `good_cause_presentation_timely`, grounded against `106 CMR 367.700`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `good_cause_presentation_timely`, grounded against `106 CMR 367.700`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/750/block-1#ipv_determination_supported
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ipv_determination_supported`, grounded against `106 CMR 367.750`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ipv_determination_supported`, grounded against `106 CMR 367.750`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/800/block-1#voluntary_quit_first_finding_disqualification_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `voluntary_quit_first_finding_disqualification_months`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `voluntary_quit_first_finding_disqualification_months`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/800/block-1#voluntary_quit_second_finding_disqualification_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `voluntary_quit_second_finding_disqualification_months`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `voluntary_quit_second_finding_disqualification_months`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/800/block-1#voluntary_quit_third_finding_disqualification_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `voluntary_quit_third_finding_disqualification_months`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `voluntary_quit_third_finding_disqualification_months`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/800/block-1#head_of_household_quit_disqualification_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `head_of_household_quit_disqualification_months`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `head_of_household_quit_disqualification_months`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/800/block-1#person_ineligible_as_fleeing_felon
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_ineligible_as_fleeing_felon`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_ineligible_as_fleeing_felon`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/800/block-1#person_voluntary_quit_disqualification_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_voluntary_quit_disqualification_months`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_voluntary_quit_disqualification_months`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/800/block-1#person_ineligible_due_to_voluntary_quit
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_ineligible_due_to_voluntary_quit`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_ineligible_due_to_voluntary_quit`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/800/block-1#household_ineligible_due_to_head_voluntary_quit
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_ineligible_due_to_head_voluntary_quit`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_ineligible_due_to_head_voluntary_quit`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/800/block-1#household_categorically_eligible_blocked_by_disqualified_member
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_categorically_eligible_blocked_by_disqualified_member`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_categorically_eligible_blocked_by_disqualified_member`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/800/block-1#household_benefit_level_increase_from_ipv_disqualification_prohibited
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_benefit_level_increase_from_ipv_disqualification_prohibited`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_benefit_level_increase_from_ipv_disqualification_prohibited`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/800/block-1#law_enforcement_actively_seeking_established
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `law_enforcement_actively_seeking_established`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `law_enforcement_actively_seeking_established`, grounded against `106 CMR 367.800`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/900/block-1#person_disqualified_for_court_ipv
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_disqualified_for_court_ipv`, grounded against `106 CMR 367.900`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_disqualified_for_court_ipv`, grounded against `106 CMR 367.900`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/925/block-1#disqualification_start_max_days_after_court_order
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `disqualification_start_max_days_after_court_order`, grounded against `106 CMR 367.925`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `disqualification_start_max_days_after_court_order`, grounded against `106 CMR 367.925`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/925/block-1#ipv_disqualification_start_compliant
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ipv_disqualification_start_compliant`, grounded against `106 CMR 367.925`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ipv_disqualification_start_compliant`, grounded against `106 CMR 367.925`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/950/block-1#individual_reinstated_in_program
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `individual_reinstated_in_program`, grounded against `106 CMR 367.950`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `individual_reinstated_in_program`, grounded against `106 CMR 367.950`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/367/950/block-1#benefits_lost_due_to_disqualification_restored
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `benefits_lost_due_to_disqualification_restored`, grounded against `106 CMR 367.950`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `benefits_lost_due_to_disqualification_restored`, grounded against `106 CMR 367.950`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-nc:regulations/10a-ncac/71u/0210/block-1#educational_assistance_is_excepted_scholarship
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `educational_assistance_is_excepted_scholarship`, grounded against `10A NCAC 71U .0210 (additional exclusions clause)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `educational_assistance_is_excepted_scholarship`, grounded against `10A NCAC 71U .0210 (additional exclusions clause)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-nc:regulations/10a-ncac/71u/0210/block-1#additional_excluded_earned_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `additional_excluded_earned_income`, grounded against `10A NCAC 71U .0210 (additional exclusions clause)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `additional_excluded_earned_income`, grounded against `10A NCAC 71U .0210 (additional exclusions clause)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-nc:regulations/10a-ncac/71u/0212/block-1#transitional_fns_benefit_period_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `transitional_fns_benefit_period_months`, grounded against `10A NCAC 71U .0212 (transitional FNS benefits for a period of five months)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `transitional_fns_benefit_period_months`, grounded against `10A NCAC 71U .0212 (transitional FNS benefits for a period of five months)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-nc:regulations/10a-ncac/71u/0212/block-1#household_eligible_for_transitional_fns_benefits
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_eligible_for_transitional_fns_benefits`, grounded against `10A NCAC 71U .0212 (transitional FNS benefits when households lose Work First benefits; not eligible if loss is for enumerated disqualifying reason)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_eligible_for_transitional_fns_benefits`, grounded against `10A NCAC 71U .0212 (transitional FNS benefits when households lose Work First benefits; not eligible if loss is for enumerated disqualifying reason)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-nc:regulations/10a-ncac/71u/0212/block-1#transitional_fns_benefit_amount
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `transitional_fns_benefit_amount`, grounded against `10A NCAC 71U .0212 (FNS benefits shall be no less than the amount received prior to termination of Work First; only adjustment is deletion of Work First benefit`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `transitional_fns_benefit_amount`, grounded against `10A NCAC 71U .0212 (FNS benefits shall be no less than the amount received prior to termination of Work First; only adjustment is deletion of Work First benefit`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-nc:regulations/10a-ncac/71u/0302/block-1#applicant_may_participate_in_food_and_nutrition_services
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `applicant_may_participate_in_food_and_nutrition_services`, grounded against `10A NCAC 71U .0302 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `applicant_may_participate_in_food_and_nutrition_services`, grounded against `10A NCAC 71U .0302 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/03/10/block-1#citizenship_verification_accepted
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `citizenship_verification_accepted`, grounded against `Tenn. Comp. R. & Regs. 1240-01-03-.10`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `citizenship_verification_accepted`, grounded against `Tenn. Comp. R. & Regs. 1240-01-03-.10`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/03/13/block-1#food_stamp_program_ineligibility_period_years
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `food_stamp_program_ineligibility_period_years`, grounded against `1240-1-3-.13`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `food_stamp_program_ineligibility_period_years`, grounded against `1240-1-3-.13`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/03/13/block-1#alien_eligible_for_food_stamp_and_cash_assistance
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `alien_eligible_for_food_stamp_and_cash_assistance`, grounded against `1240-1-3-.13`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `alien_eligible_for_food_stamp_and_cash_assistance`, grounded against `1240-1-3-.13`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/03/13/block-1#alien_eligible_for_food_stamp_program
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `alien_eligible_for_food_stamp_program`, grounded against `1240-1-3-.13`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `alien_eligible_for_food_stamp_program`, grounded against `1240-1-3-.13`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/03/13/block-1#alien_included_in_assistance_group
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `alien_included_in_assistance_group`, grounded against `1240-1-3-.13`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `alien_included_in_assistance_group`, grounded against `1240-1-3-.13`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/03/15/block-1#person_meets_ssn_enumeration_requirement
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_meets_ssn_enumeration_requirement`, grounded against `Tenn. Comp. R. & Regs. 1240-01-03-.15`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_meets_ssn_enumeration_requirement`, grounded against `Tenn. Comp. R. & Regs. 1240-01-03-.15`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/03/15/block-1#food_stamp_member_must_apply_at_dhs_county_office
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `food_stamp_member_must_apply_at_dhs_county_office`, grounded against `Tenn. Comp. R. & Regs. 1240-01-03-.15 (Food Stamps Only)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `food_stamp_member_must_apply_at_dhs_county_office`, grounded against `Tenn. Comp. R. & Regs. 1240-01-03-.15 (Food Stamps Only)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/03/46/block-1#voluntary_quit_minimum_hours_per_week
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `voluntary_quit_minimum_hours_per_week`, grounded against `Tenn. Comp. R. & Regs. 1240-01-03-.46`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `voluntary_quit_minimum_hours_per_week`, grounded against `Tenn. Comp. R. & Regs. 1240-01-03-.46`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/03/46/block-1#voluntary_reduction_hours_per_week_threshold
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `voluntary_reduction_hours_per_week_threshold`, grounded against `Tenn. Comp. R. & Regs. 1240-01-03-.46`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `voluntary_reduction_hours_per_week_threshold`, grounded against `Tenn. Comp. R. & Regs. 1240-01-03-.46`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/03/46/block-1#member_subject_to_food_stamp_disqualification_for_voluntary_quit_or_reduction
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `member_subject_to_food_stamp_disqualification_for_voluntary_quit_or_reduction`, grounded against `Tenn. Comp. R. & Regs. 1240-01-03-.46`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `member_subject_to_food_stamp_disqualification_for_voluntary_quit_or_reduction`, grounded against `Tenn. Comp. R. & Regs. 1240-01-03-.46`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/07/block-1#total_countable_resources
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `total_countable_resources`, grounded against `Tenn. Comp. R. & Regs. 1240-01-04-.07`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `total_countable_resources`, grounded against `Tenn. Comp. R. & Regs. 1240-01-04-.07`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/09/block-1#jointly_owned_resource_totally_inaccessible
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `jointly_owned_resource_totally_inaccessible`, grounded against `Tenn. Comp. R. & Regs. 1240-01-04-.09`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `jointly_owned_resource_totally_inaccessible`, grounded against `Tenn. Comp. R. & Regs. 1240-01-04-.09`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/09/block-1#ineligible_alien_or_disqualified_individual_is_food_stamp_household_member
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `ineligible_alien_or_disqualified_individual_is_food_stamp_household_member`, grounded against `Tenn. Comp. R. & Regs. 1240-01-04-.09`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `ineligible_alien_or_disqualified_individual_is_food_stamp_household_member`, grounded against `Tenn. Comp. R. & Regs. 1240-01-04-.09`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/16/block-1#payment_treated_as_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `payment_treated_as_income`, grounded against `TN Reg. 1240-01-04-.16 block 1`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `payment_treated_as_income`, grounded against `TN Reg. 1240-01-04-.16 block 1`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#household_size
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_size`, grounded against `Tables I-VII row key`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_size`, grounded against `Tables I-VII row key`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_gross_income_standard
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_gross_income_standard`, grounded against `Table I`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_gross_income_standard`, grounded against `Table I`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_gross_income_standard_additional_member
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_gross_income_standard_additional_member`, grounded against `Table I \"For each additional member add $406\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_gross_income_standard_additional_member`, grounded against `Table I \"For each additional member add $406\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_max_net_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_max_net_income`, grounded against `Table II`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_max_net_income`, grounded against `Table II`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_max_net_income_additional_member
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_max_net_income_additional_member`, grounded against `Table II \"For each additional member add $312\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_max_net_income_additional_member`, grounded against `Table II \"For each additional member add $312\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_max_coupon_allotment
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_max_coupon_allotment`, grounded against `Table III`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_max_coupon_allotment`, grounded against `Table III`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_standard_deduction
     country: us
@@ -14961,7 +14961,7 @@ mappings:
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_max_shelter_deduction_non_elderly_disabled`, grounded against `Table IV-B`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_max_shelter_deduction_non_elderly_disabled`, grounded against `Table IV-B`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_standard_utility_allowance
     country: us
@@ -14973,487 +14973,487 @@ mappings:
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_basic_utility_allowance`, grounded against `Table V-B`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_basic_utility_allowance`, grounded against `Table V-B`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_telephone_standard
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_telephone_standard`, grounded against `Food Stamp Standard Telephone Allowance`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_telephone_standard`, grounded against `Food Stamp Standard Telephone Allowance`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_homeless_shelter_standard
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `snap_homeless_shelter_standard`, grounded against `Table VII Homeless Household Shelter Allowance`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `snap_homeless_shelter_standard`, grounded against `Table VII Homeless Household Shelter Allowance`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#assistance_unit_size
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `assistance_unit_size`, grounded against `Table VIII row key`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `assistance_unit_size`, grounded against `Table VIII row key`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#afdc_gross_income_standard
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `afdc_gross_income_standard`, grounded against `Table VIII Gross Income Standard`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `afdc_gross_income_standard`, grounded against `Table VIII Gross Income Standard`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#afdc_consolidated_need_standard
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `afdc_consolidated_need_standard`, grounded against `Table VIII Consolidated Need Standard`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `afdc_consolidated_need_standard`, grounded against `Table VIII Consolidated Need Standard`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#afdc_standard_payment_amount
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `afdc_standard_payment_amount`, grounded against `Table VIII Standard Payment Amount`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `afdc_standard_payment_amount`, grounded against `Table VIII Standard Payment Amount`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#minimum_afdc_payment
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `minimum_afdc_payment`, grounded against `Table VIII Minimum AFDC Payment`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `minimum_afdc_payment`, grounded against `Table VIII Minimum AFDC Payment`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/12/06/block-1#coupon_allotment_excluded_from_income_and_resources
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `coupon_allotment_excluded_from_income_and_resources`, grounded against `TN Reg 1240-01-12-.06`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `coupon_allotment_excluded_from_income_and_resources`, grounded against `TN Reg 1240-01-12-.06`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/14/09/block-1#gross_income_limit_rate
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `gross_income_limit_rate`, grounded against `1240-01-14-.09 (gross income limit of 130 percent)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `gross_income_limit_rate`, grounded against `1240-01-14-.09 (gross income limit of 130 percent)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/14/09/block-1#gross_income_test_applies
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `gross_income_test_applies`, grounded against `1240-01-14-.09 (households without elderly or disabled member subject to gross income limit)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `gross_income_test_applies`, grounded against `1240-01-14-.09 (households without elderly or disabled member subject to gross income limit)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/14/09/block-1#household_passes_gross_income_test
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_passes_gross_income_test`, grounded against `1240-01-14-.09 (if monthly income exceeds Table I, household is ineligible)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_passes_gross_income_test`, grounded against `1240-01-14-.09 (if monthly income exceeds Table I, household is ineligible)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/14/09/block-1#household_passes_net_income_test
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_passes_net_income_test`, grounded against `1240-01-14-.09 (all households subject to net monthly income standards in Table II)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_passes_net_income_test`, grounded against `1240-01-14-.09 (all households subject to net monthly income standards in Table II)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/14/09/block-1#household_financially_eligible
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_financially_eligible`, grounded against `1240-01-14-.09 (financial eligibility determination)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_financially_eligible`, grounded against `1240-01-14-.09 (financial eligibility determination)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/14/11/block-1#eligibility_notice_deadline_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `eligibility_notice_deadline_days`, grounded against `Tenn. Comp. R. & Regs. 1240-01-14-.11`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `eligibility_notice_deadline_days`, grounded against `Tenn. Comp. R. & Regs. 1240-01-14-.11`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/14/11/block-1#eligibility_notice_timely
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `eligibility_notice_timely`, grounded against `Tenn. Comp. R. & Regs. 1240-01-14-.11`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `eligibility_notice_timely`, grounded against `Tenn. Comp. R. & Regs. 1240-01-14-.11`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-fl:regulations/fac/65a-1/711/block-1#person_considered_florida_resident_for_medicaid
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_considered_florida_resident_for_medicaid`, grounded against `Fla. Admin. Code r. 65A-1.711 (Florida temporary residents may be considered residents on a case-by-case basis if intent and verification are shown)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_considered_florida_resident_for_medicaid`, grounded against `Fla. Admin. Code r. 65A-1.711 (Florida temporary residents may be considered residents on a case-by-case basis if intent and verification are shown)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-fl:regulations/fac/65a-1/711/block-1#person_may_qualify_for_breast_and_cervical_cancer_treatment_medicaid
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_may_qualify_for_breast_and_cervical_cancer_treatment_medicaid`, grounded against `Fla. Admin. Code r. 65A-1.711 (exception that individuals who are neither aged nor disabled may qualify for breast and cervical cancer treatment)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_may_qualify_for_breast_and_cervical_cancer_treatment_medicaid`, grounded against `Fla. Admin. Code r. 65A-1.711 (exception that individuals who are neither aged nor disabled may qualify for breast and cervical cancer treatment)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-13#student_minimum_age
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `student_minimum_age`, grounded against `IDAPA 16.03.04.012.17`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `student_minimum_age`, grounded against `IDAPA 16.03.04.012.17`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-13#student_maximum_age
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `student_maximum_age`, grounded against `IDAPA 16.03.04.012.17`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `student_maximum_age`, grounded against `IDAPA 16.03.04.012.17`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-13#timely_notice_minimum_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `timely_notice_minimum_days`, grounded against `IDAPA 16.03.04.012.22`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `timely_notice_minimum_days`, grounded against `IDAPA 16.03.04.012.22`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-13#person_qualifies_as_student
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_qualifies_as_student`, grounded against `IDAPA 16.03.04.012.17`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_qualifies_as_student`, grounded against `IDAPA 16.03.04.012.17`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-13#household_is_seasonal_farmworker_household
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_is_seasonal_farmworker_household`, grounded against `IDAPA 16.03.04.012.12`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_is_seasonal_farmworker_household`, grounded against `IDAPA 16.03.04.012.12`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-13#persons_are_spouses
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `persons_are_spouses`, grounded against `IDAPA 16.03.04.012.14`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `persons_are_spouses`, grounded against `IDAPA 16.03.04.012.14`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-13#person_is_self_employed
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_is_self_employed`, grounded against `IDAPA 16.03.04.012.13`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_is_self_employed`, grounded against `IDAPA 16.03.04.012.13`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-13#notice_is_timely
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `notice_is_timely`, grounded against `IDAPA 16.03.04.012.22`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `notice_is_timely`, grounded against `IDAPA 16.03.04.012.22`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-16#authorized_representative_removal_maximum_period
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `authorized_representative_removal_maximum_period`, grounded against `IDAPA 16.03.04.115.04`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `authorized_representative_removal_maximum_period`, grounded against `IDAPA 16.03.04.115.04`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-16#application_denied_for_refusal_to_cooperate
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `application_denied_for_refusal_to_cooperate`, grounded against `IDAPA 16.03.04.113`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `application_denied_for_refusal_to_cooperate`, grounded against `IDAPA 16.03.04.113`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-16#household_eligible_after_refusal_to_cooperate
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `household_eligible_after_refusal_to_cooperate`, grounded against `IDAPA 16.03.04.113`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `household_eligible_after_refusal_to_cooperate`, grounded against `IDAPA 16.03.04.113`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-16#application_may_be_withdrawn
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `application_may_be_withdrawn`, grounded against `IDAPA 16.03.04.114`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `application_may_be_withdrawn`, grounded against `IDAPA 16.03.04.114`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-16#person_has_conflict_of_interest_as_authorized_representative
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_has_conflict_of_interest_as_authorized_representative`, grounded against `IDAPA 16.03.04.115.02`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_has_conflict_of_interest_as_authorized_representative`, grounded against `IDAPA 16.03.04.115.02`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-16#person_may_act_as_authorized_representative
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `person_may_act_as_authorized_representative`, grounded against `IDAPA 16.03.04.115.02`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `person_may_act_as_authorized_representative`, grounded against `IDAPA 16.03.04.115.02`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-16#authorized_representative_may_be_removed
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `authorized_representative_may_be_removed`, grounded against `IDAPA 16.03.04.115.04`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `authorized_representative_may_be_removed`, grounded against `IDAPA 16.03.04.115.04`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-20#postponed_proof_days_non_migrant
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `postponed_proof_days_non_migrant`, grounded against `IDAPA 16.03.04.160.02.b`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `postponed_proof_days_non_migrant`, grounded against `IDAPA 16.03.04.160.02.b`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-20#postponed_proof_days_migrant_in_state
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `postponed_proof_days_migrant_in_state`, grounded against `IDAPA 16.03.04.160.03.b, .04.b`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `postponed_proof_days_migrant_in_state`, grounded against `IDAPA 16.03.04.160.03.b, .04.b`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-20#postponed_proof_days_migrant_out_of_state
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `postponed_proof_days_migrant_out_of_state`, grounded against `IDAPA 16.03.04.160.03.b, .04.b`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `postponed_proof_days_migrant_out_of_state`, grounded against `IDAPA 16.03.04.160.03.b, .04.b`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-20#migrant_late_out_of_state_issuance_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `migrant_late_out_of_state_issuance_days`, grounded against `IDAPA 16.03.04.160.03.c, .04.c`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `migrant_late_out_of_state_issuance_days`, grounded against `IDAPA 16.03.04.160.03.c, .04.c`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-20#non_migrant_case_closes_for_postponed_proof
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `non_migrant_case_closes_for_postponed_proof`, grounded against `IDAPA 16.03.04.160.02.c`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `non_migrant_case_closes_for_postponed_proof`, grounded against `IDAPA 16.03.04.160.02.c`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-20#migrant_case_closes_for_in_state_proof
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `migrant_case_closes_for_in_state_proof`, grounded against `IDAPA 16.03.04.160.03.c, .04.c`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `migrant_case_closes_for_in_state_proof`, grounded against `IDAPA 16.03.04.160.03.c, .04.c`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-20#migrant_case_closes_for_out_of_state_proof
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `migrant_case_closes_for_out_of_state_proof`, grounded against `IDAPA 16.03.04.160.03.c, .04.c`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `migrant_case_closes_for_out_of_state_proof`, grounded against `IDAPA 16.03.04.160.03.c, .04.c`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-id:regulations/idapa/16/03/04/page-20#reapplying_household_requires_postponed_proof_for_expedited
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `reapplying_household_requires_postponed_proof_for_expedited`, grounded against `IDAPA 16.03.04.160.05`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `reapplying_household_requires_postponed_proof_for_expedited`, grounded against `IDAPA 16.03.04.160.05`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/1/03/block-1#first_violation_minimum_disqualification_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `first_violation_minimum_disqualification_months`, grounded against `AL 660-4-1-.03 first violation`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `first_violation_minimum_disqualification_months`, grounded against `AL 660-4-1-.03 first violation`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/1/03/block-1#second_violation_minimum_disqualification_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `second_violation_minimum_disqualification_months`, grounded against `AL 660-4-1-.03 second violation`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `second_violation_minimum_disqualification_months`, grounded against `AL 660-4-1-.03 second violation`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/1/03/block-1#third_violation_minimum_disqualification_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `third_violation_minimum_disqualification_months`, grounded against `AL 660-4-1-.03 third violation`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `third_violation_minimum_disqualification_months`, grounded against `AL 660-4-1-.03 third violation`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/1/03/block-1#abawd_caseload_exemption_share
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `abawd_caseload_exemption_share`, grounded against `AL 660-4-1-.03 Balanced Budget Act of 1997 ABAWD exemption`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `abawd_caseload_exemption_share`, grounded against `AL 660-4-1-.03 Balanced Budget Act of 1997 ABAWD exemption`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/1/03/block-1#abawd_time_limit_period_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `abawd_time_limit_period_months`, grounded against `AL 660-4-1-.03 ABAWD 36-month period`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `abawd_time_limit_period_months`, grounded against `AL 660-4-1-.03 ABAWD 36-month period`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/1/03/block-1#abawd_work_hours_threshold_per_week
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `abawd_work_hours_threshold_per_week`, grounded against `AL 660-4-1-.03 ABAWD work hours threshold`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `abawd_work_hours_threshold_per_week`, grounded against `AL 660-4-1-.03 ABAWD work hours threshold`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/1/03/block-1#minimum_disqualification_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `minimum_disqualification_months`, grounded against `AL 660-4-1-.03 violation tier selection`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `minimum_disqualification_months`, grounded against `AL 660-4-1-.03 violation tier selection`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/03/block-1#member_disqualified_for_ssn_noncompliance
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `member_disqualified_for_ssn_noncompliance`, grounded against `Alabama FAP Manual 660-4-2-.03`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `member_disqualified_for_ssn_noncompliance`, grounded against `Alabama FAP Manual 660-4-2-.03`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/03/block-1#member_satisfies_ssn_requirement
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `member_satisfies_ssn_requirement`, grounded against `Alabama FAP Manual 660-4-2-.03`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `member_satisfies_ssn_requirement`, grounded against `Alabama FAP Manual 660-4-2-.03`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/06/block-1#self_employment_cost_of_doing_business_rate
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `self_employment_cost_of_doing_business_rate`, grounded against `AL 660-4-2-.06 Allowable Costs of Producing Self-employment Income`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `self_employment_cost_of_doing_business_rate`, grounded against `AL 660-4-2-.06 Allowable Costs of Producing Self-employment Income`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/06/block-1#earned_income_deduction_rate
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `earned_income_deduction_rate`, grounded against `AL 660-4-2-.06 Other Household Income and Self-employment Income`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `earned_income_deduction_rate`, grounded against `AL 660-4-2-.06 Other Household Income and Self-employment Income`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/06/block-1#self_employed_farmer_minimum_annual_gross_proceeds
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `self_employed_farmer_minimum_annual_gross_proceeds`, grounded against `AL 660-4-2-.06 Special Provision for Farmers`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `self_employed_farmer_minimum_annual_gross_proceeds`, grounded against `AL 660-4-2-.06 Special Provision for Farmers`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/06/block-1#self_employment_annualization_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `self_employment_annualization_months`, grounded against `AL 660-4-2-.06 S Corporations`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `self_employment_annualization_months`, grounded against `AL 660-4-2-.06 S Corporations`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/06/block-1#maximum_self_employment_certification_months
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `maximum_self_employment_certification_months`, grounded against `AL 660-4-2-.06 Assigning Certification Periods`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `maximum_self_employment_certification_months`, grounded against `AL 660-4-2-.06 Assigning Certification Periods`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/06/block-1#s_corporation_countable_earned_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `s_corporation_countable_earned_income`, grounded against `AL 660-4-2-.06 S Corporations and Other Corporations`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `s_corporation_countable_earned_income`, grounded against `AL 660-4-2-.06 S Corporations and Other Corporations`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/06/block-1#self_employment_cost_of_doing_business_deduction
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `self_employment_cost_of_doing_business_deduction`, grounded against `AL 660-4-2-.06 Determining Monthly Income from Self-employment`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `self_employment_cost_of_doing_business_deduction`, grounded against `AL 660-4-2-.06 Determining Monthly Income from Self-employment`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/06/block-1#monthly_net_self_employment_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `monthly_net_self_employment_income`, grounded against `AL 660-4-2-.06 Determining Monthly Income from Self-employment`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `monthly_net_self_employment_income`, grounded against `AL 660-4-2-.06 Determining Monthly Income from Self-employment`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/06/block-1#is_self_employed_farmer
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `is_self_employed_farmer`, grounded against `AL 660-4-2-.06 Special Provision for Farmers`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `is_self_employed_farmer`, grounded against `AL 660-4-2-.06 Special Provision for Farmers`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/06/block-1#is_self_employed_fisherman
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `is_self_employed_fisherman`, grounded against `AL 660-4-2-.06 Special Provision for Farmers`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `is_self_employed_fisherman`, grounded against `AL 660-4-2-.06 Special Provision for Farmers`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/06/block-1#farm_disaster_payment_excluded_from_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `farm_disaster_payment_excluded_from_income`, grounded against `AL 660-4-2-.06 Special Provision for Farmers (Disaster Relief Act of 1974)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `farm_disaster_payment_excluded_from_income`, grounded against `AL 660-4-2-.06 Special Provision for Farmers (Disaster Relief Act of 1974)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/06/block-1#recaptured_depreciation_counted_as_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `recaptured_depreciation_counted_as_income`, grounded against `AL 660-4-2-.06 Recaptured Depreciation`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `recaptured_depreciation_counted_as_income`, grounded against `AL 660-4-2-.06 Recaptured Depreciation`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/06/block-1#recaptured_investment_credit_counted_as_income
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `recaptured_investment_credit_counted_as_income`, grounded against `AL 660-4-2-.06 Recaptured Investment Credit`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `recaptured_investment_credit_counted_as_income`, grounded against `AL 660-4-2-.06 Recaptured Investment Credit`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/06/block-1#capital_gain_countable_amount
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `capital_gain_countable_amount`, grounded against `AL 660-4-2-.06 Capital Gains`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `capital_gain_countable_amount`, grounded against `AL 660-4-2-.06 Capital Gains`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/11/block-1#member_resources_included_in_household_resource_determination
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `member_resources_included_in_household_resource_determination`, grounded against `Alabama Admin. Code r. 660-4-2-.11 (Treatment of Resources)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `member_resources_included_in_household_resource_determination`, grounded against `Alabama Admin. Code r. 660-4-2-.11 (Treatment of Resources)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/11/block-1#income_counted_as_resource_same_month
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `income_counted_as_resource_same_month`, grounded against `Alabama Admin. Code r. 660-4-2-.11 (Treatment of Resources)`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `income_counted_as_resource_same_month`, grounded against `Alabama Admin. Code r. 660-4-2-.11 (Treatment of Resources)`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/12/block-1#child_support_payment_deduction
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `child_support_payment_deduction`, grounded against `Alabama Food Assistance Manual 660-4-2-.12 (implementing Section 13921 of the Leland Act, Pub. L. 103-66 Title I, Chapter 3, August 10, 1993, amending Section 5`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `child_support_payment_deduction`, grounded against `Alabama Food Assistance Manual 660-4-2-.12 (implementing Section 13921 of the Leland Act, Pub. L. 103-66 Title I, Chapter 3, August 10, 1993, amending Section 5`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/2/12/block-1#child_support_deduction_allowed
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `child_support_deduction_allowed`, grounded against `Alabama Food Assistance Manual 660-4-2-.12`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `child_support_deduction_allowed`, grounded against `Alabama Food Assistance Manual 660-4-2-.12`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/7/05/block-1#six_month_report_form_due_day
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `six_month_report_form_due_day`, grounded against `Ala. Admin. Code 660-4-7-.05`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `six_month_report_form_due_day`, grounded against `Ala. Admin. Code 660-4-7-.05`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/7/05/block-1#six_month_report_notice_generation_day
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `six_month_report_notice_generation_day`, grounded against `Ala. Admin. Code 660-4-7-.05`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `six_month_report_notice_generation_day`, grounded against `Ala. Admin. Code 660-4-7-.05`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/7/05/block-1#six_month_report_notice_generated
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `six_month_report_notice_generated`, grounded against `Ala. Admin. Code 660-4-7-.05`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `six_month_report_notice_generated`, grounded against `Ala. Admin. Code 660-4-7-.05`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/7/05/block-1#six_month_report_benefits_terminated
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `six_month_report_benefits_terminated`, grounded against `Ala. Admin. Code 660-4-7-.05`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `six_month_report_benefits_terminated`, grounded against `Ala. Admin. Code 660-4-7-.05`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/7/07/block-1#county_office_processing_days
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `county_office_processing_days`, grounded against `Alabama SNAP Manual 660-4-7-07 - \"must return the incomplete form within 10 days\" / \"must process the complete form within 10 days\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `county_office_processing_days`, grounded against `Alabama SNAP Manual 660-4-7-07 - \"must return the incomplete form within 10 days\" / \"must process the complete form within 10 days\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/7/07/block-1#processing_month_cutoff_day
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `processing_month_cutoff_day`, grounded against `Alabama SNAP Manual 660-4-7-07 - \"received by the 10th of the processing month\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `processing_month_cutoff_day`, grounded against `Alabama SNAP Manual 660-4-7-07 - \"received by the 10th of the processing month\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/7/07/block-1#benefits_must_be_prorated_for_seventh_month_reinstatement
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `benefits_must_be_prorated_for_seventh_month_reinstatement`, grounded against `Alabama SNAP Manual 660-4-7-07 - \"If eligible, benefits for the month of reinstatement must be prorated.\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `benefits_must_be_prorated_for_seventh_month_reinstatement`, grounded against `Alabama SNAP Manual 660-4-7-07 - \"If eligible, benefits for the month of reinstatement must be prorated.\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/7/07/block-1#case_must_close_for_failure_to_report
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `case_must_close_for_failure_to_report`, grounded against `Alabama SNAP Manual 660-4-7-07 - \"the case will close for failure to provide a complete six-month report\"`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `case_must_close_for_failure_to_report`, grounded against `Alabama SNAP Manual 660-4-7-07 - \"the case will close for failure to provide a complete six-month report\"`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/7/07/block-1#report_considered_timely_when_received_on_first_workday_after_weekend_or_holiday
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `report_considered_timely_when_received_on_first_workday_after_weekend_or_holiday`, grounded against `Alabama SNAP Manual 660-4-7-07 - \"When the last day of the month falls on a weekend or a holiday, those reports received ... on the first workday after the fina`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `report_considered_timely_when_received_on_first_workday_after_weekend_or_holiday`, grounded against `Alabama SNAP Manual 660-4-7-07 - \"When the last day of the month falls on a weekend or a holiday, those reports received ... on the first workday after the fina`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/7/07/block-1#case_must_remain_closed_after_seventh_month
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `case_must_remain_closed_after_seventh_month`, grounded against `Alabama SNAP Manual 660-4-7-07 - \"If the household fails to return a complete form with the required documentation and verification by the end of the seventh mo`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `case_must_remain_closed_after_seventh_month`, grounded against `Alabama SNAP Manual 660-4-7-07 - \"If the household fails to return a complete form with the required documentation and verification by the end of the seventh mo`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/7/08/block-1#timely_recertification_application_first_day_of_month
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `timely_recertification_application_first_day_of_month`, grounded against `Ala. Admin. Code 660-4-7-.08`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `timely_recertification_application_first_day_of_month`, grounded against `Ala. Admin. Code 660-4-7-.08`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/7/08/block-1#timely_recertification_application_last_day_of_month
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `timely_recertification_application_last_day_of_month`, grounded against `Ala. Admin. Code 660-4-7-.08`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `timely_recertification_application_last_day_of_month`, grounded against `Ala. Admin. Code 660-4-7-.08`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-al:regulations/660-4/7/08/block-1#timely_application_for_recertification
     country: us
     program: snap
     mapping_type: not_comparable
-    rationale: "Source-specific intermediate output (rule `timely_application_for_recertification`, grounded against `Ala. Admin. Code 660-4-7-.08`). Not present in the PolicyEngine ECPS adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
+    rationale: "Source-specific intermediate output (rule `timely_application_for_recertification`, grounded against `Ala. Admin. Code 660-4-7-.08`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us:statutes/26/25D#fuel_cell_credit_per_half_kilowatt_cap_amount
     country: us

--- a/src/axiom_encode/oracles/policyengine/population.py
+++ b/src/axiom_encode/oracles/policyengine/population.py
@@ -1,0 +1,75 @@
+"""PolicyEngine population loaders for Axiom validation oracles."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+DEFAULT_US_POPULACE_YEAR = 2024
+DEFAULT_UK_POPULACE_YEAR = 2023
+DEFAULT_LOCAL_POPULACE_DATA_PACKAGE = (
+    Path.home() / "PolicyEngine" / "populace" / "packages" / "populace-data"
+)
+
+
+def load_populace_dataset(
+    country: str,
+    *,
+    year: int | None = None,
+    command: str,
+) -> Any:
+    """Load a published Populace artifact as a PolicyEngine dataset."""
+    try:
+        from populace.data import load
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(populace_install_message(country, command)) from exc
+    try:
+        return load(country, year)
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(populace_install_message(country, command)) from exc
+    except Exception as exc:  # pragma: no cover - depends on external dataset access
+        year_label = "latest" if year is None else str(year)
+        raise SystemExit(
+            f"Failed to load Populace {country.upper()} {year_label} dataset: {exc}"
+        ) from exc
+
+
+def population_table(dataset: Any, name: str) -> Any:
+    """Return an entity table from a PolicyEngine dataset object."""
+    table = getattr(dataset, name, None)
+    if table is None and hasattr(dataset, "data"):
+        table = getattr(dataset.data, name, None)
+    if table is None:
+        raise ValueError(f"Populace dataset does not expose {name!r} table.")
+    return table.copy() if hasattr(table, "copy") else table
+
+
+def local_dataset_path(value: str | None) -> Path | None:
+    """Return ``value`` as a local dataset path when it names an existing file."""
+    if not value:
+        return None
+    path = Path(value).expanduser()
+    if path.exists():
+        return path
+    return None
+
+
+def populace_install_message(country: str, command: str) -> str:
+    return (
+        "Populace validation requires populace-data and the matching "
+        "PolicyEngine country engine. Run with: "
+        f"uv run --with {populace_data_requirement(country)} "
+        f"axiom-encode {command}"
+    )
+
+
+def populace_data_requirement(country: str) -> str:
+    """Return the best uv requirement string for the local Populace data shard."""
+    country = country.lower()
+    override = os.environ.get("AXIOM_POPULACE_DATA_PACKAGE")
+    if override:
+        return f"{Path(override).expanduser()}[{country}]"
+    if DEFAULT_LOCAL_POPULACE_DATA_PACKAGE.exists():
+        return f"{DEFAULT_LOCAL_POPULACE_DATA_PACKAGE}[{country}]"
+    return f"populace-data[{country}]"

--- a/src/axiom_encode/oracles/policyengine/snap_readiness.py
+++ b/src/axiom_encode/oracles/policyengine/snap_readiness.py
@@ -30,7 +30,7 @@ class SnapReadinessItem:
     companion_test_files: int
     executable_outputs: int
     corpus_snap_provisions: int
-    policyengine_ecps_configured: bool
+    policyengine_populace_configured: bool
     program_module: str | None
     program_module_exists: bool
     status: str
@@ -45,7 +45,7 @@ class SnapReadinessItem:
             "companion_test_files": self.companion_test_files,
             "executable_outputs": self.executable_outputs,
             "corpus_snap_provisions": self.corpus_snap_provisions,
-            "policyengine_ecps_configured": self.policyengine_ecps_configured,
+            "policyengine_populace_configured": self.policyengine_populace_configured,
             "program_module": self.program_module,
             "program_module_exists": self.program_module_exists,
             "status": self.status,
@@ -106,17 +106,18 @@ def build_snap_readiness_item(
         corpus_root,
         jurisdiction=jurisdiction,
     )
-    ecps_config = JURISDICTION_CONFIGS.get(jurisdiction)
+    populace_config = JURISDICTION_CONFIGS.get(jurisdiction)
     program_module = (
-        ecps_config.program_relative_path.as_posix() if ecps_config else None
+        populace_config.program_relative_path.as_posix() if populace_config else None
     )
     program_module_exists = (
-        bool(ecps_config) and (repo / ecps_config.program_relative_path).exists()
+        bool(populace_config)
+        and (repo / populace_config.program_relative_path).exists()
     )
     status, blockers = _classify_status(
         rulespec_files=rulespec_files,
         corpus_snap_provisions=corpus_snap_provisions,
-        ecps_configured=ecps_config is not None,
+        populace_configured=populace_config is not None,
         program_module_exists=program_module_exists,
     )
     return SnapReadinessItem(
@@ -127,7 +128,7 @@ def build_snap_readiness_item(
         companion_test_files=companion_test_files,
         executable_outputs=executable_outputs,
         corpus_snap_provisions=corpus_snap_provisions,
-        policyengine_ecps_configured=ecps_config is not None,
+        policyengine_populace_configured=populace_config is not None,
         program_module=program_module,
         program_module_exists=program_module_exists,
         status=status,
@@ -271,7 +272,7 @@ def _classify_status(
     *,
     rulespec_files: int,
     corpus_snap_provisions: int,
-    ecps_configured: bool,
+    populace_configured: bool,
     program_module_exists: bool,
 ) -> tuple[str, list[str]]:
     blockers: list[str] = []
@@ -283,10 +284,10 @@ def _classify_status(
         return "needs_corpus", blockers
     if corpus_snap_provisions == 0:
         return "rules_without_corpus", blockers
-    if not ecps_configured:
-        blockers.append("missing PolicyEngine ECPS jurisdiction config")
-        return "needs_ecps_config", blockers
+    if not populace_configured:
+        blockers.append("missing PolicyEngine Populace jurisdiction config")
+        return "needs_populace_config", blockers
     if not program_module_exists:
         blockers.append("missing configured SNAP program module")
         return "missing_program_module", blockers
-    return "ecps_ready", blockers
+    return "populace_ready", blockers

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -470,10 +470,10 @@ class TestMain:
                 main()
                 mock_cmd.assert_called_once()
 
-    def test_uk_efrs_coverage_command_dispatches(self):
-        with patch("sys.argv", ["axiom_encode", "uk-efrs-coverage"]):
+    def test_uk_populace_coverage_command_dispatches(self):
+        with patch("sys.argv", ["axiom_encode", "uk-populace-coverage"]):
             with patch(
-                "axiom_encode.cli.run_uk_efrs_coverage", return_value=0
+                "axiom_encode.cli.run_uk_populace_coverage", return_value=0
             ) as mock_cmd:
                 with pytest.raises(SystemExit) as exc_info:
                     main()

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -21,9 +21,6 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     OASDI_WAGE_BASE_BASE,
     OASDI_WAGE_BASE_EXCLUSION_OUTPUT,
     OASDI_WAGE_BASE_PROGRAM_PATH,
-    POLICYENGINE_CORE_VERSION,
-    POLICYENGINE_US_VERSION,
-    POLICYENGINE_VERSION,
     SECTION_32_C_2_BASE,
     SECTION_112_BASE,
     SECTION_152_C_BASE,
@@ -2376,6 +2373,7 @@ def test_compare_oasdi_stage_runs_encoded_ssa_base_before_3121(
         positive_ctc_only=False,
         surface="employee-oasdi",
         data_folder=tmp_path,
+        populace_year=2024,
         tolerance=0.01,
         relative_tolerance=2e-7,
     )
@@ -2388,46 +2386,33 @@ def test_compare_oasdi_stage_runs_encoded_ssa_base_before_3121(
     ]
 
 
-def test_policyengine_version_guard_rejects_unpinned_us_version(monkeypatch):
+def test_policyengine_version_guard_rejects_old_us_version(monkeypatch):
     def fake_version(package):
-        if package == "policyengine":
-            return POLICYENGINE_VERSION
-        if package == "policyengine-core":
-            return POLICYENGINE_CORE_VERSION
         if package == "policyengine-us":
-            return "999.0.0"
+            return "1.722.99"
         raise AssertionError(package)
 
     monkeypatch.setattr(ecps_tax, "version", fake_version)
 
-    with pytest.raises(SystemExit, match="policyengine-us=="):
+    with pytest.raises(SystemExit, match="policyengine-us>="):
         require_policyengine_versions()
 
 
-def test_policyengine_version_guard_rejects_unpinned_core_version(monkeypatch):
+def test_policyengine_version_guard_allows_newer_us_version(monkeypatch):
     def fake_version(package):
-        if package == "policyengine":
-            return POLICYENGINE_VERSION
-        if package == "policyengine-core":
-            return "999.0.0"
         if package == "policyengine-us":
-            return POLICYENGINE_US_VERSION
+            return "1.739.2"
         raise AssertionError(package)
 
     monkeypatch.setattr(ecps_tax, "version", fake_version)
 
-    with pytest.raises(SystemExit, match="policyengine-core=="):
-        require_policyengine_versions()
+    require_policyengine_versions()
 
 
 def test_policyengine_version_guard_allows_local_us_override(monkeypatch):
     def fake_version(package):
-        if package == "policyengine":
-            return POLICYENGINE_VERSION
-        if package == "policyengine-core":
-            return POLICYENGINE_CORE_VERSION
         if package == "policyengine-us":
-            return "999.0.0"
+            return "1.722.99"
         raise AssertionError(package)
 
     monkeypatch.setattr(ecps_tax, "version", fake_version)
@@ -2435,58 +2420,13 @@ def test_policyengine_version_guard_allows_local_us_override(monkeypatch):
     require_policyengine_versions(allow_policyengine_us_version=True)
 
 
-def test_policyengine_data_certification_override_is_required_for_pinned_us_bump():
-    assert policyengine_data_certification_override_required() is True
+def test_policyengine_data_certification_override_not_required_for_populace():
+    assert policyengine_data_certification_override_required() is False
 
 
-def test_policyengine_data_certification_override_runs_on_default_pinned_bump(
-    monkeypatch, tmp_path
-):
-    def fake_install_override():
-        raise RuntimeError("certification override installed")
-
-    monkeypatch.setattr(
-        ecps_tax,
-        "policyengine_data_certification_override_required",
-        lambda: True,
-    )
-    monkeypatch.setattr(
-        ecps_tax,
-        "_install_policyengine_data_certification_override",
-        fake_install_override,
-    )
-
-    with pytest.raises(RuntimeError, match="certification override installed"):
-        ecps_tax.load_policyengine_tax_data(
-            year=2026,
-            sample_size=1,
-            positive_ctc_only=False,
-            data_folder=tmp_path,
-            tax_unit_variables=(),
-            person_variables=(),
-        )
-
-
-def test_uncertified_policyengine_data_requires_local_us_override(tmp_path):
-    with pytest.raises(SystemExit, match="requires --allow-policyengine-us-version"):
-        compare_tax_ecps(
-            workspace_root=tmp_path,
-            rulespec_root=tmp_path / "rulespec-us",
-            axiom_rules_path=tmp_path / "axiom-rules-engine",
-            year=2026,
-            sample_size=1,
-            positive_ctc_only=False,
-            surface="all",
-            data_folder=tmp_path,
-            tolerance=0.01,
-            relative_tolerance=2e-7,
-            allow_uncertified_policyengine_data=True,
-        )
-
-
-def test_policyengine_data_certification_override_sets_skip_imports(monkeypatch):
+def test_policyengine_data_certification_override_noop_for_populace(monkeypatch):
     monkeypatch.delenv("POLICYENGINE_SKIP_COUNTRY_IMPORTS", raising=False)
 
     ecps_tax._install_policyengine_data_certification_override()
 
-    assert ecps_tax.os.environ["POLICYENGINE_SKIP_COUNTRY_IMPORTS"] == "1"
+    assert "POLICYENGINE_SKIP_COUNTRY_IMPORTS" not in ecps_tax.os.environ

--- a/tests/test_policyengine_efrs_uk.py
+++ b/tests/test_policyengine_efrs_uk.py
@@ -4555,22 +4555,20 @@ class hbai_household_net_income(Variable):
 def test_policyengine_uk_version_guard_rejects_unpinned_version(monkeypatch):
     def fake_version(package):
         versions = {
-            "policyengine-core": efrs_uk.POLICYENGINE_CORE_VERSION,
-            "policyengine-uk": "2.88.41",
+            "policyengine-uk": "2.87.99",
         }
         return versions[package]
 
     monkeypatch.setattr(efrs_uk, "version", fake_version)
 
-    with pytest.raises(SystemExit, match="policyengine-uk==2.88.56 required"):
+    with pytest.raises(SystemExit, match="policyengine-uk>=2.88 required"):
         require_policyengine_uk_versions()
 
 
 def test_policyengine_uk_version_guard_allows_pinned_versions(monkeypatch):
     def fake_version(package):
         versions = {
-            "policyengine-core": efrs_uk.POLICYENGINE_CORE_VERSION,
-            "policyengine-uk": efrs_uk.POLICYENGINE_UK_VERSION,
+            "policyengine-uk": "2.89.2",
         }
         return versions[package]
 
@@ -4585,8 +4583,8 @@ def test_policyengine_uk_version_guard_names_coverage_command(monkeypatch):
 
     monkeypatch.setattr(efrs_uk, "version", fake_version)
 
-    with pytest.raises(SystemExit, match="axiom-encode uk-efrs-coverage"):
-        require_policyengine_uk_versions(command="uk-efrs-coverage")
+    with pytest.raises(SystemExit, match="axiom-encode uk-populace-coverage"):
+        require_policyengine_uk_versions(command="uk-populace-coverage")
 
 
 def test_compare_outputs_reports_personal_allowance_mismatch():
@@ -6596,8 +6594,9 @@ def test_compare_uk_efrs_runs_axiom_personal_allowance(
         year=2026,
         sample_size=100,
         surface="personal-allowance",
-        dataset="enhanced_frs_2023_24",
+        dataset="",
         data_folder=Path(".axiom/policyengine-data"),
+        populace_year=2023,
         tolerance=0.01,
         relative_tolerance=2e-7,
     )
@@ -6645,8 +6644,9 @@ def test_main_returns_nonzero_when_requested_for_mismatches(monkeypatch, tmp_pat
                 year=2026,
                 sample_size=100,
                 surface="all",
-                dataset="enhanced_frs_2023_24",
+                dataset="",
                 data_folder=Path(".axiom/policyengine-data"),
+                populace_year=2023,
                 tolerance=0.01,
                 relative_tolerance=2e-7,
                 person_ids=None,

--- a/tests/test_snap_readiness.py
+++ b/tests/test_snap_readiness.py
@@ -101,7 +101,7 @@ def test_snap_readiness_reports_ready_to_encode_when_corpus_exists_without_rules
     assert by_jurisdiction["us-tn"]["rulespec_files"] == 0
 
 
-def test_snap_readiness_reports_ecps_ready_for_configured_program_module(tmp_path):
+def test_snap_readiness_reports_populace_ready_for_configured_program_module(tmp_path):
     root = tmp_path / "workspace"
     corpus_root = root / "axiom-corpus"
     repo = root / "rulespec-us-co"
@@ -112,8 +112,8 @@ def test_snap_readiness_reports_ecps_ready_for_configured_program_module(tmp_pat
 
     by_jurisdiction = {item["jurisdiction"]: item for item in report["items"]}
     colorado = by_jurisdiction["us-co"]
-    assert colorado["status"] == "ecps_ready"
-    assert colorado["policyengine_ecps_configured"] is True
+    assert colorado["status"] == "populace_ready"
+    assert colorado["policyengine_populace_configured"] is True
     assert colorado["program_module_exists"] is True
     assert colorado["executable_outputs"] == 1
 
@@ -146,9 +146,9 @@ def test_snap_readiness_flags_rules_without_policyengine_config(tmp_path):
     report = build_snap_readiness_report(root, corpus_root=corpus_root)
 
     by_jurisdiction = {item["jurisdiction"]: item for item in report["items"]}
-    assert by_jurisdiction["us-tn"]["status"] == "needs_ecps_config"
+    assert by_jurisdiction["us-tn"]["status"] == "needs_populace_config"
     assert (
-        "missing PolicyEngine ECPS jurisdiction config"
+        "missing PolicyEngine Populace jurisdiction config"
         in by_jurisdiction["us-tn"]["blockers"]
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.789"
+version = "0.2.790"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a shared Populace dataset loader and switch PolicyEngine population validation to Populace-backed datasets
- add canonical Populace CLI commands while keeping ECPS/EFRS command names as hidden compatibility aliases
- update SNAP readiness, oracle mapping labels, docs, tests, and encoder version metadata for the Populace validation surface

## Validation
- uv run ruff check src tests
- uv run ruff format --check src tests
- uv run --with towncrier python -m towncrier build --draft --version 0.0.0
- uv run --with pytest --with pytest-cov python -m pytest tests/test_snap_readiness.py tests/test_cli.py tests/test_policyengine_ecps_snap.py tests/test_policyengine_ecps_tax.py tests/test_policyengine_efrs_uk.py -q
- uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- US Populace loader smoke: load_populace_dataset('us', 2024) returned USSingleYearDataset with 87,519 tax units

## Notes
- UK Populace loader reaches the private Hugging Face dataset but this shell lacks authorized HF credentials, so the PR wraps dataset-access failures in a clear CLI SystemExit instead of a raw stack trace.
- Internal module/function names still include ecps/efrs for compatibility; the public validation commands and reporting surface are Populace-backed.