### PR TITLE
Classify California SSP PE surface

### DIFF
--- a/changelog.d/bump-encoder-0-2-892.changed.md
+++ b/changelog.d/bump-encoder-0-2-892.changed.md
@@ -1,0 +1,1 @@
+Bump axiom-encode to 0.2.892.

--- a/changelog.d/ca-ssp-oracle-surface.fixed.md
+++ b/changelog.d/ca-ssp-oracle-surface.fixed.md
@@ -1,0 +1,1 @@
+Classify California SSP's encoded chart amount as adjacent to PolicyEngine's final CA state supplement surface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.891"
+version = "0.2.892"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.891"
+__version__ = "0.2.892"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2628,6 +2628,14 @@ mappings:
     comparison: money
     rationale: California CAPI final benefit amount under MPP 49-055; the PE adapter compares individual non-couple cases by projecting the source-selected SSI/SSP standard, CAPI eligibility, and countable income into PolicyEngine's CA CAPI surface while excluding person-level couple-share cases that PE exposes only as an SPM-unit total.
 
+  - legal_id: us-ca:policies/dor/spotlight-on-social-security/2026-01/block-7#ca_state_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: ca_state_supplement
+    candidate_priority: P3
+    rationale: Axiom's DOR 2026 chart output is the monthly CA Supplement column selected by SSI/SSP living-arrangement and blindness/couple rows. PolicyEngine's ca_state_supplement is an annual SPM-unit final benefit after subtracting SSI and SSI countable income from its California payment-standard graph, so this encoded chart component is adjacent but not a one-to-one oracle target for the final PE surface.
+
   - legal_id: us-co:regulations/10-ccr-2506-1/4.407.3#excess_shelter_deduction
     country: us
     program: snap

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1556,10 +1556,12 @@ surfaces:
   variable: ca_state_supplement
   source_type: state_implementation
   state: CA
-  axiom_status: deferred_jurisdiction
+  axiom_status: known_not_comparable
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: Axiom encodes California's 2026 SSI/SSP chart amounts from state guidance, including the monthly CA Supplement
+    column. PolicyEngine's `ca_state_supplement` is an annual SPM-unit final amount after subtracting SSI and SSI countable
+    income from a broader California payment-standard graph, so compare encoded chart/payment-standard components separately
+    until Axiom has an equivalent WIC 12200/12204 final benefit composition surface.
 - country: us
   program_id: ssi_state_supplement
   program_name: Connecticut SSP

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1156,6 +1156,24 @@ def test_policyengine_program_surface_marks_ca_capi_wired():
     assert "us-ca:regulations/cdss/eas/49/49-055#ca_capi" in ca_capi["legal_ids"]
 
 
+def test_policyengine_program_surface_marks_california_ssp_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="ca_state_supplement")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    ca_ssp = items_by_variable["ca_state_supplement"]
+
+    assert ca_ssp["program_id"] == "ssi_state_supplement"
+    assert ca_ssp["state"] == "CA"
+    assert ca_ssp["axiom_status"] == "known_not_comparable"
+    assert ca_ssp["mapping_count"] >= 1
+    assert ca_ssp["comparable_mapping_count"] == 0
+    assert (
+        "us-ca:policies/dor/spotlight-on-social-security/2026-01/block-7#ca_state_supplement"
+        in ca_ssp["legal_ids"]
+    )
+    assert "annual SPM-unit final amount" in ca_ssp["rationale"]
+
+
 def test_policyengine_coverage_maps_georgia_ssp_nursing_home_supplement(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "us-ga" / "policies/dfcs/medicaid/2578.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.891"
+version = "0.2.892"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify PolicyEngine `ca_state_supplement` as known-not-comparable instead of deferred jurisdiction
- add the encoded California DOR SSI/SSP chart output as a not-comparable legal mapping for the PE surface
- bump axiom-encode to 0.2.892 and add coverage regression for the CA SSP program surface

## Validation
- `env -u UV_FROZEN uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_california_ssp_known_not_comparable tests/test_policyengine_coverage.py -q`
- `AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/axiom-corpus AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus AXIOM_RULESPEC_REPO_ROOTS=/Users/maxghenis/TheAxiomFoundation env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ca-ssp-oracle-20260627 --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --include-program-surfaces --json`
