### PR TITLE
Repair generated day test periods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.834"
+version = "0.2.835"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.834"
+__version__ = "0.2.835"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -19902,6 +19902,34 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_day_period_cases = (
+                    _try_repair_generated_day_period_test_shorthands_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_day_period_cases:
+                    outcome["auto_repaired_day_test_periods"] = (
+                        repaired_day_period_cases
+                    )
+                    print(
+                        "  apply=auto_repaired_day_test_periods:"
+                        + ",".join(repaired_day_period_cases)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_input_field_accesses = (
                     _try_repair_generated_input_field_access_for_apply(
                         result,
@@ -27253,6 +27281,82 @@ def _try_repair_generated_empty_test_outputs_for_apply(
     )
 
 
+def _try_repair_generated_day_period_test_shorthands_for_apply(
+    result,
+    *,
+    output_root: Path,
+    issues: list[str],
+) -> list[str]:
+    """Convert generated `YYYY-MM-DD` test periods to explicit day mappings."""
+    case_periods = _day_period_test_cases_from_issues(issues)
+    if not case_periods:
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    test_file = _rulespec_test_path(Path(str(getattr(result, "output_file", "") or "")))
+    return _rewrite_generated_day_period_test_shorthands(
+        test_file=test_file,
+        case_periods=case_periods,
+    )
+
+
+def _day_period_test_cases_from_issues(issues: list[str]) -> dict[str, str]:
+    case_periods: dict[str, str] = {}
+    for issue in issues:
+        match = _DAY_PERIOD_TEST_ISSUE_PATTERN.search(str(issue))
+        if match is not None:
+            case_periods[match.group("case").strip()] = match.group("period")
+    return case_periods
+
+
+def _rewrite_generated_day_period_test_shorthands(
+    *,
+    test_file: Path,
+    case_periods: dict[str, str],
+) -> list[str]:
+    if not test_file.exists():
+        return []
+    try:
+        test_cases = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(test_cases, list):
+        return []
+
+    repaired: list[str] = []
+    for index, case in enumerate(test_cases):
+        if not isinstance(case, dict):
+            continue
+        case_name = str(case.get("name") or f"case[{index}]")
+        current_period = case.get("period")
+        if isinstance(current_period, date):
+            current_day = current_period.isoformat()
+        else:
+            current_day = str(current_period or "").strip()
+        if _DAY_PERIOD_VALUE_PATTERN.fullmatch(current_day) is None:
+            continue
+        reported_day = case_periods.get(case_name)
+        if reported_day is not None and current_day != reported_day:
+            continue
+        case["period"] = {
+            "period_kind": "custom",
+            "name": "day",
+            "start": current_day,
+            "end": current_day,
+        }
+        repaired.append(case_name)
+
+    if not repaired:
+        return []
+    test_file.write_text(
+        yaml.safe_dump(test_cases, sort_keys=False, allow_unicode=False)
+    )
+    return repaired
+
+
 def _empty_test_output_case_names_from_issues(issues: list[str]) -> set[str]:
     names: set[str] = set()
     for issue in issues:
@@ -27408,6 +27512,11 @@ _UNRESOLVED_TEST_OUTPUT_ISSUE_PATTERN = re.compile(
 _EMPTY_TEST_OUTPUT_ISSUE_PATTERN = re.compile(
     r"Test case `(?P<case>[^`]+)` output must be a mapping\."
 )
+_DAY_PERIOD_TEST_ISSUE_PATTERN = re.compile(
+    r"Test case `(?P<case>[^`]+)` period invalid: unsupported period shorthand: "
+    r"['\"](?P<period>\d{4}-\d{2}-\d{2})['\"]"
+)
+_DAY_PERIOD_VALUE_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}")
 _SHARED_STATUTORY_RATE_NAME_ISSUE_PATTERN = re.compile(
     r"Shared statutory rate name [^:]+: `([^`]+)`"
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -120,6 +120,7 @@ from axiom_encode.cli import (
     _try_repair_generated_bare_snapunit_entity_for_apply,
     _try_repair_generated_boolean_comparison_predicates_for_apply,
     _try_repair_generated_conditional_vacuity_tests_for_apply,
+    _try_repair_generated_day_period_test_shorthands_for_apply,
     _try_repair_generated_delegated_policy_settings_for_apply,
     _try_repair_generated_embedded_scalar_literals_for_apply,
     _try_repair_generated_empty_test_outputs_for_apply,
@@ -17969,6 +17970,59 @@ rules:
             "us:policies/des/ccap/reimbursement-rates#cda_enhancement_rate",
             "us:policies/des/ccap/reimbursement-rates#quality_enhancement_rate",
         ]
+
+    def test_repair_generated_day_period_test_shorthands_for_apply(self, tmp_path):
+        output_root = tmp_path / "out"
+        runner = "openai-gpt-5.5"
+        rules_file = output_root / runner / "policies/des/ccap/reimbursement-rates.yaml"
+        test_file = rules_file.with_name("reimbursement-rates.test.yaml")
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text("format: rulespec/v1\nrules: []\n")
+        test_file.write_text(
+            """- name: daily_case
+  period: '2024-08-01'
+  input: {}
+  output:
+    us-az:policies/des/ccap/reimbursement-rates#daily_rate_attendance_requirement_met: holds
+- name: monthly_case
+  period: 2024-08
+  input: {}
+  output:
+    us-az:policies/des/ccap/reimbursement-rates#school_age_summer_daily_rate_months_apply: not_holds
+- name: second_daily_case
+  period: '2024-08-15'
+  input: {}
+  output:
+    us-az:policies/des/ccap/reimbursement-rates#daily_rate_attendance_requirement_met: holds
+"""
+        )
+        result = SimpleNamespace(output_file=str(rules_file), runner=runner)
+
+        repaired = _try_repair_generated_day_period_test_shorthands_for_apply(
+            result,
+            output_root=output_root,
+            issues=[
+                "policies/des/ccap/reimbursement-rates.yaml: ci: "
+                "Test case `daily_case` period invalid: unsupported period "
+                "shorthand: '2024-08-01'"
+            ],
+        )
+
+        payload = yaml.safe_load(test_file.read_text())
+        assert repaired == ["daily_case", "second_daily_case"]
+        assert payload[0]["period"] == {
+            "period_kind": "custom",
+            "name": "day",
+            "start": "2024-08-01",
+            "end": "2024-08-01",
+        }
+        assert payload[1]["period"] == "2024-08"
+        assert payload[2]["period"] == {
+            "period_kind": "custom",
+            "name": "day",
+            "start": "2024-08-15",
+            "end": "2024-08-15",
+        }
 
     def test_unsafe_formula_output_repair_defers_tax_status_components(self, tmp_path):
         output_root = tmp_path / "out"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.834"
+version = "0.2.835"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- normalize generated companion test periods that use YYYY-MM-DD shorthand into explicit custom day periods during apply repair
- repair all generated day-period cases in the companion test file when validation reports a day shorthand issue
- bump axiom-encode to 0.2.835

## Tests
- uv run ruff format --check src/ tests/
- uv run python -m pytest tests/test_cli.py -q -k "day_period_test_shorthands or current_encoder_affecting_changes_are_behind_version_bump or unsafe_formula_output_repair"