### PR TITLE
Classify ACA PTC surface as non-comparable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.883"
+version = "0.2.884"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.883"
+__version__ = "0.2.884"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -186,10 +186,12 @@ surfaces:
   coverage: US
   variable: aca_ptc
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom encodes the governing 26 USC 36B premium-assistance amount and current 2026 applicable-percentage
+    guidance, but PolicyEngine's aca_ptc is a microsimulation program surface combining SLCSP/premium proxies, filer and
+    person-level eligibility gates, take-up, and assignment mechanics. It is therefore not a one-to-one legal RuleSpec
+    output, though source-level ACA PTC outputs remain mapped separately.
 - country: us
   program_id: tanf
   program_name: CalWORKs cash benefit

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -839,6 +839,24 @@ def test_policyengine_program_surface_marks_georgia_caps_known_not_comparable():
     assert "final modeled subsidy surface" in georgia_caps["rationale"]
 
 
+def test_policyengine_program_surface_marks_aca_ptc_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="aca_ptc")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    aca_ptc = items_by_variable["aca_ptc"]
+
+    assert aca_ptc["program_id"] == "aca_subsidies"
+    assert aca_ptc["axiom_status"] == "known_not_comparable"
+    assert aca_ptc["priority"] == "P1"
+    assert aca_ptc["mapping_count"] >= 1
+    assert aca_ptc["comparable_mapping_count"] == 0
+    assert (
+        "us:statutes/26/36B/b#premium_assistance_credit_amount" in aca_ptc["legal_ids"]
+    )
+    assert "26 USC 36B premium-assistance amount" in aca_ptc["rationale"]
+    assert "microsimulation program surface" in aca_ptc["rationale"]
+
+
 def test_policyengine_program_surface_marks_head_start_known_not_comparable():
     report = build_policyengine_program_surface_report(program="head_start")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.883"
+version = "0.2.884"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark PolicyEngine's ACA PTC program surface as known-not-comparable to RuleSpec legal outputs
- document why PE's aca_ptc combines legal 36B credit logic with simulation-specific premium, eligibility, take-up, and assignment mechanics
- add a regression test that ACA PTC has no pending PE surface while keeping source legal mappings attached

## Tests
- env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage.py -k "aca_ptc or program_surface" -q
- env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program aca_ptc --include-program-surfaces --fail-on-pending-program-surfaces --limit 100
- git diff --check