### PR TITLE
Map SSI resource limits to PolicyEngine oracle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.792"
+version = "0.2.793"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.792"
+__version__ = "0.2.793"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -86,6 +86,42 @@ mappings:
     comparison: rate
     rationale: Same federal SNAP earned-income deduction rate.
 
+  - legal_id: us:statutes/42/1382/a/3#resource_limit_amount_for_paragraph_1_B_i_and_paragraph_2_B
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.eligibility.resources.limit.couple
+    candidate_priority: P4
+    rationale: RuleSpec exposes the raw 42 USC 1382(a)(3)(A) schedule for the amount referred to by paragraph (1)(B)(i) and paragraph (2)(B). Compare the applied `couple_or_living_with_spouse_resource_limit` output to PolicyEngine's SSI couple resource-limit parameter instead.
+
+  - legal_id: us:statutes/42/1382/a/3#resource_limit_amount_for_paragraph_1_B_ii
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.eligibility.resources.limit.individual
+    candidate_priority: P4
+    rationale: RuleSpec exposes the raw 42 USC 1382(a)(3)(B) schedule for the amount referred to by paragraph (1)(B)(ii). Compare the applied `individual_no_spouse_resource_limit` output to PolicyEngine's SSI individual resource-limit parameter instead.
+
+  - legal_id: us:statutes/42/1382/a/3#couple_or_living_with_spouse_resource_limit
+    country: us
+    program: ssi
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ssa.ssi.eligibility.resources.limit.couple
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same federal SSI resource limit for an eligible couple, and for an individual living with a spouse under 42 USC 1382(a)(1)(B)(i).
+
+  - legal_id: us:statutes/42/1382/a/3#individual_no_spouse_resource_limit
+    country: us
+    program: ssi
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ssa.ssi.eligibility.resources.limit.individual
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same federal SSI resource limit for an individual with no spouse living with the individual under 42 USC 1382(a)(1)(B)(ii).
+
   - legal_id: us:statutes/42/1382/b#statutory_base_annual_rate_without_eligible_spouse
     country: us
     program: ssi

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -339,6 +339,50 @@ def test_policyengine_coverage_classifies_federal_ssi_benefit_rate_intermediates
     tmp_path,
 ):
     _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/42/1382/a/3.yaml",
+        """format: rulespec/v1
+rules:
+  - name: resource_limit_amount_for_paragraph_1_B_i_and_paragraph_2_B
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '1974-01-01'
+        formula: 2250
+      - effective_from: '1989-01-01'
+        formula: 3000
+  - name: resource_limit_amount_for_paragraph_1_B_ii
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '1974-01-01'
+        formula: 1500
+      - effective_from: '1989-01-01'
+        formula: 2000
+  - name: couple_or_living_with_spouse_resource_limit
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '1974-01-01'
+        formula: resource_limit_amount_for_paragraph_1_B_i_and_paragraph_2_B
+  - name: individual_no_spouse_resource_limit
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '1974-01-01'
+        formula: resource_limit_amount_for_paragraph_1_B_ii
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/42/1382/a/3.test.yaml",
+        """- name: resource_limits_on_january_1989
+  period: 1989-01
+  input: {}
+  output:
+    us:statutes/42/1382/a/3#couple_or_living_with_spouse_resource_limit: 3000
+    us:statutes/42/1382/a/3#individual_no_spouse_resource_limit: 2000
+""",
+    )
+    _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/42/1382/b.yaml",
         """format: rulespec/v1
 rules:
@@ -431,9 +475,10 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path, program="ssi")
 
-    assert report["total_outputs"] == 11
+    assert report["total_outputs"] == 15
     assert report["status_counts"] == {
-        "known_not_comparable": 10,
+        "comparable": 2,
+        "known_not_comparable": 12,
         "unmapped": 1,
     }
     items_by_id = {item["legal_id"]: item for item in report["items"]}
@@ -466,6 +511,24 @@ rules:
             "us:statutes/42/1382/b#statutory_base_annual_rate_with_eligible_spouse"
         ]["policyengine_parameter"]
         == "gov.ssa.ssi.amount.couple"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/42/1382/a/3#couple_or_living_with_spouse_resource_limit"
+        ]["policyengine_parameter"]
+        == "gov.ssa.ssi.eligibility.resources.limit.couple"
+    )
+    assert (
+        items_by_id["us:statutes/42/1382/a/3#individual_no_spouse_resource_limit"][
+            "policyengine_parameter"
+        ]
+        == "gov.ssa.ssi.eligibility.resources.limit.individual"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/42/1382/a/3#couple_or_living_with_spouse_resource_limit"
+        ]["test_output_count"]
+        == 1
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.792"
+version = "0.2.793"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add PolicyEngine oracle mappings for SSI individual and couple resource limits from 42 USC 1382(a)(3)
- classify raw statutory schedules as not-comparable intermediates and compare applied outputs to PE resource-limit parameters
- bump axiom-encode to 0.2.793 for RuleSpec provenance

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::test_package_version_metadata_matches_pyproject
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/