### PR TITLE
Classify SSI PolicyBench surface as non-comparable

### DIFF
--- a/changelog.d/ssi-policybench-surface-known-not-comparable.changed.md
+++ b/changelog.d/ssi-policybench-surface-known-not-comparable.changed.md
@@ -1,0 +1,1 @@
+Classify the SSI PolicyBench program surface as known not comparable to existing source-level RuleSpec outputs and bump axiom-encode to 0.2.877.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.876"
+version = "0.2.877"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.876"
+__version__ = "0.2.877"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1503,10 +1503,12 @@ surfaces:
   coverage: US
   variable: ssi
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom encodes tested SSI federal benefit-rate, income-exclusion, resource-limit, eligibility-branch, blindness,
+    and COLA source-level outputs, including 42 USC 1382(b)(1)'s annual benefit formula. PolicyEngine's final person-level
+    ssi surface also includes broader eligibility, resource, take-up, and modeled administrative assumptions, so compare
+    the encoded legal components separately until Axiom has an equivalent final program-composition surface.
 - country: us
   program_id: ssi_state_supplement
   program_name: Alaska SSP

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -793,6 +793,23 @@ def test_policyengine_program_surface_marks_head_start_known_not_comparable():
     assert items_by_variable["wa_birth_to_three_eceap"]["priority"] == "P3"
 
 
+def test_policyengine_program_surface_marks_ssi_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="ssi")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    ssi = items_by_variable["ssi"]
+
+    assert ssi["axiom_status"] == "known_not_comparable"
+    assert ssi["priority"] == "P1"
+    assert ssi["mapping_count"] == 1
+    assert ssi["comparable_mapping_count"] == 0
+    assert ssi["legal_ids"] == [
+        "us:statutes/42/1382/b#annual_benefit_without_eligible_spouse"
+    ]
+    assert "final person-level" in ssi["rationale"]
+    assert "final program-composition surface" in ssi["rationale"]
+
+
 def test_policyengine_program_surface_marks_calworks_cash_benefit_known_not_comparable():
     report = build_policyengine_program_surface_report(program="tanf")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.876"
+version = "0.2.877"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark the SSI PolicyBench `ssi` program surface as `known_not_comparable`
- document that existing SSI RuleSpec outputs cover source-level legal components, while PolicyEngine's final person-level `ssi` includes broader eligibility, resource, take-up, and modeled administrative assumptions
- add a regression test for the SSI program-surface classification

## SSI lane findings
- Active pending surface before this change: `program_id=ssi`, `variable=ssi`, PolicyBench household weight 1.97
- Existing generated RuleSpec: `us:statutes/42/1382/b#annual_benefit_without_eligible_spouse`, with signed `axiom-encode encode --apply` manifest in `rulespec-us`
- Existing oracle mapping: `not_comparable` to PolicyEngine `ssi`; the RuleSpec output is source-level 42 USC 1382(b)(1), while PE `ssi` is a final person-level modeled program amount

## Checks
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k 'program_surface_marks_ssi_known_not_comparable or program_surface_report_overlays_legal_registry'`
- `uv run axiom-encode oracle-coverage --root /tmp/axiom-ssi-coverage-workspace --program ssi --include-program-surfaces --fail-on-pending-program-surfaces --fail-on-unmapped --fail-on-untested-comparable --json`
  - result: 45 SSI outputs, 8 comparable, 37 known_not_comparable, 0 untested comparable, 0 active pending program surfaces
- `uv run ruff check src/axiom_encode/oracles/policyengine/coverage.py tests/test_policyengine_coverage.py`
- `uv run python -m compileall -q src/axiom_encode scripts`

## Review note
I could not run a separate subagent review in this Codex session because no independent review tool was exposed. I did a local diff review after rebase and recorded the focused gates above.
