### PR TITLE
Classify Medicaid SSI mandatory helpers

### DIFF
--- a/changelog.d/medicaid-435-120-oracle-mappings.fixed.md
+++ b/changelog.d/medicaid-435-120-oracle-mappings.fixed.md
@@ -1,0 +1,1 @@
+Classify 42 CFR 435.120 SSI mandatory-group helper outputs as not comparable to PolicyEngine final Medicaid eligibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.870"
+version = "0.2.871"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.870"
+__version__ = "0.2.871"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1,4 +1,18 @@
 mappings:
+  - legal_id: us:regulations/42-cfr/435/120/ssi-mandatory-group#person_receiving_or_deemed_receiving_ssi_for_mandatory_group
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This RuleSpec output is a 42 CFR 435.120 source-level predicate for SSI-related mandatory Medicaid coverage. PolicyEngine exposes final Medicaid eligibility after category, state, income, immigration, and exception gates are composed, not this regulatory intermediate as a one-to-one variable.
+
+  - legal_id: us:regulations/42-cfr/435/120/ssi-mandatory-group#medicaid_required_for_ssi_mandatory_group
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This RuleSpec output is the 42 CFR 435.120 SSI mandatory-group required-coverage branch, including the section 435.121 exception. PolicyEngine exposes final Medicaid eligibility, not this source-specific Medicaid obligation as a standalone oracle target.
+
   - legal_id: us:regulations/42-cfr/435/121#medicaid_required_for_section_1619_b_3_individual
     country: us
     program: medicaid

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -3225,6 +3225,20 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
 
 
+def test_policyengine_registry_classifies_medicaid_435_120_helpers_not_comparable():
+    registry = load_policyengine_registry()
+
+    for legal_id in (
+        "us:regulations/42-cfr/435/120/ssi-mandatory-group#person_receiving_or_deemed_receiving_ssi_for_mandatory_group",
+        "us:regulations/42-cfr/435/120/ssi-mandatory-group#medicaid_required_for_ssi_mandatory_group",
+    ):
+        mapping = registry.mapping_for_legal_id(legal_id, country="us")
+        assert mapping is not None
+        assert mapping.program == "medicaid"
+        assert mapping.mapping_type == "not_comparable"
+        assert mapping.candidate_priority == "P4"
+
+
 def test_policyengine_registry_includes_acp_parameter_and_not_comparable_mappings():
     registry = load_policyengine_registry()
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.870"
+version = "0.2.871"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify the new 42 CFR 435.120 SSI mandatory-group helper outputs as PolicyEngine not-comparable Medicaid intermediates
- add a focused registry regression test for those mappings
- bump axiom-encode to `0.2.871`

## Why
RuleSpec PR #462 adds source-level Medicaid helper outputs. Full oracle coverage correctly required explicit classification before the RuleSpec toolchain bump can pass.

## Validation
- `env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_rulespec_validation.py::test_policyengine_registry_classifies_medicaid_435_120_helpers_not_comparable -q`
- `env -u UV_FROZEN uv run ruff check pyproject.toml src/axiom_encode/__init__.py tests/test_rulespec_validation.py`
- `env -u UV_FROZEN uv run ruff format --check pyproject.toml src/axiom_encode/__init__.py tests/test_rulespec_validation.py`
- temporary-root `axiom-encode oracle-coverage --fail-on-unmapped --fail-on-untested-comparable --limit 50` against RuleSpec PR #462 worktree now passes with `unmapped=0`