### PR TITLE
Fix nested source-id validation overlay

### DIFF
--- a/changelog.d/nested-source-id-validation.fixed.md
+++ b/changelog.d/nested-source-id-validation.fixed.md
@@ -1,0 +1,1 @@
+Resolve generated nested `--source-id` companion test references against validation overlay files before apply.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.868"
+version = "0.2.869"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.868"
+__version__ = "0.2.869"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3478,10 +3478,24 @@ def _apply_generated_eval_repairs(
 
 def _validation_policy_repo_root(validation_file: Path, policy_repo_root: Path) -> Path:
     """Return the repo root that contains the validation copy."""
-    repo_name = policy_repo_root.name
+    repo_names = {
+        name
+        for name in (
+            policy_repo_root.name,
+            canonical_rulespec_repo_name(policy_repo_root),
+        )
+        if name
+    }
+    jurisdiction = jurisdiction_prefix(policy_repo_root)
     for parent in validation_file.parents:
-        if parent.name == repo_name:
+        if parent.name in repo_names:
+            content_root = jurisdiction_content_dir(parent, jurisdiction)
+            if _is_under_root(validation_file, content_root):
+                return content_root
             return parent
+    discovered = find_policy_repo_root(validation_file)
+    if discovered is not None:
+        return discovered
     return policy_repo_root
 
 
@@ -3602,7 +3616,11 @@ def _rulespec_validation_target(
                 )
             except OSError:
                 shutil.copytree(eval_workspaces_root, eval_overlay)
-        validation_file = overlay_repo / relative
+        validation_content_root = jurisdiction_content_dir(
+            overlay_repo,
+            jurisdiction_prefix(policy_repo_root),
+        )
+        validation_file = validation_content_root / relative
         validation_file.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(rulespec_file, validation_file)
         companion_test = rulespec_file.with_name(f"{rulespec_file.stem}.test.yaml")

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -49,6 +49,7 @@ from axiom_encode.harness.evals import (
     _select_cross_section_context_files,
     _source_identifier_to_relative_rulespec_path,
     _target_source_scope_for_heuristics,
+    _validation_policy_repo_root,
     _wait_for_codex_process,
     evaluate_artifact,
     find_admin_agency_aggregate_entity_issues,
@@ -2021,6 +2022,91 @@ def test_rulespec_validation_overlay_preserves_eval_source_metadata(tmp_path):
 
     assert metadata is not None
     assert metadata["requested_source"] == "us-co/statute/39/39-22-104/1.5"
+
+
+def test_rulespec_validation_overlay_resolves_generated_nested_source_id(
+    tmp_path,
+):
+    policy_repo = tmp_path / "rulespec-us-medicaid-program-composite-20260626"
+    policy_repo.mkdir()
+    subprocess.run(["git", "init"], cwd=policy_repo, check=True, capture_output=True)
+    subprocess.run(
+        [
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/TheAxiomFoundation/rulespec-us.git",
+        ],
+        cwd=policy_repo,
+        check=True,
+        capture_output=True,
+    )
+    (policy_repo / "us").mkdir()
+
+    output_file = (
+        tmp_path
+        / "out"
+        / "codex-gpt-5.5"
+        / "regulations"
+        / "42-cfr"
+        / "435"
+        / "120"
+        / "ssi-mandatory-group.yaml"
+    )
+    output_file.parent.mkdir(parents=True)
+    output_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: ssi_mandatory_group
+    kind: derived
+    entity: Person
+    dtype: Boolean
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: person_is_aged_blind_or_disabled
+"""
+    )
+    output_file.with_name("ssi-mandatory-group.test.yaml").write_text(
+        """- name: aged_blind_or_disabled_person_is_in_group
+  period:
+    period_kind: month
+    start: '2026-01-01'
+    end: '2026-01-31'
+  input:
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_aged_blind_or_disabled: true
+  output:
+    us:regulations/42-cfr/435/120/ssi-mandatory-group#ssi_mandatory_group: true
+"""
+    )
+
+    with _rulespec_validation_target(output_file, policy_repo) as validation_file:
+        validation_policy_root = _validation_policy_repo_root(
+            validation_file,
+            policy_repo,
+        )
+        target_ref = validator_pipeline._parse_rulespec_target(
+            "us:regulations/42-cfr/435/120/ssi-mandatory-group"
+            "#input.person_is_aged_blind_or_disabled"
+        )
+
+        assert validation_file.parts[-6:] == (
+            "us",
+            "regulations",
+            "42-cfr",
+            "435",
+            "120",
+            "ssi-mandatory-group.yaml",
+        )
+        assert validation_policy_root == validation_file.parents[4]
+        assert target_ref is not None
+        resolved_target = validator_pipeline._resolve_rulespec_target_file(
+            target_ref,
+            validation_policy_root,
+        )
+        assert resolved_target is not None
+        assert resolved_target.resolve() == validation_file.resolve()
 
 
 def test_materialize_eval_artifact_repairs_source_table_band_scalars(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.868"
+version = "0.2.869"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Fix validation overlay rooting for generated nested `--source-id` outputs in country monorepos like `rulespec-us`.
- Ensure companion test references resolve against generated validation files before apply.
- Add regression coverage for issue #805 and bump axiom-encode to 0.2.869.

Fixes #805.

## Tests
- `uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_evals.py::test_rulespec_validation_overlay_preserves_eval_source_metadata tests/test_evals.py::test_rulespec_validation_overlay_resolves_generated_nested_source_id -q`
- `uv run --extra dev python -m pytest tests/test_cli.py -k "apply_overlay_validation_stages_country_monorepo_dependencies or apply_overlay_validation_routes_country_monorepo_root" -q`
- `uv run ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/harness/evals.py tests/test_evals.py`
- `uv run ruff format --check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/harness/evals.py tests/test_evals.py`