### PR TITLE
Fix plural generated input defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.855"
+version = "0.2.856"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.855"
+__version__ = "0.2.856"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -32748,11 +32748,15 @@ def _factual_input_appears_numeric(
         "value",
         "count",
         "cost",
+        "costs",
         "need",
         "needs",
         "expense",
+        "expenses",
         "deduction",
+        "deductions",
         "credit",
+        "credits",
         "tax",
         "gross",
         "net",
@@ -36274,6 +36278,8 @@ def _default_refs_for_missing_input(
 
 def _infer_missing_input_default(input_name: str) -> object:
     normalized = input_name.lower()
+    if _factual_input_name_looks_boolean(input_name):
+        return False
     if "contribution_and_benefit_base" in normalized:
         return 999999999
     tokens = set(re.split(r"[^a-z0-9]+", normalized))
@@ -36284,8 +36290,11 @@ def _infer_missing_input_default(input_name: str) -> object:
         "cost",
         "costs",
         "credit",
+        "credits",
         "deduction",
+        "deductions",
         "expense",
+        "expenses",
         "gross",
         "hour",
         "hours",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16103,6 +16103,56 @@ rules:
 
         assert value == 0
 
+    @pytest.mark.parametrize(
+        ("input_name", "formula"),
+        [
+            (
+                "eligible_childcare_costs",
+                "max(0, eligible_childcare_costs)",
+            ),
+            (
+                "incapacitated_adult_care_expenses",
+                (
+                    "monthly_work_expense_disregard_amount "
+                    "+ max(0, incapacitated_adult_care_expenses)"
+                ),
+            ),
+            (
+                "above_the_line_deductions",
+                "max(0, gross_income - above_the_line_deductions)",
+            ),
+            (
+                "income_tax_refundable_credits",
+                (
+                    "max(0, tax_before_refundable_credits "
+                    "- income_tax_refundable_credits)"
+                ),
+            ),
+        ],
+    )
+    def test_generated_test_input_defaults_treat_plural_numeric_markers_as_money(
+        self,
+        input_name,
+        formula,
+    ):
+        rules_payload = {
+            "rules": [
+                {
+                    "name": "derived_money_amount",
+                    "kind": "derived",
+                    "dtype": "Money",
+                    "versions": [{"formula": formula}],
+                }
+            ]
+        }
+
+        value = _default_generated_test_input_value(
+            input_name,
+            rules_payload=rules_payload,
+        )
+
+        assert value == 0
+
     def test_generated_test_input_defaults_treat_month_counts_as_numeric(self):
         rules_payload = {
             "rules": [
@@ -25631,11 +25681,39 @@ rules:
             == 999999999
         )
 
+    @pytest.mark.parametrize(
+        "input_name",
+        [
+            "eligible_childcare_costs",
+            "incapacitated_adult_care_expenses",
+            "above_the_line_deductions",
+            "income_tax_refundable_credits",
+        ],
+    )
+    def test_missing_input_default_treats_plural_numeric_markers_as_numeric(
+        self, input_name
+    ):
+        assert _infer_missing_input_default(input_name) == 0
+
     def test_missing_input_default_does_not_treat_taxpayer_as_tax_numeric(self):
         assert (
             _infer_missing_input_default("is_dependent_under_section_152_of_taxpayer")
             is False
         )
+
+    @pytest.mark.parametrize(
+        "input_name",
+        [
+            "household_has_childcare_costs",
+            "household_has_out_of_pocket_dependent_care_expenses",
+            "taxpayer_has_above_the_line_deductions",
+            "filer_has_refundable_credits",
+        ],
+    )
+    def test_missing_input_default_preserves_boolean_plural_marker_names(
+        self, input_name
+    ):
+        assert _infer_missing_input_default(input_name) is False
 
     def test_repair_imported_proof_hashes_writes_target_file_hash(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.855"
+version = "0.2.856"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Treat plural numeric markers (`costs`, `expenses`, `deductions`, `credits`) as numeric in generated and missing-input default repair paths.
- Preserve boolean-name precedence for lower-level missing-input repair defaults.
- Bump axiom-encode to 0.2.856.

## Checks
- `uv run --extra dev pytest -q tests/test_cli.py -k 'generated_test_input_defaults or missing_input_default'` (20 passed)\n- `uv run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py`\n- `uv run --extra dev ruff format --check src/axiom_encode/cli.py tests/test_cli.py`\n- `uv run python -m compileall -q src/axiom_encode`\n\n## Review Cycle\n- Independent read-only review found missing `credits` coverage in `_infer_missing_input_default`; fixed.\n- Follow-up review found missing generated-default coverage for plural `credits`; fixed.\n- Follow-up review found missing coverage for plural `costs` and `deductions`; fixed.\n- Follow-up review found missing boolean precedence in `_infer_missing_input_default`; fixed.\n- Final read-only review reported no actionable findings.