### PR TITLE
Map Indiana TANF outputs to PE registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.854"
+version = "0.2.855"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.854"
+__version__ = "0.2.855"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -31,7 +31,7 @@ from calendar import monthrange
 from collections import Counter, defaultdict
 from dataclasses import asdict, is_dataclass
 from datetime import date, datetime, timezone
-from decimal import Decimal, InvalidOperation
+from decimal import Decimal, InvalidOperation, localcontext
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, NamedTuple
@@ -15583,9 +15583,21 @@ def _scalar_formula_value(formula: object) -> int | float | str | bool | None:
         denominator = int(fraction_match.group(2))
         if denominator == 0:
             return None
+        if not _fraction_has_terminating_decimal(denominator):
+            with localcontext() as context:
+                context.prec = 28
+                return format(Decimal(numerator) / Decimal(denominator), "f")
         return numerator / denominator
     parsed = yaml.safe_load(stripped)
     return parsed if isinstance(parsed, (int, float)) else None
+
+
+def _fraction_has_terminating_decimal(denominator: int) -> bool:
+    remaining = abs(denominator)
+    for prime in (2, 5):
+        while remaining and remaining % prime == 0:
+            remaining //= prime
+    return remaining == 1
 
 
 def _rulespec_companion_test_failures(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -20287,6 +20287,12 @@ class ValidatorPipeline:
             expected_judgment = expected_value.strip().lower().replace("-", "_")
             if expected_judgment in {"holds", "not_holds"}:
                 expected_value = expected_judgment == "holds"
+        if actual_scalar.get("kind") in {"integer", "decimal"} and isinstance(
+            expected_value, str
+        ):
+            expected_numeric_text = expected_value.strip()
+            if re.fullmatch(r"-?(?:\d+(?:\.\d*)?|\.\d+)", expected_numeric_text):
+                expected_value = Decimal(expected_numeric_text)
         expected_scalar = self._rulespec_expected_scalar_value(expected_value)
         if not self._rulespec_scalar_values_equal(actual_scalar, expected_scalar):
             return (

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2685,6 +2685,154 @@ mappings:
     comparison: rate
     rationale: Same Arizona TANF base income-limit rate for parent or non-parent caretaker relative self-and-child cases.
 
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_thirty_dollar_earned_income_disregard
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.in.fssa.tanf.income.deductions.eligibility.flat_disregard.amount
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Indiana TANF $30 earned-income disregard amount used in the $30 and 1/3 eligibility deduction.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_one_third_earned_income_disregard_rate
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.in.fssa.tanf.income.deductions.eligibility.earned_income_disregard.rate
+    period: month
+    comparison: rate
+    rationale: Same Indiana TANF one-third earned-income disregard rate used in eligibility countable-income calculations.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_gross_earned_income_disregard_rate
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.in.fssa.tanf.income.deductions.benefit.earned_income_disregard.rate
+    period: month
+    comparison: rate
+    rationale: Same Indiana TANF 75% earned-income disregard rate used when calculating the benefit amount.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_gross_earned_income_applied_rate
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.in.fssa.tanf.income.deductions.benefit.earned_income_disregard.rate
+    candidate_priority: P4
+    rationale: Axiom exposes the applied 25% complement of the statutory 75% earned-income disregard as a source-local helper. PolicyEngine stores the disregard rate itself, not this complementary helper.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_benefit_total_grant_amount_for_participating_ag_members
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: in_tanf_maximum_benefit
+    candidate_priority: P4
+    rationale: Axiom selects the manual's participating-AG grant amount from the 3050.10 source tables and composition-type inputs. PolicyEngine's adjacent in_tanf_maximum_benefit is keyed by SPM-unit size and includes PE's current parameterization, so this legal helper is not a one-to-one oracle target.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_nonexempt_gross_income_for_benefit_calculation
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: in_tanf_countable_income_for_payment
+    candidate_priority: P4
+    rationale: Axiom exposes the pre-deduction sum of non-exempt earned, unearned, and deemed income for the Indiana manual's benefit-calculation section. PolicyEngine exposes the post-disregard payment-countable income aggregate, not this source-local gross-income boundary.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_thirty_and_one_third_earned_income_disregard
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: in_tanf_countable_income_for_eligibility
+    candidate_priority: P4
+    rationale: Axiom exposes the manual's standalone $30 and one-third earned-income disregard amount. PolicyEngine applies the same parameters inside its eligibility countable-income formula but does not expose this deduction amount separately.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_applicable_earned_income_deductions
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: in_tanf_countable_income_for_eligibility
+    candidate_priority: P4
+    rationale: Axiom exposes the source-local sum of work-expense, $30 and one-third, and incapacitated-adult-care deductions. PolicyEngine's adjacent countable-income formula does not expose this combined deduction boundary.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_net_countable_income_for_benefit_calculation
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: in_tanf_countable_income_for_eligibility
+    candidate_priority: P4
+    rationale: Axiom exposes the manual's adjusted net countable income after earned-income deductions for benefit-calculation tests. PolicyEngine has adjacent eligibility and payment countable-income variables with PE-specific helper boundaries, so this source-local amount is not a direct oracle target.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_financially_eligible_for_benefit_calculation
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: in_tanf_income_eligible
+    candidate_priority: P4
+    rationale: Axiom exposes only the 3450.35.05 adjusted-net-income-below-grant condition for new applications. PolicyEngine's Indiana TANF income eligibility combines initial and continuing branches with gross-income and PE graph inputs.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_gross_earned_income_disregarded_for_benefit
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: in_tanf_countable_earned_income
+    candidate_priority: P4
+    rationale: Axiom exposes the disregarded 75% of gross earned income as a standalone legal helper. PolicyEngine exposes the remaining countable earned income aggregate, not the disregarded amount.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_gross_earned_income_applied_for_benefit
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: in_tanf_countable_earned_income
+    candidate_priority: P4
+    rationale: Axiom exposes the source-local 25% applied earned-income amount before adding unearned and deemed income. PolicyEngine's adjacent in_tanf_countable_earned_income aggregates over PE SPM-unit members and is not this legal helper boundary.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_countable_income_for_benefit_amount
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: in_tanf_countable_income_for_payment
+    candidate_priority: P4
+    rationale: Axiom combines the applied 25% earned income with non-exempt unearned and deemed income for the manual's benefit amount. PolicyEngine's payment countable income is adjacent but does not expose the same source-local deemed-income boundary.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_monthly_benefit_entitlement
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: in_tanf
+    candidate_priority: P4
+    rationale: Axiom's 3450.35.05 output is the source-local new-application benefit entitlement after the manual's adjusted-net-income test and 75% earned-income disregard. PolicyEngine's in_tanf is a final PE SPM-unit benefit gated by its broader eligibility graph, so compare legal components separately.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_minimum_grant_with_earned_income
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: in_tanf
+    candidate_priority: P4
+    rationale: Axiom exposes the manual's $10 ongoing minimum grant when earned income is the sole factor and no sanctions, voluntary quit, or fiscal penalties apply. PolicyEngine's Indiana TANF final benefit does not expose this minimum-grant rule as a separate parameter or output.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_countable_income_below_100_percent_fpl
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: in_tanf_countable_income_eligible
+    candidate_priority: P4
+    rationale: Axiom exposes only the ongoing 100% FPG countable-income condition from 3450.35.05. PolicyEngine's in_tanf_countable_income_eligible combines initial and continuing branches and PE-specific income helpers.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_adjusted_net_income_equals_or_exceeds_adjusted_needs
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: in_tanf_payment_eligible
+    candidate_priority: P4
+    rationale: Axiom exposes the manual's adjusted-net-income-equals-or-exceeds-adjusted-needs predicate, which triggers the $10 or $0 ongoing grant branch. PolicyEngine's adjacent payment eligibility is a strict countable-income-below-maximum-benefit predicate and does not expose this branch condition.
+
+  - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_monthly_benefit_entitlement
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: in_tanf
+    candidate_priority: P4
+    rationale: Axiom's ongoing benefit entitlement captures the manual's 100% FPG screen plus the $10 minimum-grant and $0 grant branches. PolicyEngine's in_tanf computes a final PE SPM-unit benefit with a strict payment-eligibility gate, so this is adjacent rather than a one-to-one oracle target.
+
   - legal_id: us-wa:regulations/388/388-478/388-478-0020#cash_assistance_payment_standard_size_floor_for_final_row
     country: us
     program: tanf

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26433,6 +26433,12 @@ rules:
     versions:
       - effective_from: '1974-01-01'
         formula: '1 / 2'
+  - name: earned_income_one_third_exclusion_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '1974-01-01'
+        formula: '1 / 3'
 """
         )
         test_file.write_text(
@@ -26455,6 +26461,8 @@ rules:
                     == "us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_initial_phase"
                     or legal_id
                     == "us-co:statutes/39/39-22-104/4/y#earned_income_remainder_exclusion_rate"
+                    or legal_id
+                    == "us-co:statutes/39/39-22-104/4/y#earned_income_one_third_exclusion_rate"
                 ):
                     return SimpleNamespace(mapping_type="parameter_value")
                 return None
@@ -26489,7 +26497,7 @@ rules:
             cmd_repair_oracle_parameter_tests(args)
 
         payload = yaml.safe_load(test_file.read_text())
-        added = payload[-2]
+        added = payload[-3]
         assert (
             added["name"]
             == "oracle_parameter_military_retirement_benefits_cap_initial_phase"
@@ -26498,7 +26506,7 @@ rules:
         assert added["output"] == {
             "us-co:statutes/39/39-22-104/4/y#military_retirement_benefits_cap_initial_phase": 4500
         }
-        fraction_added = payload[-1]
+        fraction_added = payload[-2]
         assert (
             fraction_added["name"]
             == "oracle_parameter_earned_income_remainder_exclusion_rate"
@@ -26506,6 +26514,15 @@ rules:
         assert fraction_added["input"] == {}
         assert fraction_added["output"] == {
             "us-co:statutes/39/39-22-104/4/y#earned_income_remainder_exclusion_rate": 0.5
+        }
+        nonterminating_fraction_added = payload[-1]
+        assert (
+            nonterminating_fraction_added["name"]
+            == "oracle_parameter_earned_income_one_third_exclusion_rate"
+        )
+        assert nonterminating_fraction_added["input"] == {}
+        assert nonterminating_fraction_added["output"] == {
+            "us-co:statutes/39/39-22-104/4/y#earned_income_one_third_exclusion_rate": "0.3333333333333333333333333333"
         }
 
     def test_repair_oracle_parameter_tests_does_not_mutate_without_signing_key(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -132,6 +132,30 @@ def test_rulespec_numeric_output_comparison_tolerates_decimal_residue(tmp_path):
     )
 
 
+def test_rulespec_numeric_output_comparison_accepts_quoted_decimal(tmp_path):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path / "rulespec-us",
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    assert (
+        pipeline._compare_rulespec_output(
+            case_name="one_third",
+            output_name="rate",
+            expected_value="0.3333333333333333333333333333",
+            actual_output={
+                "kind": "scalar",
+                "value": {
+                    "kind": "decimal",
+                    "value": Decimal("0.3333333333333333333333333333"),
+                },
+            },
+        )
+        is None
+    )
+
+
 def test_rulespec_compile_env_exposes_policy_repo_roots(monkeypatch, tmp_path):
     repo_parent = tmp_path / "repos"
     policy_repo = repo_parent / "rulespec-us-ny"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.854"
+version = "0.2.855"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map new Indiana TANF RuleSpec outputs to the PolicyEngine oracle registry
- classify source-local Indiana TANF benefit-calculation helpers as adjacent/not comparable where PE exposes different helper boundaries
- bump axiom-encode to 0.2.855 and preserve non-terminating fraction precision in generated oracle parameter tests

## Validation
- uv run --extra dev pytest -q tests/test_policyengine_coverage.py tests/test_cli.py::TestApplyDependencyValidation::test_repair_oracle_parameter_tests_appends_scalar_parameter_case tests/test_rulespec_validation.py::test_rulespec_numeric_output_comparison_accepts_quoted_decimal
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/in-tanf-final-benefit-20260626 --oracle policyengine --include-program-surfaces --program tanf --json
- uv run axiom-encode oracle-candidates --root /Users/maxghenis/TheAxiomFoundation/_worktrees/in-tanf-final-benefit-20260626 --oracle policyengine --program tanf --json

## Follow-up
After this lands, refresh rulespec-us PR #457 with the merged 0.2.855 toolchain so its generated Indiana TANF oracle parameter tests run in CI.
