### PR TITLE
Map Pell outputs for PolicyEngine coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.802"
+version = "0.2.803"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.802"
+__version__ = "0.2.803"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -15362,7 +15362,7 @@ def _append_oracle_parameter_tests_if_missing(
         sample = _first_scalar_parameter_value(rule, indexed=index_name is not None)
         if sample is None:
             continue
-        key, value = sample
+        key, value, effective_from = sample
         case_name_parts = ["oracle_parameter", _safe_test_name(rule_name)]
         if index_name is not None:
             case_name_parts.append(_safe_test_name(str(key)))
@@ -15370,11 +15370,7 @@ def _append_oracle_parameter_tests_if_missing(
         appended_cases.append(
             {
                 "name": "_".join(case_name_parts),
-                "period": {
-                    "period_kind": "tax_year",
-                    "start": "2026-01-01",
-                    "end": "2026-12-31",
-                },
+                "period": _oracle_parameter_test_period(effective_from),
                 "input": inputs,
                 "output": {legal_id: value},
             }
@@ -15424,25 +15420,62 @@ def _single_parameter_index_name(rule: dict) -> str | None:
 
 def _first_scalar_parameter_value(
     rule: dict, *, indexed: bool
-) -> tuple[object | None, object] | None:
+) -> tuple[object | None, object, str | None] | None:
     versions = rule.get("versions")
     if not isinstance(versions, list):
         return None
     for version in versions:
         if not isinstance(version, dict):
             continue
+        effective_from = version.get("effective_from")
+        effective_from_text = (
+            str(effective_from).strip() if effective_from is not None else None
+        )
         if indexed:
             values = version.get("values")
             if not isinstance(values, dict):
                 continue
             for key, value in values.items():
                 if isinstance(value, (str, int, float, bool)) or value is None:
-                    return key, value
+                    return key, value, effective_from_text
         else:
             value = _scalar_formula_value(version.get("formula"))
             if value is not None:
-                return None, value
+                return None, value, effective_from_text
     return None
+
+
+def _oracle_parameter_test_period(effective_from: str | None) -> dict[str, str]:
+    """Return a one-year period that is valid for a generated parameter test."""
+    default = {
+        "period_kind": "tax_year",
+        "start": "2026-01-01",
+        "end": "2026-12-31",
+    }
+    if not effective_from:
+        return default
+    try:
+        start = date.fromisoformat(effective_from)
+    except ValueError:
+        return default
+    if start.year < 1900:
+        return default
+    if start.month == 1 and start.day == 1:
+        return {
+            "period_kind": "tax_year",
+            "start": f"{start.year:04d}-01-01",
+            "end": f"{start.year:04d}-12-31",
+        }
+    try:
+        next_start = start.replace(year=start.year + 1)
+    except ValueError:
+        next_start = start.replace(year=start.year + 1, day=28)
+    return {
+        "period_kind": "custom",
+        "name": "policy_year",
+        "start": start.isoformat(),
+        "end": date.fromordinal(next_start.toordinal() - 1).isoformat(),
+    }
 
 
 def _scalar_formula_value(formula: object) -> int | float | str | bool | None:

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -109,6 +109,166 @@ mappings:
     candidate_priority: P4
     rationale: The current Axiom Florida TCA amount depends on the incomplete Axiom eligibility wrapper and DCF page 21's no-issuance rule for deficits below $10. PolicyEngine's adjacent fl_tca uses its own eligibility, countable-income, and payment-standard graph and does not share this exact DCF program boundary yet.
 
+  - legal_id: us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#maximum_pell_grant_award
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.amount.max
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Department of Education maximum Pell Grant award amount.
+
+  - legal_id: us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#minimum_pell_grant_award
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.amount.min
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same Department of Education minimum Pell Grant award amount.
+
+  - legal_id: us:statutes/20/1070a/b/1#maximum_pell_single_parent_poverty_line_multiplier
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.sai.fpg_fraction.max_pell_limits
+    parameter_key: DEPENDENT_SINGLE
+    period: year
+    comparison: rate
+    rationale: Same 225 percent maximum-Pell poverty-line threshold used by PolicyEngine's single-parent Pell household type.
+
+  - legal_id: us:statutes/20/1070a/b/1#maximum_pell_not_single_parent_poverty_line_multiplier
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.sai.fpg_fraction.max_pell_limits
+    parameter_key: DEPENDENT_NOT_SINGLE
+    period: year
+    comparison: rate
+    rationale: Same 175 percent maximum-Pell poverty-line threshold used by PolicyEngine's not-single-parent Pell household type.
+
+  - legal_id: us:statutes/20/1070a/b/1#minimum_pell_dependent_single_parent_poverty_line_multiplier
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.sai.fpg_fraction.min_pell_limits
+    parameter_key: DEPENDENT_SINGLE
+    period: year
+    comparison: rate
+    rationale: Same 325 percent dependent single-parent minimum-Pell poverty-line threshold.
+
+  - legal_id: us:statutes/20/1070a/b/1#minimum_pell_dependent_not_single_parent_poverty_line_multiplier
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.sai.fpg_fraction.min_pell_limits
+    parameter_key: DEPENDENT_NOT_SINGLE
+    period: year
+    comparison: rate
+    rationale: Same 275 percent dependent not-single-parent minimum-Pell poverty-line threshold.
+
+  - legal_id: us:statutes/20/1070a/b/1#minimum_pell_independent_single_parent_poverty_line_multiplier
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.sai.fpg_fraction.min_pell_limits
+    parameter_key: INDEPENDENT_SINGLE
+    period: year
+    comparison: rate
+    rationale: Same 400 percent independent single-parent minimum-Pell poverty-line threshold.
+
+  - legal_id: us:statutes/20/1070a/b/1#minimum_pell_independent_parent_not_single_parent_poverty_line_multiplier
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.sai.fpg_fraction.min_pell_limits
+    parameter_key: INDEPENDENT_NOT_SINGLE
+    period: year
+    comparison: rate
+    rationale: Same 350 percent independent parent not-single-parent minimum-Pell poverty-line threshold.
+
+  - legal_id: us:statutes/20/1070a/b/1#minimum_pell_independent_not_parent_poverty_line_multiplier
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.sai.fpg_fraction.min_pell_limits
+    parameter_key: INDEPENDENT_NOT_PARENT
+    period: year
+    comparison: rate
+    rationale: Same 275 percent independent not-parent minimum-Pell poverty-line threshold.
+
+  - legal_id: us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#maximum_pell_single_parent_poverty_guideline_rate
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.sai.fpg_fraction.max_pell_limits
+    parameter_key: DEPENDENT_SINGLE
+    period: year
+    comparison: rate
+    rationale: Same 225 percent maximum-Pell poverty-guideline threshold used by PolicyEngine's single-parent Pell household type.
+
+  - legal_id: us:policies/ed/fsa/2026-27-sai-pell-guide/page-8#maximum_pell_not_single_parent_poverty_guideline_rate
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.sai.fpg_fraction.max_pell_limits
+    parameter_key: DEPENDENT_NOT_SINGLE
+    period: year
+    comparison: rate
+    rationale: Same 175 percent maximum-Pell poverty-guideline threshold used by PolicyEngine's not-single-parent Pell household type.
+
+  - legal_id: us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#dependent_minimum_pell_single_parent_poverty_guideline_rate
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.sai.fpg_fraction.min_pell_limits
+    parameter_key: DEPENDENT_SINGLE
+    period: year
+    comparison: rate
+    rationale: Same 325 percent dependent single-parent minimum-Pell poverty-guideline threshold.
+
+  - legal_id: us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#dependent_minimum_pell_not_single_parent_poverty_guideline_rate
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.sai.fpg_fraction.min_pell_limits
+    parameter_key: DEPENDENT_NOT_SINGLE
+    period: year
+    comparison: rate
+    rationale: Same 275 percent dependent not-single-parent minimum-Pell poverty-guideline threshold.
+
+  - legal_id: us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_minimum_pell_single_parent_poverty_guideline_rate
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.sai.fpg_fraction.min_pell_limits
+    parameter_key: INDEPENDENT_SINGLE
+    period: year
+    comparison: rate
+    rationale: Same 400 percent independent single-parent minimum-Pell poverty-guideline threshold.
+
+  - legal_id: us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_minimum_pell_parent_not_single_parent_poverty_guideline_rate
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.sai.fpg_fraction.min_pell_limits
+    parameter_key: INDEPENDENT_NOT_SINGLE
+    period: year
+    comparison: rate
+    rationale: Same 350 percent independent parent not-single-parent minimum-Pell poverty-guideline threshold.
+
+  - legal_id: us:policies/ed/fsa/2026-27-sai-pell-guide/page-30#independent_minimum_pell_not_parent_poverty_guideline_rate
+    country: us
+    program: pell
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ed.pell_grant.sai.fpg_fraction.min_pell_limits
+    parameter_key: INDEPENDENT_NOT_PARENT
+    period: year
+    comparison: rate
+    rationale: Same 275 percent independent not-parent minimum-Pell poverty-guideline threshold.
+
   - legal_id: us-ma:policies/dta/snap/fy-2026-cola/heating-cooling-standard-utility-allowance#heating_cooling_standard_utility_allowance
     country: us
     program: snap
@@ -16198,6 +16358,27 @@ mappings:
     rationale: PolicyEngine does not expose the section 25C(g) basis-reduction amount as a separate variable.
 
 prefixes:
+  - legal_id_prefix: us:policies/ed/fsa/2026-27-sai-pell-guide/
+    country: us
+    program: pell
+    mapping_type: not_comparable
+    candidate_priority: P3
+    rationale: PolicyEngine-US exposes final Pell amount, SAI, eligibility type, and FPG threshold surfaces, but not the FSA guide's ISIR indicator, flag, and branch-level procedural outputs at one-to-one legal granularity; exact comparable Pell parameters carry mappings which take precedence over this prefix.
+
+  - legal_id_prefix: us:policies/ed/fsa/gen-26-01-pell-award-amounts/
+    country: us
+    program: pell
+    mapping_type: not_comparable
+    candidate_priority: P3
+    rationale: PolicyEngine-US exposes adjacent Pell award amount parameters and final grant variables, but not GEN-26-01's SAI prohibition, rounding, annual receipt cap, lifetime semester limit, or SAI-calculated award intermediates as one-to-one surfaces; exact comparable Pell parameters carry mappings which take precedence over this prefix.
+
+  - legal_id_prefix: us:statutes/20/1070a/b/
+    country: us
+    program: pell
+    mapping_type: not_comparable
+    candidate_priority: P3
+    rationale: PolicyEngine-US exposes adjacent Pell amount, SAI, eligibility type, and poverty-threshold surfaces, but not HEA section 401(b)'s statutory subparagraph predicates and intermediate amount determinations at one-to-one legal granularity; exact comparable Pell parameters carry mappings which take precedence over this prefix.
+
   - legal_id_prefix: us:statutes/26/25E#
     country: us
     program: clean_vehicle_credits

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.802"
+version = "0.2.803"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add PolicyEngine oracle coverage mappings for Pell Grant award and FPG threshold outputs
- classify Pell guide/statutory internals that PE does not expose one-to-one with explicit not-comparable prefixes
- update oracle-parameter test repair generation to use a custom one-year period when the parameter's first effective date is mid-year

## Validation
- uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py tests/test_cli.py -k 'oracle_parameter or oracle_coverage or policyengine_registry'
- registry load smoke test for Pell mappings