### PR TITLE
Fix local corpus lookup for prefixed source ids

### DIFF
--- a/changelog.d/bump-encoder-0-2-889.fixed.md
+++ b/changelog.d/bump-encoder-0-2-889.fixed.md
@@ -1,0 +1,1 @@
+Fix local corpus lookup for jurisdiction-prefixed source identifiers such as `us-ca:regulation/...`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.888"
+version = "0.2.889"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.888"
+__version__ = "0.2.889"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -170,6 +170,19 @@ _RULESPEC_SOURCE_ROOT_TOKENS = {
     "statute",
     "statutes",
 }
+_CORPUS_DOCUMENT_CLASS_BY_SOURCE_TOKEN = {
+    "form": "form",
+    "forms": "form",
+    "guidance": "guidance",
+    "manual": "manual",
+    "manuals": "manual",
+    "policies": "policy",
+    "policy": "policy",
+    "regulation": "regulation",
+    "regulations": "regulation",
+    "statute": "statute",
+    "statutes": "statute",
+}
 _RULESPEC_OUTPUT_ROOT_BY_SOURCE_TOKEN = {
     "form": "policies",
     "forms": "policies",
@@ -2379,11 +2392,29 @@ def _candidate_corpus_citation_paths(identifier: str) -> tuple[str, ...]:
         if cleaned and cleaned not in candidates:
             candidates.append(cleaned)
 
+    primary = _normalize_rulespec_source_id_to_corpus_path(primary)
     add(primary)
     parts = primary.split("/")
     for end in range(len(parts) - 1, 2, -1):
         add("/".join(parts[:end]))
     return tuple(candidates)
+
+
+def _normalize_rulespec_source_id_to_corpus_path(identifier: str) -> str:
+    """Convert ``us-ca:regulation/...`` source ids to corpus paths.
+
+    RuleSpec source ids use a jurisdiction-prefixed root to keep generated file
+    paths repository-relative, while corpus.provisions stores the same source as
+    ``jurisdiction/document_class/...`` with singular document classes.
+    """
+    parts = [part for part in identifier.strip().strip("/").split("/") if part]
+    if not parts or ":" not in parts[0]:
+        return identifier
+    jurisdiction, source_root = parts[0].split(":", 1)
+    document_class = _CORPUS_DOCUMENT_CLASS_BY_SOURCE_TOKEN.get(source_root)
+    if not jurisdiction or document_class is None:
+        return identifier
+    return "/".join((jurisdiction, document_class, *parts[1:]))
 
 
 _CFR_CITATION_RE = re.compile(

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -133,6 +133,23 @@ def test_source_identifier_maps_colon_prefixed_regulation_to_repo_path():
     ) == Path("regulations/10-ccr-2506-1/4.804.1.yaml")
 
 
+def test_resolve_corpus_source_unit_normalizes_colon_prefixed_local_citation(tmp_path):
+    corpus_path = _write_test_corpus_provision(
+        tmp_path,
+        citation_path="us-ca/regulation/cdss/eas/49/49-040",
+        body="CAPI resource limits.",
+    )
+
+    source_unit = resolve_corpus_source_unit(
+        "us-ca:regulation/cdss/eas/49/49-040",
+        corpus_path,
+    )
+
+    assert source_unit.source == "local"
+    assert source_unit.citation_path == "us-ca/regulation/cdss/eas/49/49-040"
+    assert source_unit.body == "CAPI resource limits."
+
+
 def test_source_identifier_maps_state_manual_to_policies_repo_path():
     assert _source_identifier_to_relative_rulespec_path(
         "us-az/manual/des/faa5/na-child-support-expense/block-2"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.888"
+version = "0.2.889"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- normalize jurisdiction-prefixed RuleSpec source ids before local corpus lookup
- add a regression test for resolving `us-ca:regulation/...` against `us-ca/regulation/...` corpus provisions
- bump axiom-encode to 0.2.889

## Why
The CAPI ingest produced local corpus provisions under the canonical corpus path form, but the encoder probe resolved the RuleSpec source id form directly and failed to find the source text.

## Checks
- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-local-corpus-colon-20260627 --extra dev pytest -q tests/test_evals.py::test_resolve_corpus_source_unit_normalizes_colon_prefixed_local_citation tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-local-corpus-colon-20260627 --extra dev ruff check src/ tests/`
- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-local-corpus-colon-20260627 --extra dev ruff format --check src/ tests/`
