### PR TITLE
Add Michigan SSP oracle metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.900"
+version = "0.2.901"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.900"
+__version__ = "0.2.901"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2448,6 +2448,94 @@ mappings:
     candidate_priority: P4
     rationale: Georgia DFCS Policy 2578 patient-liability computation after admission is a Medicaid long-term-care budgeting rule; PolicyEngine's Georgia SSP model does not expose this liability boundary.
 
+  - legal_id: us-mi:policies/mdhhs/rft/248#independent_living_individual_state_ssi_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mi.mdhhs.ssp.payment.individual
+    parameter_key_path:
+      - INDEPENDENT_LIVING
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Michigan monthly individual State SSI Payment amount for independent living under RFT 248.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#household_of_another_individual_state_ssi_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mi.mdhhs.ssp.payment.individual
+    parameter_key_path:
+      - HOUSEHOLD_OF_ANOTHER
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Michigan monthly individual State SSI Payment amount for household-of-another living arrangements under RFT 248.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#domiciliary_care_individual_dhs_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mi.mdhhs.ssp.payment.individual
+    parameter_key_path:
+      - DOMICILIARY_CARE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Michigan monthly individual DHS supplement amount for domiciliary-care adult foster care under RFT 248.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#personal_care_individual_dhs_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mi.mdhhs.ssp.payment.individual
+    parameter_key_path:
+      - PERSONAL_CARE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Michigan monthly individual DHS supplement amount for personal-care adult foster care under RFT 248.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#home_for_aged_individual_dhs_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mi.mdhhs.ssp.payment.individual
+    parameter_key_path:
+      - HOME_FOR_AGED
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Michigan monthly individual DHS supplement amount for home-for-aged living arrangements under RFT 248.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#institution_individual_dhs_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mi.mdhhs.ssp.payment.individual
+    parameter_key_path:
+      - INSTITUTION
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Michigan monthly individual DHS supplement amount for institutional living arrangements under RFT 248.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#mi_ssp_person
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: mi_ssp_person
+    candidate_priority: P3
+    rationale: RuleSpec's RFT 248 output selects the current-law monthly source table amount by living arrangement and couple status. PolicyEngine's `mi_ssp_person` also gates on Michigan SSP eligibility and reduces the payment by residual countable income, so this source-table selector is adjacent but not a one-to-one final person benefit.
+
+  - legal_id: us-mi:policies/mdhhs/bridges/bem/660#mi_ssp_eligible
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: mi_ssp_eligible
+    candidate_priority: P3
+    rationale: BEM 660's encoded predicate covers MDHHS-issued State SSI Payments for independent-living and household-of-another recipients with a regular first-of-month federal benefit and excludes section 1619 recipients. PolicyEngine's `mi_ssp_eligible` also covers SSA-issued care, home-for-aged, and institution categories and applies PolicyEngine's broader SSI eligibility graph.
+
   - legal_id: us-co:regulations/10-ccr-2506-1/4.407.31#snap_heating_cooling_utility_allowance_eligible
     country: us
     program: snap

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1727,10 +1727,11 @@ surfaces:
   variable: mi_ssp
   source_type: state_implementation
   state: MI
-  axiom_status: deferred_jurisdiction
+  axiom_status: known_not_comparable
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: RuleSpec encodes Michigan BEM 660 MDHHS-issued State SSI Payment eligibility and RFT 248 current-law payment
+    cells. PolicyEngine's `mi_ssp` is an SPM-unit aggregate over person-level amounts, category overrides, SSI eligibility,
+    and countable-income reductions, so no single encoded source output is a one-to-one oracle target for the final aggregate.
 - country: us
   program_id: ssi_state_supplement
   program_name: Maine SSP

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1330,6 +1330,18 @@ def test_policyengine_program_surface_marks_georgia_ssp_known_not_comparable():
     )
 
 
+def test_policyengine_program_surface_marks_michigan_ssp_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="mi_ssp")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    michigan_ssp = items_by_variable["mi_ssp"]
+
+    assert michigan_ssp["program_id"] == "ssi_state_supplement"
+    assert michigan_ssp["state"] == "MI"
+    assert michigan_ssp["axiom_status"] == "known_not_comparable"
+    assert "SPM-unit aggregate" in michigan_ssp["rationale"]
+
+
 def test_policyengine_program_surface_marks_florida_oss_known_not_comparable():
     report = build_policyengine_program_surface_report(program="fl_oss")
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2540,6 +2540,24 @@ def test_policyengine_registry_is_legal_id_keyed():
         colorado_ssp_grant_standard_mapping.policyengine_parameter
         == "gov.states.co.ssa.state_supplement.grant_standard"
     )
+    michigan_ssp_independent_living_mapping = registry.mapping_for_legal_id(
+        "us-mi:policies/mdhhs/rft/248#independent_living_individual_state_ssi_payment",
+        country="us",
+    )
+    assert michigan_ssp_independent_living_mapping.mapping_type == "parameter_value"
+    assert (
+        michigan_ssp_independent_living_mapping.policyengine_parameter
+        == "gov.states.mi.mdhhs.ssp.payment.individual"
+    )
+    assert michigan_ssp_independent_living_mapping.parameter_key_path == (
+        "INDEPENDENT_LIVING",
+    )
+    michigan_ssp_person_mapping = registry.mapping_for_legal_id(
+        "us-mi:policies/mdhhs/rft/248#mi_ssp_person",
+        country="us",
+    )
+    assert michigan_ssp_person_mapping.mapping_type == "not_comparable"
+    assert michigan_ssp_person_mapping.policyengine_variable == "mi_ssp_person"
     section_2014c_net_failure_mapping = registry.mapping_for_legal_id(
         "us:statutes/7/2014/c#snap_net_income_exceeds_poverty_line",
         country="us",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.900"
+version = "0.2.901"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify the Michigan SSP PolicyEngine surface as known-not-comparable at the final aggregate level
- map the Michigan RFT 248 individual payment cells to the corresponding PolicyEngine parameters
- mark the generated RFT 248 table selector and BEM 660 eligibility predicate as not one-to-one comparable to PE final variables
- bump axiom-encode to 0.2.901

## Tests
- env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k "michigan_ssp or georgia_ssp or florida_oss or california_ssp" -q
- env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed -q
- git diff --check

Note: the broader local module run currently has a pre-existing failure on clean main in tests/test_rulespec_validation.py::test_rulespec_ci_rejects_scalar_kind_mismatches with the local axiom-rules-engine binary present.