### PR TITLE
Use period-aligned Populace tax inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.860"
+version = "0.2.861"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.860"
+__version__ = "0.2.861"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -443,6 +443,7 @@ PE_TAX_UNIT_VARIABLES = tuple(
             "standard_deduction",
             "tax_unit_childcare_expenses",
             "taxable_income",
+            "unrecaptured_section_1250_gain",
             "used_clean_vehicle_credit",
             "lifetime_learning_credit",
         }
@@ -458,7 +459,10 @@ PE_PERSON_VARIABLES = tuple(
             "attends_eligible_educational_institution_for_american_opportunity_credit",
             "american_opportunity_credit_claimed_prior_years",
             "educational_assistance",
+            "employment_income",
+            "employment_income_before_lsr",
             "irs_employment_income",
+            "farm_operations_income",
             "has_american_opportunity_credit_1098_t_or_exception",
             "has_american_opportunity_credit_institution_ein",
             "has_completed_first_four_years_of_postsecondary_education",
@@ -468,8 +472,23 @@ PE_PERSON_VARIABLES = tuple(
             "is_tax_unit_head",
             "is_tax_unit_head_or_spouse",
             "is_tax_unit_spouse",
+            "investment_income_elected_form_4952",
+            "long_term_capital_gains",
+            "long_term_capital_gains_before_response",
+            "long_term_capital_gains_on_collectibles",
+            "long_term_capital_gains_on_small_business_stock",
+            "non_qualified_dividend_income",
             "payroll_tax_gross_wages",
+            "pre_tax_health_insurance_premiums",
             "qualified_tuition_expenses",
+            "qualified_dividend_income",
+            "rental_income",
+            "self_employment_income_before_lsr",
+            "short_term_capital_gains",
+            "sstb_self_employment_income_before_lsr",
+            "taxable_interest_income",
+            "tax_exempt_interest_income",
+            "health_savings_account_payroll_contributions",
         }
     )
 )
@@ -854,7 +873,7 @@ def load_policyengine_tax_data(
         tax_unit_ids=tax_unit_ids,
     )
     selected = raw_tax_units.iloc[indices].copy()
-    tax_unit_outputs = remove_output_columns_already_in_raw(
+    selected = remove_raw_columns_replaced_by_outputs(
         raw=selected,
         outputs=tax_unit_outputs,
         key="tax_unit_id",
@@ -869,7 +888,7 @@ def load_policyengine_tax_data(
     selected_persons = raw_persons[
         raw_persons["person_tax_unit_id"].astype(int).isin(selected_ids)
     ].copy()
-    person_outputs = remove_output_columns_already_in_raw(
+    selected_persons = remove_raw_columns_replaced_by_outputs(
         raw=selected_persons,
         outputs=person_outputs,
         key="person_id",
@@ -888,18 +907,19 @@ def load_policyengine_tax_data(
     }
 
 
-def remove_output_columns_already_in_raw(*, raw: Any, outputs: Any, key: str) -> Any:
-    """Avoid pandas suffixing when dataset inputs already contain a PE variable.
+def remove_raw_columns_replaced_by_outputs(*, raw: Any, outputs: Any, key: str) -> Any:
+    """Avoid suffixing while keeping period-aligned PolicyEngine values.
 
-    Newer Populace data releases can store source variables that the harness
-    also requests from PolicyEngine. Those columns are already present in the
-    raw table, so keep the raw copy and merge only genuinely new outputs.
+    Populace stores source-year inputs, while the oracle may compare a later
+    tax year after PolicyEngine uprating. If a requested PE output shares a raw
+    column name, drop the raw column before merging so projections use the
+    period-specific PE value instead of stale source-year data.
     """
 
     duplicate_columns = set(raw.columns).intersection(outputs.columns) - {key}
     if not duplicate_columns:
-        return outputs
-    return outputs.drop(columns=sorted(duplicate_columns))
+        return raw
+    return raw.drop(columns=sorted(duplicate_columns))
 
 
 def policyengine_variables_for_surfaces(

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -79,7 +79,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     project_standard_deduction_inputs,
     project_tax_unit_inputs,
     project_tax_unit_person_contexts,
-    remove_output_columns_already_in_raw,
+    remove_raw_columns_replaced_by_outputs,
     require_policyengine_versions,
     resolve_rulespec_program_path,
     select_tax_unit_indices,
@@ -126,7 +126,7 @@ def test_scalar_value_keeps_plain_float_literal_format():
     }
 
 
-def test_remove_output_columns_already_in_raw_prevents_suffixing():
+def test_remove_raw_columns_replaced_by_outputs_prefers_period_values():
     pd = pytest.importorskip("pandas")
     raw = pd.DataFrame(
         [
@@ -141,22 +141,23 @@ def test_remove_output_columns_already_in_raw_prevents_suffixing():
         [
             {
                 "person_id": 1,
-                "qualified_tuition_expenses": 4_000,
+                "qualified_tuition_expenses": 4_400,
                 "american_opportunity_credit": 2_500,
             }
         ]
     )
 
-    filtered = remove_output_columns_already_in_raw(
+    filtered = remove_raw_columns_replaced_by_outputs(
         raw=raw,
         outputs=outputs,
         key="person_id",
     )
-    merged = raw.merge(filtered, on="person_id", how="left", validate="one_to_one")
+    merged = filtered.merge(outputs, on="person_id", how="left", validate="one_to_one")
 
     assert "qualified_tuition_expenses" in merged
     assert "qualified_tuition_expenses_x" not in merged
     assert "qualified_tuition_expenses_y" not in merged
+    assert merged.loc[0, "qualified_tuition_expenses"] == 4_400
     assert merged.loc[0, "american_opportunity_credit"] == 2_500
 
 
@@ -2273,6 +2274,9 @@ def test_policyengine_variables_for_tax_before_credits_include_main_rates_inputs
 
     assert "income_tax_main_rates" in tax_unit_variables
     assert "taxable_income" in tax_unit_variables
+    assert "unrecaptured_section_1250_gain" in tax_unit_variables
+    assert "long_term_capital_gains" in person_variables
+    assert "qualified_dividend_income" in person_variables
     assert person_variables == ecps_tax.PE_PERSON_VARIABLES
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.860"
+version = "0.2.861"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- replace raw Populace duplicate columns with PE-calculated period outputs before projection
- request period-aligned tax/person leaves used by federal tax projections
- bump axiom-encode to 0.2.861

## Validation
- `uv run --extra dev ruff check src/axiom_encode/oracles/policyengine/ecps_tax.py tests/test_policyengine_ecps_tax.py`
- `uv run --extra dev --with pandas pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_ecps_tax.py`
- `axiom-encode tax-populace-compare --year 2026 --populace-year 2024 --sample-size 500 --surface tax-before-credits --json`: 500 compared, 0 mismatches
- `axiom-encode tax-populace-compare --year 2026 --populace-year 2024 --sample-size 500 --surface capital-gain-definitions --json`: 1000 compared, 0 mismatches