### PR TITLE
Add CalWORKs PolicyEngine oracle mappings

### DIFF
--- a/changelog.d/calworks-policyengine-oracle.changed.md
+++ b/changelog.d/calworks-policyengine-oracle.changed.md
@@ -1,0 +1,1 @@
+Add PolicyEngine oracle coverage for comparable California CalWORKs MAP and resource-limit outputs.

--- a/docs/policyengine-oracle-registry.md
+++ b/docs/policyengine-oracle-registry.md
@@ -104,6 +104,24 @@ fixed `parameter_keys` that must agree, or by a RuleSpec test input through
     3: HEAD_OF_HOUSEHOLD
 ```
 
+For nested PE parameter objects, use `parameter_key_path`. Path entries can
+select from RuleSpec inputs and can optionally bound numeric keys before
+lookup. This is for source-stated capped rows such as "10 or more", where the
+RuleSpec output and PE parameter table share the same capped row:
+
+```yaml
+- legal_id: us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_maximum_aid_payment
+  mapping_type: parameter_value
+  policyengine_parameter: gov.states.ca.cdss.tanf.cash.monthly_payment.region1
+  parameter_key_path:
+    - input: assistance_unit_is_exempt
+      key_map:
+        "True": exempt
+        "False": non_exempt
+    - input: persons_on_aid
+      max_value: 10
+```
+
 Use `parameter_keys` when one legal output intentionally groups multiple PE
 table cells that should have the same value:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.821"
+version = "0.2.822"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.821"
+__version__ = "0.2.822"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -25555,6 +25555,7 @@ print(f'RESULT:{{float(value)}}')
             key_map = part.get("parameter_key_map") or part.get("key_map") or {}
             key_map = {str(key): str(value) for key, value in key_map.items()}
             raw_key = str(input_value)
+            raw_key = self._bounded_pe_parameter_key(raw_key, part)
             if raw_key in key_map:
                 resolved_path.append(key_map[raw_key])
             elif key_map:
@@ -25565,6 +25566,24 @@ print(f'RESULT:{{float(value)}}')
             else:
                 resolved_path.append(raw_key)
         return [resolved_path]
+
+    @staticmethod
+    def _bounded_pe_parameter_key(raw_key: str, selector: dict) -> str:
+        minimum = selector.get("min_value", selector.get("min"))
+        maximum = selector.get("max_value", selector.get("max"))
+        if minimum is None and maximum is None:
+            return raw_key
+        try:
+            value = Decimal(str(raw_key))
+            if minimum is not None:
+                value = max(value, Decimal(str(minimum)))
+            if maximum is not None:
+                value = min(value, Decimal(str(maximum)))
+        except (InvalidOperation, TypeError, ValueError):
+            return raw_key
+        if value == value.to_integral_value():
+            return str(int(value))
+        return format(value.normalize(), "f")
 
     def _resolve_pe_parameter_calc_values(
         self,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2061,6 +2061,55 @@ mappings:
     candidate_priority: P4
     rationale: California CalFresh benefit composition gates the federal allotment through Axiom eligibility and state shelter surfaces; PE's SNAP amount is adjacent but depends on PE's own full graph.
 
+  - legal_id: us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_maximum_aid_payment
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ca.cdss.tanf.cash.monthly_payment.region1
+    parameter_key_path:
+      - input: assistance_unit_is_exempt
+        key_map:
+          "True": exempt
+          "False": non_exempt
+      - input: persons_on_aid
+        max_value: 10
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same California CalWORKs Region 1 monthly maximum-aid-payment table, keyed by exempt status and persons on aid with the source 10-or-more cap.
+
+  - legal_id: us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#calworks_region_2_maximum_aid_payment
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ca.cdss.tanf.cash.monthly_payment.region2
+    parameter_key_path:
+      - input: assistance_unit_is_exempt
+        key_map:
+          "True": exempt
+          "False": non_exempt
+      - input: persons_on_aid
+        max_value: 10
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same California CalWORKs Region 2 monthly maximum-aid-payment table, keyed by exempt status and persons on aid with the source 10-or-more cap.
+
+  - legal_id: us-ca:policies/cdss/calworks/maximum-resource-limit#calworks_maximum_resource_limit
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ca.cdss.tanf.cash.resources.limit
+    parameter_key_path:
+      - input: assistance_unit_includes_member_age_60_or_older_or_disabled
+        key_map:
+          "True": with_elderly_or_disabled_member
+          "False": without_elderly_or_disabled_member
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same California CalWORKs maximum resource limit, selecting the elderly-or-disabled assistance-unit parameter when the legal condition holds.
+
   - legal_id: us-co:regulations/10-ccr-2506-1/4.407.3#excess_shelter_deduction
     country: us
     program: snap

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1489,6 +1489,124 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_calworks_exact_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-ca"
+        / "policies/cdss/calworks/maximum-aid-payment-region-1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: calworks_region_1_maximum_aid_payment
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2024-10-01'
+        formula: calworks_region_1_non_exempt_maximum_aid_payment[10]
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-ca"
+        / "policies/cdss/calworks/maximum-aid-payment-region-1.test.yaml",
+        """- name: non_exempt_more_than_ten_person_region_1_map
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#input.persons_on_aid: 12
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#input.assistance_unit_is_exempt: false
+  output:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_maximum_aid_payment: 2876
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-ca"
+        / "policies/cdss/calworks/maximum-aid-payment-region-2.yaml",
+        """format: rulespec/v1
+rules:
+  - name: calworks_region_2_maximum_aid_payment
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2024-10-01'
+        formula: calworks_region_2_exempt_maximum_aid_payment[1]
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-ca"
+        / "policies/cdss/calworks/maximum-aid-payment-region-2.test.yaml",
+        """- name: exempt_one_person_region_2_map
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#input.persons_on_aid: 1
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#input.assistance_unit_is_exempt: true
+  output:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#calworks_region_2_maximum_aid_payment: 770
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-ca"
+        / "policies/cdss/calworks/maximum-resource-limit.yaml",
+        """format: rulespec/v1
+rules:
+  - name: calworks_maximum_resource_limit
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2025-01-01'
+        formula: 12137
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us-ca"
+        / "policies/cdss/calworks/maximum-resource-limit.test.yaml",
+        """- name: standard_calworks_resource_limit
+  period: 2025-01
+  input:
+    us-ca:policies/cdss/calworks/maximum-resource-limit#input.assistance_unit_includes_member_age_60_or_older_or_disabled: false
+  output:
+    us-ca:policies/cdss/calworks/maximum-resource-limit#calworks_maximum_resource_limit: 12137
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tanf")
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+
+    exact_ids = {
+        "us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_maximum_aid_payment",
+        "us-ca:policies/cdss/calworks/maximum-aid-payment-region-2#calworks_region_2_maximum_aid_payment",
+        "us-ca:policies/cdss/calworks/maximum-resource-limit#calworks_maximum_resource_limit",
+    }
+
+    assert report["total_outputs"] == 3
+    assert report["status_counts"] == {"comparable": 3}
+    assert report["untested_comparable"] == 0
+    assert {items_by_id[legal_id]["mapping_type"] for legal_id in exact_ids} == {
+        "parameter_value"
+    }
+    assert {items_by_id[legal_id]["tested"] for legal_id in exact_ids} == {True}
+    assert (
+        items_by_id[
+            "us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_maximum_aid_payment"
+        ]["policyengine_parameter"]
+        == "gov.states.ca.cdss.tanf.cash.monthly_payment.region1"
+    )
+    assert (
+        items_by_id[
+            "us-ca:policies/cdss/calworks/maximum-resource-limit#calworks_maximum_resource_limit"
+        ]["policyengine_parameter"]
+        == "gov.states.ca.cdss.tanf.cash.resources.limit"
+    )
+
+
 def test_policyengine_coverage_classifies_new_york_tanf_state_plan_outputs(
     tmp_path,
 ):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2586,6 +2586,31 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
     assert ca_snap_monthly_income_mapping.mapping_type == "not_comparable"
     assert ca_snap_monthly_income_mapping.policyengine_variable == "snap_gross_income"
+    ca_calworks_region1_map_mapping = registry.mapping_for_legal_id(
+        "us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_maximum_aid_payment",
+        country="us",
+    )
+    assert ca_calworks_region1_map_mapping.mapping_type == "parameter_value"
+    assert (
+        ca_calworks_region1_map_mapping.policyengine_parameter
+        == "gov.states.ca.cdss.tanf.cash.monthly_payment.region1"
+    )
+    assert ca_calworks_region1_map_mapping.parameter_key_path == (
+        {
+            "input": "assistance_unit_is_exempt",
+            "key_map": {"True": "exempt", "False": "non_exempt"},
+        },
+        {"input": "persons_on_aid", "max_value": 10},
+    )
+    ca_calworks_resource_mapping = registry.mapping_for_legal_id(
+        "us-ca:policies/cdss/calworks/maximum-resource-limit#calworks_maximum_resource_limit",
+        country="us",
+    )
+    assert ca_calworks_resource_mapping.mapping_type == "parameter_value"
+    assert (
+        ca_calworks_resource_mapping.policyengine_parameter
+        == "gov.states.ca.cdss.tanf.cash.resources.limit"
+    )
     shelter_cap_mapping = registry.mapping_for_legal_id(
         "us:policies/usda/snap/fy-2026-cola/deductions#snap_maximum_excess_shelter_deduction_alaska",
         country="us",
@@ -3575,6 +3600,64 @@ def test_policyengine_oracle_compares_nested_parameter_key_path(tmp_path):
     assert result.details["coverage"]["comparable"] == 1
     assert "gov.irs.income.bracket.thresholds" in scripts[0]
     assert 'key_paths = [["1", "SINGLE"]]' in scripts[0]
+
+
+def test_policyengine_oracle_clamps_nested_parameter_key_path(tmp_path):
+    rules_file = tmp_path / "rules.yaml"
+    rules_file.write_text("format: rulespec/v1\n")
+    rules_file.with_name("rules.test.yaml").write_text(
+        """- name: calworks_region_1_more_than_ten
+  period: 2024-10
+  input:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#input.assistance_unit_is_exempt: false
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#input.persons_on_aid: 12
+  output:
+    us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_maximum_aid_payment: 2876
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=True,
+        oracle_validators=("policyengine",),
+    )
+    pipeline.policyengine_registry = PolicyEngineOracleRegistry(
+        {
+            "us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_maximum_aid_payment": PolicyEngineMapping(
+                legal_id="us-ca:policies/cdss/calworks/maximum-aid-payment-region-1#calworks_region_1_maximum_aid_payment",
+                country="us",
+                mapping_type="parameter_value",
+                policyengine_parameter="gov.states.ca.cdss.tanf.cash.monthly_payment.region1",
+                parameter_key_path=(
+                    {
+                        "input": "assistance_unit_is_exempt",
+                        "key_map": {"True": "exempt", "False": "non_exempt"},
+                    },
+                    {"input": "persons_on_aid", "max_value": 10},
+                ),
+                period="month",
+            )
+        }
+    )
+    pipeline._detect_policyengine_country = lambda *_args, **_kwargs: "us"
+    pipeline._find_pe_python = lambda _country: Path("python")
+    pipeline._is_pe_test_mappable = lambda *_args, **_kwargs: (True, None)
+
+    scripts = []
+
+    def fake_run(script, *_args, **_kwargs):
+        scripts.append(script)
+        return OracleSubprocessResult(returncode=0, stdout="RESULT:2876\n")
+
+    pipeline._run_pe_subprocess_detailed = fake_run
+
+    result = pipeline._run_policyengine(rules_file)
+
+    assert result.score == 1.0
+    assert result.passed is True
+    assert result.issues == []
+    assert "gov.states.ca.cdss.tanf.cash.monthly_payment.region1" in scripts[0]
+    assert 'key_paths = [["non_exempt", "10"]]' in scripts[0]
 
 
 def test_policyengine_oracle_compares_integer_parameter_key_path(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.821"
+version = "0.2.822"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add exact PolicyEngine oracle mappings for comparable California CalWORKs Region 1/2 MAP outputs and maximum resource limit
- add bounded nested parameter-key lookup support for source-stated capped rows like CalWORKs "10 or more"
- document the new mapping option and add registry/coverage/oracle regression tests

## Validation
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_rulespec_validation.py::test_policyengine_oracle_clamps_nested_parameter_key_path tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_calworks_exact_outputs
- uv run --extra dev ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py tests/test_policyengine_coverage.py
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tanf --json
- uv run --extra dev axiom-encode validate --skip-reviewers --oracle policyengine --json /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-ca/policies/cdss/calworks/maximum-aid-payment-region-1.yaml /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-ca/policies/cdss/calworks/maximum-aid-payment-region-2.yaml /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-ca/policies/cdss/calworks/maximum-resource-limit.yaml

TANF coverage summary after this change: 13 comparable, 331 known not comparable, 0 untested comparable. CalWORKs contributes 3 comparable tested outputs.