### PR TITLE
Classify Medicaid Title XIX oracle helpers

### DIFF
--- a/changelog.d/bump-encoder-0-2-891.changed.md
+++ b/changelog.d/bump-encoder-0-2-891.changed.md
@@ -1,0 +1,1 @@
+Bump axiom-encode to 0.2.891.

--- a/changelog.d/medicaid-title-xix-oracle-coverage.fixed.md
+++ b/changelog.d/medicaid-title-xix-oracle-coverage.fixed.md
@@ -1,0 +1,1 @@
+Classify Medicaid Title XIX MAGI and child-category helper outputs in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.890"
+version = "0.2.891"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.890"
+__version__ = "0.2.891"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -19567,6 +19567,20 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 1396a(xx) Medicaid community-engagement outputs implement the H.R.1 work-requirement mandate and source-specific exceptions; PolicyEngine US does not expose this federal Medicaid work-requirement workflow as one-to-one oracle variables.
 
+  - legal_id_prefix: us:statutes/42/1396a/e/14#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 1396a(e)(14) MAGI methodology outputs are federal source-level Medicaid income-methodology, disregard, asset-test, lottery-lump-sum, hardship, and redetermination helpers. PolicyEngine US exposes final eligibility and effective state/category thresholds, not these statutory helper outputs as one-to-one oracle variables or parameters.
+
+  - legal_id_prefix: us:statutes/42/1396a/l#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 1396a(l) qualified pregnant woman and child outputs are federal source-level age-band, postpartum-period, income-rate, resource-option, and waiver-state helpers. PolicyEngine US exposes final Medicaid eligibility and effective state/category thresholds, not these statutory helper outputs as one-to-one oracle variables or parameters.
+
   - legal_id_prefix: us:regulations/42-cfr/431/213#
     country: us
     program: medicaid

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -3273,6 +3273,23 @@ def test_policyengine_registry_classifies_medicaid_435_120_helpers_not_comparabl
         assert mapping.candidate_priority == "P4"
 
 
+def test_policyengine_registry_classifies_medicaid_title_xix_statutory_helpers_not_comparable():
+    registry = load_policyengine_registry()
+
+    for legal_id in (
+        "us:statutes/42/1396a/e/14#magi_standard_increase_percentage_points",
+        "us:statutes/42/1396a/e/14#lottery_lump_sum_maximum_months",
+        "us:statutes/42/1396a/l#pregnancy_postpartum_period_days",
+        "us:statutes/42/1396a/l#older_child_income_level_rate",
+    ):
+        mapping = registry.mapping_for_legal_id(legal_id, country="us")
+        assert mapping is not None
+        assert mapping.program == "medicaid"
+        assert mapping.mapping_type == "not_comparable"
+        assert mapping.match_type == "prefix"
+        assert mapping.candidate_priority == "P4"
+
+
 def test_policyengine_registry_includes_acp_parameter_and_not_comparable_mappings():
     registry = load_policyengine_registry()
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.890"
+version = "0.2.891"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify generated 42 USC 1396a(e)(14) MAGI helper outputs as PolicyEngine not-comparable
- classify generated 42 USC 1396a(l) qualified pregnant woman/child helper outputs as PolicyEngine not-comparable
- add registry coverage assertions for representative generated outputs

## Validation
- env -u UV_FROZEN uv run --extra dev pytest tests/test_rulespec_validation.py::test_policyengine_registry_classifies_medicaid_title_xix_statutory_helpers_not_comparable tests/test_rulespec_validation.py::test_policyengine_registry_classifies_medicaid_435_120_helpers_not_comparable -q
- env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage.py -q
- AXIOM_RULESPEC_REPO_ROOTS=/tmp/axiom-rulespec-us-coverage-root-medicaid AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/axiom-corpus AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-medicaid-oracle-20260627 --extra dev axiom-encode oracle-coverage --root /tmp/axiom-rulespec-us-coverage-root-medicaid --fail-on-unmapped --fail-on-untested-comparable --limit 50

## Note
- env -u UV_FROZEN uv run --extra dev pytest tests/test_rulespec_validation.py tests/test_policyengine_coverage.py -q has one unrelated local failure in tests/test_rulespec_validation.py::test_rulespec_ci_rejects_scalar_kind_mismatches against the local rules-engine binary.