### PR TITLE
Map ACA PTC family size oracle status

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.882"
+version = "0.2.883"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.882"
+__version__ = "0.2.883"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -5104,6 +5104,14 @@ mappings:
     candidate_priority: P4
     rationale: PolicyEngine applies the ACA PTC income range through gov.aca.ptc_income_eligibility inside is_aca_ptc_eligible, which also includes filing status, immigration, coverage, and premium-payment conditions. This RuleSpec output is only the section 36B(c)(1) income-percentage predicate.
 
+  - legal_id: us:statutes/26/36B#family_size
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_variable: tax_unit_size
+    candidate_priority: P4
+    rationale: Section 36B(d)(1) family size counts individuals for whom the taxpayer is allowed a section 151 deduction. PolicyEngine exposes tax_unit_size as an adjacent tax-unit membership count, but not this section-specific deduction-family-size helper as a one-to-one oracle target.
+
   - legal_id: us:statutes/26/36B/c/1/A#applicable_taxpayer_lower_poverty_line_percentage
     country: us
     program: aca_ptc

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2841,6 +2841,32 @@ rules:
     assert "Indexed interval-bound helper" in str(lower_bound["rationale"])
 
 
+def test_policyengine_coverage_classifies_aca_ptc_family_size_not_comparable(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/26/36B.yaml",
+        """format: rulespec/v1
+rules:
+  - name: family_size
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: taxpayer_section_151_deduction_count
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="aca_ptc")
+
+    assert report["total_outputs"] == 1
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == "us:statutes/26/36B#family_size"
+    assert item["mapping_type"] == "not_comparable"
+    assert item["policyengine_variable"] == "tax_unit_size"
+    assert "section 151 deduction" in str(item["rationale"])
+
+
 def test_policyengine_coverage_classifies_alabama_snap_manual_prefix(tmp_path):
     _write_rulespec_file(
         tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.882"
+version = "0.2.883"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- marks `us:statutes/26/36B#family_size` as a PolicyEngine not-comparable ACA PTC helper
- adds a focused oracle coverage regression test for the 36B family-size output

## Validation
- `env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage.py -k "aca_ptc_family_size or aca_ptc_percentage" -q`
- `env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root <rulespec-us-only temp root> --fail-on-unmapped --fail-on-untested-comparable --limit 50`
- `env -u UV_FROZEN uv run --extra dev ruff check tests/test_policyengine_coverage.py`
- `env -u UV_FROZEN uv run --extra dev ruff format --check tests/test_policyengine_coverage.py`
- parsed `src/axiom_encode/oracles/policyengine/mappings/us.yaml` with PyYAML
