### PR TITLE
Add ACP PolicyEngine oracle mappings

### DIFF
--- a/changelog.d/acp-policyengine-oracle-coverage.changed.md
+++ b/changelog.d/acp-policyengine-oracle-coverage.changed.md
@@ -1,0 +1,1 @@
+Add Affordable Connectivity Program PolicyEngine oracle coverage metadata.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.799"
+version = "0.2.800"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.799"
+__version__ = "0.2.800"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -366,6 +366,160 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec exposes the 47 CFR 54.403(b)(1) carrier application of support to residential service-plan costs. PolicyEngine's lifeline output computes an annual household benefit with cost caps and state supplements rather than this carrier discount-application boundary.
 
+  - legal_id: us:regulations/47-cfr/54/1800#standard_affordable_connectivity_benefit_cap
+    country: us
+    program: acp
+    mapping_type: parameter_value
+    policyengine_parameter: gov.fcc.acp.amount.standard
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same federal monthly standard Affordable Connectivity Program benefit cap in 47 CFR 54.1800(b), represented in PolicyEngine as the FCC ACP standard amount parameter.
+
+  - legal_id: us:regulations/47-cfr/54/1800#tribal_land_affordable_connectivity_benefit_cap
+    country: us
+    program: acp
+    mapping_type: parameter_value
+    policyengine_parameter: gov.fcc.acp.amount.tribal
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same federal monthly Tribal-land Affordable Connectivity Program benefit cap in 47 CFR 54.1800(b), represented in PolicyEngine as the FCC ACP Tribal amount parameter.
+
+  - legal_id: us:regulations/47-cfr/54/1800#affordable_connectivity_benefit
+    country: us
+    program: acp
+    mapping_type: not_comparable
+    policyengine_variable: acp
+    candidate_priority: P4
+    rationale: RuleSpec exposes the source-level monthly ACP benefit definition from 47 CFR 54.1800(b). PolicyEngine's acp variable is an annual SPM-unit benefit capped by broadband_cost_after_lifeline and zeroed after the program sunset.
+
+  - legal_id: us:regulations/47-cfr/54/1800#eligible_household_income_limit_ratio
+    country: us
+    program: acp
+    mapping_type: parameter_value
+    policyengine_parameter: gov.fcc.acp.fpg_limit
+    period: month
+    comparison: rate
+    rationale: Same 200 percent Federal Poverty Guidelines income limit for ACP eligible households in 47 CFR 54.1800(j), represented in PolicyEngine as the FCC ACP FPG limit parameter.
+
+  - legal_id: us:regulations/47-cfr/54/1800/j#federal_poverty_guidelines_income_limit_multiplier
+    country: us
+    program: acp
+    mapping_type: parameter_value
+    policyengine_parameter: gov.fcc.acp.fpg_limit
+    period: month
+    comparison: rate
+    rationale: Same 200 percent Federal Poverty Guidelines income limit in the targeted 47 CFR 54.1800(j) eligible-household definition.
+
+  - legal_id: us:regulations/47-cfr/54/1800/j#eligible_household
+    country: us
+    program: acp
+    mapping_type: not_comparable
+    policyengine_variable: is_acp_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 47 CFR 54.1800(j) eligible-household definition, including source-level categorical and income paths. PolicyEngine's is_acp_eligible is an annual SPM-unit surface that folds in separate Lifeline categorical lists, excludes Emergency Broadband Benefit enrollment, and omits some source-level verification/provider conditions as separate predicates.
+
+  - legal_id: us:regulations/47-cfr/54/1803#standard_monthly_support_amount_cap
+    country: us
+    program: acp
+    mapping_type: parameter_value
+    policyengine_parameter: gov.fcc.acp.amount.standard
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same monthly standard Affordable Connectivity Program support cap in 47 CFR 54.1803(a), represented in PolicyEngine as the FCC ACP standard amount parameter.
+
+  - legal_id: us:regulations/47-cfr/54/1803#tribal_lands_monthly_support_amount_cap
+    country: us
+    program: acp
+    mapping_type: parameter_value
+    policyengine_parameter: gov.fcc.acp.amount.tribal
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same monthly Tribal-lands Affordable Connectivity Program support cap in 47 CFR 54.1803(a), represented in PolicyEngine as the FCC ACP Tribal amount parameter.
+
+  - legal_id: us:regulations/47-cfr/54/1803#high_cost_area_monthly_support_amount_cap
+    country: us
+    program: acp
+    mapping_type: not_comparable
+    policyengine_variable: acp
+    candidate_priority: P4
+    rationale: RuleSpec exposes the separate enhanced high-cost-area ACP support cap in 47 CFR 54.1803(a). PolicyEngine's acp amount selects only standard versus Tribal-land amounts and does not expose the high-cost-area provider approval branch as a comparable oracle surface.
+
+  - legal_id: us:regulations/47-cfr/54/1803#monthly_affordable_connectivity_benefit_support_amount
+    country: us
+    program: acp
+    mapping_type: not_comparable
+    policyengine_variable: acp
+    candidate_priority: P4
+    rationale: RuleSpec exposes the source-level monthly provider support amount under 47 CFR 54.1803(a), including pass-through certifications and high-cost-area approval. PolicyEngine's acp variable is an annual household benefit capped by broadband_cost_after_lifeline and sunset to zero after June 2024.
+
+  - legal_id: us:regulations/47-cfr/54/1803#connected_device_reimbursement_amount_cap
+    country: us
+    program: acp
+    mapping_type: not_comparable
+    policyengine_variable: acp
+    candidate_priority: P4
+    rationale: RuleSpec exposes the separate connected-device reimbursement cap in 47 CFR 54.1803(b). PolicyEngine's ACP surface models broadband-service benefit amounts and does not model the one-time connected-device reimbursement.
+
+  - legal_id: us:regulations/47-cfr/54/1803#connected_device_household_charge_lower_bound
+    country: us
+    program: acp
+    mapping_type: not_comparable
+    policyengine_variable: acp
+    candidate_priority: P4
+    rationale: RuleSpec exposes the separate household contribution lower bound for connected-device reimbursement in 47 CFR 54.1803(b)(1). PolicyEngine's ACP surface does not model connected-device reimbursement eligibility.
+
+  - legal_id: us:regulations/47-cfr/54/1803#connected_device_household_charge_upper_bound
+    country: us
+    program: acp
+    mapping_type: not_comparable
+    policyengine_variable: acp
+    candidate_priority: P4
+    rationale: RuleSpec exposes the separate household contribution upper bound for connected-device reimbursement in 47 CFR 54.1803(b)(1). PolicyEngine's ACP surface does not model connected-device reimbursement eligibility.
+
+  - legal_id: us:regulations/47-cfr/54/1803#connected_device_per_household_limit
+    country: us
+    program: acp
+    mapping_type: not_comparable
+    policyengine_variable: acp
+    candidate_priority: P4
+    rationale: RuleSpec exposes the one-connected-device-per-household limit in 47 CFR 54.1803(b)(2). PolicyEngine's ACP surface does not model connected-device reimbursement.
+
+  - legal_id: us:regulations/47-cfr/54/1803#connected_device_reimbursement_available
+    country: us
+    program: acp
+    mapping_type: not_comparable
+    policyengine_variable: acp
+    candidate_priority: P4
+    rationale: RuleSpec exposes connected-device reimbursement eligibility under 47 CFR 54.1803(b). PolicyEngine's ACP surface does not model connected-device reimbursement availability.
+
+  - legal_id: us:regulations/47-cfr/54/1803#connected_device_reimbursement_amount
+    country: us
+    program: acp
+    mapping_type: not_comparable
+    policyengine_variable: acp
+    candidate_priority: P4
+    rationale: RuleSpec exposes the connected-device reimbursement amount under 47 CFR 54.1803(b). PolicyEngine's ACP surface does not model connected-device reimbursement amounts.
+
+  - legal_id: us:regulations/47-cfr/54/1805#qualifies_for_affordable_connectivity_program
+    country: us
+    program: acp
+    mapping_type: not_comparable
+    policyengine_variable: is_acp_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 47 CFR 54.1805(a) cross-reference to the eligible-household definition. Compare the targeted 54.1800(j) eligibility definition for the source-level eligibility paths; PolicyEngine's is_acp_eligible also includes EBB exclusion and annual SPM-unit aggregation.
+
+  - legal_id: us:regulations/47-cfr/54/1805#qualifies_to_receive_affordable_connectivity_benefit_from_participating_provider
+    country: us
+    program: acp
+    mapping_type: not_comparable
+    policyengine_variable: is_acp_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 47 CFR 54.1805(b) provider-specific no-duplicate-benefit receipt rule. PolicyEngine's is_acp_eligible is a household/SPM-unit eligibility surface and does not expose provider-specific duplicate-benefit receipt as a comparable output.
+
   - legal_id: us:statutes/42/1382/a/3#resource_limit_amount_for_paragraph_1_B_i_and_paragraph_2_B
     country: us
     program: ssi

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1845,10 +1845,13 @@ surfaces:
   coverage: US
   variable: acp
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom encodes ACP benefit caps, the 200 percent FPG income limit, source-level eligible-household paths, provider
+    receipt constraints, and connected-device reimbursement from 47 CFR 54.1800, 54.1803, and 54.1805. PolicyEngine's acp
+    variable is an annual SPM-unit broadband benefit capped by broadband_cost_after_lifeline and sunset to zero after June
+    2024; Axiom maps comparable federal parameters separately and classifies source-level eligibility, provider-support,
+    high-cost-area, and connected-device outputs.
 - country: us
   program_id: pell_grant
   program_name: Pell Grant

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -365,6 +365,23 @@ def test_policyengine_program_surface_marks_section_25c_known_not_comparable():
     assert "product-identification-number gate" in section_25c["rationale"]
 
 
+def test_policyengine_program_surface_marks_acp_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="acp")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    acp = items_by_variable["acp"]
+
+    assert acp["axiom_status"] == "known_not_comparable"
+    assert acp["mapping_count"] >= 1
+    assert acp["comparable_mapping_count"] == 0
+    assert (
+        "us:regulations/47-cfr/54/1803#monthly_affordable_connectivity_benefit_support_amount"
+        in acp["legal_ids"]
+    )
+    assert "broadband_cost_after_lifeline" in acp["rationale"]
+    assert "connected-device" in acp["rationale"]
+
+
 def test_policyengine_program_surface_marks_colorado_oap_wired():
     report = build_policyengine_program_surface_report(program="co_oap")
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -3101,6 +3101,40 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
 
 
+def test_policyengine_registry_includes_acp_parameter_and_not_comparable_mappings():
+    registry = load_policyengine_registry()
+
+    fpg_mapping = registry.mapping_for_legal_id(
+        "us:regulations/47-cfr/54/1800/j#federal_poverty_guidelines_income_limit_multiplier",
+        country="us",
+    )
+    assert fpg_mapping.mapping_type == "parameter_value"
+    assert fpg_mapping.policyengine_parameter == "gov.fcc.acp.fpg_limit"
+
+    standard_amount_mapping = registry.mapping_for_legal_id(
+        "us:regulations/47-cfr/54/1803#standard_monthly_support_amount_cap",
+        country="us",
+    )
+    assert standard_amount_mapping.mapping_type == "parameter_value"
+    assert (
+        standard_amount_mapping.policyengine_parameter == "gov.fcc.acp.amount.standard"
+    )
+
+    eligible_household_mapping = registry.mapping_for_legal_id(
+        "us:regulations/47-cfr/54/1800/j#eligible_household",
+        country="us",
+    )
+    assert eligible_household_mapping.mapping_type == "not_comparable"
+    assert eligible_household_mapping.policyengine_variable == "is_acp_eligible"
+
+    device_mapping = registry.mapping_for_legal_id(
+        "us:regulations/47-cfr/54/1803#connected_device_reimbursement_amount",
+        country="us",
+    )
+    assert device_mapping.mapping_type == "not_comparable"
+    assert device_mapping.policyengine_variable == "acp"
+
+
 def test_policyengine_oracle_tracks_not_comparable_without_issue_noise(tmp_path):
     rules_file = tmp_path / "rules.yaml"
     rules_file.write_text("format: rulespec/v1\n")

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.799"
+version = "0.2.800"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add ACP PolicyEngine oracle mappings for comparable FCC ACP FPG and monthly support parameters
- classify ACP source-level eligibility, provider-support, high-cost-area, and connected-device outputs as known not comparable to PE final surfaces
- mark ACP program surface known-not-comparable with focused regression coverage

## Tests
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py::test_policyengine_registry_includes_acp_parameter_and_not_comparable_mappings tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_acp_known_not_comparable
- uv run --extra dev ruff check tests/test_rulespec_validation.py tests/test_policyengine_coverage.py
- uv run python - <<'PY'
import yaml
from pathlib import Path
for path in [Path('src/axiom_encode/oracles/policyengine/mappings/us.yaml'), Path('src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml')]:
    data = yaml.safe_load(path.read_text())
    print(path, sorted(data.keys()))
PY
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --oracle policyengine --program acp --include-program-surfaces --json