### PR TITLE
Add PolicyEngine cloud queue export

### DIFF
--- a/docs/policyengine-oracle-registry.md
+++ b/docs/policyengine-oracle-registry.md
@@ -190,3 +190,47 @@ The command prioritizes untested comparable mappings, unmapped outputs that look
 like exact PolicyEngine variables, and known adjacent targets that may deserve a
 small adapter. `candidate_priority` can lower already-reviewed non-comparables
 without hiding them from the report.
+
+## Cloud Queue Export
+
+Use the cloud queue command to export deterministic work items before assigning
+parallel encoding work:
+
+```bash
+axiom-encode cloud-queue --root /path/to/workspace --json
+```
+
+The queue is model-free orchestration input. It converts PolicyEngine program
+surfaces into explicit work items without running encoders, opening branches, or
+claiming that any surface is legally comparable. The current schema is:
+
+```text
+axiom-encode/policyengine-cloud-queue/v1
+```
+
+Each item includes:
+
+- `action`: one of `ingest_source`, `encode_rulespec`, `wire_oracle_mapping`, or
+  `bootstrap_jurisdiction`
+- `priority`: the program-surface priority such as `P1` or `P2`
+- `target_repo` and `target_prefix`: where generated RuleSpec or source work
+  should eventually land
+- `policyengine_variable`: the oracle surface that motivated the item
+- `lock_scopes`: deterministic repo, prefix, legal-ID, and source locks for
+  future cloud workers
+- `oracle_expectation`: what a successful worker should prove or classify
+
+By default the queue includes `pending_source_ingestion`,
+`pending_rulespec_encoding`, and `pending_oracle_mapping` surfaces. Add
+`--include-deferred-jurisdictions` when planning repo/bootstrap work for
+jurisdictions that do not have a ready RuleSpec target yet.
+
+Cloud workers should emit artifacts using the companion run-artifact schema:
+
+```text
+axiom-encode/policyengine-cloud-run-artifact/v1
+```
+
+At minimum, run artifacts should preserve the work item ID, encoder version and
+git SHA, corpus reference, RuleSpec base SHA, model and prompt hash, generated
+diff, validation logs, oracle results, retry history, and final classification.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.902"
+version = "0.2.903"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.902"
+__version__ = "0.2.903"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -114,6 +114,7 @@ from .harness.validator_pipeline import (
 )
 from .oracles.policyengine.coverage import (
     build_policyengine_candidate_report,
+    build_policyengine_cloud_queue_report,
     build_policyengine_coverage_report,
 )
 from .oracles.policyengine.ecps_snap import (
@@ -798,6 +799,50 @@ def main():
         help="Maximum candidates to print in text mode",
     )
     oracle_candidates_parser.add_argument(
+        "--json", action="store_true", help="Output as JSON"
+    )
+
+    cloud_queue_parser = subparsers.add_parser(
+        "cloud-queue",
+        help=(
+            "Export deterministic PolicyEngine parity work items for future "
+            "cloud-parallel encoding"
+        ),
+    )
+    cloud_queue_parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Workspace root containing rulespec-* repos",
+    )
+    cloud_queue_parser.add_argument(
+        "--oracle",
+        choices=["policyengine"],
+        default="policyengine",
+        help="Oracle surface inventory to inspect",
+    )
+    cloud_queue_parser.add_argument(
+        "--program",
+        default=None,
+        help="Restrict queue to a program label such as snap or tax",
+    )
+    cloud_queue_parser.add_argument(
+        "--country",
+        default="us",
+        help="PolicyEngine program surface country manifest to inspect",
+    )
+    cloud_queue_parser.add_argument(
+        "--include-deferred-jurisdictions",
+        action="store_true",
+        help="Include repo/bootstrap tasks for deferred jurisdictions",
+    )
+    cloud_queue_parser.add_argument(
+        "--limit",
+        type=int,
+        default=25,
+        help="Maximum work items to print in text mode",
+    )
+    cloud_queue_parser.add_argument(
         "--json", action="store_true", help="Output as JSON"
     )
 
@@ -2204,6 +2249,8 @@ def main():
         cmd_oracle_coverage(args)
     elif args.command == "oracle-candidates":
         cmd_oracle_candidates(args)
+    elif args.command == "cloud-queue":
+        cmd_cloud_queue(args)
     elif args.command == "classify":
         cmd_classify(args)
     elif args.command in {"snap-populace-compare", "snap-ecps-compare"}:
@@ -3806,6 +3853,47 @@ def cmd_oracle_candidates(args):
             print(f"    {item['recommendation']}")
             if item.get("rationale"):
                 print(f"    current rationale: {item['rationale']}")
+
+
+def cmd_cloud_queue(args):
+    """Export deterministic work items for future cloud-parallel encoding."""
+    if args.oracle != "policyengine":
+        print(f"Unsupported oracle: {args.oracle}")
+        sys.exit(2)
+
+    root = (args.root or _default_rulespec_inventory_root()).resolve()
+    report = build_policyengine_cloud_queue_report(
+        root,
+        country=args.country,
+        program=args.program,
+        include_deferred_jurisdictions=args.include_deferred_jurisdictions,
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        sys.exit(0)
+
+    print("PolicyEngine cloud-parallel work queue")
+    print(f"Schema: {report['schema']}")
+    print(f"Root: {report['root']}")
+    print(f"Country: {report['country']}")
+    if args.program:
+        print(f"Program: {args.program}")
+    print(f"Items: {report['total_items']}")
+    print(f"Actions: {_format_counter(report['action_counts'])}")
+    print(f"Priorities: {_format_counter(report['priority_counts'])}")
+
+    items = report["items"]
+    if items:
+        print()
+        print(f"Top work items (first {args.limit}):")
+        for item in items[: args.limit]:
+            state = f" [{item['state']}]" if item.get("state") else ""
+            print(
+                f"  - [{item.get('priority') or 'unprioritized'}] "
+                f"{item['action']} {item['policyengine_variable']}{state} "
+                f"-> {item['target_repo']}"
+            )
+            print(f"    locks: {', '.join(item['lock_scopes'])}")
         if len(items) > args.limit:
             print(f"  - ... {len(items) - args.limit} more")
 

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -36,6 +36,21 @@ PROGRAM_SURFACE_STATUSES = {
     "wired",
 }
 PROGRAM_SURFACE_LIFECYCLES = {"active", "inactive", "sunset", "historical"}
+POLICYENGINE_CLOUD_QUEUE_SCHEMA = "axiom-encode/policyengine-cloud-queue/v1"
+POLICYENGINE_CLOUD_RUN_ARTIFACT_SCHEMA = (
+    "axiom-encode/policyengine-cloud-run-artifact/v1"
+)
+CLOUD_QUEUE_STATUSES = {
+    "pending_oracle_mapping",
+    "pending_rulespec_encoding",
+    "pending_source_ingestion",
+}
+CLOUD_QUEUE_STATUS_ACTIONS = {
+    "pending_oracle_mapping": "wire_oracle_mapping",
+    "pending_rulespec_encoding": "encode_rulespec",
+    "pending_source_ingestion": "ingest_source",
+    "deferred_jurisdiction": "bootstrap_jurisdiction",
+}
 _PROGRAM_TOKEN_RE = {
     token: re.compile(rf"(^|[^a-z0-9]){token}([^a-z0-9]|$)")
     for token in ("medicaid", "chip", "aca")
@@ -289,6 +304,56 @@ class PolicyEngineProgramSurfaceItem:
         }
 
 
+@dataclass(frozen=True)
+class PolicyEngineCloudQueueItem:
+    """One deterministic work item for future cloud-parallel encoding."""
+
+    id: str
+    action: str
+    priority: str | None
+    axiom_status: str
+    country: str
+    target_repo: str
+    target_prefix: str
+    program_id: str
+    program_name: str
+    category: str
+    policyengine_variable: str
+    policyengine_status: str
+    coverage: str
+    source_type: str
+    agency: str | None = None
+    state: str | None = None
+    oracle_expectation: str | None = None
+    lock_scopes: tuple[str, ...] = ()
+    legal_ids: tuple[str, ...] = ()
+    rationale: str | None = None
+
+    def as_dict(self) -> dict[str, str | list[str] | None]:
+        return {
+            "id": self.id,
+            "action": self.action,
+            "priority": self.priority,
+            "axiom_status": self.axiom_status,
+            "country": self.country,
+            "target_repo": self.target_repo,
+            "target_prefix": self.target_prefix,
+            "program_id": self.program_id,
+            "program_name": self.program_name,
+            "category": self.category,
+            "agency": self.agency,
+            "state": self.state,
+            "policyengine_variable": self.policyengine_variable,
+            "policyengine_status": self.policyengine_status,
+            "coverage": self.coverage,
+            "source_type": self.source_type,
+            "oracle_expectation": self.oracle_expectation,
+            "lock_scopes": list(self.lock_scopes),
+            "legal_ids": list(self.legal_ids),
+            "rationale": self.rationale,
+        }
+
+
 def build_policyengine_coverage_report(
     root: Path,
     *,
@@ -372,6 +437,90 @@ def _coverage_item_preference_key(item: PolicyEngineCoverageItem) -> tuple:
     )
 
 
+def build_policyengine_cloud_queue_report(
+    root: Path,
+    *,
+    country: str = "us",
+    program: str | None = None,
+    manifest_path: Path | None = None,
+    include_deferred_jurisdictions: bool = False,
+) -> dict[str, Any]:
+    """Export a deterministic work queue from PolicyEngine program surfaces.
+
+    The queue is intentionally model-free: it does not assign agents or create
+    branches. It gives cloud workers a stable work-item contract while the
+    orchestration layer is still being designed.
+    """
+    root = root.resolve()
+    surface_report = build_policyengine_program_surface_report(
+        country=country,
+        program=program,
+        manifest_path=manifest_path,
+    )
+    statuses = set(CLOUD_QUEUE_STATUSES)
+    if include_deferred_jurisdictions:
+        statuses.add("deferred_jurisdiction")
+    raw_items = [
+        _cloud_queue_item_from_program_surface(item)
+        for item in surface_report["items"]
+        if item.get("axiom_status") in statuses
+    ]
+    items = sorted(
+        raw_items,
+        key=lambda item: (
+            _candidate_priority_rank(item.priority or ""),
+            _cloud_queue_action_rank(item.action),
+            item.target_repo,
+            item.program_id,
+            item.policyengine_variable,
+        ),
+    )
+    action_counts = Counter(item.action for item in items)
+    priority_counts = Counter(item.priority for item in items if item.priority)
+    repo_counts: dict[str, Counter[str]] = {}
+    for item in items:
+        repo_counts.setdefault(item.target_repo, Counter())[item.action] += 1
+    return {
+        "schema": POLICYENGINE_CLOUD_QUEUE_SCHEMA,
+        "run_artifact_schema": POLICYENGINE_CLOUD_RUN_ARTIFACT_SCHEMA,
+        "oracle": "policyengine",
+        "root": str(root),
+        "country": country,
+        "program": program,
+        "source": surface_report.get("source", {}),
+        "total_items": len(items),
+        "action_counts": dict(sorted(action_counts.items())),
+        "priority_counts": dict(sorted(priority_counts.items())),
+        "repos": [
+            {
+                "repo": repo,
+                "total_items": sum(counter.values()),
+                "action_counts": dict(sorted(counter.items())),
+            }
+            for repo, counter in sorted(repo_counts.items())
+        ],
+        "artifact_contract": {
+            "required_fields": [
+                "schema",
+                "work_item_id",
+                "status",
+                "encoder_version",
+                "encoder_git_sha",
+                "corpus_ref",
+                "rulespec_base_sha",
+                "model",
+                "prompt_hash",
+                "generated_diff",
+                "validation_logs",
+                "oracle_results",
+                "retry_history",
+                "final_classification",
+            ],
+        },
+        "items": [item.as_dict() for item in items],
+    }
+
+
 def build_policyengine_program_surface_report(
     *,
     country: str = "us",
@@ -449,6 +598,98 @@ def build_policyengine_program_surface_report(
         "actionable_surfaces": [surface.as_dict() for surface in actionable_surfaces],
         "items": [surface.as_dict() for surface in surfaces],
     }
+
+
+def _cloud_queue_item_from_program_surface(
+    item: dict[str, Any],
+) -> PolicyEngineCloudQueueItem:
+    status = str(item.get("axiom_status") or "")
+    action = CLOUD_QUEUE_STATUS_ACTIONS[status]
+    country = str(item.get("country") or "us").lower()
+    state = item.get("state")
+    state_text = str(state).lower() if state else None
+    target_prefix = f"{country}-{state_text}" if state_text else country
+    target_repo = (
+        "axiom-corpus"
+        if action == "ingest_source"
+        else canonical_rulespec_repo_name_from_prefix(target_prefix)
+    )
+    variable = str(item.get("variable") or "")
+    queue_id = ":".join(
+        [
+            "policyengine-surface",
+            country,
+            str(item.get("coverage") or "").lower(),
+            _queue_slug(variable),
+        ]
+    )
+    lock_scopes = [
+        f"policyengine-surface:{country}:{variable}",
+        f"target-prefix:{target_prefix}",
+    ]
+    if target_repo:
+        lock_scopes.append(f"repo:{target_repo}")
+    legal_ids = tuple(str(legal_id) for legal_id in item.get("legal_ids", []) or ())
+    lock_scopes.extend(f"legal-id:{legal_id}" for legal_id in legal_ids)
+    if action == "ingest_source":
+        lock_scopes.append(
+            "corpus-source:"
+            f"{country}:{str(item.get('program_id') or '').lower()}:{variable}"
+        )
+
+    return PolicyEngineCloudQueueItem(
+        id=queue_id,
+        action=action,
+        priority=item.get("priority"),
+        axiom_status=status,
+        country=country,
+        target_repo=target_repo,
+        target_prefix=target_prefix,
+        program_id=str(item.get("program_id") or ""),
+        program_name=str(item.get("program_name") or ""),
+        category=str(item.get("category") or ""),
+        agency=item.get("agency"),
+        state=str(state) if state else None,
+        policyengine_variable=variable,
+        policyengine_status=str(item.get("policyengine_status") or ""),
+        coverage=str(item.get("coverage") or ""),
+        source_type=str(item.get("source_type") or "program"),
+        oracle_expectation=_cloud_queue_oracle_expectation(action),
+        lock_scopes=tuple(dict.fromkeys(lock_scopes)),
+        legal_ids=legal_ids,
+        rationale=item.get("rationale"),
+    )
+
+
+def canonical_rulespec_repo_name_from_prefix(prefix: str) -> str:
+    """Return the legacy per-jurisdiction RuleSpec repo name for a prefix."""
+    return f"rulespec-{prefix}"
+
+
+def _cloud_queue_oracle_expectation(action: str) -> str:
+    if action == "encode_rulespec":
+        return "encode source-law output and add exact oracle mapping when comparable"
+    if action == "ingest_source":
+        return "ingest source before scheduling RuleSpec encoding"
+    if action == "wire_oracle_mapping":
+        return "classify existing legal outputs in the oracle registry"
+    if action == "bootstrap_jurisdiction":
+        return "prepare jurisdiction repo/source routing before encoding"
+    return "classify outcome before merge"
+
+
+def _cloud_queue_action_rank(action: str) -> int:
+    return {
+        "ingest_source": 0,
+        "bootstrap_jurisdiction": 1,
+        "encode_rulespec": 2,
+        "wire_oracle_mapping": 3,
+    }.get(action, 99)
+
+
+def _queue_slug(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "unknown"
 
 
 def build_policyengine_candidate_report(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1879,10 +1879,8 @@ class TestCmdValidate:
                 ],
             },
         ):
-            with pytest.raises(SystemExit) as exc_info:
-                cmd_oracle_candidates(args)
+            cmd_oracle_candidates(args)
 
-        assert exc_info.value.code == 0
         output = capsys.readouterr().out
         assert "PolicyEngine oracle candidates" in output
         assert "[P1] exact_variable_unmapped" in output

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4,6 +4,7 @@ import pytest
 
 from axiom_encode.oracles.policyengine.coverage import (
     build_policyengine_candidate_report,
+    build_policyengine_cloud_queue_report,
     build_policyengine_coverage_report,
     build_policyengine_program_surface_report,
 )
@@ -809,6 +810,132 @@ surfaces:
             manifest_path=manifest,
             registry=_ProgramSurfaceRegistry({}),
         )
+
+
+def test_policyengine_cloud_queue_exports_actionable_program_surfaces(tmp_path):
+    manifest = tmp_path / "program_surfaces.yaml"
+    manifest.write_text(
+        """source:
+  repository: PolicyEngine/policyengine-us
+  ref: test
+  path: policyengine_us/programs.yaml
+surfaces:
+  - country: us
+    program_id: federal_income_tax
+    program_name: New tax surface
+    category: Taxes
+    policyengine_status: complete
+    coverage: US
+    variable: new_tax_surface
+    axiom_status: pending_rulespec_encoding
+    priority: P1
+    rationale: Needs governing law encoding.
+  - country: us
+    program_id: ccdf
+    program_name: Arizona CCAP
+    category: Benefits
+    policyengine_status: complete
+    coverage: AZ
+    variable: az_ccap
+    source_type: state_implementation
+    state: AZ
+    axiom_status: pending_source_ingestion
+    priority: P1
+    rationale: Needs source ingestion first.
+  - country: us
+    program_id: snap
+    program_name: Montana SNAP
+    category: Benefits
+    policyengine_status: complete
+    coverage: MT
+    variable: mt_snap
+    source_type: state_implementation
+    state: MT
+    axiom_status: deferred_jurisdiction
+    priority: P2
+    rationale: Needs jurisdiction setup.
+  - country: us
+    program_id: fdpir
+    program_name: FDPIR
+    category: Benefits
+    policyengine_status: partial
+    coverage: US
+    variable: fdpir
+    axiom_status: input_only
+    priority: P1
+    rationale: Not queue material.
+""",
+        encoding="utf-8",
+    )
+
+    report = build_policyengine_cloud_queue_report(
+        tmp_path,
+        manifest_path=manifest,
+    )
+
+    assert report["schema"] == "axiom-encode/policyengine-cloud-queue/v1"
+    assert (
+        report["run_artifact_schema"]
+        == "axiom-encode/policyengine-cloud-run-artifact/v1"
+    )
+    assert report["total_items"] == 2
+    assert report["action_counts"] == {
+        "encode_rulespec": 1,
+        "ingest_source": 1,
+    }
+    items_by_variable = {
+        item["policyengine_variable"]: item for item in report["items"]
+    }
+
+    new_tax_surface = items_by_variable["new_tax_surface"]
+    assert new_tax_surface["action"] == "encode_rulespec"
+    assert new_tax_surface["target_repo"] == "rulespec-us"
+    assert new_tax_surface["target_prefix"] == "us"
+    assert "repo:rulespec-us" in new_tax_surface["lock_scopes"]
+    assert new_tax_surface["oracle_expectation"].startswith("encode source-law output")
+
+    az_ccap = items_by_variable["az_ccap"]
+    assert az_ccap["action"] == "ingest_source"
+    assert az_ccap["target_repo"] == "axiom-corpus"
+    assert az_ccap["target_prefix"] == "us-az"
+    assert "corpus-source:us:ccdf:az_ccap" in az_ccap["lock_scopes"]
+
+
+def test_policyengine_cloud_queue_can_include_deferred_jurisdictions(tmp_path):
+    manifest = tmp_path / "program_surfaces.yaml"
+    manifest.write_text(
+        """source:
+  repository: PolicyEngine/policyengine-us
+  ref: test
+  path: policyengine_us/programs.yaml
+surfaces:
+  - country: us
+    program_id: snap
+    program_name: Montana SNAP
+    category: Benefits
+    policyengine_status: complete
+    coverage: MT
+    variable: mt_snap
+    source_type: state_implementation
+    state: MT
+    axiom_status: deferred_jurisdiction
+    priority: P2
+    rationale: Needs jurisdiction setup.
+""",
+        encoding="utf-8",
+    )
+
+    report = build_policyengine_cloud_queue_report(
+        tmp_path,
+        manifest_path=manifest,
+        include_deferred_jurisdictions=True,
+    )
+
+    assert report["total_items"] == 1
+    item = report["items"][0]
+    assert item["action"] == "bootstrap_jurisdiction"
+    assert item["target_repo"] == "rulespec-us-mt"
+    assert item["target_prefix"] == "us-mt"
 
 
 def test_policyengine_program_surface_marks_colorado_ccap_final_subsidy_known_not_comparable():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.902"
+version = "0.2.903"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Adds a deterministic `axiom-encode cloud-queue` export for PolicyEngine parity work, so future cloud workers have a stable work-item contract before we build the parallel execution layer.

- adds `axiom-encode/policyengine-cloud-queue/v1` with action, priority, target repo/prefix, lock scopes, and oracle expectations
- adds companion run-artifact contract fields for worker outputs
- exposes text and JSON CLI modes via `axiom-encode cloud-queue --root ...`
- documents the queue export in the PolicyEngine oracle registry
- bumps `axiom-encode` to `0.2.903` because this touches encoder-affecting files

## Current workspace export

`uv run axiom-encode cloud-queue --root /Users/maxghenis/TheAxiomFoundation --json` currently reports:

- 60 total work items
- 59 `encode_rulespec` items
- 1 `ingest_source` item
- all P1 under the current impact categories

The first blocker is `az_ccap` source ingestion; the rest are queued encoding surfaces such as ACP, clean vehicle credit, energy rebates, Head Start, Lifeline, Medicare eligibility, Pell Grant, and state TANF/benefit surfaces.

## Checks

Local checks on commit `406b79e6`:

- `uv run ruff check src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/cli.py tests/test_policyengine_coverage.py tests/test_cli.py src/axiom_encode/__init__.py`
- `uv run ruff format --check src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/cli.py tests/test_policyengine_coverage.py tests/test_cli.py src/axiom_encode/__init__.py pyproject.toml`
- `uv run python -m compileall -q src/axiom_encode`
- `uv run --extra dev python -m pytest` — 2180 passed, 22 skipped
- `uv run axiom-encode cloud-queue --root /Users/maxghenis/TheAxiomFoundation --limit 5`
- `git diff --check`

After the 2026-06-27 rebase, GitHub CI passes on commit `39b37732` (`test (3.13)` and `lint`). Local focused checks also passed: `pytest tests/test_policyengine_coverage.py tests/test_cli.py -q`, `ruff check ...`, and `git diff --check`.

## Review status

Refreshed on 2026-06-27 after rebasing onto `main`: GitHub CI now passes and the branch is clean/mergeable.
