### PR TITLE
Track active PolicyEngine program surfaces

### DIFF
--- a/changelog.d/bump-encoder-0-2-802.changed.md
+++ b/changelog.d/bump-encoder-0-2-802.changed.md
@@ -1,0 +1,1 @@
+Bump axiom-encode to 0.2.802 for active PolicyEngine program-surface lifecycle metadata.

--- a/changelog.d/program-surface-lifecycle.changed.md
+++ b/changelog.d/program-surface-lifecycle.changed.md
@@ -1,0 +1,1 @@
+PolicyEngine program surface coverage now records lifecycle metadata and exposes an active-only actionable queue so expired or sunset programs cannot remain top-priority parity targets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.801"
+version = "0.2.802"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.801"
+__version__ = "0.2.802"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3647,12 +3647,18 @@ def cmd_oracle_coverage(args):
             "PolicyEngine program surfaces: "
             f"{surfaces['total_surfaces']} "
             f"status={_format_counter(surfaces['status_counts'])} "
-            f"pending={surfaces['pending_surfaces']}"
+            f"pending={surfaces['pending_surfaces']} "
+            f"active_pending={surfaces.get('active_pending_surfaces', 0)}"
         )
         print(
             "PolicyEngine surface priorities: "
             f"{_format_counter(surfaces['priority_counts'])}"
         )
+        if surfaces.get("lifecycle_counts"):
+            print(
+                "PolicyEngine surface lifecycles: "
+                f"{_format_counter(surfaces['lifecycle_counts'])}"
+            )
     print()
 
     for repo in report["repos"]:
@@ -3689,7 +3695,8 @@ def cmd_oracle_coverage(args):
     program_surfaces = report.get("program_surfaces") or {}
     pending_surface_items = [
         item
-        for item in program_surfaces.get("items", [])
+        for item in program_surfaces.get("actionable_surfaces")
+        or program_surfaces.get("items", [])
         if item.get("axiom_status")
         in {
             "deferred_jurisdiction",
@@ -3697,10 +3704,11 @@ def cmd_oracle_coverage(args):
             "pending_rulespec_encoding",
             "pending_source_ingestion",
         }
+        and item.get("lifecycle", "active") == "active"
     ]
     if pending_surface_items:
         print()
-        print(f"Pending PolicyEngine program surfaces (first {args.limit}):")
+        print(f"Active pending PolicyEngine program surfaces (first {args.limit}):")
         for item in pending_surface_items[: args.limit]:
             state = f" [{item['state']}]" if item.get("state") else ""
             print(

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -35,6 +35,7 @@ PROGRAM_SURFACE_STATUSES = {
     "pending_source_ingestion",
     "wired",
 }
+PROGRAM_SURFACE_LIFECYCLES = {"active", "inactive", "sunset", "historical"}
 _PROGRAM_TOKEN_RE = {
     token: re.compile(rf"(^|[^a-z0-9]){token}([^a-z0-9]|$)")
     for token in ("medicaid", "chip", "aca")
@@ -133,6 +134,7 @@ class PolicyEngineProgramSurfaceItem:
     coverage: str
     variable: str
     axiom_status: str
+    lifecycle: str = "active"
     source_type: str = "program"
     agency: str | None = None
     state: str | None = None
@@ -152,6 +154,7 @@ class PolicyEngineProgramSurfaceItem:
             "coverage": self.coverage,
             "variable": self.variable,
             "axiom_status": self.axiom_status,
+            "lifecycle": self.lifecycle,
             "source_type": self.source_type,
             "agency": self.agency,
             "state": self.state,
@@ -241,6 +244,12 @@ def build_policyengine_program_surface_report(
     priority_counts = Counter(
         surface.priority for surface in surfaces if surface.priority
     )
+    lifecycle_counts = Counter(surface.lifecycle for surface in surfaces)
+    active_priority_counts = Counter(
+        surface.priority
+        for surface in surfaces
+        if surface.lifecycle == "active" and surface.priority
+    )
     unwired_statuses = {
         "deferred_jurisdiction",
         "pending_oracle_mapping",
@@ -250,6 +259,19 @@ def build_policyengine_program_surface_report(
     pending_surfaces = [
         surface for surface in surfaces if surface.axiom_status in unwired_statuses
     ]
+    active_pending_surfaces = [
+        surface for surface in pending_surfaces if surface.lifecycle == "active"
+    ]
+    actionable_surfaces = sorted(
+        active_pending_surfaces,
+        key=lambda surface: (
+            _candidate_priority_rank(surface.priority or ""),
+            surface.category,
+            surface.coverage,
+            surface.program_id,
+            surface.variable,
+        ),
+    )
     return {
         "oracle": "policyengine",
         "country": country,
@@ -258,7 +280,11 @@ def build_policyengine_program_surface_report(
         "total_surfaces": len(surfaces),
         "status_counts": dict(sorted(status_counts.items())),
         "priority_counts": dict(sorted(priority_counts.items())),
+        "lifecycle_counts": dict(sorted(lifecycle_counts.items())),
+        "active_priority_counts": dict(sorted(active_priority_counts.items())),
         "pending_surfaces": len(pending_surfaces),
+        "active_pending_surfaces": len(active_pending_surfaces),
+        "actionable_surfaces": [surface.as_dict() for surface in actionable_surfaces],
         "items": [surface.as_dict() for surface in surfaces],
     }
 
@@ -823,6 +849,20 @@ def _load_policyengine_program_surface_manifest(
                 f"Unsupported PolicyEngine surface status for "
                 f"{raw_surface.get('variable')}: {status}"
             )
+        lifecycle = str(raw_surface.get("lifecycle") or "active")
+        if lifecycle not in PROGRAM_SURFACE_LIFECYCLES:
+            raise ValueError(
+                f"Unsupported PolicyEngine surface lifecycle for "
+                f"{raw_surface.get('variable')}: {lifecycle}"
+            )
+        priority = raw_surface.get("priority")
+        if lifecycle != "active" and priority in {"P1", "P2"}:
+            raise ValueError(
+                f"Non-active PolicyEngine surface {raw_surface.get('variable')} "
+                f"must not use top priority {priority}; mark active current-law "
+                "surfaces P1/P2 and demote historical, inactive, or sunset "
+                "surfaces."
+            )
     return payload
 
 
@@ -854,6 +894,7 @@ def _program_surface_item_from_payload(
         coverage=str(payload["coverage"]),
         variable=variable,
         axiom_status=axiom_status,
+        lifecycle=str(payload.get("lifecycle") or "active"),
         source_type=str(payload.get("source_type") or "program"),
         agency=payload.get("agency"),
         state=payload.get("state"),

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1845,6 +1845,7 @@ surfaces:
   coverage: US
   variable: acp
   source_type: program
+  lifecycle: sunset
   axiom_status: known_not_comparable
   priority: P3
   rationale: Axiom encodes ACP benefit caps, the 200 percent FPG income limit, source-level eligible-household paths, provider

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -293,9 +293,7 @@ surfaces:
     assert report["active_priority_counts"] == {"P1": 6}
     assert report["pending_surfaces"] == 1
     assert report["active_pending_surfaces"] == 1
-    assert [
-        item["variable"] for item in report["actionable_surfaces"]
-    ] == ["wic"]
+    assert [item["variable"] for item in report["actionable_surfaces"]] == ["wic"]
     items_by_variable = {item["variable"]: item for item in report["items"]}
     assert items_by_variable["income_tax"]["axiom_status"] == "wired"
     assert items_by_variable["income_tax"]["lifecycle"] == "active"

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -289,9 +289,16 @@ surfaces:
         "pending_rulespec_encoding": 1,
         "wired": 1,
     }
+    assert report["lifecycle_counts"] == {"active": 6}
+    assert report["active_priority_counts"] == {"P1": 6}
     assert report["pending_surfaces"] == 1
+    assert report["active_pending_surfaces"] == 1
+    assert [
+        item["variable"] for item in report["actionable_surfaces"]
+    ] == ["wic"]
     items_by_variable = {item["variable"]: item for item in report["items"]}
     assert items_by_variable["income_tax"]["axiom_status"] == "wired"
+    assert items_by_variable["income_tax"]["lifecycle"] == "active"
     assert items_by_variable["income_tax"]["mapping_count"] == 1
     assert items_by_variable["wic"]["axiom_status"] == "pending_rulespec_encoding"
     assert items_by_variable["aca_ptc"]["axiom_status"] == "known_not_comparable"
@@ -303,6 +310,36 @@ surfaces:
     assert items_by_variable["employee_payroll_tax"]["mapping_count"] == 1
     assert items_by_variable["employee_payroll_tax"]["comparable_mapping_count"] == 0
     assert items_by_variable["fdpir"]["axiom_status"] == "input_only"
+
+
+def test_policyengine_program_surface_rejects_top_priority_sunset_surface(tmp_path):
+    manifest = tmp_path / "program_surfaces.yaml"
+    manifest.write_text(
+        """source:
+  repository: PolicyEngine/policyengine-us
+  ref: test
+  path: policyengine_us/programs.yaml
+surfaces:
+  - country: us
+    program_id: acp
+    program_name: Affordable Connectivity Program
+    category: Benefits
+    policyengine_status: complete
+    coverage: US
+    variable: acp
+    lifecycle: sunset
+    axiom_status: pending_rulespec_encoding
+    priority: P1
+    rationale: Expired program should not stay in the top active queue.
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="must not use top priority"):
+        build_policyengine_program_surface_report(
+            manifest_path=manifest,
+            registry=_ProgramSurfaceRegistry({}),
+        )
 
 
 def test_policyengine_program_surface_marks_colorado_ccap_final_subsidy_known_not_comparable():
@@ -375,6 +412,7 @@ def test_policyengine_program_surface_marks_acp_known_not_comparable():
     acp = items_by_variable["acp"]
 
     assert acp["axiom_status"] == "known_not_comparable"
+    assert acp["lifecycle"] == "sunset"
     assert acp["priority"] == "P3"
     assert acp["mapping_count"] >= 1
     assert acp["comparable_mapping_count"] == 0

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.801"
+version = "0.2.802"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add lifecycle metadata to PolicyEngine program surfaces with active/sunset validation
- expose active-only pending/actionable surface counts in oracle coverage reports
- mark ACP as a sunset surface so it cannot re-enter P1/P2 active parity queues

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_program_surface_report_overlays_legal_registry tests/test_policyengine_coverage.py::test_policyengine_program_surface_rejects_top_priority_sunset_surface tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_acp_known_not_comparable
- uv run --extra dev python -m pytest tests/test_cli.py -k fail_on_pending_program_surfaces
- uv run --extra dev ruff check src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/cli.py tests/test_policyengine_coverage.py
- uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --oracle policyengine --include-program-surfaces --json