### PR TITLE
Resolve child corpus source text for validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.816"
+version = "0.2.817"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.816"
+__version__ = "0.2.817"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -17131,10 +17131,16 @@ def _fetch_corpus_source_text(citation_path: str) -> str | None:
     local_text = _fetch_local_corpus_source_text(citation_path)
     if local_text is not None:
         return local_text
-    for candidate_path in _candidate_corpus_source_paths(citation_path):
+    for requested_path, candidate_path in _candidate_corpus_source_lookup_paths(
+        citation_path
+    ):
         source_text = _fetch_supabase_corpus_source_text(candidate_path)
         if source_text is not None:
-            return source_text
+            return _slice_parent_corpus_text_for_requested_path(
+                source_text,
+                requested_path=requested_path,
+                resolved_path=candidate_path,
+            )
     return None
 
 
@@ -17145,7 +17151,9 @@ def _fetch_local_corpus_source_text(citation_path: str) -> str | None:
         return None
 
     for provisions_root in _local_corpus_provisions_roots():
-        for candidate_path in _candidate_corpus_source_paths(normalized_path):
+        for requested_path, candidate_path in _candidate_corpus_source_lookup_paths(
+            normalized_path
+        ):
             exact_records: list[dict[str, Any]] = []
             for provision_file in _candidate_local_corpus_provision_files(
                 provisions_root,
@@ -17159,8 +17167,14 @@ def _fetch_local_corpus_source_text(citation_path: str) -> str | None:
                 )
             source_text = _select_local_corpus_record_body(exact_records)
             if source_text is not None:
-                return source_text
+                return _slice_parent_corpus_text_for_requested_path(
+                    source_text,
+                    requested_path=requested_path,
+                    resolved_path=candidate_path,
+                )
 
+            if candidate_path != requested_path:
+                continue
             for provision_file in _candidate_local_corpus_provision_files(
                 provisions_root,
                 candidate_path,
@@ -17181,6 +17195,35 @@ def _candidate_corpus_source_paths(citation_path: str) -> tuple[str, ...]:
 
     candidates = [normalized_path]
     candidates.extend(_uk_legislation_gov_source_path_aliases(normalized_path))
+    return tuple(dict.fromkeys(candidates))
+
+
+def _candidate_corpus_source_lookup_paths(
+    citation_path: str,
+) -> tuple[tuple[str, str], ...]:
+    """Return requested and resolvable source paths for validation.
+
+    Ingesters sometimes store statute and regulation text at section granularity
+    while an encoding targets a child paragraph. Validation should ground
+    numeric literals against the same sliced parent text that the encoder used.
+    """
+    lookup_paths: list[tuple[str, str]] = []
+    for requested_path in _candidate_corpus_source_paths(citation_path):
+        lookup_paths.append((requested_path, requested_path))
+        lookup_paths.extend(
+            (requested_path, parent_path)
+            for parent_path in _parent_corpus_source_paths(requested_path)
+        )
+    return tuple(dict.fromkeys(lookup_paths))
+
+
+def _parent_corpus_source_paths(citation_path: str) -> tuple[str, ...]:
+    parts = citation_path.strip().strip("/").split("/")
+    candidates: list[str] = []
+    for end in range(len(parts) - 1, 2, -1):
+        candidate = "/".join(parts[:end])
+        if _citation_path_supports_parenthetical_slicing(candidate.split("/")):
+            candidates.append(candidate)
     return tuple(dict.fromkeys(candidates))
 
 
@@ -17222,6 +17265,264 @@ def _uk_legislation_gov_source_path_aliases(citation_path: str) -> tuple[str, ..
             )
         return tuple(candidates)
     return ()
+
+
+def _slice_parent_corpus_text_for_requested_path(
+    text: str,
+    *,
+    requested_path: str,
+    resolved_path: str,
+) -> str:
+    requested_parts = requested_path.strip("/").split("/")
+    resolved_parts = resolved_path.strip("/").split("/")
+    if (
+        len(requested_parts) <= len(resolved_parts)
+        or requested_parts[: len(resolved_parts)] != resolved_parts
+        or not _citation_path_supports_parenthetical_slicing(resolved_parts)
+    ):
+        return text
+    missing_fragments = tuple(requested_parts[len(resolved_parts) :])
+    sliced = _slice_legal_text_by_parenthetical_fragments(text, missing_fragments)
+    return sliced if sliced is not None else text
+
+
+def _citation_path_supports_parenthetical_slicing(parts: list[str]) -> bool:
+    return len(parts) >= 2 and parts[1] in {"statute", "regulation"}
+
+
+def _slice_legal_text_by_parenthetical_fragments(
+    text: str,
+    fragments: tuple[str, ...],
+) -> str | None:
+    sliced = _slice_legal_text_by_parenthetical_fragments_from(
+        text,
+        fragments,
+        depth=0,
+    )
+    return sliced.strip() if sliced is not None else None
+
+
+def _slice_legal_text_by_parenthetical_fragments_from(
+    text: str,
+    fragments: tuple[str, ...],
+    *,
+    depth: int,
+) -> str | None:
+    if not fragments:
+        return text
+
+    fragment = fragments[0]
+    simple_slice = _slice_legal_text_by_parenthetical_fragment(
+        text,
+        fragment,
+        top_level=depth == 0,
+    )
+    if simple_slice is not None:
+        simple_result = _slice_legal_text_by_parenthetical_fragments_from(
+            simple_slice,
+            fragments[1:],
+            depth=depth + 1,
+        )
+        if simple_result is not None:
+            return simple_result
+
+    if len(fragments) >= 2:
+        combined = _combined_dotted_parenthetical_fragment(fragment, fragments[1])
+        if combined is not None:
+            combined_slice = _slice_legal_text_by_parenthetical_fragment(
+                text,
+                combined,
+                top_level=depth == 0,
+            )
+            if combined_slice is not None:
+                return _slice_legal_text_by_parenthetical_fragments_from(
+                    combined_slice,
+                    fragments[2:],
+                    depth=depth + 2,
+                )
+
+    return None
+
+
+def _combined_dotted_parenthetical_fragment(
+    fragment: str, next_fragment: str
+) -> str | None:
+    if not next_fragment.isdigit():
+        return None
+    if re.fullmatch(r"(?:[A-Za-z]|\d+)(?:\.\d+)*", fragment):
+        return f"{fragment}.{next_fragment}"
+    return None
+
+
+def _slice_legal_text_by_parenthetical_fragment(
+    text: str,
+    fragment: str,
+    *,
+    top_level: bool,
+) -> str | None:
+    escaped = re.escape(fragment)
+    if top_level:
+        marker_pattern = re.compile(rf"(?:^|\n\s*)(\[?\({escaped}\)\s+)")
+    else:
+        marker_pattern = re.compile(rf"(?<![A-Za-z0-9])(\({escaped}\)\s+)")
+    marker_match = next(
+        (
+            match
+            for match in marker_pattern.finditer(text)
+            if _parenthetical_marker_context_is_structural(text, match.start(1))
+        ),
+        None,
+    )
+    if marker_match is None:
+        return None
+
+    start = marker_match.start(1)
+    body_start = marker_match.end(1)
+    sibling_pattern = _sibling_parenthetical_marker_pattern(fragment, top_level)
+    end = len(text)
+    for sibling_match in sibling_pattern.finditer(text, body_start):
+        if sibling_match.start(
+            1
+        ) > start and _parenthetical_marker_context_is_structural(
+            text,
+            sibling_match.start(1),
+        ):
+            end = sibling_match.start(1)
+            break
+    return text[start:end]
+
+
+_NONSTRUCTURAL_PARENTHETICAL_REFERENCE_LABEL = (
+    r"(?:paragraphs?|subparagraphs?|clauses?|subclauses?|sections?|"
+    r"subsections?|chapters?|titles?|parts?|items?|sentences?|regulations?)"
+)
+_NONSTRUCTURAL_PARENTHETICAL_REFERENCE_PREFIX = re.compile(
+    rf"\b{_NONSTRUCTURAL_PARENTHETICAL_REFERENCE_LABEL}\s+$",
+    re.IGNORECASE,
+)
+
+
+def _parenthetical_marker_context_is_structural(text: str, marker_start: int) -> bool:
+    prefix = text[max(0, marker_start - 60) : marker_start]
+    previous = prefix.rstrip()[-1:] if prefix.rstrip() else ""
+    if previous == ")" and not re.search(
+        r"(?:^|\n)\s*\([A-Za-z0-9]+(?:\.[0-9]+)*\)\s+$",
+        prefix,
+    ):
+        return False
+    if _NONSTRUCTURAL_PARENTHETICAL_REFERENCE_PREFIX.search(prefix):
+        return False
+    return not _parenthetical_marker_is_in_reference_list(prefix)
+
+
+def _parenthetical_marker_is_in_reference_list(prefix: str) -> bool:
+    segment = re.split(r"(?:[.;]\s+|\n+)", prefix)[-1]
+    if not re.search(
+        rf"\b{_NONSTRUCTURAL_PARENTHETICAL_REFERENCE_LABEL}\b",
+        segment,
+        flags=re.IGNORECASE,
+    ):
+        return False
+    if not re.search(r"\([A-Za-z0-9]+\)", segment):
+        return False
+    return re.search(r"(?:,\s*|\b(?:or|and)\s+)$", segment) is not None
+
+
+def _sibling_parenthetical_marker_pattern(
+    fragment: str,
+    top_level: bool,
+) -> re.Pattern[str]:
+    if re.fullmatch(r"\d+(?:\.\d+)*", fragment):
+        marker = _numeric_sibling_parenthetical_marker(fragment)
+    elif re.fullmatch(r"[A-Z](?:\.\d+)*", fragment):
+        marker = _alpha_sibling_parenthetical_marker(fragment, top_level=top_level)
+    elif re.fullmatch(r"[a-z](?:\.\d+)*", fragment):
+        marker = _alpha_sibling_parenthetical_marker(fragment, top_level=top_level)
+    elif len(fragment) == 1 and fragment.isalpha() and fragment.isupper():
+        marker = (
+            _next_alpha_parenthetical_marker(fragment) if top_level else r"\([A-Z]\)"
+        )
+    elif len(fragment) == 1 and fragment.isalpha() and fragment.islower():
+        marker = (
+            _next_alpha_parenthetical_marker(fragment) if top_level else r"\([a-z]\)"
+        )
+    elif re.fullmatch(r"[ivxlcdm]+", fragment, re.IGNORECASE):
+        marker = r"\([ivxlcdm]+\)"
+    else:
+        marker = r"\([A-Za-z0-9]+\)"
+    if top_level:
+        return re.compile(rf"\n\s*(\[?{marker}\s+)")
+    return re.compile(rf"(?<![A-Za-z0-9])({marker}\s+)")
+
+
+def _numeric_sibling_parenthetical_marker(fragment: str) -> str:
+    stem = fragment.split(".", 1)[0]
+    same_stem = _same_stem_dotted_sibling_marker(stem, fragment)
+    following_stem = _following_numeric_parenthetical_stem_marker(stem)
+    return rf"\((?:{same_stem}|{following_stem}(?:\.[0-9]+)*)\)"
+
+
+def _following_numeric_parenthetical_stem_marker(stem: str) -> str:
+    digits = str(int(stem))
+    same_width_patterns: list[str] = []
+    for idx, digit in enumerate(digits):
+        lower = int(digit) + 1
+        if idx == 0:
+            lower = max(lower, 1)
+        if lower > 9:
+            continue
+        prefix = re.escape(digits[:idx])
+        suffix_len = len(digits) - idx - 1
+        suffix = rf"[0-9]{{{suffix_len}}}" if suffix_len else ""
+        same_width_patterns.append(rf"{prefix}[{lower}-9]{suffix}")
+    longer_width = rf"[1-9][0-9]{{{len(digits)},}}"
+    return "(?:" + "|".join([*same_width_patterns, longer_width]) + ")"
+
+
+def _alpha_sibling_parenthetical_marker(fragment: str, *, top_level: bool) -> str:
+    stem = fragment[0]
+    same_stem = _same_stem_dotted_sibling_marker(stem, fragment)
+    following_stem = (
+        _next_alpha_parenthetical_stem_marker(stem)
+        if top_level
+        else _following_alpha_parenthetical_stem_marker(stem)
+    )
+    return rf"\((?:{same_stem}|{following_stem}(?:\.[0-9]+)*)\)"
+
+
+def _next_alpha_parenthetical_stem_marker(stem: str) -> str:
+    next_codepoint = ord(stem) + 1
+    if stem.islower() and next_codepoint <= ord("z"):
+        return chr(next_codepoint)
+    if stem.isupper() and next_codepoint <= ord("Z"):
+        return chr(next_codepoint)
+    return r"\b\B"
+
+
+def _following_alpha_parenthetical_stem_marker(stem: str) -> str:
+    next_codepoint = ord(stem) + 1
+    if stem.islower() and next_codepoint <= ord("z"):
+        return f"[{chr(next_codepoint)}-z]"
+    if stem.isupper() and next_codepoint <= ord("Z"):
+        return f"[{chr(next_codepoint)}-Z]"
+    return r"\b\B"
+
+
+def _same_stem_dotted_sibling_marker(stem: str, fragment: str) -> str:
+    escaped_stem = re.escape(stem)
+    if "." not in fragment:
+        return rf"{escaped_stem}(?:\.[0-9]+)+"
+    suffix = re.escape(fragment.split(".", 1)[1])
+    return rf"{escaped_stem}\.(?!{suffix}(?:\.|\)))[0-9]+(?:\.[0-9]+)*"
+
+
+def _next_alpha_parenthetical_marker(fragment: str) -> str:
+    next_codepoint = ord(fragment) + 1
+    if fragment.islower() and next_codepoint <= ord("z"):
+        return rf"\({chr(next_codepoint)}\)"
+    if fragment.isupper() and next_codepoint <= ord("Z"):
+        return rf"\({chr(next_codepoint)}\)"
+    return r"\b\B"
 
 
 def _local_corpus_provisions_roots() -> tuple[Path, ...]:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -13299,6 +13299,61 @@ rules:
     assert find_ungrounded_numeric_issues(content) == []
 
 
+def test_source_verification_slices_local_parent_corpus_artifact(
+    tmp_path,
+    monkeypatch,
+):
+    provisions_dir = tmp_path / "data" / "corpus" / "provisions" / "us-ca" / "statute"
+    provisions_dir.mkdir(parents=True)
+    (provisions_dir / "wic.jsonl").write_text(
+        json.dumps(
+            {
+                "citation_path": "us-ca/statute/wic/11450",
+                "body": (
+                    "(a) (1) (A) Aid shall be paid to families. "
+                    "For family size 1, the maximum aid payment is $326. "
+                    "(B) Different aid is $999. "
+                    "\n(b) Pregnancy aid is $47."
+                ),
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AXIOM_CORPUS_REPO", str(tmp_path))
+    validator_pipeline._fetch_corpus_source_text.cache_clear()
+    validator_pipeline._fetch_local_corpus_source_text.cache_clear()
+
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ca/statute/wic/11450/a/1/A
+    values:
+      maximum_aid_payment_family_size_1: 326
+rules:
+  - name: maximum_aid_payment_family_size_1
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '326'
+"""
+
+    source_text = validator_pipeline._fetch_local_corpus_source_text(
+        "us-ca/statute/wic/11450/a/1/A"
+    )
+
+    assert source_text is not None
+    assert source_text.startswith("(A) Aid shall be paid")
+    assert "$326" in source_text
+    assert "$999" not in source_text
+    assert "$47" not in source_text
+    assert find_source_verification_issues(content) == []
+    assert find_ungrounded_numeric_issues(content) == []
+
+
 def test_source_verification_prefers_current_repo_corpus_artifact(
     tmp_path,
     monkeypatch,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.816"
+version = "0.2.817"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- allow source verification to resolve statute/regulation child citation paths through parent corpus rows
- slice resolved parent source text to the requested child path before numeric grounding
- add a regression for a California WIC-style parent row backing a child path
- bump axiom-encode to 0.2.817

## Tests
- ruff check src/ tests/
- ruff format --check src/ tests/
- uv run --extra dev pytest tests/test_rulespec_validation.py::test_source_verification_slices_local_parent_corpus_artifact tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
- uv run --extra dev pytest tests/