### PR TITLE
Accept compound ordinal words in numeric grounding

### DIFF
--- a/changelog.d/compound-ordinal-grounding.fixed.md
+++ b/changelog.d/compound-ordinal-grounding.fixed.md
@@ -1,0 +1,1 @@
+Ground compound ordinal words such as `twenty-fifth` as their numeric values during RuleSpec numeric grounding validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.825"
+version = "0.2.826"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.825"
+__version__ = "0.2.826"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -907,8 +907,37 @@ _ORDINAL_WORD_VALUES = {
     "eightieth": 80.0,
     "ninetieth": 90.0,
 }
+_COMPOUND_ORDINAL_TENS_VALUES = {
+    "twenty": 20.0,
+    "thirty": 30.0,
+    "forty": 40.0,
+    "fifty": 50.0,
+    "sixty": 60.0,
+    "seventy": 70.0,
+    "eighty": 80.0,
+    "ninety": 90.0,
+}
+_COMPOUND_ORDINAL_UNIT_VALUES = {
+    "first": 1.0,
+    "second": 2.0,
+    "third": 3.0,
+    "fourth": 4.0,
+    "fifth": 5.0,
+    "sixth": 6.0,
+    "seventh": 7.0,
+    "eighth": 8.0,
+    "ninth": 9.0,
+}
+for _tens_word, _tens_value in _COMPOUND_ORDINAL_TENS_VALUES.items():
+    for _unit_word, _unit_value in _COMPOUND_ORDINAL_UNIT_VALUES.items():
+        _ORDINAL_WORD_VALUES[f"{_tens_word}-{_unit_word}"] = _tens_value + _unit_value
+        _ORDINAL_WORD_VALUES[f"{_tens_word} {_unit_word}"] = _tens_value + _unit_value
 _ORDINAL_WORD_PATTERN = re.compile(
-    r"\b(" + "|".join(re.escape(word) for word in _ORDINAL_WORD_VALUES) + r")\b",
+    r"\b("
+    + "|".join(
+        re.escape(word) for word in sorted(_ORDINAL_WORD_VALUES, key=len, reverse=True)
+    )
+    + r")\b",
     re.IGNORECASE,
 )
 _SCHEDULE_BLOCK_HEADING_PATTERN = re.compile(r"^[A-Z][A-Z0-9_ ]+:\s*$")
@@ -2581,10 +2610,16 @@ def extract_numbers_from_text(text: str) -> set[float]:
             continue
         numbers.add(value)
         occupied_spans.append(span)
+    for span, value in _iter_ordinal_word_number_matches(text):
+        if _span_overlaps(span, occupied_spans):
+            continue
+        numbers.add(value)
+        occupied_spans.append(span)
     for span, value in _iter_cardinal_word_number_matches(text):
         if _span_overlaps(span, occupied_spans):
             continue
         numbers.add(value)
+        occupied_spans.append(span)
 
     for match in SOURCE_TEXT_NUMBER_PATTERN.finditer(text):
         if _span_overlaps(match.span(1), occupied_spans):
@@ -2597,16 +2632,16 @@ def extract_numbers_from_text(text: str) -> set[float]:
         with contextlib.suppress(ValueError):
             numbers.add(float(match.group(1)))
 
-    for match in _ORDINAL_WORD_PATTERN.finditer(text):
-        numbers.add(_ORDINAL_WORD_VALUES[match.group(1).lower()])
-
     for glyph, value in _UNICODE_FRACTION_VALUES.items():
         if glyph in text:
             numbers.add(value)
 
     text_lower = text.lower()
     for match in _CARDINAL_WORD_PATTERN.finditer(text_lower):
+        if _span_overlaps(match.span(1), occupied_spans):
+            continue
         numbers.add(_CARDINAL_WORD_VALUES[match.group(1)])
+        occupied_spans.append(match.span(1))
 
     return numbers
 
@@ -2710,6 +2745,19 @@ def _iter_normalized_special_numeric_matches(
         with contextlib.suppress(ValueError):
             matches.append((match.span(1), float(match.group(1).replace(",", ""))))
 
+    return matches
+
+
+def _iter_ordinal_word_number_matches(
+    text: str,
+) -> list[tuple[tuple[int, int], float]]:
+    """Return English ordinal word phrases such as "twenty-fifth"."""
+    matches: list[tuple[tuple[int, int], float]] = []
+    for match in _ORDINAL_WORD_PATTERN.finditer(text):
+        value = _ORDINAL_WORD_VALUES.get(match.group(1).lower())
+        if value is None:
+            continue
+        matches.append((match.span(), value))
     return matches
 
 
@@ -3048,10 +3096,12 @@ def extract_numeric_occurrences_from_text(text: str) -> list[float]:
                 continue
             occurrences.append(value)
 
-    for match in _ORDINAL_WORD_PATTERN.finditer(cleaned):
-        value = _ORDINAL_WORD_VALUES[match.group(1).lower()]
+    for span, value in _iter_ordinal_word_number_matches(cleaned):
+        if _span_overlaps(span, spans):
+            continue
         if value not in GROUNDING_ALLOWED_VALUES:
             occurrences.append(value)
+        spans.append(span)
 
     for glyph, value in _UNICODE_FRACTION_VALUES.items():
         occurrences.extend(value for _ in re.finditer(re.escape(glyph), cleaned))

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -22487,6 +22487,36 @@ rules:
     assert 4 in extract_numeric_occurrences_from_text(source_text)
 
 
+def test_ungrounded_numeric_accepts_compound_source_ordinal_word():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/42/426/h
+rules:
+  - name: ordinary_entitlement_beginning_month_replaced_for_als
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          25
+"""
+    source_text = (
+        "The entitlement under such subsection shall begin with the first month "
+        "(rather than twenty-fifth month) of entitlement or status."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    source_values = extract_numbers_from_text(source_text)
+    assert 25 in source_values
+    assert 20 not in source_values
+    assert 5 not in source_values
+    occurrences = extract_numeric_occurrences_from_text(source_text)
+    assert 25 in occurrences
+    assert 20 not in occurrences
+    assert 5 not in occurrences
+
+
 def test_ungrounded_numeric_preserves_substantive_parenthetical_days():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.825"
+version = "0.2.826"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- ground compound ordinal words like `twenty-fifth` as their numeric values
- prefer longest ordinal phrase spans so `twenty-fifth` does not also count as `20` or `5`
- add a Medicare-shaped regression test for 42 USC 426(h)

## Tests
- `uv run --extra dev pytest -q tests/test_rulespec_validation.py -k "ordinal_word or cardinal_words"`