### PR TITLE
Repair generated maximum predecessor limits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.858"
+version = "0.2.859"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.858"
+__version__ = "0.2.859"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -22519,6 +22519,13 @@ def _repair_predecessor_scalar_limits(
 
     numeric_parameter_formulas: dict[int, list[str]] = {}
     referenced_names = _formula_referenced_names(rules)
+    maximum_parameter_names = [
+        str(rule.get("name") or "").strip()
+        for rule in rules
+        if isinstance(rule, dict)
+        and str(rule.get("name") or "").strip()
+        and _is_maximum_parameter_name(str(rule.get("name") or "").strip())
+    ]
     for rule in rules:
         if not isinstance(rule, dict):
             continue
@@ -22537,7 +22544,7 @@ def _repair_predecessor_scalar_limits(
         if str(rule.get("kind") or "").strip().lower() != "parameter":
             continue
         name = str(rule.get("name") or "").strip()
-        if not name.endswith("_scalar_limit"):
+        if not (name.endswith("_scalar_limit") or _is_maximum_parameter_name(name)):
             continue
         if name not in referenced_names:
             continue
@@ -22547,6 +22554,11 @@ def _repair_predecessor_scalar_limits(
         predecessor_of = _single_predecessor_maximum_parameter(
             numeric_parameter_formulas.get(literal + 1, [])
         )
+        if predecessor_of is None:
+            predecessor_of = _single_predecessor_maximum_name_parameter(
+                name,
+                maximum_parameter_names,
+            )
         if predecessor_of is None:
             continue
         versions = rule.get("versions")
@@ -22628,13 +22640,62 @@ def _single_integer_formula(rule: dict[str, Any]) -> int | None:
 
 def _single_predecessor_maximum_parameter(candidates: list[str]) -> str | None:
     maximum_candidates = [
-        candidate
-        for candidate in candidates
-        if candidate.startswith("maximum_") or candidate.startswith("max_")
+        candidate for candidate in candidates if _is_maximum_parameter_name(candidate)
     ]
     if len(maximum_candidates) != 1:
         return None
     return maximum_candidates[0]
+
+
+def _is_maximum_parameter_name(name: str) -> bool:
+    return name.startswith("maximum_") or name.startswith("max_")
+
+
+def _single_predecessor_maximum_name_parameter(
+    name: str,
+    maximum_parameter_names: list[str],
+) -> str | None:
+    """Infer a grounded maximum predecessor from a generated maximum helper name."""
+    if not _is_maximum_parameter_name(name):
+        return None
+    name_tokens = name.split("_")
+    candidates: list[str] = []
+    for candidate in maximum_parameter_names:
+        if candidate == name:
+            continue
+        candidate_tokens = candidate.split("_")
+        if len(candidate_tokens) >= len(name_tokens):
+            continue
+        if not _tokens_are_ordered_subsequence(candidate_tokens, name_tokens):
+            continue
+        if not _maximum_names_share_structural_suffix(candidate_tokens, name_tokens):
+            continue
+        candidates.append(candidate)
+    if len(candidates) != 1:
+        return None
+    return candidates[0]
+
+
+def _tokens_are_ordered_subsequence(
+    candidate_tokens: list[str],
+    name_tokens: list[str],
+) -> bool:
+    position = 0
+    for token in name_tokens:
+        if position < len(candidate_tokens) and candidate_tokens[position] == token:
+            position += 1
+    return position == len(candidate_tokens)
+
+
+def _maximum_names_share_structural_suffix(
+    candidate_tokens: list[str],
+    name_tokens: list[str],
+) -> bool:
+    suffix_length = min(3, len(candidate_tokens), len(name_tokens))
+    return (
+        suffix_length > 0
+        and candidate_tokens[-suffix_length:] == name_tokens[-suffix_length:]
+    )
 
 
 def _bare_snapunit_entity_issue_records(issues: list[str]) -> list[dict[str, str]]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8088,6 +8088,73 @@ rules:
             == "monthly_185_percent_fpl_table[monthly_185_percent_fpl_income_standard_scalar_limit]"
         )
 
+    def test_repair_predecessor_named_maximum_index_limits(self, tmp_path):
+        rules_file = tmp_path / "fl_tca.yaml"
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+- name: maximum_listed_filing_unit_size
+  kind: parameter
+  dtype: Decimal
+  versions:
+  - effective_from: '1996-07-01'
+    formula: '24'
+- name: half_filing_unit_increment
+  kind: parameter
+  dtype: Decimal
+  versions:
+  - effective_from: '1996-07-01'
+    formula: '0.5'
+- name: maximum_listed_half_unit_index
+  kind: parameter
+  dtype: Integer
+  versions:
+  - effective_from: '1996-07-01'
+    formula: floor(maximum_listed_filing_unit_size / half_filing_unit_increment)
+- name: maximum_listed_income_standard_half_unit_index
+  kind: parameter
+  dtype: Integer
+  versions:
+  - effective_from: '2025-04-01'
+    formula: '47'
+- name: unrelated_maximum_income_standard_half_unit_index
+  kind: parameter
+  dtype: Integer
+  versions:
+  - effective_from: '2025-04-01'
+    formula: '47'
+- name: income_standard_half_unit_index
+  kind: derived
+  entity: TanfUnit
+  dtype: Integer
+  period: Month
+  versions:
+  - effective_from: '2025-04-01'
+    formula: min(filing_unit_half_unit_index, maximum_listed_income_standard_half_unit_index)
+"""
+        )
+
+        repaired = _repair_predecessor_scalar_limits(
+            rules_file,
+            ungrounded_literals={47},
+            target_anchor="us-fl:policies/dcf/ess-program-policy-manual/appendix-a-5",
+        )
+
+        assert repaired == ["maximum_listed_income_standard_half_unit_index"]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["rules"][3]["versions"][0]["formula"] == (
+            "maximum_listed_half_unit_index - 1"
+        )
+        assert payload["rules"][3]["metadata"]["proof"]["atoms"][-1]["import"] == {
+            "target": (
+                "us-fl:policies/dcf/ess-program-policy-manual/appendix-a-5"
+                "#maximum_listed_half_unit_index"
+            ),
+            "output": "maximum_listed_half_unit_index",
+            "hash": "sha256:local",
+        }
+        assert payload["rules"][4]["versions"][0]["formula"] == "47"
+
     def test_repair_bare_indexed_parameter_references(self, tmp_path):
         rules_file = tmp_path / "credit.yaml"
         rules_file.write_text(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.858"
+version = "0.2.859"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair generated maximum/index helper parameters by inferring a unique grounded predecessor maximum by name
- preserve the literal fallback repair path and add a Florida TCA Appendix A-5 regression
- bump axiom-encode to 0.2.859

## Tests
- uv run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run --extra dev ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- git diff --check
- uv run --extra dev pytest -q tests/test_cli.py -k "repair_predecessor_scalar_limits or repair_predecessor_named_maximum_index_limits or repair_float_keyed_indexed_parameter_values or repair_half_unit_add_person_formulas or current_encoder_affecting_changes_are_behind_version_bump"
- uv run --extra dev pytest -q tests/test_cli.py