### PR TITLE
Fix zero branch auto test repair

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.842"
+version = "0.2.843"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.842"
+__version__ = "0.2.843"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -16162,7 +16162,22 @@ def _zero_branch_numeric_upper_bound_input_overrides(
         return {}
     scalar_values = _local_scalar_formula_values_by_name(rules_payload)
     overrides: dict[str, int | float] = {}
+    target_formula = _local_formula_for_rule(
+        output_name=output_name,
+        rules_payload=rules_payload,
+    )
     for input_name in sorted(factual_inputs):
+        zero_branch_thresholds = _numeric_upper_bounds_returning_zero_for_input(
+            input_name,
+            formulas=[target_formula] if target_formula else [],
+            scalar_values=scalar_values,
+        )
+        if zero_branch_thresholds:
+            threshold, inclusive = zero_branch_thresholds[0]
+            overrides[f"{target_base}#input.{input_name}"] = _within_upper_bound_value(
+                threshold, inclusive=inclusive
+            )
+            continue
         thresholds = _numeric_upper_bounds_for_input(
             input_name,
             formulas=formulas,
@@ -16175,6 +16190,24 @@ def _zero_branch_numeric_upper_bound_input_overrides(
             threshold
         )
     return overrides
+
+
+def _local_formula_for_rule(
+    *,
+    output_name: str,
+    rules_payload: dict[str, object],
+) -> str | None:
+    rules = rules_payload.get("rules")
+    if not isinstance(rules, list):
+        return None
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("name") or "").strip() != output_name:
+            continue
+        formula = _first_rule_formula(rule)
+        return formula or None
+    return None
 
 
 def _reachable_local_formulas_for_rule(
@@ -16244,13 +16277,52 @@ def _numeric_upper_bounds_for_input(
     thresholds: list[float] = []
     for formula in formulas:
         for match in pattern.finditer(formula):
-            rhs = match["rhs"]
-            if re.fullmatch(r"-?\d+(?:\.\d+)?", rhs):
-                with contextlib.suppress(ValueError):
-                    thresholds.append(float(rhs))
-            elif rhs in scalar_values:
-                thresholds.append(scalar_values[rhs])
+            value = _numeric_formula_rhs_value(match["rhs"], scalar_values)
+            if value is not None:
+                thresholds.append(value)
     return thresholds
+
+
+def _numeric_upper_bounds_returning_zero_for_input(
+    input_name: str,
+    *,
+    formulas: list[str],
+    scalar_values: dict[str, float],
+) -> list[tuple[float, bool]]:
+    rhs_pattern = r"(?P<rhs>-?\d+(?:\.\d+)?|[A-Za-z_][A-Za-z0-9_]*)"
+    pattern = re.compile(
+        rf"\b{re.escape(input_name)}\b\s*(?P<op><=|<)\s*{rhs_pattern}\s*:"
+        r"\s*0(?:\.0+)?\b"
+    )
+    thresholds: list[tuple[float, bool]] = []
+    for formula in formulas:
+        for match in pattern.finditer(formula):
+            value = _numeric_formula_rhs_value(match["rhs"], scalar_values)
+            if value is not None:
+                thresholds.append((value, match["op"] == "<="))
+    return thresholds
+
+
+def _numeric_formula_rhs_value(
+    rhs: str,
+    scalar_values: dict[str, float],
+) -> float | None:
+    if re.fullmatch(r"-?\d+(?:\.\d+)?", rhs):
+        with contextlib.suppress(ValueError):
+            return float(rhs)
+    return scalar_values.get(rhs)
+
+
+def _within_upper_bound_value(
+    threshold: float,
+    *,
+    inclusive: bool,
+) -> int | float:
+    if inclusive:
+        return int(threshold) if threshold.is_integer() else threshold
+    if threshold.is_integer():
+        return int(threshold) - 1
+    return threshold - max(0.01, abs(threshold) * 0.01)
 
 
 def _above_upper_bound_value(threshold: float) -> int | float:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11252,6 +11252,64 @@ rules:
             "us:statutes/26/36B/b/3/A#applicable_percentage": 0
         }
 
+    def test_zero_branch_repair_uses_first_upper_bound_for_target_band_zero(
+        self, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us"
+        rules_file = (
+            tmp_path / "out" / "regulations" / "388" / "388-450" / "388-450-0170.yaml"
+        )
+        test_file = rules_file.with_name("388-450-0170.test.yaml")
+        rules_file.parent.mkdir(parents=True)
+        repo.mkdir()
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: dependent_care_hours_band
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if hours_worked_per_month <= dependent_care_band_0_upper_hours: 0 else: if hours_worked_per_month <= dependent_care_band_1_upper_hours: 1 else: 2
+  - name: dependent_care_band_0_upper_hours
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '40'
+  - name: dependent_care_band_1_upper_hours
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '80'
+"""
+        )
+        test_file.write_text("[]\n")
+
+        repaired = _append_generated_zero_branch_tests_if_missing(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=repo,
+            relative_output=Path("regulations/388/388-450/388-450-0170.yaml"),
+            issues=[
+                "Zero branch test coverage missing: `dependent_care_hours_band` "
+                "has a formula branch that returns 0."
+            ],
+        )
+
+        assert repaired == ["auto_zero_dependent_care_hours_band"]
+        cases = yaml.safe_load(test_file.read_text())
+        assert cases[0]["input"] == {
+            "us:regulations/388/388-450/388-450-0170#input.hours_worked_per_month": 40
+        }
+        assert cases[0]["output"] == {
+            "us:regulations/388/388-450/388-450-0170#dependent_care_hours_band": 0
+        }
+
     def test_repair_zero_branch_tests_derives_hidden_zero_issues(
         self, capsys, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.842"
+version = "0.2.843"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- make zero-branch auto test repair prefer target-rule upper-bound branches that return zero
- keep the existing above-max-threshold behavior for downstream band selectors
- bump axiom-encode to 0.2.843 so RuleSpec toolchains can pin the fix

## Tests
- uv run pytest tests/test_cli.py -k 'zero_branch_repair_uses_upper_bound_input_for_band_selector or zero_branch_repair_uses_first_upper_bound_for_target_band_zero or repair_zero_branch_tests_derives_hidden_zero_issues'
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/