### PR TITLE
Classify Louisiana FITAP oracle surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.897"
+version = "0.2.898"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.897"
+__version__ = "0.2.898"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -18357,6 +18357,14 @@ prefixes:
     candidate_priority: P4
     rationale: Kansas KEESM 7411 outputs decompose source-local TANF basic allowances, shelter groups, Table I and Table II shelter-percentage selection, and budgetary-standard calculations. PolicyEngine-US exposes adjacent Kansas TANF maximum-benefit and final-benefit surfaces keyed by its own assistance-unit size and parameterization, not these source-specific KEESM 7411 legal helper boundaries one-to-one.
 
+  - legal_id_prefix: us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: la_fitap
+    candidate_priority: P4
+    rationale: Louisiana FITAP B-640 outputs decompose source-local income-limit, flat-grant, 18+ household, minimum-payment, and rounded-deficit grant rules. PolicyEngine-US exposes la_fitap as a final monthly benefit surface, but currently omits the B-640 rounded-down deficit and under-$10 no-payment rules, so these source-faithful RuleSpec outputs are not one-to-one comparable.
+
   - legal_id_prefix: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#
     country: us
     program: tanf

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -845,10 +845,12 @@ surfaces:
   variable: la_fitap
   source_type: state_implementation
   state: LA
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: RuleSpec encodes Louisiana FITAP income-limit, flat-grant, 18+ household, minimum-payment, and rounded-deficit
+    legal slices from DCFS B-640. PolicyEngine's la_fitap is a final monthly benefit surface, but currently omits the
+    source's rounded-down deficit and under-$10 no-payment rules, so direct oracle comparison is not one-to-one until
+    PolicyEngine is updated or an adapter targets the same legal boundary.
 - country: us
   program_id: tanf
   program_name: New Mexico Works

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1361,6 +1361,24 @@ def test_policyengine_program_surface_marks_florida_tca_known_not_comparable():
     assert "final SPM-unit benefit" in florida_tca["rationale"]
 
 
+def test_policyengine_program_surface_marks_louisiana_fitap_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    louisiana_fitap = items_by_variable["la_fitap"]
+
+    assert louisiana_fitap["program_id"] == "tanf"
+    assert louisiana_fitap["state"] == "LA"
+    assert louisiana_fitap["axiom_status"] == "known_not_comparable"
+    assert louisiana_fitap["mapping_count"] == 1
+    assert louisiana_fitap["comparable_mapping_count"] == 0
+    assert louisiana_fitap["legal_ids"] == [
+        "us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#"
+    ]
+    assert "Louisiana FITAP income-limit" in louisiana_fitap["rationale"]
+    assert "under-$10 no-payment rules" in louisiana_fitap["rationale"]
+
+
 def test_policyengine_program_surface_marks_wyoming_power_known_not_comparable():
     report = build_policyengine_program_surface_report(program="tanf")
 
@@ -1377,6 +1395,44 @@ def test_policyengine_program_surface_marks_wyoming_power_known_not_comparable()
     ]
     assert "Wyoming POWER payment-test legal slices" in wyoming_power["rationale"]
     assert "final benefit surface" in wyoming_power["rationale"]
+
+
+def test_policyengine_coverage_classifies_louisiana_fitap_income_limit_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-la"
+        / "policies/dcfs/economic-independence/b-640-fitap-income-limits-398921.yaml",
+        """format: rulespec/v1
+rules:
+  - name: la_fitap
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    versions:
+      - effective_from: '2023-01-01'
+        formula: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path)
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == (
+        "us-la:policies/dcfs/economic-independence/"
+        "b-640-fitap-income-limits-398921#la_fitap"
+    )
+    assert item["status"] == "known_not_comparable"
+    assert item["program"] == "tanf"
+    assert item["mapping_type"] == "not_comparable"
+    assert item["policyengine_variable"] == "la_fitap"
+    assert item["candidate_priority"] == "P4"
+    assert "under-$10 no-payment rules" in item["rationale"]
 
 
 def test_policyengine_coverage_classifies_wyoming_power_payment_helpers(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.897"
+version = "0.2.898"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Louisiana FITAP B-640 RuleSpec outputs as source-backed but not one-to-one comparable to PolicyEngine's current la_fitap
- move the la_fitap program surface from pending encoding to known_not_comparable
- add coverage regressions for the LA FITAP program surface and legal-ID prefix

## Validation
- env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage.py -k 'louisiana_fitap or louisiana_fitap_income_limit'
- env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage.py -k tanf
- env -u UV_FROZEN uv run --extra dev ruff check tests/test_policyengine_coverage.py
- env -u UV_FROZEN uv run python -c 'import yaml, pathlib; [yaml.safe_load(pathlib.Path(p).read_text()) for p in ["src/axiom_encode/oracles/policyengine/mappings/us.yaml", "src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml"]]; print("YAML OK")'
- git diff --check

Note: the Louisiana manual includes rounded-down deficit and under- no-payment rules; PolicyEngine's current la_fitap formula omits those, so this intentionally does not claim a comparable mapping.