### PR TITLE
Fix direct-root coverage and classify Kansas TANF

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.895"
+version = "0.2.896"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.895"
+__version__ = "0.2.896"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -18349,6 +18349,14 @@ prefixes:
     candidate_priority: P4
     rationale: Colorado Works basic-cash-assistance composition outputs are Axiom assembly points across encoded 9 CCR 2503-6 Section 3.606.1 and 3.606.2 provisions. PolicyEngine-US does not expose this exact composed monthly TANF legal slice one-to-one; direct oracle comparison should wait for an adapter that targets the same Colorado Works source boundaries and updated grant parameters.
 
+  - legal_id_prefix: us-ks:policies/dcf/keesm/keesm7410#
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ks_tanf_maximum_benefit
+    candidate_priority: P4
+    rationale: Kansas KEESM 7411 outputs decompose source-local TANF basic allowances, shelter groups, Table I and Table II shelter-percentage selection, and budgetary-standard calculations. PolicyEngine-US exposes adjacent Kansas TANF maximum-benefit and final-benefit surfaces keyed by its own assistance-unit size and parameterization, not these source-specific KEESM 7411 legal helper boundaries one-to-one.
+
   - legal_id_prefix: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#
     country: us
     program: tanf

--- a/src/axiom_encode/repo_routing.py
+++ b/src/axiom_encode/repo_routing.py
@@ -237,7 +237,13 @@ def iter_jurisdiction_content_dirs(workspace_root: Path) -> list[tuple[str, Path
             seen.add(resolved)
             out.append((prefix, content_dir))
 
-    for checkout in sorted(Path(workspace_root).glob("rulespec-*")):
+    root = Path(workspace_root)
+    candidate_checkouts = []
+    if root.is_dir() and root.name.startswith("rulespec-"):
+        candidate_checkouts.append(root)
+    candidate_checkouts.extend(sorted(root.glob("rulespec-*")))
+
+    for checkout in candidate_checkouts:
         if not checkout.is_dir():
             continue
         suffix = _checkout_suffix(checkout)

--- a/tests/test_policyengine_coverage_monorepo.py
+++ b/tests/test_policyengine_coverage_monorepo.py
@@ -31,6 +31,15 @@ rules:
         formula: state_input
 """
 
+_KS_TANF_RULESPEC = """format: rulespec/v1
+rules:
+  - name: ks_tanf_maximum_benefit
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: tanf_basic_allowance + tanf_shelter_allowance
+"""
+
 _UNMAPPED_UK_RULESPEC = """format: rulespec/v1
 rules:
   - name: brand_new_local_helper_xyz
@@ -84,6 +93,53 @@ def test_monorepo_and_legacy_layouts_derive_identical_ids(tmp_path):
     # The repo attribution is the canonical legacy repo name in both layouts.
     assert {item["repo"] for item in monorepo_report["items"]} == {"rulespec-us-al"}
     assert {item["repo"] for item in legacy_report["items"]} == {"rulespec-us-al"}
+
+
+def test_direct_monorepo_root_is_enumerated(tmp_path):
+    """``--root <rulespec-us>`` should scan that checkout, not only siblings."""
+    root = tmp_path / "rulespec-us"
+    _write(root / "us-al" / "policies" / "dhr" / "poe.yaml", _UNMAPPED_US_RULESPEC)
+
+    report = build_policyengine_coverage_report(root)
+
+    assert [item["legal_id"] for item in report["items"]] == [
+        "us-al:policies/dhr/poe#brand_new_state_helper_xyz"
+    ]
+    assert {item["repo"] for item in report["items"]} == {"rulespec-us-al"}
+
+
+def test_direct_legacy_root_is_enumerated(tmp_path):
+    """``--root <rulespec-us-al>`` should scan legacy standalone checkouts."""
+    root = tmp_path / "rulespec-us-al"
+    _write(root / "policies" / "dhr" / "poe.yaml", _UNMAPPED_US_RULESPEC)
+
+    report = build_policyengine_coverage_report(root)
+
+    assert [item["legal_id"] for item in report["items"]] == [
+        "us-al:policies/dhr/poe#brand_new_state_helper_xyz"
+    ]
+    assert {item["repo"] for item in report["items"]} == {"rulespec-us-al"}
+
+
+def test_kansas_tanf_keesm_prefix_is_classified_not_comparable(tmp_path):
+    """Kansas KEESM 7411 source helpers are explicit non-comparable TANF slices."""
+    root = tmp_path / "rulespec-us"
+    _write(
+        root / "us-ks" / "policies" / "dcf" / "keesm" / "keesm7410.yaml",
+        _KS_TANF_RULESPEC,
+    )
+
+    report = build_policyengine_coverage_report(root, program="tanf")
+
+    assert len(report["items"]) == 1
+    item = report["items"][0]
+    assert item["legal_id"] == (
+        "us-ks:policies/dcf/keesm/keesm7410#ks_tanf_maximum_benefit"
+    )
+    assert item["repo"] == "rulespec-us-ks"
+    assert item["status"] == "known_not_comparable"
+    assert item["mapping_type"] == "not_comparable"
+    assert item["policyengine_variable"] == "ks_tanf_maximum_benefit"
 
 
 def test_monorepo_country_directory_is_not_doubled(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.895"
+version = "0.2.896"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- include direct rulespec checkout roots in PolicyEngine coverage enumeration
- classify Kansas KEESM 7411 TANF source outputs as known non-comparable to PolicyEngine's adjacent Kansas TANF surfaces
- bump axiom-encode to 0.2.896

## Validation
- env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage_monorepo.py tests/test_policyengine_classifier.py -q
- env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ks-tanf-payment-standard-20260627 --oracle policyengine --program tanf
- git diff --check