### PR TITLE
Handle string labels in judgment positive repairs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.824"
+version = "0.2.825"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.824"
+__version__ = "0.2.825"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -16922,6 +16922,12 @@ def _positive_generated_test_input_value(
     rules_payload: dict[str, object],
     formula: str,
 ) -> object:
+    string_value = _string_positive_assignment_for_expression(
+        input_name=input_name,
+        expression=formula,
+    )
+    if string_value is not None:
+        return string_value
     comparison_value = _numeric_positive_assignment_for_expression(
         input_name=input_name,
         expression=formula,
@@ -16931,6 +16937,33 @@ def _positive_generated_test_input_value(
     if not _factual_input_appears_numeric(input_name, rules_payload=rules_payload):
         return True
     return 999999
+
+
+def _string_positive_assignment_for_expression(
+    *,
+    input_name: str,
+    expression: str,
+) -> str | None:
+    token = re.escape(input_name)
+    literal = _RULESPEC_STRING_LITERAL_RE
+    right_pattern = re.compile(rf"\b{token}\b\s*==\s*(?P<literal>{literal})")
+    left_pattern = re.compile(rf"(?P<literal>{literal})\s*==\s*\b{token}\b")
+    for pattern in (right_pattern, left_pattern):
+        match = pattern.search(expression)
+        if match is None:
+            continue
+        return _rulespec_string_literal_value(match["literal"])
+    return None
+
+
+def _rulespec_string_literal_value(token: str) -> str | None:
+    try:
+        value = yaml.safe_load(token)
+    except yaml.YAMLError:
+        return None
+    if isinstance(value, str):
+        return value
+    return None
 
 
 def _numeric_positive_assignment_for_expression(
@@ -26967,7 +27000,7 @@ def _generated_rule_formula_identifiers(rule: dict[str, Any]) -> set[str]:
             continue
         formula = version.get("formula")
         if isinstance(formula, str):
-            identifiers.update(_RULESPEC_IDENTIFIER_PATTERN.findall(formula))
+            identifiers.update(_formula_identifiers(formula))
     return identifiers - _RULESPEC_FORMULA_BUILTINS
 
 
@@ -27307,6 +27340,8 @@ _INPUT_FIELD_ACCESS_PATTERN = re.compile(
     r"(?<![A-Za-z0-9_])input\.([A-Za-z_][A-Za-z0-9_]*)"
 )
 _RULESPEC_IDENTIFIER_PATTERN = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")
+_RULESPEC_STRING_LITERAL_RE = r'"(?:\\.|[^"\\])*"|\'(?:\'\'|\\.|[^\'\\])*\''
+_RULESPEC_STRING_LITERAL_PATTERN = re.compile(_RULESPEC_STRING_LITERAL_RE)
 _RULESPEC_FORMULA_BUILTINS = {
     "abs",
     "all",
@@ -29660,9 +29695,21 @@ def _first_rule_formula(rule: dict[str, object]) -> str:
     return ""
 
 
+def _formula_without_string_literals(formula: str) -> str:
+    return _RULESPEC_STRING_LITERAL_PATTERN.sub(
+        lambda match: " " * (match.end() - match.start()),
+        formula,
+    )
+
+
 def _formula_identifiers(formula: str) -> set[str]:
     return (
-        set(_RULESPEC_IDENTIFIER_PATTERN.findall(formula)) - _RULESPEC_FORMULA_BUILTINS
+        set(
+            _RULESPEC_IDENTIFIER_PATTERN.findall(
+                _formula_without_string_literals(formula)
+            )
+        )
+        - _RULESPEC_FORMULA_BUILTINS
     )
 
 
@@ -31264,6 +31311,15 @@ def _factual_input_appears_numeric(
                 if not isinstance(formula, str) or not pattern.search(formula):
                     continue
                 formula_hits.append(formula)
+        if any(
+            _string_positive_assignment_for_expression(
+                input_name=input_name,
+                expression=formula,
+            )
+            is not None
+            for formula in formula_hits
+        ):
+            return False
         if any(numeric_context.search(formula) for formula in formula_hits):
             return True
         if any(boolean_context.search(formula) for formula in formula_hits):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14316,6 +14316,55 @@ rules:
             not in synthesized["input"]
         )
 
+    def test_judgment_positive_test_repair_synthesizes_string_equality_input(
+        self, tmp_path
+    ):
+        repo_path = tmp_path / "rulespec-us-ga"
+        rules_file = (
+            repo_path / "policies" / "decal" / "caps" / "appendix-c-payment-zones.yaml"
+        )
+        test_file = rules_file.with_name("appendix-c-payment-zones.test.yaml")
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: county_in_payment_zone_1
+    kind: derived
+    entity: Business
+    dtype: Judgment
+    period: Day
+    versions:
+      - effective_from: '2025-10-01'
+        formula: |-
+          county_name == "Camden"
+          or county_name == "Cobb"
+"""
+        )
+        test_file.write_text("[]\n")
+
+        repaired = _append_generated_judgment_positive_tests_if_missing(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=repo_path,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            relative_output=Path("policies/decal/caps/appendix-c-payment-zones.yaml"),
+            issues=[
+                "Judgment rule missing positive companion output coverage: "
+                "`us-ga:policies/decal/caps/appendix-c-payment-zones#county_in_payment_zone_1` "
+                "is not asserted as `holds` by the companion `.test.yaml` file."
+            ],
+        )
+
+        assert repaired == ["auto_positive_county_in_payment_zone_1"]
+        test_payload = yaml.safe_load(test_file.read_text())
+        synthesized = test_payload[0]
+        assert synthesized["input"] == {
+            "us-ga:policies/decal/caps/appendix-c-payment-zones#input.county_name": "Camden"
+        }
+        assert synthesized["output"] == {
+            "us-ga:policies/decal/caps/appendix-c-payment-zones#county_in_payment_zone_1": "holds"
+        }
+
     def test_judgment_positive_test_repair_synthesizes_count_helper_inputs(
         self, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.824"
+version = "0.2.825"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- ignore quoted string literals when scanning RuleSpec formulas for identifiers
- synthesize string-equality inputs for generated positive Judgment tests
- bump axiom-encode to 0.2.825

## Tests
- uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
- uv run --extra dev python -m pytest tests/test_cli.py -k "judgment_positive_test_repair"
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/