### PR TITLE
Preserve identifier digits in scalar literal repair

### DIFF
--- a/changelog.d/embedded-scalar-literal-boundaries.fixed.md
+++ b/changelog.d/embedded-scalar-literal-boundaries.fixed.md
@@ -1,0 +1,1 @@
+Preserve digits inside RuleSpec identifiers when repairing generated embedded scalar literals reported as standalone numeric expressions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.832"
+version = "0.2.833"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.832"
+__version__ = "0.2.833"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -21869,7 +21869,11 @@ def _replace_embedded_scalar_literal(
         parameter_name,
         expression,
     )
-    if expression_replacement != expression and expression in formula:
+    if (
+        expression.strip() != literal
+        and expression_replacement != expression
+        and expression in formula
+    ):
         formula = formula.replace(expression, expression_replacement, 1)
     return re.sub(
         rf"(?<![A-Za-z0-9_.]){re.escape(literal)}(?![A-Za-z0-9_.])",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5607,6 +5607,54 @@ rules:
             "snap_gross_income_standard_for_household_scalar_limit" in repaired_formula
         )
 
+    def test_embedded_scalar_literal_repair_preserves_table_name_digits(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "policies" / "des" / "ccap" / "chart.yaml"
+        rules_file.parent.mkdir(parents=True)
+        formula = (
+            "if family_monthly_gross_income "
+            "<= fee_level_4_income_upper_limit_by_family_size[family_size]: "
+            "4 else: -1"
+        )
+        rules_file.write_text(
+            f"""format: rulespec/v1
+module:
+  summary: Arizona CCAP income chart.
+rules:
+- name: child_care_assistance_fee_level
+  kind: derived
+  entity: Family
+  dtype: Integer
+  period: Month
+  source: Gross Monthly Income Eligibility Chart
+  versions:
+  - effective_from: '2025-10-01'
+    formula: {formula!r}
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_embedded_scalar_literals_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=tmp_path / "rulespec-us-az",
+            issues=[
+                "Embedded scalar literal: child_care_assistance_fee_level "
+                "line 10 embeds 4 in `4`; extract the value to its own named "
+                "numeric concept or indexed table/grid value"
+            ],
+        )
+
+        assert repaired == ["child_care_assistance_fee_level_scalar_limit"]
+        payload = yaml.safe_load(rules_file.read_text())
+        derived = payload["rules"][1]
+        repaired_formula = derived["versions"][0]["formula"]
+        assert "fee_level_4_income_upper_limit_by_family_size" in repaired_formula
+        assert "fee_level_child_care_assistance_fee_level_scalar_limit" not in (
+            repaired_formula
+        )
+        assert "child_care_assistance_fee_level_scalar_limit else" in repaired_formula
+
     def test_embedded_scalar_literal_repair_reuses_existing_scalar_parameter(
         self, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.832"
+version = "0.2.833"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- avoid plain expression replacement when an embedded scalar issue reports the expression as only the numeric literal
- preserve digits inside RuleSpec identifiers such as `fee_level_4_income_upper_limit_by_family_size`
- add an AZ CCAP-shaped regression for scalar-literal repair

## Tests
- uv run ruff format --check src/ tests/
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run pytest tests/test_cli.py -k "embedded_scalar_literal_repair_preserves_table_name_digits or embedded_scalar_literal_repair_replaces_repeated_expression_literals or repair_embedded_scalar_literals_extracts_parameter"
- uv run pytest tests/test_cli.py -k "current_encoder_affecting_changes_are_behind_version_bump or package_version_matches_lockfile or lock_version"
- uv run python -m towncrier build --draft --version 0.0.0
- git diff --check