### PR TITLE
Classify Head Start PE surfaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.874"
+version = "0.2.875"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.874"
+__version__ = "0.2.875"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -3625,7 +3625,7 @@ def cmd_oracle_coverage(args):
     unmapped = int(report["status_counts"].get("unmapped", 0))
     untested_comparable = int(report.get("untested_comparable", 0))
     pending_program_surfaces = int(
-        (report.get("program_surfaces") or {}).get("pending_surfaces", 0)
+        (report.get("program_surfaces") or {}).get("active_pending_surfaces", 0)
     )
     should_fail = (
         (args.fail_on_unmapped and unmapped)

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1400,10 +1400,13 @@ surfaces:
   coverage: US
   variable: is_head_start_eligible
   source_type: eligibility
-  axiom_status: pending_oracle_mapping
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyBench scores this direct person-level Head Start eligibility variable. Axiom has national eligibility slices, but
-    the PE eligibility boundary still needs a reviewed exact composite or a documented non-comparable classification.
+  rationale: Axiom encodes and classifies the national 45 CFR 1302.12 eligibility slices that touch Head Start eligibility,
+    including ordinary paragraph (c) participant eligibility, preschool age, over-income enrollment allowances, Tribal
+    service-area eligibility, and Migrant or Seasonal eligibility. PolicyEngine's `is_head_start_eligible` variable is a
+    direct person-level model surface that does not expose those legal branches and program-administration predicates as a
+    one-to-one RuleSpec oracle boundary.
 - country: us
   program_id: head_start
   program_name: Early Head Start eligibility
@@ -1413,10 +1416,12 @@ surfaces:
   coverage: US
   variable: is_early_head_start_eligible
   source_type: eligibility
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyBench scores this direct person-level Early Head Start eligibility variable. Axiom should encode the infant,
-    toddler, and pregnancy eligibility boundary before claiming parity.
+  rationale: Axiom encodes and classifies the 45 CFR 1302.12(b)(1) Early Head Start age requirement and the paragraph (c)
+    participant eligibility paths. PolicyEngine's `is_early_head_start_eligible` variable is a direct person-level model
+    surface combining Early Head Start age or pregnancy eligibility with broader model eligibility logic, so the existing
+    source-specific RuleSpec outputs are not a one-to-one oracle boundary.
 - country: us
   program_id: head_start
   program_name: ECEAP
@@ -1428,7 +1433,8 @@ surfaces:
   source_type: state_implementation
   state: WA
   axiom_status: deferred_jurisdiction
-  priority: P1
+  priority: P3
+  lifecycle: inactive
   rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
     and Georgia law before other jurisdictions.
 - country: us
@@ -1442,7 +1448,8 @@ surfaces:
   source_type: state_implementation
   state: WA
   axiom_status: deferred_jurisdiction
-  priority: P1
+  priority: P3
+  lifecycle: inactive
   rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
     and Georgia law before other jurisdictions.
 - country: us

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1825,6 +1825,7 @@ class TestCmdValidate:
                     "status_counts": {"pending_rulespec_encoding": 1},
                     "priority_counts": {"P1": 1},
                     "pending_surfaces": 1,
+                    "active_pending_surfaces": 1,
                     "items": [
                         {
                             "variable": "wic",

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -632,14 +632,14 @@ def test_policyengine_program_surface_includes_policybench_person_eligibility_su
     assert wic["policybench_household_weight"] == pytest.approx(0.32)
 
     assert head_start["program_id"] == "head_start"
-    assert head_start["axiom_status"] == "pending_oracle_mapping"
+    assert head_start["axiom_status"] == "known_not_comparable"
     assert head_start["mapping_count"] == 6
     assert head_start["comparable_mapping_count"] == 0
     assert head_start["policybench_output"] == "person_level_head_start_eligibility"
     assert head_start["policybench_household_weight"] == pytest.approx(1.18)
 
     assert early_head_start["program_id"] == "head_start"
-    assert early_head_start["axiom_status"] == "pending_rulespec_encoding"
+    assert early_head_start["axiom_status"] == "known_not_comparable"
     assert early_head_start["mapping_count"] == 1
     assert early_head_start["comparable_mapping_count"] == 0
     assert (
@@ -783,10 +783,14 @@ def test_policyengine_program_surface_marks_head_start_known_not_comparable():
         "us:regulations/45-cfr/1302/12#paragraph_c_participant_eligible"
     ]
     assert items_by_variable["wa_eceap"]["axiom_status"] == "deferred_jurisdiction"
+    assert items_by_variable["wa_eceap"]["lifecycle"] == "inactive"
+    assert items_by_variable["wa_eceap"]["priority"] == "P3"
     assert (
         items_by_variable["wa_birth_to_three_eceap"]["axiom_status"]
         == "deferred_jurisdiction"
     )
+    assert items_by_variable["wa_birth_to_three_eceap"]["lifecycle"] == "inactive"
+    assert items_by_variable["wa_birth_to_three_eceap"]["priority"] == "P3"
 
 
 def test_policyengine_program_surface_marks_calworks_cash_benefit_known_not_comparable():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.874"
+version = "0.2.875"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify national Head Start and Early Head Start PolicyEngine eligibility surfaces as known-not-comparable based on existing 45 CFR 1302.12 RuleSpec mappings
- mark Washington Head Start variants as inactive deferred jurisdiction surfaces outside the national lane
- make the oracle-coverage pending-surface fail gate use active pending surfaces
- bump axiom-encode to 0.2.875 for the encoder-affecting mapping/tooling change

## Checks
- env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::TestCmdValidate::test_oracle_coverage_fail_on_pending_program_surfaces_exits_nonzero tests/test_policyengine_coverage.py
- env -u UV_FROZEN uv run --extra dev python -m ruff check src/axiom_encode/cli.py src/axiom_encode/__init__.py tests/test_cli.py tests/test_policyengine_coverage.py
- env -u UV_FROZEN uv run axiom-encode oracle-coverage --root /tmp/axiom-head-start-coverage-20260626 --program head_start --include-program-surfaces --fail-on-unmapped --fail-on-untested-comparable --fail-on-pending-program-surfaces
- env -u UV_FROZEN uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-head-start-pe-parity-fresh-20260626 us/regulations/45-cfr/1302/12.test.yaml us/regulations/45-cfr/1302/12/b.test.yaml
- env -u UV_FROZEN uv run axiom-encode validate --skip-reviewers /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-head-start-pe-parity-fresh-20260626/us/regulations/45-cfr/1302/12.yaml /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-head-start-pe-parity-fresh-20260626/us/regulations/45-cfr/1302/12/b.yaml
- env -u UV_FROZEN uv run axiom-encode proof-validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-head-start-pe-parity-fresh-20260626/us/regulations/45-cfr/1302/12.yaml /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-head-start-pe-parity-fresh-20260626/us/regulations/45-cfr/1302/12/b.yaml
- env -u UV_FROZEN uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-head-start-pe-parity-fresh-20260626 --base-ref origin/main --head-ref HEAD

## Note
- Earlier full local pytest had one unrelated local axiom-rules-engine scalar-kind mismatch in tests/test_rulespec_validation.py::test_rulespec_ci_rejects_scalar_kind_mismatches; CI did not report that local engine-only failure on the prior push.
