### PR TITLE
Map Head Start PE oracle surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.808"
+version = "0.2.809"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.808"
+__version__ = "0.2.809"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -386,6 +386,74 @@ mappings:
     comparison: rate
     rationale: Same federal Lifeline household-income limit in 47 CFR 54.409(a)(1), represented in PolicyEngine as the FCC Lifeline FPG limit parameter.
 
+  - legal_id: us:regulations/45-cfr/1302/12#overincome_exception_enrollment_cap
+    country: us
+    program: head_start
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 45 CFR 1302.12(c)(2) 10 percent over-income enrollment allowance. PolicyEngine's Head Start model does not expose this program-level enrollment-cap parameter or apply program-cap administration.
+
+  - legal_id: us:regulations/45-cfr/1302/12#additional_allowance_enrollment_cap
+    country: us
+    program: head_start
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 45 CFR 1302.12(d)(1) additional 35 percent participant allowance. PolicyEngine does not model this separate discretionary enrollment allowance.
+
+  - legal_id: us:regulations/45-cfr/1302/12#additional_allowance_income_limit_multiplier
+    country: us
+    program: head_start
+    mapping_type: not_comparable
+    policyengine_variable: is_head_start_income_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes the paragraph (d) below-130-percent-of-poverty allowance for additional participants. PolicyEngine's income eligibility variable models only the ordinary at-or-below-poverty path, not this separate allowance.
+
+  - legal_id: us:regulations/45-cfr/1302/12#reportable_overincome_lower_bound_multiplier
+    country: us
+    program: head_start
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 100 percent lower bound for paragraph (d)(2) reporting on 100-to-130-percent-of-poverty enrollments. PolicyEngine does not expose this reporting threshold.
+
+  - legal_id: us:regulations/45-cfr/1302/12#paragraph_c_participant_eligible
+    country: us
+    program: head_start
+    mapping_type: not_comparable
+    policyengine_variable: head_start
+    candidate_priority: P4
+    rationale: RuleSpec exposes the paragraph (c) participant eligibility paths before age, take-up, per-slot spending, and final benefit assignment. PolicyEngine's head_start variable is a final imputed dollar value after eligibility, state spending/enrollment allocation, and take-up.
+
+  - legal_id: us:regulations/45-cfr/1302/12#additional_allowance_participant_may_be_enrolled
+    country: us
+    program: head_start
+    mapping_type: not_comparable
+    policyengine_variable: is_head_start_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes the paragraph (d) additional-enrollment allowance, including required program outreach and selection policies. PolicyEngine's Head Start eligibility variable does not model this discretionary allowance or its program-administration predicates.
+
+  - legal_id: us:regulations/45-cfr/1302/12#report_to_regional_office_required_for_between_100_and_130_percent_enrollment
+    country: us
+    program: head_start
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the paragraph (d)(2) regional-office reporting trigger. PolicyEngine does not expose Head Start reporting duties.
+
+  - legal_id: us:regulations/45-cfr/1302/12#tribal_service_area_participant_eligible
+    country: us
+    program: head_start
+    mapping_type: not_comparable
+    policyengine_variable: is_head_start_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes the paragraph (e) Tribal program service-area eligibility path notwithstanding paragraph (c). PolicyEngine's Head Start eligibility variable does not model Tribal service-area eligibility as a distinct legal branch.
+
+  - legal_id: us:regulations/45-cfr/1302/12#migrant_or_seasonal_participant_eligible
+    country: us
+    program: head_start
+    mapping_type: not_comparable
+    policyengine_variable: is_head_start_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes the paragraph (f) Migrant or Seasonal Head Start eligibility path based on primary agricultural-employment income and age requirements. PolicyEngine's Head Start eligibility variable does not model this branch separately.
+
   - legal_id: us:regulations/47-cfr/54/409#income_qualifies_for_lifeline
     country: us
     program: lifeline

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1332,10 +1332,11 @@ surfaces:
   coverage: US, WA
   variable: head_start
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom encodes the national 45 CFR 1302.12 Head Start eligibility and enrollment-allowance rules. PolicyEngine's
+    `head_start` variable is a final imputed dollar value using eligibility, take-up, and state spending/enrollment allocation,
+    so the national legal surface is not a one-to-one oracle boundary.
 - country: us
   program_id: head_start
   program_name: ECEAP

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -110,6 +110,72 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_head_start_45_cfr_1302_12(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us/us/regulations/45-cfr/1302/12.yaml",
+        """format: rulespec/v1
+rules:
+  - name: overincome_exception_enrollment_cap
+    kind: parameter
+    versions:
+      - effective_from: '2021-01-01'
+        formula: 0.10
+  - name: additional_allowance_enrollment_cap
+    kind: parameter
+    versions:
+      - effective_from: '2021-01-01'
+        formula: 0.35
+  - name: additional_allowance_income_limit_multiplier
+    kind: parameter
+    versions:
+      - effective_from: '2021-01-01'
+        formula: 1.30
+  - name: reportable_overincome_lower_bound_multiplier
+    kind: parameter
+    versions:
+      - effective_from: '2021-01-01'
+        formula: 1.00
+  - name: paragraph_c_participant_eligible
+    kind: derived
+    versions:
+      - effective_from: '2021-01-01'
+        formula: family_income <= poverty_line_amount
+  - name: additional_allowance_participant_may_be_enrolled
+    kind: derived
+    versions:
+      - effective_from: '2021-01-01'
+        formula: family_income < poverty_line_amount * additional_allowance_income_limit_multiplier
+  - name: report_to_regional_office_required_for_between_100_and_130_percent_enrollment
+    kind: derived
+    versions:
+      - effective_from: '2021-01-01'
+        formula: family_income >= poverty_line_amount
+  - name: tribal_service_area_participant_eligible
+    kind: derived
+    versions:
+      - effective_from: '2021-01-01'
+        formula: tribal_program and participant_in_approved_service_area
+  - name: migrant_or_seasonal_participant_eligible
+    kind: derived
+    versions:
+      - effective_from: '2021-01-01'
+        formula: at_least_one_family_member_income_comes_primarily_from_agricultural_employment
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="head_start")
+
+    assert report["total_outputs"] == 9
+    assert report["status_counts"] == {"known_not_comparable": 9}
+    assert {item["program"] for item in report["items"]} == {"head_start"}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    final_surface = items_by_id[
+        "us:regulations/45-cfr/1302/12#paragraph_c_participant_eligible"
+    ]
+    assert final_surface["policyengine_variable"] == "head_start"
+    assert final_surface["mapping_type"] == "not_comparable"
+
+
 def test_policyengine_coverage_includes_program_spec_outputs(tmp_path):
     checkout = tmp_path / "rulespec-us"
     _write_rulespec_file(
@@ -364,6 +430,25 @@ def test_policyengine_program_surface_marks_arizona_ccap_pending_source_ingestio
     assert arizona_ccap["axiom_status"] == "pending_source_ingestion"
     assert arizona_ccap["mapping_count"] == 0
     assert "official DES/AZSOS sources" in arizona_ccap["rationale"]
+
+
+def test_policyengine_program_surface_marks_head_start_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="head_start")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    national = items_by_variable["head_start"]
+
+    assert national["axiom_status"] == "known_not_comparable"
+    assert national["mapping_count"] == 1
+    assert national["comparable_mapping_count"] == 0
+    assert national["legal_ids"] == [
+        "us:regulations/45-cfr/1302/12#paragraph_c_participant_eligible"
+    ]
+    assert items_by_variable["wa_eceap"]["axiom_status"] == "deferred_jurisdiction"
+    assert (
+        items_by_variable["wa_birth_to_three_eceap"]["axiom_status"]
+        == "deferred_jurisdiction"
+    )
 
 
 def test_policyengine_program_surface_marks_colorado_health_value_surfaces_out_of_scope():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.808"
+version = "0.2.809"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 45 CFR 1302.12 Head Start RuleSpec outputs in the PolicyEngine oracle registry
- mark the national Head Start program surface as known-not-comparable instead of pending RuleSpec encoding
- bump axiom-encode to 0.2.809 and add regression coverage for the legal IDs and program surface

## Validation
- uv --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-head-start-oracle-20260624 run pytest /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-head-start-oracle-20260624/tests/test_policyengine_coverage.py -q
- uv --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-head-start-oracle-20260624 run axiom-encode oracle-coverage --root /tmp/axiom-root-head-start --program head_start --include-program-surfaces --json
