### PR TITLE
Map SSI outputs for PE coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.803"
+version = "0.2.804"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.804"
+version = "0.2.805"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.803"
+__version__ = "0.2.804"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.804"
+__version__ = "0.2.805"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -4590,7 +4590,8 @@ def _applied_manifest_matches_current_deterministic_repair(
     axiom_encode_git: dict[str, object],
     signing_key: str,
 ) -> bool:
-    manifest_path = repo_path / _applied_encoding_manifest_path(relative_output)
+    content_root = _rulespec_apply_content_root(repo_path, relative_output)
+    manifest_path = content_root / _applied_encoding_manifest_path(relative_output)
     if not manifest_path.exists():
         return False
     try:
@@ -4617,7 +4618,7 @@ def _applied_manifest_matches_current_deterministic_repair(
             return False
 
     expected_hashes = {
-        path.relative_to(repo_path).as_posix(): _sha256_file(path)
+        path.relative_to(content_root).as_posix(): _sha256_file(path)
         for path in applied_files
         if path.exists()
     }
@@ -8305,9 +8306,9 @@ def _repair_current_year_final_amount_test_expectations(
     if not isinstance(payload, dict):
         return False
 
-    target_base = (
-        f"{_repo_jurisdiction_prefix(repo_path)}:"
-        f"{_relative_rulespec_import_target(relative_output)}"
+    target_base = _relative_output_to_anchor(
+        relative_output,
+        policy_repo_path=repo_path,
     )
     specs = _current_year_final_amount_test_specs(payload, repo_path=repo_path)
     if not specs:
@@ -8760,9 +8761,9 @@ def cmd_repair_invalid_test_inputs(args):
 
     removed_refs: list[str] = []
     seen_invalid_refs: set[str] = set()
-    target_base = (
-        f"{_repo_jurisdiction_prefix(repo_path)}:"
-        f"{_relative_rulespec_import_target(relative_output)}"
+    target_base = _relative_output_to_anchor(
+        relative_output,
+        policy_repo_path=repo_path,
     )
     while True:
         validation = ValidatorPipeline(
@@ -12332,9 +12333,13 @@ def cmd_repair_oracle_parameter_tests(args):
 
     test_file = _rulespec_test_path(rules_file)
     original_test_content = test_file.read_text() if test_file.exists() else ""
-    target_base = (
-        f"{_repo_jurisdiction_prefix(repo_path)}:"
-        f"{_relative_rulespec_import_target(relative_output)}"
+    target_base = _relative_output_to_anchor(
+        relative_output,
+        policy_repo_path=repo_path,
+    )
+    manifest_relative_output = _relative_to_live_rulespec_content_root(
+        rules_file,
+        repo_path,
     )
     signing_key = _require_applied_encoding_manifest_signing_key()
     axiom_encode_git = _require_clean_axiom_encode_git_provenance()
@@ -12343,9 +12348,25 @@ def cmd_repair_oracle_parameter_tests(args):
         test_file=test_file,
         target_base=target_base,
     )
+    covered_test_cases = _mapped_oracle_parameter_test_outputs(
+        rules_file=rules_file,
+        test_file=test_file,
+        target_base=target_base,
+    )
     if not repaired_test_cases:
-        print("No oracle parameter test repairs found.")
-        return
+        if not covered_test_cases:
+            print("No oracle parameter test repairs found.")
+            return
+        if _applied_manifest_matches_current_deterministic_repair(
+            repo_path=repo_path,
+            relative_output=manifest_relative_output,
+            applied_files=[rules_file, test_file],
+            model="oracle-parameter-test-v1",
+            axiom_encode_git=axiom_encode_git,
+            signing_key=signing_key,
+        ):
+            print("No oracle parameter test repairs found.")
+            return
 
     axiom_rules_path = getattr(
         args, "axiom_rules_path", None
@@ -12382,7 +12403,9 @@ def cmd_repair_oracle_parameter_tests(args):
 
     with tempfile.TemporaryDirectory() as tmpdir:
         output_root = Path(tmpdir)
-        generated_output = output_root / "deterministic-repair" / relative_output
+        generated_output = (
+            output_root / "deterministic-repair" / manifest_relative_output
+        )
         generated_output.parent.mkdir(parents=True, exist_ok=True)
         generated_output.write_text(rules_file.read_text())
         result = argparse.Namespace(
@@ -12400,17 +12423,21 @@ def cmd_repair_oracle_parameter_tests(args):
             result,
             output_root=output_root,
             policy_repo_path=repo_path,
-            relative_output=relative_output,
+            relative_output=manifest_relative_output,
             applied_files=[rules_file, test_file],
             run_id="deterministic-repair",
             signing_key=signing_key,
             axiom_encode_git=axiom_encode_git,
         )
 
-    print(
+    changed_message = (
         "Applied oracle parameter test repair to "
         f"{relative_output}: {', '.join(repaired_test_cases)}"
+        if repaired_test_cases
+        else "Refreshed oracle parameter test repair manifest for "
+        f"{relative_output}: {', '.join(covered_test_cases)}"
     )
+    print(changed_message)
     print(f"manifest={manifest_path}")
 
 
@@ -15386,6 +15413,38 @@ def _append_oracle_parameter_tests_if_missing(
     separator = "" if not existing_content or existing_content.endswith("\n") else "\n"
     test_file.write_text(f"{existing_content}{separator}{rendered}")
     return repaired
+
+
+def _mapped_oracle_parameter_test_outputs(
+    *,
+    rules_file: Path,
+    test_file: Path,
+    target_base: str,
+) -> list[str]:
+    payload = yaml.safe_load(rules_file.read_text()) or {}
+    rules = payload.get("rules") if isinstance(payload, dict) else None
+    if not isinstance(rules, list):
+        return []
+
+    existing_outputs = _rulespec_test_output_keys(test_file)
+    registry = load_policyengine_registry()
+    covered: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip() != "parameter":
+            continue
+        rule_name = str(rule.get("name") or "").strip()
+        if not rule_name:
+            continue
+        legal_id = f"{target_base}#{rule_name}"
+        if legal_id not in existing_outputs:
+            continue
+        mapping = registry.mapping_for_legal_id(legal_id, country="us")
+        if mapping is None or mapping.mapping_type != "parameter_value":
+            continue
+        covered.append(rule_name)
+    return covered
 
 
 def _rulespec_test_output_keys(test_file: Path) -> set[str]:
@@ -30940,6 +30999,26 @@ def _relative_to_rulespec_apply_content_root(
         return Path(path).relative_to(content_root)
     except ValueError:
         return Path(path).relative_to(repo_path)
+
+
+def _relative_to_live_rulespec_content_root(path: Path, repo_path: Path) -> Path:
+    """Return a live repo file path relative to its jurisdiction content root."""
+    resolved_path = Path(path).resolve()
+    resolved_repo = Path(repo_path).resolve()
+    repo_relative = resolved_path.relative_to(resolved_repo)
+    parts = repo_relative.parts
+    if (
+        len(parts) >= 2
+        and parts[1] in RULESPEC_SOURCE_ROOTS
+        and re.fullmatch(r"[a-z]{2}(?:-[a-z0-9_]+)*", parts[0])
+        and (resolved_repo / parts[0]).is_dir()
+    ):
+        return resolved_path.relative_to(resolved_repo / parts[0])
+    content_root = jurisdiction_content_dir(
+        resolved_repo,
+        _repo_jurisdiction_prefix(resolved_repo),
+    )
+    return resolved_path.relative_to(content_root)
 
 
 def _enforce_canonical_concept_registry(

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -934,6 +934,103 @@ mappings:
     result_multiplier: 12
     rationale: Same federal SSI couple benefit-rate amount, with PolicyEngine storing the monthly parameter and RuleSpec encoding the annual amount determined under 42 USC 1382f(a) for section 1382(b)(2).
 
+  - legal_id: us:statutes/42/1382c/a/1#aged_age_threshold_years
+    country: us
+    program: ssi
+    mapping_type: parameter_value
+    policyengine_parameter: gov.ssa.ssi.eligibility.aged_threshold
+    period: month
+    comparison: count
+    rationale: Same statutory SSI aged-category threshold of age 65.
+
+  - legal_id: us:statutes/42/1382c/a/1#aged_blind_or_disabled_individual
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: is_ssi_aged_blind_disabled
+    candidate_priority: P4
+    rationale: RuleSpec encodes the full 42 USC 1382c(a)(1) defined term, including the age/blind/disabled limb plus United States residence, citizen-or-qualified-alien status, and the Armed-Forces child-abroad branch. PolicyEngine's is_ssi_aged_blind_disabled variable exposes only the age/blind/disabled limb.
+
+  - legal_id: us:statutes/42/1382c/a/2#blindness_visual_acuity_threshold_numerator
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: is_blind
+    candidate_priority: P4
+    rationale: RuleSpec exposes the statutory visual-acuity numerator used by 42 USC 1382c(a)(2). PolicyEngine treats is_blind as a scenario/input-style boolean and does not expose the legal visual-acuity threshold as a parameter.
+
+  - legal_id: us:statutes/42/1382c/a/2#blindness_visual_acuity_threshold_denominator
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: is_blind
+    candidate_priority: P4
+    rationale: RuleSpec exposes the statutory visual-acuity denominator used by 42 USC 1382c(a)(2). PolicyEngine treats is_blind as a scenario/input-style boolean and does not expose the legal visual-acuity threshold as a parameter.
+
+  - legal_id: us:statutes/42/1382c/a/2#blindness_visual_field_widest_diameter_max_degrees
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: is_blind
+    candidate_priority: P4
+    rationale: RuleSpec exposes the statutory visual-field threshold used by 42 USC 1382c(a)(2). PolicyEngine treats is_blind as a scenario/input-style boolean and does not expose the legal visual-field threshold as a parameter.
+
+  - legal_id: us:statutes/42/1382c/a/2#blind_for_subchapter
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: is_blind
+    candidate_priority: P4
+    rationale: RuleSpec encodes the full SSI blindness definition, including visual-acuity, visual-field, and legacy state-plan branches. PolicyEngine's is_blind surface is an input-style demographic boolean rather than this source-level legal determination.
+
+  - legal_id: us:statutes/42/1382/a/1#individual_annual_income_base_limit
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.individual
+    candidate_priority: P4
+    rationale: RuleSpec exposes the original 1974 annual income-limit base in 42 USC 1382(a)(1)(A). PolicyEngine stores the final monthly federal benefit-rate parameter after later statutory increases and COLA uprating; the one-to-one PE parameter mapping lives on the final 1382f amount output.
+
+  - legal_id: us:statutes/42/1382/a/1#applicable_individual_annual_income_limit
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.individual
+    candidate_priority: P4
+    rationale: RuleSpec exposes the source-level 42 USC 1382(a)(1)(A) eligibility income-limit branch using the greater of the original base and a 1382f amount. PolicyEngine stores the materialized monthly federal benefit-rate parameter and does not expose this eligibility-branch helper separately.
+
+  - legal_id: us:statutes/42/1382/a/1#eligible_individual
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: is_ssi_eligible
+    candidate_priority: P4
+    rationale: RuleSpec encodes the 42 USC 1382(a)(1) source-level no-eligible-spouse eligibility branch, including full 1382c(a)(1) status, countable-income limit, and living-with-spouse resource branch. PolicyEngine's SSI eligibility surfaces use a different decomposition and do not expose this statutory branch one-to-one.
+
+  - legal_id: us:statutes/42/1382/a/2#couple_annual_income_base_limit
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.couple
+    candidate_priority: P4
+    rationale: RuleSpec exposes the original 1974 annual couple income-limit base in 42 USC 1382(a)(2)(A). PolicyEngine stores the final monthly couple federal benefit-rate parameter after later statutory increases and COLA uprating; the one-to-one PE parameter mapping lives on the final 1382f amount output.
+
+  - legal_id: us:statutes/42/1382/a/2#applicable_couple_annual_income_limit
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_parameter: gov.ssa.ssi.amount.couple
+    candidate_priority: P4
+    rationale: RuleSpec exposes the source-level 42 USC 1382(a)(2)(A) couple eligibility income-limit branch using the greater of the original base and a 1382f amount. PolicyEngine stores the materialized monthly couple federal benefit-rate parameter and does not expose this eligibility-branch helper separately.
+
+  - legal_id: us:statutes/42/1382/a/2#eligible_individual_with_eligible_spouse
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    policyengine_variable: is_ssi_eligible_spouse
+    candidate_priority: P4
+    rationale: RuleSpec encodes the 42 USC 1382(a)(2) source-level eligible-spouse branch, including full 1382c(a)(1) status plus joint countable-income and resource tests. PolicyEngine's eligible-spouse surface is a narrower marital/status helper and does not expose this statutory eligibility branch one-to-one.
+
   - legal_id: us:statutes/42/1382f/c#dollar_amount_increase_for_section_1382_a_1_a_and_b_1
     country: us
     program: ssi

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25047,6 +25047,172 @@ rules:
             "statutes/26/32.test.yaml",
         ]
 
+    def test_repair_oracle_parameter_tests_uses_canonical_country_monorepo_anchor(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "us/statutes/42/1382c/a/1.yaml"
+        test_file = policy_repo / "us/statutes/42/1382c/a/1.test.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+rules:
+  - name: aged_age_threshold_years
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '1974-01-01'
+        formula: '65'
+"""
+        )
+        test_file.write_text(
+            """- name: existing
+  output:
+    us:statutes/42/1382c/a/1#some_other_output: 1
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("us/statutes/42/1382c/a/1.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakeRegistry:
+            def mapping_for_legal_id(self, legal_id, *, country=None):
+                assert country == "us"
+                if legal_id == ("us:statutes/42/1382c/a/1#aged_age_threshold_years"):
+                    return SimpleNamespace(mapping_type="parameter_value")
+                return None
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli.load_policyengine_registry",
+                return_value=FakeRegistry(),
+            ),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures", return_value=[]
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_oracle_parameter_tests(args)
+
+        payload = yaml.safe_load(test_file.read_text())
+        added = payload[-1]
+        assert added["name"] == "oracle_parameter_aged_age_threshold_years"
+        assert added["input"] == {}
+        assert added["output"] == {
+            "us:statutes/42/1382c/a/1#aged_age_threshold_years": 65
+        }
+        manifest = (
+            policy_repo / "us/.axiom/encoding-manifests/statutes/42/1382c/a/1.json"
+        )
+        manifest_payload = json.loads(manifest.read_text())
+        assert [item["path"] for item in manifest_payload["applied_files"]] == [
+            "statutes/42/1382c/a/1.yaml",
+            "statutes/42/1382c/a/1.test.yaml",
+        ]
+
+    def test_repair_oracle_parameter_tests_refreshes_manifest_when_case_exists(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "us/statutes/42/1382c/a/1.yaml"
+        test_file = policy_repo / "us/statutes/42/1382c/a/1.test.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+rules:
+  - name: aged_age_threshold_years
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '1974-01-01'
+        formula: '65'
+"""
+        )
+        original_test_content = """- name: existing
+  output:
+    us:statutes/42/1382c/a/1#some_other_output: 1
+- name: oracle_parameter_aged_age_threshold_years
+  period:
+    period_kind: tax_year
+    start: '1974-01-01'
+    end: '1974-12-31'
+  input: {}
+  output:
+    us:statutes/42/1382c/a/1#aged_age_threshold_years: 65
+"""
+        test_file.write_text(original_test_content)
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("us/statutes/42/1382c/a/1.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakeRegistry:
+            def mapping_for_legal_id(self, legal_id, *, country=None):
+                assert country == "us"
+                if legal_id == ("us:statutes/42/1382c/a/1#aged_age_threshold_years"):
+                    return SimpleNamespace(mapping_type="parameter_value")
+                return None
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli.load_policyengine_registry",
+                return_value=FakeRegistry(),
+            ),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures", return_value=[]
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_oracle_parameter_tests(args)
+
+        assert test_file.read_text() == original_test_content
+        manifest = (
+            policy_repo / "us/.axiom/encoding-manifests/statutes/42/1382c/a/1.json"
+        )
+        manifest_payload = json.loads(manifest.read_text())
+        assert manifest_payload["model"] == "oracle-parameter-test-v1"
+        assert [item["path"] for item in manifest_payload["applied_files"]] == [
+            "statutes/42/1382c/a/1.yaml",
+            "statutes/42/1382c/a/1.test.yaml",
+        ]
+
     def test_repair_oracle_parameter_tests_appends_scalar_parameter_case(
         self, tmp_path
     ):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2431,8 +2431,7 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
     assert ssi_couple_eligibility_mapping.mapping_type == "not_comparable"
     assert (
-        ssi_couple_eligibility_mapping.policyengine_variable
-        == "is_ssi_eligible_spouse"
+        ssi_couple_eligibility_mapping.policyengine_variable == "is_ssi_eligible_spouse"
     )
     ssi_individual_benefit_mapping = registry.mapping_for_legal_id(
         "us:statutes/42/1382/b#annual_benefit_without_eligible_spouse",

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2398,6 +2398,42 @@ def test_policyengine_registry_is_legal_id_keyed():
     assert ssi_couple_fbr_mapping.mapping_type == "parameter_value"
     assert ssi_couple_fbr_mapping.policyengine_parameter == "gov.ssa.ssi.amount.couple"
     assert ssi_couple_fbr_mapping.result_multiplier == 12
+    ssi_aged_threshold_mapping = registry.mapping_for_legal_id(
+        "us:statutes/42/1382c/a/1#aged_age_threshold_years",
+        country="us",
+    )
+    assert ssi_aged_threshold_mapping.mapping_type == "parameter_value"
+    assert (
+        ssi_aged_threshold_mapping.policyengine_parameter
+        == "gov.ssa.ssi.eligibility.aged_threshold"
+    )
+    ssi_full_abd_mapping = registry.mapping_for_legal_id(
+        "us:statutes/42/1382c/a/1#aged_blind_or_disabled_individual",
+        country="us",
+    )
+    assert ssi_full_abd_mapping.mapping_type == "not_comparable"
+    assert ssi_full_abd_mapping.policyengine_variable == "is_ssi_aged_blind_disabled"
+    ssi_blind_mapping = registry.mapping_for_legal_id(
+        "us:statutes/42/1382c/a/2#blind_for_subchapter",
+        country="us",
+    )
+    assert ssi_blind_mapping.mapping_type == "not_comparable"
+    assert ssi_blind_mapping.policyengine_variable == "is_blind"
+    ssi_individual_eligibility_mapping = registry.mapping_for_legal_id(
+        "us:statutes/42/1382/a/1#eligible_individual",
+        country="us",
+    )
+    assert ssi_individual_eligibility_mapping.mapping_type == "not_comparable"
+    assert ssi_individual_eligibility_mapping.policyengine_variable == "is_ssi_eligible"
+    ssi_couple_eligibility_mapping = registry.mapping_for_legal_id(
+        "us:statutes/42/1382/a/2#eligible_individual_with_eligible_spouse",
+        country="us",
+    )
+    assert ssi_couple_eligibility_mapping.mapping_type == "not_comparable"
+    assert (
+        ssi_couple_eligibility_mapping.policyengine_variable
+        == "is_ssi_eligible_spouse"
+    )
     ssi_individual_benefit_mapping = registry.mapping_for_legal_id(
         "us:statutes/42/1382/b#annual_benefit_without_eligible_spouse",
         country="us",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.803"
+version = "0.2.804"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.804"
+version = "0.2.805"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- Map SSI eligibility outputs to PolicyEngine oracle surfaces for coverage.
- Canonicalize deterministic repair anchors for country-monorepo RuleSpec repos.
- Make `repair-oracle-parameter-tests` idempotently refresh signed manifests when the oracle test case already exists.

## Validation

- `uv run --extra dev python -m pytest -q tests/test_cli.py::TestApplyDependencyValidation::test_repair_oracle_parameter_tests_adds_missing_parameter_output tests/test_cli.py::TestApplyDependencyValidation::test_repair_oracle_parameter_tests_uses_canonical_country_monorepo_anchor tests/test_cli.py::TestApplyDependencyValidation::test_repair_oracle_parameter_tests_refreshes_manifest_when_case_exists tests/test_cli.py::TestApplyDependencyValidation::test_repair_oracle_parameter_tests_appends_scalar_parameter_case tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_policyengine_coverage.py -k 'ssi or oracle_coverage or program_surface'`
