### PR TITLE
Assign inputs in oracle parameter test repair

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.839"
+version = "0.2.840"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.839"
+__version__ = "0.2.840"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -15362,11 +15362,21 @@ def _append_oracle_parameter_tests_if_missing(
     test_file: Path,
     target_base: str,
 ) -> list[str]:
-    payload = yaml.safe_load(rules_file.read_text()) or {}
+    rules_content = rules_file.read_text()
+    payload = yaml.safe_load(rules_content) or {}
     rules = payload.get("rules") if isinstance(payload, dict) else None
     if not isinstance(rules, list):
         return []
 
+    factual_inputs = _local_factual_input_names_from_rules_content(rules_content)
+    input_defaults = {
+        f"{target_base}#input.{input_name}": _default_generated_test_input_value(
+            input_name,
+            rules_payload=payload,
+            prefer_positive_counts=True,
+        )
+        for input_name in sorted(factual_inputs)
+    }
     existing_outputs = _rulespec_test_output_keys(test_file)
     registry = load_policyengine_registry()
     appended_cases: list[dict] = []
@@ -15394,7 +15404,9 @@ def _append_oracle_parameter_tests_if_missing(
         case_name_parts = ["oracle_parameter", _safe_test_name(rule_name)]
         if index_name is not None:
             case_name_parts.append(_safe_test_name(str(key)))
-        inputs = {f"{target_base}#input.{index_name}": key} if index_name else {}
+        inputs = dict(input_defaults)
+        if index_name:
+            inputs[f"{target_base}#input.{index_name}"] = key
         appended_cases.append(
             {
                 "name": "_".join(case_name_parts),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25507,6 +25507,102 @@ rules:
             "statutes/26/32.test.yaml",
         ]
 
+    def test_repair_oracle_parameter_tests_assigns_local_factual_inputs(self, tmp_path):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "us-wa/regulations/388/388-478/388-478-0020.yaml"
+        test_file = policy_repo / "us-wa/regulations/388/388-478/388-478-0020.test.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: cash_assistance_payment_standard_size_band
+    kind: derived
+    entity: AssistanceUnit
+    dtype: Integer
+    period: Month
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if assistance_unit_size >= 10: 10 else: assistance_unit_size
+  - name: cash_assistance_maximum_monthly_payment_standard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: cash_assistance_payment_standard_size_band
+    versions:
+      - effective_from: '0001-01-01'
+        values:
+          1: 450
+          10: 1662
+"""
+        )
+        test_file.write_text(
+            """- name: existing
+  output:
+    us-wa:regulations/388/388-478/388-478-0020#some_other_output: 1
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("us-wa/regulations/388/388-478/388-478-0020.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakeRegistry:
+            def mapping_for_legal_id(self, legal_id, *, country=None):
+                assert country == "us"
+                if legal_id == (
+                    "us-wa:regulations/388/388-478/388-478-0020"
+                    "#cash_assistance_maximum_monthly_payment_standard"
+                ):
+                    return SimpleNamespace(mapping_type="parameter_value")
+                return None
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli.load_policyengine_registry",
+                return_value=FakeRegistry(),
+            ),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures", return_value=[]
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_oracle_parameter_tests(args)
+
+        payload = yaml.safe_load(test_file.read_text())
+        added = payload[-1]
+        assert added["name"] == (
+            "oracle_parameter_cash_assistance_maximum_monthly_payment_standard_1"
+        )
+        assert added["input"] == {
+            "us-wa:regulations/388/388-478/388-478-0020#input.assistance_unit_size": 1,
+            "us-wa:regulations/388/388-478/388-478-0020#input.cash_assistance_payment_standard_size_band": 1,
+        }
+        assert added["output"] == {
+            "us-wa:regulations/388/388-478/388-478-0020#cash_assistance_maximum_monthly_payment_standard": 450
+        }
+
     def test_repair_oracle_parameter_tests_replaces_empty_list_file(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"
         target = policy_repo / "statutes/42/18795a/c/3.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.839"
+version = "0.2.840"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- include deterministic defaults for local factual inputs when repair-oracle-parameter-tests appends mapped parameter companion tests
- keep existing parameter-only behavior unchanged when no local factual inputs exist
- bump axiom-encode to 0.2.840

## Validation
- uv run python -m pytest tests/test_cli.py -q --no-cov -k repair_oracle_parameter_tests
- uv run python -m pytest tests/test_cli.py -q --no-cov
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py pyproject.toml
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py