### PR TITLE
Classify Medicare 426 oracle outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.827"
+version = "0.2.828"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.827"
+__version__ = "0.2.828"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -16921,6 +16921,13 @@ mappings:
     rationale: RuleSpec encodes the statutory high-efficiency electric home rebate item caps, total cap, and project-cost percentage limits as source-level project/payment components. PolicyEngine's high_efficiency_electric_home_rebate sums tax-unit expenditure helper variables and caps the result, so it is not a one-to-one legal oracle until Axiom has the same project/entity/rebate aggregation surface.
 
 prefixes:
+  - legal_id_prefix: us:statutes/42/426
+    country: us
+    program: medicare
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: 42 USC 426 section-level hospital-insurance entitlement outputs not carrying exact parameter mappings are source-level Medicare Part A, railroad-retirement, government-employment, death-month, widow/widower, ALS, and entitlement-timing paths. PolicyEngine-US exposes a simplified Medicare eligibility surface and a small set of parameters, but not these statutory path and timing intermediates one-to-one.
+
   - legal_id_prefix: us:statutes/42/18795
     country: us
     program: doe_efficiency_rebate

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.827"
+version = "0.2.828"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify remaining 42 USC 426 Medicare hospital-insurance entitlement outputs as not comparable to PolicyEngine's simplified Medicare eligibility surface
- keep existing exact Medicare parameter mappings taking precedence over the prefix
- bump axiom-encode to 0.2.828 for rulespec toolchain pinning

## Tests
- uv run pytest tests/test_policyengine_coverage.py tests/test_policyengine_coverage_monorepo.py