### PR TITLE
Add Florida OSS oracle metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.899"
+version = "0.2.900"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.899"
+__version__ = "0.2.900"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2360,6 +2360,30 @@ mappings:
     comparison: money
     rationale: Same Colorado AND-CS monthly grant-standard-minus-countable-income amount.
 
+  - legal_id: us-fl:policies/dcf/ess-program-policy-manual/appendix-a-12-state-funded-programs-eligibility-standards/page-1#fl_oss_max_oss
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: fl_oss_max_oss
+    candidate_priority: P4
+    rationale: RuleSpec returns the Appendix A-12 OSS maximum payment standard by Florida assistance-unit category; PolicyEngine's `fl_oss_max_oss` returns a person-level cap after marital-unit logic and therefore is not a one-to-one oracle target.
+
+  - legal_id: us-fl:policies/dcf/ess-program-policy-manual/200-general-program-information/page-15#fl_oss_eligible
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: fl_oss_eligible
+    candidate_priority: P4
+    rationale: RuleSpec encodes Florida ESS 0240.0118 legal eligibility, including age or Title XVI disability, Florida residence intent, citizenship or qualified-noncitizen status, income, assets, pursuit of benefits, licensed-facility placement, and counselor certification; PolicyEngine's `fl_oss_eligible` is a simplified modeled predicate over SSI eligibility, living arrangement, OSS track, and income-standard checks.
+
+  - legal_id: us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-58#fl_oss
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: fl_oss
+    candidate_priority: P4
+    rationale: Florida ESS 2640.0131.04-.06 computes the source-level OSS payment deficit from recognized cost of care and income available for cost of care, including dependent-allocation and SSI-eligible-couple treatment. PolicyEngine's `fl_oss` is a person-level modeled wrapper that applies its own eligibility predicate, SSI-countable-income projection, provider-rate arithmetic, and cap logic, so the final surfaces are not one-to-one.
+
   - legal_id: us-ga:policies/dfcs/medicaid/2578#resource_transfer_lookback_months
     country: us
     program: ssi_state_supplement

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1639,10 +1639,12 @@ surfaces:
   variable: fl_oss
   source_type: state_implementation
   state: FL
-  axiom_status: deferred_jurisdiction
+  axiom_status: known_not_comparable
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: Axiom encodes the Florida ESS legal eligibility, source-local OSS payment deficit, and Appendix A-12 standards
+    for Optional State Supplementation. PolicyEngine's `fl_oss` is a person-level modeled wrapper that combines simplified
+    eligibility, SSI-countable-income projection, provider-rate arithmetic, and cap logic rather than exposing the same
+    source-local benefit-computation concepts one-to-one.
 - country: us
   program_id: ssi_state_supplement
   program_name: Georgia SSP

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1330,6 +1330,24 @@ def test_policyengine_program_surface_marks_georgia_ssp_known_not_comparable():
     )
 
 
+def test_policyengine_program_surface_marks_florida_oss_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="fl_oss")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    florida_oss = items_by_variable["fl_oss"]
+
+    assert florida_oss["program_id"] == "ssi_state_supplement"
+    assert florida_oss["state"] == "FL"
+    assert florida_oss["axiom_status"] == "known_not_comparable"
+    assert florida_oss["mapping_count"] >= 1
+    assert florida_oss["comparable_mapping_count"] == 0
+    assert (
+        "us-fl:policies/dcf/ess-program-policy-manual/2600-calculation-of-benefits/page-58#fl_oss"
+        in florida_oss["legal_ids"]
+    )
+    assert "source-local OSS payment deficit" in florida_oss["rationale"]
+
+
 def test_policyengine_program_surface_marks_georgia_tanf_known_not_comparable():
     report = build_policyengine_program_surface_report(program="tanf")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.899"
+version = "0.2.900"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Florida OSS as a known non-comparable PolicyEngine program surface now that source RuleSpec encodings exist
- add non-comparable mappings for Florida OSS eligibility, max OSS cap, and payment computation outputs
- bump axiom-encode to 0.2.900 and add a regression test for the surface status

## Tests
- env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_florida_oss_known_not_comparable
- env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-fl-oss-pe-parity-20260627 --oracle policyengine --include-program-surfaces --json