### PR TITLE
Preserve proof for repaired table bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.845"
+version = "0.2.846"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.845"
+__version__ = "0.2.846"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -16,6 +16,7 @@ Uses Claude Code CLI (subprocess) for reviewer agents - cheaper than direct API.
 
 import ast
 import contextlib
+import copy
 import functools
 import hashlib
 import json
@@ -4505,6 +4506,13 @@ def _upsert_source_table_bound_values_rule(
         }
         if sample_rule.get("source") is not None:
             target_rule["source"] = sample_rule["source"]
+        metadata = _source_table_bound_values_metadata(
+            selector_rule=selector_rule,
+            source_rules=source_rules,
+            sample_rule=sample_rule,
+        )
+        if metadata:
+            target_rule["metadata"] = metadata
         with contextlib.suppress(ValueError):
             rules.insert(rules.index(selector_rule), target_rule)
             return
@@ -4516,6 +4524,20 @@ def _upsert_source_table_bound_values_rule(
     target_rule.setdefault("dtype", sample_rule.get("dtype") or "Decimal")
     target_rule["indexed_by"] = selector_name
     target_rule.setdefault("source", sample_rule.get("source"))
+    metadata = _source_table_bound_values_metadata(
+        selector_rule=selector_rule,
+        source_rules=source_rules,
+        sample_rule=sample_rule,
+    )
+    if metadata and not _rule_has_source_proof(target_rule):
+        existing_metadata = target_rule.get("metadata")
+        if isinstance(existing_metadata, dict):
+            target_rule["metadata"] = {
+                **existing_metadata,
+                "proof": metadata["proof"],
+            }
+        else:
+            target_rule["metadata"] = metadata
     versions = target_rule.get("versions")
     if not isinstance(versions, list) or not versions:
         target_rule["versions"] = [
@@ -4543,6 +4565,59 @@ def _upsert_source_table_bound_values_rule(
         or "1900-01-01",
     )
     first_version["values"] = sorted_values
+
+
+def _source_table_bound_values_metadata(
+    *,
+    selector_rule: dict[str, Any],
+    source_rules: list[dict[str, Any]],
+    sample_rule: dict[str, Any],
+) -> dict[str, Any]:
+    source = _source_table_bound_values_proof_source(
+        [selector_rule, *source_rules],
+    )
+    if source is None:
+        raw_source = sample_rule.get("source") or selector_rule.get("source")
+        if raw_source is not None:
+            source = {"excerpt": str(raw_source)}
+    if source is None:
+        return {}
+    return {
+        "proof": {
+            "atoms": [
+                {
+                    "path": "versions[0].values",
+                    "kind": "parameter_table",
+                    "source": source,
+                }
+            ]
+        }
+    }
+
+
+def _source_table_bound_values_proof_source(
+    rules: list[dict[str, Any]],
+) -> dict[str, Any] | None:
+    for rule in rules:
+        metadata = rule.get("metadata")
+        proof = metadata.get("proof") if isinstance(metadata, dict) else None
+        atoms = proof.get("atoms") if isinstance(proof, dict) else None
+        if not isinstance(atoms, list):
+            continue
+        for atom in atoms:
+            if not isinstance(atom, dict):
+                continue
+            source = atom.get("source")
+            if not isinstance(source, dict):
+                continue
+            if not (
+                source.get("corpus_citation_path")
+                or source.get("corpus_citation_paths")
+                or source.get("excerpt")
+            ):
+                continue
+            return copy.deepcopy(source)
+    return None
 
 
 def _single_version_effective_from(rule: dict[str, Any]) -> str | None:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -13249,6 +13249,94 @@ rules:
     assert find_source_table_row_scalar_parameter_issues(repaired) == []
 
 
+def test_repair_source_table_band_bound_scalars_adds_proof_to_bound_table():
+    content = """format: rulespec/v1
+module:
+  summary: |-
+    Dependent Care Maximum Deductions | Hours Worked Per Month | Child Under Two Years of Age
+    | 0 to 40 | $50 |
+    | 41 to 80 | $100 |
+    | 81 to 120 | $150 |
+    | 121 or more | $200 |
+rules:
+  - name: dependent_care_hours_band_0_upper_bound
+    kind: parameter
+    dtype: Decimal
+    source: us-wa/regulation/388/388-450/388-450-0170(a)
+    versions:
+      - effective_from: '2019-12-01'
+        formula: 40
+  - name: dependent_care_hours_band_1_upper_bound
+    kind: parameter
+    dtype: Decimal
+    source: us-wa/regulation/388/388-450/388-450-0170(a)
+    versions:
+      - effective_from: '2019-12-01'
+        formula: 80
+  - name: dependent_care_hours_band_2_upper_bound
+    kind: parameter
+    dtype: Decimal
+    source: us-wa/regulation/388/388-450/388-450-0170(a)
+    versions:
+      - effective_from: '2019-12-01'
+        formula: 120
+  - name: dependent_care_hours_band
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Month
+    source: us-wa/regulation/388/388-450/388-450-0170(a)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter_table
+            source:
+              corpus_citation_path: us-wa/regulation/388/388-450/388-450-0170
+              table:
+                header: Dependent Care Maximum Deductions Hours Worked Per Month
+                row_key: hours_worked_per_month
+                column_key: dependent_care_maximum_deduction
+    versions:
+      - effective_from: '2019-12-01'
+        formula: |-
+          if dependent_care_recipient_hours_worked_per_month <= dependent_care_hours_band_0_upper_bound:
+            0
+          else: if dependent_care_recipient_hours_worked_per_month <= dependent_care_hours_band_1_upper_bound:
+            1
+          else: if dependent_care_recipient_hours_worked_per_month <= dependent_care_hours_band_2_upper_bound:
+            2
+          else:
+            3
+"""
+
+    repaired, repaired_rules = repair_source_table_band_scalar_parameters(content)
+
+    payload = yaml.safe_load(repaired)
+    upper_bound = next(
+        rule
+        for rule in payload["rules"]
+        if rule["name"] == "dependent_care_hours_band_upper_bound"
+    )
+    assert upper_bound["versions"][0]["values"] == {0: 40, 1: 80, 2: 120}
+    assert upper_bound["metadata"]["proof"]["atoms"] == [
+        {
+            "path": "versions[0].values",
+            "kind": "parameter_table",
+            "source": {
+                "corpus_citation_path": "us-wa/regulation/388/388-450/388-450-0170",
+                "table": {
+                    "header": "Dependent Care Maximum Deductions Hours Worked Per Month",
+                    "row_key": "hours_worked_per_month",
+                    "column_key": "dependent_care_maximum_deduction",
+                },
+            },
+        }
+    ]
+    assert "dependent_care_hours_band_upper_bound" in repaired_rules
+    assert find_source_table_row_scalar_parameter_issues(repaired) == []
+
+
 def test_repair_source_table_band_bound_scalars_uses_external_table_text():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.845"
+version = "0.2.846"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- preserve proof metadata when source-table scalar bound parameters are migrated into indexed bound tables
- attach a versions[0].values parameter_table proof atom to generated bound tables
- add a WA-shaped regression test for dependent care hours bands and bump axiom-encode to 0.2.846

## Why
A Washington TANF encode blocked after auto_repaired_source_table_band_scalars because the generated dependent_care_hours_band_upper_bound parameter lacked metadata.proof.atoms.

## Validation
- uv run pytest tests/test_rulespec_validation.py -k 'repair_source_table_band_bound_scalars_adds_proof_to_bound_table or repair_source_table_band_bound_scalars_preserves_adjacent_upper_aliases'
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/