### PR TITLE
Classify Illinois oracle helper outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.885"
+version = "0.2.886"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.885"
+__version__ = "0.2.886"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -19765,6 +19765,12 @@ prefixes:
     candidate_priority: P4
     rationale: PolicyEngine-US does not model ID agency policy manuals or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
 
+  - legal_id_prefix: "us-il:"
+    country: us
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: PolicyEngine-US does not model IL statutes, agency policy manuals, or state regulations at output granularity; comparable state outputs carry exact mappings which take precedence over this prefix.
+
   - legal_id_prefix: "us-in:"
     country: us
     mapping_type: not_comparable

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2930,6 +2930,32 @@ rules:
     assert "state income bridge" in str(exact_output["rationale"])
 
 
+def test_policyengine_coverage_classifies_illinois_state_prefix(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "us-il/statutes/320/30/3.yaml",
+        """format: rulespec/v1
+rules:
+  - name: remaining_equity_deferral_capacity
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: max(0, property_equity_limit - existing_deferrals)
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path)
+
+    assert report["total_outputs"] == 1
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == (
+        "us-il:statutes/320/30/3#remaining_equity_deferral_capacity"
+    )
+    assert item["mapping_type"] == "not_comparable"
+    assert item["candidate_priority"] == "P4"
+    assert "IL statutes" in str(item["rationale"])
+
+
 def test_policyengine_coverage_classifies_medicaid_work_requirement_prefixes(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "statutes/42/1396a/xx.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.885"
+version = "0.2.886"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add the missing Illinois jurisdiction prefix to the PolicyEngine oracle mapping registry
- classify Illinois state/statute helper outputs as known-not-comparable by default while preserving exact mappings
- bump axiom-encode to 0.2.886 for the catalog change

## Why
rulespec-us#469 triggered full oracle coverage and exposed unmapped IL SCRETD helper outputs. The program surface was already classified, but helper outputs need the same state-prefix fallback used by other state repos.

## Checks
- env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage.py tests/test_policyengine_coverage_monorepo.py
- env -u UV_FROZEN uv run --extra dev pytest tests/test_cli.py -k version
- env -u UV_FROZEN uv run --extra dev ruff check src tests/test_policyengine_coverage.py
- env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root /tmp/axiom-rulespec-us-il-scretd-root --fail-on-unmapped --fail-on-untested-comparable --limit 50