### PR TITLE
Ignore section-symbol citations in numeric coverage

### DIFF
--- a/changelog.d/section-symbol-numeric.fixed.md
+++ b/changelog.d/section-symbol-numeric.fixed.md
@@ -1,0 +1,1 @@
+Ignore section-symbol legal citations such as `§ 435.121` when checking source numeric occurrence coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.869"
+version = "0.2.870"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.869"
+__version__ = "0.2.870"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -797,7 +797,7 @@ _STRUCTURAL_SOURCE_BARE_DOTTED_REFERENCE_PATTERN = re.compile(
     r"(?<![\w$£€])\d+(?:\.\d+){2,}(?![\w%])"
 )
 _STRUCTURAL_SOURCE_SECTION_PATTERN = re.compile(
-    r"\b(?:section|sec\.?)\s+\d+(?:[.-]\d+)*"
+    r"(?:\b(?:section|sec\.?)|§{1,2})\s+\d+(?:[.-]\d+)*"
     r"(?:"
     r"(?:\([A-Za-z0-9]+\))+"
     r"(?:-(?:\([A-Za-z0-9]+\))+)*)?"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -6496,6 +6496,15 @@ def test_numeric_occurrence_extraction_ignores_bare_dotted_regulatory_reference(
     assert extract_numeric_occurrences_from_text(text) == [pytest.approx(0.0831)]
 
 
+def test_numeric_occurrence_extraction_ignores_section_symbol_reference():
+    text = (
+        "Except as allowed under § 435.121, the agency must provide Medicaid. "
+        "The matching threshold is 8.31%."
+    )
+
+    assert extract_numeric_occurrences_from_text(text) == [pytest.approx(0.0831)]
+
+
 def test_numeric_occurrence_extraction_ignores_form_and_line_identifiers():
     text = (
         "Show the shortage on Line 13 of Form FNS-250. Attach Form G-845 "

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.869"
+version = "0.2.870"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- ignore section-symbol legal citations such as § 435.121 during source numeric occurrence coverage checks
- add a regression test for section-symbol regulatory references
- bump axiom-encode to 0.2.870

## Validation
- env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_rulespec_validation.py::test_numeric_occurrence_extraction_ignores_section_symbol_reference tests/test_rulespec_validation.py::test_numeric_occurrence_extraction_ignores_bare_dotted_regulatory_reference tests/test_evals.py::test_rulespec_validation_overlay_resolves_generated_nested_source_id -q
- env -u UV_FROZEN uv run ruff check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- env -u UV_FROZEN uv run ruff format --check pyproject.toml src/axiom_encode/__init__.py src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- evaluated the generated Medicaid 42 CFR 435.120 artifact: compile_pass=True, ci_pass=True, numeric_occurrence_issues=[]