### PR TITLE
Map SSI 1382f amounts to PolicyEngine oracle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.793"
+version = "0.2.794"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.793"
+__version__ = "0.2.794"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -286,6 +286,44 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec exposes the 42 USC 1382f(a) post-COLA amount before it is folded into final monthly SSI benefit-rate parameters; PolicyEngine does not expose this statutory intermediate as a comparable target.
 
+  - legal_id: us:statutes/42/1382f/a#prior_rounding_carryover_increase_for_section_1382_b_1_amount
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.individual
+    candidate_priority: P4
+    rationale: RuleSpec exposes the branch-specific annual rounding carryover used to determine the individual SSI federal benefit rate under 42 USC 1382f(a); PolicyEngine materializes the final monthly amount and does not expose this carryover intermediate.
+
+  - legal_id: us:statutes/42/1382f/a#amount_determined_under_section_1382f_for_section_1382_b_1
+    country: us
+    program: ssi
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ssa.ssi.amount.individual
+    period: year
+    unit: USD
+    comparison: money
+    result_multiplier: 12
+    rationale: Same federal SSI individual benefit-rate amount, with PolicyEngine storing the monthly parameter and RuleSpec encoding the annual amount determined under 42 USC 1382f(a) for section 1382(b)(1).
+
+  - legal_id: us:statutes/42/1382f/a#prior_rounding_carryover_increase_for_section_1382_b_2_amount
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.couple
+    candidate_priority: P4
+    rationale: RuleSpec exposes the branch-specific annual rounding carryover used to determine the couple SSI federal benefit rate under 42 USC 1382f(a); PolicyEngine materializes the final monthly amount and does not expose this carryover intermediate.
+
+  - legal_id: us:statutes/42/1382f/a#amount_determined_under_section_1382f_for_section_1382_b_2
+    country: us
+    program: ssi
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ssa.ssi.amount.couple
+    period: year
+    unit: USD
+    comparison: money
+    result_multiplier: 12
+    rationale: Same federal SSI couple benefit-rate amount, with PolicyEngine storing the monthly parameter and RuleSpec encoding the annual amount determined under 42 USC 1382f(a) for section 1382(b)(2).
+
   - legal_id: us:statutes/42/1382f/c#dollar_amount_increase_for_section_1382_a_1_a_and_b_1
     country: us
     program: ssi

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -434,6 +434,30 @@ rules:
     versions:
       - effective_from: '1975-01-01'
         formula: 1
+  - name: prior_rounding_carryover_increase_for_section_1382_b_1_amount
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '1975-01-01'
+        formula: 0
+  - name: amount_determined_under_section_1382f_for_section_1382_b_1
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '1975-01-01'
+        formula: 1200
+  - name: prior_rounding_carryover_increase_for_section_1382_b_2_amount
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '1975-01-01'
+        formula: 0
+  - name: amount_determined_under_section_1382f_for_section_1382_b_2
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '1975-01-01'
+        formula: 1800
 """,
     )
     _write_rulespec_file(
@@ -475,10 +499,10 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path, program="ssi")
 
-    assert report["total_outputs"] == 15
+    assert report["total_outputs"] == 19
     assert report["status_counts"] == {
-        "comparable": 2,
-        "known_not_comparable": 12,
+        "comparable": 4,
+        "known_not_comparable": 14,
         "unmapped": 1,
     }
     items_by_id = {item["legal_id"]: item for item in report["items"]}
@@ -523,6 +547,18 @@ rules:
             "policyengine_parameter"
         ]
         == "gov.ssa.ssi.eligibility.resources.limit.individual"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/42/1382f/a#amount_determined_under_section_1382f_for_section_1382_b_1"
+        ]["policyengine_parameter"]
+        == "gov.ssa.ssi.amount.individual"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/42/1382f/a#amount_determined_under_section_1382f_for_section_1382_b_2"
+        ]["policyengine_parameter"]
+        == "gov.ssa.ssi.amount.couple"
     )
     assert (
         items_by_id[

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2381,6 +2381,23 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
     assert ssi_blind_expense_mapping.mapping_type == "not_comparable"
     assert ssi_blind_expense_mapping.policyengine_variable == "ssi_countable_income"
+    ssi_individual_fbr_mapping = registry.mapping_for_legal_id(
+        "us:statutes/42/1382f/a#amount_determined_under_section_1382f_for_section_1382_b_1",
+        country="us",
+    )
+    assert ssi_individual_fbr_mapping.mapping_type == "parameter_value"
+    assert (
+        ssi_individual_fbr_mapping.policyengine_parameter
+        == "gov.ssa.ssi.amount.individual"
+    )
+    assert ssi_individual_fbr_mapping.result_multiplier == 12
+    ssi_couple_fbr_mapping = registry.mapping_for_legal_id(
+        "us:statutes/42/1382f/a#amount_determined_under_section_1382f_for_section_1382_b_2",
+        country="us",
+    )
+    assert ssi_couple_fbr_mapping.mapping_type == "parameter_value"
+    assert ssi_couple_fbr_mapping.policyengine_parameter == "gov.ssa.ssi.amount.couple"
+    assert ssi_couple_fbr_mapping.result_multiplier == 12
     maximum_allotment_mapping = registry.mapping_for_legal_id(
         "us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_table",
         country="us",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.793"
+version = "0.2.794"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map branch-specific 42 USC 1382f(a) final SSI FBR amounts to PolicyEngine's individual and couple SSI amount parameters
- classify the branch-specific rounding carryover outputs as known non-comparable intermediates
- bump axiom-encode to 0.2.794 for RuleSpec apply provenance

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_federal_ssi_benefit_rate_intermediates tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_rulespec_validation.py::test_policyengine_oracle_applies_result_multiplier
- uv run --extra dev python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::test_package_version_metadata_matches_pyproject
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/