### PR TITLE
Classify ACA applicable taxpayer helpers

### DIFF
--- a/changelog.d/aca-36b-c1a-oracle-mappings.fixed.md
+++ b/changelog.d/aca-36b-c1a-oracle-mappings.fixed.md
@@ -1,0 +1,1 @@
+Classify 26 USC 36B(c)(1)(A) applicable-taxpayer helper outputs as not comparable to PolicyEngine final ACA PTC eligibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.871"
+version = "0.2.872"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.871"
+__version__ = "0.2.872"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -4965,6 +4965,30 @@ mappings:
     candidate_priority: P4
     rationale: PolicyEngine applies the ACA PTC income range through gov.aca.ptc_income_eligibility inside is_aca_ptc_eligible, which also includes filing status, immigration, coverage, and premium-payment conditions. This RuleSpec output is only the section 36B(c)(1) income-percentage predicate.
 
+  - legal_id: us:statutes/26/36B/c/1/A#applicable_taxpayer_lower_poverty_line_percentage
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.ptc_income_eligibility
+    candidate_priority: P4
+    rationale: This RuleSpec output is the statutory lower household-income-to-poverty-line threshold for section 36B(c)(1)(A). PolicyEngine stores ACA PTC income eligibility in a threshold parameter used inside final eligibility, not this scalar as a one-to-one oracle target.
+
+  - legal_id: us:statutes/26/36B/c/1/A#applicable_taxpayer_upper_poverty_line_percentage
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.ptc_income_eligibility
+    candidate_priority: P4
+    rationale: This RuleSpec output is the statutory general upper household-income-to-poverty-line threshold for section 36B(c)(1)(A). PolicyEngine stores ACA PTC income eligibility as a time-varying threshold parameter, including temporary upper-limit overrides, not this scalar as a one-to-one oracle target.
+
+  - legal_id: us:statutes/26/36B/c/1/A#applicable_taxpayer
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.ptc_income_eligibility
+    candidate_priority: P4
+    rationale: This RuleSpec output is only the section 36B(c)(1)(A) income-range predicate for being an applicable taxpayer. PolicyEngine applies this through gov.aca.ptc_income_eligibility inside final ACA PTC eligibility, alongside filing, coverage, premium-payment, and other gates.
+
   - legal_id: us:statutes/26/36B#employer_sponsored_coverage_affordability_ratio
     country: us
     program: aca_ptc

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2915,6 +2915,18 @@ def test_policyengine_registry_is_legal_id_keyed():
             "policyengine_parameter",
             "gov.aca.ptc_income_eligibility",
         ),
+        "us:statutes/26/36B/c/1/A#applicable_taxpayer_lower_poverty_line_percentage": (
+            "policyengine_parameter",
+            "gov.aca.ptc_income_eligibility",
+        ),
+        "us:statutes/26/36B/c/1/A#applicable_taxpayer_upper_poverty_line_percentage": (
+            "policyengine_parameter",
+            "gov.aca.ptc_income_eligibility",
+        ),
+        "us:statutes/26/36B/c/1/A#applicable_taxpayer": (
+            "policyengine_parameter",
+            "gov.aca.ptc_income_eligibility",
+        ),
         "us:statutes/26/36B#employer_sponsored_coverage_affordability_ratio": (
             "policyengine_variable",
             "offered_aca_disqualifying_esi",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.871"
+version = "0.2.872"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify 26 USC 36B(c)(1)(A) applicable-taxpayer helper outputs as PolicyEngine oracle not-comparable
- bump axiom-encode to 0.2.872
- add registry coverage for the legal IDs

## Tests
- env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed -q
- env -u UV_FROZEN uv run ruff check pyproject.toml src/axiom_encode/__init__.py tests/test_rulespec_validation.py
- env -u UV_FROZEN uv run ruff format --check pyproject.toml src/axiom_encode/__init__.py tests/test_rulespec_validation.py
- env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root /tmp/axiom-aca-root.TYfiMj --program aca_ptc --fail-on-unmapped --fail-on-untested-comparable --limit 20