### PR TITLE
Accept split schedule rows in numeric grounding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.813"
+version = "0.2.814"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.813"
+__version__ = "0.2.814"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -933,6 +933,14 @@ _SCHEDULE_BARE_ARROW_ROW_PATTERN = re.compile(
     r"^\s*[-*]\s*(?:=>|->|=)\s*(?:[$£€]\s*)?(-?[\d,]+(?:\.\d+)?)\s*$",
     re.IGNORECASE,
 )
+_SCHEDULE_SPLIT_ROW_KEY_PATTERN = re.compile(
+    r"^\s*(\d+)(?:\s+or\s+more)?\s*\.{2,}\s*$",
+    re.IGNORECASE,
+)
+_SCHEDULE_SPLIT_VALUE_PATTERN = re.compile(
+    r"^\s*(?:[$£€]\s*)?(-?[\d,]+(?:\.\d+)?)\s*$",
+    re.IGNORECASE,
+)
 _VALUE_BEARING_TABLE_ROW_PATTERN = re.compile(
     r"^\s*[-*]?\s*[^:]+:\s*(?:[$£€]\s*)?(-?[\d,]+(?:\.\d+)?)\s*$",
     re.IGNORECASE,
@@ -2824,9 +2832,21 @@ def _clean_source_text_for_numeric_extraction(text: str) -> str:
     text = re.sub(r"\\r\\n|\\n|\\r", "\n", text)
     text = text.replace(r"\t", "\t")
     cleaned_lines: list[str] = []
+    preserve_split_schedule_value = False
     for line in text.splitlines():
         stripped = line.strip()
         structural_stripped = stripped.strip(_STRUCTURAL_SOURCE_QUOTE_CHARS)
+        if preserve_split_schedule_value and _SCHEDULE_SPLIT_VALUE_PATTERN.fullmatch(
+            structural_stripped
+        ):
+            cleaned_lines.append(line)
+            preserve_split_schedule_value = False
+            continue
+        preserve_split_schedule_value = False
+        if _SCHEDULE_SPLIT_ROW_KEY_PATTERN.fullmatch(structural_stripped):
+            cleaned_lines.append(line)
+            preserve_split_schedule_value = True
+            continue
         if _STRUCTURAL_SOURCE_LINE_PATTERN.match(structural_stripped):
             continue
         if _STRUCTURAL_SOURCE_HEADING_PATTERN.match(structural_stripped):
@@ -2914,13 +2934,46 @@ def _extract_collapsed_schedule_row_occurrences(
     seen_values: set[float] = set()
     ungrouped_block = 0
     current_ungrouped_block: str | None = None
+    pending_split_block_key: str | None = None
 
     for line in text.splitlines():
         stripped = line.strip()
+        if pending_split_block_key is not None:
+            split_value_match = _SCHEDULE_SPLIT_VALUE_PATTERN.fullmatch(stripped)
+            if split_value_match:
+                with contextlib.suppress(ValueError):
+                    value = float(split_value_match.group(1).replace(",", ""))
+                    if (
+                        last_value_by_block.get(pending_split_block_key) != value
+                        and value not in seen_values
+                    ):
+                        occurrences.append(value)
+                        last_value_by_block[pending_split_block_key] = value
+                        seen_values.add(value)
+                pending_split_block_key = None
+                continue
+            pending_split_block_key = None
+
         if _SCHEDULE_BLOCK_HEADING_PATTERN.fullmatch(stripped):
             current_heading = stripped
             current_ungrouped_block = None
             retained_lines.append(line)
+            continue
+
+        split_key_match = _SCHEDULE_SPLIT_ROW_KEY_PATTERN.fullmatch(stripped)
+        if split_key_match:
+            with contextlib.suppress(ValueError):
+                key_value = float(split_key_match.group(1).replace(",", ""))
+                if key_value not in seen_values:
+                    occurrences.append(key_value)
+                    seen_values.add(key_value)
+            if current_heading is not None:
+                pending_split_block_key = current_heading
+            else:
+                if current_ungrouped_block is None:
+                    ungrouped_block += 1
+                    current_ungrouped_block = f"__ungrouped_{ungrouped_block}"
+                pending_split_block_key = current_ungrouped_block
             continue
 
         row_match = (

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -4333,6 +4333,31 @@ rules:
         assert 0.1224 in numbers
         assert 683 in numbers
 
+    def test_extracts_split_california_schedule_table_money_cells(self):
+        numbers = validator_pipeline.extract_numbers_from_text(
+            """The schedule of minimum basic standards of adequate care is as follows:
+Number of eligible needy persons in the same family
+Minimum basic standards of adequate care
+1 ........................
+$ 341
+2 ........................
+560
+3 ........................
+694
+4 ........................
+824
+5 ........................
+940
+6 ........................
+1,057
+10 ........................
+1,489
+plus fourteen dollars ($14) for each additional needy person."""
+        )
+
+        for value in (10, 341, 560, 694, 824, 940, 1057, 1489, 14):
+            assert float(value) in numbers
+
     def test_accepts_pence_threshold_grounded_as_decimal_gbp(self, tmp_path):
         rulespec_file = tmp_path / "example.yaml"
         rulespec_file.write_text(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.813"
+version = "0.2.814"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- capture split dotted schedule row keys and values as numeric grounding source values
- preserve the California LegInfo table shape where row keys and money values are on separate lines
- add a regression test covering the WIC 11452 MBSAC schedule layout

## Validation
- uv run --extra dev pytest tests/test_evals.py -k 'split_california_schedule_table_money_cells or preserves_bracketed_formula_numeric_source_text'
- uv run --extra dev ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_evals.py
- uv run --extra dev axiom-encode validate --skip-reviewers /tmp/axiom-encode-encodings/codex-gpt-5.5/policies/cdss/calworks/minimum-basic-standard-of-adequate-care.yaml (numeric grounding cleared; remaining failure is expected tmp-file repo resolution before apply)