### PR TITLE
Classify Colorado health value surfaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.791"
+version = "0.2.792"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.791"
+__version__ = "0.2.792"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -15523,6 +15523,156 @@ mappings:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose the section 25D(c) carryforward amount as a separate variable.
 
+  - legal_id: us:statutes/26/25C#energy_efficient_home_improvement_credit_rate
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    rationale: RuleSpec exposes the unified section 25C(a) post-2022 rate across improvements, property, and audits, while PolicyEngine stores separate rate parameters with different historical structure.
+
+  - legal_id: us:statutes/26/25C#general_annual_credit_limit
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.credits.energy_efficient_home_improvement.cap.annual.total
+    rationale: Same broad $1,200 annual cap amount, but PolicyEngine applies it inside a stale lifetime/in-effect graph; promote to parameter comparison only with a dedicated 25C parameter test surface.
+
+  - legal_id: us:statutes/26/25C#qualified_energy_property_item_credit_limit
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.credits.energy_efficient_home_improvement.cap.annual.energy_efficient_building_property
+    rationale: Same broad $600 qualified-energy-property cap amount, but PolicyEngine applies it through property-specific helpers and a stale in-effect graph rather than this statutory item-cap output.
+
+  - legal_id: us:statutes/26/25C#windows_and_skylights_aggregate_credit_limit
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.credits.energy_efficient_home_improvement.cap.annual.window
+    rationale: Same broad $600 windows-and-skylights amount, but PolicyEngine combines it with a pre-current-law lifetime window cap surface, so it is not an exact oracle target for current section 25C.
+
+  - legal_id: us:statutes/26/25C#exterior_door_per_door_credit_limit
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    rationale: PolicyEngine stores the aggregate exterior-door cap but does not expose the section 25C(b)(4)(A) $250 per-door cap as a separate parameter or output.
+
+  - legal_id: us:statutes/26/25C#exterior_doors_aggregate_credit_limit
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.credits.energy_efficient_home_improvement.cap.annual.door
+    rationale: Same broad $500 aggregate exterior-door amount, but PolicyEngine omits the per-door cap and therefore is not an exact oracle target for the statutory door-limit pair.
+
+  - legal_id: us:statutes/26/25C#heat_pump_biomass_aggregate_credit_limit
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.credits.energy_efficient_home_improvement.cap.annual.heat_pump_heat_pump_water_heater_biomass_stove_boiler
+    rationale: Same broad $2,000 cap amount, but PolicyEngine applies it through rebate-adjusted helper variables and a stale in-effect graph, not as this current-law statutory cap output.
+
+  - legal_id: us:statutes/26/25C#home_energy_audit_credit_limit
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    policyengine_parameter: gov.irs.credits.energy_efficient_home_improvement.cap.annual.home_energy_audit
+    rationale: Same broad $150 cap amount, but PolicyEngine's audit helper lacks the section 25C(e)(2) substantiation gate encoded by RuleSpec.
+
+  - legal_id: us:statutes/26/25C#qualified_energy_efficiency_improvement_minimum_expected_use_years
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the section 25C(c)(1)(B) five-year expected-use property-classification threshold as a parameter or output.
+
+  - legal_id: us:statutes/26/25C#biomass_stove_or_boiler_minimum_thermal_efficiency_rate
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the section 25C(d)(2)(B) biomass thermal-efficiency threshold as a parameter or output.
+
+  - legal_id: us:statutes/26/25C#panelboard_minimum_load_capacity_amps
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the section 25C(d)(2)(D)(ii) panelboard load-capacity threshold as a parameter or output.
+
+  - legal_id: us:statutes/26/25C#eligible_fuel_blend_minimum_volume_rate
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the section 25C(d)(3)(B) eligible-fuel blend threshold as a parameter or output.
+
+  - legal_id: us:statutes/26/25C#home_energy_auditor_guidance_deadline_days_after_enactment
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the section 25C(e)(4) Secretary guidance deadline as a parameter or output.
+
+  - legal_id: us:statutes/26/25C#windows_and_skylights_credit
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    policyengine_variable: capped_energy_efficient_window_credit
+    rationale: PolicyEngine's window helper applies a stale lifetime window cap and prior-credit subtraction, while RuleSpec encodes the current-law annual windows-and-skylights component.
+
+  - legal_id: us:statutes/26/25C#exterior_doors_credit
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    policyengine_variable: capped_energy_efficient_door_credit
+    rationale: PolicyEngine's exterior-door helper omits the $250 per-door cap, so it is not an exact oracle target for RuleSpec's section 25C(b)(4) door component.
+
+  - legal_id: us:statutes/26/25C#other_envelope_improvements_credit
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    rationale: PolicyEngine splits non-window, non-door envelope improvements into separate insulation and roof helpers and does not expose this combined statutory component.
+
+  - legal_id: us:statutes/26/25C#non_heat_pump_residential_energy_property_credit
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    rationale: PolicyEngine splits non-heat-pump residential energy property into several rebate-adjusted helpers and does not expose this combined section 25C(a)(2)/(b)(2) component.
+
+  - legal_id: us:statutes/26/25C#heat_pump_biomass_credit
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    policyengine_variable: capped_heat_pump_heat_pump_water_heater_biomass_stove_boiler_credit
+    rationale: PolicyEngine's heat-pump/biomass helper subtracts rebate variables and lives in a stale in-effect graph, while RuleSpec exposes the statutory current-law component before the final PIN and termination gates.
+
+  - legal_id: us:statutes/26/25C#home_energy_audit_credit
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    policyengine_variable: capped_home_energy_audit_credit
+    rationale: PolicyEngine caps audit expenditures but does not encode the section 25C(e)(2) return-documentation condition that can zero the audit component.
+
+  - legal_id: us:statutes/26/25C#general_limited_credit_before_heat_pump_biomass
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    rationale: PolicyEngine computes a broader potential credit using its own qualified-expenditure helper list, lifetime cap, and stale in-effect parameter rather than this pre-heat-pump current-law annual cap subtotal.
+
+  - legal_id: us:statutes/26/25C#energy_efficient_home_improvement_credit_before_termination_and_pin_gate
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    policyengine_variable: energy_efficient_home_improvement_credit_potential
+    rationale: PolicyEngine's potential credit includes stale lifetime/in-effect handling and no product-identification-number gate; it is not this current-law pre-termination/PIN subtotal.
+
+  - legal_id: us:statutes/26/25C#energy_efficient_home_improvement_credit
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    policyengine_variable: energy_efficient_home_improvement_credit
+    rationale: Same final section 25C credit surface, but PolicyEngine still uses the pre-current-law 2033 in-effect schedule, does not include the section 25C(h) product-identification-number gate, and computes the tax-liability limit through its full tax stack; see PolicyEngine/policyengine-us#8703.
+
+  - legal_id: us:statutes/26/25C#basis_increase_reduction_for_credited_property_expenditure
+    country: us
+    program: ira_tax_credits
+    mapping_type: not_comparable
+    rationale: PolicyEngine does not expose the section 25C(g) basis-reduction amount as a separate variable.
+
 prefixes:
   - legal_id_prefix: us:statutes/5/5566#
     country: us

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1907,10 +1907,13 @@ surfaces:
   coverage: US
   variable: energy_efficient_home_improvement_credit
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: >-
+    RuleSpec PR 428 encodes current-law section 25C, but PolicyEngine's energy_efficient_home_improvement_credit
+    still uses the pre-current-law 2033 in-effect schedule, lacks the section 25C(h) product-identification-number gate,
+    and computes tax-liability limiting through PE's full tax stack rather than the legal boundary inputs exposed in RuleSpec;
+    see PolicyEngine/policyengine-us#8703.
 - country: us
   program_id: doe_high_efficiency_rebate
   program_name: DOE high efficiency rebate
@@ -1959,10 +1962,11 @@ surfaces:
   coverage: CO
   variable: co_chp
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: out_of_scope
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: PolicyEngine's co_chp variable reports modeled annual expense savings after applying CHP+ eligibility, copay,
+    and medical-expense assumptions. It is not a direct statutory cash benefit or eligibility output. RuleSpec should compare
+    Colorado CHP+ eligibility, income-limit, copay, out-of-pocket, and state-set parameter rules separately.
 - country: us
   program_id: co_omnisalud
   program_name: Colorado OmniSalud
@@ -1972,10 +1976,11 @@ surfaces:
   coverage: CO
   variable: co_omnisalud
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: out_of_scope
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: PolicyEngine's co_omnisalud variable reports a modeled annual premium-subsidy value equal to the household's
+    SLCSP premium when eligibility holds. It is not a direct statutory amount. RuleSpec should compare Colorado OmniSalud
+    eligibility, immigration-status, income-limit, program-effect, and premium-assistance component rules separately.
 - country: us
   program_id: dc_power
   program_name: DC Power

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -262,6 +262,43 @@ def test_policyengine_program_surface_marks_arizona_ccap_pending_source_ingestio
     assert "official DES/AZSOS sources" in arizona_ccap["rationale"]
 
 
+def test_policyengine_program_surface_marks_colorado_health_value_surfaces_out_of_scope():
+    report = build_policyengine_program_surface_report()
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    colorado_chp = items_by_variable["co_chp"]
+    colorado_omnisalud = items_by_variable["co_omnisalud"]
+
+    assert colorado_chp["program_id"] == "co_chp"
+    assert colorado_chp["coverage"] == "CO"
+    assert colorado_chp["axiom_status"] == "out_of_scope"
+    assert "modeled annual expense savings" in colorado_chp["rationale"]
+    assert "eligibility, income-limit, copay" in colorado_chp["rationale"]
+
+    assert colorado_omnisalud["program_id"] == "co_omnisalud"
+    assert colorado_omnisalud["coverage"] == "CO"
+    assert colorado_omnisalud["axiom_status"] == "out_of_scope"
+    assert "modeled annual premium-subsidy value" in colorado_omnisalud["rationale"]
+    assert "eligibility, immigration-status" in colorado_omnisalud["rationale"]
+
+
+def test_policyengine_program_surface_marks_section_25c_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="ira_tax_credits")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    section_25c = items_by_variable["energy_efficient_home_improvement_credit"]
+
+    assert section_25c["axiom_status"] == "known_not_comparable"
+    assert section_25c["mapping_count"] >= 1
+    assert section_25c["comparable_mapping_count"] == 0
+    assert (
+        "us:statutes/26/25C#energy_efficient_home_improvement_credit"
+        in section_25c["legal_ids"]
+    )
+    assert "2033 in-effect schedule" in section_25c["rationale"]
+    assert "product-identification-number gate" in section_25c["rationale"]
+
+
 def test_policyengine_program_surface_marks_colorado_oap_wired():
     report = build_policyengine_program_surface_report(program="co_oap")
 
@@ -494,6 +531,75 @@ rules:
     tax_report = build_policyengine_coverage_report(tmp_path, program="tax")
     assert tax_report["total_outputs"] == 3
     assert tax_report["status_counts"] == {"known_not_comparable": 3}
+
+
+def test_policyengine_coverage_classifies_section_25c_outputs_not_comparable(
+    tmp_path,
+):
+    output_names = (
+        "energy_efficient_home_improvement_credit_rate",
+        "general_annual_credit_limit",
+        "qualified_energy_property_item_credit_limit",
+        "windows_and_skylights_aggregate_credit_limit",
+        "exterior_door_per_door_credit_limit",
+        "exterior_doors_aggregate_credit_limit",
+        "heat_pump_biomass_aggregate_credit_limit",
+        "home_energy_audit_credit_limit",
+        "qualified_energy_efficiency_improvement_minimum_expected_use_years",
+        "biomass_stove_or_boiler_minimum_thermal_efficiency_rate",
+        "panelboard_minimum_load_capacity_amps",
+        "eligible_fuel_blend_minimum_volume_rate",
+        "home_energy_auditor_guidance_deadline_days_after_enactment",
+        "windows_and_skylights_credit",
+        "exterior_doors_credit",
+        "other_envelope_improvements_credit",
+        "non_heat_pump_residential_energy_property_credit",
+        "heat_pump_biomass_credit",
+        "home_energy_audit_credit",
+        "general_limited_credit_before_heat_pump_biomass",
+        "energy_efficient_home_improvement_credit_before_termination_and_pin_gate",
+        "energy_efficient_home_improvement_credit",
+        "basis_increase_reduction_for_credited_property_expenditure",
+    )
+    rules = "\n".join(
+        f"""  - name: {name}
+    kind: derived
+    versions:
+      - effective_from: '2023-01-01'
+        formula: '1'"""
+        for name in output_names
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/25C.yaml",
+        f"""format: rulespec/v1
+rules:
+{rules}
+""",
+    )
+
+    report = build_policyengine_coverage_report(
+        tmp_path,
+        program="ira_tax_credits",
+    )
+
+    assert report["total_outputs"] == len(output_names)
+    assert report["status_counts"] == {"known_not_comparable": len(output_names)}
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    final_credit = items_by_id[
+        "us:statutes/26/25C#energy_efficient_home_improvement_credit"
+    ]
+    audit_credit = items_by_id["us:statutes/26/25C#home_energy_audit_credit"]
+    door_limit = items_by_id["us:statutes/26/25C#exterior_door_per_door_credit_limit"]
+
+    assert final_credit["policyengine_variable"] == (
+        "energy_efficient_home_improvement_credit"
+    )
+    assert "pre-current-law 2033 in-effect schedule" in final_credit["rationale"]
+    assert "product-identification-number gate" in final_credit["rationale"]
+    assert audit_credit["policyengine_variable"] == "capped_home_energy_audit_credit"
+    assert "return-documentation condition" in audit_credit["rationale"]
+    assert door_limit["policyengine_variable"] is None
 
 
 def test_policyengine_coverage_classifies_7_cfr_275_admin_prefix(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.791"
+version = "0.2.792"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary\n- mark PolicyEngine co_chp and co_omnisalud program surfaces out of scope because they are modeled value surfaces rather than direct legal RuleSpec targets\n- add coverage test assertions for the classification rationale\n\n## Tests\n- git diff --check\n- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k "program_surface_marks_colorado_health_value_surfaces_out_of_scope or program_surface_marks_colorado_oap_wired or program_surface_marks_arizona_ccap_pending_source_ingestion"\n- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/oracles/policyengine/coverage.py