### PR TITLE
Retry missing relation repair after input repairs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.844"
+version = "0.2.845"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.844"
+__version__ = "0.2.845"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -21065,6 +21065,38 @@ def cmd_encode(args):
                         repaired_input_cases
                     )
             if not can_apply:
+                repaired_missing_relations = (
+                    _try_repair_generated_missing_data_relations_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_missing_relations:
+                    prior_repairs = outcome.get("auto_repaired_missing_data_relations")
+                    if not isinstance(prior_repairs, list):
+                        prior_repairs = []
+                    outcome["auto_repaired_missing_data_relations"] = [
+                        *prior_repairs,
+                        *repaired_missing_relations,
+                    ]
+                    print(
+                        "  apply=auto_repaired_missing_data_relations:"
+                        + ",".join(repaired_missing_relations)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_invalid_input_refs = list(
                     outcome.get("auto_repaired_invalid_test_inputs") or []
                 )
@@ -21147,6 +21179,38 @@ def cmd_encode(args):
                             "  apply=auto_repaired_scalar_relation_rows:"
                             + ",".join(repaired_batch)
                         )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
+                repaired_missing_relations = (
+                    _try_repair_generated_missing_data_relations_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_missing_relations:
+                    prior_repairs = outcome.get("auto_repaired_missing_data_relations")
+                    if not isinstance(prior_repairs, list):
+                        prior_repairs = []
+                    outcome["auto_repaired_missing_data_relations"] = [
+                        *prior_repairs,
+                        *repaired_missing_relations,
+                    ]
+                    print(
+                        "  apply=auto_repaired_missing_data_relations:"
+                        + ",".join(repaired_missing_relations)
+                    )
                     can_apply, apply_issues, supplemental_files = (
                         _validate_generated_encoding_in_policy_overlay(
                             result,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.844"
+version = "0.2.845"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- rerun the generated missing data_relation repair after test input assignment repairs
- also rerun it after the combined scalar relation row / test input repair loop
- bump axiom-encode to 0.2.845

## Why
The Washington TANF WAC 388-450-0170 encode produced relation tests only after auto_repaired_test_input_assignments. The earlier missing-relation repair had already run, so apply still blocked on an undeclared relation.

## Validation
- uv run pytest tests/test_cli.py -k 'repair_missing_data_relation_from_generated_aggregate or repair_scalar_relation_rows_from_generated_formula or repair_scalar_relation_rows_from_companion_tests or encode_apply_repeats_scalar_relation_row_repair or zero_branch_repair_uses_first_upper_bound_for_target_band_zero or zero_branch_repair_uses_upper_bound_input_for_band_selector'
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/