### PR TITLE
Handle coordinated cardinal grounding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.828"
+version = "0.2.829"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.828"
+__version__ = "0.2.829"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2785,11 +2785,63 @@ def _iter_cardinal_word_number_matches(
     """Return English cardinal number phrases such as "five hundred thousand"."""
     matches: list[tuple[tuple[int, int], float]] = []
     for match in _CARDINAL_NUMBER_WORD_PATTERN.finditer(text):
-        value = _parse_cardinal_number_words(match.group(0))
+        phrase = match.group(0)
+        split_values = _split_flat_coordinated_cardinal_phrase(
+            phrase, offset=match.start()
+        )
+        if split_values is not None:
+            matches.extend(split_values)
+            continue
+        value = _parse_cardinal_number_words(phrase)
         if value is None:
             continue
         matches.append((match.span(), value))
     return matches
+
+
+def _split_flat_coordinated_cardinal_phrase(
+    phrase: str,
+    *,
+    offset: int = 0,
+) -> list[tuple[tuple[int, int], float]] | None:
+    """Split phrases like "sixteen and eighteen" into separate values.
+
+    The generic cardinal parser treats all number words in one phrase as one
+    value, which is correct for scaled phrases such as "one hundred and
+    twenty" but wrong for statutory ranges written as coordinated bare
+    cardinals. Only split when the phrase contains "and", has no scale word,
+    and each side independently parses as a simple cardinal sequence.
+    """
+    lowered = phrase.lower()
+    if not re.search(r"\band\b", lowered):
+        return None
+    if any(
+        re.search(rf"\b{re.escape(scale_word)}\b", lowered)
+        for scale_word in _CARDINAL_SCALE_WORD_VALUES
+    ):
+        return None
+
+    segments: list[tuple[tuple[int, int], float]] = []
+    start = 0
+    for separator in re.finditer(r"\band\b", lowered):
+        raw_segment = phrase[start : separator.start()]
+        parsed = _parse_cardinal_word_sequence(raw_segment)
+        if parsed is None:
+            return None
+        segment_start = start + len(raw_segment) - len(raw_segment.lstrip())
+        segment_end = start + len(raw_segment.rstrip())
+        segments.append(((offset + segment_start, offset + segment_end), parsed))
+        start = separator.end()
+
+    raw_segment = phrase[start:]
+    parsed = _parse_cardinal_word_sequence(raw_segment)
+    if parsed is None:
+        return None
+    segment_start = start + len(raw_segment) - len(raw_segment.lstrip())
+    segment_end = start + len(raw_segment.rstrip())
+    segments.append(((offset + segment_start, offset + segment_end), parsed))
+
+    return segments if len(segments) >= 2 else None
 
 
 def _parse_cardinal_number_words(text: str) -> float | None:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6077,6 +6077,36 @@ rules:
     )
 
 
+def test_rulespec_grounding_accepts_coordinated_cardinal_age_bounds():
+    content = """format: rulespec/v1
+rules:
+  - name: youth_exemption_lower_age_years
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 16
+  - name: youth_exemption_upper_age_years
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 18
+"""
+
+    source_text = "a person between the ages of sixteen and eighteen"
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    source_values = extract_numbers_from_text(source_text)
+    assert 16 in source_values
+    assert 18 in source_values
+    assert 34 not in source_values
+    occurrences = extract_numeric_occurrences_from_text(source_text)
+    assert 16 in occurrences
+    assert 18 in occurrences
+    assert 34 not in occurrences
+
+
 def test_rulespec_grounding_accepts_large_cardinal_word_amounts():
     content = """format: rulespec/v1
 rules:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.828"
+version = "0.2.829"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- split flat coordinated cardinal phrases like "sixteen and eighteen" into separate grounding values
- preserve scaled cardinal parsing such as "one hundred and twenty"
- bump axiom-encode to 0.2.829 for rulespec toolchain pinning

## Tests
- uv run pytest tests/test_rulespec_validation.py
- axiom-encode validate us/statutes/7/2015/d/2/F.yaml --skip-reviewers