### PR TITLE
Classify Georgia CAPS PE surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.829"
+version = "0.2.830"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.829"
+__version__ = "0.2.830"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -1139,6 +1139,8 @@ def _infer_program_from_legal_id(legal_id: str, *, rule_name: str = "") -> str:
         return "aca_ptc"
     if lowered.startswith("us:statutes/26/36b"):
         return "aca_ptc"
+    if lowered.startswith("us-ga:policies/decal/caps/"):
+        return "ccap"
     if "snap" in lowered:
         return "snap"
     if lowered.startswith(("us:statutes/42/1382", "us:statutes/42/1382f")):

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1322,10 +1322,12 @@ surfaces:
   variable: ga_caps
   source_type: state_implementation
   state: GA
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom encodes tested Georgia CAPS income-limit, payment-zone, reimbursement-rate, and family-fee legal slices from
+    the Georgia DECAL CAPS manual and appendices. PolicyEngine's `ga_caps` variable is a final modeled subsidy surface, so those
+    source-specific RuleSpec outputs are not one-to-one comparable to the aggregate PE program variable until Axiom has an equivalent
+    final CAPS subsidy surface or PolicyEngine exposes compatible helper boundaries.
 - country: us
   program_id: head_start
   program_name: Head Start

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -432,6 +432,19 @@ def test_policyengine_program_surface_marks_arizona_ccap_pending_source_ingestio
     assert "official DES/AZSOS sources" in arizona_ccap["rationale"]
 
 
+def test_policyengine_program_surface_marks_georgia_caps_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="ccap")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    georgia_caps = items_by_variable["ga_caps"]
+
+    assert georgia_caps["program_id"] == "ccdf"
+    assert georgia_caps["state"] == "GA"
+    assert georgia_caps["axiom_status"] == "known_not_comparable"
+    assert georgia_caps["mapping_count"] == 0
+    assert "final modeled subsidy surface" in georgia_caps["rationale"]
+
+
 def test_policyengine_program_surface_marks_head_start_known_not_comparable():
     report = build_policyengine_program_surface_report(program="head_start")
 
@@ -6544,6 +6557,47 @@ rules:
     assert (
         combined_predicate["policyengine_variable"] == "co_ccap_entry_income_eligible"
     )
+
+
+def test_policyengine_coverage_tags_georgia_caps_manual_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-ga/policies/decal/caps/appendix-a-income-limits.yaml",
+        """format: rulespec/v1
+rules:
+  - name: initial_eligibility_income_limit
+    kind: parameter
+    entity: Family
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        value: 28792
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-ga/policies/decal/caps/appendix-a-income-limits.test.yaml",
+        """- name: family size one
+  period: 2026
+  output:
+    us-ga:policies/decal/caps/appendix-a-income-limits#initial_eligibility_income_limit: 28792
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="ccap")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == (
+        "us-ga:policies/decal/caps/appendix-a-income-limits"
+        "#initial_eligibility_income_limit"
+    )
+    assert item["program"] == "ccap"
+    assert item["mapping_type"] == "not_comparable"
+    assert item["tested"] is True
 
 
 def test_policyengine_coverage_maps_colorado_taxable_income_base(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.829"
+version = "0.2.830"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- tag Georgia CAPS manual outputs as CCAP coverage so `oracle-coverage --program ccap` includes them
- mark the Georgia CAPS PolicyEngine program surface as known-not-comparable because Axiom has legal slices while PE exposes a final modeled subsidy
- add regression tests for the program surface and coverage program tag

## Validation
- `uv run pytest tests/test_policyengine_coverage.py`
- `uv run ruff check src/axiom_encode/oracles/policyengine/coverage.py tests/test_policyengine_coverage.py`
- `uv run ruff format --check src/axiom_encode/oracles/policyengine/coverage.py tests/test_policyengine_coverage.py`
- `git diff --check`
- `uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program ccap --include-program-surfaces --json > /tmp/ccap-coverage-after-ga-caps.json`
- `uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --include-program-surfaces --json > /tmp/program-surfaces-after-ga-caps.json`