### PR TITLE
Wire California CAPI PolicyEngine oracle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.889"
+version = "0.2.890"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.889"
+__version__ = "0.2.890"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -25142,6 +25142,7 @@ print("BENCHMARK:" + json.dumps(result))
             for source_key, _pe_key in (
                 *adapter.direct_spm_overrides,
                 *adapter.annual_direct_spm_overrides,
+                *adapter.direct_person_inputs,
                 *adapter.annualized_person_inputs,
                 *adapter.monthly_person_inputs,
                 *adapter.boolean_person_inputs,
@@ -25886,6 +25887,17 @@ print(f'RESULT:{{float(value)}}')
                 )
             elif operation == "monthly_to_annual" and len(source_values) == 1:
                 derived_value = source_values[0] * 12.0
+            elif operation == "positive_if_any":
+                derived_value = (
+                    1.0 if any(value > 0 for value in source_values) else 0.0
+                )
+            elif (
+                operation == "choose_second_if_third_truthy_else_first"
+                and len(source_values) >= 3
+            ):
+                derived_value = (
+                    source_values[1] if source_values[2] else source_values[0]
+                )
             return derived_value
 
         def pe_literal(value: Any) -> str:
@@ -26053,12 +26065,10 @@ print(f'RESULT:{{float(value)}}')
                 if not numeric_values:
                     continue
                 if operation == "max":
-                    derived_value: float | bool = max(numeric_values)
-                elif operation == "positive_if_any":
-                    derived_value = (
-                        1.0 if any(value > 0 for value in numeric_values) else 0.0
-                    )
+                    derived_value = max(numeric_values)
                 else:
+                    derived_value = derive_override_value(operation, numeric_values)
+                if derived_value is None:
                     continue
                 attrs = (
                     target_person_attrs
@@ -26066,6 +26076,16 @@ print(f'RESULT:{{float(value)}}')
                     else adult_attrs
                 )
                 attrs.append(f"'{pe_attr}': {{'{year}': {pe_literal(derived_value)}}}")
+            for rule_key, pe_attr in adapter.direct_person_inputs:
+                value = self._rulespec_test_input_value(inputs, rule_key)
+                if value is None:
+                    continue
+                attrs = (
+                    target_person_attrs
+                    if target_person_attrs is not None
+                    else adult_attrs
+                )
+                attrs.append(f"'{pe_attr}': {{'{year}': {pe_literal(value)}}}")
             for rule_key, pe_attr in adapter.annualized_person_inputs:
                 value = self._rulespec_test_input_value(inputs, rule_key)
                 if value is None:

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -17,6 +17,7 @@ class PolicyEngineUSVarAdapter:
     monthly: bool = False
     spm: bool = False
     derived_person_inputs: tuple[tuple[str, str, tuple[str, ...]], ...] = ()
+    direct_person_inputs: tuple[tuple[str, str], ...] = ()
     annualized_person_inputs: tuple[tuple[str, str], ...] = ()
     monthly_person_inputs: tuple[tuple[str, str], ...] = ()
     boolean_person_inputs: tuple[tuple[str, str], ...] = ()
@@ -498,6 +499,67 @@ PE_US_VAR_ADAPTERS = (
         unsupported_input_reason=(
             "PolicyEngine Colorado SSP does not model these 3.548 grant-payment "
             "exclusion facts"
+        ),
+    ),
+    PolicyEngineUSVarAdapter(
+        rule_names=("ca_capi",),
+        pe_var="ca_capi",
+        default_state_code="CA",
+        derived_person_inputs=(
+            (
+                "ssi_amount_if_eligible",
+                "difference",
+                (
+                    "ssi_ssp_payment_standard_for_selected_individual_living_arrangement",
+                    "ssi_ssp_payment_standard_for_selected_individual_living_arrangement",
+                ),
+            ),
+            (
+                "ca_capi_eligible_person",
+                "positive_if_any",
+                (
+                    "ssi_ssp_payment_standard_for_selected_individual_living_arrangement",
+                    "ssi_ssp_payment_standard_for_selected_eligible_couple_living_arrangement",
+                ),
+            ),
+        ),
+        direct_person_inputs=(
+            (
+                "ca_capi_countable_income_for_payment_month_under_retrospective_accounting",
+                "ssi_countable_income",
+            ),
+        ),
+        direct_spm_overrides=(
+            ("person_is_member_of_eligible_couple", "spm_unit_is_married"),
+        ),
+        derived_spm_overrides=(
+            (
+                "ca_state_supplement",
+                "choose_second_if_third_truthy_else_first",
+                (
+                    "ssi_ssp_payment_standard_for_selected_individual_living_arrangement",
+                    "ssi_ssp_payment_standard_for_selected_eligible_couple_living_arrangement",
+                    "person_is_member_of_eligible_couple",
+                ),
+            ),
+            (
+                "ca_capi_eligible",
+                "positive_if_any",
+                (
+                    "ssi_ssp_payment_standard_for_selected_individual_living_arrangement",
+                    "ssi_ssp_payment_standard_for_selected_eligible_couple_living_arrangement",
+                ),
+            ),
+        ),
+        unsupported_truthy_input_keys=(
+            "person_is_member_of_eligible_couple",
+            "couple_one_member_receiving_or_applying_for_capi_and_other_receiving_ssi_ssp",
+            "each_member_of_eligible_couple_receives_capi",
+        ),
+        unsupported_input_reason=(
+            "PolicyEngine California CAPI exposes the SPM-unit total and does "
+            "not directly compare the person-level eligible-couple share or "
+            "mixed CAPI/SSI-SSP couple branch"
         ),
     ),
     PolicyEngineUSVarAdapter(

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2617,6 +2617,17 @@ mappings:
     candidate_priority: P4
     rationale: Axiom's WIC 11450 monthly aid payment is the family-level legal payment formula after state income exemptions and special-needs inputs. PolicyEngine's ca_tanf is an annual SPM-unit final benefit gated through PE's demographic, resource, vehicle-value, and immigration-proration graph, so this is an adjacent final cash-benefit surface rather than a one-to-one oracle target.
 
+  - legal_id: us-ca:regulations/cdss/eas/49/49-055#ca_capi
+    country: us
+    program: ssi_state_supplement
+    mapping_type: direct_variable
+    policyengine_variable: ca_capi
+    entity: person
+    period: month
+    unit: USD
+    comparison: money
+    rationale: California CAPI final benefit amount under MPP 49-055; the PE adapter compares individual non-couple cases by projecting the source-selected SSI/SSP standard, CAPI eligibility, and countable income into PolicyEngine's CA CAPI surface while excluding person-level couple-share cases that PE exposes only as an SPM-unit total.
+
   - legal_id: us-co:regulations/10-ccr-2506-1/4.407.3#excess_shelter_deduction
     country: us
     program: snap

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -2151,12 +2151,14 @@ surfaces:
   agency: State
   policyengine_status: complete
   coverage: CA
+  state: CA
   variable: ca_capi
   source_type: program
-  axiom_status: deferred_jurisdiction
+  axiom_status: pending_oracle_mapping
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: California CDSS EAS Chapter 49 CAPI benefit determination is encoded in RuleSpec and wired through an
+    exact final-benefit oracle mapping; coverage promotes this surface to wired when the mapping is present in the
+    scanned RuleSpec checkout.
 - country: us
   program_id: care
   program_name: California CARE

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1142,6 +1142,20 @@ def test_policyengine_program_surface_marks_colorado_ssp_wired():
     )
 
 
+def test_policyengine_program_surface_marks_ca_capi_wired():
+    report = build_policyengine_program_surface_report(program="ca_capi")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    ca_capi = items_by_variable["ca_capi"]
+
+    assert ca_capi["program_id"] == "ca_capi"
+    assert ca_capi["state"] == "CA"
+    assert ca_capi["axiom_status"] == "wired"
+    assert ca_capi["mapping_count"] >= 1
+    assert ca_capi["comparable_mapping_count"] >= 1
+    assert "us-ca:regulations/cdss/eas/49/49-055#ca_capi" in ca_capi["legal_ids"]
+
+
 def test_policyengine_coverage_maps_georgia_ssp_nursing_home_supplement(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "us-ga" / "policies/dfcs/medicaid/2578.yaml",

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2524,6 +2524,13 @@ def test_policyengine_registry_is_legal_id_keyed():
         colorado_ssp_legacy_name_mapping.policyengine_variable == "co_state_supplement"
     )
     assert colorado_ssp_legacy_name_mapping.result_multiplier is None
+    ca_capi_mapping = registry.mapping_for_legal_id(
+        "us-ca:regulations/cdss/eas/49/49-055#ca_capi",
+        country="us",
+    )
+    assert ca_capi_mapping.mapping_type == "direct_variable"
+    assert ca_capi_mapping.policyengine_variable == "ca_capi"
+    assert ca_capi_mapping.result_multiplier is None
     colorado_ssp_grant_standard_mapping = registry.mapping_for_legal_id(
         "us-co:regulations/9-ccr-2503-5/3.546#and_cs_total_grant_standard",
         country="us",
@@ -4682,6 +4689,59 @@ def test_policyengine_and_cs_mappability_blocks_active_unmodeled_exclusions(
     assert mappable is False
     assert "does not model these 3.548 grant-payment exclusion facts" in (reason or "")
     assert "client_is_resident_in_unlicensed_or_uncertified_facility" in (reason or "")
+
+
+def test_policyengine_ca_capi_adapter_projects_individual_inputs(tmp_path):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    script = pipeline._build_pe_us_scenario_script(
+        "ca_capi",
+        {
+            "period": "2024-01",
+            "us-ca:regulations/cdss/eas/49/49-050#input.ssi_ssp_payment_standard_for_selected_individual_living_arrangement": 1000,
+            "us-ca:regulations/cdss/eas/49/49-050#input.ssi_ssp_payment_standard_for_selected_eligible_couple_living_arrangement": 2000,
+            "us-ca:regulations/cdss/eas/49/49-050#input.person_is_member_of_eligible_couple": False,
+            "us-ca:regulations/cdss/eas/49/49-055#input.ca_capi_countable_income_for_payment_month_under_retrospective_accounting": 390,
+        },
+        "2024",
+    )
+
+    assert "'state_code_str': {'2024': 'CA'}" in script
+    assert "'ssi_amount_if_eligible': {'2024': 0.0}" in script
+    assert "'ca_capi_eligible_person': {'2024': 1.0}" in script
+    assert "'ssi_countable_income': {'2024': 390}" in script
+    assert "'ca_state_supplement': {'2024': 1000}" in script
+    assert "'ca_capi_eligible': {'2024': 1}" in script
+    assert "'spm_unit_is_married': {'2024': False}" in script
+
+
+def test_policyengine_ca_capi_blocks_person_level_couple_share(tmp_path):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    inputs = {
+        "us-ca:regulations/cdss/eas/49/49-050#input.ssi_ssp_payment_standard_for_selected_individual_living_arrangement": 1000,
+        "us-ca:regulations/cdss/eas/49/49-050#input.ssi_ssp_payment_standard_for_selected_eligible_couple_living_arrangement": 2000,
+        "us-ca:regulations/cdss/eas/49/49-050#input.person_is_member_of_eligible_couple": True,
+        "us-ca:regulations/cdss/eas/49/49-055#input.ca_capi_countable_income_for_payment_month_under_retrospective_accounting": 980,
+        "us-ca:regulations/cdss/eas/49/49-055#input.each_member_of_eligible_couple_receives_capi": True,
+    }
+
+    mappable, reason = pipeline._is_pe_test_mappable(
+        "us",
+        "ca_capi",
+        inputs,
+        pe_var="ca_capi",
+    )
+
+    assert mappable is False
+    assert "SPM-unit total" in (reason or "")
+    assert "each_member_of_eligible_couple_receives_capi" in (reason or "")
 
 
 def test_policyengine_medicare_adapter_projects_disability_inputs(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.889"
+version = "0.2.890"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a CA CAPI PolicyEngine adapter for individual final-benefit comparisons
- map MPP 49-055 ca_capi to PolicyEngine ca_capi and mark the CA CAPI surface wired when present
- keep eligible-couple person-share cases unsupported because PE exposes the SPM-unit total
- bump axiom-encode to 0.2.890

## Validation
- env -u UV_FROZEN uv run --project . --extra dev ruff check src/axiom_encode/oracles/policyengine/adapters.py src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py tests/test_policyengine_coverage.py
- env -u UV_FROZEN uv run --project . --extra dev pytest tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed tests/test_rulespec_validation.py::test_policyengine_ca_capi_adapter_projects_individual_inputs tests/test_rulespec_validation.py::test_policyengine_ca_capi_blocks_person_level_couple_share tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_ca_capi_wired
- env -u UV_FROZEN uv run --project . --extra dev pytest tests/test_policyengine_coverage.py
- AXIOM_RULESPEC_REPO_ROOTS=/tmp/axiom-rulespec-roots-capi env -u UV_FROZEN uv run --project . --extra dev axiom-encode validate --skip-reviewers --oracle policyengine 49-010.yaml 49-025.yaml 49-030.yaml 49-035.yaml 49-040.yaml 49-050.yaml 49-055.yaml