### PR TITLE
Add Nevada TANF PolicyEngine oracle metadata

### DIFF
--- a/changelog.d/nv-tanf-oracle-coverage.changed.md
+++ b/changelog.d/nv-tanf-oracle-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify generated Nevada TANF A-660.12 outputs in PolicyEngine oracle coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.898"
+version = "0.2.899"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.898"
+__version__ = "0.2.899"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -18365,6 +18365,92 @@ prefixes:
     candidate_priority: P4
     rationale: Louisiana FITAP B-640 outputs decompose source-local income-limit, flat-grant, 18+ household, minimum-payment, and rounded-deficit grant rules. PolicyEngine-US exposes la_fitap as a final monthly benefit surface, but currently omits the B-640 rounded-down deficit and under-$10 no-payment rules, so these source-faithful RuleSpec outputs are not one-to-one comparable.
 
+  - legal_id: us-nv:policies/dwss/eligibility-payments/a-600/page-38#tanf_minimum_issuable_benefit
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: nv_tanf
+    candidate_priority: P4
+    rationale: Axiom exposes Nevada E&P Manual A-660.12's standalone $10 TANF minimum-issuance amount. PolicyEngine's nv_tanf computes a final monthly benefit from its payment-standard and countable-income graph, not this source-specific legal parameter.
+
+  - legal_id: us-nv:policies/dwss/eligibility-payments/a-600/page-38#employment_retention_payment_amount
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: nv_tanf
+    candidate_priority: P4
+    rationale: Axiom exposes the source-stated $50 Nevada TANF Employment Retention Payment amount. PolicyEngine's nv_tanf final benefit does not expose the ERP amount as a one-to-one oracle target.
+
+  - legal_id: us-nv:policies/dwss/eligibility-payments/a-600/page-38#employment_retention_payment_duration_months
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: nv_tanf
+    candidate_priority: P4
+    rationale: Axiom exposes the source-stated six-month Nevada TANF Employment Retention Payment duration. PolicyEngine's nv_tanf final benefit does not expose the ERP duration as a one-to-one oracle target.
+
+  - legal_id: us-nv:policies/dwss/eligibility-payments/a-600/page-38#earned_income_for_employment_retention_payment_minimum
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: nv_tanf
+    candidate_priority: P4
+    rationale: Axiom exposes the source-stated earned-income threshold for Nevada TANF Employment Retention Payment eligibility. PolicyEngine's nv_tanf final benefit does not expose this ERP eligibility threshold as a one-to-one oracle target.
+
+  - legal_id: us-nv:policies/dwss/eligibility-payments/a-600/page-38#tanf_gross_income_poverty_test_rate
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: nv_tanf
+    candidate_priority: P4
+    rationale: Axiom exposes the A-660.12 130 percent poverty gross-income-test rate used before Nevada TANF cash-benefit calculation. PolicyEngine's nv_tanf final benefit does not expose this source-specific eligibility-test parameter as a one-to-one oracle target.
+
+  - legal_id: us-nv:policies/dwss/eligibility-payments/a-600/page-38#tanf_cash_gross_income_test_passes
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: nv_tanf
+    candidate_priority: P4
+    rationale: Axiom exposes the A-660.12 Nevada TANF gross-income-test predicate. PolicyEngine's nv_tanf final benefit does not expose this source-specific month-level predicate as a one-to-one oracle target.
+
+  - legal_id: us-nv:policies/dwss/eligibility-payments/a-600/page-38#nv_tanf
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: nv_tanf
+    candidate_priority: P4
+    rationale: Axiom applies A-660.12's gross-income test, whole-dollar rounding, $10 minimum-issuance rule, and under-$10 exceptions to the Nevada TANF cash-benefit slice. PolicyEngine's nv_tanf final benefit computes payment-standard minus countable income and does not expose or fully model those source-specific legal boundaries; tracked in PolicyEngine/policyengine-us#8771.
+
+  - legal_id: us-nv:policies/dwss/eligibility-payments/a-600/page-38#employment_retention_payment_eligible
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: nv_tanf
+    candidate_priority: P4
+    rationale: Axiom exposes the A-660.12 Nevada TANF Employment Retention Payment eligibility predicate. PolicyEngine's nv_tanf final benefit does not expose ERP eligibility as a one-to-one oracle target.
+
+  - legal_id: us-nv:policies/dwss/eligibility-payments/a-600/page-38#employment_retention_payment
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: nv_tanf
+    candidate_priority: P4
+    rationale: Axiom exposes the A-660.12 Nevada TANF Employment Retention Payment amount as a separate legal output. PolicyEngine's nv_tanf final benefit does not expose the ERP as a one-to-one oracle target.
+
+  - legal_id: us-nv:policies/dwss/eligibility-payments/a-600/page-38#snap_net_income_reduction_rate
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes a Nevada manual SNAP allotment helper from the mixed TANF/SNAP A-660.12 page. PolicyEngine's final SNAP surfaces are federal/state simulation aggregates rather than this source-page helper.
+
+  - legal_id: us-nv:policies/dwss/eligibility-payments/a-600/page-38#monthly_snap_allotment
+    country: us
+    program: snap
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the Nevada manual's SNAP allotment computation from the mixed TANF/SNAP A-660.12 page. PolicyEngine's snap program surface includes broader simulation behavior and is not a one-to-one target for this helper.
+
   - legal_id_prefix: us-wy:policies/dfs/snap-power-policy-manual/1101-power-payment-tests-computations#
     country: us
     program: tanf

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -537,10 +537,13 @@ surfaces:
   variable: nv_tanf
   source_type: state_implementation
   state: NV
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Current RuleSpec repos include tested Nevada E&P Manual A-660.12 TANF cash-benefit, gross-income-test,
+    whole-dollar rounding, $10 minimum-issuance, under-$10 exception, and employment-retention-payment legal slices.
+    PolicyEngine's nv_tanf final benefit computes payment-standard minus countable income and does not expose those
+    source-specific month-level legal boundaries or the Employment Retention Payment as one-to-one oracle targets;
+    tracked in PolicyEngine/policyengine-us#8771.
 - country: us
   program_id: tanf
   program_name: Kansas TANF

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1379,6 +1379,25 @@ def test_policyengine_program_surface_marks_louisiana_fitap_known_not_comparable
     assert "under-$10 no-payment rules" in louisiana_fitap["rationale"]
 
 
+def test_policyengine_program_surface_marks_nevada_tanf_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    nevada_tanf = items_by_variable["nv_tanf"]
+
+    assert nevada_tanf["program_id"] == "tanf"
+    assert nevada_tanf["state"] == "NV"
+    assert nevada_tanf["axiom_status"] == "known_not_comparable"
+    assert nevada_tanf["mapping_count"] == 9
+    assert nevada_tanf["comparable_mapping_count"] == 0
+    assert (
+        "us-nv:policies/dwss/eligibility-payments/a-600/page-38#nv_tanf"
+        in nevada_tanf["legal_ids"]
+    )
+    assert "Nevada E&P Manual A-660.12" in nevada_tanf["rationale"]
+    assert "Employment Retention Payment" in nevada_tanf["rationale"]
+
+
 def test_policyengine_program_surface_marks_wyoming_power_known_not_comparable():
     report = build_policyengine_program_surface_report(program="tanf")
 
@@ -1433,6 +1452,70 @@ rules:
     assert item["policyengine_variable"] == "la_fitap"
     assert item["candidate_priority"] == "P4"
     assert "under-$10 no-payment rules" in item["rationale"]
+
+
+def test_policyengine_coverage_classifies_nevada_tanf_and_snap_outputs(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-nv"
+        / "policies/dwss/eligibility-payments/a-600/page-38.yaml",
+        """format: rulespec/v1
+rules:
+  - name: nv_tanf
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    versions:
+      - effective_from: '2025-08-11'
+        formula: 0
+  - name: employment_retention_payment
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    versions:
+      - effective_from: '2025-08-11'
+        formula: 0
+  - name: snap_net_income_reduction_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2025-08-11'
+        formula: '0.3'
+  - name: monthly_snap_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    unit: USD
+    period: Month
+    versions:
+      - effective_from: '2025-08-11'
+        formula: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path)
+
+    assert report["status_counts"] == {"known_not_comparable": 4}
+    items_by_name = {item["rule_name"]: item for item in report["items"]}
+    assert items_by_name["nv_tanf"]["program"] == "tanf"
+    assert items_by_name["nv_tanf"]["policyengine_variable"] == "nv_tanf"
+    assert items_by_name["employment_retention_payment"]["program"] == "tanf"
+    assert items_by_name["employment_retention_payment"]["policyengine_variable"] == (
+        "nv_tanf"
+    )
+    assert items_by_name["snap_net_income_reduction_rate"]["program"] == "snap"
+    assert (
+        items_by_name["snap_net_income_reduction_rate"]["policyengine_variable"] is None
+    )
+    assert items_by_name["monthly_snap_allotment"]["program"] == "snap"
+    assert items_by_name["monthly_snap_allotment"]["policyengine_variable"] is None
 
 
 def test_policyengine_coverage_classifies_wyoming_power_payment_helpers(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.898"
+version = "0.2.899"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark the `nv_tanf` PolicyEngine program surface as known-not-comparable after the Nevada A-660.12 RuleSpec encoding
- add exact legal-ID oracle mappings for Nevada TANF cash benefit, minimum issuance, Employment Retention Payment, and mixed-page SNAP helper outputs
- add coverage tests for the Nevada TANF surface and generated RuleSpec outputs

## Notes
- PolicyEngine current `nv_tanf` models the payment-standard minus countable-income final benefit but does not fully model A-660.12 whole-dollar rounding, minimum issuance exceptions, or the Employment Retention Payment.
- Filed PE follow-up: PolicyEngine/policyengine-us#8771.

## Checks
- `uv run --extra dev pytest tests/test_policyengine_coverage.py -k 'nevada_tanf or tanf'`
- `uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `uv run --extra dev python - <<'PY' ... yaml.safe_load(...) ... PY`
- `uv run --extra dev ruff check tests/test_policyengine_coverage.py`
- `git diff --check`
