### PR TITLE
Classify WIC and Head Start oracle outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.866"
+version = "0.2.867"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.867"
+version = "0.2.868"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.867"
+__version__ = "0.2.868"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.866"
+__version__ = "0.2.867"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -23564,11 +23564,16 @@ Output ONLY valid JSON:
                 coverage.unsupported += 1
                 continue
 
-            mappability_inputs = policyengine_inputs or inputs
+            pe_inputs = inputs
+            if pe_parameter and isinstance(inputs, dict):
+                pe_inputs = self._pe_parameter_inputs_for_mapping(inputs, mapping)
+
+            mappability_inputs = policyengine_inputs or pe_inputs
             if (
                 country == "us"
                 and not policyengine_inputs
                 and isinstance(mappability_inputs, dict)
+                and not pe_parameter
             ):
                 mappability_inputs = self._pe_us_projectable_inputs_for_mappability(
                     mappability_inputs,
@@ -23595,7 +23600,7 @@ Output ONLY valid JSON:
                 continue
 
             # Build and run PE scenario — include period in inputs for monthly detection
-            inputs_with_period = {**inputs, "period": str(period)}
+            inputs_with_period = {**pe_inputs, "period": str(period)}
             inputs_with_period = {
                 **_policyengine_us_snap_input_aliases(inputs_with_period),
                 **inputs_with_period,
@@ -25035,6 +25040,40 @@ print("BENCHMARK:" + json.dumps(result))
         if saw_projectable_legal_input and saw_unprojectable_legal_input:
             return projected
         return inputs
+
+    @classmethod
+    def _pe_parameter_inputs_for_mapping(
+        cls,
+        inputs: dict,
+        mapping: PolicyEngineMapping | None,
+    ) -> dict:
+        """Keep only inputs needed to resolve a PE parameter mapping.
+
+        Parameter-value oracle comparisons read PolicyEngine's parameter tree.
+        They should not inherit unrelated RuleSpec legal inputs from a companion
+        test case, because those inputs are scenario facts and cannot affect a
+        static parameter lookup unless the mapping names them as key selectors.
+        """
+        if mapping is None or mapping.mapping_type != "parameter_value":
+            return inputs
+
+        required_aliases = {
+            alias.lower() for alias in cls._policyengine_mapping_input_aliases(mapping)
+        }
+        if not required_aliases:
+            return {}
+
+        projected: dict = {}
+        for key, value in inputs.items():
+            key_text = str(key)
+            input_alias = cls._rulespec_legal_input_alias(key_text)
+            if input_alias is not None:
+                if input_alias.lower() in required_aliases:
+                    projected[key] = value
+                continue
+            if key_text.lower() in required_aliases:
+                projected[key] = value
+        return projected
 
     @staticmethod
     def _rulespec_legal_input_alias(key_text: str) -> str | None:

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -1047,10 +1047,15 @@ def _program_surface_item_from_payload(
     country = str(payload.get("country") or "us")
     mappings = registry.mappings_for_policyengine_variable(variable, country=country)
     comparable_mapping_count = sum(1 for mapping in mappings if mapping.comparable)
+    final_non_comparable_mapping_count = sum(
+        1
+        for mapping in mappings
+        if not mapping.comparable and mapping.candidate_priority != "P4"
+    )
     manifest_status = str(payload["axiom_status"])
     if comparable_mapping_count:
         axiom_status = "wired"
-    elif mappings and manifest_status in {
+    elif final_non_comparable_mapping_count and manifest_status in {
         "pending_oracle_mapping",
         "pending_rulespec_encoding",
     }:

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -682,6 +682,14 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec exposes the paragraph (c) participant eligibility paths before age, take-up, per-slot spending, and final benefit assignment. PolicyEngine's head_start variable is a final imputed dollar value after eligibility, state spending/enrollment allocation, and take-up.
 
+  - legal_id: us:regulations/45-cfr/1302/12#paragraph_c_overincome_exception_participant_may_be_enrolled
+    country: us
+    program: head_start
+    mapping_type: not_comparable
+    policyengine_variable: is_head_start_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes the paragraph (c)(2) over-income exception participant branch, including the program-level 10 percent enrollment cap and service-benefit determination. PolicyEngine's Head Start eligibility variable does not model this over-income exception branch or program enrollment-cap administration as a one-to-one surface.
+
   - legal_id: us:regulations/45-cfr/1302/12#additional_allowance_participant_may_be_enrolled
     country: us
     program: head_start
@@ -712,6 +720,49 @@ mappings:
     policyengine_variable: is_head_start_eligible
     candidate_priority: P4
     rationale: RuleSpec exposes the paragraph (f) Migrant or Seasonal Head Start eligibility path based on primary agricultural-employment income and age requirements. PolicyEngine's Head Start eligibility variable does not model this branch separately.
+
+  - legal_id: us:regulations/45-cfr/1302/12/b#early_head_start_age_threshold_years
+    country: us
+    program: head_start
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.head_start.early_head_start.age_limit
+    period: year
+    rationale: Same Early Head Start under-three age limit in 45 CFR 1302.12(b)(1), represented in PolicyEngine as the Head Start early_head_start age_limit parameter.
+
+  - legal_id: us:regulations/45-cfr/1302/12/b#head_start_preschool_age_threshold_years
+    country: us
+    program: head_start
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.head_start.age_range
+    parameter_key_path:
+      - thresholds
+      - 1
+    period: year
+    rationale: Same Head Start Preschool minimum age threshold in 45 CFR 1302.12(b)(2)(i), represented in PolicyEngine as the lower true bracket threshold of the Head Start age_range parameter.
+
+  - legal_id: us:regulations/45-cfr/1302/12/b#early_head_start_age_requirement
+    country: us
+    program: head_start
+    mapping_type: not_comparable
+    policyengine_variable: is_early_head_start_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes only the 45 CFR 1302.12(b)(1) Early Head Start age requirement and transition exception. PolicyEngine's is_early_head_start_eligible composes age or pregnancy with income and categorical eligibility, so this isolated age predicate is not a one-to-one oracle surface.
+
+  - legal_id: us:regulations/45-cfr/1302/12/b#head_start_preschool_age_requirement
+    country: us
+    program: head_start
+    mapping_type: not_comparable
+    policyengine_variable: is_head_start_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes only the 45 CFR 1302.12(b)(2) Head Start Preschool age requirement, including the public-school eligibility-date alternative and school-attendance-age ceiling. PolicyEngine's is_head_start_eligible composes an age-range parameter with income and categorical eligibility, so this isolated age predicate is not a one-to-one oracle surface.
+
+  - legal_id: us:regulations/45-cfr/1302/12/b#migrant_or_seasonal_head_start_age_requirement
+    country: us
+    program: head_start
+    mapping_type: not_comparable
+    policyengine_variable: is_head_start_eligible
+    candidate_priority: P4
+    rationale: RuleSpec exposes the 45 CFR 1302.12(b)(3) Migrant or Seasonal Head Start age requirement keyed to the community compulsory-school-age date. PolicyEngine does not expose this migrant-or-seasonal age branch separately from final Head Start eligibility.
 
   - legal_id: us:regulations/47-cfr/54/409#income_qualifies_for_lifeline
     country: us
@@ -18161,6 +18212,13 @@ prefixes:
     program: snap
     mapping_type: not_comparable
     rationale: Federal SNAP regulatory outputs are provision-level eligibility and mechanics intermediates unless an exact PolicyEngine mapping overrides this prefix.
+
+  - legal_id_prefix: us:regulations/7-cfr/246/7/
+    country: us
+    program: wic
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: 7 CFR 246.7(c)-(e) encodes WIC certification, residency, identity, income-screening, adjunctive eligibility, pregnancy-documentation, nutritional-risk, and State/local agency workflow predicates. PolicyEngine-US exposes final WIC eligibility and benefit surfaces, not these certification-procedure helper outputs as one-to-one oracle targets; exact mappings should be added only for later composed WIC eligibility or parameter outputs that share PolicyEngine's variable boundary.
 
   - legal_id_prefix: us:statutes/7/2012/j#
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -632,13 +632,16 @@ def test_policyengine_program_surface_includes_policybench_person_eligibility_su
     assert wic["policybench_household_weight"] == pytest.approx(0.32)
 
     assert head_start["program_id"] == "head_start"
-    assert head_start["axiom_status"] == "known_not_comparable"
-    assert head_start["mapping_count"] == 3
+    assert head_start["axiom_status"] == "pending_oracle_mapping"
+    assert head_start["mapping_count"] == 6
+    assert head_start["comparable_mapping_count"] == 0
     assert head_start["policybench_output"] == "person_level_head_start_eligibility"
     assert head_start["policybench_household_weight"] == pytest.approx(1.18)
 
     assert early_head_start["program_id"] == "head_start"
     assert early_head_start["axiom_status"] == "pending_rulespec_encoding"
+    assert early_head_start["mapping_count"] == 1
+    assert early_head_start["comparable_mapping_count"] == 0
     assert (
         early_head_start["policybench_output"]
         == "person_level_early_head_start_eligibility"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2542,6 +2542,44 @@ def test_policyengine_registry_is_legal_id_keyed():
         section_2014c_net_failure_mapping.policyengine_variable
         == "meets_snap_net_income_test"
     )
+    wic_certification_mapping = registry.mapping_for_legal_id(
+        "us:regulations/7-cfr/246/7/c#applicant_meets_basic_wic_eligibility_criteria",
+        country="us",
+    )
+    assert wic_certification_mapping.mapping_type == "not_comparable"
+    assert wic_certification_mapping.program == "wic"
+    assert wic_certification_mapping.candidate_priority == "P4"
+    assert "certification-procedure helper outputs" in (
+        wic_certification_mapping.rationale or ""
+    )
+    wic_income_mapping = registry.mapping_for_legal_id(
+        "us:regulations/7-cfr/246/7/d#applicant_adjunctively_income_eligible",
+        country="us",
+    )
+    assert wic_income_mapping.mapping_type == "not_comparable"
+    assert wic_income_mapping.program == "wic"
+    early_head_start_age_mapping = registry.mapping_for_legal_id(
+        "us:regulations/45-cfr/1302/12/b#early_head_start_age_threshold_years",
+        country="us",
+    )
+    assert early_head_start_age_mapping.mapping_type == "parameter_value"
+    assert (
+        early_head_start_age_mapping.policyengine_parameter
+        == "gov.hhs.head_start.early_head_start.age_limit"
+    )
+    head_start_age_mapping = registry.mapping_for_legal_id(
+        "us:regulations/45-cfr/1302/12/b#head_start_preschool_age_threshold_years",
+        country="us",
+    )
+    assert head_start_age_mapping.mapping_type == "parameter_value"
+    assert head_start_age_mapping.policyengine_parameter == "gov.hhs.head_start.age_range"
+    assert head_start_age_mapping.parameter_key_path == ("thresholds", 1)
+    head_start_overincome_exception_mapping = registry.mapping_for_legal_id(
+        "us:regulations/45-cfr/1302/12#paragraph_c_overincome_exception_participant_may_be_enrolled",
+        country="us",
+    )
+    assert head_start_overincome_exception_mapping.mapping_type == "not_comparable"
+    assert head_start_overincome_exception_mapping.program == "head_start"
     residential_clean_energy_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/25D#residential_clean_energy_credit",
         country="us",

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2572,7 +2572,9 @@ def test_policyengine_registry_is_legal_id_keyed():
         country="us",
     )
     assert head_start_age_mapping.mapping_type == "parameter_value"
-    assert head_start_age_mapping.policyengine_parameter == "gov.hhs.head_start.age_range"
+    assert (
+        head_start_age_mapping.policyengine_parameter == "gov.hhs.head_start.age_range"
+    )
     assert head_start_age_mapping.parameter_key_path == ("thresholds", 1)
     head_start_overincome_exception_mapping = registry.mapping_for_legal_id(
         "us:regulations/45-cfr/1302/12#paragraph_c_overincome_exception_participant_may_be_enrolled",
@@ -3501,6 +3503,59 @@ def test_policyengine_oracle_compares_parameter_value_mapping(tmp_path):
     assert result.details["coverage"]["passed"] == 1
     assert "gov.irs.payroll.medicare.additional.exclusion" in scripts[0]
     assert 'keys = ["JOINT"]' in scripts[0]
+
+
+def test_policyengine_parameter_mapping_ignores_unrelated_legal_inputs(tmp_path):
+    rules_file = tmp_path / "rules.yaml"
+    rules_file.write_text("format: rulespec/v1\n")
+    rules_file.with_name("rules.test.yaml").write_text(
+        """- name: early_head_start_age_threshold
+  period: 2026
+  input:
+    us:regulations/45-cfr/1302/12/b#input.child_age_years: 0
+    us:regulations/45-cfr/1302/12/b#input.child_is_infant_or_toddler: false
+    us:regulations/45-cfr/1302/12/b#input.child_transitioning_to_head_start_preschool: false
+  output:
+    us:regulations/45-cfr/1302/12/b#early_head_start_age_threshold_years: 3
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=True,
+        oracle_validators=("policyengine",),
+    )
+    pipeline.policyengine_registry = PolicyEngineOracleRegistry(
+        {
+            "us:regulations/45-cfr/1302/12/b#early_head_start_age_threshold_years": PolicyEngineMapping(
+                legal_id="us:regulations/45-cfr/1302/12/b#early_head_start_age_threshold_years",
+                country="us",
+                mapping_type="parameter_value",
+                policyengine_parameter="gov.hhs.head_start.early_head_start.age_limit",
+                period="year",
+            )
+        }
+    )
+    pipeline._detect_policyengine_country = lambda *_args, **_kwargs: "us"
+    pipeline._find_pe_python = lambda _country: Path("python")
+
+    scripts = []
+
+    def fake_run(script, *_args, **_kwargs):
+        scripts.append(script)
+        return OracleSubprocessResult(returncode=0, stdout="RESULT:3\n")
+
+    pipeline._run_pe_subprocess_detailed = fake_run
+
+    result = pipeline._run_policyengine(rules_file)
+
+    assert result.score == 1.0
+    assert result.passed is True
+    assert result.issues == []
+    assert result.details["coverage"]["comparable"] == 1
+    assert result.details["coverage"]["passed"] == 1
+    assert "gov.hhs.head_start.early_head_start.age_limit" in scripts[0]
+    assert "child_age_years" not in scripts[0]
 
 
 def test_policyengine_oracle_compares_multi_key_parameter_value_mapping(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.866"
+version = "0.2.867"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.867"
+version = "0.2.868"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 7 CFR 246.7 WIC certification/procedure outputs as PolicyEngine-known non-comparable helper surfaces
- add Head Start 45 CFR 1302.12 mappings for PE-comparable age threshold parameters and classify isolated age/procedure predicates as non-comparable
- fix PE parameter-value oracle validation so unrelated RuleSpec legal inputs in the same companion test do not block parameter comparisons

## Validation
- env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_rulespec_validation.py::test_policyengine_parameter_mapping_ignores_unrelated_legal_inputs tests/test_rulespec_validation.py::test_policyengine_oracle_compares_parameter_value_mapping tests/test_rulespec_validation.py::test_policyengine_oracle_passes_through_parameter_key_input tests/test_rulespec_validation.py::test_policyengine_oracle_compares_nested_parameter_key_path
- env -u UV_FROZEN uv run --extra dev axiom-encode validate --skip-reviewers --oracle policyengine /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-head-start-pe-parity-20260626/us/regulations/45-cfr/1302/12.yaml /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-head-start-pe-parity-20260626/us/regulations/45-cfr/1302/12/b.yaml