### PR TITLE
Classify Wyoming POWER PE oracle surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.851"
+version = "0.2.852"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.851"
+__version__ = "0.2.852"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -17672,6 +17672,14 @@ prefixes:
     candidate_priority: P4
     rationale: Colorado Works basic-cash-assistance composition outputs are Axiom assembly points across encoded 9 CCR 2503-6 Section 3.606.1 and 3.606.2 provisions. PolicyEngine-US does not expose this exact composed monthly TANF legal slice one-to-one; direct oracle comparison should wait for an adapter that targets the same Colorado Works source boundaries and updated grant parameters.
 
+  - legal_id_prefix: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: wy_power
+    candidate_priority: P4
+    rationale: Wyoming POWER payment-test outputs decompose DFS manual section 1101 earned-income disregards, deeming, maximum-benefit-level testing, performance-payment calculation, and child-support termination predicates. PolicyEngine-US exposes wy_power as a final benefit surface built from its own TANF graph and parameter table, not these source-specific POWER legal helper boundaries one-to-one.
+
   - legal_id_prefix: us-co:policies/cdhs/snap/
     country: us
     program: snap

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -875,10 +875,13 @@ surfaces:
   variable: wy_power
   source_type: state_implementation
   state: WY
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Current RuleSpec repos include tested Wyoming POWER payment-test legal slices for earned-income disregards,
+    deeming, maximum-benefit-level testing, performance-payment calculation, and child-support termination. Those outputs
+    are source-specific DFS manual boundaries, while PolicyEngine's wy_power is a final benefit surface built from PE's
+    TANF graph and parameter table; do not treat it as a direct one-to-one oracle target until Axiom has an equivalent
+    final Wyoming POWER benefit surface or PE exposes compatible helper boundaries.
 - country: us
   program_id: ccdf
   program_name: CCAP

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1074,6 +1074,58 @@ def test_policyengine_program_surface_marks_georgia_tanf_known_not_comparable():
     assert "final monthly TANF benefit variable" in georgia_tanf["rationale"]
 
 
+def test_policyengine_program_surface_marks_wyoming_power_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    wyoming_power = items_by_variable["wy_power"]
+
+    assert wyoming_power["program_id"] == "tanf"
+    assert wyoming_power["state"] == "WY"
+    assert wyoming_power["axiom_status"] == "known_not_comparable"
+    assert wyoming_power["mapping_count"] == 1
+    assert wyoming_power["comparable_mapping_count"] == 0
+    assert wyoming_power["legal_ids"] == [
+        "us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#"
+    ]
+    assert "Wyoming POWER payment-test legal slices" in wyoming_power["rationale"]
+    assert "final benefit surface" in wyoming_power["rationale"]
+
+
+def test_policyengine_coverage_classifies_wyoming_power_payment_helpers(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-wy/policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations.yaml",
+        """format: rulespec/v1
+rules:
+  - name: power_performance_payment_amount
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: maximum_benefit_level - countable_income
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path)
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == (
+        "us-wy:policies/dfs/snap-power-policy-manual/"
+        "1101-power-payment-tests-computations#power_performance_payment_amount"
+    )
+    assert item["status"] == "known_not_comparable"
+    assert item["program"] == "tanf"
+    assert item["mapping_type"] == "not_comparable"
+    assert item["policyengine_variable"] == "wy_power"
+    assert item["candidate_priority"] == "P4"
+    assert "source-specific POWER legal helper boundaries" in item["rationale"]
+
+
 def test_policyengine_coverage_classifies_federal_ssi_benefit_rate_intermediates(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.851"
+version = "0.2.852"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Wyoming POWER section 1101 RuleSpec outputs as source-specific non-comparable PE oracle surfaces adjacent to wy_power
- mark the Wyoming POWER program surface known_not_comparable while preserving the PolicyBench TANF weight
- add regression coverage for the program-surface manifest and output-level oracle classification

## Validation
- uv run python -m pytest -q tests/test_policyengine_coverage.py -k "wyoming_power or georgia_tanf or program_surface"
- uv run python -m pytest -q tests/test_policyengine_coverage.py
- uv run python -m pytest -q tests/test_rulespec_validation.py -k policyengine_registry
- uv run axiom-encode oracle-coverage --root /tmp/axiom-pe-parity-root-wy-20260626 --include-program-surfaces --json