### PR TITLE
Classify Illinois SCRETD oracle surface

### DIFF
--- a/changelog.d/il-scretd-oracle-catalog.changed.md
+++ b/changelog.d/il-scretd-oracle-catalog.changed.md
@@ -1,0 +1,1 @@
+Classify the Illinois SCRETD PolicyEngine program surface as non-comparable to the law-complete Axiom output.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.884"
+version = "0.2.885"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.884"
+__version__ = "0.2.885"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -493,6 +493,14 @@ mappings:
     candidate_priority: P4
     rationale: The current Axiom Florida TCA amount depends on the incomplete Axiom eligibility wrapper and DCF page 21's no-issuance rule for deficits below $10. PolicyEngine's adjacent fl_tca uses its own eligibility, countable-income, and payment-standard graph and does not share this exact DCF program boundary yet.
 
+  - legal_id: us-il:programs/scretd/fy-2026#il_scretd_deferral_amount
+    country: us
+    program: il_scretd
+    mapping_type: not_comparable
+    policyengine_variable: il_scretd_deferral_amount
+    candidate_priority: P4
+    rationale: Axiom's Illinois SCRETD output follows 320 ILCS 30/2 and 30/3, including qualifying-property requirements, application and agreement gates, requested amount, real-estate taxes or special-assessment installments, available revolving-fund dollars, the annual statutory cap, and remaining 80% equity capacity. PolicyEngine's adjacent variable only gates on age and household-income eligibility before capping real-estate taxes by the annual deferral maximum, so it is not a one-to-one legal oracle boundary.
+
   - legal_id: us:policies/ed/fsa/gen-26-01-pell-award-amounts/block-1#maximum_pell_grant_award
     country: us
     program: pell

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -2250,10 +2250,11 @@ surfaces:
   coverage: IL
   variable: il_scretd_deferral_amount
   source_type: program
-  axiom_status: deferred_jurisdiction
+  axiom_status: known_not_comparable
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: Axiom encodes the current Illinois statute's application, qualifying-property, agreement, fund-availability,
+    requested-amount, special-assessment, and 80% equity-cap constraints. PolicyEngine's adjacent output only applies
+    age/income eligibility and caps real-estate taxes by the annual maximum, so this is not a one-to-one oracle surface.
 - country: us
   program_id: il_ipass_assist
   program_name: Illinois I-PASS Assist

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.884"
+version = "0.2.885"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark Illinois SCRETD as a known non-comparable PolicyEngine program surface
- map the new rulespec-us SCRETD program output to the adjacent PE variable as not comparable
- bump axiom-encode to 0.2.885

## Rationale
The Axiom encoding follows 320 ILCS 30/2 and 30/3, including qualifying-property, application, agreement, fund-availability, requested-amount, special-assessment, and 80% equity-cap constraints. PolicyEngine's adjacent variable only checks age/income eligibility and caps real-estate taxes by the annual maximum, so this should not be counted as an exact oracle surface.

## Tests
- env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage.py tests/test_policyengine_coverage_monorepo.py
- env -u UV_FROZEN uv run --extra dev pytest tests/test_cli.py -k version
- env -u UV_FROZEN uv run --extra dev ruff check src tests
- env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-il-scretd-oracle-20260626 --extra dev axiom-encode oracle-coverage --root /tmp/axiom-rulespec-us-il-scretd-root --program il_scretd --include-program-surfaces --limit 100