### PR TITLE
Resolve CFR corpus citations correctly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.862"
+version = "0.2.864"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.862"
+__version__ = "0.2.864"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -2363,11 +2363,10 @@ def _candidate_corpus_citation_paths(identifier: str) -> tuple[str, ...]:
         return ()
 
     try:
-        primary = (
-            normalized
-            if _looks_like_corpus_citation_path(normalized)
-            else citation_to_citation_path(normalized)
-        )
+        if _looks_like_corpus_citation_path(normalized):
+            primary = normalized
+        else:
+            primary = _citation_to_corpus_citation_path(normalized)
     except ValueError:
         primary = normalized
 
@@ -2383,6 +2382,44 @@ def _candidate_corpus_citation_paths(identifier: str) -> tuple[str, ...]:
     for end in range(len(parts) - 1, 2, -1):
         add("/".join(parts[:end]))
     return tuple(candidates)
+
+
+_CFR_CITATION_RE = re.compile(
+    r"^(?P<title>\d+)\s+C\.?\s*F\.?\s*R\.?\s+"
+    r"(?:(?:part|pt\.?)\s+)?(?:§+\s*)?"
+    r"(?P<section>[0-9A-Za-z.-]+)"
+    r"(?P<tail>(?:\([^)]+\))*)$",
+    re.IGNORECASE,
+)
+
+
+def _citation_to_corpus_citation_path(citation: str) -> str:
+    """Convert a bare legal citation to a corpus citation path."""
+    cfr_path = _cfr_citation_to_corpus_citation_path(citation)
+    if cfr_path is not None:
+        return cfr_path
+    if re.search(r"\bC\.?\s*F\.?\s*R\.?\b", citation, flags=re.IGNORECASE):
+        raise ValueError(f"Could not parse CFR citation: {citation}")
+    return citation_to_citation_path(citation)
+
+
+def _cfr_citation_to_corpus_citation_path(citation: str) -> str | None:
+    match = _CFR_CITATION_RE.match(citation.strip().replace("§", "§ "))
+    if match is None:
+        return None
+    section_parts = [part for part in match.group("section").split(".") if part]
+    if not section_parts:
+        return None
+    fragments = re.findall(r"\(([^)]+)\)", match.group("tail"))
+    return "/".join(
+        (
+            "us",
+            "regulation",
+            match.group("title"),
+            *section_parts,
+            *fragments,
+        )
+    )
 
 
 def _looks_like_corpus_citation_path(identifier: str) -> bool:
@@ -2447,7 +2484,7 @@ def _read_local_corpus_descendant_text(
     except OSError:
         return None
 
-    descendants: list[tuple[int, int, str | None, str]] = []
+    descendants: list[tuple[int, int, str, str, str]] = []
     child_prefix = f"{citation_path}/"
     for line in lines:
         if not line.strip():
@@ -2468,7 +2505,8 @@ def _read_local_corpus_descendant_text(
             (
                 int(record.get("level") or 0),
                 int(record.get("ordinal") or 0),
-                str(record.get("heading") or "") or None,
+                str(record.get("heading") or ""),
+                record_path,
                 str(body),
             )
         )
@@ -2476,7 +2514,7 @@ def _read_local_corpus_descendant_text(
     if not descendants:
         return None
     chunks: list[str] = []
-    for _, _, heading, body in sorted(descendants):
+    for _, _, heading, _, body in sorted(descendants):
         if heading:
             chunks.append(f"{heading}\n\n{body}")
         else:
@@ -3019,7 +3057,7 @@ def _relative_rulespec_path_to_import_target(
 
 
 def _target_rel_for_eval_identifier(citation: str) -> Path | None:
-    """Return the canonical RuleSpec target path for corpus or USC citations."""
+    """Return the canonical RuleSpec target path for corpus or bare citations."""
     normalized = citation.strip().strip("/")
     first_part = normalized.split("/", 1)[0]
     if ":" in first_part:
@@ -3030,7 +3068,9 @@ def _target_rel_for_eval_identifier(citation: str) -> Path | None:
     if _looks_like_corpus_citation_path(normalized):
         return _source_identifier_to_relative_rulespec_path(normalized)
     try:
-        return citation_to_relative_rulespec_path(citation)
+        return _source_identifier_to_relative_rulespec_path(
+            _citation_to_corpus_citation_path(citation)
+        )
     except Exception:
         return None
 
@@ -4022,6 +4062,12 @@ def _resolve_eval_output_path(
     )
     if source_identifier != citation or _looks_like_corpus_citation_path(citation):
         return _source_identifier_to_relative_rulespec_path(source_identifier)
+    try:
+        return _source_identifier_to_relative_rulespec_path(
+            _citation_to_corpus_citation_path(citation)
+        )
+    except ValueError:
+        pass
     if fallback is not None:
         return fallback(citation)
     return _source_identifier_to_relative_rulespec_path(citation)
@@ -9630,9 +9676,33 @@ def _materialize_eval_artifact(
         bundle_by_candidate_name = {
             Path(file_name).name: content for file_name, content in bundle.items()
         }
+        main_bundle_name = expected_path.name
+        test_bundle_name = expected_test_path.name
+        if main_bundle_name not in bundle_by_candidate_name:
+            generated_main_names = [
+                Path(file_name).name
+                for file_name in bundle
+                if Path(file_name).suffix in {".yaml", ".yml"}
+                and not Path(file_name).name.endswith(".test.yaml")
+            ]
+            if len(generated_main_names) == 1:
+                main_bundle_name = generated_main_names[0]
+                generated_test_name = (
+                    Path(main_bundle_name).with_suffix(".test.yaml").name
+                )
+                if generated_test_name in bundle_by_candidate_name:
+                    test_bundle_name = generated_test_name
+                else:
+                    generated_test_names = [
+                        Path(file_name).name
+                        for file_name in bundle
+                        if Path(file_name).name.endswith(".test.yaml")
+                    ]
+                    if len(generated_test_names) == 1:
+                        test_bundle_name = generated_test_names[0]
         normalized_main_content: str | None = None
         stripped_test_output_names: set[str] = set()
-        raw_main_content = bundle_by_candidate_name.get(expected_path.name)
+        raw_main_content = bundle_by_candidate_name.get(main_bundle_name)
         if raw_main_content is not None:
             try:
                 normalized_main_content = _normalize_main_eval_content(
@@ -9653,9 +9723,9 @@ def _materialize_eval_artifact(
                 stripped_test_output_names = set()
         for file_name, content in bundle.items():
             candidate_name = Path(file_name).name
-            if candidate_name == expected_path.name:
+            if candidate_name == main_bundle_name:
                 target_path = expected_path
-            elif candidate_name == expected_test_path.name:
+            elif candidate_name == test_bundle_name:
                 target_path = expected_test_path
             else:
                 continue

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -397,6 +397,92 @@ def test_resolve_corpus_source_unit_uses_form_child_blocks(tmp_path):
     assert "Colorado 142% 142% 142% 260% 195% 260% 68% 133%" in source_unit.body
 
 
+def test_resolve_corpus_source_unit_uses_headingless_child_blocks(tmp_path):
+    citation = "us/regulation/42/435/119"
+    corpus_path = tmp_path / "axiom-corpus"
+    provisions_dir = (
+        corpus_path / "data" / "corpus" / "provisions" / "us" / "regulation"
+    )
+    provisions_dir.mkdir(parents=True)
+    (provisions_dir / "test.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "citation_path": citation,
+                        "body": None,
+                        "heading": "Coverage for adults",
+                        "level": 1,
+                        "ordinal": 1,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "citation_path": f"{citation}/b",
+                        "body": "The agency must provide Medicaid to adults.",
+                        "heading": None,
+                        "level": 2,
+                        "ordinal": 2,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "citation_path": f"{citation}/a",
+                        "body": "This section applies beginning January 1, 2014.",
+                        "heading": None,
+                        "level": 2,
+                        "ordinal": 1,
+                    }
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    source_unit = resolve_corpus_source_unit(citation, corpus_path)
+
+    assert source_unit.citation_path == citation
+    assert source_unit.source == "local"
+    assert source_unit.body == (
+        "This section applies beginning January 1, 2014.\n\n"
+        "The agency must provide Medicaid to adults."
+    )
+
+
+def test_resolve_corpus_source_unit_parses_bare_cfr_citation(tmp_path):
+    citation = "us/regulation/42/435/119"
+    corpus_path = tmp_path / "axiom-corpus"
+    provisions_dir = (
+        corpus_path / "data" / "corpus" / "provisions" / "us" / "regulation"
+    )
+    provisions_dir.mkdir(parents=True)
+    (provisions_dir / "test.jsonl").write_text(
+        json.dumps(
+            {
+                "citation_path": citation,
+                "body": (
+                    "(a) Basis. This section implements coverage for adults.\n\n"
+                    "(b) Eligibility. The agency must provide Medicaid to adults."
+                ),
+                "heading": "Coverage for adults",
+                "level": 2,
+                "ordinal": 119,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    source_unit = resolve_corpus_source_unit("42 CFR 435.119(b)", corpus_path)
+
+    assert source_unit.citation_path == citation
+    assert source_unit.source == "local"
+    assert source_unit.body == (
+        "(b) Eligibility. The agency must provide Medicaid to adults."
+    )
+
+
 def test_canonical_target_ref_prefix_handles_canonical_source_id():
     assert (
         _canonical_target_ref_prefix(
@@ -513,6 +599,17 @@ def test_resolve_eval_output_path_uses_path_like_citation_directly():
 
     assert _resolve_eval_output_path("us/statute/7/2014/e/2/B") == Path(
         "statutes/7/2014/e/2/B.yaml"
+    )
+
+
+def test_resolve_eval_output_path_parses_bare_cfr_citation():
+    from axiom_encode.harness.evals import _resolve_eval_output_path
+
+    assert _resolve_eval_output_path("42 CFR 435.119") == Path(
+        "regulations/42-cfr/435/119.yaml"
+    )
+    assert _resolve_eval_output_path("42 C.F.R. § 435.119(b)(5)") == Path(
+        "regulations/42-cfr/435/119/b/5.yaml"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.862"
+version = "0.2.864"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map bare CFR citations like `42 CFR 435.119` to corpus paths such as `us/regulation/42/435/119`
- route CFR encode outputs to `regulations/42-cfr/...` instead of falling back to statute-style paths
- make local corpus descendant reads robust to headingless rows by sorting with normalized headings and record paths
- keep generated companion `.test.yaml` files aligned with canonical output paths when bundle filenames differ from the canonical fallback

## Validation
- `env -u UV_FROZEN uv run --extra dev ruff check src/axiom_encode/harness/evals.py tests/test_evals.py`
- `env -u UV_FROZEN uv run --extra dev pytest -q tests/test_evals.py::TestSourceEval::test_run_source_eval_uses_explicit_context_without_statute_lookup tests/test_evals.py::test_resolve_corpus_source_unit_uses_headingless_child_blocks tests/test_evals.py::test_resolve_corpus_source_unit_parses_bare_cfr_citation tests/test_evals.py::test_resolve_eval_output_path_parses_bare_cfr_citation tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- live probe: `axiom-encode encode '42 CFR 435.119' ...` now resolves source metadata to `us/regulation/42/435/119` and writes `regulations/42-cfr/435/119.yaml`; generated RuleSpec still failed downstream CI, so no probe artifact was applied