### PR TITLE
Update active PE surface metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.800"
+version = "0.2.801"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.800"
+__version__ = "0.2.801"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -16198,6 +16198,20 @@ mappings:
     rationale: PolicyEngine does not expose the section 25C(g) basis-reduction amount as a separate variable.
 
 prefixes:
+  - legal_id_prefix: us:statutes/26/25E#
+    country: us
+    program: clean_vehicle_credits
+    mapping_type: not_comparable
+    candidate_priority: P3
+    rationale: Section 25E RuleSpec outputs expose current-law statutory parameters, buyer/sale/vehicle predicates, and pre-MAGI credit intermediates. PolicyEngine's used-clean-vehicle variables are tax-unit simplifications with separate eligibility gating and no exact source-boundary output for these legal intermediates. Add exact mappings above this prefix when a one-to-one PE target exists.
+
+  - legal_id_prefix: us:statutes/26/30D#
+    country: us
+    program: clean_vehicle_credits
+    mapping_type: not_comparable
+    candidate_priority: P3
+    rationale: Section 30D RuleSpec outputs expose current-law statutory parameters, vehicle predicates, per-vehicle credit components, transfer rules, and deferred taxpayer-to-vehicle aggregation. PolicyEngine's new-clean-vehicle variables are tax-unit simplifications and include legacy/pre-IRA mechanics, so these outputs are not exact PE oracle targets unless a narrower exact mapping is added above this prefix.
+
   - legal_id_prefix: us:statutes/5/5566#
     country: us
     program: unknown

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1846,12 +1846,13 @@ surfaces:
   variable: acp
   source_type: program
   axiom_status: known_not_comparable
-  priority: P1
+  priority: P3
   rationale: Axiom encodes ACP benefit caps, the 200 percent FPG income limit, source-level eligible-household paths, provider
     receipt constraints, and connected-device reimbursement from 47 CFR 54.1800, 54.1803, and 54.1805. PolicyEngine's acp
     variable is an annual SPM-unit broadband benefit capped by broadband_cost_after_lifeline and sunset to zero after June
-    2024; Axiom maps comparable federal parameters separately and classifies source-level eligibility, provider-support,
-    high-cost-area, and connected-device outputs.
+    2024, so ACP is historical/sunset and should not be prioritized ahead of active current-law surfaces. Axiom maps comparable
+    federal parameters separately and classifies source-level eligibility, provider-support, high-cost-area, and connected-device
+    outputs.
 - country: us
   program_id: pell_grant
   program_name: Pell Grant
@@ -1887,10 +1888,13 @@ surfaces:
   coverage: US
   variable: clean_vehicle_credit
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: pending_oracle_mapping
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: RuleSpec PR 436 encodes current-law sections 25E and 30D from the House US Code releasepoint, including source-backed
+    clean-vehicle credit parameters and per-vehicle rules. Axiom still should not claim a final `clean_vehicle_credit` oracle
+    match because section 30D(a)'s tax-unit aggregate is deferred until a taxpayer-to-vehicle relation with raw per-vehicle
+    credit amounts is represented, and PolicyEngine's clean-vehicle variables are tax-unit simplifications rather than the
+    full statutory relation surface.
 - country: us
   program_id: residential_clean_energy_credit
   program_name: Residential clean energy credit

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -7,7 +7,10 @@ from axiom_encode.oracles.policyengine.coverage import (
     build_policyengine_coverage_report,
     build_policyengine_program_surface_report,
 )
-from axiom_encode.oracles.policyengine.registry import PolicyEngineMapping
+from axiom_encode.oracles.policyengine.registry import (
+    PolicyEngineMapping,
+    load_policyengine_registry,
+)
 
 
 class _ProgramSurfaceRegistry:
@@ -372,6 +375,7 @@ def test_policyengine_program_surface_marks_acp_known_not_comparable():
     acp = items_by_variable["acp"]
 
     assert acp["axiom_status"] == "known_not_comparable"
+    assert acp["priority"] == "P3"
     assert acp["mapping_count"] >= 1
     assert acp["comparable_mapping_count"] == 0
     assert (
@@ -379,7 +383,43 @@ def test_policyengine_program_surface_marks_acp_known_not_comparable():
         in acp["legal_ids"]
     )
     assert "broadband_cost_after_lifeline" in acp["rationale"]
+    assert "historical/sunset" in acp["rationale"]
     assert "connected-device" in acp["rationale"]
+
+
+def test_policyengine_program_surface_marks_clean_vehicle_pending_oracle_mapping():
+    report = build_policyengine_program_surface_report(program="clean_vehicle_credits")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    clean_vehicle = items_by_variable["clean_vehicle_credit"]
+
+    assert clean_vehicle["axiom_status"] == "pending_oracle_mapping"
+    assert clean_vehicle["priority"] == "P1"
+    assert "sections 25E and 30D" in clean_vehicle["rationale"]
+    assert "taxpayer-to-vehicle relation" in clean_vehicle["rationale"]
+    assert "tax-unit simplifications" in clean_vehicle["rationale"]
+
+
+def test_policyengine_registry_classifies_clean_vehicle_sections_as_noncomparable():
+    registry = load_policyengine_registry()
+
+    section_25e = registry.mapping_for_legal_id(
+        "us:statutes/26/25E#tentative_previously_owned_clean_vehicle_credit",
+        country="us",
+    )
+    section_30d = registry.mapping_for_legal_id(
+        "us:statutes/26/30D#per_vehicle_credit_amount_before_special_rules",
+        country="us",
+    )
+
+    assert section_25e is not None
+    assert section_25e.mapping_type == "not_comparable"
+    assert section_25e.program == "clean_vehicle_credits"
+    assert "tax-unit simplifications" in section_25e.rationale
+    assert section_30d is not None
+    assert section_30d.mapping_type == "not_comparable"
+    assert section_30d.program == "clean_vehicle_credits"
+    assert "taxpayer-to-vehicle aggregation" in section_30d.rationale
 
 
 def test_policyengine_program_surface_marks_colorado_oap_wired():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.800"
+version = "0.2.801"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- demotes ACP from P1 to P3 because it is historical/sunset and should not rank ahead of active current-law surfaces
- moves clean vehicle credits from `pending_rulespec_encoding` to `pending_oracle_mapping` after rulespec-us PR 436 encoded 26 U.S.C. 25E and 30D
- classifies 25E/30D generated statutory outputs as `not_comparable` by prefix unless a narrower exact PE mapping is added later
- bumps axiom-encode to `0.2.801` so generated RuleSpec artifacts can point at the updated oracle/catalog state
- adds focused coverage tests for the queue decisions and clean-vehicle prefix classifications

## Verification
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k 'acp or clean_vehicle'`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q -k 'acp or clean_vehicle' tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `uv run axiom-encode oracle-coverage --root /tmp/axiom-clean-vehicle-coverage-root --oracle policyengine --program clean_vehicle_credits --fail-on-unmapped --json`
  - simulated against the clean vehicle rulespec PR worktree: `{'known_not_comparable': 40}`, `total_outputs 40`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --oracle policyengine --include-program-surfaces --json`
- `uv run ruff check tests/test_policyengine_coverage.py`
- `uv run python -m compileall -q src/axiom_encode/oracles/policyengine tests/test_policyengine_coverage.py`

## Review status
Opened as draft because axiom-encode requires a review loop before ready/merge. I did not spawn a subagent review in this turn because the current tool policy requires explicit user authorization for subagents.
