### PR TITLE
Map Medicaid policy composite oracle surface

### DIFF
--- a/changelog.d/medicaid-policy-composite-oracle.changed.md
+++ b/changelog.d/medicaid-policy-composite-oracle.changed.md
@@ -1,0 +1,1 @@
+Classify the generated Medicaid policy composite for PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.877"
+version = "0.2.878"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.877"
+__version__ = "0.2.878"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -104,6 +104,61 @@ mappings:
     candidate_priority: P4
     rationale: This RuleSpec output marks a qualified noncitizen whose Medicaid coverage is limited to emergency services by the five-year bar. PolicyEngine does not expose this limitation predicate as a separate Medicaid oracle target.
 
+  - legal_id: us:policies/hhs/medicaid/eligibility#child_ssi_deeming_age_ceiling_years
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This RuleSpec output is a statutory child age threshold used inside the Medicaid eligibility composition. PolicyEngine exposes final Medicaid eligibility, not this helper scalar as a one-to-one oracle target.
+
+  - legal_id: us:policies/hhs/medicaid/eligibility#specified_low_income_medicare_beneficiary_income_limit_poverty_line_rate
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This RuleSpec output is a Medicare Savings Program-adjacent statutory income-limit helper. PolicyEngine's Medicaid oracle surface is final eligibility and state/effective thresholds, not this source-level scalar.
+
+  - legal_id: us:policies/hhs/medicaid/eligibility#inpatient_hospital_durational_limit_exception_age_ceiling_years
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This RuleSpec output is a durational-limit exception age threshold for inpatient hospital services, not a person-level Medicaid eligibility result or exposed PolicyEngine Medicaid parameter.
+
+  - legal_id: us:policies/hhs/medicaid/eligibility#adult_expansion_mandatory_eligible
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_variable: is_medicaid_eligible
+    candidate_priority: P4
+    rationale: This RuleSpec output is the adult-expansion limb of the Medicaid eligibility composition. PolicyEngine exposes final Medicaid eligibility after all category, state, income, and immigration gates, not this limb as a one-to-one variable.
+
+  - legal_id: us:policies/hhs/medicaid/eligibility#former_foster_care_mandatory_eligible
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_variable: is_medicaid_eligible
+    candidate_priority: P4
+    rationale: This RuleSpec output is the former-foster-care limb of the Medicaid eligibility composition. PolicyEngine exposes final Medicaid eligibility, not this source-level mandatory-group branch separately.
+
+  - legal_id: us:policies/hhs/medicaid/eligibility#optional_group_eligible
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    policyengine_variable: is_medicaid_eligible
+    candidate_priority: P4
+    rationale: This RuleSpec output is the state-elected optional-group limb of Medicaid eligibility. PolicyEngine exposes final Medicaid eligibility and does not expose this state-election branch as a separate oracle variable.
+
+  - legal_id: us:policies/hhs/medicaid/eligibility#is_medicaid_eligible
+    country: us
+    program: medicaid
+    mapping_type: direct_variable
+    policyengine_variable: is_medicaid_eligible
+    entity: person
+    period: year
+    comparison: decision
+    rationale: Same person-level Medicaid eligibility decision surface used by PolicyBench and PolicyEngine.
+
   - legal_id: us:statutes/42/1396a/a/10#adult_expansion_age_ceiling_years
     country: us
     program: medicaid

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -176,6 +176,78 @@ rules:
     assert final_surface["mapping_type"] == "not_comparable"
 
 
+def test_policyengine_coverage_classifies_medicaid_policy_composite(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us/us/policies/hhs/medicaid/eligibility.yaml",
+        """format: rulespec/v1
+rules:
+  - name: child_ssi_deeming_age_ceiling_years
+    kind: parameter
+    versions:
+      - effective_from: '1974-01-01'
+        formula: 21
+  - name: specified_low_income_medicare_beneficiary_income_limit_poverty_line_rate
+    kind: parameter
+    versions:
+      - effective_from: '1995-01-01'
+        formula: 1.2
+  - name: inpatient_hospital_durational_limit_exception_age_ceiling_years
+    kind: parameter
+    versions:
+      - effective_from: '1974-01-01'
+        formula: 1
+  - name: adult_expansion_mandatory_eligible
+    kind: derived
+    versions:
+      - effective_from: '2014-01-01'
+        formula: adult_expansion_conditions_met
+  - name: former_foster_care_mandatory_eligible
+    kind: derived
+    versions:
+      - effective_from: '1974-01-01'
+        formula: former_foster_care_conditions_met
+  - name: optional_group_eligible
+    kind: derived
+    versions:
+      - effective_from: '1974-01-01'
+        formula: optional_group_conditions_met
+  - name: is_medicaid_eligible
+    kind: derived
+    versions:
+      - effective_from: '2014-01-01'
+        formula: adult_expansion_mandatory_eligible or former_foster_care_mandatory_eligible or optional_group_eligible
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us/us/policies/hhs/medicaid/eligibility.test.yaml",
+        """- name: medicaid composite covered
+  period: 2024
+  input:
+    us:policies/hhs/medicaid/eligibility#input.adult_expansion_conditions_met: true
+    us:policies/hhs/medicaid/eligibility#input.former_foster_care_conditions_met: false
+    us:policies/hhs/medicaid/eligibility#input.optional_group_conditions_met: false
+  output:
+    us:policies/hhs/medicaid/eligibility#is_medicaid_eligible: holds
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="medicaid")
+
+    assert report["total_outputs"] == 7
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 6,
+    }
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    final_surface = items_by_id[
+        "us:policies/hhs/medicaid/eligibility#is_medicaid_eligible"
+    ]
+    assert final_surface["mapping_type"] == "direct_variable"
+    assert final_surface["policyengine_variable"] == "is_medicaid_eligible"
+    assert final_surface["tested"] is True
+
+
 def test_policyengine_coverage_includes_program_spec_outputs(tmp_path):
     checkout = tmp_path / "rulespec-us"
     _write_rulespec_file(
@@ -617,7 +689,9 @@ def test_policyengine_program_surface_includes_policybench_person_eligibility_su
 
     assert medicaid["program_id"] == "medicaid"
     assert medicaid["source_type"] == "eligibility"
-    assert medicaid["axiom_status"] == "pending_rulespec_encoding"
+    assert medicaid["axiom_status"] == "wired"
+    assert medicaid["mapping_count"] == 4
+    assert medicaid["comparable_mapping_count"] == 1
     assert medicaid["policybench_output"] == "person_level_medicaid_eligibility"
     assert medicaid["policybench_household_weight"] == pytest.approx(29.86)
 
@@ -655,14 +729,9 @@ def test_policyengine_program_surface_medicaid_filter_prioritizes_eligibility():
     assert report["total_surfaces"] == 2
     assert report["status_counts"] == {
         "out_of_scope": 1,
-        "pending_rulespec_encoding": 1,
+        "wired": 1,
     }
-    assert [item["variable"] for item in report["actionable_surfaces"]] == [
-        "is_medicaid_eligible"
-    ]
-    assert report["actionable_surfaces"][0]["policybench_household_weight"] == (
-        pytest.approx(29.86)
-    )
+    assert report["actionable_surfaces"] == []
 
 
 def test_policyengine_program_surface_local_tax_credit_uses_local_weight(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.877"
+version = "0.2.878"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map the generated Medicaid policy composite final output to PolicyEngine's is_medicaid_eligible oracle surface
- classify the generated Medicaid helper/scalar outputs as known non-comparable
- add regression coverage and bump axiom-encode to 0.2.878

## Checks
- env -u UV_FROZEN uv run --extra dev pytest tests/test_cli.py -k current_encoder_affecting_changes_are_behind_version_bump
- env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage.py -k medicaid_policy_composite
- env -u UV_FROZEN uv run --extra dev ruff check tests/test_policyengine_coverage.py
- Medicaid oracle coverage against staged rulespec-us worktree: comparable=5, known_not_comparable=208, unmapped=0, untested comparable=0