### PR TITLE
Prioritize PolicyBench-weighted oracle gaps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.841"
+version = "0.2.842"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.840"
+version = "0.2.841"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.841"
+__version__ = "0.2.842"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.840"
+__version__ = "0.2.841"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3655,6 +3655,13 @@ def cmd_oracle_coverage(args):
             "PolicyEngine surface priorities: "
             f"{_format_counter(surfaces['priority_counts'])}"
         )
+        policybench = surfaces.get("policybench")
+        if policybench:
+            print(
+                "PolicyBench weights: "
+                f"{policybench.get('weighting')} "
+                f"snapshot={policybench.get('snapshot')}"
+            )
         if surfaces.get("lifecycle_counts"):
             print(
                 "PolicyEngine surface lifecycles: "
@@ -3712,8 +3719,10 @@ def cmd_oracle_coverage(args):
         print(f"Active pending PolicyEngine program surfaces (first {args.limit}):")
         for item in pending_surface_items[: args.limit]:
             state = f" [{item['state']}]" if item.get("state") else ""
+            weight = item.get("policybench_household_weight")
+            weight_prefix = f"{weight:.2f}% " if isinstance(weight, (int, float)) else ""
             print(
-                f"  - {item['variable']}{state}: "
+                f"  - {weight_prefix}{item['variable']}{state}: "
                 f"{item['axiom_status']} ({item['program_id']})"
             )
         if len(pending_surface_items) > args.limit:
@@ -3755,9 +3764,15 @@ def cmd_oracle_candidates(args):
             )
             target_suffix = f" -> {target}" if target else ""
             tested = "tested" if item.get("tested") else "untested"
+            weight = item.get("policybench_household_weight")
+            weight_suffix = (
+                f" policybench={weight:.2f}%"
+                if isinstance(weight, (int, float))
+                else ""
+            )
             print(
                 f"  - [{item['priority']}] {item['category']} "
-                f"{item['legal_id']}{target_suffix} ({tested})"
+                f"{item['legal_id']}{target_suffix} ({tested}{weight_suffix})"
             )
             print(f"    {item['recommendation']}")
             if item.get("rationale"):

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3720,7 +3720,9 @@ def cmd_oracle_coverage(args):
         for item in pending_surface_items[: args.limit]:
             state = f" [{item['state']}]" if item.get("state") else ""
             weight = item.get("policybench_household_weight")
-            weight_prefix = f"{weight:.2f}% " if isinstance(weight, (int, float)) else ""
+            weight_prefix = (
+                f"{weight:.2f}% " if isinstance(weight, (int, float)) else ""
+            )
             print(
                 f"  - {weight_prefix}{item['variable']}{state}: "
                 f"{item['axiom_status']} ({item['program_id']})"

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -1172,7 +1172,7 @@ def _is_us_tax_like_coverage_item(
     legal_id = str(item.get("legal_id") or "").lower()
     if legal_id.startswith("us:statutes/26/"):
         return True
-    parameter = (policyengine_parameter or item.get("policyengine_parameter") or "")
+    parameter = policyengine_parameter or item.get("policyengine_parameter") or ""
     parameter = str(parameter).lower()
     if parameter.startswith("gov.irs."):
         return True

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -41,9 +41,119 @@ _PROGRAM_TOKEN_RE = {
     for token in ("medicaid", "chip", "aca")
 }
 _HEALTH_PROGRAMS = frozenset({"medicaid", "chip", "aca_ptc"})
+_US_STATE_CODES = frozenset(
+    {
+        "ak",
+        "al",
+        "ar",
+        "az",
+        "ca",
+        "co",
+        "ct",
+        "dc",
+        "de",
+        "fl",
+        "ga",
+        "hi",
+        "ia",
+        "id",
+        "il",
+        "in",
+        "ks",
+        "ky",
+        "la",
+        "ma",
+        "md",
+        "me",
+        "mi",
+        "mn",
+        "mo",
+        "ms",
+        "mt",
+        "nc",
+        "nd",
+        "ne",
+        "nh",
+        "nj",
+        "nm",
+        "nv",
+        "ny",
+        "oh",
+        "ok",
+        "or",
+        "pa",
+        "ri",
+        "sc",
+        "sd",
+        "tn",
+        "tx",
+        "ut",
+        "va",
+        "vt",
+        "wa",
+        "wi",
+        "wv",
+        "wy",
+    }
+)
+_US_STATE_VARIABLE_PREFIX_RE = re.compile(
+    rf"(^|\s)({'|'.join(sorted(_US_STATE_CODES))})_"
+)
 _INTERVAL_BOUND_HELPER_RE = re.compile(
     r"(^|_)(tier|band|bracket|interval|row)_(lower|upper)_bound$"
 )
+POLICYBENCH_SOURCE_URL = "https://policybench.org/"
+POLICYBENCH_SNAPSHOT = "2026-06-14"
+POLICYBENCH_HOUSEHOLD_OUTPUT_WEIGHTS = {
+    "person_level_medicaid_eligibility": 29.86,
+    "federal_tax_before_refundable_credits": 19.14,
+    "payroll_tax": 15.65,
+    "person_level_medicare_eligibility": 10.74,
+    "state_tax_before_refundable_credits": 6.00,
+    "snap": 4.15,
+    "federal_refundable_credits": 3.70,
+    "person_level_early_head_start_eligibility": 3.10,
+    "self_employment_tax": 2.09,
+    "ssi": 1.97,
+    "person_level_head_start_eligibility": 1.18,
+    "free_school_meals_eligibility": 0.74,
+    "state_refundable_credits": 0.55,
+    "person_level_wic_eligibility": 0.32,
+    "local_income_tax": 0.26,
+    "tanf": 0.26,
+    "person_level_chip_eligibility": 0.18,
+    "reduced_price_school_meals_eligibility": 0.10,
+}
+_POLICYBENCH_OUTPUT_BY_PROGRAM_ID = {
+    "federal_income_tax": "federal_tax_before_refundable_credits",
+    "state_income_tax": "state_tax_before_refundable_credits",
+    "payroll_taxes": "payroll_tax",
+    "medicaid": "person_level_medicaid_eligibility",
+    "medicare": "person_level_medicare_eligibility",
+    "snap": "snap",
+    "wic": "person_level_wic_eligibility",
+    "chip": "person_level_chip_eligibility",
+    "tanf": "tanf",
+    "ssi": "ssi",
+    "ssi_state_supplement": "ssi",
+    "head_start": "person_level_head_start_eligibility",
+    "school_meals": "free_school_meals_eligibility",
+}
+_POLICYBENCH_OUTPUT_BY_VARIABLE = {
+    "income_tax": "federal_tax_before_refundable_credits",
+    "employee_payroll_tax": "payroll_tax",
+    "is_medicare_eligible": "person_level_medicare_eligibility",
+    "state_income_tax": "state_tax_before_refundable_credits",
+    "snap": "snap",
+    "wic": "person_level_wic_eligibility",
+    "medicaid": "person_level_medicaid_eligibility",
+    "chip": "person_level_chip_eligibility",
+    "ssi": "ssi",
+    "free_school_meals": "free_school_meals_eligibility",
+    "reduced_price_school_meals": "reduced_price_school_meals_eligibility",
+    "self_employment_tax": "self_employment_tax",
+    "nyc_income_tax": "local_income_tax",
+}
 
 
 @dataclass(frozen=True)
@@ -102,8 +212,10 @@ class PolicyEngineCandidateItem:
     rationale: str | None = None
     tested: bool = False
     test_output_count: int = 0
+    policybench_output: str | None = None
+    policybench_household_weight: float | None = None
 
-    def as_dict(self) -> dict[str, str | int | bool | None]:
+    def as_dict(self) -> dict[str, str | int | float | bool | None]:
         return {
             "legal_id": self.legal_id,
             "repo": self.repo,
@@ -119,6 +231,8 @@ class PolicyEngineCandidateItem:
             "rationale": self.rationale,
             "tested": self.tested,
             "test_output_count": self.test_output_count,
+            "policybench_output": self.policybench_output,
+            "policybench_household_weight": self.policybench_household_weight,
         }
 
 
@@ -143,8 +257,10 @@ class PolicyEngineProgramSurfaceItem:
     mapping_count: int = 0
     comparable_mapping_count: int = 0
     legal_ids: tuple[str, ...] = ()
+    policybench_output: str | None = None
+    policybench_household_weight: float | None = None
 
-    def as_dict(self) -> dict[str, str | int | list[str] | None]:
+    def as_dict(self) -> dict[str, str | int | float | list[str] | None]:
         return {
             "country": self.country,
             "program_id": self.program_id,
@@ -163,6 +279,8 @@ class PolicyEngineProgramSurfaceItem:
             "mapping_count": self.mapping_count,
             "comparable_mapping_count": self.comparable_mapping_count,
             "legal_ids": list(self.legal_ids),
+            "policybench_output": self.policybench_output,
+            "policybench_household_weight": self.policybench_household_weight,
         }
 
 
@@ -175,8 +293,12 @@ def build_policyengine_coverage_report(
     """Classify executable RuleSpec outputs against the PolicyEngine registry."""
     registry = load_policyengine_registry()
     root = root.resolve()
+    raw_items = _iter_policyengine_coverage_items(root, registry)
+    duplicate_outputs_collapsed = len(raw_items) - len(
+        {item.legal_id for item in raw_items}
+    )
     items = sorted(
-        _iter_policyengine_coverage_items(root, registry),
+        _dedupe_coverage_items_by_legal_id(raw_items),
         key=lambda item: item.legal_id,
     )
     if program:
@@ -196,6 +318,7 @@ def build_policyengine_coverage_report(
         "oracle": "policyengine",
         "root": str(root),
         "total_outputs": len(items),
+        "duplicate_outputs_collapsed": duplicate_outputs_collapsed,
         "status_counts": dict(sorted(status_counts.items())),
         "untested_comparable": len(untested_comparable),
         "program_counts": dict(sorted(program_counts.items())),
@@ -215,6 +338,33 @@ def build_policyengine_coverage_report(
             registry=registry,
         )
     return report
+
+
+def _dedupe_coverage_items_by_legal_id(
+    items: list[PolicyEngineCoverageItem],
+) -> list[PolicyEngineCoverageItem]:
+    """Collapse migrated legacy/country-monorepo duplicates by legal output."""
+    by_legal_id: dict[str, PolicyEngineCoverageItem] = {}
+    for item in items:
+        current = by_legal_id.get(item.legal_id)
+        if current is None or _coverage_item_preference_key(
+            item
+        ) < _coverage_item_preference_key(current):
+            by_legal_id[item.legal_id] = item
+    return list(by_legal_id.values())
+
+
+def _coverage_item_preference_key(item: PolicyEngineCoverageItem) -> tuple:
+    prefix = item.legal_id.split(":", 1)[0]
+    country = prefix.split("-", 1)[0]
+    monorepo_prefixes = (f"rulespec-{country}/{prefix}/", f"{prefix}/")
+    monorepo_rank = 0 if item.file.startswith(monorepo_prefixes) else 1
+    return (
+        monorepo_rank,
+        -item.test_output_count,
+        item.file,
+        item.repo,
+    )
 
 
 def build_policyengine_program_surface_report(
@@ -265,6 +415,7 @@ def build_policyengine_program_surface_report(
     actionable_surfaces = sorted(
         active_pending_surfaces,
         key=lambda surface: (
+            -(surface.policybench_household_weight or 0.0),
             _candidate_priority_rank(surface.priority or ""),
             surface.category,
             surface.coverage,
@@ -282,6 +433,12 @@ def build_policyengine_program_surface_report(
         "priority_counts": dict(sorted(priority_counts.items())),
         "lifecycle_counts": dict(sorted(lifecycle_counts.items())),
         "active_priority_counts": dict(sorted(active_priority_counts.items())),
+        "policybench": {
+            "source": POLICYBENCH_SOURCE_URL,
+            "snapshot": POLICYBENCH_SNAPSHOT,
+            "weighting": "household",
+            "weights": POLICYBENCH_HOUSEHOLD_OUTPUT_WEIGHTS,
+        },
         "pending_surfaces": len(pending_surfaces),
         "active_pending_surfaces": len(active_pending_surfaces),
         "actionable_surfaces": [surface.as_dict() for surface in actionable_surfaces],
@@ -313,6 +470,7 @@ def build_policyengine_candidate_report(
         (candidate for candidate in raw_candidates if candidate is not None),
         key=lambda item: (
             _candidate_priority_rank(item.priority),
+            -(item.policybench_household_weight or 0.0),
             item.category,
             item.legal_id,
         ),
@@ -654,6 +812,11 @@ def _candidate_item(
     policyengine_variable: str | None = None,
     policyengine_parameter: str | None = None,
 ) -> PolicyEngineCandidateItem:
+    output = _policybench_output_for_coverage_item(
+        item,
+        policyengine_variable=policyengine_variable,
+        policyengine_parameter=policyengine_parameter,
+    )
     return PolicyEngineCandidateItem(
         legal_id=str(item.get("legal_id") or ""),
         repo=str(item.get("repo") or ""),
@@ -673,6 +836,10 @@ def _candidate_item(
         rationale=item.get("rationale"),
         tested=bool(item.get("tested")),
         test_output_count=int(item.get("test_output_count") or 0),
+        policybench_output=output,
+        policybench_household_weight=(
+            POLICYBENCH_HOUSEHOLD_OUTPUT_WEIGHTS.get(output) if output else None
+        ),
     )
 
 
@@ -885,6 +1052,11 @@ def _program_surface_item_from_payload(
         axiom_status = "known_not_comparable"
     else:
         axiom_status = manifest_status
+    legal_ids = tuple(mapping.legal_id for mapping in mappings)
+    policybench_output = _policybench_output_for_program_surface(
+        payload,
+        legal_ids=legal_ids,
+    )
     return PolicyEngineProgramSurfaceItem(
         country=country,
         program_id=str(payload["program_id"]),
@@ -902,8 +1074,191 @@ def _program_surface_item_from_payload(
         rationale=payload.get("rationale"),
         mapping_count=len(mappings),
         comparable_mapping_count=comparable_mapping_count,
-        legal_ids=tuple(mapping.legal_id for mapping in mappings),
+        legal_ids=legal_ids,
+        policybench_output=policybench_output,
+        policybench_household_weight=(
+            POLICYBENCH_HOUSEHOLD_OUTPUT_WEIGHTS.get(policybench_output)
+            if policybench_output
+            else None
+        ),
     )
+
+
+def _policybench_output_for_program_surface(
+    payload: dict[str, Any],
+    *,
+    legal_ids: tuple[str, ...] = (),
+) -> str | None:
+    """Return the PolicyBench household output group for a PE program surface."""
+    program_id = str(payload.get("program_id") or "")
+    variable = str(payload.get("variable") or "")
+    category = str(payload.get("category") or "")
+    program_name = str(payload.get("program_name") or "").lower()
+    if "early head start" in program_name:
+        return "person_level_early_head_start_eligibility"
+    if variable in _POLICYBENCH_OUTPUT_BY_VARIABLE:
+        return _POLICYBENCH_OUTPUT_BY_VARIABLE[variable]
+    if program_id in _POLICYBENCH_OUTPUT_BY_PROGRAM_ID:
+        return _POLICYBENCH_OUTPUT_BY_PROGRAM_ID[program_id]
+    if variable.endswith(("_tanf", "_tafdc", "_tca")) or program_id == "tanf":
+        return "tanf"
+    if variable.endswith("_income_tax") and variable != "state_income_tax":
+        return "local_income_tax"
+    if "federal_refundable" in program_id or "federal_refundable" in variable:
+        return "federal_refundable_credits"
+    if "refundable" in variable:
+        return "state_refundable_credits"
+    lowered_legal_ids = tuple(legal_id.lower() for legal_id in legal_ids)
+    if any(legal_id.startswith("us:statutes/26/") for legal_id in lowered_legal_ids):
+        text = " ".join(
+            (program_id, variable, program_name, category, *lowered_legal_ids)
+        ).lower()
+        return _policybench_tax_output_from_text("", text)
+    if category.lower() == "taxes":
+        text = " ".join((program_id, variable, program_name, category)).lower()
+        return _policybench_tax_output_from_text("", text)
+    return None
+
+
+def _policybench_output_for_coverage_item(
+    item: dict[str, Any],
+    *,
+    policyengine_variable: str | None = None,
+    policyengine_parameter: str | None = None,
+) -> str | None:
+    program = str(item.get("program") or "")
+    if program == "medicaid":
+        return "person_level_medicaid_eligibility"
+    if program == "chip":
+        return "person_level_chip_eligibility"
+    if program == "medicare":
+        return "person_level_medicare_eligibility"
+    if program == "snap":
+        return "snap"
+    if program == "wic":
+        return "person_level_wic_eligibility"
+    if program in {"ssi", "ssi_state_supplement"}:
+        return "ssi"
+    if program in {"tanf", "tca"}:
+        return "tanf"
+    if program == "head_start":
+        text = _policybench_candidate_text(
+            item,
+            policyengine_variable=policyengine_variable,
+            policyengine_parameter=policyengine_parameter,
+        )
+        if "early_head_start" in text or "early head start" in text:
+            return "person_level_early_head_start_eligibility"
+        return "person_level_head_start_eligibility"
+    if program == "tax" or _is_us_tax_like_coverage_item(
+        item,
+        policyengine_variable=policyengine_variable,
+        policyengine_parameter=policyengine_parameter,
+    ):
+        return _policybench_tax_output_for_coverage_item(
+            item,
+            policyengine_variable=policyengine_variable,
+            policyengine_parameter=policyengine_parameter,
+        )
+    return None
+
+
+def _is_us_tax_like_coverage_item(
+    item: dict[str, Any],
+    *,
+    policyengine_variable: str | None = None,
+    policyengine_parameter: str | None = None,
+) -> bool:
+    legal_id = str(item.get("legal_id") or "").lower()
+    if legal_id.startswith("us:statutes/26/"):
+        return True
+    parameter = (policyengine_parameter or item.get("policyengine_parameter") or "")
+    parameter = str(parameter).lower()
+    if parameter.startswith("gov.irs."):
+        return True
+    if parameter.startswith("gov.states.") and ".tax." in parameter:
+        return True
+    text = _policybench_candidate_text(
+        item,
+        policyengine_variable=policyengine_variable,
+        policyengine_parameter=policyengine_parameter,
+    )
+    return bool(legal_id.startswith("us-") and ".tax." in text)
+
+
+def _policybench_tax_output_for_coverage_item(
+    item: dict[str, Any],
+    *,
+    policyengine_variable: str | None = None,
+    policyengine_parameter: str | None = None,
+) -> str:
+    legal_id = str(item.get("legal_id") or "").lower()
+    text = _policybench_candidate_text(
+        item,
+        policyengine_variable=policyengine_variable,
+        policyengine_parameter=policyengine_parameter,
+    )
+    return _policybench_tax_output_from_text(legal_id, text)
+
+
+def _policybench_tax_output_from_text(legal_id: str, text: str) -> str:
+    if "self_employment" in text or legal_id.startswith(
+        ("us:statutes/26/1401", "us:statutes/26/1402")
+    ):
+        return "self_employment_tax"
+    if any(
+        token in text
+        for token in (
+            "payroll",
+            "oasdi",
+            "fica",
+            "social_security_tax",
+            "medicare_tax",
+        )
+    ) or legal_id.startswith(
+        (
+            "us:statutes/26/3101",
+            "us:statutes/26/3102",
+            "us:statutes/26/3111",
+            "us:statutes/26/3121",
+            "us:statutes/26/3128",
+            "us:statutes/26/3201",
+            "us:statutes/26/3221",
+        )
+    ):
+        return "payroll_tax"
+    if "refundable" in text:
+        return (
+            "state_refundable_credits"
+            if _is_state_tax_candidate(legal_id, text)
+            else "federal_refundable_credits"
+        )
+    if _is_state_tax_candidate(legal_id, text):
+        return "state_tax_before_refundable_credits"
+    return "federal_tax_before_refundable_credits"
+
+
+def _is_state_tax_candidate(legal_id: str, text: str) -> bool:
+    return bool(
+        re.match(r"^us-[a-z]{2}:", legal_id)
+        or ".states." in text
+        or _US_STATE_VARIABLE_PREFIX_RE.search(text)
+    )
+
+
+def _policybench_candidate_text(
+    item: dict[str, Any],
+    *,
+    policyengine_variable: str | None = None,
+    policyengine_parameter: str | None = None,
+) -> str:
+    parts = [
+        str(item.get("legal_id") or ""),
+        str(item.get("rule_name") or ""),
+        str(policyengine_variable or item.get("policyengine_variable") or ""),
+        str(policyengine_parameter or item.get("policyengine_parameter") or ""),
+    ]
+    return " ".join(parts).lower()
 
 
 def _program_surface_matches_filter(

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2763,6 +2763,52 @@ mappings:
     candidate_priority: P4
     rationale: Axiom exposes the PM 08-01-02-c earned-income deduction amount itself. PolicyEngine computes adjacent Illinois TANF countable earned income after applying its disregard parameter, but does not expose the standalone deduction amount at this legal boundary.
 
+  - legal_id: us-il:policies/dhs/csmm/15820/block-1#tanf_minimum_cash_payment_amount
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: il_tanf
+    candidate_priority: P4
+    rationale: Axiom exposes the PM 10-01-02 one-dollar no-issuance threshold as a standalone legal amount. PolicyEngine's adjacent Illinois TANF benefit formula currently does not expose this minimum-payment threshold as a parameter or separate output.
+
+  - legal_id: us-il:policies/dhs/csmm/15820/block-1#non_regular_roll_minimum_check_amount
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the PM 10-01-02 one-dollar minimum for non-regular roll checks. PolicyEngine does not model Illinois TANF non-regular roll or Mercury checks as a distinct surface.
+
+  - legal_id: us-il:policies/dhs/csmm/15820/block-1#tanf_cash_eligible
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: il_tanf_income_eligible
+    candidate_priority: P4
+    rationale: Axiom applies PM 10-01-02's rule that nonexempt income must be at least one dollar less than the payment level. PolicyEngine's adjacent il_tanf_income_eligible currently allows income equal to the payment level; see PolicyEngine/policyengine-us#8761.
+
+  - legal_id: us-il:policies/dhs/csmm/15820/block-1#regular_monthly_tanf_benefit
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: il_tanf
+    candidate_priority: P4
+    rationale: Axiom applies PM 10-01-02's one-dollar no-issuance rule and rounds regular monthly TANF benefits down to the nearest whole dollar. PolicyEngine's adjacent il_tanf computes payment level minus countable income without those final-payment rules; see PolicyEngine/policyengine-us#8761.
+
+  - legal_id: us-il:policies/dhs/csmm/15820/block-1#initial_prorated_entitlement_payment
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: il_tanf
+    candidate_priority: P4
+    rationale: Axiom exposes the PM 10-01-02 Initial Prorated Entitlement rounding/no-issuance rule. PolicyEngine's adjacent Illinois TANF amount does not model IPE payments as a distinct surface.
+
+  - legal_id: us-il:policies/dhs/csmm/15820/block-1#non_regular_roll_check_amount
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the PM 10-01-02 non-regular roll check minimum-payment rule. PolicyEngine does not model Illinois TANF non-regular roll or Mercury checks as a distinct surface.
+
   - legal_id: us-wa:regulations/388/388-478/388-478-0035#cash_assistance_earned_income_limit_final_family_size_floor
     country: us
     program: tanf

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2737,6 +2737,32 @@ mappings:
     comparison: money
     rationale: Same $500 family earnings deduction referenced by WAC 388-478-0035 and used by PolicyEngine's Washington TANF earned-income-disregard parameter.
 
+  - legal_id: us-il:policies/dhs/csmm/15232/block-1#earned_income_deduction_rate
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.il.dhs.tanf.income.disregard.rate
+    period: month
+    unit: /1
+    comparison: numeric
+    rationale: Same three-quarters earned-income deduction rate stated by Illinois DHS PM 08-01-02-c and used by PolicyEngine's Illinois TANF income-disregard parameter.
+
+  - legal_id: us-il:policies/dhs/csmm/15232/block-1#three_quarters_earned_income_deduction_allowed
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: il_tanf_countable_earned_income_for_grant_calculation
+    candidate_priority: P4
+    rationale: Axiom exposes the PM 08-01-02-c legal predicate for when Illinois allows the three-quarters earned-income deduction. PolicyEngine applies its Illinois TANF disregard inside countable earned income formulas and does not expose this source-specific allowed predicate as a one-to-one output.
+
+  - legal_id: us-il:policies/dhs/csmm/15232/block-1#three_quarters_earned_income_deduction_amount
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: il_tanf_countable_earned_income_for_grant_calculation
+    candidate_priority: P4
+    rationale: Axiom exposes the PM 08-01-02-c earned-income deduction amount itself. PolicyEngine computes adjacent Illinois TANF countable earned income after applying its disregard parameter, but does not expose the standalone deduction amount at this legal boundary.
+
   - legal_id: us-wa:regulations/388/388-478/388-478-0035#cash_assistance_earned_income_limit_final_family_size_floor
     country: us
     program: tanf
@@ -3328,16 +3354,16 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_qualified_business_income_deduction_addback_required
-    candidate_priority: P2
-    rationale: This RuleSpec predicate includes the statutory Schedule F exception for section 199A addbacks; PolicyEngine's required predicate only applies the AGI threshold by filing status.
+    candidate_priority: P4
+    rationale: This RuleSpec predicate includes the statutory Schedule F exception for section 199A addbacks; PolicyEngine's required predicate only applies the AGI threshold by filing status. Tracked in PolicyEngine/policyengine-us#8754.
 
   - legal_id: us-co:statutes/39/39-22-104/3/o#section_199a_deduction_addition_to_federal_taxable_income
     country: us
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_qualified_business_income_deduction_addback
-    candidate_priority: P2
-    rationale: This RuleSpec output applies the statutory Schedule F exception before adding back the section 199A deduction; PolicyEngine's addback amount does not model that exception.
+    candidate_priority: P4
+    rationale: This RuleSpec output applies the statutory Schedule F exception before adding back the section 199A deduction; PolicyEngine's addback amount does not model that exception. Tracked in PolicyEngine/policyengine-us#8754.
 
   - legal_id: us-co:statutes/39/39-22-104/3/p#federal_adjusted_gross_income_threshold_for_itemized_deduction_addition
     country: us
@@ -3376,7 +3402,7 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_federal_deduction_addback_required
-    candidate_priority: P3
+    candidate_priority: P4
     rationale: This RuleSpec predicate is limited to the subsection (3)(p) itemized-deduction rule and is displaced by subsection (3)(p.5); PolicyEngine exposes a unified federal-deduction addback predicate across both statutory windows.
 
   - legal_id: us-co:statutes/39/39-22-104/3/p/5#federal_adjusted_gross_income_threshold
@@ -3416,7 +3442,7 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_federal_deduction_addback_required
-    candidate_priority: P3
+    candidate_priority: P4
     rationale: This RuleSpec predicate includes the statutory healthy-school-meals repeal exception and source-window boundary; PolicyEngine exposes a unified federal-deduction addback predicate without that repeal condition.
 
   - legal_id: us-co:statutes/39/39-22-104/3/p/5#initial_window_addition_to_federal_taxable_income
@@ -3424,7 +3450,7 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_federal_deduction_addback
-    candidate_priority: P3
+    candidate_priority: P4
     rationale: This RuleSpec output is the subsection (3)(p.5) initial-window amount and includes the healthy-school-meals repeal exception; PolicyEngine exposes a unified federal-deduction addback amount without that repeal condition.
 
   - legal_id: us-co:statutes/39/39-22-104/3/p/7#ongoing_federal_adjusted_gross_income_threshold
@@ -3442,16 +3468,16 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_parameter: gov.states.co.tax.income.additions.federal_deductions.exemption
-    candidate_priority: P2
-    rationale: This RuleSpec parameter is the 2026 ongoing subsection (3)(p.7) single-return exemption amount; PolicyEngine's federal-deduction exemption table currently retains the prior $12,000 single-filer schedule, so this is an adjacent PE target but not a valid parameter comparison.
+    candidate_priority: P4
+    rationale: This RuleSpec parameter is the 2026 ongoing subsection (3)(p.7) single-return exemption amount; PolicyEngine's federal-deduction exemption table currently retains the prior $12,000 single-filer schedule, so this is an adjacent PE target but not a valid parameter comparison. Tracked in PolicyEngine/policyengine-us#8755.
 
   - legal_id: us-co:statutes/39/39-22-104/3/p/7#ongoing_joint_return_deduction_threshold
     country: us
     program: tax
     mapping_type: not_comparable
     policyengine_parameter: gov.states.co.tax.income.additions.federal_deductions.exemption
-    candidate_priority: P2
-    rationale: This RuleSpec parameter is the 2026 ongoing subsection (3)(p.7) joint-return exemption amount; PolicyEngine's federal-deduction exemption table currently retains the prior $16,000 joint-filer schedule, so this is an adjacent PE target but not a valid parameter comparison.
+    candidate_priority: P4
+    rationale: This RuleSpec parameter is the 2026 ongoing subsection (3)(p.7) joint-return exemption amount; PolicyEngine's federal-deduction exemption table currently retains the prior $16,000 joint-filer schedule, so this is an adjacent PE target but not a valid parameter comparison. Tracked in PolicyEngine/policyengine-us#8755.
 
   - legal_id: us-co:statutes/39/39-22-104/3/p/7#ongoing_return_deduction_threshold
     country: us
@@ -3466,7 +3492,7 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_federal_deduction_addback_required
-    candidate_priority: P3
+    candidate_priority: P4
     rationale: This RuleSpec predicate includes the subsection (3)(p.7) ongoing source-window boundary and healthy-school-meals repeal exception; PolicyEngine exposes a unified federal-deduction addback predicate without that repeal condition.
 
   - legal_id: us-co:statutes/39/39-22-104/3/p/7#ongoing_itemized_or_standard_deduction_addition_to_federal_taxable_income
@@ -3474,7 +3500,7 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_federal_deduction_addback
-    candidate_priority: P3
+    candidate_priority: P4
     rationale: This RuleSpec output is the subsection (3)(p.7) ongoing amount and includes the healthy-school-meals repeal exception; PolicyEngine exposes a unified federal-deduction addback amount without that repeal condition.
 
   - legal_id: us-co:statutes/39/39-22-104/4/a#united_states_possessions_obligations_interest_income_subtraction
@@ -3503,7 +3529,7 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_charitable_contribution_subtraction
-    candidate_priority: P3
+    candidate_priority: P4
     rationale: This RuleSpec output is person-level and includes the 2015-2019 hunger-relief food-contribution credit disallowance; PolicyEngine exposes a tax-unit aggregate charitable contribution subtraction without that credit exception.
 
   - legal_id: us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction_cap_for_age_fifty_five_to_sixty_four
@@ -3530,14 +3556,14 @@ mappings:
     country: us
     program: tax
     mapping_type: not_comparable
-    candidate_priority: P2
+    candidate_priority: P4
     rationale: PolicyEngine-US does not currently expose or implement the 2025 individual-filer AGI threshold for the age 55-64 Social Security cap increase; tracked in PolicyEngine/policyengine-us#8541.
 
   - legal_id: us-co:statutes/39/39-22-104/4/f#joint_filing_agi_limit_for_age_fifty_five_to_sixty_four_social_security_cap_increase
     country: us
     program: tax
     mapping_type: not_comparable
-    candidate_priority: P2
+    candidate_priority: P4
     rationale: PolicyEngine-US does not currently expose or implement the 2025 joint-filer AGI threshold for the age 55-64 Social Security cap increase; tracked in PolicyEngine/policyengine-us#8541.
 
   - legal_id: us-co:statutes/39/39-22-104/4/f#individual_qualifies_for_pension_annuity_subtraction
@@ -3545,7 +3571,7 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_pension_subtraction_indv_eligible
-    candidate_priority: P2
+    candidate_priority: P4
     rationale: This RuleSpec predicate captures the statutory age-or-death-benefit qualification; PE's similarly named eligibility variable only limits the claim to the tax-unit head or spouse and leaves age and survivor logic inside amount formulas.
 
   - legal_id: us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction_applicable_cap
@@ -3553,7 +3579,7 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_pension_subtraction_indv
-    candidate_priority: P2
+    candidate_priority: P4
     rationale: This RuleSpec output is the person-level statutory cap after Social Security cap-increase rules; PE computes separate Social Security and pension components and does not expose this combined cap boundary.
 
   - legal_id: us-co:statutes/39/39-22-104/4/f#pension_annuity_subtraction
@@ -3561,7 +3587,7 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_pension_subtraction
-    candidate_priority: P2
+    candidate_priority: P4
     rationale: This RuleSpec output is the person-level subsection (4)(f) subtraction including pension and Social Security benefit treatment; PE exposes a tax-unit aggregate split across pension and Social Security component variables and is missing the 2025 age 55-64 AGI-limited Social Security cap increase tracked in PolicyEngine/policyengine-us#8541.
 
   - legal_id: us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_initial_phase
@@ -3634,7 +3660,7 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_tentative_minimum_tax
-    candidate_priority: P2
+    candidate_priority: P4
     rationale: This RuleSpec output is the person-level statutory AMT amount before the regular-tax offset and before nonresident apportionment; PolicyEngine exposes a tax-unit tentative minimum tax derived from its Colorado AMTI aggregate.
 
   - legal_id: us-co:statutes/39/39-22-119.5#low_income_adjusted_gross_income_limit
@@ -3889,7 +3915,7 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_ctc
-    candidate_priority: P2
+    candidate_priority: P4
     rationale: This RuleSpec output is a statutory per-child amount selected from resident single/joint AGI bands; PolicyEngine exposes final tax-unit co_ctc after eligible-child counting, filing-status mapping, and inflation-adjusted bracket-scale lookup.
 
   - legal_id: us-co:statutes/39/39-22-123.5#credit_percentage_after_revenue_adjustment
@@ -3897,7 +3923,7 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_parameter: gov.states.co.tax.income.credits.eitc.match
-    candidate_priority: P2
+    candidate_priority: P4
     rationale: This RuleSpec output computes Colorado's EITC percentage from the statutory base rate plus temporary and revenue-growth adjustments using the estimated adjustment factor; PolicyEngine stores a final date-varying match parameter and does not expose the adjustment-factor calculation boundary.
 
   - legal_id: us-co:statutes/39/39-22-123.5#regular_federal_return_eitc_branch_before_part_year_apportionment
@@ -3905,7 +3931,7 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_eitc
-    candidate_priority: P2
+    candidate_priority: P4
     rationale: This RuleSpec output is the person-level regular federal-return branch before part-year apportionment; PolicyEngine exposes a final tax-unit Colorado EITC amount computed from federal eitc and a date-varying match parameter, not this branch-specific statutory boundary.
 
   - legal_id: us-co:statutes/39/39-22-123.5#missing_valid_ssn_eitc_branch_before_part_year_apportionment
@@ -3913,8 +3939,8 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_eitc
-    candidate_priority: P2
-    rationale: This RuleSpec output is the Colorado branch for credits that would have been allowed but for missing valid employment Social Security numbers; PolicyEngine's co_eitc uses federal eitc and does not expose this alternate state statutory branch.
+    candidate_priority: P4
+    rationale: This RuleSpec output is the Colorado branch for credits that would have been allowed but for missing valid employment Social Security numbers; PolicyEngine's co_eitc uses federal eitc and does not expose this alternate state statutory branch. Tracked in PolicyEngine/policyengine-us#8758.
 
   - legal_id_prefix: us-ny:regulations/18-nycrr/387/14/a/1#
     country: us
@@ -4124,16 +4150,16 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: taxable_self_employment_income
-    candidate_priority: P2
-    rationale: Section 1402(b) self-employment income is adjacent to PE taxable_self_employment_income, but this RuleSpec output is a tax-unit statutory boundary with nonresident-alien exclusions and imported section 1402(a) source components. Use a section-specific adapter before treating it as an exact PE oracle target.
+    candidate_priority: P4
+    rationale: Section 1402(b) self-employment income is adjacent to PE taxable_self_employment_income, but this RuleSpec output applies nonresident-alien, section 233 agreement, and territory-resident branches that PolicyEngine does not currently expose. Tracked in PolicyEngine/policyengine-us#8759.
 
   - legal_id: us:statutes/26/1402/b#self_employment_income_for_section_1401_a
     country: us
     program: tax
     mapping_type: not_comparable
     policyengine_variable: social_security_taxable_self_employment_income
-    candidate_priority: P2
-    rationale: Section 1402(b)(1) wage-base-limited self-employment income is adjacent to PE social_security_taxable_self_employment_income, but the generated RuleSpec tests can supply source-specific wage-base inputs and nonresident-alien exclusions that PE does not expose as direct scenario inputs. Compare through an explicit SECA adapter.
+    candidate_priority: P4
+    rationale: Section 1402(b)(1) wage-base-limited self-employment income is adjacent to PE social_security_taxable_self_employment_income, but the generated RuleSpec tests can supply source-specific wage-base inputs and nonresident-alien, section 233 agreement, and territory-resident branches that PE does not expose as direct scenario inputs. Tracked in PolicyEngine/policyengine-us#8759.
 
   - legal_id: us:statutes/26/1402/b#self_employment_income_excluded_for_taxpayer
     country: us
@@ -7680,6 +7706,14 @@ mappings:
     comparison: money
     rationale: Same CTC phaseout income increment.
 
+  - legal_id: us:statutes/26/24#ctc_qualifying_child
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: ctc_qualifying_child
+    candidate_priority: P4
+    rationale: RuleSpec exposes the section 24(c) qualifying-child predicate before the separate identification-number reduction is applied to the child count, while PolicyEngine folds identification requirements into its person-level ctc_qualifying_child variable. Compare ctc_qualifying_children_count to PolicyEngine ctc_qualifying_children instead.
+
   - legal_id: us:statutes/26/24#ctc_qualifying_children_count
     country: us
     program: tax
@@ -8808,6 +8842,7 @@ mappings:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: is_eligible_for_american_opportunity_credit
+    candidate_priority: P4
     rationale: Axiom derives the person-level AOTC claim predicate from section 25A facts; PolicyEngine treats the equivalent eligibility as an input.
 
   - legal_id: us:statutes/26/25A#aotc_student_first_band_expenses
@@ -14549,6 +14584,7 @@ mappings:
     country: us
     program: snap
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: "Source-specific intermediate output (rule `medical_expense_deduction`, grounded against `106 CMR 364.400 medical expense deduction table`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-ma:regulations/106-cmr/364/400/block-1#earned_income_deduction_allowed_for_overissuance
@@ -16019,6 +16055,7 @@ mappings:
     country: us
     program: snap
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: "Source-specific intermediate output (rule `household_size`, grounded against `Tables I-VII row key`). Not present in the PolicyEngine Populace adapter catalog (`PE_US_VAR_ADAPTERS`). Promote to `direct_variable` by adding an adapter entry once a one-to-one PE target is identified."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_gross_income_standard
@@ -16055,6 +16092,7 @@ mappings:
     country: us
     program: snap
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: "Historical Tennessee regulation table value from 1240-01-04-.27 block 1. It shares the generic rule name `snap_standard_deduction`, but the encoded table is not the current FY PolicyEngine SNAP standard deduction parameter and should not be treated as a direct oracle comparable."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_max_shelter_deduction_non_elderly_disabled
@@ -16067,6 +16105,7 @@ mappings:
     country: us
     program: snap
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: "Historical Tennessee regulation table value from 1240-01-04-.27 block 1. It shares the generic rule name `snap_standard_utility_allowance`, but the encoded table is not the current FY PolicyEngine SNAP utility allowance parameter and should not be treated as a direct oracle comparable."
 
   - legal_id: us-tn:regulations/1240-01/04/27/block-1#snap_basic_utility_allowance
@@ -16559,6 +16598,7 @@ mappings:
     country: us
     program: residential_clean_energy_credit
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_parameter: gov.irs.credits.residential_clean_energy.fuel_cell_cap_per_kw
     rationale: Section 25D(b)(1) states the fuel-cell cap per half kilowatt, while PolicyEngine stores the related amount per kilowatt; compare this after adding transformed parameter comparisons for this surface.
 
@@ -16566,12 +16606,14 @@ mappings:
     country: us
     program: residential_clean_energy_credit
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine does not expose the section 25D(e) joint-occupancy fuel-cell expenditure limit as a separate parameter or variable.
 
   - legal_id: us:statutes/26/25D#residential_clean_energy_credit_applicable_percentage_property_placed_after_2016_and_before_2020
     country: us
     program: residential_clean_energy_credit
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_parameter: gov.irs.credits.residential_clean_energy.applicable_percentage
     rationale: RuleSpec exposes the statutory placed-in-service percentage branch separately, while PolicyEngine exposes a period-selected percentage schedule.
 
@@ -16579,6 +16621,7 @@ mappings:
     country: us
     program: residential_clean_energy_credit
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_parameter: gov.irs.credits.residential_clean_energy.applicable_percentage
     rationale: RuleSpec exposes the statutory placed-in-service percentage branch separately, while PolicyEngine exposes a period-selected percentage schedule.
 
@@ -16586,6 +16629,7 @@ mappings:
     country: us
     program: residential_clean_energy_credit
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_parameter: gov.irs.credits.residential_clean_energy.applicable_percentage
     rationale: RuleSpec exposes the statutory placed-in-service percentage branch separately, while PolicyEngine exposes a period-selected percentage schedule that is stale after Pub. L. 119-21; see PolicyEngine/policyengine-us#8694.
 
@@ -16593,6 +16637,7 @@ mappings:
     country: us
     program: residential_clean_energy_credit
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_parameter: gov.irs.credits.residential_clean_energy.applicable_percentage
     rationale: PolicyEngine's applicable percentage schedule still includes the pre-Pub. L. 119-21 2033/2034 phase-down and has not yet been updated for the current-law post-2025 termination; see PolicyEngine/policyengine-us#8694.
 
@@ -16600,6 +16645,7 @@ mappings:
     country: us
     program: residential_clean_energy_credit
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_variable: residential_clean_energy_credit_potential
     rationale: PolicyEngine exposes the potential credit, but its applicable percentage schedule is stale after Pub. L. 119-21 and differs for post-2025 positive-expenditure cases; see PolicyEngine/policyengine-us#8694.
 
@@ -16607,6 +16653,7 @@ mappings:
     country: us
     program: residential_clean_energy_credit
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_variable: residential_clean_energy_credit_credit_limit
     rationale: Same broad section 25D(c) current-year limitation concept, but RuleSpec exposes the section 26(a) limit and other-credit subtraction as legal boundary inputs while PolicyEngine computes them from its full tax stack.
 
@@ -16614,6 +16661,7 @@ mappings:
     country: us
     program: residential_clean_energy_credit
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_variable: residential_clean_energy_credit
     rationale: Same final residential clean energy credit surface, but PolicyEngine is stale after Pub. L. 119-21 and still allows post-2025 credits; see PolicyEngine/policyengine-us#8694.
 
@@ -16621,18 +16669,21 @@ mappings:
     country: us
     program: residential_clean_energy_credit
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine does not expose the section 25D(c) carryforward amount as a separate variable.
 
   - legal_id: us:statutes/26/25C#energy_efficient_home_improvement_credit_rate
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: RuleSpec exposes the unified section 25C(a) post-2022 rate across improvements, property, and audits, while PolicyEngine stores separate rate parameters with different historical structure.
 
   - legal_id: us:statutes/26/25C#general_annual_credit_limit
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_parameter: gov.irs.credits.energy_efficient_home_improvement.cap.annual.total
     rationale: Same broad $1,200 annual cap amount, but PolicyEngine applies it inside a stale lifetime/in-effect graph; promote to parameter comparison only with a dedicated 25C parameter test surface.
 
@@ -16640,6 +16691,7 @@ mappings:
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_parameter: gov.irs.credits.energy_efficient_home_improvement.cap.annual.energy_efficient_building_property
     rationale: Same broad $600 qualified-energy-property cap amount, but PolicyEngine applies it through property-specific helpers and a stale in-effect graph rather than this statutory item-cap output.
 
@@ -16647,6 +16699,7 @@ mappings:
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_parameter: gov.irs.credits.energy_efficient_home_improvement.cap.annual.window
     rationale: Same broad $600 windows-and-skylights amount, but PolicyEngine combines it with a pre-current-law lifetime window cap surface, so it is not an exact oracle target for current section 25C.
 
@@ -16654,12 +16707,14 @@ mappings:
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine stores the aggregate exterior-door cap but does not expose the section 25C(b)(4)(A) $250 per-door cap as a separate parameter or output.
 
   - legal_id: us:statutes/26/25C#exterior_doors_aggregate_credit_limit
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_parameter: gov.irs.credits.energy_efficient_home_improvement.cap.annual.door
     rationale: Same broad $500 aggregate exterior-door amount, but PolicyEngine omits the per-door cap and therefore is not an exact oracle target for the statutory door-limit pair.
 
@@ -16667,6 +16722,7 @@ mappings:
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_parameter: gov.irs.credits.energy_efficient_home_improvement.cap.annual.heat_pump_heat_pump_water_heater_biomass_stove_boiler
     rationale: Same broad $2,000 cap amount, but PolicyEngine applies it through rebate-adjusted helper variables and a stale in-effect graph, not as this current-law statutory cap output.
 
@@ -16674,6 +16730,7 @@ mappings:
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_parameter: gov.irs.credits.energy_efficient_home_improvement.cap.annual.home_energy_audit
     rationale: Same broad $150 cap amount, but PolicyEngine's audit helper lacks the section 25C(e)(2) substantiation gate encoded by RuleSpec.
 
@@ -16681,36 +16738,42 @@ mappings:
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine does not expose the section 25C(c)(1)(B) five-year expected-use property-classification threshold as a parameter or output.
 
   - legal_id: us:statutes/26/25C#biomass_stove_or_boiler_minimum_thermal_efficiency_rate
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine does not expose the section 25C(d)(2)(B) biomass thermal-efficiency threshold as a parameter or output.
 
   - legal_id: us:statutes/26/25C#panelboard_minimum_load_capacity_amps
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine does not expose the section 25C(d)(2)(D)(ii) panelboard load-capacity threshold as a parameter or output.
 
   - legal_id: us:statutes/26/25C#eligible_fuel_blend_minimum_volume_rate
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine does not expose the section 25C(d)(3)(B) eligible-fuel blend threshold as a parameter or output.
 
   - legal_id: us:statutes/26/25C#home_energy_auditor_guidance_deadline_days_after_enactment
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine does not expose the section 25C(e)(4) Secretary guidance deadline as a parameter or output.
 
   - legal_id: us:statutes/26/25C#windows_and_skylights_credit
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_variable: capped_energy_efficient_window_credit
     rationale: PolicyEngine's window helper applies a stale lifetime window cap and prior-credit subtraction, while RuleSpec encodes the current-law annual windows-and-skylights component.
 
@@ -16718,6 +16781,7 @@ mappings:
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_variable: capped_energy_efficient_door_credit
     rationale: PolicyEngine's exterior-door helper omits the $250 per-door cap, so it is not an exact oracle target for RuleSpec's section 25C(b)(4) door component.
 
@@ -16725,18 +16789,21 @@ mappings:
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine splits non-window, non-door envelope improvements into separate insulation and roof helpers and does not expose this combined statutory component.
 
   - legal_id: us:statutes/26/25C#non_heat_pump_residential_energy_property_credit
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine splits non-heat-pump residential energy property into several rebate-adjusted helpers and does not expose this combined section 25C(a)(2)/(b)(2) component.
 
   - legal_id: us:statutes/26/25C#heat_pump_biomass_credit
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_variable: capped_heat_pump_heat_pump_water_heater_biomass_stove_boiler_credit
     rationale: PolicyEngine's heat-pump/biomass helper subtracts rebate variables and lives in a stale in-effect graph, while RuleSpec exposes the statutory current-law component before the final PIN and termination gates.
 
@@ -16744,6 +16811,7 @@ mappings:
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_variable: capped_home_energy_audit_credit
     rationale: PolicyEngine caps audit expenditures but does not encode the section 25C(e)(2) return-documentation condition that can zero the audit component.
 
@@ -16751,12 +16819,14 @@ mappings:
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine computes a broader potential credit using its own qualified-expenditure helper list, lifetime cap, and stale in-effect parameter rather than this pre-heat-pump current-law annual cap subtotal.
 
   - legal_id: us:statutes/26/25C#energy_efficient_home_improvement_credit_before_termination_and_pin_gate
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_variable: energy_efficient_home_improvement_credit_potential
     rationale: PolicyEngine's potential credit includes stale lifetime/in-effect handling and no product-identification-number gate; it is not this current-law pre-termination/PIN subtotal.
 
@@ -16764,6 +16834,7 @@ mappings:
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     policyengine_variable: energy_efficient_home_improvement_credit
     rationale: Same final section 25C credit surface, but PolicyEngine still uses the pre-current-law 2033 in-effect schedule, does not include the section 25C(h) product-identification-number gate, and computes the tax-liability limit through its full tax stack; see PolicyEngine/policyengine-us#8703.
 
@@ -16771,6 +16842,7 @@ mappings:
     country: us
     program: ira_tax_credits
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine does not expose the section 25C(g) basis-reduction amount as a separate variable.
 
   - legal_id: us:statutes/42/18795/c/2#modeled_savings_lower_threshold
@@ -17105,15 +17177,15 @@ prefixes:
     country: us
     program: clean_vehicle_credits
     mapping_type: not_comparable
-    candidate_priority: P3
-    rationale: Section 25E RuleSpec outputs expose current-law statutory parameters, buyer/sale/vehicle predicates, and pre-MAGI credit intermediates. PolicyEngine's used-clean-vehicle variables are tax-unit simplifications with separate eligibility gating and no exact source-boundary output for these legal intermediates. Add exact mappings above this prefix when a one-to-one PE target exists.
+    candidate_priority: P4
+    rationale: Section 25E RuleSpec outputs expose current-law statutory parameters, buyer/sale/vehicle predicates, and pre-MAGI credit intermediates. PolicyEngine's used-clean-vehicle variables are tax-unit simplifications with separate eligibility gating and no exact source-boundary output for these legal intermediates; see PolicyEngine/policyengine-us#8760. Add exact mappings above this prefix when a one-to-one PE target exists.
 
   - legal_id_prefix: us:statutes/26/30D#
     country: us
     program: clean_vehicle_credits
     mapping_type: not_comparable
-    candidate_priority: P3
-    rationale: Section 30D RuleSpec outputs expose current-law statutory parameters, vehicle predicates, per-vehicle credit components, transfer rules, and deferred taxpayer-to-vehicle aggregation. PolicyEngine's new-clean-vehicle variables are tax-unit simplifications and include legacy/pre-IRA mechanics, so these outputs are not exact PE oracle targets unless a narrower exact mapping is added above this prefix.
+    candidate_priority: P4
+    rationale: Section 30D RuleSpec outputs expose current-law statutory parameters, vehicle predicates, per-vehicle credit components, transfer rules, and deferred taxpayer-to-vehicle aggregation. PolicyEngine's new-clean-vehicle variables are tax-unit simplifications and include legacy/pre-IRA mechanics, so these outputs are not exact PE oracle targets unless a narrower exact mapping is added above this prefix; see PolicyEngine/policyengine-us#8760.
 
   - legal_id_prefix: us:statutes/5/5566#
     country: us
@@ -17143,24 +17215,28 @@ prefixes:
     country: us
     program: snap
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: Tennessee DHS SNAP manual pages encode state administrative procedures, verification rules, disqualification predicates, eligibility subtests, and other generated policy intermediates. PolicyEngine does not expose one-to-one variables for this manual-page surface; exact direct mappings should be added later only for individually verified outputs.
 
   - legal_id_prefix: us-nc:policies/dhhs/fns/
     country: us
     program: snap
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: North Carolina DHHS FNS manual sections encode state SNAP administrative procedures, verification rules, simplified nutrition assistance procedures, eligibility subtests, notices, and other generated policy intermediates. PolicyEngine does not expose one-to-one variables for this manual-page surface; exact direct mappings should be added later only for individually verified outputs.
 
   - legal_id_prefix: us-sc:policies/dss/snap-policy-manual/
     country: us
     program: snap
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: South Carolina DSS SNAP manual sections encode state administrative procedures, verification rules, work-requirement predicates, notices, disqualification branches, and other generated policy intermediates. PolicyEngine does not expose one-to-one variables for this manual-page surface; exact direct mappings should be added later only for individually verified outputs.
 
   - legal_id_prefix: us-al:policies/dhr/poe/
     country: us
     program: snap
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: Alabama DHR POE SNAP manual sections encode state administrative procedures, verification rules, disqualification predicates, eligibility subtests, and other generated policy intermediates. PolicyEngine does not expose one-to-one variables for this manual-page surface; exact direct mappings should be added later only for individually verified outputs.
 
   - legal_id_prefix: us-co:statutes/39/39-22-104/3/
@@ -17168,16 +17244,16 @@ prefixes:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_additions
-    candidate_priority: P3
-    rationale: Remaining Colorado subsection 3 generated outputs decompose source-specific federal-taxable-income additions, predicates, timing windows, and caps; exact mappings above compare PE-exposed parameters or one-to-one variables, while PolicyEngine otherwise exposes only aggregate co_additions and selected addback variables. Keep this prefix visible in candidate triage because future generated outputs may deserve exact mappings.
+    candidate_priority: P4
+    rationale: Remaining Colorado subsection 3 generated outputs decompose source-specific federal-taxable-income additions, predicates, timing windows, and caps; exact mappings above compare PE-exposed parameters or one-to-one variables, while PolicyEngine otherwise exposes only aggregate co_additions and selected addback variables.
 
   - legal_id_prefix: us-co:statutes/39/39-22-104/4/
     country: us
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_subtractions
-    candidate_priority: P3
-    rationale: Remaining Colorado subsection 4 generated outputs decompose source-specific federal-taxable-income subtractions, predicates, timing windows, and caps; exact mappings above compare PE-exposed parameters or one-to-one variables, while PolicyEngine otherwise exposes only aggregate co_subtractions and selected subtraction variables. Keep this prefix visible in candidate triage because future generated outputs may deserve exact mappings.
+    candidate_priority: P4
+    rationale: Remaining Colorado subsection 4 generated outputs decompose source-specific federal-taxable-income subtractions, predicates, timing windows, and caps; exact mappings above compare PE-exposed parameters or one-to-one variables, while PolicyEngine otherwise exposes only aggregate co_subtractions and selected subtraction variables.
 
   - legal_id_prefix: us-co:statutes/39/39-22-105#
     country: us
@@ -17190,29 +17266,30 @@ prefixes:
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_cdcc
-    candidate_priority: P2
-    rationale: Colorado section 119 generated outputs decompose the regular child and dependent care expenses credit into source-specific eligibility, federal-credit-base, child-care-assistance, inflation-adjusted limit, and refundable-excess pieces; PolicyEngine exposes a final tax-unit co_cdcc amount from capped federal CDCC and match parameters, not these statutory boundaries.
+    candidate_priority: P4
+    rationale: Colorado section 119 generated outputs decompose the regular child and dependent care expenses credit into source-specific eligibility, federal-credit-base, child-care-assistance, inflation-adjusted limit, and refundable-excess pieces; PolicyEngine exposes a final tax-unit co_cdcc amount from capped federal CDCC and match parameters, not these statutory boundaries. The 2026 70 percent/pre-section-26 update is tracked in PolicyEngine/policyengine-us#8756.
 
   - legal_id_prefix: us-co:statutes/39/39-22-119.5#
     country: us
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_low_income_cdcc
-    candidate_priority: P2
-    rationale: Colorado section 119.5 generated outputs decompose the low-income child care expenses credit into statutory-window, provider-identification, dependent-age, earned-income-limit, cap, eligibility, amount, and refundable-excess pieces; exact parameter mappings above compare shared PE parameters, while PolicyEngine exposes final tax-unit co_low_income_cdcc and a simplified eligibility predicate.
+    candidate_priority: P4
+    rationale: Colorado section 119.5 generated outputs decompose the low-income child care expenses credit into statutory-window, provider-identification, dependent-age, earned-income-limit, cap, eligibility, amount, and refundable-excess pieces; exact parameter mappings above compare shared PE parameters, while PolicyEngine exposes final tax-unit co_low_income_cdcc and a simplified eligibility predicate. The statutory window and omitted eligibility predicates are tracked in PolicyEngine/policyengine-us#8757.
 
   - legal_id_prefix: us-co:statutes/39/39-22-129/4.5#
     country: us
     program: tax
     mapping_type: not_comparable
     policyengine_variable: co_ctc
-    candidate_priority: P2
+    candidate_priority: P4
     rationale: Remaining Colorado CTC subsection 4.5 outputs are adjacent current-law statutory helpers; exact mappings above compare the threshold and amount parameters, while PolicyEngine exposes final tax-unit co_ctc after eligible-child counting, filing-status mapping, and inflation adjustments.
 
   - legal_id_prefix: us-co:statutes/39/39-22-123.5#
     country: us
     program: tax
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: Colorado EITC generated outputs decompose statutory rates, revenue-growth adjustments, person-level branches, refundable-excess amounts, and public-benefit exclusions; PolicyEngine exposes only a final tax-unit co_eitc amount and date-varying match parameter unless an exact mapping above records a narrower adjacent target.
 
   - legal_id_prefix: us-az:policies/des/faa5/na-child-support-expense/allowable-deductions#
@@ -17615,6 +17692,14 @@ prefixes:
     program: tax
     mapping_type: not_comparable
     rationale: Section 152(c) qualifying-child outputs are dependency-law predicates and tiebreaker intermediates that PolicyEngine derives inside household and dependent-status logic rather than exposing as one-to-one oracle variables.
+
+  - legal_id: us:statutes/26/199A#qualified_business_income_deduction
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    policyengine_variable: qualified_business_income_deduction
+    candidate_priority: P4
+    rationale: RuleSpec's section 199A qualified_business_income_deduction output represents the current-law statutory deduction after active-QBI minimum-deduction predicates, while PolicyEngine's qualified_business_income_deduction is a Form 8995/Pub. 535-style graph over qbid_amount with a taxable-income-less-QBI cap and optional floor parameter. Compare narrower shared parameters or add an adapter only if the formulas are made semantically identical.
 
   - legal_id_prefix: us:statutes/26/199A#
     country: us
@@ -18784,89 +18869,107 @@ prefixes:
   - legal_id_prefix: "us-al:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model AL agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-ar:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model AR agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-az:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model AZ agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-ca:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model CA agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-co:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model CO agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-de:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model DE agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-fl:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model FL agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-ga:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model GA agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-id:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model ID agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-ma:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model MA agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-md:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model MD agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-nc:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model NC agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-nh:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model NH agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-ny:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model NY agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-ok:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model OK agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-sc:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model SC agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-tn:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model TN agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
   - legal_id_prefix: "us-tx:"
     country: us
     mapping_type: not_comparable
+    candidate_priority: P4
     rationale: PolicyEngine-US does not model TX agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -242,6 +242,132 @@ outputs:
     assert item["file"] == "rulespec-us/programs/us-fl/tca/fy-2026.yaml"
 
 
+def test_policyengine_coverage_deduplicates_migrated_legacy_checkouts(tmp_path):
+    content = """format: rulespec/v1
+rules:
+  - name: co_state_tax_deduplicated_output
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 1
+"""
+    _write_rulespec_file(
+        tmp_path / "rulespec-us/us-co/statutes/39/example.yaml",
+        content,
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us-co/statutes/39/example.yaml",
+        content,
+    )
+
+    report = build_policyengine_coverage_report(tmp_path)
+
+    assert report["total_outputs"] == 1
+    assert report["duplicate_outputs_collapsed"] == 1
+    item = report["items"][0]
+    assert (
+        item["legal_id"]
+        == "us-co:statutes/39/example#co_state_tax_deduplicated_output"
+    )
+    assert item["file"] == "rulespec-us/us-co/statutes/39/example.yaml"
+
+
+def test_policyengine_candidate_report_sorts_same_priority_by_policybench_weight(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/7/snap-test.yaml",
+        """format: rulespec/v1
+rules:
+  - name: snap_new_exact_variable
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 1
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/9999.yaml",
+        """format: rulespec/v1
+rules:
+  - name: new_income_tax_exact_variable
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 1
+""",
+    )
+
+    report = build_policyengine_candidate_report(
+        tmp_path,
+        policyengine_variables={
+            "new_income_tax_exact_variable",
+            "snap_new_exact_variable",
+        },
+    )
+
+    assert [item["rule_name"] for item in report["items"][:2]] == [
+        "new_income_tax_exact_variable",
+        "snap_new_exact_variable",
+    ]
+    assert [
+        item["policybench_household_weight"] for item in report["items"][:2]
+    ] == [pytest.approx(19.14), pytest.approx(4.15)]
+
+
+def test_policyengine_candidate_policybench_state_detection_ignores_is_prefix(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/25A.yaml",
+        """format: rulespec/v1
+rules:
+  - name: is_eligible_for_american_opportunity_credit
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: true
+""",
+    )
+
+    report = build_policyengine_candidate_report(
+        tmp_path,
+        policyengine_variables={"is_eligible_for_american_opportunity_credit"},
+    )
+
+    item = report["items"][0]
+    assert item["policybench_output"] == "federal_tax_before_refundable_credits"
+    assert item["policybench_household_weight"] == pytest.approx(19.14)
+
+
+def test_policyengine_candidate_policybench_weights_mapped_title_26_credit_program(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/25C.yaml",
+        """format: rulespec/v1
+rules:
+  - name: energy_efficient_home_improvement_credit
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+""",
+    )
+
+    report = build_policyengine_candidate_report(
+        tmp_path,
+        policyengine_variables={"energy_efficient_home_improvement_credit"},
+    )
+
+    item = report["items"][0]
+    assert item["legal_id"] == (
+        "us:statutes/26/25C#energy_efficient_home_improvement_credit"
+    )
+    assert item["policybench_output"] == "federal_tax_before_refundable_credits"
+    assert item["policybench_household_weight"] == pytest.approx(19.14)
+
+
 def test_policyengine_program_surface_report_overlays_legal_registry(tmp_path):
     manifest = tmp_path / "program_surfaces.yaml"
     manifest.write_text(
@@ -374,6 +500,95 @@ surfaces:
     assert items_by_variable["employee_payroll_tax"]["mapping_count"] == 1
     assert items_by_variable["employee_payroll_tax"]["comparable_mapping_count"] == 0
     assert items_by_variable["fdpir"]["axiom_status"] == "input_only"
+    assert (
+        items_by_variable["employee_payroll_tax"]["policybench_output"]
+        == "payroll_tax"
+    )
+    assert items_by_variable["employee_payroll_tax"][
+        "policybench_household_weight"
+    ] == pytest.approx(15.65)
+
+
+def test_policyengine_program_surface_report_sorts_actionable_by_policybench_weight(
+    tmp_path,
+):
+    manifest = tmp_path / "program_surfaces.yaml"
+    manifest.write_text(
+        """source:
+  repository: PolicyEngine/policyengine-us
+  ref: test
+  path: policyengine_us/programs.yaml
+surfaces:
+  - country: us
+    program_id: tanf
+    program_name: DC TANF
+    category: Benefits
+    policyengine_status: complete
+    coverage: DC
+    variable: dc_tanf
+    axiom_status: pending_rulespec_encoding
+    priority: P1
+    rationale: Needs RuleSpec encoding.
+  - country: us
+    program_id: medicare
+    program_name: Medicare
+    category: Healthcare
+    policyengine_status: complete
+    coverage: US
+    variable: is_medicare_eligible
+    axiom_status: pending_rulespec_encoding
+    priority: P1
+    rationale: Needs RuleSpec encoding.
+  - country: us
+    program_id: wic
+    program_name: WIC
+    category: Benefits
+    policyengine_status: complete
+    coverage: US
+    variable: wic
+    axiom_status: pending_rulespec_encoding
+    priority: P1
+    rationale: Needs RuleSpec encoding.
+  - country: us
+    program_id: montgomery_county_eitc
+    program_name: Montgomery County EITC
+    category: Taxes
+    policyengine_status: complete
+    coverage: Montgomery County
+    variable: md_montgomery_eitc_refundable
+    axiom_status: deferred_jurisdiction
+    priority: P1
+    rationale: Needs jurisdictional RuleSpec repo.
+""",
+        encoding="utf-8",
+    )
+
+    report = build_policyengine_program_surface_report(
+        manifest_path=manifest,
+        registry=_ProgramSurfaceRegistry({}),
+    )
+
+    assert report["policybench"]["snapshot"] == "2026-06-14"
+    assert [item["variable"] for item in report["actionable_surfaces"]] == [
+        "is_medicare_eligible",
+        "md_montgomery_eitc_refundable",
+        "wic",
+        "dc_tanf",
+    ]
+    assert [
+        item["policybench_household_weight"]
+        for item in report["actionable_surfaces"]
+    ] == [
+        pytest.approx(10.74),
+        pytest.approx(0.55),
+        pytest.approx(0.32),
+        pytest.approx(0.26),
+    ]
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    assert (
+        items_by_variable["md_montgomery_eitc_refundable"]["policybench_output"]
+        == "state_refundable_credits"
+    )
 
 
 def test_policyengine_program_surface_rejects_top_priority_sunset_surface(tmp_path):
@@ -519,6 +734,10 @@ def test_policyengine_program_surface_marks_section_25c_known_not_comparable():
         "us:statutes/26/25C#energy_efficient_home_improvement_credit"
         in section_25c["legal_ids"]
     )
+    assert section_25c["policybench_output"] == (
+        "federal_tax_before_refundable_credits"
+    )
+    assert section_25c["policybench_household_weight"] == pytest.approx(19.14)
     assert "2033 in-effect schedule" in section_25c["rationale"]
     assert "product-identification-number gate" in section_25c["rationale"]
 
@@ -6937,9 +7156,9 @@ rules:
         "us-co:statutes/39/39-22-104/4/z#retroactive_cares_act_subtraction"
     ]
     assert addition["policyengine_variable"] == "co_additions"
-    assert addition["candidate_priority"] == "P3"
+    assert addition["candidate_priority"] == "P4"
     assert subtraction["policyengine_variable"] == "co_subtractions"
-    assert subtraction["candidate_priority"] == "P3"
+    assert subtraction["candidate_priority"] == "P4"
 
 
 def test_policyengine_coverage_classifies_colorado_base_rates_not_comparable(
@@ -7364,6 +7583,7 @@ rules:
     )
     assert p5_addback["status"] == "known_not_comparable"
     assert p5_addback["policyengine_variable"] == "co_federal_deduction_addback"
+    assert p5_addback["candidate_priority"] == "P4"
     assert (
         p7_agi_threshold["policyengine_parameter"]
         == "gov.states.co.tax.income.additions.federal_deductions.agi_threshold"
@@ -7373,10 +7593,11 @@ rules:
         == "gov.states.co.tax.income.additions.federal_deductions.exemption"
     )
     assert p7_single_threshold["status"] == "known_not_comparable"
-    assert p7_single_threshold["candidate_priority"] == "P2"
+    assert p7_single_threshold["candidate_priority"] == "P4"
     assert p7_single_threshold["tested"] is True
     assert p7_addback["status"] == "known_not_comparable"
     assert p7_addback["policyengine_variable"] == "co_federal_deduction_addback"
+    assert p7_addback["candidate_priority"] == "P4"
     assert (
         charitable_floor["policyengine_parameter"]
         == "gov.states.co.tax.income.subtractions.charitable_contribution.adjustment"
@@ -7386,6 +7607,7 @@ rules:
         charitable_subtraction["policyengine_variable"]
         == "co_charitable_contribution_subtraction"
     )
+    assert charitable_subtraction["candidate_priority"] == "P4"
 
 
 def test_policyengine_coverage_classifies_colorado_military_retirement_outputs(
@@ -7973,7 +8195,7 @@ rules:
     assert (
         rate["policyengine_parameter"] == "gov.states.co.tax.income.credits.eitc.match"
     )
-    assert rate["candidate_priority"] == "P2"
+    assert rate["candidate_priority"] == "P4"
     assert regular_branch["policyengine_variable"] == "co_eitc"
     assert missing_ssn_branch["policyengine_variable"] == "co_eitc"
     assert refundable_excess["policyengine_variable"] is None

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -266,8 +266,7 @@ rules:
     assert report["duplicate_outputs_collapsed"] == 1
     item = report["items"][0]
     assert (
-        item["legal_id"]
-        == "us-co:statutes/39/example#co_state_tax_deduplicated_output"
+        item["legal_id"] == "us-co:statutes/39/example#co_state_tax_deduplicated_output"
     )
     assert item["file"] == "rulespec-us/us-co/statutes/39/example.yaml"
 
@@ -310,9 +309,10 @@ rules:
         "new_income_tax_exact_variable",
         "snap_new_exact_variable",
     ]
-    assert [
-        item["policybench_household_weight"] for item in report["items"][:2]
-    ] == [pytest.approx(19.14), pytest.approx(4.15)]
+    assert [item["policybench_household_weight"] for item in report["items"][:2]] == [
+        pytest.approx(19.14),
+        pytest.approx(4.15),
+    ]
 
 
 def test_policyengine_candidate_policybench_state_detection_ignores_is_prefix(
@@ -501,8 +501,7 @@ surfaces:
     assert items_by_variable["employee_payroll_tax"]["comparable_mapping_count"] == 0
     assert items_by_variable["fdpir"]["axiom_status"] == "input_only"
     assert (
-        items_by_variable["employee_payroll_tax"]["policybench_output"]
-        == "payroll_tax"
+        items_by_variable["employee_payroll_tax"]["policybench_output"] == "payroll_tax"
     )
     assert items_by_variable["employee_payroll_tax"][
         "policybench_household_weight"
@@ -576,8 +575,7 @@ surfaces:
         "dc_tanf",
     ]
     assert [
-        item["policybench_household_weight"]
-        for item in report["actionable_surfaces"]
+        item["policybench_household_weight"] for item in report["actionable_surfaces"]
     ] == [
         pytest.approx(10.74),
         pytest.approx(0.55),

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.841"
+version = "0.2.842"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.840"
+version = "0.2.841"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add PolicyBench household output weights to PolicyEngine oracle coverage/candidate prioritization
- surface weighted active pending PE program gaps
- map Illinois TANF earned income deduction outputs for the new RuleSpec encode
- bump axiom-encode to 0.2.841

## Checks
- uv run pytest tests/test_policyengine_coverage.py -q
- uv run pytest tests/test_cli.py -k "version_provenance or lock_version" -q
- uv run ruff check src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/cli.py tests/test_policyengine_coverage.py

Draft until this gets an independent review cycle per AGENTS.md.