### PR TITLE
Mark Arizona CCAP source ready

### DIFF
--- a/changelog.d/az-ccap-source-ready.changed.md
+++ b/changelog.d/az-ccap-source-ready.changed.md
@@ -1,0 +1,1 @@
+Move the Arizona CCAP PolicyEngine surface from source-ingestion blocked to RuleSpec-encoding pending after corpus ingestion landed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.830"
+version = "0.2.831"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.830"
+__version__ = "0.2.831"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -926,12 +926,11 @@ surfaces:
   variable: az_ccap
   source_type: state_implementation
   state: AZ
-  axiom_status: pending_source_ingestion
+  axiom_status: pending_rulespec_encoding
   priority: P1
   rationale: PolicyEngine models Arizona CCAP from Arizona Administrative Code Title 6, Chapter 5 plus DES income-fee
-    and reimbursement schedules. Those official DES/AZSOS sources are not yet in the Axiom corpus, and live unattended
-    fetches currently return Cloudflare challenge pages. Track the source-ingestion blocker in TheAxiomFoundation/axiom-corpus#110;
-    ingestion must land before RuleSpec encoding/oracle wiring can claim parity.
+    and reimbursement schedules. The official DES/AZSOS sources were ingested in TheAxiomFoundation/axiom-corpus#130;
+    RuleSpec encoding and oracle wiring remain before this surface can claim parity.
 - country: us
   program_id: ccdf
   program_name: CalWORKs childcare

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -419,7 +419,7 @@ def test_policyengine_program_surface_marks_colorado_ccap_final_subsidy_known_no
     assert "final modeled subsidy" in colorado_ccap["rationale"]
 
 
-def test_policyengine_program_surface_marks_arizona_ccap_pending_source_ingestion():
+def test_policyengine_program_surface_marks_arizona_ccap_pending_rulespec_encoding():
     report = build_policyengine_program_surface_report(program="ccap")
 
     items_by_variable = {item["variable"]: item for item in report["items"]}
@@ -427,9 +427,9 @@ def test_policyengine_program_surface_marks_arizona_ccap_pending_source_ingestio
 
     assert arizona_ccap["program_id"] == "ccdf"
     assert arizona_ccap["state"] == "AZ"
-    assert arizona_ccap["axiom_status"] == "pending_source_ingestion"
+    assert arizona_ccap["axiom_status"] == "pending_rulespec_encoding"
     assert arizona_ccap["mapping_count"] == 0
-    assert "official DES/AZSOS sources" in arizona_ccap["rationale"]
+    assert "TheAxiomFoundation/axiom-corpus#130" in arizona_ccap["rationale"]
 
 
 def test_policyengine_program_surface_marks_georgia_caps_known_not_comparable():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.830"
+version = "0.2.831"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- move Arizona CCAP from `pending_source_ingestion` to `pending_rulespec_encoding` now that axiom-corpus#130 ingested the DES/AZSOS sources
- update the surface regression test and rationale
- bump axiom-encode to `0.2.831` with a changelog fragment

## Checks
- `uv run ruff check src/axiom_encode/oracles/policyengine/coverage.py tests/test_policyengine_coverage.py`
- `uv run pytest tests/test_policyengine_coverage.py -k 'arizona_ccap or colorado_ccap or georgia_caps'`
- `uv run pytest tests/test_cli.py -k 'current_encoder_affecting_changes_are_behind_version_bump or package_version_matches_lockfile or lock_version'`
- `uv run python -m towncrier build --draft --version 0.0.0`
- `git diff --check`
