### PR TITLE
Skip same-named wrapper roots in coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.896"
+version = "0.2.897"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.896"
+__version__ = "0.2.897"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/repo_routing.py
+++ b/src/axiom_encode/repo_routing.py
@@ -239,7 +239,11 @@ def iter_jurisdiction_content_dirs(workspace_root: Path) -> list[tuple[str, Path
 
     root = Path(workspace_root)
     candidate_checkouts = []
-    if root.is_dir() and root.name.startswith("rulespec-"):
+    if (
+        root.is_dir()
+        and root.name.startswith("rulespec-")
+        and not (root / root.name).is_dir()
+    ):
         candidate_checkouts.append(root)
     candidate_checkouts.extend(sorted(root.glob("rulespec-*")))
 

--- a/tests/test_policyengine_coverage_monorepo.py
+++ b/tests/test_policyengine_coverage_monorepo.py
@@ -108,6 +108,23 @@ def test_direct_monorepo_root_is_enumerated(tmp_path):
     assert {item["repo"] for item in report["items"]} == {"rulespec-us-al"}
 
 
+def test_same_named_workspace_wrapper_does_not_become_country_root(tmp_path):
+    """GitHub Actions uses ``.../rulespec-us/rulespec-us``; only the child is a checkout."""
+    workspace = tmp_path / "rulespec-us"
+    checkout = workspace / "rulespec-us"
+    _write(
+        checkout / "us-al" / "policies" / "dhr" / "poe.yaml",
+        _UNMAPPED_US_RULESPEC,
+    )
+
+    report = build_policyengine_coverage_report(workspace)
+
+    assert [item["legal_id"] for item in report["items"]] == [
+        "us-al:policies/dhr/poe#brand_new_state_helper_xyz"
+    ]
+    assert {item["repo"] for item in report["items"]} == {"rulespec-us-al"}
+
+
 def test_direct_legacy_root_is_enumerated(tmp_path):
     """``--root <rulespec-us-al>`` should scan legacy standalone checkouts."""
     root = tmp_path / "rulespec-us-al"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.896"
+version = "0.2.897"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- avoid treating a same-named GitHub Actions workspace wrapper as a direct RuleSpec checkout
- keep direct checkout coverage support from 0.2.896 while preserving parent-workspace enumeration
- bump axiom-encode to 0.2.897

## Validation
- env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage_monorepo.py tests/test_policyengine_classifier.py -q
- local CI-shape wrapper run: parent named rulespec-us containing child rulespec-us checkout, full oracle-coverage with --fail-on-unmapped and --fail-on-untested-comparable
- git diff --check