### PR TITLE
Fix local tax PolicyBench surface weights

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.850"
+version = "0.2.851"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.850"
+__version__ = "0.2.851"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -1108,6 +1108,13 @@ def _policybench_output_for_program_surface(
         return "federal_refundable_credits"
     if "refundable" in variable:
         return "state_refundable_credits"
+    if category.lower() == "taxes" and _is_local_tax_program_surface(
+        coverage=str(payload.get("coverage") or ""),
+        program_id=program_id,
+        program_name=program_name,
+        variable=variable,
+    ):
+        return "local_income_tax"
     lowered_legal_ids = tuple(legal_id.lower() for legal_id in legal_ids)
     if any(legal_id.startswith("us:statutes/26/") for legal_id in lowered_legal_ids):
         text = " ".join(
@@ -1243,6 +1250,37 @@ def _is_state_tax_candidate(legal_id: str, text: str) -> bool:
         re.match(r"^us-[a-z]{2}:", legal_id)
         or ".states." in text
         or _US_STATE_VARIABLE_PREFIX_RE.search(text)
+    )
+
+
+def _is_local_tax_program_surface(
+    *,
+    coverage: str,
+    program_id: str,
+    program_name: str,
+    variable: str,
+) -> bool:
+    normalized_coverage = coverage.strip().lower()
+    if not normalized_coverage:
+        return False
+    if normalized_coverage in {"us", "u.s.", "united states", "national"}:
+        return False
+    if normalized_coverage in _US_STATE_CODES:
+        return False
+    text = " ".join((normalized_coverage, program_id, program_name, variable)).lower()
+    return bool(
+        re.match(r"^(sf|nyc)_", variable)
+        or any(
+            token in text
+            for token in (
+                "city",
+                "county",
+                "local",
+                "municipal",
+                "san francisco",
+                "new york city",
+            )
+        )
     )
 
 

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -589,6 +589,38 @@ surfaces:
     )
 
 
+def test_policyengine_program_surface_local_tax_credit_uses_local_weight(tmp_path):
+    manifest = tmp_path / "program_surfaces.yaml"
+    manifest.write_text(
+        """source:
+  repository: PolicyEngine/policyengine-us
+  ref: test
+  path: policyengine_us/programs.yaml
+surfaces:
+  - country: us
+    program_id: sf_wftc
+    program_name: San Francisco WFTC
+    category: Taxes
+    policyengine_status: complete
+    coverage: San Francisco
+    variable: sf_wftc
+    axiom_status: deferred_jurisdiction
+    priority: P2
+    rationale: Needs jurisdictional RuleSpec repo.
+""",
+        encoding="utf-8",
+    )
+
+    report = build_policyengine_program_surface_report(
+        manifest_path=manifest,
+        registry=_ProgramSurfaceRegistry({}),
+    )
+
+    item = report["items"][0]
+    assert item["policybench_output"] == "local_income_tax"
+    assert item["policybench_household_weight"] == pytest.approx(0.26)
+
+
 def test_policyengine_program_surface_rejects_top_priority_sunset_surface(tmp_path):
     manifest = tmp_path / "program_surfaces.yaml"
     manifest.write_text(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.850"
+version = "0.2.851"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Classifies local tax program surfaces, such as San Francisco WFTC, as `local_income_tax` for PolicyBench household weighting instead of falling through to the broad federal tax bucket.
- Adds a regression test covering `sf_wftc`.
- Bumps `axiom-encode` to `0.2.851`.

## Validation
- `uv run pytest -q tests/test_policyengine_coverage.py tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `uv run ruff check .`
