### PR TITLE
Classify WIC and CHIP final surfaces

### DIFF
--- a/changelog.d/bump-encoder-0-2-887.changed.md
+++ b/changelog.d/bump-encoder-0-2-887.changed.md
@@ -1,0 +1,1 @@
+Bump axiom-encode to 0.2.887 for PolicyEngine program surface catalog classification updates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.886"
+version = "0.2.887"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.886"
+__version__ = "0.2.887"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -82,10 +82,12 @@ surfaces:
   coverage: US
   variable: is_wic_eligible
   source_type: eligibility
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyBench scores this direct person-level WIC eligibility variable. Axiom should encode WIC categorical, income,
-    adjunctive, and nutritional-risk eligibility before claiming parity.
+  rationale: PolicyBench scores this direct person-level WIC eligibility variable. Axiom encodes 7 CFR 246.7(c)-(e) source
+    predicates for WIC certification, income, adjunctive eligibility, and nutritional risk; PolicyEngine's is_wic_eligible
+    is a simplified final person-level eligibility surface and does not expose the same residency, identity, agency-workflow,
+    and certification-condition boundary as a one-to-one oracle target.
 - country: us
   program_id: school_meals
   program_name: Free and reduced school meals
@@ -173,10 +175,12 @@ surfaces:
   coverage: US
   variable: is_chip_eligible
   source_type: eligibility
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyBench scores this direct person-level CHIP eligibility variable. Axiom should encode the final CHIP category
-    composite and state-set income-limit parameters before claiming parity.
+  rationale: PolicyBench scores this direct person-level CHIP eligibility variable. Axiom encodes federal CHIP child and
+    targeted-low-income-child source definitions plus mapped state-set income-limit parameters where available; PolicyEngine's
+    is_chip_eligible is a final category aggregate over child, standard pregnant, and FCEP paths, so the currently encoded
+    legal outputs are adjacent rather than a one-to-one oracle target.
 - country: us
   program_id: aca_subsidies
   program_name: ACA subsidies

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -696,12 +696,12 @@ def test_policyengine_program_surface_includes_policybench_person_eligibility_su
     assert medicaid["policybench_household_weight"] == pytest.approx(29.86)
 
     assert chip["program_id"] == "chip"
-    assert chip["axiom_status"] == "pending_rulespec_encoding"
+    assert chip["axiom_status"] == "known_not_comparable"
     assert chip["policybench_output"] == "person_level_chip_eligibility"
     assert chip["policybench_household_weight"] == pytest.approx(0.18)
 
     assert wic["program_id"] == "wic"
-    assert wic["axiom_status"] == "pending_rulespec_encoding"
+    assert wic["axiom_status"] == "known_not_comparable"
     assert wic["policybench_output"] == "person_level_wic_eligibility"
     assert wic["policybench_household_weight"] == pytest.approx(0.32)
 
@@ -732,6 +732,21 @@ def test_policyengine_program_surface_medicaid_filter_prioritizes_eligibility():
         "wired": 1,
     }
     assert report["actionable_surfaces"] == []
+
+
+def test_policyengine_program_surface_marks_wic_and_chip_final_eligibility_known_not_comparable():
+    report = build_policyengine_program_surface_report()
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    assert items_by_variable["is_wic_eligible"]["axiom_status"] == (
+        "known_not_comparable"
+    )
+    assert items_by_variable["is_chip_eligible"]["axiom_status"] == (
+        "known_not_comparable"
+    )
+    assert {item["variable"] for item in report["actionable_surfaces"]}.isdisjoint(
+        {"is_wic_eligible", "is_chip_eligible"}
+    )
 
 
 def test_policyengine_program_surface_local_tax_credit_uses_local_weight(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.886"
+version = "0.2.887"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Mark WIC and CHIP final eligibility PolicyEngine surfaces as known-not-comparable now that source-level encodings exist but do not match the final PE variable boundary.
- Add a regression test that keeps those surfaces out of the actionable pending queue.

## Validation
- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-program-surface-known-not-comparable-20260626 --extra dev pytest -q /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-program-surface-known-not-comparable-20260626/tests/test_policyengine_coverage.py -k 'program_surface'`\n- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-program-surface-known-not-comparable-20260626 --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --include-program-surfaces --json > /tmp/axiom-pe-coverage-after-wic-chip-status.json`\n\nCoverage summary: `untested_comparable=0`; WIC and CHIP final eligibility are now `known_not_comparable`; active pending program surfaces drop from 143 to 141.