### PR TITLE
Fix state subroot oracle repair manifests

### DIFF
--- a/changelog.d/state-subroot-oracle-repair.changed.md
+++ b/changelog.d/state-subroot-oracle-repair.changed.md
@@ -1,0 +1,1 @@
+Fix deterministic oracle-parameter repair manifests for state subroots in country monorepos.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.810"
+version = "0.2.811"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.810"
+__version__ = "0.2.811"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -12337,7 +12337,7 @@ def cmd_repair_oracle_parameter_tests(args):
         relative_output,
         policy_repo_path=repo_path,
     )
-    manifest_relative_output = _relative_to_live_rulespec_content_root(
+    manifest_relative_output = _deterministic_repair_manifest_relative_output(
         rules_file,
         repo_path,
     )
@@ -31021,6 +31021,33 @@ def _relative_to_live_rulespec_content_root(path: Path, repo_path: Path) -> Path
         _repo_jurisdiction_prefix(resolved_repo),
     )
     return resolved_path.relative_to(content_root)
+
+
+def _deterministic_repair_manifest_relative_output(
+    path: Path,
+    repo_path: Path,
+) -> Path:
+    """Return a manifest relative path for deterministic repairs.
+
+    Country monorepo files such as ``rulespec-us/us/statutes/...`` keep the
+    existing content-root-relative layout under ``us/.axiom``. State subroots
+    such as ``rulespec-us/us-ga/policies/...`` keep their subroot prefix so
+    deterministic repair manifests are written under the root manifest tree
+    like other monorepo state repair tools.
+    """
+    resolved_path = Path(path).resolve()
+    resolved_repo = Path(repo_path).resolve()
+    repo_relative = resolved_path.relative_to(resolved_repo)
+    parts = repo_relative.parts
+    jurisdiction = _repo_jurisdiction_prefix(resolved_repo)
+    if (
+        len(parts) >= 2
+        and parts[1] in RULESPEC_SOURCE_ROOTS
+        and parts[0].startswith(f"{jurisdiction}-")
+        and (resolved_repo / parts[0]).is_dir()
+    ):
+        return repo_relative
+    return _relative_to_live_rulespec_content_root(resolved_path, resolved_repo)
 
 
 def _enforce_canonical_concept_registry(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25200,6 +25200,96 @@ rules:
             "statutes/42/1382c/a/1.test.yaml",
         ]
 
+    def test_repair_oracle_parameter_tests_uses_state_subroot_manifest(self, tmp_path):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "us-ga/policies/dfcs/medicaid/2578.yaml"
+        test_file = policy_repo / "us-ga/policies/dfcs/medicaid/2578.test.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+rules:
+  - name: nursing_home_state_supplement_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    versions:
+      - effective_from: '2006-07-01'
+        formula: '20'
+"""
+        )
+        test_file.write_text(
+            """- name: existing
+  output:
+    us-ga:policies/dfcs/medicaid/2578#some_other_output: 1
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("us-ga/policies/dfcs/medicaid/2578.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakeRegistry:
+            def mapping_for_legal_id(self, legal_id, *, country=None):
+                assert country == "us"
+                if legal_id == (
+                    "us-ga:policies/dfcs/medicaid/2578"
+                    "#nursing_home_state_supplement_amount"
+                ):
+                    return SimpleNamespace(mapping_type="parameter_value")
+                return None
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli.load_policyengine_registry",
+                return_value=FakeRegistry(),
+            ),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures", return_value=[]
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_oracle_parameter_tests(args)
+
+        payload = yaml.safe_load(test_file.read_text())
+        added = payload[-1]
+        assert added["name"] == "oracle_parameter_nursing_home_state_supplement_amount"
+        assert added["input"] == {}
+        assert added["output"] == {
+            "us-ga:policies/dfcs/medicaid/2578#nursing_home_state_supplement_amount": 20
+        }
+        manifest = (
+            policy_repo
+            / ".axiom/encoding-manifests/us-ga/policies/dfcs/medicaid/2578.json"
+        )
+        manifest_payload = json.loads(manifest.read_text())
+        assert [item["path"] for item in manifest_payload["applied_files"]] == [
+            "us-ga/policies/dfcs/medicaid/2578.yaml",
+            "us-ga/policies/dfcs/medicaid/2578.test.yaml",
+        ]
+        assert not (
+            policy_repo
+            / "us/.axiom/encoding-manifests/policies/dfcs/medicaid/2578.json"
+        ).exists()
+
     def test_repair_oracle_parameter_tests_refreshes_manifest_when_case_exists(
         self, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.810"
+version = "0.2.811"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- fix deterministic oracle-parameter repair manifests for state subroots in country monorepos
- keep canonical federal content-root behavior unchanged
- add regression coverage for a Georgia state-subroot repair writing a root `.axiom/encoding-manifests/us-ga/...` manifest

## Tests
- `uv run --extra dev python -m pytest tests/test_cli.py::TestApplyDependencyValidation::test_repair_oracle_parameter_tests_uses_canonical_country_monorepo_anchor tests/test_cli.py::TestApplyDependencyValidation::test_repair_oracle_parameter_tests_uses_state_subroot_manifest tests/test_cli.py::TestApplyDependencyValidation::test_repair_oracle_parameter_tests_refreshes_manifest_when_case_exists tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`