### PR TITLE
Preserve sliced source citation metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.815"
+version = "0.2.816"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.815"
+__version__ = "0.2.816"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -64,6 +64,7 @@ from .harness.evals import (
     _canonical_uk_legislation_tail,
     _eval_result_from_payload,
     _looks_like_corpus_citation_path,
+    _prompt_corpus_citation_path,
     _source_identifier_to_relative_rulespec_path,
     _target_source_scope_for_heuristics,
     evaluate_artifact,
@@ -18941,6 +18942,7 @@ def cmd_encode(args):
     source_unit = None
     if source_id:
         source_unit = resolve_corpus_source_unit(args.citation, corpus_path)
+        prompt_corpus_citation_path = _prompt_corpus_citation_path(source_unit)
         source_text = _scoped_source_text_for_encode_source_id(
             source_unit.body,
             source_id=source_id,
@@ -18953,9 +18955,10 @@ def cmd_encode(args):
             output_root=args.output,
             policy_path=policy_repo_path,
             source_metadata_payload={
-                "corpus_citation_path": source_unit.citation_path,
+                "corpus_citation_path": prompt_corpus_citation_path,
                 "corpus_source": source_unit.source,
                 "requested_source": source_unit.requested,
+                "resolved_corpus_citation_path": source_unit.citation_path,
             },
             runtime_axiom_rules_path=axiom_rules_path,
             mode=args.mode,
@@ -35245,6 +35248,7 @@ def cmd_eval_source(args):
         sys.exit(1)
 
     source_unit = resolve_corpus_source_unit(args.corpus_citation_path, corpus_path)
+    prompt_corpus_citation_path = _prompt_corpus_citation_path(source_unit)
     source_id = args.source_id or source_unit.citation_path
     policy_repo_path = _resolve_policy_repo_for_corpus_source(
         source_unit.citation_path,
@@ -35270,9 +35274,10 @@ def cmd_eval_source(args):
         output_root=args.output,
         policy_path=policy_repo_path,
         source_metadata_payload={
-            "corpus_citation_path": source_unit.citation_path,
+            "corpus_citation_path": prompt_corpus_citation_path,
             "corpus_source": source_unit.source,
             "requested_source": source_unit.requested,
+            "resolved_corpus_citation_path": source_unit.citation_path,
         },
         runtime_axiom_rules_path=runtime_axiom_rules_path,
         mode=args.mode,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3699,6 +3699,7 @@ def _run_single_eval(
 ) -> EvalResult:
     source_unit = resolve_corpus_source_unit(citation, corpus_path)
     source_text = source_unit.body
+    prompt_corpus_citation_path = _prompt_corpus_citation_path(source_unit)
 
     workspace = prepare_eval_workspace(
         citation=citation,
@@ -3708,9 +3709,10 @@ def _run_single_eval(
         axiom_rules_path=policy_path,
         mode=mode,
         source_metadata_payload={
-            "corpus_citation_path": source_unit.citation_path,
+            "corpus_citation_path": prompt_corpus_citation_path,
             "corpus_source": source_unit.source,
             "requested_source": source_unit.requested,
+            "resolved_corpus_citation_path": source_unit.citation_path,
         },
         extra_context_paths=extra_context_paths,
     )
@@ -3987,6 +3989,33 @@ def _resolve_eval_output_path(
     if fallback is not None:
         return fallback(citation)
     return _source_identifier_to_relative_rulespec_path(citation)
+
+
+def _prompt_corpus_citation_path(source_unit: CorpusSourceUnit) -> str:
+    """Return the citation path the prompt should ask RuleSpec to verify.
+
+    `CorpusSourceUnit.citation_path` intentionally records the row that supplied
+    text. For child-fragment requests resolved by slicing a parent row, prompts
+    and validators should use the requested child path so source coverage is
+    scoped to the encoded subtree instead of the whole parent section.
+    """
+
+    resolved = source_unit.citation_path.strip().strip("/")
+    requested = source_unit.requested.strip().strip("/")
+    if not resolved or not requested:
+        return resolved
+    try:
+        primary_requested = _candidate_corpus_citation_paths(requested)[0]
+    except (IndexError, ValueError):
+        return resolved
+    primary_requested = primary_requested.strip().strip("/")
+    if (
+        primary_requested
+        and primary_requested != resolved
+        and primary_requested.startswith(f"{resolved}/")
+    ):
+        return primary_requested
+    return resolved
 
 
 def _resolve_eval_reference_source_id(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3773,6 +3773,7 @@ class TestCmdEncode:
             "corpus_citation_path": "us/guidance/irs/rev-proc-2025-32/page-18",
             "corpus_source": "local",
             "requested_source": "us/guidance/irs/rev-proc-2025-32/page-18",
+            "resolved_corpus_citation_path": "us/guidance/irs/rev-proc-2025-32/page-18",
         }
         output = capsys.readouterr().out
         assert (

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -39,6 +39,7 @@ from axiom_encode.harness.evals import (
     _normalize_test_case_value,
     _normalize_test_periods_to_effective_dates,
     _post_openai_eval_request,
+    _prompt_corpus_citation_path,
     _resolve_eval_output_path,
     _resolve_eval_reference_source_id,
     _rulespec_validation_target,
@@ -959,6 +960,69 @@ class TestCorpusSourceResolution:
             in prompt
         )
         assert "Do not emit `source_url`" in prompt
+
+    def test_child_slice_prompt_uses_requested_corpus_locator(self, tmp_path):
+        corpus_path = tmp_path / "axiom-corpus"
+        provisions_dir = (
+            corpus_path / "data" / "corpus" / "provisions" / "us-ca" / "statute"
+        )
+        provisions_dir.mkdir(parents=True)
+        (provisions_dir / "2026-01-01.jsonl").write_text(
+            json.dumps(
+                {
+                    "citation_path": "us-ca/statute/wic/11450",
+                    "body": (
+                        "(a) (1) (A) Aid shall be paid after deducting income. "
+                        "(B) Federal contribution adjustment. "
+                        "(2) Cost-of-living adjustment pause. "
+                        "(b) Pregnancy aid."
+                    ),
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        source = resolve_corpus_source_unit(
+            "us-ca/statute/wic/11450/a/1/A", corpus_path
+        )
+
+        assert source.citation_path == "us-ca/statute/wic/11450"
+        assert source.body.startswith("(A) Aid shall be paid")
+        assert _prompt_corpus_citation_path(source) == ("us-ca/statute/wic/11450/a/1/A")
+
+        workspace = prepare_eval_workspace(
+            citation="policies/cdss/calworks/monthly-aid-payment",
+            runner=parse_runner_spec("codex:gpt-5.4"),
+            output_root=tmp_path / "out",
+            source_text=source.body,
+            axiom_rules_path=tmp_path / "rulespec-us",
+            mode="cold",
+            source_metadata_payload={
+                "corpus_citation_path": _prompt_corpus_citation_path(source),
+                "requested_source": source.requested,
+                "resolved_corpus_citation_path": source.citation_path,
+            },
+            extra_context_paths=[],
+        )
+
+        prompt = _build_eval_prompt(
+            "policies/cdss/calworks/monthly-aid-payment",
+            "cold",
+            workspace,
+            [],
+            target_file_name="monthly-aid-payment.yaml",
+            include_tests=True,
+            runner_backend="codex",
+        )
+
+        assert (
+            "read from `corpus.provisions` at `us-ca/statute/wic/11450/a/1/A`"
+        ) in prompt
+        assert (
+            "module.source_verification.corpus_citation_path: "
+            "us-ca/statute/wic/11450/a/1/A"
+        ) in prompt
 
     def test_workspace_writes_corpus_source_metadata_payload(self, tmp_path):
         workspace = prepare_eval_workspace(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.815"
+version = "0.2.816"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- preserve requested child corpus paths in encoder prompt metadata when text is resolved by slicing a parent corpus row
- record the resolved parent citation separately for provenance
- add a regression test covering child-source prompt metadata and bump axiom-encode to 0.2.816

## Tests
- uv run --extra dev ruff check src/axiom_encode/harness/evals.py src/axiom_encode/cli.py tests/test_evals.py
- uv run --extra dev pytest tests/test_evals.py::TestCorpusSourceResolution::test_child_slice_prompt_uses_requested_corpus_locator tests/test_evals.py::TestCorpusSourceResolution::test_build_prompt_requires_resolved_corpus_locator tests/test_evals.py::test_rulespec_validation_overlay_preserves_eval_source_metadata tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump