### PR TITLE
Treat month counts as numeric test defaults

### DIFF
--- a/changelog.d/zero-branch-month-default.fixed.md
+++ b/changelog.d/zero-branch-month-default.fixed.md
@@ -1,0 +1,1 @@
+Treat month-count factual inputs as numeric when generating auto-zero tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.826"
+version = "0.2.827"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.826"
+__version__ = "0.2.827"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -31335,6 +31335,8 @@ def _factual_input_appears_numeric(
         "remuneration",
         "salary",
         "age",
+        "month",
+        "months",
         "threshold",
         "rate",
         "value",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15797,6 +15797,37 @@ rules:
 
         assert value == 0
 
+    def test_generated_test_input_defaults_treat_month_counts_as_numeric(self):
+        rules_payload = {
+            "rules": [
+                {
+                    "name": "countable_months_for_required_disability_entitlement_period",
+                    "kind": "derived",
+                    "dtype": "Count",
+                    "versions": [
+                        {
+                            "formula": (
+                                "current_period_months_entitled_to_specified_monthly_benefits_on_basis_of_disability\n"
+                                "+ (if previous_period_months_not_included_in_required_count: 0 else: previous_period_months_entitled_to_specified_monthly_benefits)"
+                            )
+                        }
+                    ],
+                }
+            ]
+        }
+
+        numeric_value = _default_generated_test_input_value(
+            "previous_period_months_entitled_to_specified_monthly_benefits",
+            rules_payload=rules_payload,
+        )
+        boolean_value = _default_generated_test_input_value(
+            "individual_had_been_entitled_to_specified_monthly_benefits_of_same_type_during_previous_period",
+            rules_payload=rules_payload,
+        )
+
+        assert numeric_value == 0
+        assert boolean_value is False
+
     def test_encode_apply_repeats_missing_test_input_assignment_repairs(
         self, capsys, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.826"
+version = "0.2.827"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Treat factual inputs containing month/months as numeric when generating deterministic auto-zero companion tests.
- Add a regression for Medicare-style prior-period month counts while preserving boolean defaults for had/entitled facts.
- Bump axiom-encode to 0.2.827.

## Tests
- uv run --extra dev pytest -q tests/test_cli.py::TestCmdEncode::test_generated_test_input_defaults_treat_month_counts_as_numeric tests/test_cli.py::TestCmdEncode::test_generated_test_input_defaults_treat_remuneration_as_money
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev python -m towncrier build --draft --version 0.0.0
- uv run --extra dev pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump