### PR TITLE
Map Medicare PE final eligibility surface

### DIFF
--- a/changelog.d/medicare-pe-final-surface.fixed.md
+++ b/changelog.d/medicare-pe-final-surface.fixed.md
@@ -1,0 +1,1 @@
+Map the CMS-backed Medicare final eligibility RuleSpec output to PolicyEngine's `is_medicare_eligible` program surface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.878"
+version = "0.2.879"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.879"
+version = "0.2.880"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.880"
+version = "0.2.881"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.881"
+version = "0.2.882"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.880"
+__version__ = "0.2.881"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.879"
+__version__ = "0.2.880"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.878"
+__version__ = "0.2.879"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.881"
+__version__ = "0.2.882"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -26259,6 +26259,7 @@ def _repair_child_numeric_reencoding_parent_aliases(
             if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", parent_name):
                 continue
             remove_names.add(parent_name)
+            replacements[parent_name] = child_name
         replacements.update(
             _child_numeric_reencoding_wrapper_replacements(
                 rules,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -841,6 +841,7 @@ def run_model_eval(
     extra_context_paths: list[Path] | None = None,
     include_tests: bool = False,
     skip_reviewers: bool = False,
+    policyengine_rule_hint: str | None = None,
 ) -> list[EvalResult]:
     """Run a deterministic comparison over one or more citations."""
     results: list[EvalResult] = []
@@ -859,6 +860,7 @@ def run_model_eval(
                     extra_context_paths=extra_context_paths or [],
                     include_tests=include_tests,
                     skip_reviewers=skip_reviewers,
+                    policyengine_rule_hint=policyengine_rule_hint,
                 )
             )
 
@@ -3790,6 +3792,7 @@ def _run_single_eval(
     extra_context_paths: list[Path],
     include_tests: bool = False,
     skip_reviewers: bool = False,
+    policyengine_rule_hint: str | None = None,
 ) -> EvalResult:
     source_unit = resolve_corpus_source_unit(citation, corpus_path)
     source_text = source_unit.body
@@ -3843,6 +3846,7 @@ def _run_single_eval(
         ),
         include_tests=include_tests,
         runner_backend=runner.backend,
+        policyengine_rule_hint=policyengine_rule_hint,
     )
     generation_prompt_sha256 = _sha256_text(prompt)
     output_file = Path(output_root) / runner.name / relative_output
@@ -3855,6 +3859,7 @@ def _run_single_eval(
         source_text=source_text,
         target_file_name=relative_output.name,
         include_tests=include_tests,
+        policyengine_rule_hint=policyengine_rule_hint,
     )
     if wrote_artifact:
         eval_root = Path(output_root) / runner.name

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3878,6 +3878,7 @@ def _run_single_eval(
             policy_repo_root=policy_path,
             axiom_rules_path=runtime_axiom_rules_path,
             source_text=source_text,
+            policyengine_rule_hint=policyengine_rule_hint,
             skip_reviewers=skip_reviewers,
         )
     validation_error = _eval_artifact_validation_error(metrics)

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -25149,6 +25149,10 @@ print("BENCHMARK:" + json.dumps(result))
             ):
                 aliases.add(source_key)
             for _target_key, _operation, source_keys in (
+                *adapter.derived_person_inputs,
+            ):
+                aliases.update(source_keys)
+            for _target_key, _operation, source_keys in (
                 *adapter.monthly_derived_boolean_person_inputs,
             ):
                 aliases.update(source_keys)
@@ -26035,6 +26039,33 @@ print(f'RESULT:{{float(value)}}')
             )
 
         if adapter is not None:
+            for pe_attr, operation, rule_keys in adapter.derived_person_inputs:
+                raw_values = [
+                    self._rulespec_test_input_value(inputs, rule_key)
+                    for rule_key in rule_keys
+                ]
+                numeric_values: list[float] = []
+                for raw_value in raw_values:
+                    if raw_value is None:
+                        continue
+                    with contextlib.suppress(TypeError, ValueError):
+                        numeric_values.append(float(raw_value))
+                if not numeric_values:
+                    continue
+                if operation == "max":
+                    derived_value: float | bool = max(numeric_values)
+                elif operation == "positive_if_any":
+                    derived_value = (
+                        1.0 if any(value > 0 for value in numeric_values) else 0.0
+                    )
+                else:
+                    continue
+                attrs = (
+                    target_person_attrs
+                    if target_person_attrs is not None
+                    else adult_attrs
+                )
+                attrs.append(f"'{pe_attr}': {{'{year}': {pe_literal(derived_value)}}}")
             for rule_key, pe_attr in adapter.annualized_person_inputs:
                 value = self._rulespec_test_input_value(inputs, rule_key)
                 if value is None:

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -732,27 +732,23 @@ PE_US_MEDICARE_VAR_ADAPTERS = (
             (
                 "months_receiving_social_security_disability",
                 "max",
-                (
-                    "months_received_social_security_disability_benefits",
-                    "months_of_disability_benefit_entitlement",
-                ),
+                ("months_received_social_security_disability_benefits",),
             ),
             (
                 "social_security_disability",
                 "positive_if_any",
-                (
-                    "months_received_social_security_disability_benefits",
-                    "months_of_disability_benefit_entitlement",
-                ),
+                ("months_received_social_security_disability_benefits",),
             ),
         ),
         unsupported_truthy_input_keys=(
             "enrolled_during_initial_enrollment_period",
             "coverage_month_is_month_after_enrollment",
+            "months_of_disability_benefit_entitlement",
         ),
         unsupported_input_reason=(
             "PolicyEngine's Medicare eligibility oracle does not expose CMS "
-            "enrollment-window coverage timing facts"
+            "enrollment-window coverage timing facts or the separate "
+            "25th-month disability-entitlement boundary"
         ),
     ),
 )

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -16,6 +16,7 @@ class PolicyEngineUSVarAdapter:
     comparison: str | None = None
     monthly: bool = False
     spm: bool = False
+    derived_person_inputs: tuple[tuple[str, str, tuple[str, ...]], ...] = ()
     annualized_person_inputs: tuple[tuple[str, str], ...] = ()
     monthly_person_inputs: tuple[tuple[str, str], ...] = ()
     boolean_person_inputs: tuple[tuple[str, str], ...] = ()
@@ -720,10 +721,47 @@ PE_US_ACA_PTC_VAR_ADAPTERS = (
     ),
 )
 
+PE_US_MEDICARE_VAR_ADAPTERS = (
+    PolicyEngineUSVarAdapter(
+        rule_names=("is_medicare_eligible",),
+        pe_var="is_medicare_eligible",
+        entity="person",
+        period="year",
+        comparison="decision",
+        derived_person_inputs=(
+            (
+                "months_receiving_social_security_disability",
+                "max",
+                (
+                    "months_received_social_security_disability_benefits",
+                    "months_of_disability_benefit_entitlement",
+                ),
+            ),
+            (
+                "social_security_disability",
+                "positive_if_any",
+                (
+                    "months_received_social_security_disability_benefits",
+                    "months_of_disability_benefit_entitlement",
+                ),
+            ),
+        ),
+        unsupported_truthy_input_keys=(
+            "enrolled_during_initial_enrollment_period",
+            "coverage_month_is_month_after_enrollment",
+        ),
+        unsupported_input_reason=(
+            "PolicyEngine's Medicare eligibility oracle does not expose CMS "
+            "enrollment-window coverage timing facts"
+        ),
+    ),
+)
+
 PE_US_HEALTH_VAR_ADAPTERS = (
     *PE_US_MEDICAID_VAR_ADAPTERS,
     *PE_US_CHIP_VAR_ADAPTERS,
     *PE_US_ACA_PTC_VAR_ADAPTERS,
+    *PE_US_MEDICARE_VAR_ADAPTERS,
 )
 
 PE_US_SSI_VAR_ADAPTERS = (
@@ -786,6 +824,7 @@ PE_US_PROGRAM_VAR_ADAPTERS = {
     "medicaid": PE_US_MEDICAID_VAR_ADAPTERS,
     "chip": PE_US_CHIP_VAR_ADAPTERS,
     "aca_ptc": PE_US_ACA_PTC_VAR_ADAPTERS,
+    "medicare": PE_US_MEDICARE_VAR_ADAPTERS,
     "health": PE_US_HEALTH_VAR_ADAPTERS,
     "ssi": PE_US_SSI_VAR_ADAPTERS,
 }

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -761,6 +761,34 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec composes the 42 USC 426(b)(2) disability, child disability, widow(er), railroad-retirement, and government-employment entitlement paths. PolicyEngine's is_medicare_eligible uses a simplified SSDI-months proxy and omits several statutory paths and entitlement-timing conditions, so this is not an exact oracle comparison.
 
+  - legal_id: us:policies/cms/original-medicare-part-a-b#medicare_age_trigger_years
+    country: us
+    program: medicare
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicare.eligibility.min_age
+    period: month
+    comparison: count
+    rationale: CMS's Original Medicare guidance uses age 65 as the age-based Medicare eligibility trigger, matching PolicyEngine's Medicare minimum-age parameter.
+
+  - legal_id: us:policies/cms/original-medicare-part-a-b#disability_auto_enrollment_months
+    country: us
+    program: medicare
+    mapping_type: parameter_value
+    policyengine_parameter: gov.hhs.medicare.eligibility.min_months_receiving_social_security_disability
+    period: month
+    comparison: count
+    rationale: CMS's Original Medicare guidance states disabled individuals are automatically enrolled in Medicare Part A and Part B after receiving Social Security disability benefits for 24 months, matching PolicyEngine's simplified disability-month threshold.
+
+  - legal_id: us:policies/cms/original-medicare-part-a-b#is_medicare_eligible
+    country: us
+    program: medicare
+    mapping_type: direct_variable
+    policyengine_variable: is_medicare_eligible
+    entity: person
+    period: month
+    comparison: boolean
+    rationale: CMS's Original Medicare guidance backs the simplified PolicyEngine Medicare eligibility surface for age-based eligibility at 65 and disability-based automatic Medicare Part A and Part B enrollment after 24 months of Social Security disability benefits.
+
   - legal_id: us:regulations/47-cfr/54/409#lifeline_income_limit_ratio
     country: us
     program: lifeline
@@ -17916,6 +17944,13 @@ prefixes:
     mapping_type: not_comparable
     candidate_priority: P4
     rationale: 42 USC 426 section-level hospital-insurance entitlement outputs not carrying exact parameter mappings are source-level Medicare Part A, railroad-retirement, government-employment, death-month, widow/widower, ALS, and entitlement-timing paths. PolicyEngine-US exposes a simplified Medicare eligibility surface and a small set of parameters, but not these statutory path and timing intermediates one-to-one.
+
+  - legal_id_prefix: us:policies/cms/original-medicare-part-a-b
+    country: us
+    program: medicare
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: CMS Original Medicare Part A and Part B guidance outputs not carrying exact final-eligibility or parameter mappings are source-level enrollment-window and coverage-start helpers. PolicyEngine's Medicare surface exposes the simplified final eligibility variable and age/disability-month parameters, not the CMS enrollment administration helpers one-to-one.
 
   - legal_id_prefix: us:statutes/42/18795
     country: us

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -785,7 +785,7 @@ mappings:
     mapping_type: direct_variable
     policyengine_variable: is_medicare_eligible
     entity: person
-    period: month
+    period: year
     comparison: boolean
     rationale: CMS's Original Medicare guidance backs the simplified PolicyEngine Medicare eligibility surface for age-based eligibility at 65 and disability-based automatic Medicare Part A and Part B enrollment after 24 months of Social Security disability benefits.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2366,6 +2366,26 @@ rules:
         formula: |-
           1 / premium_assistance_annual_income_month_count
 
+  - name: direct_parent_alias_consumer
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    period: Year
+    source: 26 USC 36B(b)(2)(B)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/26/36B#premium_assistance_annual_income_month_count
+              output: premium_assistance_annual_income_month_count
+              hash: sha256:local
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          household_income <= premium_assistance_annual_income_month_count
+
   - name: applicable_taxpayer_minimum_household_income_poverty_line_ratio
     kind: parameter
     dtype: Rate
@@ -2403,8 +2423,22 @@ rules:
         ]
         payload = yaml.safe_load(rules_file.read_text())
         assert [rule["name"] for rule in payload["rules"]] == [
-            "applicable_taxpayer_minimum_household_income_poverty_line_ratio"
+            "direct_parent_alias_consumer",
+            "applicable_taxpayer_minimum_household_income_poverty_line_ratio",
         ]
+        consumer = payload["rules"][0]
+        assert (
+            consumer["versions"][0]["formula"]
+            == "household_income <= required_contribution_monthly_fraction"
+        )
+        assert (
+            consumer["metadata"]["proof"]["atoms"][0]["import"]["target"]
+            == "us:statutes/26/36B/b#required_contribution_monthly_fraction"
+        )
+        assert (
+            consumer["metadata"]["proof"]["atoms"][0]["import"]["output"]
+            == "required_contribution_monthly_fraction"
+        )
         assert payload["module"]["deferred_outputs"][0]["source_values"] == [
             "us:statutes/26/36B/b#required_contribution_monthly_fraction"
         ]

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -10864,7 +10864,10 @@ class TestUnexpectedAccessDetection:
 
 
 class TestSourceEval:
-    def test_run_model_eval_passes_skip_reviewers_to_evaluate_artifact(self, tmp_path):
+    def test_run_model_eval_passes_validation_options_to_evaluate_artifact(
+        self,
+        tmp_path,
+    ):
         corpus_path = _write_test_corpus_provision(
             tmp_path,
             citation_path="us/statute/7/2017/a",
@@ -10917,10 +10920,15 @@ class TestSourceEval:
                 corpus_path=corpus_path,
                 mode="cold",
                 include_tests=True,
+                policyengine_rule_hint="source_amount",
                 skip_reviewers=True,
             )
 
         assert mock_evaluate_artifact.call_args.kwargs["skip_reviewers"] is True
+        assert (
+            mock_evaluate_artifact.call_args.kwargs["policyengine_rule_hint"]
+            == "source_amount"
+        )
 
     def test_run_source_eval_uses_explicit_context_without_statute_lookup(
         self, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -4719,6 +4719,34 @@ def test_policyengine_medicare_adapter_projects_disability_inputs(tmp_path):
     assert "calculate('is_medicare_eligible', int('2026'))" in script
 
 
+def test_policyengine_medicare_mappability_blocks_entitlement_boundary(
+    tmp_path,
+):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    inputs = {
+        "period": "2026-01",
+        "us:policies/cms/original-medicare-part-a-b#input.enrolled_during_initial_enrollment_period": False,
+        "us:policies/cms/original-medicare-part-a-b#input.coverage_month_is_month_after_enrollment": False,
+        "us:policies/cms/original-medicare-part-a-b#input.months_received_social_security_disability_benefits": 0,
+        "us:policies/cms/original-medicare-part-a-b#input.months_of_disability_benefit_entitlement": 24,
+    }
+
+    mappable, reason = pipeline._is_pe_test_mappable(
+        "us",
+        "is_medicare_eligible",
+        inputs,
+        pe_var="is_medicare_eligible",
+    )
+
+    assert mappable is False
+    assert "25th-month disability-entitlement boundary" in (reason or "")
+    assert "months_of_disability_benefit_entitlement" in (reason or "")
+
+
 def test_policyengine_medicare_mappability_blocks_active_enrollment_timing(
     tmp_path,
 ):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -4684,6 +4684,71 @@ def test_policyengine_and_cs_mappability_blocks_active_unmodeled_exclusions(
     assert "client_is_resident_in_unlicensed_or_uncertified_facility" in (reason or "")
 
 
+def test_policyengine_medicare_adapter_projects_disability_inputs(tmp_path):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    inputs = {
+        "period": "2026-01",
+        "us:policies/cms/original-medicare-part-a-b#input.enrolled_during_initial_enrollment_period": False,
+        "us:policies/cms/original-medicare-part-a-b#input.coverage_month_is_month_after_enrollment": False,
+        "us:policies/cms/original-medicare-part-a-b#input.months_received_social_security_disability_benefits": 24,
+        "us:policies/cms/original-medicare-part-a-b#input.months_of_disability_benefit_entitlement": 0,
+    }
+
+    mappable, reason = pipeline._is_pe_test_mappable(
+        "us",
+        "is_medicare_eligible",
+        inputs,
+        pe_var="is_medicare_eligible",
+    )
+
+    assert mappable is True
+    assert reason is None
+
+    script = pipeline._build_pe_us_scenario_script(
+        "is_medicare_eligible",
+        inputs,
+        "2026",
+    )
+
+    assert "'months_receiving_social_security_disability': {'2026': 24.0}" in script
+    assert "'social_security_disability': {'2026': 1.0}" in script
+    assert "calculate('is_medicare_eligible', int('2026'))" in script
+
+
+def test_policyengine_medicare_mappability_blocks_active_enrollment_timing(
+    tmp_path,
+):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    inputs = {
+        "period": "2026-01",
+        "us:policies/cms/original-medicare-part-a-b#input.enrolled_during_initial_enrollment_period": True,
+        "us:policies/cms/original-medicare-part-a-b#input.coverage_month_is_month_after_enrollment": True,
+        "us:policies/cms/original-medicare-part-a-b#input.months_received_social_security_disability_benefits": 0,
+        "us:policies/cms/original-medicare-part-a-b#input.months_of_disability_benefit_entitlement": 0,
+    }
+
+    mappable, reason = pipeline._is_pe_test_mappable(
+        "us",
+        "is_medicare_eligible",
+        inputs,
+        pe_var="is_medicare_eligible",
+    )
+
+    assert mappable is False
+    assert "does not expose CMS enrollment-window coverage timing facts" in (
+        reason or ""
+    )
+    assert "coverage_month_is_month_after_enrollment" in (reason or "")
+
+
 def test_policyengine_tax_scenario_skips_unmodelled_niit_components(tmp_path):
     pipeline = ValidatorPipeline(
         policy_repo_path=tmp_path,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.878"
+version = "0.2.879"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.879"
+version = "0.2.880"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.881"
+version = "0.2.882"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.880"
+version = "0.2.881"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map the CMS Medicare eligibility RuleSpec surface to PolicyEngine's Medicare oracle parameter and variable names
- mark source-level enrollment-window/coverage-start helpers as known-not-comparable
- bump axiom-encode version for the mapping change

## Dependencies
- Corpus source PR: https://github.com/TheAxiomFoundation/axiom-corpus/pull/135
- RuleSpec PR: https://github.com/TheAxiomFoundation/rulespec-us/pull/467

## Checks
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /tmp/axiom-medicare-coverage-root --program medicare --include-program-surfaces --fail-on-pending-program-surfaces --fail-on-unmapped --fail-on-untested-comparable --json

Draft note: left draft pending the repo-required review-cycle before marking ready.