### PR TITLE
Create missing monorepo jurisdiction dirs for source encodes

### DIFF
--- a/changelog.d/create-missing-monorepo-jurisdiction.fixed.md
+++ b/changelog.d/create-missing-monorepo-jurisdiction.fixed.md
@@ -1,0 +1,1 @@
+Create missing country-monorepo jurisdiction directories before source encodes so first-time state encodings validate and apply under the correct jurisdiction root.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.894"
+version = "0.2.895"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.894"
+__version__ = "0.2.895"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -219,11 +219,32 @@ def _resolve_policy_repo_for_prefix(prefix: str) -> Path:
 def _resolve_policy_repo_for_corpus_source(
     corpus_citation_path: str,
     override: Path | None = None,
+    *,
+    create_missing_monorepo_content_root: bool = False,
 ) -> Path:
     jurisdiction = corpus_citation_path.strip().split("/", 1)[0] or "us"
     if override is not None:
-        return jurisdiction_content_dir(override, jurisdiction).resolve()
+        override = Path(override)
+        content_root = jurisdiction_content_dir(override, jurisdiction)
+        if (
+            create_missing_monorepo_content_root
+            and content_root == override
+            and _override_is_country_monorepo_for_jurisdiction(override, jurisdiction)
+        ):
+            content_root = override / jurisdiction
+            content_root.mkdir(parents=True, exist_ok=True)
+        return content_root.resolve()
     return _resolve_policy_repo_for_prefix(jurisdiction)
+
+
+def _override_is_country_monorepo_for_jurisdiction(
+    override: Path, jurisdiction: str
+) -> bool:
+    """Return whether ``override`` is the country monorepo for ``jurisdiction``."""
+    repo_name = canonical_rulespec_repo_name(override) or Path(override).name
+    if repo_name != monorepo_checkout_name(jurisdiction):
+        return False
+    return jurisdiction != repo_name.removeprefix("rulespec-")
 
 
 def _resolve_validation_repo_roots(rulespec_file: Path) -> tuple[Path, Path]:
@@ -19186,6 +19207,7 @@ def cmd_encode(args):
         policy_repo_path = _resolve_policy_repo_for_corpus_source(
             args.citation,
             args.policy_repo_path,
+            create_missing_monorepo_content_root=True,
         )
     else:
         policy_repo_path = args.policy_repo_path or _resolve_policy_repo_for_prefix(
@@ -38004,6 +38026,7 @@ def cmd_eval_source(args):
     policy_repo_path = _resolve_policy_repo_for_corpus_source(
         source_unit.citation_path,
         args.policy_repo_path,
+        create_missing_monorepo_content_root=True,
     )
     runtime_axiom_rules_path = args.axiom_rules_path
     runtime_axiom_rules_path = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3779,6 +3779,23 @@ class TestCmdEncode:
         assert exit_code == 0
         assert mock_run.call_args.kwargs["policy_path"] == policy_repo_path / "us-co"
 
+    def test_encode_creates_missing_state_monorepo_jurisdiction_dir(
+        self, capsys, tmp_path
+    ):
+        policy_repo_path = tmp_path / "rulespec-us"
+        (policy_repo_path / "us").mkdir(parents=True)
+        args = self._make_args(
+            tmp_path,
+            citation="us-ks/manual/dcf/keesm/keesm7410",
+            policy_repo_path=policy_repo_path,
+        )
+
+        mock_run, exit_code = self._run_encode(args, self._make_eval_result(True))
+
+        assert exit_code == 0
+        assert mock_run.call_args.kwargs["policy_path"] == policy_repo_path / "us-ks"
+        assert (policy_repo_path / "us-ks").is_dir()
+
     def test_encode_passes_skip_reviewers_to_model_eval(self, capsys, tmp_path):
         args = self._make_args(tmp_path, skip_reviewers=True)
         mock_run, exit_code = self._run_encode(args, self._make_eval_result(True))

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.894"
+version = "0.2.895"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- create missing country-monorepo jurisdiction content dirs when source encodes target a new state under a supplied monorepo checkout
- keep existing legacy and existing-state routing behavior intact
- bump axiom-encode to 0.2.895 and add changelog entry

## Tests
- env -u UV_FROZEN uv run --extra dev pytest tests/test_cli.py::TestCmdEncode::test_encode_creates_missing_state_monorepo_jurisdiction_dir tests/test_cli.py::TestCmdEncode::test_encode_routes_state_corpus_citation_to_monorepo_jurisdiction_dir tests/test_cli.py::TestCmdEncode::test_apply_generated_encoding_routes_new_state_monorepo_prefix tests/test_cli.py::TestCmdEncode::test_apply_generated_encoding_routes_country_monorepo_root tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- env -u UV_FROZEN uv run --extra dev ruff check src/axiom_encode/cli.py tests/test_cli.py
- env -u UV_FROZEN uv run --extra dev ruff format --check src/axiom_encode/cli.py tests/test_cli.py