### PR TITLE
Classify NY TANF PolicyEngine surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.795"
+version = "0.2.796"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.795"
+__version__ = "0.2.796"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -219,10 +219,12 @@ surfaces:
   variable: ny_tanf
   source_type: state_implementation
   state: NY
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Current RuleSpec repos include a runnable us-ny/tanf FY 2026 composition over tested State Plan standard-of-need,
+    grant, home-energy, shelter-cap, asset, and income-disregard legal slices. Direct oracle comparison should wait for a
+    New York TANF adapter that targets the same source-faithful monthly boundaries; PolicyEngine's ny_tanf is a final annual
+    program variable with its own graph and older parameterization, and the Axiom shelter table remains partially deferred.
 - country: us
   program_id: tanf
   program_name: Massachusetts TAFDC

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.795"
+version = "0.2.796"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- update the NY TANF PE program surface from pending encoding to known_not_comparable
- point the rationale at the new runnable us-ny/tanf FY 2026 composition
- document why direct PE oracle comparison should wait: the Axiom composition is source-faithful and monthly, PE's ny_tanf is final annual, and shelter tables remain partially deferred

## Validation
- uv run axiom-encode oracle-coverage --oracle policyengine --root /Users/maxghenis/TheAxiomFoundation --include-program-surfaces --program tanf --limit 30 --json
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q