### PR TITLE
Include program specs in PolicyEngine oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.796"
+version = "0.2.797"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.796"
+__version__ = "0.2.797"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import ast
+import importlib.util
+import os
 import re
 from collections import Counter
 from dataclasses import dataclass
@@ -308,6 +311,7 @@ def _iter_policyengine_coverage_items(
     registry,
 ) -> list[PolicyEngineCoverageItem]:
     items: list[PolicyEngineCoverageItem] = []
+    items.extend(_iter_program_spec_coverage_items(root, registry))
     # Enumerate each jurisdiction's content root under the workspace, handling
     # both layouts: a legacy ``rulespec-<prefix>`` checkout contributes itself
     # under its prefix; a country monorepo ``rulespec-<country>`` contributes
@@ -379,6 +383,132 @@ def _iter_policyengine_coverage_items(
                     )
                 )
     return items
+
+
+def _iter_program_spec_coverage_items(
+    root: Path,
+    registry,
+) -> list[PolicyEngineCoverageItem]:
+    """Enumerate outputs declared by monorepo-native ``programs/`` specs."""
+    items: list[PolicyEngineCoverageItem] = []
+    for programs_dir, checkout_dir in _program_spec_dirs(root):
+        repo_name = canonical_rulespec_repo_name(checkout_dir) or checkout_dir.name
+        for spec_file in sorted(programs_dir.glob("*/*/*.y*ml")):
+            items.extend(
+                _program_spec_coverage_items_for_file(
+                    root=root,
+                    repo_name=repo_name,
+                    spec_file=spec_file,
+                    registry=registry,
+                )
+            )
+    return items
+
+
+def _program_spec_dirs(root: Path) -> list[tuple[Path, Path]]:
+    """Return ``(programs_dir, checkout_dir)`` pairs under a checkout/workspace."""
+    candidates: list[tuple[Path, Path]] = []
+    direct = root / "programs"
+    if direct.is_dir():
+        candidates.append((direct, root))
+    for checkout in sorted(root.glob("rulespec-*")):
+        programs_dir = checkout / "programs"
+        if programs_dir.is_dir():
+            candidates.append((programs_dir, checkout))
+
+    seen: set[Path] = set()
+    out: list[tuple[Path, Path]] = []
+    for programs_dir, checkout_dir in candidates:
+        resolved = programs_dir.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        out.append((programs_dir, checkout_dir))
+    return out
+
+
+def _program_spec_coverage_items_for_file(
+    *,
+    root: Path,
+    repo_name: str,
+    spec_file: Path,
+    registry,
+) -> list[PolicyEngineCoverageItem]:
+    payload = _load_program_spec_payload(spec_file)
+    if not payload:
+        return []
+    raw_program = payload.get("program")
+    raw_outputs = payload.get("outputs")
+    if not isinstance(raw_program, str) or not raw_program.strip():
+        return []
+    if not isinstance(raw_outputs, list):
+        return []
+    program_id = raw_program.strip()
+    prefix, _, program_path = program_id.partition("/")
+    if not prefix or not program_path:
+        return []
+    period_stem = spec_file.with_suffix("").name
+    spec_legal_path = f"programs/{program_path}/{period_stem}"
+    country = _country_from_rulespec_prefix(prefix)
+    file_path = _display_file_path(spec_file, root)
+    items: list[PolicyEngineCoverageItem] = []
+    for raw_output in raw_outputs:
+        if not isinstance(raw_output, str) or not raw_output.strip():
+            continue
+        output_name = raw_output.strip()
+        legal_id = f"{prefix}:{spec_legal_path}#{output_name}"
+        mapping = registry.mapping_for_legal_id(legal_id, country=country)
+        items.append(
+            _coverage_item_from_program_spec_mapping(
+                legal_id=legal_id,
+                repo_name=repo_name,
+                file_path=file_path,
+                rule_name=output_name,
+                program=program_path,
+                mapping=mapping,
+            )
+        )
+    return items
+
+
+def _coverage_item_from_program_spec_mapping(
+    *,
+    legal_id: str,
+    repo_name: str,
+    file_path: str,
+    rule_name: str,
+    program: str,
+    mapping: PolicyEngineMapping | None,
+) -> PolicyEngineCoverageItem:
+    if mapping is None:
+        status = "unmapped"
+        mapping_type = None
+        report_program = program
+    elif mapping.comparable:
+        status = "comparable"
+        mapping_type = mapping.mapping_type
+        report_program = mapping.program or program
+    else:
+        status = "known_not_comparable"
+        mapping_type = mapping.mapping_type
+        report_program = mapping.program or program
+
+    return PolicyEngineCoverageItem(
+        legal_id=legal_id,
+        repo=repo_name,
+        file=file_path,
+        rule_name=rule_name,
+        kind="program_output",
+        status=status,
+        program=report_program,
+        mapping_type=mapping_type,
+        policyengine_variable=mapping.policyengine_variable if mapping else None,
+        policyengine_parameter=mapping.policyengine_parameter if mapping else None,
+        rationale=mapping.rationale if mapping else None,
+        candidate_priority=mapping.candidate_priority if mapping else None,
+        tested=False,
+        test_output_count=0,
+    )
 
 
 def _candidate_from_coverage_item(
@@ -551,6 +681,9 @@ def _is_policyengine_looking_rule_name(rule_name: str) -> bool:
 
 
 def _load_policyengine_variable_names() -> set[str] | None:
+    source_names = _load_policyengine_variable_names_from_source()
+    if source_names is not None:
+        return source_names
     try:
         from policyengine_us import CountryTaxBenefitSystem
     except Exception:
@@ -559,6 +692,82 @@ def _load_policyengine_variable_names() -> set[str] | None:
         return set(CountryTaxBenefitSystem().variables)
     except Exception:
         return None
+
+
+def _load_policyengine_variable_names_from_source() -> set[str] | None:
+    """Load PolicyEngine-US variable names without importing its model package.
+
+    Candidate triage only needs to know whether a RuleSpec output name exists
+    as a PolicyEngine variable. Importing ``policyengine_us`` can execute the
+    full tax-benefit system and fail before triage starts, so prefer a source
+    tree scan when the package or a local checkout is available.
+    """
+    source_dirs = _policyengine_variable_source_dirs()
+    if not source_dirs:
+        return None
+    names: set[str] = set()
+    for source_dir in source_dirs:
+        for source_file in sorted(source_dir.rglob("*.py")):
+            names.update(_policyengine_variable_names_from_file(source_file))
+    return names
+
+
+def _policyengine_variable_source_dirs() -> list[Path]:
+    source_dirs: list[Path] = []
+    for env_name in ("AXIOM_POLICYENGINE_US_ROOT", "POLICYENGINE_US_ROOT"):
+        raw_path = os.environ.get(env_name)
+        if raw_path:
+            source_dirs.extend(_policyengine_variable_dirs_for_path(Path(raw_path)))
+
+    spec = importlib.util.find_spec("policyengine_us")
+    if spec and spec.submodule_search_locations:
+        for location in spec.submodule_search_locations:
+            source_dirs.extend(_policyengine_variable_dirs_for_path(Path(location)))
+
+    seen: set[Path] = set()
+    out: list[Path] = []
+    for source_dir in source_dirs:
+        resolved = source_dir.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        out.append(source_dir)
+    return out
+
+
+def _policyengine_variable_dirs_for_path(path: Path) -> list[Path]:
+    candidates = (
+        path,
+        path / "variables",
+        path / "policyengine_us" / "variables",
+    )
+    return [
+        candidate
+        for candidate in candidates
+        if candidate.is_dir() and candidate.name == "variables"
+    ]
+
+
+def _policyengine_variable_names_from_file(path: Path) -> set[str]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError, UnicodeDecodeError):
+        return set()
+    names: set[str] = set()
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if any(_is_policyengine_variable_base(base) for base in node.bases):
+            names.add(node.name)
+    return names
+
+
+def _is_policyengine_variable_base(node: ast.expr) -> bool:
+    if isinstance(node, ast.Name):
+        return node.id == "Variable"
+    if isinstance(node, ast.Attribute):
+        return node.attr == "Variable"
+    return False
 
 
 def _load_policyengine_program_surface_manifest(
@@ -684,6 +893,14 @@ def _load_rulespec_payload(path: Path) -> dict[str, Any] | None:
     if not isinstance(payload, dict) or payload.get("format") != "rulespec/v1":
         return None
     return payload
+
+
+def _load_program_spec_payload(path: Path) -> dict[str, Any] | None:
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
 
 
 def _rulespec_test_output_counts(path: Path) -> Counter[str]:

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -45,6 +45,70 @@ mappings:
     candidate_priority: P4
     rationale: Alabama's manual output combines categorical eligibility, elderly-or-disabled net-only treatment, and gross/net income standards into a state income bridge. PolicyEngine exposes separate gross, net, categorical, and final eligibility variables, but not this exact combined state bridge.
 
+  - legal_id: us-fl:programs/tca/fy-2026#fl_tca_payment_standard
+    country: us
+    program: tca
+    mapping_type: not_comparable
+    policyengine_variable: fl_tca_payment_standard
+    candidate_priority: P4
+    rationale: Axiom's Florida TCA program output composes the DCF Appendix A-5 shelter-tier payment-standard table through filing-unit size 24 plus additional-person increments. PolicyEngine's adjacent fl_tca_payment_standard uses its own shelter inputs and currently caps the payment-standard family size lower, so this is not a one-to-one oracle boundary.
+
+  - legal_id: us-fl:programs/tca/fy-2026#fl_tca_gross_income
+    country: us
+    program: tca
+    mapping_type: not_comparable
+    policyengine_variable: fl_tca_gross_income
+    candidate_priority: P4
+    rationale: Axiom's Florida TCA gross-income output follows the DCF eligibility-standard-test income boundary, including source-specific exclusions and assistance-group inputs. PolicyEngine's fl_tca_gross_income sums its general TANF earned and unearned income source graph, which is adjacent but not the same legal boundary.
+
+  - legal_id: us-fl:programs/tca/fy-2026#fl_tca_gross_income_eligible
+    country: us
+    program: tca
+    mapping_type: not_comparable
+    policyengine_variable: fl_tca_gross_income_eligible
+    candidate_priority: P4
+    rationale: Axiom applies the DCF "cannot exceed" eligibility-standard test against the Appendix A-5 185 percent standard. PolicyEngine's adjacent variable uses a strict less-than comparison against its FPG-derived threshold, so exact-threshold cases do not share a one-to-one boundary.
+
+  - legal_id: us-fl:programs/tca/fy-2026#fl_tca_countable_income
+    country: us
+    program: tca
+    mapping_type: not_comparable
+    policyengine_variable: fl_tca_countable_income
+    candidate_priority: P4
+    rationale: Axiom's Florida TCA countable-income output follows DCF page 21, including the conditional eligibility for the remainder of the $200-and-one-half earned-income disregard. PolicyEngine's adjacent countable-income path applies its TANF income/disregard graph directly, so this needs a PE fix or adapter before it is comparable.
+
+  - legal_id: us-fl:programs/tca/fy-2026#fl_tca_net_income_eligible
+    country: us
+    program: tca
+    mapping_type: not_comparable
+    policyengine_variable: fl_tca_net_income_eligible
+    candidate_priority: P4
+    rationale: Axiom treats Florida TCA net-income eligibility as no DCF budget surplus, allowing countable income equal to the applicable budget standard. PolicyEngine's adjacent variable uses a strict countable-income-less-than-payment-standard test and depends on PE's adjacent countable-income and payment-standard boundaries.
+
+  - legal_id: us-fl:programs/tca/fy-2026#fl_tca_resources_eligible
+    country: us
+    program: tca
+    mapping_type: not_comparable
+    policyengine_variable: fl_tca_resources_eligible
+    candidate_priority: P4
+    rationale: Axiom applies the DCF TCA standard filing unit resource limit to countable assets excluding TCA deemed individuals. PolicyEngine's adjacent variable compares spm_unit_cash_assets to the asset-limit parameter, so the legal asset boundary is not yet one-to-one.
+
+  - legal_id: us-fl:programs/tca/fy-2026#fl_tca_eligible
+    country: us
+    program: tca
+    mapping_type: not_comparable
+    policyengine_variable: fl_tca_eligible
+    candidate_priority: P4
+    rationale: The current Axiom Florida TCA wrapper acknowledges final eligibility as incomplete and only composes the financial gates. PolicyEngine's fl_tca_eligible also includes demographic and immigration eligibility, so this output should stay non-comparable until those legal predicates are wired.
+
+  - legal_id: us-fl:programs/tca/fy-2026#fl_tca
+    country: us
+    program: tca
+    mapping_type: not_comparable
+    policyengine_variable: fl_tca
+    candidate_priority: P4
+    rationale: The current Axiom Florida TCA amount depends on the incomplete Axiom eligibility wrapper and DCF page 21's no-issuance rule for deficits below $10. PolicyEngine's adjacent fl_tca uses its own eligibility, countable-income, and payment-standard graph and does not share this exact DCF program boundary yet.
+
   - legal_id: us-ma:policies/dta/snap/fy-2026-cola/heating-cooling-standard-utility-allowance#heating_cooling_standard_utility_allowance
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -107,6 +107,74 @@ rules:
     )
 
 
+def test_policyengine_coverage_includes_program_spec_outputs(tmp_path):
+    checkout = tmp_path / "rulespec-us"
+    _write_rulespec_file(
+        checkout / "programs/us-fl/tca/fy-2026.yaml",
+        """program: us-fl/tca
+period: 2026-01
+outputs:
+  - fl_tca_payment_standard
+  - fl_tca
+""",
+    )
+
+    report = build_policyengine_coverage_report(checkout, program="tca")
+
+    assert report["total_outputs"] == 2
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    payment_standard = items_by_id[
+        "us-fl:programs/tca/fy-2026#fl_tca_payment_standard"
+    ]
+    assert payment_standard["repo"] == "rulespec-us"
+    assert payment_standard["file"] == "programs/us-fl/tca/fy-2026.yaml"
+    assert payment_standard["kind"] == "program_output"
+    assert payment_standard["program"] == "tca"
+    assert payment_standard["rule_name"] == "fl_tca_payment_standard"
+    assert payment_standard["policyengine_variable"] == "fl_tca_payment_standard"
+    assert payment_standard["candidate_priority"] == "P4"
+
+
+def test_policyengine_candidates_classify_program_spec_adjacent_targets(tmp_path):
+    checkout = tmp_path / "rulespec-us"
+    _write_rulespec_file(
+        checkout / "programs/us-fl/tca/fy-2026.yaml",
+        """program: us-fl/tca
+period: 2026-01
+outputs:
+  - fl_tca_payment_standard
+  - fl_tca
+""",
+    )
+
+    report = build_policyengine_candidate_report(checkout, program="tca")
+
+    assert report["category_counts"] == {"known_adjacent_target": 2}
+    assert report["priority_counts"] == {"P4": 2}
+    targets = {item["policyengine_variable"] for item in report["items"]}
+    assert targets == {"fl_tca_payment_standard", "fl_tca"}
+
+
+def test_policyengine_coverage_includes_program_specs_from_workspace_root(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us/programs/us-fl/tca/fy-2026.yaml",
+        """program: us-fl/tca
+period: 2026-01
+outputs:
+  - fl_tca
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tca")
+
+    assert report["total_outputs"] == 1
+    item = report["items"][0]
+    assert item["legal_id"] == "us-fl:programs/tca/fy-2026#fl_tca"
+    assert item["repo"] == "rulespec-us"
+    assert item["file"] == "rulespec-us/programs/us-fl/tca/fy-2026.yaml"
+
+
 def test_policyengine_program_surface_report_overlays_legal_registry(tmp_path):
     manifest = tmp_path / "program_surfaces.yaml"
     manifest.write_text(
@@ -13194,6 +13262,46 @@ rules:
     assert first["legal_id"] == "us:statutes/7/9999#snap_new_exact_variable"
     assert first["priority"] == "P1"
     assert first["policyengine_variable"] == "snap_new_exact_variable"
+
+
+def test_policyengine_candidates_discover_variables_from_source_tree(
+    tmp_path, monkeypatch
+):
+    _write_rulespec_file(
+        tmp_path
+        / "policyengine-us"
+        / "policyengine_us"
+        / "variables/gov/states/xx/snap.py",
+        """from policyengine_us.model_api import *
+
+
+class snap_exact_variable_from_source_scan(Variable):
+    value_type = float
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/7/9998.yaml",
+        """format: rulespec/v1
+rules:
+  - name: snap_exact_variable_from_source_scan
+    kind: derived
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 1
+""",
+    )
+    monkeypatch.setenv(
+        "AXIOM_POLICYENGINE_US_ROOT",
+        str(tmp_path / "policyengine-us"),
+    )
+
+    report = build_policyengine_candidate_report(tmp_path, program="snap")
+
+    assert report["policyengine_variables_available"] is True
+    assert report["category_counts"]["exact_variable_unmapped"] == 1
+    candidate = report["items"][0]
+    assert candidate["policyengine_variable"] == "snap_exact_variable_from_source_scan"
+    assert candidate["priority"] == "P2"
 
 
 def test_policyengine_candidates_report_known_adjacent_targets(tmp_path):

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -124,9 +124,7 @@ outputs:
     assert report["total_outputs"] == 2
     assert report["status_counts"] == {"known_not_comparable": 2}
     items_by_id = {item["legal_id"]: item for item in report["items"]}
-    payment_standard = items_by_id[
-        "us-fl:programs/tca/fy-2026#fl_tca_payment_standard"
-    ]
+    payment_standard = items_by_id["us-fl:programs/tca/fy-2026#fl_tca_payment_standard"]
     assert payment_standard["repo"] == "rulespec-us"
     assert payment_standard["file"] == "programs/us-fl/tca/fy-2026.yaml"
     assert payment_standard["kind"] == "program_output"

--- a/tests/test_policyengine_coverage_monorepo.py
+++ b/tests/test_policyengine_coverage_monorepo.py
@@ -131,9 +131,8 @@ def test_monorepo_uk_jurisdiction_directories(tmp_path):
     assert repos == {"rulespec-uk", "rulespec-uk-kingston-upon-thames"}
 
 
-def test_monorepo_skips_non_jurisdiction_directories(tmp_path):
-    """Shared directories such as ``programs/`` are not treated as a
-    jurisdiction, so no ``programs:...`` IDs are emitted."""
+def test_monorepo_program_directory_is_not_a_jurisdiction(tmp_path):
+    """``programs/`` emits program specs without becoming a fake jurisdiction."""
     root = tmp_path / "mono"
     _write(
         root / "rulespec-us" / "us-al" / "policies" / "dhr" / "poe.yaml",
@@ -148,9 +147,11 @@ def test_monorepo_skips_non_jurisdiction_directories(tmp_path):
     report = build_policyengine_coverage_report(root)
     ids = [item["legal_id"] for item in report["items"]]
 
-    assert ids == ["us-al:policies/dhr/poe#brand_new_state_helper_xyz"]
+    assert ids == [
+        "us-al:policies/dhr/poe#brand_new_state_helper_xyz",
+        "us-al:programs/snap/fy-2026#snap_eligible",
+    ]
     assert all(not legal_id.startswith("programs:") for legal_id in ids)
-    assert not any(":programs/" in legal_id for legal_id in ids)
 
 
 def test_fake_monorepo_produces_no_malformed_country_doubled_ids(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.796"
+version = "0.2.797"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- include monorepo `programs/<jurisdiction>/<program>/*.yaml` outputs in PolicyEngine oracle coverage and candidate reports
- add source-tree PolicyEngine-US variable discovery so exact-name candidate hints work even when importing `policyengine_us` fails
- classify the new Florida TCA program outputs as exact PE-adjacent known non-comparables, with rationale for the legal-boundary mismatches

## Validation

- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --with /Users/maxghenis/PolicyEngine/policyengine-us python - <<'PY' ... build_policyengine_candidate_report(..., program='tca') ... PY`

## Notes

The FL TCA comparison surfaced likely PolicyEngine-US implementation mismatches against the DCF manual / Appendix A-5; filed PolicyEngine/policyengine-us#8728.
