### PR TITLE
Use corpus source for table numeric grounding

### DIFF
--- a/changelog.d/table-grounding-corpus-source.fixed.md
+++ b/changelog.d/table-grounding-corpus-source.fixed.md
@@ -1,0 +1,1 @@
+Use authoritative corpus source text for numeric grounding of table-backed RuleSpec artifacts with compact summaries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.831"
+version = "0.2.832"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.831"
+__version__ = "0.2.832"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -576,6 +576,35 @@ def _extract_proof_source_excerpt_text(content: str) -> str:
     return ""
 
 
+def _has_parameter_table_proof_atom(content: str) -> bool:
+    """Return true when a RuleSpec artifact grounds values in a source table."""
+    with contextlib.suppress(ValueError, TypeError, yaml.YAMLError):
+        payload = yaml.safe_load(content)
+        if not isinstance(payload, dict):
+            return False
+        rules = payload.get("rules")
+        if not isinstance(rules, list):
+            return False
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            metadata = rule.get("metadata")
+            if not isinstance(metadata, dict):
+                continue
+            proof = metadata.get("proof")
+            if not isinstance(proof, dict):
+                continue
+            atoms = proof.get("atoms")
+            if not isinstance(atoms, list):
+                continue
+            if any(
+                isinstance(atom, dict) and atom.get("kind") == "parameter_table"
+                for atom in atoms
+            ):
+                return True
+    return False
+
+
 @dataclass(frozen=True)
 class EvalRunnerSpec:
     """How to invoke a model in an eval."""
@@ -3132,8 +3161,15 @@ def evaluate_artifact(
     if not numeric_source_text and source_text:
         numeric_source_text = source_text
     numeric_validation_source_text = embedded_source or numeric_source_text
+    numeric_grounding_validation_source_text = numeric_validation_source_text
+    if source_text and _has_parameter_table_proof_atom(content):
+        numeric_grounding_validation_source_text = "\n".join(
+            part for part in (source_text, numeric_validation_source_text) if part
+        )
     numeric_grounding_source_text = "\n".join(
-        part for part in (numeric_validation_source_text, proof_excerpt_text) if part
+        part
+        for part in (numeric_grounding_validation_source_text, proof_excerpt_text)
+        if part
     )
     source_numbers = extract_numbers_from_text(numeric_grounding_source_text or "")
     source_numeric_occurrences = Counter(
@@ -3153,7 +3189,7 @@ def evaluate_artifact(
         _imported_named_scalar_occurrences(content, policy_repo_root)
     )
     source_is_table = _source_text_looks_like_table(
-        numeric_validation_source_text or ""
+        numeric_grounding_validation_source_text or ""
     )
     inline_table_formula_occurrences = (
         _inline_table_formula_numeric_occurrences(content)

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3986,6 +3986,67 @@ rules:
         assert metrics.ungrounded_numeric_count == 0
         assert metrics.source_numeric_occurrence_count == 0
 
+    def test_parameter_table_grounding_uses_corpus_source_with_compact_summary(
+        self, tmp_path
+    ):
+        rulespec_file = tmp_path / "policies" / "des" / "ccap" / "chart.yaml"
+        rulespec_file.parent.mkdir(parents=True)
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+  summary: |-
+    Child Care Assistance Gross Monthly Income Eligibility Chart and Fee Schedule.
+rules:
+  - name: fee_level_1_monthly_income_maximum
+    kind: parameter
+    dtype: Money
+    period: Month
+    unit: USD
+    indexed_by: family_size
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].values
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-az/manual/des/ccap/income-chart-ffy2026/page-1
+              excerpt: Fee Level 1 monthly income maximum
+              table:
+                header: Gross Monthly Income Eligibility Chart
+                row_key: Family Size
+                column_key: Fee Level 1
+    versions:
+      - effective_from: '2025-10-01'
+        values:
+          1: 1110
+"""
+        )
+
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline, "_run_compile_check", return_value=compile_result
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=tmp_path,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text=(
+                    "Family Size Fee Level 1 Income Maximum 1 0-1,110 2 0-1,499"
+                ),
+            )
+
+        assert metrics.ci_pass
+        assert metrics.grounded_numeric_count == 1
+        assert metrics.ungrounded_numeric_count == 0
+        assert metrics.source_numeric_occurrence_count == 0
+
     def test_numeric_occurrence_check_counts_imported_named_scalars(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"
         child = policy_repo / "statutes" / "7" / "2015" / "d" / "2" / "B.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.831"
+version = "0.2.832"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- use full corpus source text for numeric grounding when a generated RuleSpec artifact proves a parameter table
- preserve compact embedded-summary behavior for non-table artifacts
- add a regression for table values grounded in source text but absent from a compact module summary

## Tests
- uv run ruff check src/axiom_encode/harness/evals.py tests/test_evals.py
- uv run pytest tests/test_evals.py -k "numeric_grounding_uses_embedded_operating_excerpt or generated_numeric_grounding_uses_proof_excerpts_with_compact_summary or parameter_table_grounding_uses_corpus_source_with_compact_summary"
- uv run pytest tests/test_cli.py -k "current_encoder_affecting_changes_are_behind_version_bump or package_version_matches_lockfile or lock_version"
- uv run python -m towncrier build --draft --version 0.0.0
- git diff --check