### PR TITLE
Classify Illinois and Indiana TANF PE surfaces

### DIFF
--- a/changelog.d/bump-encoder-0-2-893.changed.md
+++ b/changelog.d/bump-encoder-0-2-893.changed.md
@@ -1,0 +1,1 @@
+Bump axiom-encode to 0.2.893.

--- a/changelog.d/il-in-tanf-surface-status.fixed.md
+++ b/changelog.d/il-in-tanf-surface-status.fixed.md
@@ -1,0 +1,1 @@
+Classify Illinois and Indiana TANF PolicyEngine final surfaces as known-not-comparable to their encoded source-local RuleSpec legal components.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.892"
+version = "0.2.893"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.892"
+__version__ = "0.2.893"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -252,10 +252,13 @@ surfaces:
   variable: il_tanf
   source_type: state_implementation
   state: IL
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Current RuleSpec repos include tested Illinois DHS CSM Manual earned-income-disregard and cash-payment legal
+    slices, including the one-dollar no-issuance threshold and whole-dollar rounding for regular monthly TANF benefits.
+    Those outputs are source-specific legal boundaries, while PolicyEngine's il_tanf final benefit currently omits the
+    no-issuance and rounding behavior and has a known income-eligibility boundary mismatch; compare the encoded legal
+    components separately until PE exposes compatible helpers or the final legal behavior matches.
 - country: us
   program_id: tanf
   program_name: NY TANF
@@ -486,10 +489,13 @@ surfaces:
   variable: in_tanf
   source_type: state_implementation
   state: IN
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Current RuleSpec repos include tested Indiana DFR cash-assistance standards, maximum-benefit tables, and
+    new-application and ongoing benefit-entitlement legal slices from the TANF manual. Those outputs expose source-local
+    monthly benefit entitlement, minimum-grant, countable-income, and parameter boundaries, while PolicyEngine's in_tanf
+    is a final SPM-unit benefit built from PE's broader eligibility graph; compare the encoded legal components separately
+    until Axiom has an equivalent final PE graph surface or PE exposes compatible helper boundaries.
 - country: us
   program_id: tanf
   program_name: Florida TCA

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1174,6 +1174,46 @@ def test_policyengine_program_surface_marks_california_ssp_known_not_comparable(
     assert "annual SPM-unit final amount" in ca_ssp["rationale"]
 
 
+def test_policyengine_program_surface_marks_illinois_tanf_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="il_tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    illinois_tanf = items_by_variable["il_tanf"]
+
+    assert illinois_tanf["program_id"] == "tanf"
+    assert illinois_tanf["state"] == "IL"
+    assert illinois_tanf["axiom_status"] == "known_not_comparable"
+    assert illinois_tanf["mapping_count"] >= 1
+    assert illinois_tanf["comparable_mapping_count"] == 0
+    assert (
+        "us-il:policies/dhs/csmm/15820/block-1#regular_monthly_tanf_benefit"
+        in illinois_tanf["legal_ids"]
+    )
+    assert "one-dollar no-issuance" in illinois_tanf["rationale"]
+
+
+def test_policyengine_program_surface_marks_indiana_tanf_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="in_tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    indiana_tanf = items_by_variable["in_tanf"]
+
+    assert indiana_tanf["program_id"] == "tanf"
+    assert indiana_tanf["state"] == "IN"
+    assert indiana_tanf["axiom_status"] == "known_not_comparable"
+    assert indiana_tanf["mapping_count"] >= 1
+    assert indiana_tanf["comparable_mapping_count"] == 0
+    assert (
+        "us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_new_application_monthly_benefit_entitlement"
+        in indiana_tanf["legal_ids"]
+    )
+    assert (
+        "us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation-continuation#tanf_ongoing_monthly_benefit_entitlement"
+        in indiana_tanf["legal_ids"]
+    )
+    assert "source-local monthly benefit entitlement" in indiana_tanf["rationale"]
+
+
 def test_policyengine_coverage_maps_georgia_ssp_nursing_home_supplement(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us" / "us-ga" / "policies/dfcs/medicaid/2578.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.892"
+version = "0.2.893"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark Illinois and Indiana TANF final PolicyEngine surfaces as known-not-comparable to Axiom source-local RuleSpec components
- keep existing legal mappings grounded while avoiding false direct parity claims for PE final benefit variables
- bump axiom-encode to 0.2.893 and add coverage regressions for both surfaces

## Validation
- `env -u UV_FROZEN uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_illinois_tanf_known_not_comparable tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_indiana_tanf_known_not_comparable tests/test_policyengine_coverage.py -q`
- `AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/axiom-corpus AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus AXIOM_RULESPEC_REPO_ROOTS=/Users/maxghenis/TheAxiomFoundation env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-il-in-tanf-status-20260627 --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --include-program-surfaces --json`
