### PR TITLE
Prefer final amounts over explanatory rates

### DIFF
--- a/changelog.d/final-amount-over-explanatory-rate.changed.md
+++ b/changelog.d/final-amount-over-explanatory-rate.changed.md
@@ -1,0 +1,1 @@
+Clarified the encoder prompt to prefer final stated legal amounts over explanatory increase rates that cannot be independently applied.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.812"
+version = "0.2.813"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.812"
+__version__ = "0.2.813"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -5063,6 +5063,13 @@ RuleSpec requirements:
   exists. Do not defer that excess output merely because a later aggregate
   resource, income, or liability calculation is outside the source slice; defer
   only the later aggregate if necessary.
+- When the source states a final effective legal amount and also explains that
+  amount as an increase by a percentage, inflation index, or cost-of-living
+  adjustment, do not encode the explanatory percentage or index as a standalone
+  scalar unless the source also supplies the prior base and the target formula
+  uses that calculation. Encode the final effective amount as the operative
+  scalar; keep the explanatory increase text in the summary or proof excerpt
+  rather than as an unused modifier parameter.
 - Supported relation aggregators are `len(relation)`,
   `count_where(relation, predicate_fact)`, `sum(relation.amount_fact)`, and
   `sum_where(relation, amount_fact_or_derived, predicate_fact)`. Do not write

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1218,6 +1218,13 @@ _NUMERIC_GROUNDING = """- If the source states a substitution, higher amount, in
   exists. Do not defer that excess output merely because a later aggregate
   resource, income, or liability calculation is outside the source slice; defer
   only the later aggregate if necessary.
+- When the source states a final effective legal amount and also explains that
+  amount as an increase by a percentage, inflation index, or cost-of-living
+  adjustment, do not encode the explanatory percentage or index as a standalone
+  scalar unless the source also supplies the prior base and the target formula
+  uses that calculation. Encode the final effective amount as the operative
+  scalar; keep the explanatory increase text in the summary or proof excerpt
+  rather than as an unused modifier parameter.
 - Every substantive numeric occurrence in `./source.txt` must be represented by
   a named numeric concept when it is a legal amount, rate, threshold, cap, or
   limit, including structural interval-table row labels used by a source-backed

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1213,6 +1213,9 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "in excess of" in prompt
     assert "max(0, measured_value - limit)" in prompt
     assert "Do not defer that excess output merely" in prompt
+    assert "final effective legal amount" in prompt
+    assert "explanatory percentage or index" in prompt
+    assert "unused modifier parameter" in prompt
     assert "do not model that numeric term as a local" in prompt
     assert "tier_1_applicable_percentage" in prompt
     assert "output` target path must include that source path segment" in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.812"
+version = "0.2.813"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Teach the encoder prompt to prefer final effective legal amounts over explanatory percentage/index increases when the source already states the operative amount.
- Add a focused prompt regression so CPI/COLA explanation text does not become an unused standalone scalar.
- Bump axiom-encode to 0.2.813 for the prompt-affecting change.

## Why
This unblocks the California CalWORKs vehicle limit source: the ACL states the operative ,968 limit and also explains it as a CPI-U increase. The encoder generated the right excess-value formula, but auto-apply deferred it because the explanatory CPI-U rate was encoded as an unused parameter.

## Checks
- uv run --extra dev python -m pytest tests/test_evals.py::test_build_eval_prompt_targets_rulespec_yaml tests/test_cli.py::test_package_version_metadata_matches_pyproject
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev towncrier check
- uv run --extra dev python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump