### PR TITLE
Wire Arizona CCAP income limit oracle mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.835"
+version = "0.2.836"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.835"
+__version__ = "0.2.836"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1708,6 +1708,34 @@ mappings:
     candidate_priority: P2
     rationale: PolicyEngine's Colorado CCAP entry income predicate does not include the 3.111(H)(4)(c) one-million-dollar asset cap and uses PE's separate FPG entry-rate predicate.
 
+  - legal_id: us-az:policies/des/ccap/income-fee-schedule-ffy2026#initial_application_monthly_income_limit
+    country: us
+    program: ccap
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.az.hhs.ccap.income.threshold.level_6
+    parameter_key_path:
+      - input: family_size
+        min_value: 1
+        max_value: 12
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Arizona CCAP initial-application monthly gross-income limit, using the FFY 2026 level 6 table keyed by family size.
+
+  - legal_id: us-az:policies/des/ccap/income-fee-schedule-ffy2026#redetermination_monthly_income_limit
+    country: us
+    program: ccap
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.az.hhs.ccap.income.threshold.level_7
+    parameter_key_path:
+      - input: family_size
+        min_value: 1
+        max_value: 12
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Arizona CCAP redetermination monthly gross-income limit, using the FFY 2026 level 7 table keyed by family size.
+
   - legal_id: us-co:regulations/9-ccr-2503-5/3.530#oap_total_monthly_grant_standard
     country: us
     program: co_oap

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -926,11 +926,14 @@ surfaces:
   variable: az_ccap
   source_type: state_implementation
   state: AZ
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models Arizona CCAP from Arizona Administrative Code Title 6, Chapter 5 plus DES income-fee
-    and reimbursement schedules. The official DES/AZSOS sources were ingested in TheAxiomFoundation/axiom-corpus#130;
-    RuleSpec encoding and oracle wiring remain before this surface can claim parity.
+  rationale: Current RuleSpec encodes Arizona Administrative Code Title 6, Chapter 5 eligibility, activity/need,
+    income, fee-assignment, DES FFY 2026 income-fee schedule, and DES reimbursement-rate source components, with
+    exact oracle mappings for the shared income-limit tables. PolicyEngine's az_ccap is a final monthly subsidy amount
+    that also depends on actual childcare expenses, final eligibility rollup, copay aggregation, maximum reimbursement,
+    and PE-specific proxies, so this program surface is adjacent rather than one-to-one until Axiom has a final Arizona
+    CCAP composition and adapter.
 - country: us
   program_id: ccdf
   program_name: CalWORKs childcare

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -419,7 +419,7 @@ def test_policyengine_program_surface_marks_colorado_ccap_final_subsidy_known_no
     assert "final modeled subsidy" in colorado_ccap["rationale"]
 
 
-def test_policyengine_program_surface_marks_arizona_ccap_pending_rulespec_encoding():
+def test_policyengine_program_surface_marks_arizona_ccap_known_not_comparable():
     report = build_policyengine_program_surface_report(program="ccap")
 
     items_by_variable = {item["variable"]: item for item in report["items"]}
@@ -427,9 +427,13 @@ def test_policyengine_program_surface_marks_arizona_ccap_pending_rulespec_encodi
 
     assert arizona_ccap["program_id"] == "ccdf"
     assert arizona_ccap["state"] == "AZ"
-    assert arizona_ccap["axiom_status"] == "pending_rulespec_encoding"
+    assert arizona_ccap["axiom_status"] == "known_not_comparable"
     assert arizona_ccap["mapping_count"] == 0
-    assert "TheAxiomFoundation/axiom-corpus#130" in arizona_ccap["rationale"]
+    assert "final monthly subsidy amount" in arizona_ccap["rationale"]
+    assert (
+        "exact oracle mappings for the shared income-limit tables"
+        in (arizona_ccap["rationale"])
+    )
 
 
 def test_policyengine_program_surface_marks_georgia_caps_known_not_comparable():
@@ -6557,6 +6561,70 @@ rules:
     assert (
         combined_predicate["policyengine_variable"] == "co_ccap_entry_income_eligible"
     )
+
+
+def test_policyengine_coverage_maps_arizona_ccap_income_limits(tmp_path):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-az/policies/des/ccap/income-fee-schedule-ffy2026.yaml",
+        """format: rulespec/v1
+rules:
+  - name: initial_application_monthly_income_limit
+    kind: derived
+    entity: Family
+    dtype: Money
+    unit: USD
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: fee_level_6_income_max_by_family_size[family_size]
+  - name: redetermination_monthly_income_limit
+    kind: derived
+    entity: Family
+    dtype: Money
+    unit: USD
+    period: Month
+    versions:
+      - effective_from: '2025-10-01'
+        formula: fee_level_7_income_max_by_family_size[family_size]
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-az/policies/des/ccap/income-fee-schedule-ffy2026.test.yaml",
+        """- name: family size two limits
+  period: 2025-10
+  input:
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#input.family_size: 2
+  output:
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#initial_application_monthly_income_limit: 2909
+    us-az:policies/des/ccap/income-fee-schedule-ffy2026#redetermination_monthly_income_limit: 5202
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="ccap")
+
+    assert report["status_counts"] == {"comparable": 2}
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    initial = items_by_id[
+        "us-az:policies/des/ccap/income-fee-schedule-ffy2026#initial_application_monthly_income_limit"
+    ]
+    redetermination = items_by_id[
+        "us-az:policies/des/ccap/income-fee-schedule-ffy2026#redetermination_monthly_income_limit"
+    ]
+    assert initial["mapping_type"] == "parameter_value"
+    assert initial["policyengine_parameter"] == (
+        "gov.states.az.hhs.ccap.income.threshold.level_6"
+    )
+    assert initial["tested"] is True
+    assert redetermination["mapping_type"] == "parameter_value"
+    assert redetermination["policyengine_parameter"] == (
+        "gov.states.az.hhs.ccap.income.threshold.level_7"
+    )
+    assert redetermination["tested"] is True
 
 
 def test_policyengine_coverage_tags_georgia_caps_manual_outputs(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.835"
+version = "0.2.836"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map Arizona CCAP initial and redetermination income-limit RuleSpec outputs to PE-US level 6/7 threshold parameters
- mark the PE az_ccap final subsidy program surface as adjacent/not-comparable now that source components are encoded
- bump axiom-encode to 0.2.836 and add coverage tests for the new mappings/status

## Tests
- uv run ruff format --check src/ tests/
- uv run python -m pytest tests/test_cli.py -q -k current_encoder_affecting_changes_are_behind_version_bump --no-cov
- uv run python -m pytest tests/test_policyengine_coverage.py -q --no-cov
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program ccap --include-program-surfaces --json > /tmp/axiom_ccap_coverage.json