### PR TITLE
Repair generated parameter value application

### DIFF
--- a/changelog.d/bump-encoder-0-2-818.changed.md
+++ b/changelog.d/bump-encoder-0-2-818.changed.md
@@ -1,0 +1,1 @@
+Bump axiom-encode to 0.2.818 for generated top-level parameter value repair.

--- a/changelog.d/bump-encoder-0-2-820.changed.md
+++ b/changelog.d/bump-encoder-0-2-820.changed.md
@@ -1,0 +1,1 @@
+Bump axiom-encode to 0.2.820 after formatting generated repair helpers.

--- a/changelog.d/generated-percent-label-parameters.fixed.md
+++ b/changelog.d/generated-percent-label-parameters.fixed.md
@@ -1,0 +1,1 @@
+Drop generated percent-label scalar parameters during apply when they are unreferenced and only restate source labels such as "160% FPL".

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.818"
+version = "0.2.819"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.817"
+version = "0.2.818"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.819"
+version = "0.2.820"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.819"
+__version__ = "0.2.820"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.818"
+__version__ = "0.2.819"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.817"
+__version__ = "0.2.818"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -20046,18 +20046,16 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
-                repaired_percent_label_parameters = (
-                    _try_repair_generated_unreferenced_percent_label_parameters_for_apply(
-                        result,
-                        output_root=args.output,
-                        policy_repo_path=policy_repo_path,
-                        issues=apply_issues,
-                    )
+                repaired_percent_label_parameters = _try_repair_generated_unreferenced_percent_label_parameters_for_apply(
+                    result,
+                    output_root=args.output,
+                    policy_repo_path=policy_repo_path,
+                    issues=apply_issues,
                 )
                 if repaired_percent_label_parameters:
-                    outcome[
-                        "auto_repaired_unreferenced_percent_label_parameters"
-                    ] = repaired_percent_label_parameters
+                    outcome["auto_repaired_unreferenced_percent_label_parameters"] = (
+                        repaired_percent_label_parameters
+                    )
                     print(
                         "  apply=auto_repaired_unreferenced_percent_label_parameters:"
                         + ",".join(repaired_percent_label_parameters)
@@ -27963,7 +27961,9 @@ def _referenced_local_rule_names(rules: list[Any]) -> set[str]:
     return referenced
 
 
-def _rulespec_rule_formula_texts_for_generated_repair(rule: dict[str, Any]) -> list[str]:
+def _rulespec_rule_formula_texts_for_generated_repair(
+    rule: dict[str, Any],
+) -> list[str]:
     formulas: list[str] = []
     versions = rule.get("versions")
     if not isinstance(versions, list):
@@ -27985,7 +27985,9 @@ def _is_unreferenced_percent_label_parameter(
     if str(rule.get("kind") or "").strip().lower() != "parameter":
         return False
     value = _single_numeric_formula_value(rule)
-    if value is None or not any(math.isclose(value, item) for item in ungrounded_values):
+    if value is None or not any(
+        math.isclose(value, item) for item in ungrounded_values
+    ):
         return False
     if value <= 0:
         return False

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -20046,6 +20046,35 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_percent_label_parameters = (
+                    _try_repair_generated_unreferenced_percent_label_parameters_for_apply(
+                        result,
+                        output_root=args.output,
+                        policy_repo_path=policy_repo_path,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_percent_label_parameters:
+                    outcome[
+                        "auto_repaired_unreferenced_percent_label_parameters"
+                    ] = repaired_percent_label_parameters
+                    print(
+                        "  apply=auto_repaired_unreferenced_percent_label_parameters:"
+                        + ",".join(repaired_percent_label_parameters)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_shared_rate_names = (
                     _try_repair_generated_shared_statutory_rate_names_for_apply(
                         result,
@@ -27818,6 +27847,261 @@ def _try_repair_generated_indexed_parameter_lookups_for_apply(
 
     rules_file = Path(str(getattr(result, "output_file", "") or ""))
     return _repair_bare_indexed_parameter_references(rules_file)
+
+
+def _try_repair_generated_unreferenced_percent_label_parameters_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path | None = None,
+    issues: list[str],
+) -> list[str]:
+    ungrounded_values = _ungrounded_numeric_values_from_issues(issues)
+    if not ungrounded_values:
+        return []
+    try:
+        relative_output = _relative_generated_output_path(
+            result,
+            output_root=output_root,
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    referenced_names = _referenced_local_rule_names(rules)
+    retained_rules: list[object] = []
+    removed: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            retained_rules.append(rule)
+            continue
+        name = str(rule.get("name") or "").strip()
+        if (
+            not name
+            or name in referenced_names
+            or not _is_unreferenced_percent_label_parameter(
+                rule,
+                ungrounded_values=ungrounded_values,
+            )
+        ):
+            retained_rules.append(rule)
+            continue
+        removed.append(name)
+
+    if not removed:
+        return []
+    payload["rules"] = retained_rules
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+
+    test_file = _rulespec_test_path(rules_file)
+    target_anchor = _relative_output_to_anchor(
+        relative_output,
+        policy_repo_path=policy_repo_path,
+    )
+    _remove_companion_outputs_for_removed_rules(
+        test_file,
+        target_anchor=target_anchor,
+        removed_names=set(removed),
+    )
+    return removed
+
+
+def _ungrounded_numeric_values_from_issues(issues: list[str]) -> set[float]:
+    values: set[float] = set()
+    pattern = re.compile(
+        r"Ungrounded generated numeric literal:\s+"
+        r"(?P<raw>-?[\d,]+(?:\.\d+)?)"
+        r"(?:\s+\((?P<normalized>-?[\d,]+(?:\.\d+)?)\))?"
+    )
+    for issue in issues:
+        match = pattern.search(str(issue))
+        if match is None:
+            continue
+        raw_value = match.group("normalized") or match.group("raw")
+        with contextlib.suppress(ValueError):
+            values.add(float(raw_value.replace(",", "")))
+    return values
+
+
+def _referenced_local_rule_names(rules: list[Any]) -> set[str]:
+    referenced: set[str] = set()
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        for formula in _rulespec_rule_formula_texts_for_generated_repair(rule):
+            referenced.update(_formula_identifiers(formula))
+        metadata = rule.get("metadata")
+        proof = metadata.get("proof") if isinstance(metadata, dict) else None
+        atoms = proof.get("atoms") if isinstance(proof, dict) else None
+        if not isinstance(atoms, list):
+            continue
+        for atom in atoms:
+            if not isinstance(atom, dict):
+                continue
+            import_payload = atom.get("import")
+            if not isinstance(import_payload, dict):
+                continue
+            output = str(import_payload.get("output") or "").strip()
+            if output:
+                referenced.add(output)
+                continue
+            target = str(import_payload.get("target") or "").strip()
+            if "#" in target:
+                referenced.add(target.rsplit("#", 1)[1].strip())
+    return referenced
+
+
+def _rulespec_rule_formula_texts_for_generated_repair(rule: dict[str, Any]) -> list[str]:
+    formulas: list[str] = []
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return formulas
+    for version in versions:
+        if not isinstance(version, dict):
+            continue
+        formula = version.get("formula")
+        if isinstance(formula, str) and formula.strip():
+            formulas.append(formula)
+    return formulas
+
+
+def _is_unreferenced_percent_label_parameter(
+    rule: dict[str, Any],
+    *,
+    ungrounded_values: set[float],
+) -> bool:
+    if str(rule.get("kind") or "").strip().lower() != "parameter":
+        return False
+    value = _single_numeric_formula_value(rule)
+    if value is None or not any(math.isclose(value, item) for item in ungrounded_values):
+        return False
+    if value <= 0:
+        return False
+    percent = value * 100
+    if not math.isfinite(percent) or percent <= 0:
+        return False
+    source_text = _generated_rule_source_context(rule)
+    if not source_text:
+        return False
+    percent_text = ("%f" % percent).rstrip("0").rstrip(".")
+    return bool(
+        re.search(
+            rf"(?<![\d.]){re.escape(percent_text)}\s*(?:%(?!\w)|percent\b)",
+            source_text,
+            flags=re.IGNORECASE,
+        )
+    )
+
+
+def _single_numeric_formula_value(rule: dict[str, Any]) -> float | None:
+    versions = rule.get("versions")
+    if not isinstance(versions, list) or len(versions) != 1:
+        return None
+    version = versions[0]
+    if not isinstance(version, dict):
+        return None
+    formula = version.get("formula")
+    if isinstance(formula, bool):
+        return None
+    if isinstance(formula, int | float):
+        return float(formula)
+    if isinstance(formula, str):
+        normalized = formula.strip().replace(",", "")
+        if re.fullmatch(r"-?\d+(?:\.\d+)?", normalized):
+            return float(normalized)
+    return None
+
+
+def _generated_rule_source_context(rule: dict[str, Any]) -> str:
+    parts: list[str] = []
+    source = rule.get("source")
+    if isinstance(source, str):
+        parts.append(source)
+    metadata = rule.get("metadata")
+    proof = metadata.get("proof") if isinstance(metadata, dict) else None
+    atoms = proof.get("atoms") if isinstance(proof, dict) else None
+    if isinstance(atoms, list):
+        for atom in atoms:
+            if not isinstance(atom, dict):
+                continue
+            source_payload = atom.get("source")
+            if not isinstance(source_payload, dict):
+                continue
+            excerpt = source_payload.get("excerpt")
+            if isinstance(excerpt, str):
+                parts.append(excerpt)
+    return "\n".join(parts)
+
+
+def _remove_companion_outputs_for_removed_rules(
+    test_file: Path,
+    *,
+    target_anchor: str,
+    removed_names: set[str],
+) -> None:
+    if not removed_names or not test_file.exists():
+        return
+    try:
+        cases = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, yaml.YAMLError, ValueError):
+        return
+    if not isinstance(cases, list):
+        return
+    changed = False
+    retained_cases: list[object] = []
+    for case in cases:
+        if not isinstance(case, dict):
+            retained_cases.append(case)
+            continue
+        outputs = case.get("output")
+        if not isinstance(outputs, dict):
+            retained_cases.append(case)
+            continue
+        retained_outputs = {
+            key: value
+            for key, value in outputs.items()
+            if not _test_output_targets_removed_rule(
+                key,
+                target_anchor=target_anchor,
+                removed_names=removed_names,
+            )
+        }
+        if len(retained_outputs) != len(outputs):
+            changed = True
+            if retained_outputs:
+                case["output"] = retained_outputs
+                retained_cases.append(case)
+            continue
+        retained_cases.append(case)
+    if changed:
+        test_file.write_text(
+            yaml.safe_dump(retained_cases, sort_keys=False, allow_unicode=False)
+        )
+
+
+def _test_output_targets_removed_rule(
+    key: object,
+    *,
+    target_anchor: str,
+    removed_names: set[str],
+) -> bool:
+    key_text = str(key).strip()
+    if "#" in key_text:
+        base, fragment = key_text.split("#", 1)
+        return base.strip() == target_anchor and fragment.strip() in removed_names
+    return key_text in removed_names
 
 
 def _repair_bare_indexed_parameter_references(rules_file: Path) -> list[str]:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -27796,6 +27796,11 @@ def _try_repair_generated_indexed_parameter_values_for_apply(
 
     if not any("has no formula version" in str(issue) for issue in issues):
         return []
+    repaired_top_level_values = _normalize_top_level_parameter_values_to_versions(
+        rules_file
+    )
+    if repaired_top_level_values:
+        return repaired_top_level_values
     return _convert_indexed_parameter_values_to_derived_formulas(rules_file, test_file)
 
 
@@ -27894,6 +27899,122 @@ def _rewrite_bare_indexed_parameter_reference(
         rf"(?!\s*\[)(?![A-Za-z0-9_])"
     )
     return pattern.sub(f"{parameter_name}[{index_name}]", formula)
+
+
+def _normalize_top_level_parameter_values_to_versions(rules_file: Path) -> list[str]:
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    repaired: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip().lower() != "parameter":
+            continue
+        if "versions" in rule:
+            continue
+        values = rule.get("values")
+        if not isinstance(values, dict) or not values:
+            continue
+
+        versions: list[dict[str, object]] = []
+        version_kind: str | None = None
+        for effective_key, value in values.items():
+            effective_from = _effective_from_from_top_level_values_key(effective_key)
+            if effective_from is None:
+                versions = []
+                break
+            if isinstance(value, dict):
+                if version_kind not in (None, "values"):
+                    versions = []
+                    break
+                version_kind = "values"
+                versions.append(
+                    {
+                        "effective_from": effective_from,
+                        "values": value,
+                    }
+                )
+                continue
+            formula = _formula_text_from_top_level_parameter_value(value)
+            if formula is None:
+                versions = []
+                break
+            if version_kind not in (None, "formula"):
+                versions = []
+                break
+            version_kind = "formula"
+            versions.append(
+                {
+                    "effective_from": effective_from,
+                    "formula": formula,
+                }
+            )
+
+        if not versions or version_kind is None:
+            continue
+        rule.pop("values", None)
+        rule["versions"] = versions
+        _retarget_top_level_values_proof_atoms(
+            rule,
+            "versions[0].values" if version_kind == "values" else "versions[0].formula",
+        )
+        repaired.append(str(rule.get("name") or ""))
+
+    if not repaired:
+        return []
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repaired
+
+
+def _effective_from_from_top_level_values_key(value: object) -> str | None:
+    if isinstance(value, datetime):
+        return None
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, str) and re.fullmatch(r"\d{4}-\d{2}-\d{2}", value.strip()):
+        return value.strip()
+    return None
+
+
+def _formula_text_from_top_level_parameter_value(value: object) -> str | None:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int | float):
+        return str(value)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _retarget_top_level_values_proof_atoms(
+    rule: dict[str, object],
+    target_path: str,
+) -> None:
+    metadata = rule.get("metadata")
+    if not isinstance(metadata, dict):
+        return
+    proof = metadata.get("proof")
+    if not isinstance(proof, dict):
+        return
+    atoms = proof.get("atoms")
+    if not isinstance(atoms, list):
+        return
+    for atom in atoms:
+        if not isinstance(atom, dict):
+            continue
+        path = atom.get("path")
+        if isinstance(path, str) and (path == "values" or path.startswith("values[")):
+            atom["path"] = target_path
 
 
 def _convert_indexed_parameter_values_to_derived_formulas(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -136,6 +136,7 @@ from axiom_encode.cli import (
     _try_repair_generated_section_1401_b_1_self_employment_income_for_apply,
     _try_repair_generated_source_relation_delegations_for_apply,
     _try_repair_generated_source_table_band_scalars_for_apply,
+    _try_repair_generated_unreferenced_percent_label_parameters_for_apply,
     _try_repair_generated_unresolved_local_test_outputs_for_apply,
     _try_repair_generated_unsafe_formula_outputs_for_apply,
     _unit_scoped_person_definition_issue_names,
@@ -7453,6 +7454,120 @@ rules:
             }
         ]
         assert rule["metadata"]["proof"]["atoms"][0]["path"] == "versions[0].formula"
+
+    def test_repair_unreferenced_percent_label_parameter_for_apply(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies/dfcs/tanf/appendix-a.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: grg_income_limit_for_listed_assistance_unit_size
+  kind: parameter
+  dtype: Money
+  indexed_by: assistance_unit_size
+  versions:
+  - effective_from: '0001-01-01'
+    values:
+      1: 2128
+- name: grg_income_limit_fpl_rate
+  kind: parameter
+  dtype: Rate
+  source: DFCS TANF Appendix A, GRG income limit column
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: parameter
+        source:
+          corpus_citation_path: us-ga/manual/dfcs/tanf/appendix-a/block-2
+          excerpt: "160% FPL GRG Income Limits"
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 1.60
+- name: grg_income_limit_160_percent_fpl
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '0001-01-01'
+    formula: grg_income_limit_for_listed_assistance_unit_size[assistance_unit_size]
+"""
+        )
+        test_file = rules_file.with_name("appendix-a.test.yaml")
+        test_file.write_text(
+            """- name: grg
+  output:
+    us-ga:policies/dfcs/tanf/appendix-a#grg_income_limit_fpl_rate: 1.6
+    us-ga:policies/dfcs/tanf/appendix-a#grg_income_limit_160_percent_fpl: 2128
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = (
+            _try_repair_generated_unreferenced_percent_label_parameters_for_apply(
+                result,
+                output_root=output_root,
+                policy_repo_path=tmp_path / "rulespec-us-ga",
+                issues=[
+                    "Ungrounded generated numeric literal: 1.60 (1.6) does not "
+                    "appear as a substantive numeric value in the source text."
+                ],
+            )
+        )
+
+        assert repaired == ["grg_income_limit_fpl_rate"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert [rule["name"] for rule in payload["rules"]] == [
+            "grg_income_limit_for_listed_assistance_unit_size",
+            "grg_income_limit_160_percent_fpl",
+        ]
+        tests = yaml.safe_load(test_file.read_text())
+        assert tests[0]["output"] == {
+            "us-ga:policies/dfcs/tanf/appendix-a#grg_income_limit_160_percent_fpl": 2128
+        }
+
+    def test_repair_percent_label_parameter_keeps_referenced_rule(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies/dfcs/tanf/appendix-a.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: grg_income_limit_fpl_rate
+  kind: parameter
+  dtype: Rate
+  source: 160% FPL GRG Income Limits
+  versions:
+  - effective_from: '0001-01-01'
+    formula: 1.60
+- name: grg_amount
+  kind: derived
+  entity: TanfUnit
+  dtype: Money
+  period: Month
+  versions:
+  - effective_from: '0001-01-01'
+    formula: federal_poverty_line * grg_income_limit_fpl_rate
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = (
+            _try_repair_generated_unreferenced_percent_label_parameters_for_apply(
+                result,
+                output_root=output_root,
+                policy_repo_path=tmp_path / "rulespec-us-ga",
+                issues=[
+                    "Ungrounded generated numeric literal: 1.60 (1.6) does not "
+                    "appear as a substantive numeric value in the source text."
+                ],
+            )
+        )
+
+        assert repaired == []
+        assert "grg_income_limit_fpl_rate" in rules_file.read_text()
 
     def test_convert_indexed_parameter_values_skips_unsafe_literals(self, tmp_path):
         rules_file = tmp_path / "credit.yaml"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,6 +50,7 @@ from axiom_encode.cli import (
     _local_factual_input_names_from_rules_content,
     _looks_like_absolute_rulespec_output_target,
     _medicaid_magi_income_helper_issue_names,
+    _normalize_top_level_parameter_values_to_versions,
     _parse_child_numeric_reencoding_issue,
     _person_scoped_definition_issue_names,
     _promote_boolean_comparison_predicates_to_judgment,
@@ -7382,6 +7383,76 @@ rules:
         )
         assert tests[0]["input"][selector] is False
         assert tests[1]["input"][selector] is True
+
+    def test_normalize_top_level_parameter_table_values_to_versions(self, tmp_path):
+        rules_file = tmp_path / "appendix_a.yaml"
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: tanf_gross_income_ceiling_base
+  kind: parameter
+  dtype: Money
+  indexed_by: appendix_a_table_row
+  metadata:
+    proof:
+      atoms:
+      - path: values
+        kind: parameter_table
+  values:
+    '2026-03-01':
+      1: 435
+      2: 659
+"""
+        )
+
+        repaired = _normalize_top_level_parameter_values_to_versions(rules_file)
+
+        payload = yaml.safe_load(rules_file.read_text())
+        rule = payload["rules"][0]
+        assert repaired == ["tanf_gross_income_ceiling_base"]
+        assert "values" not in rule
+        assert rule["versions"] == [
+            {
+                "effective_from": "2026-03-01",
+                "values": {
+                    1: 435,
+                    2: 659,
+                },
+            }
+        ]
+        assert rule["metadata"]["proof"]["atoms"][0]["path"] == "versions[0].values"
+
+    def test_normalize_top_level_scalar_values_to_formula_versions(self, tmp_path):
+        rules_file = tmp_path / "appendix_a.yaml"
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: tanf_standard_of_need_additional_member_increment
+  kind: parameter
+  dtype: Money
+  metadata:
+    proof:
+      atoms:
+      - path: values
+        kind: amount
+  values:
+    '2026-03-01': 24
+"""
+        )
+
+        repaired = _normalize_top_level_parameter_values_to_versions(rules_file)
+
+        payload = yaml.safe_load(rules_file.read_text())
+        rule = payload["rules"][0]
+        assert repaired == ["tanf_standard_of_need_additional_member_increment"]
+        assert "values" not in rule
+        assert rule["versions"] == [
+            {
+                "effective_from": "2026-03-01",
+                "formula": "24",
+            }
+        ]
+        assert rule["metadata"]["proof"]["atoms"][0]["path"] == "versions[0].formula"
 
     def test_convert_indexed_parameter_values_skips_unsafe_literals(self, tmp_path):
         rules_file = tmp_path / "credit.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.817"
+version = "0.2.818"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.818"
+version = "0.2.819"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.819"
+version = "0.2.820"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair generated top-level parameter `values` during apply so keyed literals are preserved in RuleSpec YAML
- repair unreferenced percent-label parameters by dropping dead generated labels before apply
- bump encoder package metadata to 0.2.819 and add regression tests

## Tests
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run --extra dev pytest tests/test_cli.py -k "package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump or unreferenced_percent_label_parameter or normalize_top_level_parameter_values"
- git diff --check

## Downstream
- Georgia TANF RuleSpec encodings were generated with encoder 0.2.819 from this branch.