### PR TITLE
Close encoded PE program surfaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.806"
+version = "0.2.807"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.805"
+version = "0.2.806"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.805"
+__version__ = "0.2.806"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.806"
+__version__ = "0.2.807"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1863,10 +1863,13 @@ surfaces:
   coverage: US
   variable: pell_grant
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: RuleSpec PR 437 encodes current-law Pell Grant statutory and Department of Education guidance surfaces, including
+    exact mappings for comparable Pell award and poverty-line threshold parameters. Axiom should not claim a one-to-one oracle
+    match for PolicyEngine's final `pell_grant` program aggregate because PolicyEngine composes SAI/EFC-era paths, cost-of-attendance
+    caps, enrollment timing, eligibility-type variables, and simplified program inputs outside a single source-boundary legal
+    output. Compare exact Pell parameters and source-level branch outputs separately.
 - country: us
   program_id: education_tax_credits
   program_name: Education tax credits
@@ -1889,7 +1892,7 @@ surfaces:
   coverage: US
   variable: clean_vehicle_credit
   source_type: program
-  axiom_status: pending_oracle_mapping
+  axiom_status: known_not_comparable
   priority: P1
   rationale: RuleSpec PR 436 encodes current-law sections 25E and 30D from the House US Code releasepoint, including source-backed
     clean-vehicle credit parameters and per-vehicle rules. Axiom still should not claim a final `clean_vehicle_credit` oracle

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1879,10 +1879,11 @@ surfaces:
   coverage: US
   variable: american_opportunity_credit
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: pending_oracle_mapping
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: RuleSpec encodes current-law section 25A education credit surfaces and the PolicyEngine registry maps the American
+    Opportunity Credit, refundable and nonrefundable AOTC components, Lifetime Learning Credit components, and education tax
+    credit aggregate to exact PE variables for supported current-law cases.
 - country: us
   program_id: clean_vehicle_credits
   program_name: Clean vehicle credits
@@ -1908,10 +1909,12 @@ surfaces:
   coverage: US
   variable: residential_clean_energy_credit
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: RuleSpec encodes current-law section 25D residential clean energy credit surfaces. Axiom should not claim a comparable
+    oracle match for PolicyEngine's final `residential_clean_energy_credit` surface because PolicyEngine is stale after Pub.
+    L. 119-21 and still allows post-2025 credits; see PolicyEngine/policyengine-us#8694. Source-level parameters and intermediates
+    remain classified individually in the legal-ID registry.
 - country: us
   program_id: ira_tax_credits
   program_name: IRA tax credits

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -423,13 +423,28 @@ def test_policyengine_program_surface_marks_acp_known_not_comparable():
     assert "connected-device" in acp["rationale"]
 
 
-def test_policyengine_program_surface_marks_clean_vehicle_pending_oracle_mapping():
+def test_policyengine_program_surface_marks_pell_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="pell_grant")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    pell = items_by_variable["pell_grant"]
+
+    assert pell["axiom_status"] == "known_not_comparable"
+    assert pell["priority"] == "P1"
+    assert pell["mapping_count"] == 0
+    assert pell["comparable_mapping_count"] == 0
+    assert "exact mappings for comparable Pell" in pell["rationale"]
+    assert "program aggregate" in pell["rationale"]
+    assert "Compare exact Pell parameters" in pell["rationale"]
+
+
+def test_policyengine_program_surface_marks_clean_vehicle_known_not_comparable():
     report = build_policyengine_program_surface_report(program="clean_vehicle_credits")
 
     items_by_variable = {item["variable"]: item for item in report["items"]}
     clean_vehicle = items_by_variable["clean_vehicle_credit"]
 
-    assert clean_vehicle["axiom_status"] == "pending_oracle_mapping"
+    assert clean_vehicle["axiom_status"] == "known_not_comparable"
     assert clean_vehicle["priority"] == "P1"
     assert "sections 25E and 30D" in clean_vehicle["rationale"]
     assert "taxpayer-to-vehicle relation" in clean_vehicle["rationale"]

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -403,6 +403,38 @@ def test_policyengine_program_surface_marks_section_25c_known_not_comparable():
     assert "product-identification-number gate" in section_25c["rationale"]
 
 
+def test_policyengine_program_surface_marks_education_tax_credit_wired():
+    report = build_policyengine_program_surface_report(program="education_tax_credits")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    aotc = items_by_variable["american_opportunity_credit"]
+
+    assert aotc["axiom_status"] == "wired"
+    assert aotc["mapping_count"] >= 1
+    assert aotc["comparable_mapping_count"] >= 1
+    assert "us:statutes/26/25A#american_opportunity_credit" in aotc["legal_ids"]
+    assert "section 25A education credit surfaces" in aotc["rationale"]
+    assert "exact PE variables" in aotc["rationale"]
+
+
+def test_policyengine_program_surface_marks_section_25d_known_not_comparable():
+    report = build_policyengine_program_surface_report(
+        program="residential_clean_energy_credit"
+    )
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    section_25d = items_by_variable["residential_clean_energy_credit"]
+
+    assert section_25d["axiom_status"] == "known_not_comparable"
+    assert section_25d["mapping_count"] >= 1
+    assert section_25d["comparable_mapping_count"] == 0
+    assert (
+        "us:statutes/26/25D#residential_clean_energy_credit" in section_25d["legal_ids"]
+    )
+    assert "Pub. L. 119-21" in section_25d["rationale"]
+    assert "post-2025 credits" in section_25d["rationale"]
+
+
 def test_policyengine_program_surface_marks_acp_known_not_comparable():
     report = build_policyengine_program_surface_report(program="acp")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.806"
+version = "0.2.807"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.805"
+version = "0.2.806"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark Pell Grant as known-not-comparable at the final PE aggregate surface now that exact Pell parameter and branch surfaces are encoded
- mark clean vehicle credit as known-not-comparable instead of pending an oracle mapping for PE's tax-unit simplification
- add program-surface regression tests for both statuses

## Validation
- uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_pell_known_not_comparable tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_clean_vehicle_known_not_comparable tests/test_policyengine_coverage.py::test_policyengine_registry_classifies_clean_vehicle_sections_as_noncomparable
- uv run --extra dev python -m pytest -q tests/test_policyengine_coverage.py -k 'program_surface or clean_vehicle or pell'
- uv tool run ruff check src/ tests/
- uv tool run ruff format --check src/ tests/
- axiom-encode oracle-coverage --include-program-surfaces reports active pending PE surfaces drop from 155 to 153