### PR TITLE
Classify Florida TCA final surface

### DIFF
--- a/changelog.d/bump-encoder-0-2-888.changed.md
+++ b/changelog.d/bump-encoder-0-2-888.changed.md
@@ -1,0 +1,1 @@
+Bump axiom-encode to 0.2.888 for Florida TCA program surface catalog classification.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.887"
+version = "0.2.888"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.887"
+__version__ = "0.2.888"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -500,10 +500,13 @@ surfaces:
   variable: fl_tca
   source_type: state_implementation
   state: FL
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Current RuleSpec repos include a runnable us-fl/tca FY 2026 composition over DCF ESS manual financial,
+    resource, payment-standard, and benefit-calculation boundaries, with legal-ID oracle mappings for the Florida TCA
+    outputs. The Axiom wrapper still acknowledges final eligibility as incomplete, while PolicyEngine's fl_tca is a
+    final SPM-unit benefit using PE-specific eligibility, income, and payment-standard helpers, so compare the legal
+    components separately until both runtimes expose the same final Florida TCA boundary.
 - country: us
   program_id: tanf
   program_name: Maine TANF

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1273,6 +1273,22 @@ def test_policyengine_program_surface_marks_georgia_tanf_known_not_comparable():
     assert "final monthly TANF benefit variable" in georgia_tanf["rationale"]
 
 
+def test_policyengine_program_surface_marks_florida_tca_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    florida_tca = items_by_variable["fl_tca"]
+
+    assert florida_tca["program_id"] == "tanf"
+    assert florida_tca["state"] == "FL"
+    assert florida_tca["axiom_status"] == "known_not_comparable"
+    assert florida_tca["mapping_count"] == 1
+    assert florida_tca["comparable_mapping_count"] == 0
+    assert "us-fl:programs/tca/fy-2026#fl_tca" in florida_tca["legal_ids"]
+    assert "runnable us-fl/tca FY 2026 composition" in florida_tca["rationale"]
+    assert "final SPM-unit benefit" in florida_tca["rationale"]
+
+
 def test_policyengine_program_surface_marks_wyoming_power_known_not_comparable():
     report = build_policyengine_program_surface_report(program="tanf")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.887"
+version = "0.2.888"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark Florida TCA final PolicyEngine program surface as known-not-comparable now that RuleSpec has a runnable FY 2026 financial composition and legal-ID mappings
- add a regression test for the FL TCA program-surface classification
- bump axiom-encode to 0.2.888 for the encoder-affecting catalog change

## Validation
- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-fl-tca-surface-known-not-comparable-20260627 --extra dev pytest -q tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py -k 'program_surface'`\n- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-fl-tca-surface-known-not-comparable-20260627 --extra dev ruff check src/ tests/`\n- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-fl-tca-surface-known-not-comparable-20260627 --extra dev ruff format --check src/ tests/`