### PR TITLE
Clarify companion test arithmetic expectations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.814"
+version = "0.2.815"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.814"
+__version__ = "0.2.815"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -4435,6 +4435,12 @@ Test file rules:
 - Each `.test.yaml` case may assert derived outputs for only one entity type. If a module defines outputs on multiple entities, create separate cases for each entity pair, such as `Person`/`TaxUnit`, `Person`/`Employer`, or `Employer`/`Payment`. For example: `Person` cases set person facts at the top level and assert person outputs; `TaxUnit` cases use relation rows to supply person facts and assert only tax-unit outputs. Do not assert relation-child outputs in the parent entity's case.
 - Use `holds` and `not_holds` for actual `dtype: Judgment` rule keys in test inputs and outputs; do not use YAML booleans for Judgment rule values.
 - Use YAML booleans `true` and `false` for local factual `#input.<fact>` keys referenced directly by formulas.
+- Compute each expected `output:` value by evaluating the emitted RuleSpec
+  formula against the case inputs step by step. Do not guess expected outputs
+  from nearby statutory thresholds or caps. For formulas that combine a flat
+  threshold with a percentage of excess income, include the threshold amount,
+  the excess amount, and the percentage amount in the calculation reflected by
+  the scalar expected output.
 - For proration, average, ratio, or percentage tests with a source-stated denominator, choose input amounts divisible by that denominator so expected outputs are exact decimals, not rounded approximations. For example, if the denominator is 365, use a base amount like 36500 so `36500 * 182 / 365 = 18200`; if an average divides by 6, use totals like 600 or 1800, not 700. Avoid exact equality boundaries for ratios or percentages; choose clearly below/above-boundary values so decimal precision cannot decide the test outcome.
 - Every test case for a local derived formula must assign every local factual
   `#input.<fact>` referenced by that formula, including facts that are false in

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -930,6 +930,12 @@ _TESTS_PROTOCOL = """- Emit only RuleSpec YAML; use `.test.yaml` companions when
   inputs and outputs; do not use YAML booleans for Judgment rule values.
 - Use YAML booleans `true` and `false` for local factual `#input.<fact>` keys
   referenced directly by formulas.
+- Compute each expected `output:` value by evaluating the emitted RuleSpec
+  formula against the case inputs step by step. Do not guess expected outputs
+  from nearby statutory thresholds or caps. For formulas that combine a flat
+  threshold with a percentage of excess income, include the threshold amount,
+  the excess amount, and the percentage amount in the calculation reflected by
+  the scalar expected output.
 - For proration, average, ratio, or percentage tests with a source-stated
   denominator, choose input amounts divisible by that denominator so expected
   outputs are exact decimals, not rounded approximations. For example, if the

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -125,6 +125,8 @@ def _assert_encoder_prompt_topics(prompt: str) -> None:
         "predicate for the excepted category",
         "toggle each gate at least once",
         "Validation fails if a direct local `#input.*_exception_applies`",
+        "Compute each expected `output:` value by evaluating the emitted RuleSpec",
+        "flat\n  threshold with a percentage of excess income",
         "`clause_ii_provides_otherwise`",
         "Axiom formulas have no date literal type",
         "Never use `post_YYYY`, `pre_YYYY`, `after_YYYY`, `before_YYYY`",

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -1101,6 +1101,8 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "For claim, overpayment, overissuance, repayment" in prompt
     assert "as collectability caps" in prompt
     assert "not return a bare placeholder such as `claim_amount`" in prompt
+    assert "evaluating the emitted RuleSpec\n  formula" in prompt
+    assert "flat\n  threshold with a percentage of excess income" in prompt
     assert (
         "Imported definitions do not override the current source's legal subject"
         in prompt

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.814"
+version = "0.2.815"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- clarify encoder companion-test guidance to compute expected outputs from emitted formulas
- call out flat threshold plus percentage-of-excess branches, which blocked CalWORKs recipient income disregard encoding
- bump axiom-encode to 0.2.815

## Tests
- uv run --extra dev pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_encoder_backend.py::test_formula_and_tests_protocols_are_distinct_and_populated tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_durable_rule_spec_guidance tests/test_evals.py::test_build_eval_prompt_targets_rulespec_yaml
- uv run --extra dev ruff check src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_encoder_backend.py tests/test_evals.py