### PR TITLE
Fix monorepo apply routing for new jurisdictions

### DIFF
--- a/changelog.d/monorepo-new-jurisdiction-apply.fixed.md
+++ b/changelog.d/monorepo-new-jurisdiction-apply.fixed.md
@@ -1,0 +1,1 @@
+Fix apply-overlay routing for the first generated file in a new state directory inside a country RuleSpec monorepo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.893"
+version = "0.2.894"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.893"
+__version__ = "0.2.894"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -33697,16 +33697,25 @@ def _relative_output_to_anchor(
     """Convert a generated file's relative path to its RuleSpec anchor."""
     rel = relative_output.with_suffix("")
     parts = rel.parts
-    if (
-        len(parts) >= 2
-        and parts[1] in {"policies", "regulations", "statutes"}
-        and re.fullmatch(r"[a-z]{2}(?:-[a-z0-9_]+)*", parts[0])
-    ):
+    jurisdiction = _relative_output_jurisdiction_prefix(relative_output)
+    if jurisdiction is not None:
         return f"{parts[0]}:{Path(*parts[1:]).as_posix()}"
-    jurisdiction = (
+    repo_jurisdiction = (
         _repo_jurisdiction_prefix(policy_repo_path) if policy_repo_path else "us"
     )
-    return f"{jurisdiction}:{rel.as_posix()}"
+    return f"{repo_jurisdiction}:{rel.as_posix()}"
+
+
+def _relative_output_jurisdiction_prefix(relative_output: Path) -> str | None:
+    """Return a leading jurisdiction directory from a generated output path."""
+    parts = Path(relative_output).parts
+    if (
+        len(parts) >= 2
+        and parts[1] in RULESPEC_SOURCE_ROOTS
+        and re.fullmatch(r"[a-z]{2}(?:-[a-z0-9_]+)*", parts[0])
+    ):
+        return parts[0]
+    return None
 
 
 def _rulespec_apply_content_root(
@@ -33716,12 +33725,11 @@ def _rulespec_apply_content_root(
     """Return the jurisdiction content root for live generated writes."""
     repo_path = Path(policy_repo_path)
     if relative_output is not None:
-        parts = Path(relative_output).parts
+        output_jurisdiction = _relative_output_jurisdiction_prefix(relative_output)
         jurisdiction = _repo_jurisdiction_prefix(repo_path)
-        if (
-            parts
-            and (parts[0] == jurisdiction or parts[0].startswith(f"{jurisdiction}-"))
-            and (repo_path / parts[0]).is_dir()
+        if output_jurisdiction and (
+            output_jurisdiction == jurisdiction
+            or output_jurisdiction.startswith(f"{jurisdiction}-")
         ):
             return repo_path
     return jurisdiction_content_dir(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -107,6 +107,7 @@ from axiom_encode.cli import (
     _rewrite_import_output_test_input_refs,
     _rewrite_judgment_conditional_formulas,
     _rewrite_judgment_numeric_comparisons,
+    _rulespec_apply_content_root,
     _rulespec_scalar_matches,
     _scoped_source_text_for_encode_source_id,
     _sha256_file,
@@ -4158,6 +4159,81 @@ class TestCmdEncode:
             "statutes/26/36B.yaml",
             "statutes/26/36B.test.yaml",
         ]
+
+    def test_apply_generated_encoding_routes_new_state_monorepo_prefix(self, tmp_path):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us"
+        generated = (
+            output_root
+            / "codex-test-model"
+            / "us-ks"
+            / "policies"
+            / "dcf"
+            / "keesm"
+            / "keesm7410.yaml"
+        )
+        generated.parent.mkdir(parents=True)
+        generated.write_text("format: rulespec/v1\nrules: []\n")
+        generated.with_name("keesm7410.test.yaml").write_text("[]\n")
+        policy_repo.mkdir()
+        result = self._make_eval_result(True)
+        result.output_file = str(generated)
+        result.context_manifest_file = str(tmp_path / "context.json")
+        result.trace_file = str(tmp_path / "trace.json")
+        result.generation_prompt_sha256 = None
+        Path(result.context_manifest_file).write_text("{}\n")
+        Path(result.trace_file).write_text("{}\n")
+
+        with (
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+            patch(
+                "axiom_encode.cli._git_repo_provenance",
+                return_value={
+                    "root": "/repo/axiom-encode",
+                    "commit": "abc123",
+                    "dirty_tracked": False,
+                },
+            ),
+            patch(
+                "axiom_encode.cli._require_axiom_encode_version_provenance",
+                return_value={
+                    "version": AXIOM_ENCODE_TEST_VERSION,
+                    "version_commit": "version123",
+                },
+            ),
+        ):
+            applied = _apply_generated_encoding_result(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                run_id="run-123",
+            )
+
+        target = policy_repo / "us-ks/policies/dcf/keesm/keesm7410.yaml"
+        target_test = policy_repo / "us-ks/policies/dcf/keesm/keesm7410.test.yaml"
+        manifest = (
+            policy_repo
+            / ".axiom/encoding-manifests/us-ks/policies/dcf/keesm/keesm7410.json"
+        )
+        assert applied == [target, target_test, manifest]
+        assert target.exists()
+        assert target_test.exists()
+        assert not (policy_repo / "policies/dcf/keesm/keesm7410.yaml").exists()
+        payload = json.loads(manifest.read_text())
+        assert [item["path"] for item in payload["applied_files"]] == [
+            "us-ks/policies/dcf/keesm/keesm7410.yaml",
+            "us-ks/policies/dcf/keesm/keesm7410.test.yaml",
+        ]
+        assert (
+            _rulespec_apply_content_root(
+                policy_repo,
+                Path("us-ks/policies/dcf/keesm/keesm7410.yaml"),
+            )
+            == policy_repo
+        )
 
     def test_write_applied_manifest_deduplicates_applied_files(self, tmp_path):
         output_root = tmp_path / "out"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.893"
+version = "0.2.894"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- route generated outputs with leading jurisdiction directories like `us-ks/policies/...` into country monorepo checkouts even when the jurisdiction directory does not exist yet
- reuse the jurisdiction-leading output path when deriving the RuleSpec anchor
- add regression coverage for applying the first generated file for a new state in `rulespec-us`

## Tests
- `env -u UV_FROZEN uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py -k 'routes_new_state_monorepo_prefix or routes_country_monorepo_root' -q`
- `env -u UV_FROZEN uv run --extra dev pytest tests/test_repo_routing.py tests/test_concepts_cli.py::test_relative_output_to_anchor_uses_rules_repo_prefix -q`
- `env -u UV_FROZEN uv run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py`
