### PR TITLE
Clarify excess limit encoding prompt

### DIFF
--- a/changelog.d/excess-limit-formula-prompt.changed.md
+++ b/changelog.d/excess-limit-formula-prompt.changed.md
@@ -1,0 +1,1 @@
+Clarified the encoder prompt so source text counting amounts in excess of a limit becomes an executable excess formula instead of a stranded modifier parameter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.811"
+version = "0.2.812"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.811"
+__version__ = "0.2.812"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -5055,6 +5055,14 @@ RuleSpec requirements:
   otherwise explain the unknown blocker in `reason`.
   Do not solve this by deleting the affected numeric output while leaving the
   modifier parameter stranded.
+- When the source says a value or amount "in excess of" a stated limit is
+  counted, included, deemed, or added, that is an executable excess formula.
+  Encode the limit as a named scalar and encode the affected numeric output as
+  `max(0, measured_value - limit)` or the source-stated equivalent, using a
+  local factual input for `measured_value` if no source-backed upstream measure
+  exists. Do not defer that excess output merely because a later aggregate
+  resource, income, or liability calculation is outside the source slice; defer
+  only the later aggregate if necessary.
 - Supported relation aggregators are `len(relation)`,
   `count_where(relation, predicate_fact)`, `sum(relation.amount_fact)`, and
   `sum_where(relation, amount_fact_or_derived, predicate_fact)`. Do not write

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1210,6 +1210,14 @@ _NUMERIC_GROUNDING = """- If the source states a substitution, higher amount, in
   otherwise explain the unknown blocker in `reason`.
   Do not solve this by deleting the affected numeric output while leaving the
   modifier parameter stranded.
+- When the source says a value or amount "in excess of" a stated limit is
+  counted, included, deemed, or added, that is an executable excess formula.
+  Encode the limit as a named scalar and encode the affected numeric output as
+  `max(0, measured_value - limit)` or the source-stated equivalent, using a
+  local factual input for `measured_value` if no source-backed upstream measure
+  exists. Do not defer that excess output merely because a later aggregate
+  resource, income, or liability calculation is outside the source slice; defer
+  only the later aggregate if necessary.
 - Every substantive numeric occurrence in `./source.txt` must be represented by
   a named numeric concept when it is a legal amount, rate, threshold, cap, or
   limit, including structural interval-table row labels used by a source-backed

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1210,6 +1210,9 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "modifier parameter stranded" in prompt
     assert "module.deferred_outputs[]" in prompt
     assert "source_values" in prompt
+    assert "in excess of" in prompt
+    assert "max(0, measured_value - limit)" in prompt
+    assert "Do not defer that excess output merely" in prompt
     assert "do not model that numeric term as a local" in prompt
     assert "tier_1_applicable_percentage" in prompt
     assert "output` target path must include that source path segment" in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.811"
+version = "0.2.812"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- teaches the encoder that source text counting amounts in excess of a limit is an executable excess formula
- keeps the mirrored harness prompt text aligned
- bumps axiom-encode to 0.2.812 and adds a regression assertion

## Validation
- uv run --extra dev python -m pytest tests/test_evals.py::test_build_eval_prompt_targets_rulespec_yaml tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev towncrier check

This unblocks CalWORKs vehicle excess-value encoding without hand-editing RuleSpec output.