### PR TITLE
Map DOE rebate PE oracle surfaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.807"
+version = "0.2.808"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.807"
+__version__ = "0.2.808"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -15408,6 +15408,8 @@ def _append_oracle_parameter_tests_if_missing(
         return []
 
     existing_content = test_file.read_text() if test_file.exists() else ""
+    if (yaml.safe_load(existing_content) if existing_content.strip() else None) == []:
+        existing_content = ""
     test_file.parent.mkdir(parents=True, exist_ok=True)
     rendered = yaml.safe_dump(appended_cases, sort_keys=False)
     separator = "" if not existing_content or existing_content.endswith("\n") else "\n"

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -16454,7 +16454,306 @@ mappings:
     mapping_type: not_comparable
     rationale: PolicyEngine does not expose the section 25C(g) basis-reduction amount as a separate variable.
 
+  - legal_id: us:statutes/42/18795/c/2#modeled_savings_lower_threshold
+    country: us
+    program: doe_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.residential_efficiency_electrification_rebate.threshold.medium
+    period: year
+    comparison: rate
+    rationale: Same HOMES modeled energy-system savings threshold for the medium modeled-rebate branch.
+
+  - legal_id: us:statutes/42/18795/c/2#modeled_savings_higher_threshold
+    country: us
+    program: doe_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.residential_efficiency_electrification_rebate.threshold.high
+    period: year
+    comparison: rate
+    rationale: Same HOMES modeled energy-system savings threshold for the high modeled-rebate branch.
+
+  - legal_id: us:statutes/42/18795/c/2#measured_savings_threshold
+    country: us
+    program: doe_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.residential_efficiency_electrification_rebate.threshold.low
+    period: year
+    comparison: rate
+    rationale: Same HOMES measured energy-savings threshold.
+
+  - legal_id: us:statutes/42/18795/c/2#standard_single_family_lower_modeled_amount_cap
+    country: us
+    program: doe_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.residential_efficiency_electrification_rebate.cap.medium
+    parameter_key_path:
+      - amounts
+      - 1
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same non-low/moderate-income HOMES single-family medium modeled-rebate dollar cap.
+
+  - legal_id: us:statutes/42/18795/c/2#standard_single_family_higher_modeled_amount_cap
+    country: us
+    program: doe_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.residential_efficiency_electrification_rebate.cap.high
+    parameter_key_path:
+      - amounts
+      - 1
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same non-low/moderate-income HOMES single-family high modeled-rebate dollar cap.
+
+  - legal_id: us:statutes/42/18795/c/2#standard_project_cost_cap_rate
+    country: us
+    program: doe_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.residential_efficiency_electrification_rebate.percent
+    parameter_key_path:
+      - amounts
+      - 1
+    period: year
+    comparison: rate
+    rationale: Same non-low/moderate-income HOMES project-cost percentage cap.
+
+  - legal_id: us:statutes/42/18795/c/2#low_or_moderate_income_lower_modeled_amount_cap
+    country: us
+    program: doe_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.residential_efficiency_electrification_rebate.cap.medium
+    parameter_key_path:
+      - amounts
+      - 0
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same low/moderate-income HOMES medium modeled-rebate dollar cap.
+
+  - legal_id: us:statutes/42/18795/c/2#low_or_moderate_income_higher_modeled_amount_cap
+    country: us
+    program: doe_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.residential_efficiency_electrification_rebate.cap.high
+    parameter_key_path:
+      - amounts
+      - 0
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same low/moderate-income HOMES high modeled-rebate dollar cap.
+
+  - legal_id: us:statutes/42/18795/c/2#low_or_moderate_income_project_cost_cap_rate
+    country: us
+    program: doe_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.residential_efficiency_electrification_rebate.percent
+    parameter_key_path:
+      - amounts
+      - 0
+    period: year
+    comparison: rate
+    rationale: Same low/moderate-income HOMES project-cost percentage cap.
+
+  - legal_id: us:statutes/42/18795/c/2#standard_measured_payment_amount_for_twenty_percent_reduction
+    country: us
+    program: doe_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.residential_efficiency_electrification_rebate.cap.low
+    parameter_key_path:
+      - amounts
+      - 1
+    period: year
+    unit: USD
+    comparison: money
+    result_multiplier: 20
+    rationale: Same non-low/moderate-income HOMES measured-savings amount, with PolicyEngine storing the $2,000 per 20 percent statutory amount as $100 per one-percent reduction.
+
+  - legal_id: us:statutes/42/18795/c/2#low_or_moderate_income_measured_payment_amount_for_twenty_percent_reduction
+    country: us
+    program: doe_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.residential_efficiency_electrification_rebate.cap.low
+    parameter_key_path:
+      - amounts
+      - 0
+    period: year
+    unit: USD
+    comparison: money
+    result_multiplier: 20
+    rationale: Same low/moderate-income HOMES measured-savings amount, with PolicyEngine storing the $4,000 per 20 percent statutory amount as $200 per one-percent reduction.
+
+  - legal_id: us:statutes/42/18795/c#homes_rebate_program_rebate_amounts_and_limitations
+    country: us
+    program: doe_efficiency_rebate
+    mapping_type: not_comparable
+    policyengine_variable: residential_efficiency_electrification_rebate
+    candidate_priority: P4
+    rationale: RuleSpec encodes the statutory HOMES thresholds, dollar caps, project-cost caps, multifamily caps, low/moderate-income branches, and anti-combination limits at source granularity. PolicyEngine's residential_efficiency_electrification_rebate collapses the program to tax-unit retrofit expenditure and energy-use inputs, omits multifamily/building/portfolio structure, and stores the measured-savings payment rate in a transformed per-percent form, so the final PE variable is not a one-to-one legal oracle.
+
+  - legal_id: us:statutes/42/18795a/c/3#heat_pump_water_heater_rebate_cap
+    country: us
+    program: doe_high_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.high_efficiency_electric_home_rebate.cap.heat_pump_water_heater
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same high-efficiency electric home rebate cap for a heat pump water heater.
+
+  - legal_id: us:statutes/42/18795a/c/3#heat_pump_space_heating_or_cooling_rebate_cap
+    country: us
+    program: doe_high_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.high_efficiency_electric_home_rebate.cap.heat_pump
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same high-efficiency electric home rebate cap for a heat pump for space heating or cooling.
+
+  - legal_id: us:statutes/42/18795a/c/3#electric_stove_cooktop_range_oven_or_heat_pump_clothes_dryer_rebate_cap
+    country: us
+    program: doe_high_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.high_efficiency_electric_home_rebate.cap.electric_stove_cooktop_range_or_oven
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same $840 cap for electric stove, cooktop, range, or oven purchases; PolicyEngine also stores the same statutory $840 amount separately for electric heat-pump clothes dryers.
+
+  - legal_id: us:statutes/42/18795a/c/3#electric_load_service_center_upgrade_rebate_cap
+    country: us
+    program: doe_high_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.high_efficiency_electric_home_rebate.cap.electric_load_service_center_upgrade
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same high-efficiency electric home rebate cap for an electric load service center upgrade.
+
+  - legal_id: us:statutes/42/18795a/c/3#insulation_air_sealing_and_ventilation_rebate_cap
+    country: us
+    program: doe_high_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.high_efficiency_electric_home_rebate.cap.insulation_air_sealing_ventilation
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same high-efficiency electric home rebate cap for insulation, air sealing, and ventilation.
+
+  - legal_id: us:statutes/42/18795a/c/3#electric_wiring_rebate_cap
+    country: us
+    program: doe_high_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.high_efficiency_electric_home_rebate.cap.electric_wiring
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same high-efficiency electric home rebate cap for electric wiring.
+
+  - legal_id: us:statutes/42/18795a/c/3#eligible_entity_multiple_rebate_total_cap
+    country: us
+    program: doe_high_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.high_efficiency_electric_home_rebate.cap.total
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same total high-efficiency electric home rebate cap for an eligible entity receiving multiple rebates.
+
+  - legal_id: us:statutes/42/18795a/c/4#household_income_lower_bound_for_partial_project_cost_rebate
+    country: us
+    program: doe_high_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.high_efficiency_electric_home_rebate.percent_covered
+    parameter_key_path:
+      - thresholds
+      - 1
+    period: year
+    comparison: rate
+    rationale: Same 80 percent AMI threshold where the high-efficiency electric home rebate partial project-cost cap begins.
+
+  - legal_id: us:statutes/42/18795a/c/4#household_income_upper_bound_for_partial_project_cost_rebate
+    country: us
+    program: doe_high_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.high_efficiency_electric_home_rebate.percent_covered
+    parameter_key_path:
+      - thresholds
+      - 2
+    period: year
+    comparison: rate
+    rationale: Same 150 percent AMI threshold above which high-efficiency electric home rebate project-cost coverage is zero.
+
+  - legal_id: us:statutes/42/18795a/c/4#household_income_upper_bound_for_full_project_cost_rebate
+    country: us
+    program: doe_high_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.high_efficiency_electric_home_rebate.percent_covered
+    parameter_key_path:
+      - thresholds
+      - 1
+    period: year
+    comparison: rate
+    rationale: Same 80 percent AMI threshold below which high-efficiency electric home rebate project-cost coverage is 100 percent.
+
+  - legal_id: us:statutes/42/18795a/c/4#partial_project_cost_rebate_cap_rate
+    country: us
+    program: doe_high_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.high_efficiency_electric_home_rebate.percent_covered
+    parameter_key_path:
+      - amounts
+      - 1
+    period: year
+    comparison: rate
+    rationale: Same high-efficiency electric home rebate partial project-cost cap rate.
+
+  - legal_id: us:statutes/42/18795a/c/4#full_project_cost_rebate_cap_rate
+    country: us
+    program: doe_high_efficiency_rebate
+    mapping_type: parameter_value
+    policyengine_parameter: gov.doe.high_efficiency_electric_home_rebate.percent_covered
+    parameter_key_path:
+      - amounts
+      - 0
+    period: year
+    comparison: rate
+    rationale: Same high-efficiency electric home rebate full project-cost cap rate.
+
+  - legal_id: us:statutes/42/18795a/c/4#project_cost_rebate_cap_rate
+    country: us
+    program: doe_high_efficiency_rebate
+    mapping_type: not_comparable
+    policyengine_variable: high_efficiency_electric_home_rebate_percent_covered
+    candidate_priority: P4
+    rationale: RuleSpec derives the cap rate across the individual, multifamily, and entity-on-behalf-of-household branches in 42 USC 18795a(c)(4). PolicyEngine's percent-covered variable is a tax-unit income-to-AMI lookup and does not expose the statutory eligible-entity or multifamily resident-share branches.
+
+  - legal_id: us:statutes/42/18795a/c/3#high_efficiency_electric_home_rebate_program_rebate_amount
+    country: us
+    program: doe_high_efficiency_rebate
+    mapping_type: not_comparable
+    policyengine_variable: high_efficiency_electric_home_rebate
+    candidate_priority: P4
+    rationale: RuleSpec encodes the statutory high-efficiency electric home rebate item caps, total cap, and project-cost percentage limits as source-level project/payment components. PolicyEngine's high_efficiency_electric_home_rebate sums tax-unit expenditure helper variables and caps the result, so it is not a one-to-one legal oracle until Axiom has the same project/entity/rebate aggregation surface.
+
 prefixes:
+  - legal_id_prefix: us:statutes/42/18795
+    country: us
+    program: doe_efficiency_rebate
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: HOMES rebate outputs not carrying exact parameter mappings are source-level project, multifamily, portfolio, grant-administration, or anti-combination surfaces that PolicyEngine-US does not expose one-to-one.
+
+  - legal_id_prefix: us:statutes/42/18795a
+    country: us
+    program: doe_high_efficiency_rebate
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: High-efficiency electric home rebate outputs not carrying exact parameter mappings are source-level eligible-entity, project, installer-payment, grant-administration, or anti-combination surfaces that PolicyEngine-US does not expose one-to-one.
+
   - legal_id_prefix: us:policies/ed/fsa/2026-27-sai-pell-guide/
     country: us
     program: pell

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1940,10 +1940,13 @@ surfaces:
   coverage: US
   variable: high_efficiency_electric_home_rebate
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: >-
+    RuleSpec encodes 42 USC 18795a(c)(3)-(4) item caps, total caps, and project-cost percentage limits, with exact
+    PolicyEngine parameter mappings where PE exposes the same statutory values. The final PE variable collapses those
+    statutory project/entity/rebate concepts into tax-unit expenditure helpers, so Axiom should not claim one-to-one final
+    variable parity until the project/payment aggregation surface is encoded.
 - country: us
   program_id: doe_efficiency_rebate
   program_name: DOE efficiency rebate
@@ -1953,10 +1956,13 @@ surfaces:
   coverage: US
   variable: residential_efficiency_electrification_rebate
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: >-
+    RuleSpec encodes 42 USC 18795 HOMES definitions and 42 USC 18795(c)(2) thresholds, modeled/measured caps, and
+    low/moderate-income branches, with exact PolicyEngine parameter mappings where PE exposes the same statutory values.
+    The final PE variable collapses the statutory project, building, portfolio, and anti-combination structure into
+    tax-unit energy-use inputs, so it is not a one-to-one final variable oracle yet.
 - country: us
   program_id: co_oap
   program_name: Colorado OAP

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25047,6 +25047,77 @@ rules:
             "statutes/26/32.test.yaml",
         ]
 
+    def test_repair_oracle_parameter_tests_replaces_empty_list_file(self, tmp_path):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "statutes/42/18795a/c/3.yaml"
+        test_file = policy_repo / "statutes/42/18795a/c/3.test.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+rules:
+  - name: heat_pump_water_heater_rebate_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2022-08-16'
+        formula: '1750'
+"""
+        )
+        test_file.write_text("[]\n")
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("statutes/42/18795a/c/3.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakeRegistry:
+            def mapping_for_legal_id(self, legal_id, *, country=None):
+                assert country == "us"
+                if (
+                    legal_id
+                    == "us:statutes/42/18795a/c/3#heat_pump_water_heater_rebate_cap"
+                ):
+                    return SimpleNamespace(mapping_type="parameter_value")
+                return None
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli.load_policyengine_registry",
+                return_value=FakeRegistry(),
+            ),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures", return_value=[]
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_oracle_parameter_tests(args)
+
+        payload = yaml.safe_load(test_file.read_text())
+        assert isinstance(payload, list)
+        assert len(payload) == 1
+        assert payload[0]["name"] == (
+            "oracle_parameter_heat_pump_water_heater_rebate_cap"
+        )
+        assert "[]\n-" not in test_file.read_text()
+
     def test_repair_oracle_parameter_tests_uses_canonical_country_monorepo_anchor(
         self, tmp_path
     ):

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -435,6 +435,37 @@ def test_policyengine_program_surface_marks_section_25d_known_not_comparable():
     assert "post-2025 credits" in section_25d["rationale"]
 
 
+def test_policyengine_program_surface_marks_doe_rebates_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="doe_high_efficiency_rebate")
+
+    high_efficiency = {
+        item["variable"]: item for item in report["items"]
+    }["high_efficiency_electric_home_rebate"]
+
+    assert high_efficiency["axiom_status"] == "known_not_comparable"
+    assert high_efficiency["mapping_count"] >= 1
+    assert high_efficiency["comparable_mapping_count"] == 0
+    assert (
+        "us:statutes/42/18795a/c/3#high_efficiency_electric_home_rebate_program_rebate_amount"
+        in high_efficiency["legal_ids"]
+    )
+    assert "project/payment aggregation surface" in high_efficiency["rationale"]
+
+    report = build_policyengine_program_surface_report(program="doe_efficiency_rebate")
+    homes = {
+        item["variable"]: item for item in report["items"]
+    }["residential_efficiency_electrification_rebate"]
+
+    assert homes["axiom_status"] == "known_not_comparable"
+    assert homes["mapping_count"] >= 1
+    assert homes["comparable_mapping_count"] == 0
+    assert (
+        "us:statutes/42/18795/c#homes_rebate_program_rebate_amounts_and_limitations"
+        in homes["legal_ids"]
+    )
+    assert "project, building, portfolio" in homes["rationale"]
+
+
 def test_policyengine_program_surface_marks_acp_known_not_comparable():
     report = build_policyengine_program_surface_report(program="acp")
 

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -436,11 +436,13 @@ def test_policyengine_program_surface_marks_section_25d_known_not_comparable():
 
 
 def test_policyengine_program_surface_marks_doe_rebates_known_not_comparable():
-    report = build_policyengine_program_surface_report(program="doe_high_efficiency_rebate")
+    report = build_policyengine_program_surface_report(
+        program="doe_high_efficiency_rebate"
+    )
 
-    high_efficiency = {
-        item["variable"]: item for item in report["items"]
-    }["high_efficiency_electric_home_rebate"]
+    high_efficiency = {item["variable"]: item for item in report["items"]}[
+        "high_efficiency_electric_home_rebate"
+    ]
 
     assert high_efficiency["axiom_status"] == "known_not_comparable"
     assert high_efficiency["mapping_count"] >= 1
@@ -452,9 +454,9 @@ def test_policyengine_program_surface_marks_doe_rebates_known_not_comparable():
     assert "project/payment aggregation surface" in high_efficiency["rationale"]
 
     report = build_policyengine_program_surface_report(program="doe_efficiency_rebate")
-    homes = {
-        item["variable"]: item for item in report["items"]
-    }["residential_efficiency_electrification_rebate"]
+    homes = {item["variable"]: item for item in report["items"]}[
+        "residential_efficiency_electrification_rebate"
+    ]
 
     assert homes["axiom_status"] == "known_not_comparable"
     assert homes["mapping_count"] >= 1

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.807"
+version = "0.2.808"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Map DOE HOMES and high-efficiency electric home rebate RuleSpec outputs to PolicyEngine oracle parameters where exact statutory values match
- Mark the final DOE PE program surfaces known-not-comparable because PE collapses statutory project/entity/rebate aggregation into tax-unit helper inputs
- Fix repair-oracle-parameter-tests for generated empty-list companion test files and bump axiom-encode to 0.2.808

## Validation
- uv --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-doe-rebates-20260624 run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py tests/test_policyengine_coverage.py
- uv --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-doe-rebates-20260624 run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::TestApplyDependencyValidation::test_repair_oracle_parameter_tests_replaces_empty_list_file -q
- uv --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-doe-rebates-20260624 run --extra dev python -m pytest tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_doe_rebates_known_not_comparable tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_section_25d_known_not_comparable -q
- Registry validation: mappings=2651 prefixes=378 issues=0
- DOE oracle coverage gates pass with --fail-on-pending-program-surfaces --fail-on-untested-comparable