### PR TITLE
Isolate Codex evals from PolicyEngine skills

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.838"
+version = "0.2.839"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.837"
+version = "0.2.838"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.838"
+__version__ = "0.2.839"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.837"
+__version__ = "0.2.838"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -4610,6 +4610,11 @@ Preferred principal output:
 Author the output in Axiom RuleSpec YAML.
 Do not narrate your plan or describe what you will do before emitting the artifact.
 The response must begin with the requested RuleSpec artifact, not with prose.
+This is Axiom encoding work. Do not read, load, or apply PolicyEngine skills,
+PolicyEngine workflow docs, or PolicyEngine implementation guidance. PolicyEngine
+may be mentioned only as oracle/comparison data when explicitly supplied by this
+prompt. Use only the inline source, copied context files, RuleSpec/Axiom
+instructions in this prompt, and local Axiom/RuleSpec files.
 
 Primary legal authority:
 - `./source.txt` contains the complete source text for this target source unit.
@@ -8003,6 +8008,7 @@ def _run_codex_prompt_eval(
         "exec",
         "--json",
         "--skip-git-repo-check",
+        "--ignore-user-config",
         "-o",
         str(last_message_file),
         "-m",
@@ -8021,9 +8027,13 @@ def _run_codex_prompt_eval(
     timed_out = False
     timeout_reason = None
     with (
+        tempfile.TemporaryDirectory(prefix="axiom-codex-home-") as codex_home_dir,
         tempfile.NamedTemporaryFile(mode="w+", delete=False) as stdout_file,
         tempfile.NamedTemporaryFile(mode="w+", delete=False) as stderr_file,
     ):
+        codex_home = _prepare_codex_eval_home(Path(codex_home_dir))
+        codex_env = os.environ.copy()
+        codex_env["CODEX_HOME"] = str(codex_home)
         stdout_path = Path(stdout_file.name)
         stderr_path = Path(stderr_file.name)
         process = subprocess.Popen(
@@ -8033,6 +8043,7 @@ def _run_codex_prompt_eval(
             stderr=stderr_file,
             text=True,
             cwd=workspace.root,
+            env=codex_env,
         )
         try:
             terminated_after_output = _wait_for_codex_process(
@@ -8078,6 +8089,13 @@ def _run_codex_prompt_eval(
                 assistant_messages.append(item["text"])
             if item.get("type") == "command_execution":
                 command = item.get("command", "")
+                if _command_uses_policyengine_skill(command):
+                    unexpected_accesses.append(command)
+                    if not error:
+                        error = (
+                            "Codex eval attempted to use PolicyEngine skills, "
+                            "which are disallowed for Axiom encoding"
+                        )
                 if _command_looks_out_of_bounds(command, workspace.root):
                     unexpected_accesses.append(command)
         elif payload.get("type") == "turn.completed":
@@ -8133,6 +8151,23 @@ def _run_codex_prompt_eval(
         unexpected_accesses=unexpected_accesses,
         error=error,
     )
+
+
+def _prepare_codex_eval_home(codex_home: Path) -> Path:
+    """Create a minimal CODEX_HOME for eval subprocesses without user skills."""
+    codex_home.mkdir(parents=True, exist_ok=True)
+    (codex_home / "skills").mkdir(exist_ok=True)
+    source_home = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
+    for filename in ("auth.json", "installation_id"):
+        source = source_home / filename
+        target = codex_home / filename
+        if target.exists() or target.is_symlink() or not source.exists():
+            continue
+        try:
+            target.symlink_to(source)
+        except OSError:
+            shutil.copy2(source, target)
+    return codex_home
 
 
 def _codex_prompt_timeouts(workspace: EvalWorkspace) -> tuple[int, int]:
@@ -8451,6 +8486,20 @@ def _command_looks_out_of_bounds(command: str, workspace_root: Path) -> bool:
             return True
 
     return False
+
+
+def _command_uses_policyengine_skill(command: str) -> bool:
+    """Return True when a Codex shell command reads PolicyEngine skill material."""
+    if not command:
+        return False
+    normalized = command.lower()
+    policyengine_skill_markers = (
+        "/policyengine-skills/",
+        "policyengine-skills/",
+        "/skills/workflows/encode-policy",
+        "encode-policy-v2-skill",
+    )
+    return any(marker in normalized for marker in policyengine_skill_markers)
 
 
 def _extract_rulespec_content(llm_response: str) -> str | None:

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2685,6 +2685,108 @@ mappings:
     comparison: rate
     rationale: Same Arizona TANF base income-limit rate for parent or non-parent caretaker relative self-and-child cases.
 
+  - legal_id: us-wa:regulations/388/388-478/388-478-0020#cash_assistance_payment_standard_size_floor_for_final_row
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.wa.dshs.tanf.maximum_family_size
+    candidate_priority: P4
+    rationale: Axiom exposes the WAC 388-478-0020 "10 or more" table-row floor as a generated table selector helper. PolicyEngine stores the adjacent maximum family size parameter, but does not expose this source-row helper as a one-to-one output.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0020#cash_assistance_payment_standard_size_band
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.wa.dshs.tanf.payment_standard.amount
+    candidate_priority: P4
+    rationale: Axiom exposes the generated assistance-unit-size band used to select the WAC 388-478-0020 payment-standard table row. PolicyEngine compares the final table value, not this selector helper.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0020#cash_assistance_maximum_monthly_payment_standard
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.wa.dshs.tanf.payment_standard.amount
+    parameter_key_path:
+      - input: assistance_unit_size
+        max: 10
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same WAC 388-478-0020 monthly payment-standard table, keyed by assistance-unit size and capped at the 10-or-more row.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0020#cash_assistance_unit_maximum_monthly_payment_standard
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.wa.dshs.tanf.payment_standard.amount
+    parameter_key_path:
+      - input: assistance_unit_size
+        max: 10
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same WAC 388-478-0020 monthly payment-standard amount after selecting the assistance-unit-size row.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0035#cash_assistance_family_earnings_deduction
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.wa.dshs.tanf.income.deductions.earned_income_disregard.amount
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same $500 family earnings deduction referenced by WAC 388-478-0035 and used by PolicyEngine's Washington TANF earned-income-disregard parameter.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0035#cash_assistance_earned_income_limit_final_family_size_floor
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.wa.dshs.tanf.maximum_family_size
+    candidate_priority: P4
+    rationale: Axiom exposes the WAC 388-478-0035 "10 or more" table-row floor as a generated table selector helper. PolicyEngine stores the adjacent maximum family size parameter, but does not expose this source-row helper as a one-to-one output.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0035#cash_assistance_earned_income_limit_family_size_band
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.wa.dshs.tanf.income.limit
+    candidate_priority: P4
+    rationale: Axiom exposes the generated family-size band used to select the WAC 388-478-0035 gross-earned-income limit table row. PolicyEngine compares the final limit value or combined income-eligibility variable, not this selector helper.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0035#cash_assistance_maximum_monthly_gross_earned_income_level
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.wa.dshs.tanf.income.limit
+    parameter_key_path:
+      - input: number_of_family_members
+        max: 10
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same WAC 388-478-0035 monthly gross earned-income limit table, keyed by family size and capped at the 10-or-more row.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0035#cash_assistance_family_maximum_monthly_gross_earned_income_level
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.wa.dshs.tanf.income.limit
+    parameter_key_path:
+      - input: number_of_family_members
+        max: 10
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same WAC 388-478-0035 monthly gross earned-income limit after selecting the family-size row.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0035#cash_assistance_gross_earned_income_requirement_satisfied
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: wa_tanf_income_eligible
+    candidate_priority: P4
+    rationale: Axiom's WAC 388-478-0035 output is only the strict gross-earned-income-below-limit requirement. PolicyEngine's adjacent wa_tanf_income_eligible combines that gross-income test with countable-income eligibility and, in the local PE implementation reviewed, treats income equal to the limit as eligible.
+
   - legal_id: us-az:policies/des/faa5/ca-jobs-exemptions/age#jobs_program_participation_age_exemption_applies
     country: us
     program: tanf

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -28,6 +28,7 @@ from axiom_encode.harness.evals import (
     _clean_generated_file_content,
     _codex_prompt_timeouts,
     _command_looks_out_of_bounds,
+    _command_uses_policyengine_skill,
     _context_file_executable_surfaces,
     _eval_result_from_payload,
     _evaluate_generated_artifact_with_repairs,
@@ -39,6 +40,7 @@ from axiom_encode.harness.evals import (
     _normalize_test_case_value,
     _normalize_test_periods_to_effective_dates,
     _post_openai_eval_request,
+    _prepare_codex_eval_home,
     _prompt_corpus_citation_path,
     _resolve_eval_output_path,
     _resolve_eval_reference_source_id,
@@ -1162,6 +1164,8 @@ def test_build_eval_prompt_targets_rulespec_yaml(tmp_path):
     assert "unit-level placeholder or aggregate base by the rate" in prompt
     assert '"per taxpayer per beneficiary"' in prompt
     assert "Do not apply one\n  per-unit cap to a single aggregate amount" in prompt
+    assert "This is Axiom encoding work" in prompt
+    assert "Do not read, load, or apply PolicyEngine skills" in prompt
     assert "For claim, overpayment, overissuance, repayment" in prompt
     assert "as collectability caps" in prompt
     assert "not return a bare placeholder such as `claim_amount`" in prompt
@@ -2978,7 +2982,7 @@ def test_eval_result_payload_round_trips_prompt_digests():
         )
 
         class FakePopen:
-            def __init__(self, cmd, stdout, stderr, text, cwd):
+            def __init__(self, cmd, stdout, stderr, text, cwd, stdin=None, env=None):
                 self.args = cmd
                 self.returncode = None
                 Path(cwd, ".codex-last-message.txt").write_text(bundle)
@@ -3041,7 +3045,7 @@ def test_eval_result_payload_round_trips_prompt_digests():
         bundle = "=== FILE: example.yaml ===\nformat: rulespec/v1\nrules: []\n"
 
         class FakePopen:
-            def __init__(self, cmd, stdout, stderr, text, cwd):
+            def __init__(self, cmd, stdout, stderr, text, cwd, stdin=None, env=None):
                 self.args = cmd
                 self.returncode = None
                 Path(cwd, ".codex-last-message.txt").write_text(bundle)
@@ -3085,7 +3089,7 @@ def test_eval_result_payload_round_trips_prompt_digests():
         )
 
         class FakePopen:
-            def __init__(self, cmd, stdout, stderr, text, cwd):
+            def __init__(self, cmd, stdout, stderr, text, cwd, stdin=None, env=None):
                 self.args = cmd
                 self.returncode = 0
 
@@ -10516,9 +10520,159 @@ rules:
         assert "Prefer the earliest scaffold date" in prompt
 
 
+class TestCodexPromptEvalPolicyEngineSkillIsolation:
+    def test_prepare_codex_eval_home_omits_user_skills(self, tmp_path, monkeypatch):
+        source_home = tmp_path / "real-codex-home"
+        source_home.mkdir()
+        (source_home / "auth.json").write_text("{}\n")
+        (source_home / "skills").mkdir()
+        (source_home / "skills" / "encode-policy-v2-skill").mkdir()
+        monkeypatch.setenv("CODEX_HOME", str(source_home))
+
+        eval_home = _prepare_codex_eval_home(tmp_path / "eval-home")
+
+        assert (eval_home / "auth.json").exists()
+        assert (eval_home / "skills").is_dir()
+        assert not (eval_home / "skills" / "encode-policy-v2-skill").exists()
+
+    def test_run_codex_prompt_eval_ignores_user_config(self, tmp_path):
+        runner = parse_runner_spec("codex:gpt-5.4")
+        workspace = prepare_eval_workspace(
+            citation="uksi/2002/1792/regulation/6/3/a",
+            runner=runner,
+            output_root=tmp_path / "out",
+            source_text="nil amount",
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            mode="cold",
+            extra_context_paths=[],
+        )
+
+        observed_cmds: list[list[str]] = []
+        observed_envs: list[dict[str, str]] = []
+        observed_skills_dirs: list[bool] = []
+
+        class FakePopen:
+            def __init__(self, cmd, stdout, stderr, text, cwd, stdin=None, env=None):
+                self.args = cmd
+                self.returncode = 0
+                observed_cmds.append(cmd)
+                observed_envs.append(env or {})
+                observed_skills_dirs.append(
+                    bool(env) and (Path(env["CODEX_HOME"]) / "skills").is_dir()
+                )
+
+            def poll(self):
+                return self.returncode
+
+            def terminate(self):
+                self.returncode = -15
+
+            def wait(self, timeout=None):
+                return self.returncode
+
+            def kill(self):
+                self.returncode = -9
+
+        with (
+            patch("axiom_encode.harness.evals.subprocess.Popen", FakePopen),
+            patch(
+                "axiom_encode.harness.evals._wait_for_codex_process",
+                return_value=False,
+            ),
+        ):
+            _run_codex_prompt_eval(runner, workspace, "prompt")
+
+        assert "--ignore-user-config" in observed_cmds[0]
+        codex_home = Path(observed_envs[0]["CODEX_HOME"])
+        assert codex_home.name.startswith("axiom-codex-home-")
+        with pytest.raises(ValueError):
+            codex_home.resolve().relative_to(workspace.root.resolve())
+        assert observed_skills_dirs == [True]
+
+    def test_run_codex_prompt_eval_errors_on_policyengine_skill_use(self, tmp_path):
+        runner = parse_runner_spec("codex:gpt-5.4")
+        workspace = prepare_eval_workspace(
+            citation="us-wa/regulation/388/388-478/388-478-0035",
+            runner=runner,
+            output_root=tmp_path / "out",
+            source_text="income limit",
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            mode="cold",
+            extra_context_paths=[],
+        )
+
+        event_lines = "\n".join(
+            [
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "type": "command_execution",
+                            "command": (
+                                "sed -n '1,200p' "
+                                "/Users/maxghenis/.codex/policyengine-skills/"
+                                "skills/workflows/encode-policy-v2-skill/"
+                                "SKILL.md"
+                            ),
+                        },
+                    }
+                ),
+                json.dumps(
+                    {
+                        "type": "item.completed",
+                        "item": {
+                            "type": "agent_message",
+                            "text": "format: rulespec/v1\nrules: []\n",
+                        },
+                    }
+                ),
+            ]
+        )
+
+        class FakePopen:
+            def __init__(self, cmd, stdout, stderr, text, cwd, stdin=None, env=None):
+                self.args = cmd
+                self.returncode = 0
+                stdout.write(event_lines + "\n")
+                stdout.flush()
+
+            def poll(self):
+                return self.returncode
+
+            def terminate(self):
+                self.returncode = -15
+
+            def wait(self, timeout=None):
+                return self.returncode
+
+            def kill(self):
+                self.returncode = -9
+
+        with (
+            patch("axiom_encode.harness.evals.subprocess.Popen", FakePopen),
+            patch(
+                "axiom_encode.harness.evals._wait_for_codex_process",
+                return_value=False,
+            ),
+        ):
+            response = _run_codex_prompt_eval(runner, workspace, "prompt")
+
+        assert response.error is not None
+        assert "PolicyEngine skills" in response.error
+        assert response.unexpected_accesses
+
+
 class TestUnexpectedAccessDetection:
     def test_flags_parent_directory_traversal(self, tmp_path):
         assert _command_looks_out_of_bounds("bash -lc 'find .. -name *.yaml'", tmp_path)
+
+    def test_flags_policyengine_skill_reads(self):
+        command = (
+            "sed -n '1,200p' "
+            "/Users/maxghenis/.codex/policyengine-skills/skills/workflows/"
+            "encode-policy-v2-skill/SKILL.md"
+        )
+        assert _command_uses_policyengine_skill(command)
 
     def test_allows_workspace_paths(self, tmp_path):
         local = tmp_path / "context" / "b.yaml"

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1669,9 +1669,7 @@ rules:
         "parameter_value"
     }
     assert {
-        legal_id
-        for legal_id in comparable_ids
-        if items_by_id[legal_id]["tested"]
+        legal_id for legal_id in comparable_ids if items_by_id[legal_id]["tested"]
     } == {
         "us-wa:regulations/388/388-478/388-478-0020#cash_assistance_unit_maximum_monthly_payment_standard",
         "us-wa:regulations/388/388-478/388-478-0035#cash_assistance_family_maximum_monthly_gross_earned_income_level",

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1524,6 +1524,172 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_washington_tanf_wac_components(tmp_path):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-wa"
+        / "regulations/388/388-478/388-478-0020.yaml",
+        """format: rulespec/v1
+rules:
+  - name: cash_assistance_payment_standard_size_floor_for_final_row
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '0001-01-01'
+        formula: 10
+  - name: cash_assistance_payment_standard_size_band
+    kind: derived
+    entity: AssistanceUnit
+    dtype: Integer
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if assistance_unit_size >= cash_assistance_payment_standard_size_floor_for_final_row: cash_assistance_payment_standard_size_floor_for_final_row else: assistance_unit_size
+  - name: cash_assistance_maximum_monthly_payment_standard
+    kind: parameter
+    dtype: Money
+    indexed_by: cash_assistance_payment_standard_size_band
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 450
+          10: 1662
+  - name: cash_assistance_unit_maximum_monthly_payment_standard
+    kind: derived
+    entity: AssistanceUnit
+    dtype: Money
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          cash_assistance_maximum_monthly_payment_standard[cash_assistance_payment_standard_size_band]
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-wa"
+        / "regulations/388/388-478/388-478-0020.test.yaml",
+        """- name: one_person_assistance_unit_standard
+  input:
+    us-wa:regulations/388/388-478/388-478-0020#input.assistance_unit_size: 1
+  output:
+    us-wa:regulations/388/388-478/388-478-0020#cash_assistance_payment_standard_size_band: 1
+    us-wa:regulations/388/388-478/388-478-0020#cash_assistance_unit_maximum_monthly_payment_standard: 450
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-wa"
+        / "regulations/388/388-478/388-478-0035.yaml",
+        """format: rulespec/v1
+rules:
+  - name: cash_assistance_family_earnings_deduction
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '0001-01-01'
+        formula: 500
+  - name: cash_assistance_earned_income_limit_final_family_size_floor
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '0001-01-01'
+        formula: 10
+  - name: cash_assistance_earned_income_limit_family_size_band
+    kind: derived
+    entity: Family
+    dtype: Integer
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if number_of_family_members >= cash_assistance_earned_income_limit_final_family_size_floor: cash_assistance_earned_income_limit_final_family_size_floor else: number_of_family_members
+  - name: cash_assistance_maximum_monthly_gross_earned_income_level
+    kind: parameter
+    dtype: Money
+    indexed_by: cash_assistance_earned_income_limit_family_size_band
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 1400
+          10: 3824
+  - name: cash_assistance_family_maximum_monthly_gross_earned_income_level
+    kind: derived
+    entity: Family
+    dtype: Money
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          cash_assistance_maximum_monthly_gross_earned_income_level[cash_assistance_earned_income_limit_family_size_band]
+  - name: cash_assistance_gross_earned_income_requirement_satisfied
+    kind: derived
+    entity: Family
+    dtype: Judgment
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          cash_assistance_family_gross_earned_income < cash_assistance_family_maximum_monthly_gross_earned_income_level
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-wa"
+        / "regulations/388/388-478/388-478-0035.test.yaml",
+        """- name: one_person_income_below_limit_satisfies_requirement
+  input:
+    us-wa:regulations/388/388-478/388-478-0035#input.number_of_family_members: 1
+    us-wa:regulations/388/388-478/388-478-0035#input.cash_assistance_family_gross_earned_income: 1399
+  output:
+    us-wa:regulations/388/388-478/388-478-0035#cash_assistance_earned_income_limit_family_size_band: 1
+    us-wa:regulations/388/388-478/388-478-0035#cash_assistance_family_maximum_monthly_gross_earned_income_level: 1400
+    us-wa:regulations/388/388-478/388-478-0035#cash_assistance_gross_earned_income_requirement_satisfied: holds
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tanf")
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+
+    assert report["total_outputs"] == 10
+    assert report["status_counts"] == {
+        "comparable": 5,
+        "known_not_comparable": 5,
+    }
+    assert report["untested_comparable"] == 3
+
+    comparable_ids = {
+        "us-wa:regulations/388/388-478/388-478-0020#cash_assistance_maximum_monthly_payment_standard",
+        "us-wa:regulations/388/388-478/388-478-0020#cash_assistance_unit_maximum_monthly_payment_standard",
+        "us-wa:regulations/388/388-478/388-478-0035#cash_assistance_family_earnings_deduction",
+        "us-wa:regulations/388/388-478/388-478-0035#cash_assistance_maximum_monthly_gross_earned_income_level",
+        "us-wa:regulations/388/388-478/388-478-0035#cash_assistance_family_maximum_monthly_gross_earned_income_level",
+    }
+    assert {items_by_id[legal_id]["mapping_type"] for legal_id in comparable_ids} == {
+        "parameter_value"
+    }
+    assert {
+        legal_id
+        for legal_id in comparable_ids
+        if items_by_id[legal_id]["tested"]
+    } == {
+        "us-wa:regulations/388/388-478/388-478-0020#cash_assistance_unit_maximum_monthly_payment_standard",
+        "us-wa:regulations/388/388-478/388-478-0035#cash_assistance_family_maximum_monthly_gross_earned_income_level",
+    }
+    assert (
+        items_by_id[
+            "us-wa:regulations/388/388-478/388-478-0035#cash_assistance_gross_earned_income_requirement_satisfied"
+        ]["policyengine_variable"]
+        == "wa_tanf_income_eligible"
+    )
+    assert (
+        items_by_id[
+            "us-wa:regulations/388/388-478/388-478-0035#cash_assistance_gross_earned_income_requirement_satisfied"
+        ]["status"]
+        == "known_not_comparable"
+    )
+
+
 def test_policyengine_coverage_classifies_calworks_exact_outputs(tmp_path):
     _write_rulespec_file(
         tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.837"
+version = "0.2.838"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.838"
+version = "0.2.839"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- run Codex prompt evals with an isolated temp CODEX_HOME and --ignore-user-config so Axiom encoding cannot load user PolicyEngine skills
- detect PolicyEngine skill/workflow reads in Codex command traces and fail the eval response
- map Washington TANF WAC 388-478-0020 and 388-478-0035 component outputs for PolicyEngine coverage
- bump axiom-encode to 0.2.839 for signed RuleSpec provenance

## Validation
- uv run python -m pytest tests/test_evals.py -q --no-cov
- uv run python -m pytest tests/test_policyengine_coverage.py -q --no-cov
- uv run ruff check src/axiom_encode/harness/evals.py tests/test_evals.py tests/test_policyengine_coverage.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --include-program-surfaces --limit 20
