### PR TITLE
Mark Georgia TANF surface encoded

### DIFF
--- a/changelog.d/georgia-tanf-surface-status.fixed.md
+++ b/changelog.d/georgia-tanf-surface-status.fixed.md
@@ -1,0 +1,1 @@
+Classify the Georgia TANF final PolicyEngine program surface as known-not-comparable now that Axiom has source-specific DFCS TANF legal slices but not an equivalent final benefit boundary.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.820"
+version = "0.2.821"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.820"
+__version__ = "0.2.821"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -405,10 +405,13 @@ surfaces:
   variable: ga_tanf
   source_type: state_implementation
   state: GA
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Current RuleSpec repos include tested Georgia TANF assistance-standard, resource-limit, gross/net income eligibility,
+    countable-income, work-deduction, dependent-care-deduction, and benefit-amount legal slices from the DFCS manual and eligibility
+    guidance. Those outputs are source-specific legal boundaries, while PolicyEngine's ga_tanf is a final monthly TANF benefit
+    variable built from PE's own TANF graph and parameter table; do not treat it as a direct one-to-one oracle target until Axiom
+    has an equivalent final Georgia TANF benefit surface or PE exposes compatible helper boundaries.
 - country: us
   program_id: tanf
   program_name: Mississippi TANF

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -775,6 +775,21 @@ def test_policyengine_program_surface_marks_georgia_ssp_known_not_comparable():
     )
 
 
+def test_policyengine_program_surface_marks_georgia_tanf_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    georgia_tanf = items_by_variable["ga_tanf"]
+
+    assert georgia_tanf["program_id"] == "tanf"
+    assert georgia_tanf["state"] == "GA"
+    assert georgia_tanf["axiom_status"] == "known_not_comparable"
+    assert georgia_tanf["mapping_count"] == 0
+    assert georgia_tanf["comparable_mapping_count"] == 0
+    assert "Georgia TANF assistance-standard" in georgia_tanf["rationale"]
+    assert "final monthly TANF benefit variable" in georgia_tanf["rationale"]
+
+
 def test_policyengine_coverage_classifies_federal_ssi_benefit_rate_intermediates(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.820"
+version = "0.2.821"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark the Georgia TANF PolicyEngine surface as known-not-comparable now that the DFCS TANF RuleSpec slices have landed
- add a regression test so ga_tanf does not return to the pending RuleSpec encoding queue

## Tests
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k "georgia_tanf or georgia_ssp or program_surface"
- uv run --extra dev python -m pytest tests/test_cli.py -k "package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump"
- uv tool run ruff check tests/test_policyengine_coverage.py && uv tool run ruff format --check tests/test_policyengine_coverage.py
- git diff --check