### PR TITLE
Refresh existing oracle parameter test inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.856"
+version = "0.2.857"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.856"
+__version__ = "0.2.857"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -12361,11 +12361,17 @@ def cmd_repair_oracle_parameter_tests(args):
     )
     signing_key = _require_applied_encoding_manifest_signing_key()
     axiom_encode_git = _require_clean_axiom_encode_git_provenance()
-    repaired_test_cases = _append_oracle_parameter_tests_if_missing(
+    appended_test_cases = _append_oracle_parameter_tests_if_missing(
         rules_file=rules_file,
         test_file=test_file,
         target_base=target_base,
     )
+    refreshed_test_cases = _refresh_existing_oracle_parameter_test_inputs(
+        rules_file=rules_file,
+        test_file=test_file,
+        target_base=target_base,
+    )
+    repaired_test_cases = [*appended_test_cases, *refreshed_test_cases]
     covered_test_cases = _mapped_oracle_parameter_test_outputs(
         rules_file=rules_file,
         test_file=test_file,
@@ -15445,6 +15451,115 @@ def _append_oracle_parameter_tests_if_missing(
     separator = "" if not existing_content or existing_content.endswith("\n") else "\n"
     test_file.write_text(f"{existing_content}{separator}{rendered}")
     return repaired
+
+
+def _refresh_existing_oracle_parameter_test_inputs(
+    *,
+    rules_file: Path,
+    test_file: Path,
+    target_base: str,
+) -> list[str]:
+    if not test_file.exists():
+        return []
+
+    rules_content = rules_file.read_text()
+    payload = yaml.safe_load(rules_content) or {}
+    rules = payload.get("rules") if isinstance(payload, dict) else None
+    if not isinstance(rules, list):
+        return []
+
+    factual_inputs = _local_factual_input_names_from_rules_content(rules_content)
+    input_defaults = {
+        f"{target_base}#input.{input_name}": _default_generated_test_input_value(
+            input_name,
+            rules_payload=payload,
+            prefer_positive_counts=True,
+        )
+        for input_name in sorted(factual_inputs)
+    }
+    if not input_defaults:
+        return []
+
+    registry = load_policyengine_registry()
+    mapped_parameter_outputs: dict[str, tuple[str, str | None]] = {}
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if str(rule.get("kind") or "").strip() != "parameter":
+            continue
+        rule_name = str(rule.get("name") or "").strip()
+        if not rule_name:
+            continue
+        legal_id = f"{target_base}#{rule_name}"
+        mapping = registry.mapping_for_legal_id(legal_id, country="us")
+        if mapping is None or mapping.mapping_type != "parameter_value":
+            continue
+        index_name = _single_parameter_index_name(rule)
+        mapped_parameter_outputs[legal_id] = (
+            rule_name,
+            f"{target_base}#input.{index_name}" if index_name else None,
+        )
+    if not mapped_parameter_outputs:
+        return []
+
+    try:
+        test_payload = yaml.safe_load(test_file.read_text()) or []
+    except yaml.YAMLError:
+        return []
+    if isinstance(test_payload, list):
+        test_cases = test_payload
+    elif isinstance(test_payload, dict) and isinstance(test_payload.get("cases"), list):
+        test_cases = test_payload["cases"]
+    else:
+        return []
+
+    refreshed: list[str] = []
+    for case in test_cases:
+        if not isinstance(case, dict):
+            continue
+        case_name = str(case.get("name") or "")
+        if not case_name.startswith("oracle_parameter_"):
+            continue
+        outputs = case.get("output")
+        if not isinstance(outputs, dict):
+            continue
+        matching_output_specs = [
+            mapped_parameter_outputs[str(output_ref)]
+            for output_ref in outputs
+            if str(output_ref) in mapped_parameter_outputs
+        ]
+        if not matching_output_specs:
+            continue
+        matching_outputs = [rule_name for rule_name, _ in matching_output_specs]
+        selector_input_refs = {
+            input_ref for _, input_ref in matching_output_specs if input_ref
+        }
+        inputs = case.get("input")
+        if not isinstance(inputs, dict):
+            inputs = {}
+            case["input"] = inputs
+        changed = False
+        for input_ref, default_value in input_defaults.items():
+            if input_ref in selector_input_refs:
+                continue
+            existing_value = inputs.get(input_ref)
+            if (
+                input_ref not in inputs
+                or existing_value != default_value
+                or type(existing_value) is not type(default_value)
+            ):
+                inputs[input_ref] = default_value
+                changed = True
+        if changed:
+            refreshed.extend(matching_outputs)
+
+    if not refreshed:
+        return []
+
+    test_file.write_text(
+        yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
+    )
+    return refreshed
 
 
 def _mapped_oracle_parameter_test_outputs(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25992,6 +25992,12 @@ rules:
         target.write_text(
             """format: rulespec/v1
 rules:
+  - name: qualifying_child_marker
+    kind: derived
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(0, qualifying_child_count)
   - name: eitc_phase_in_rates
     kind: parameter
     dtype: Rate
@@ -26487,6 +26493,183 @@ rules:
             "statutes/42/1382c/a/1.yaml",
             "statutes/42/1382c/a/1.test.yaml",
         ]
+
+    def test_repair_oracle_parameter_tests_refreshes_existing_input_defaults(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "us/statutes/42/601.yaml"
+        test_file = policy_repo / "us/statutes/42/601.test.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+rules:
+  - name: tanf_thirty_dollar_earned_income_disregard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '30'
+  - name: earned_income_disregards
+    kind: derived
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(0, incapacitated_adult_care_expenses)
+"""
+        )
+        test_file.write_text(
+            """- name: oracle_parameter_tanf_thirty_dollar_earned_income_disregard
+  period:
+    period_kind: tax_year
+    start: '2026-01-01'
+    end: '2026-12-31'
+  input:
+    us:statutes/42/601#input.incapacitated_adult_care_expenses: false
+  output:
+    us:statutes/42/601#tanf_thirty_dollar_earned_income_disregard: 30
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("us/statutes/42/601.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakeRegistry:
+            def mapping_for_legal_id(self, legal_id, *, country=None):
+                assert country == "us"
+                if (
+                    legal_id
+                    == "us:statutes/42/601#tanf_thirty_dollar_earned_income_disregard"
+                ):
+                    return SimpleNamespace(mapping_type="parameter_value")
+                return None
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli.load_policyengine_registry",
+                return_value=FakeRegistry(),
+            ),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures", return_value=[]
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_oracle_parameter_tests(args)
+
+        payload = yaml.safe_load(test_file.read_text())
+        assert payload[0]["input"] == {
+            "us:statutes/42/601#input.incapacitated_adult_care_expenses": 0
+        }
+
+    def test_repair_oracle_parameter_tests_refreshes_cases_mapping_inputs(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "us/statutes/42/601.yaml"
+        test_file = policy_repo / "us/statutes/42/601.test.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+rules:
+  - name: tanf_thirty_dollar_earned_income_disregard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '30'
+  - name: earned_income_disregards
+    kind: derived
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(0, incapacitated_adult_care_expenses)
+"""
+        )
+        test_file.write_text(
+            """cases:
+  - name: oracle_parameter_tanf_thirty_dollar_earned_income_disregard
+    period:
+      period_kind: tax_year
+      start: '2026-01-01'
+      end: '2026-12-31'
+    input:
+      us:statutes/42/601#input.incapacitated_adult_care_expenses: false
+    output:
+      us:statutes/42/601#tanf_thirty_dollar_earned_income_disregard: 30
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("us/statutes/42/601.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakeRegistry:
+            def mapping_for_legal_id(self, legal_id, *, country=None):
+                assert country == "us"
+                if (
+                    legal_id
+                    == "us:statutes/42/601#tanf_thirty_dollar_earned_income_disregard"
+                ):
+                    return SimpleNamespace(mapping_type="parameter_value")
+                return None
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli.load_policyengine_registry",
+                return_value=FakeRegistry(),
+            ),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures", return_value=[]
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_oracle_parameter_tests(args)
+
+        payload = yaml.safe_load(test_file.read_text())
+        assert payload["cases"][0]["input"] == {
+            "us:statutes/42/601#input.incapacitated_adult_care_expenses": 0
+        }
 
     def test_repair_oracle_parameter_tests_appends_scalar_parameter_case(
         self, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.856"
+version = "0.2.857"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- refresh existing generated `oracle_parameter_*` test inputs during `repair-oracle-parameter-tests`
- preserve indexed-parameter selector inputs when refreshing defaults
- support both top-level test lists and `{cases: [...]}` test files
- bump axiom-encode to 0.2.857

## Validation
- `uv run --extra dev pytest -q tests/test_cli.py -k 'generated_test_input_defaults or missing_input_default or repair_oracle_parameter_tests'`\n- `uv run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py pyproject.toml`\n- `uv run --extra dev ruff format --check src/axiom_encode/cli.py tests/test_cli.py`\n- `uv run python -m compileall -q src/axiom_encode`\n- `git diff --check`\n\n## Review cycle\n- Independent review found indexed selector and `{cases: [...]}` refresh gaps\n- Fixed both findings and reran focused checks\n- Second independent review: no actionable findings\n