### PR TITLE
Classify SSI 1382b oracle surfaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.794"
+version = "0.2.795"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.794"
+__version__ = "0.2.795"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -138,6 +138,22 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec encodes the original 1974 statutory annual SSI couple base rate in 42 USC 1382(b); PolicyEngine stores final monthly federal benefit-rate parameters after later statutory increases and COLA uprating, not this base amount as a comparable parameter cell.
 
+  - legal_id: us:statutes/42/1382/b#annual_benefit_without_eligible_spouse
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: ssi
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 42 USC 1382(b)(1) source-level annual benefit formula for an eligible individual without an eligible spouse before broader eligibility, resource, take-up, and modeled administrative assumptions. PolicyEngine's closest exposed surface is final person-level SSI, which includes those additional gates and therefore is not a one-to-one oracle for this branch output.
+
+  - legal_id: us:statutes/42/1382/b#annual_benefit_with_eligible_spouse
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: tax_unit_ssi
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 42 USC 1382(b)(2) source-level annual benefit formula using the eligible-spouse/couple rate and combined non-excluded income. PolicyEngine's closest exposed aggregate is tax-unit SSI, but it sums person-level final SSI after eligibility, take-up, and model-specific couple allocation, so it is not a one-to-one oracle for this statutory branch output.
+
   - legal_id: us:statutes/42/1382a/b/2#annual_general_income_exclusion_limit
     country: us
     program: ssi

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -398,6 +398,18 @@ rules:
     versions:
       - effective_from: '1974-01-01'
         formula: 2628
+  - name: annual_benefit_without_eligible_spouse
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '1974-01-01'
+        formula: 1200
+  - name: annual_benefit_with_eligible_spouse
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '1974-01-01'
+        formula: 1800
 """,
     )
     _write_rulespec_file(
@@ -499,10 +511,10 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path, program="ssi")
 
-    assert report["total_outputs"] == 19
+    assert report["total_outputs"] == 21
     assert report["status_counts"] == {
         "comparable": 4,
-        "known_not_comparable": 14,
+        "known_not_comparable": 16,
         "unmapped": 1,
     }
     items_by_id = {item["legal_id"]: item for item in report["items"]}
@@ -535,6 +547,18 @@ rules:
             "us:statutes/42/1382/b#statutory_base_annual_rate_with_eligible_spouse"
         ]["policyengine_parameter"]
         == "gov.ssa.ssi.amount.couple"
+    )
+    assert (
+        items_by_id["us:statutes/42/1382/b#annual_benefit_without_eligible_spouse"][
+            "policyengine_variable"
+        ]
+        == "ssi"
+    )
+    assert (
+        items_by_id["us:statutes/42/1382/b#annual_benefit_with_eligible_spouse"][
+            "policyengine_variable"
+        ]
+        == "tax_unit_ssi"
     )
     assert (
         items_by_id[

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2398,6 +2398,18 @@ def test_policyengine_registry_is_legal_id_keyed():
     assert ssi_couple_fbr_mapping.mapping_type == "parameter_value"
     assert ssi_couple_fbr_mapping.policyengine_parameter == "gov.ssa.ssi.amount.couple"
     assert ssi_couple_fbr_mapping.result_multiplier == 12
+    ssi_individual_benefit_mapping = registry.mapping_for_legal_id(
+        "us:statutes/42/1382/b#annual_benefit_without_eligible_spouse",
+        country="us",
+    )
+    assert ssi_individual_benefit_mapping.mapping_type == "not_comparable"
+    assert ssi_individual_benefit_mapping.policyengine_variable == "ssi"
+    ssi_couple_benefit_mapping = registry.mapping_for_legal_id(
+        "us:statutes/42/1382/b#annual_benefit_with_eligible_spouse",
+        country="us",
+    )
+    assert ssi_couple_benefit_mapping.mapping_type == "not_comparable"
+    assert ssi_couple_benefit_mapping.policyengine_variable == "tax_unit_ssi"
     maximum_allotment_mapping = registry.mapping_for_legal_id(
         "us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_table",
         country="us",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.794"
+version = "0.2.795"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 42 USC 1382(b) branch benefit outputs as known PE non-comparable surfaces
- point the individual branch to PE's closest `ssi` surface and the eligible-spouse branch to `tax_unit_ssi` for auditability
- bump axiom-encode to 0.2.795

## Tests
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_federal_ssi_benefit_rate_intermediates tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::test_package_version_metadata_matches_pyproject`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`