### PR TITLE
Classify CalWORKs PE surface as adjacent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.836"
+version = "0.2.837"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.836"
+__version__ = "0.2.837"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2138,6 +2138,14 @@ mappings:
     comparison: money
     rationale: Same California CalWORKs maximum resource limit, selecting the elderly-or-disabled assistance-unit parameter when the legal condition holds.
 
+  - legal_id: us-ca:policies/cdss/calworks/monthly-aid-payment#monthly_aid_payment
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ca_tanf
+    candidate_priority: P4
+    rationale: Axiom's WIC 11450 monthly aid payment is the family-level legal payment formula after state income exemptions and special-needs inputs. PolicyEngine's ca_tanf is an annual SPM-unit final benefit gated through PE's demographic, resource, vehicle-value, and immigration-proration graph, so this is an adjacent final cash-benefit surface rather than a one-to-one oracle target.
+
   - legal_id: us-co:regulations/10-ccr-2506-1/4.407.3#excess_shelter_deduction
     country: us
     program: snap

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -161,10 +161,12 @@ surfaces:
   variable: ca_tanf
   source_type: state_implementation
   state: CA
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom encodes the WIC 11450 monthly aid payment formula and exact oracle mappings for the shared MAP
+    and resource-limit parameters. PolicyEngine's ca_tanf annual SPM-unit surface also includes PE's demographic,
+    resource, vehicle-value, and immigration-proration graph, so compare legal CalWORKs components separately
+    until a full Axiom program composition and adapter exist.
 - country: us
   program_id: tanf
   program_name: Colorado TANF

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -468,6 +468,24 @@ def test_policyengine_program_surface_marks_head_start_known_not_comparable():
     )
 
 
+def test_policyengine_program_surface_marks_calworks_cash_benefit_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    calworks = items_by_variable["ca_tanf"]
+
+    assert calworks["program_id"] == "tanf"
+    assert calworks["state"] == "CA"
+    assert calworks["axiom_status"] == "known_not_comparable"
+    assert calworks["mapping_count"] == 1
+    assert calworks["comparable_mapping_count"] == 0
+    assert calworks["legal_ids"] == [
+        "us-ca:policies/cdss/calworks/monthly-aid-payment#monthly_aid_payment"
+    ]
+    assert "WIC 11450 monthly aid payment formula" in calworks["rationale"]
+    assert "immigration-proration graph" in calworks["rationale"]
+
+
 def test_policyengine_program_surface_marks_colorado_health_value_surfaces_out_of_scope():
     report = build_policyengine_program_surface_report()
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.836"
+version = "0.2.837"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- attach the WIC 11450 monthly aid payment legal ID to PE `ca_tanf` as an adjacent/not-comparable mapping
- mark the CalWORKs final cash-benefit surface as known-not-comparable instead of pending RuleSpec encoding
- bump axiom-encode to 0.2.837 and add a regression test for the surface classification

## Checks
- `uv run ruff format --check src/ tests/`
- `uv run python -m pytest tests/test_cli.py -q -k current_encoder_affecting_changes_are_behind_version_bump --no-cov`
- `uv run python -m pytest tests/test_policyengine_coverage.py -q --no-cov`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tanf --include-program-surfaces --json`

## Coverage note
Active pending TANF final-benefit surfaces drop from 46 to 45; CalWORKs remains covered through exact component mappings for MAP/resource limits plus an explicit adjacent final-surface classification.