### PR TITLE
Fix Populace tax comparator schema handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.859"
+version = "0.2.860"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.859"
+__version__ = "0.2.860"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -374,6 +374,23 @@ SURFACE_PROGRAM_PATHS = {
     "nonrefundable-credits": NONREFUNDABLE_CREDITS_PROGRAM_PATH,
     **{surface: config["program"] for surface, config in PAYROLL_SURFACES.items()},
 }
+
+
+def resolve_rulespec_program_path(rulespec_root: Path, program_path: Path) -> Path:
+    """Resolve pre- and post-country-monorepo RuleSpec paths."""
+
+    direct = rulespec_root / program_path
+    if direct.exists():
+        return direct
+    prefix = jurisdiction_prefix(rulespec_root)
+    if prefix and (not program_path.parts or program_path.parts[0] != prefix):
+        country_scoped = rulespec_root / prefix / program_path
+        if country_scoped.exists():
+            return country_scoped
+        return country_scoped
+    return direct
+
+
 PE_TAX_UNIT_VARIABLES = tuple(
     sorted(
         {
@@ -691,16 +708,19 @@ def compare_tax_ecps(
     oasdi_wage_base_results: list[dict[str, Any]] | None = None
     contribution_base: float | None = None
     for selected_surface in surfaces:
-        program = resolved_rulespec_root / SURFACE_PROGRAM_PATHS[selected_surface]
+        program = resolve_rulespec_program_path(
+            resolved_rulespec_root,
+            SURFACE_PROGRAM_PATHS[selected_surface],
+        )
         if not program.exists():
             raise SystemExit(f"{selected_surface} RuleSpec not found: {program}")
         if selected_surface == "eitc" or payroll_surface_uses_axiom_3121(
             selected_surface
         ):
             if contribution_base is None:
-                contribution_base_program = (
-                    resolved_rulespec_root
-                    / contribution_and_benefit_base_program_path(year)
+                contribution_base_program = resolve_rulespec_program_path(
+                    resolved_rulespec_root,
+                    contribution_and_benefit_base_program_path(year),
                 )
                 if not contribution_base_program.exists():
                     raise SystemExit(
@@ -734,7 +754,10 @@ def compare_tax_ecps(
                         output=contribution_base_output,
                     )
             if oasdi_wage_base_results is None:
-                oasdi_program = resolved_rulespec_root / OASDI_WAGE_BASE_PROGRAM_PATH
+                oasdi_program = resolve_rulespec_program_path(
+                    resolved_rulespec_root,
+                    OASDI_WAGE_BASE_PROGRAM_PATH,
+                )
                 if not oasdi_program.exists():
                     raise SystemExit(
                         f"OASDI wage-base RuleSpec not found: {oasdi_program}"
@@ -814,6 +837,7 @@ def load_policyengine_tax_data(
 
     raw_tax_units = population_table(dataset, "tax_unit")
     raw_persons = population_table(dataset, "person")
+    raw_households = population_table(dataset, "household")
     tax_unit_outputs = raw_tax_units[["tax_unit_id"]].copy()
     for variable in tax_unit_variables:
         tax_unit_outputs[variable] = calculate(sim, variable, year)
@@ -822,6 +846,8 @@ def load_policyengine_tax_data(
         person_outputs[variable] = calculate(sim, variable, year)
     indices = select_tax_unit_indices(
         raw_tax_units=raw_tax_units,
+        raw_persons=raw_persons,
+        raw_households=raw_households,
         tax_units=tax_unit_outputs,
         sample_size=sample_size,
         positive_ctc_only=positive_ctc_only,
@@ -908,9 +934,15 @@ def select_tax_unit_indices(
     sample_size: int,
     positive_ctc_only: bool,
     tax_unit_ids: tuple[int, ...] = (),
+    raw_persons: Any | None = None,
+    raw_households: Any | None = None,
 ) -> Any:
     """Select Populace tax-unit row indices for oracle comparison."""
-    mask = np.asarray(raw_tax_units["tax_unit_weight"]) > 0
+    mask = tax_unit_positive_weight_mask(
+        raw_tax_units=raw_tax_units,
+        raw_persons=raw_persons,
+        raw_households=raw_households,
+    )
     if positive_ctc_only:
         mask &= np.asarray(tax_units["ctc"]) > 0
     if not tax_unit_ids:
@@ -944,6 +976,51 @@ def select_tax_unit_indices(
             + ", ".join(str(value) for value in filtered)
         )
     return np.asarray(selected, dtype=int)
+
+
+def tax_unit_positive_weight_mask(
+    *,
+    raw_tax_units: Any,
+    raw_persons: Any | None = None,
+    raw_households: Any | None = None,
+) -> np.ndarray:
+    """Return positive-weight tax-unit rows across legacy and Populace schemas."""
+
+    if "tax_unit_weight" in raw_tax_units.columns:
+        return np.asarray(raw_tax_units["tax_unit_weight"]) > 0
+    if "household_weight" in raw_tax_units.columns:
+        return np.asarray(raw_tax_units["household_weight"]) > 0
+    if raw_persons is None or raw_households is None:
+        raise SystemExit(
+            "Populace tax-unit table has no tax_unit_weight; provide person and "
+            "household tables to derive weights from household_weight."
+        )
+
+    required_person_columns = {"person_tax_unit_id", "person_household_id"}
+    missing_person_columns = required_person_columns - set(raw_persons.columns)
+    if missing_person_columns:
+        raise SystemExit(
+            "Populace person table is missing required tax-unit weight columns: "
+            + ", ".join(sorted(missing_person_columns))
+        )
+    required_household_columns = {"household_id", "household_weight"}
+    missing_household_columns = required_household_columns - set(raw_households.columns)
+    if missing_household_columns:
+        raise SystemExit(
+            "Populace household table is missing required tax-unit weight columns: "
+            + ", ".join(sorted(missing_household_columns))
+        )
+
+    household_weights = raw_households.set_index("household_id")["household_weight"]
+    person_links = raw_persons[["person_tax_unit_id", "person_household_id"]].copy()
+    person_links["tax_unit_household_weight"] = person_links["person_household_id"].map(
+        household_weights
+    )
+    tax_unit_weights = person_links.groupby("person_tax_unit_id")[
+        "tax_unit_household_weight"
+    ].max()
+    row_weights = raw_tax_units["tax_unit_id"].map(tax_unit_weights).fillna(0)
+    return np.asarray(row_weights) > 0
 
 
 def _install_policyengine_data_certification_override() -> None:
@@ -1614,9 +1691,10 @@ def contribution_and_benefit_base_from_rulespec_test(
     year: int,
     output: str | None = None,
 ) -> float | None:
-    test_path = rulespec_root / contribution_and_benefit_base_program_path(
-        year
-    ).with_suffix(".test.yaml")
+    test_path = resolve_rulespec_program_path(
+        rulespec_root,
+        contribution_and_benefit_base_program_path(year).with_suffix(".test.yaml"),
+    )
     if not test_path.exists():
         return None
     try:

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -31,6 +31,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     SECTION_7703_BASE,
     TAX_BEFORE_CREDITS_BASE,
     TAX_BEFORE_CREDITS_OUTPUTS,
+    TAX_BEFORE_CREDITS_PROGRAM_PATH,
     additional_standard_deduction_entitlement_count,
     build_aotc_request,
     build_capital_gain_definitions_request,
@@ -80,7 +81,9 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     project_tax_unit_person_contexts,
     remove_output_columns_already_in_raw,
     require_policyengine_versions,
+    resolve_rulespec_program_path,
     select_tax_unit_indices,
+    tax_unit_positive_weight_mask,
     taxable_oasdi_wages_by_person_id,
     uses_joint_ctc_phaseout_threshold,
     valid_child_ssn_type,
@@ -1765,6 +1768,28 @@ def test_select_tax_unit_indices_can_target_known_residuals():
     assert indices.tolist() == [1]
 
 
+def test_resolve_rulespec_program_path_supports_country_monorepo_root(tmp_path):
+    root = tmp_path / "rulespec-us"
+    program = root / "us" / "statutes" / "26" / "1" / "j.yaml"
+    program.parent.mkdir(parents=True)
+    program.write_text("program: {}\n")
+
+    assert (
+        resolve_rulespec_program_path(root, TAX_BEFORE_CREDITS_PROGRAM_PATH) == program
+    )
+
+
+def test_resolve_rulespec_program_path_keeps_direct_layout(tmp_path):
+    root = tmp_path / "rulespec-us"
+    program = root / "statutes" / "26" / "1" / "j.yaml"
+    program.parent.mkdir(parents=True)
+    program.write_text("program: {}\n")
+
+    assert (
+        resolve_rulespec_program_path(root, TAX_BEFORE_CREDITS_PROGRAM_PATH) == program
+    )
+
+
 def test_select_tax_unit_indices_rejects_filtered_requested_case():
     pd = pytest.importorskip("pandas")
     raw_tax_units = pd.DataFrame(
@@ -1782,6 +1807,70 @@ def test_select_tax_unit_indices_rejects_filtered_requested_case():
             positive_ctc_only=True,
             tax_unit_ids=(2976,),
         )
+
+
+def test_select_tax_unit_indices_uses_household_weights_when_tax_unit_weight_absent():
+    pd = pytest.importorskip("pandas")
+    raw_tax_units = pd.DataFrame(
+        [
+            {"tax_unit_id": 10},
+            {"tax_unit_id": 20},
+            {"tax_unit_id": 30},
+        ]
+    )
+    raw_persons = pd.DataFrame(
+        [
+            {"person_tax_unit_id": 10, "person_household_id": 1},
+            {"person_tax_unit_id": 20, "person_household_id": 2},
+            {"person_tax_unit_id": 30, "person_household_id": 3},
+        ]
+    )
+    raw_households = pd.DataFrame(
+        [
+            {"household_id": 1, "household_weight": 4.5},
+            {"household_id": 2, "household_weight": 0},
+            {"household_id": 3, "household_weight": 12},
+        ]
+    )
+    tax_units = pd.DataFrame([{"ctc": 0}, {"ctc": 0}, {"ctc": 0}])
+
+    indices = select_tax_unit_indices(
+        raw_tax_units=raw_tax_units,
+        raw_persons=raw_persons,
+        raw_households=raw_households,
+        tax_units=tax_units,
+        sample_size=0,
+        positive_ctc_only=False,
+    )
+
+    assert indices.tolist() == [0, 2]
+
+
+def test_select_tax_unit_indices_rejects_zero_household_weight_requested_case():
+    pd = pytest.importorskip("pandas")
+    raw_tax_units = pd.DataFrame([{"tax_unit_id": 20}])
+    raw_persons = pd.DataFrame([{"person_tax_unit_id": 20, "person_household_id": 2}])
+    raw_households = pd.DataFrame([{"household_id": 2, "household_weight": 0}])
+    tax_units = pd.DataFrame([{"ctc": 10}])
+
+    with pytest.raises(SystemExit, match="not eligible"):
+        select_tax_unit_indices(
+            raw_tax_units=raw_tax_units,
+            raw_persons=raw_persons,
+            raw_households=raw_households,
+            tax_units=tax_units,
+            sample_size=0,
+            positive_ctc_only=False,
+            tax_unit_ids=(20,),
+        )
+
+
+def test_tax_unit_positive_weight_mask_requires_person_household_tables():
+    pd = pytest.importorskip("pandas")
+    raw_tax_units = pd.DataFrame([{"tax_unit_id": 20}])
+
+    with pytest.raises(SystemExit, match="provide person and household tables"):
+        tax_unit_positive_weight_mask(raw_tax_units=raw_tax_units)
 
 
 def test_compare_outputs_reports_max_relative_diff_for_large_float_noise():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.859"
+version = "0.2.860"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- derive positive tax-unit sample weights from Populace household weights when tax-unit weights are absent
- resolve federal tax RuleSpec paths under the unified country monorepo layout, e.g. rulespec-us/us/statutes/...
- add regression coverage for both Populace schema handling and unified RuleSpec path resolution

## Verification
- uv run --extra dev ruff check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py
- uv run --extra dev --with pandas pytest -q tests/test_policyengine_ecps_tax.py
- uv run --with numpy --with '/Users/maxghenis/PolicyEngine/populace/packages/populace-data[us]' axiom-encode tax-populace-compare --root /Users/maxghenis/TheAxiomFoundation --rulespec-root /Users/maxghenis/TheAxiomFoundation/rulespec-us --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine --year 2026 --populace-year 2024 --sample-size 500 --surface tax-before-credits --json > /tmp/tax-before-credits-sample500.json

Sample comparison now runs end-to-end and reports 150 mismatches across 500 compared tax units for income_tax_main_rates, which is the measured residual to drive the next PB-ranked encoding work.