### PR TITLE
Classify Lifeline PE oracle surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.798"
+version = "0.2.799"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.798"
+__version__ = "0.2.799"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -217,6 +217,155 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec composes the 42 USC 426(b)(2) disability, child disability, widow(er), railroad-retirement, and government-employment entitlement paths. PolicyEngine's is_medicare_eligible uses a simplified SSDI-months proxy and omits several statutory paths and entitlement-timing conditions, so this is not an exact oracle comparison.
 
+  - legal_id: us:regulations/47-cfr/54/409#lifeline_income_limit_ratio
+    country: us
+    program: lifeline
+    mapping_type: parameter_value
+    policyengine_parameter: gov.fcc.lifeline.fpg_limit
+    period: month
+    comparison: rate
+    rationale: Same federal Lifeline household-income limit in 47 CFR 54.409(a)(1), represented in PolicyEngine as the FCC Lifeline FPG limit parameter.
+
+  - legal_id: us:regulations/47-cfr/54/409#income_qualifies_for_lifeline
+    country: us
+    program: lifeline
+    mapping_type: not_comparable
+    policyengine_variable: is_lifeline_income_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes the federal 47 CFR 54.409(a)(1) consumer income path. PolicyEngine's adjacent is_lifeline_income_eligible is an SPM-unit surface that also applies Texas' state-expanded 150 percent FPG limit, so it is not a one-to-one federal oracle boundary.
+
+  - legal_id: us:regulations/47-cfr/54/409#federal_assistance_program_qualifies_for_lifeline
+    country: us
+    program: lifeline
+    mapping_type: not_comparable
+    policyengine_variable: is_lifeline_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 47 CFR 54.409(a)(2) federal-assistance categorical path, including programs that PolicyEngine does not separately expose in its final Lifeline eligibility variable.
+
+  - legal_id: us:regulations/47-cfr/54/409#survivor_emergency_communications_support_qualifies_for_lifeline
+    country: us
+    program: lifeline
+    mapping_type: not_comparable
+    policyengine_variable: is_lifeline_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Safe Connections Act survivor emergency-communications support path in 47 CFR 54.409(a)(3). PolicyEngine's Lifeline eligibility variable does not model the survivor financial-hardship and line-separation branch as a separate comparable surface.
+
+  - legal_id: us:regulations/47-cfr/54/409#paragraph_a_lifeline_qualification
+    country: us
+    program: lifeline
+    mapping_type: not_comparable
+    policyengine_variable: is_lifeline_eligible
+    candidate_priority: P4
+    rationale: RuleSpec composes only the paragraph (a) income, federal-assistance, and survivor branches before the tribal-lands and one-per-household conditions. PolicyEngine exposes a simplified final SPM-unit eligibility variable rather than this source-level paragraph boundary.
+
+  - legal_id: us:regulations/47-cfr/54/409#tribal_specific_assistance_program_qualifies_for_lifeline
+    country: us
+    program: lifeline
+    mapping_type: not_comparable
+    policyengine_variable: is_lifeline_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 47 CFR 54.409(b) tribal-specific categorical path. PolicyEngine combines selected tribal categorical programs with federal income and non-tribal categorical eligibility in its final eligibility surface.
+
+  - legal_id: us:regulations/47-cfr/54/409#tribal_lands_lifeline_qualification
+    country: us
+    program: lifeline
+    mapping_type: not_comparable
+    policyengine_variable: is_lifeline_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes the tribal-lands qualification branch in 47 CFR 54.409(b). PolicyEngine uses household tribal-land status to choose a simplified categorical program list and does not expose this branch as a one-to-one output.
+
+  - legal_id: us:regulations/47-cfr/54/409#qualifying_low_income_consumer_for_lifeline
+    country: us
+    program: lifeline
+    mapping_type: not_comparable
+    policyengine_variable: is_lifeline_eligible
+    candidate_priority: P4
+    rationale: RuleSpec follows the 47 CFR 54.409 consumer-level qualification, including survivor emergency support and duplicate-service exclusions. PolicyEngine's SPM-unit eligibility omits several statutory branches and state-expands the income test in Texas.
+
+  - legal_id: us:regulations/47-cfr/54/403#basic_lifeline_support_amount
+    country: us
+    program: lifeline
+    mapping_type: parameter_value
+    policyengine_parameter: gov.fcc.lifeline.amount.standard
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same federal monthly basic Lifeline support amount in 47 CFR 54.403(a)(1).
+
+  - legal_id: us:regulations/47-cfr/54/403#standalone_voice_lifeline_support_amount
+    country: us
+    program: lifeline
+    mapping_type: not_comparable
+    policyengine_variable: lifeline
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 47 CFR 54.403(a)(2) standalone-voice phase-down schedule. PolicyEngine's Lifeline amount uses the current standard support amount and does not expose this historical standalone-voice schedule as a separate oracle surface.
+
+  - legal_id: us:regulations/47-cfr/54/403#only_provider_census_block_standalone_voice_support_amount
+    country: us
+    program: lifeline
+    mapping_type: not_comparable
+    policyengine_variable: lifeline
+    candidate_priority: P4
+    rationale: RuleSpec exposes the only-provider census-block exception for standalone voice support in 47 CFR 54.403(a)(2)(v). PolicyEngine does not model this provider/census-block support branch.
+
+  - legal_id: us:regulations/47-cfr/54/403#tribal_lands_support_amount_cap
+    country: us
+    program: lifeline
+    mapping_type: parameter_value
+    policyengine_parameter: gov.fcc.lifeline.amount.rural_tribal_supplement
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same monthly additional federal Lifeline support amount for eligible Tribal lands residents in 47 CFR 54.403(a)(3), represented in PolicyEngine as the rural Tribal supplement.
+
+  - legal_id: us:regulations/47-cfr/54/403#emergency_communications_support_amount_cap
+    country: us
+    program: lifeline
+    mapping_type: not_comparable
+    policyengine_variable: lifeline
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 47 CFR 54.403(a)(4) emergency communications support cap for qualifying survivors. PolicyEngine's Lifeline amount does not separately model survivor emergency communications support.
+
+  - legal_id: us:regulations/47-cfr/54/403#emergency_tribal_lands_support_amount_cap
+    country: us
+    program: lifeline
+    mapping_type: not_comparable
+    policyengine_variable: lifeline
+    candidate_priority: P4
+    rationale: RuleSpec exposes the emergency communications Tribal lands support cap in 47 CFR 54.403(a)(4)(ii). PolicyEngine does not separately model this survivor-specific Tribal support branch.
+
+  - legal_id: us:regulations/47-cfr/54/403#federal_lifeline_support_amount
+    country: us
+    program: lifeline
+    mapping_type: not_comparable
+    policyengine_variable: lifeline
+    candidate_priority: P4
+    rationale: RuleSpec exposes the federal carrier support amount before household phone/broadband cost caps and state supplements. PolicyEngine's lifeline output is an annual SPM-unit benefit capped by phone plus broadband cost and includes state-specific and Texas supplements.
+
+  - legal_id: us:regulations/47-cfr/54/403#emergency_communications_support_amount
+    country: us
+    program: lifeline
+    mapping_type: not_comparable
+    policyengine_variable: lifeline
+    candidate_priority: P4
+    rationale: RuleSpec exposes the carrier support amount for qualifying survivor emergency communications support. PolicyEngine's Lifeline amount does not model this emergency communications support path.
+
+  - legal_id: us:regulations/47-cfr/54/403#federal_end_user_common_line_charges_must_be_waived
+    country: us
+    program: lifeline
+    mapping_type: not_comparable
+    policyengine_variable: lifeline
+    candidate_priority: P4
+    rationale: RuleSpec exposes the carrier obligation to waive Federal End User Common Line or equivalent charges. PolicyEngine's Lifeline household benefit amount does not expose carrier charge-waiver compliance as an oracle output.
+
+  - legal_id: us:regulations/47-cfr/54/403#residential_service_plan_lifeline_discount_amount
+    country: us
+    program: lifeline
+    mapping_type: not_comparable
+    policyengine_variable: lifeline
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 47 CFR 54.403(b)(1) carrier application of support to residential service-plan costs. PolicyEngine's lifeline output computes an annual household benefit with cost caps and state supplements rather than this carrier discount-application boundary.
+
   - legal_id: us:statutes/42/1382/a/3#resource_limit_amount_for_paragraph_1_B_i_and_paragraph_2_B
     country: us
     program: ssi

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1831,10 +1831,11 @@ surfaces:
   coverage: US
   variable: lifeline
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom encodes federal Lifeline eligibility and support parameters from 47 CFR 54.403 and 54.409, but PolicyEngine's
+    lifeline variable is an annual SPM-unit amount capped by phone plus broadband costs and includes state-specific/Texas supplements.
+    Axiom maps comparable federal parameters separately and classifies source-level eligibility and carrier-support outputs.
 - country: us
   program_id: acp
   program_name: Affordable Connectivity Program

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.798"
+version = "0.2.799"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add PolicyEngine oracle classifications for federal Lifeline RuleSpec outputs
- map comparable 47 CFR Lifeline parameters to PE parameters
- classify PE's annual lifeline amount surface as known-not-comparable because it includes state/Texas supplements and phone+broadband cost caps
- bump axiom-encode to 0.2.799

## Validation
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py tests/test_policyengine_coverage_monorepo.py tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::test_package_version_metadata_matches_pyproject -q
- uv run axiom-encode oracle-coverage --root /tmp/axiom-lifeline-pe-root-coverage --oracle policyengine --program lifeline --include-program-surfaces --fail-on-untested-comparable --limit 100

Dependency: rulespec-us Lifeline PR uses this encoder commit in its signed deterministic repair manifests.