### PR TITLE
Map Georgia SSP PolicyEngine oracle surface

### DIFF
--- a/changelog.d/ga-ssp-oracle-mapping.changed.md
+++ b/changelog.d/ga-ssp-oracle-mapping.changed.md
@@ -1,0 +1,1 @@
+Map Georgia SSP to PolicyEngine oracle surfaces and pin encoder version 0.2.810.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.809"
+version = "0.2.810"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.809"
+__version__ = "0.2.810"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -24573,6 +24573,10 @@ print("BENCHMARK:" + json.dumps(result))
             ):
                 aliases.add(source_key)
             for _target_key, _operation, source_keys in (
+                *adapter.monthly_derived_boolean_person_inputs,
+            ):
+                aliases.update(source_keys)
+            for _target_key, _operation, source_keys in (
                 *adapter.derived_spm_overrides,
                 *adapter.annual_derived_spm_overrides,
             ):
@@ -25478,6 +25482,31 @@ print(f'RESULT:{{float(value)}}')
                         else adult_attrs
                     )
                     attrs.append(f"'{pe_attr}': {{'{period}': {bool(value)}}}")
+            for (
+                pe_attr,
+                operation,
+                rule_keys,
+            ) in adapter.monthly_derived_boolean_person_inputs:
+                values = [
+                    self._rulespec_test_input_value(inputs, rule_key)
+                    for rule_key in rule_keys
+                ]
+                if not all(value is not None for value in values):
+                    continue
+                if operation == "all":
+                    derived_value = all(bool(value) for value in values)
+                elif operation == "any":
+                    derived_value = any(bool(value) for value in values)
+                else:
+                    continue
+                attrs = (
+                    target_person_attrs
+                    if target_person_attrs is not None
+                    else adult_attrs
+                )
+                attrs.append(
+                    f"'{pe_attr}': {{'{period}': {pe_literal(derived_value)}}}"
+                )
 
         snap_eligible_member_proxy = None
         if "snap_household_has_eligible_participating_member" in inputs:

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -20,6 +20,9 @@ class PolicyEngineUSVarAdapter:
     monthly_person_inputs: tuple[tuple[str, str], ...] = ()
     boolean_person_inputs: tuple[tuple[str, str], ...] = ()
     monthly_boolean_person_inputs: tuple[tuple[str, str], ...] = ()
+    monthly_derived_boolean_person_inputs: tuple[
+        tuple[str, str, tuple[str, ...]], ...
+    ] = ()
     direct_spm_overrides: tuple[tuple[str, str], ...] = ()
     derived_spm_overrides: tuple[tuple[str, str, tuple[str, ...]], ...] = ()
     annual_direct_spm_overrides: tuple[tuple[str, str], ...] = ()
@@ -755,6 +758,26 @@ PE_US_SSI_VAR_ADAPTERS = (
         entity="person",
         period="year",
         comparison="decision",
+    ),
+    PolicyEngineUSVarAdapter(
+        rule_names=("expected_state_supplement_for_nursing_home_ssi_recipient",),
+        pe_var="ga_ssp_person",
+        entity="person",
+        period="month",
+        unit="USD",
+        comparison="money",
+        monthly=True,
+        default_state_code="GA",
+        monthly_derived_boolean_person_inputs=(
+            (
+                "ga_ssp_eligible_person",
+                "all",
+                (
+                    "receives_ssi_only",
+                    "month_following_nursing_home_admission",
+                ),
+            ),
+        ),
     ),
 )
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1861,6 +1861,70 @@ mappings:
     comparison: money
     rationale: Same Colorado AND-CS monthly grant-standard-minus-countable-income amount.
 
+  - legal_id: us-ga:policies/dfcs/medicaid/2578#resource_transfer_lookback_months
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Georgia DFCS Policy 2578 uses this nursing-home vendor-payment resource-transfer lookback; PolicyEngine's Georgia SSP model does not expose the transfer lookback as a one-to-one variable or parameter.
+
+  - legal_id: us-ga:policies/dfcs/medicaid/2578#ssi_only_nursing_home_payment_amount_after_admission
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Georgia DFCS Policy 2578 states the federal SSI-only payment reduction after nursing-home admission; PolicyEngine's Georgia SSP surface models the state supplement and does not expose this federal SSI payment boundary as a Georgia SSP oracle target.
+
+  - legal_id: us-ga:policies/dfcs/medicaid/2578#nursing_home_state_supplement_amount
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ga.dhs.ssp.amount
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Georgia monthly State Supplement amount schedule for SSI recipients in nursing-home or institutionalized-hospice settings.
+
+  - legal_id: us-ga:policies/dfcs/medicaid/2578#ssi_recipient_nursing_home_vendor_payment_authorizable
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: ga_ssp
+    candidate_priority: P4
+    rationale: RuleSpec encodes the Georgia nursing-home vendor-payment authorization predicate with residency, level-of-care, and resource-transfer gates; PolicyEngine's `ga_ssp` is an SPM-unit aggregate of person-level supplement amounts and uses separate federal living-arrangement and Georgia setting inputs.
+
+  - legal_id: us-ga:policies/dfcs/medicaid/2578#expected_ssi_only_payment_after_nursing_home_admission
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This is the expected federal SSI-only payment amount after nursing-home admission, while PolicyEngine's Georgia SSP variables expose the state supplement rather than this federal SSI payment calculation.
+
+  - legal_id: us-ga:policies/dfcs/medicaid/2578#expected_state_supplement_for_nursing_home_ssi_recipient
+    country: us
+    program: ssi_state_supplement
+    mapping_type: direct_variable
+    policyengine_variable: ga_ssp_person
+    entity: person
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Georgia monthly state supplement amount for one eligible SSI recipient; PolicyEngine's person-level variable is the comparable target, while its `ga_ssp` program variable aggregates person amounts to the SPM unit.
+
+  - legal_id: us-ga:policies/dfcs/medicaid/2578#patient_liability_for_month_of_admission_to_lad
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Georgia DFCS Policy 2578 patient-liability computation for the admission month is a Medicaid long-term-care budgeting rule; PolicyEngine's Georgia SSP model does not expose this liability boundary.
+
+  - legal_id: us-ga:policies/dfcs/medicaid/2578#patient_liability_for_month_after_admission_to_lad
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Georgia DFCS Policy 2578 patient-liability computation after admission is a Medicaid long-term-care budgeting rule; PolicyEngine's Georgia SSP model does not expose this liability boundary.
+
   - legal_id: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
     country: us
     program: snap

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1542,10 +1542,12 @@ surfaces:
   variable: ga_ssp
   source_type: state_implementation
   state: GA
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom encodes Georgia DFCS Policy 2578 and maps the monthly person-level state supplement amount to
+    `ga_ssp_person`. PolicyEngine's listed program variable `ga_ssp` is an SPM-unit aggregate over person amounts and
+    PE-specific federal living-arrangement/setting inputs, so the aggregate wrapper is reviewed but not a one-to-one legal
+    output.
 - country: us
   program_id: ssi_state_supplement
   program_name: Idaho AABD

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -659,6 +659,122 @@ def test_policyengine_program_surface_marks_colorado_ssp_wired():
     )
 
 
+def test_policyengine_coverage_maps_georgia_ssp_nursing_home_supplement(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "us-ga" / "policies/dfcs/medicaid/2578.yaml",
+        """format: rulespec/v1
+rules:
+  - name: resource_transfer_lookback_months
+    kind: parameter
+    versions:
+      - effective_from: '2019-07-01'
+        formula: 60
+  - name: ssi_only_nursing_home_payment_amount_after_admission
+    kind: parameter
+    versions:
+      - effective_from: '2019-07-01'
+        formula: 30
+  - name: nursing_home_state_supplement_amount
+    kind: parameter
+    versions:
+      - effective_from: '2019-07-01'
+        formula: 40
+  - name: ssi_recipient_nursing_home_vendor_payment_authorizable
+    kind: derived
+    versions:
+      - effective_from: '2019-07-01'
+        formula: holds
+  - name: expected_ssi_only_payment_after_nursing_home_admission
+    kind: derived
+    versions:
+      - effective_from: '2019-07-01'
+        formula: 30
+  - name: expected_state_supplement_for_nursing_home_ssi_recipient
+    kind: derived
+    versions:
+      - effective_from: '2019-07-01'
+        formula: 40
+  - name: patient_liability_for_month_of_admission_to_lad
+    kind: derived
+    versions:
+      - effective_from: '2019-07-01'
+        formula: 800
+  - name: patient_liability_for_month_after_admission_to_lad
+    kind: derived
+    versions:
+      - effective_from: '2019-07-01'
+        formula: 0
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "us-ga" / "policies/dfcs/medicaid/2578.test.yaml",
+        """- name: person_level_state_supplement
+  period: 2019-07
+  input: {}
+  output:
+    us-ga:policies/dfcs/medicaid/2578#expected_state_supplement_for_nursing_home_ssi_recipient: 40
+""",
+    )
+
+    report = build_policyengine_coverage_report(
+        tmp_path,
+        program="ssi_state_supplement",
+    )
+    items_by_name = {item["rule_name"]: item for item in report["items"]}
+
+    assert report["total_outputs"] == 8
+    assert report["status_counts"] == {
+        "comparable": 2,
+        "known_not_comparable": 6,
+    }
+    assert report["untested_comparable"] == 1
+    assert (
+        items_by_name["nursing_home_state_supplement_amount"]["policyengine_parameter"]
+        == "gov.states.ga.dhs.ssp.amount"
+    )
+    assert (
+        items_by_name["expected_state_supplement_for_nursing_home_ssi_recipient"][
+            "policyengine_variable"
+        ]
+        == "ga_ssp_person"
+    )
+    assert (
+        items_by_name["expected_state_supplement_for_nursing_home_ssi_recipient"][
+            "tested"
+        ]
+        is True
+    )
+    assert (
+        items_by_name["ssi_recipient_nursing_home_vendor_payment_authorizable"][
+            "policyengine_variable"
+        ]
+        == "ga_ssp"
+    )
+    assert (
+        items_by_name["ssi_recipient_nursing_home_vendor_payment_authorizable"][
+            "status"
+        ]
+        == "known_not_comparable"
+    )
+
+
+def test_policyengine_program_surface_marks_georgia_ssp_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="ga_ssp")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    georgia_ssp = items_by_variable["ga_ssp"]
+
+    assert georgia_ssp["program_id"] == "ssi_state_supplement"
+    assert georgia_ssp["state"] == "GA"
+    assert georgia_ssp["axiom_status"] == "known_not_comparable"
+    assert georgia_ssp["mapping_count"] >= 1
+    assert georgia_ssp["comparable_mapping_count"] == 0
+    assert (
+        "us-ga:policies/dfcs/medicaid/2578#ssi_recipient_nursing_home_vendor_payment_authorizable"
+        in georgia_ssp["legal_ids"]
+    )
+
+
 def test_policyengine_coverage_classifies_federal_ssi_benefit_rate_intermediates(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.809"
+version = "0.2.810"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Summary
- Add Georgia SSP oracle mappings for DFCS Medicaid Policy 2578.
- Map the person-level state supplement output to PolicyEngine ga_ssp_person.
- Add monthly derived boolean person-input replay support so RuleSpec inputs can drive PE ga_ssp_eligible_person.
- Mark PE aggregate ga_ssp program surface as reviewed but known-not-comparable, since it is an SPM-unit aggregate wrapper rather than a one-to-one legal output.

Validation
- uv run --extra dev ruff check src/axiom_encode/oracles/policyengine/adapters.py src/axiom_encode/harness/validator_pipeline.py tests/test_policyengine_coverage.py
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py
- uv run --extra dev python -c "from axiom_encode.oracles.policyengine.registry import load_policyengine_registry; load_policyengine_registry(); print(\"registry ok\")"
- uv run --extra dev axiom-encode validate --skip-reviewers /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ga-ssp-20260624/us-ga/policies/dfcs/medicaid/2578.yaml
- uv run --extra dev axiom-encode oracle-coverage --root /tmp/axiom-root-ga-ssp --program ssi_state_supplement --include-program-surfaces --json

Coverage summary for Georgia SSP root: 10 SSP outputs, 4 comparable, 6 known-not-comparable, 1 untested comparable. The untested comparable is nursing_home_state_supplement_amount, which is a PE parameter and is exercised through expected_state_supplement_for_nursing_home_ssi_recipient rather than emitted directly as a generated RuleSpec test output.