### PR TITLE
Classify federal CHIP definition helpers

### DIFF
--- a/changelog.d/chip-1397jj-oracle-mappings.fixed.md
+++ b/changelog.d/chip-1397jj-oracle-mappings.fixed.md
@@ -1,0 +1,1 @@
+Classify federal CHIP 42 USC 1397jj definition helper outputs as not comparable to PolicyEngine final CHIP child eligibility.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.872"
+version = "0.2.873"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.872"
+__version__ = "0.2.873"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -237,6 +237,62 @@ mappings:
     candidate_priority: P4
     rationale: This RuleSpec output is a source-level statutory definition used by Medicaid category rules. PolicyEngine exposes final Medicaid eligibility and category parameters, not this 42 USC 1396d(n) definition as a direct variable.
 
+  - legal_id: us:statutes/42/1397jj/b/1#medicaid_applicable_income_level_additional_percentage_points
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible_child
+    rationale: This RuleSpec output is the federal statutory increment used in the targeted low-income child definition. PolicyEngine exposes state effective CHIP income limits and final eligibility, not this federal definition helper as a one-to-one parameter.
+
+  - legal_id: us:statutes/42/1397jj/b/1#targeted_low_income_child
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible_child
+    rationale: This RuleSpec output is a federal source-level targeted-low-income-child definition. PolicyEngine exposes final CHIP child eligibility, not this statutory prerequisite as a standalone oracle variable.
+
+  - legal_id: us:statutes/42/1397jj/c/1#child
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible_child
+    rationale: This RuleSpec output is the federal CHIP child definition. PolicyEngine exposes final CHIP eligibility surfaces, not this statutory definition as a one-to-one variable.
+
+  - legal_id: us:statutes/42/1397jj/c/1#child_age_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible_child
+    rationale: This RuleSpec output is the age scalar inside the federal CHIP child definition. PolicyEngine does not expose this statutory helper separately from final CHIP child eligibility.
+
+  - legal_id: us:statutes/42/1397jj/c/4#low_income_child
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible_child
+    rationale: This RuleSpec output is the federal low-income-child definition used by CHIP. PolicyEngine exposes final CHIP child eligibility and state income tables, not this source-level statutory predicate.
+
+  - legal_id: us:statutes/42/1397jj/c/4#low_income_child_family_income_limit
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible_child
+    rationale: This RuleSpec output is the federal poverty-line threshold in the CHIP low-income-child definition. PolicyEngine's CHIP income-limit parameters are state effective limits, not this federal definition helper.
+
+  - legal_id: us:statutes/42/1397jj/c/8#uncovered_child
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible_child
+    rationale: This RuleSpec output is the federal uncovered-child definition. PolicyEngine exposes final CHIP eligibility and insurance-status inputs, not this statutory prerequisite as a standalone oracle variable.
+
   - legal_id: us:statutes/8/1612/b/2/G#paragraph_1_nonapplication_exception_applies
     country: us
     program: medicaid

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2582,6 +2582,21 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
     assert head_start_overincome_exception_mapping.mapping_type == "not_comparable"
     assert head_start_overincome_exception_mapping.program == "head_start"
+    chip_definition_mappings = [
+        "us:statutes/42/1397jj/b/1#medicaid_applicable_income_level_additional_percentage_points",
+        "us:statutes/42/1397jj/b/1#targeted_low_income_child",
+        "us:statutes/42/1397jj/c/1#child",
+        "us:statutes/42/1397jj/c/1#child_age_limit",
+        "us:statutes/42/1397jj/c/4#low_income_child",
+        "us:statutes/42/1397jj/c/4#low_income_child_family_income_limit",
+        "us:statutes/42/1397jj/c/8#uncovered_child",
+    ]
+    for legal_id in chip_definition_mappings:
+        mapping = registry.mapping_for_legal_id(legal_id, country="us")
+        assert mapping.mapping_type == "not_comparable"
+        assert mapping.program == "chip"
+        assert mapping.candidate_priority == "P4"
+        assert mapping.policyengine_variable == "is_chip_eligible_child"
     residential_clean_energy_mapping = registry.mapping_for_legal_id(
         "us:statutes/26/25D#residential_clean_energy_credit",
         country="us",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.872"
+version = "0.2.873"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify federal CHIP 42 USC 1397jj definition helper outputs as not comparable to PolicyEngine final CHIP child eligibility
- bump axiom-encode to 0.2.873
- add registry coverage for the new legal IDs

## Motivation
rulespec-us#463 added generated CHIP prerequisite slices, but changed-output oracle coverage correctly rejected seven new 1397jj helper outputs as unmapped. These are source-level federal definition predicates/scalars, while PolicyEngine exposes state effective CHIP limits and final CHIP eligibility surfaces.

## Tests
- env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed -q
- env -u UV_FROZEN uv run ruff check pyproject.toml src/axiom_encode/__init__.py tests/test_rulespec_validation.py
- env -u UV_FROZEN uv run ruff format --check pyproject.toml src/axiom_encode/__init__.py tests/test_rulespec_validation.py
- env -u UV_FROZEN uv run python -c 'import yaml; yaml.safe_load(open("src/axiom_encode/oracles/policyengine/mappings/us.yaml"))'
- env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root /tmp/axiom-chip-fixed-root.* --program chip --fail-on-unmapped --fail-on-untested-comparable --limit 20
