### PR TITLE
Support PolicyEngine rule hints in encode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.873"
+version = "0.2.874"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.873"
+__version__ = "0.2.874"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1747,6 +1747,12 @@ def main():
         help="Extra file path to copy into the repo-augmented workspace (repeatable)",
     )
     encode_parser.add_argument(
+        "--policyengine-rule-hint",
+        dest="policyengine_rule_hint",
+        default=None,
+        help="Canonical rule name to use as the PolicyEngine oracle target for this source slice",
+    )
+    encode_parser.add_argument(
         "--db",
         type=Path,
         default=DEFAULT_DB,
@@ -19200,6 +19206,7 @@ def cmd_encode(args):
 
     source_id = getattr(args, "source_id", None)
     skip_reviewers = bool(getattr(args, "skip_reviewers", False))
+    policyengine_rule_hint = getattr(args, "policyengine_rule_hint", None)
     source_unit = None
     if source_id:
         source_unit = resolve_corpus_source_unit(args.citation, corpus_path)
@@ -19225,6 +19232,7 @@ def cmd_encode(args):
             mode=args.mode,
             extra_context_paths=[Path(path) for path in args.allow_context],
             skip_reviewers=skip_reviewers,
+            policyengine_rule_hint=policyengine_rule_hint,
         )
     else:
         results = run_model_eval(
@@ -19238,6 +19246,7 @@ def cmd_encode(args):
             extra_context_paths=[Path(path) for path in args.allow_context],
             include_tests=True,
             skip_reviewers=skip_reviewers,
+            policyengine_rule_hint=policyengine_rule_hint,
         )
 
     result = results[0]
@@ -19249,6 +19258,8 @@ def cmd_encode(args):
     print(f"Mode: {args.mode}")
     if skip_reviewers:
         print("Reviewers: skipped")
+    if policyengine_rule_hint:
+        print(f"PolicyEngine rule hint: {policyengine_rule_hint}")
     if source_unit is not None:
         print(f"Corpus source: {source_unit.citation_path} ({source_unit.source})")
         print(f"RuleSpec source id: {source_id}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -507,6 +507,21 @@ class TestMain:
                 main()
                 mock_cmd.assert_called_once()
 
+    def test_encode_accepts_policyengine_rule_hint(self):
+        with patch(
+            "sys.argv",
+            [
+                "axiom_encode",
+                "encode",
+                "us/statute/42/1396a/a/10",
+                "--policyengine-rule-hint",
+                "is_medicaid_eligible",
+            ],
+        ):
+            with patch("axiom_encode.cli.cmd_encode") as mock_cmd:
+                main()
+                mock_cmd.assert_called_once()
+
     def test_eval_command_dispatches(self):
         with patch("sys.argv", ["axiom_encode", "eval", "26 USC 24(a)"]):
             with patch("axiom_encode.cli.cmd_eval") as mock_cmd:
@@ -3657,6 +3672,7 @@ class TestCmdEncode:
         args.policy_repo_path = overrides.get("policy_repo_path", policy_repo_path)
         args.mode = overrides.get("mode", "repo-augmented")
         args.allow_context = overrides.get("allow_context", [])
+        args.policyengine_rule_hint = overrides.get("policyengine_rule_hint", None)
         args.db = overrides.get("db", tmp_path / "encodings.db")
         args.sync = overrides.get("sync", True)
         args.skip_reviewers = overrides.get("skip_reviewers", False)
@@ -3703,6 +3719,7 @@ class TestCmdEncode:
         assert mock_run.call_args.kwargs["runner_specs"] == ["codex:test-model"]
         assert mock_run.call_args.kwargs["include_tests"] is True
         assert mock_run.call_args.kwargs["skip_reviewers"] is False
+        assert mock_run.call_args.kwargs["policyengine_rule_hint"] is None
         assert mock_run.call_args.kwargs["policy_path"] == args.policy_repo_path
         assert (
             mock_run.call_args.kwargs["runtime_axiom_rules_path"]
@@ -3773,6 +3790,7 @@ class TestCmdEncode:
         )
         assert mock_run_source.call_args.kwargs["runner_specs"] == ["codex:test-model"]
         assert mock_run_source.call_args.kwargs["skip_reviewers"] is False
+        assert mock_run_source.call_args.kwargs["policyengine_rule_hint"] is None
         assert mock_run_source.call_args.kwargs["policy_path"] == args.policy_repo_path
         assert (
             mock_run_source.call_args.kwargs["runtime_axiom_rules_path"]
@@ -3822,6 +3840,58 @@ class TestCmdEncode:
         assert exc_info.value.code == 0
         assert mock_run_source.call_args.kwargs["skip_reviewers"] is True
         assert "Reviewers: skipped" in capsys.readouterr().out
+
+    def test_encode_passes_policyengine_rule_hint_to_source_eval(
+        self, capsys, tmp_path
+    ):
+        args = self._make_args(
+            tmp_path,
+            citation="us/statute/42/1396a/a/10",
+            source_id="us/policies/hhs/medicaid/eligibility",
+            policyengine_rule_hint="is_medicaid_eligible",
+            sync=False,
+        )
+        result = self._make_eval_result(True)
+        result.citation = args.source_id
+
+        with (
+            patch(
+                "axiom_encode.cli.resolve_corpus_source_unit",
+                return_value=SimpleNamespace(
+                    body="medicaid source text",
+                    citation_path="us/statute/42/1396a/a/10",
+                    source="local",
+                    requested="us/statute/42/1396a/a/10",
+                ),
+            ),
+            patch(
+                "axiom_encode.cli.run_source_eval", return_value=[result]
+            ) as mock_run_source,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        assert (
+            mock_run_source.call_args.kwargs["policyengine_rule_hint"]
+            == "is_medicaid_eligible"
+        )
+        assert "PolicyEngine rule hint: is_medicaid_eligible" in capsys.readouterr().out
+
+    def test_encode_passes_policyengine_rule_hint_to_model_eval(self, capsys, tmp_path):
+        args = self._make_args(
+            tmp_path,
+            policyengine_rule_hint="is_medicaid_eligible",
+        )
+        mock_run, exit_code = self._run_encode(args, self._make_eval_result(True))
+
+        assert exit_code == 0
+        assert (
+            mock_run.call_args.kwargs["policyengine_rule_hint"]
+            == "is_medicaid_eligible"
+        )
+        assert "PolicyEngine rule hint: is_medicaid_eligible" in capsys.readouterr().out
 
     def test_encode_with_errors(self, capsys, tmp_path):
         args = self._make_args(tmp_path, citation="26 USC 1", model=None)

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.873"
+version = "0.2.874"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add `--policyengine-rule-hint` to `axiom-encode encode`
- pass the hint through to source/model eval generation so encode/apply can target PE-comparable output names
- bump axiom-encode to 0.2.874

## Tests
- `env -u UV_FROZEN uv run --extra dev pytest tests/test_cli.py -k 'policyengine_rule_hint or test_encode_success or test_encode_with_source_id_uses_corpus_source_unit'`
- `env -u UV_FROZEN uv run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py`