### PR TITLE
Map Michigan SSP oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.901"
+version = "0.2.902"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.901"
+__version__ = "0.2.902"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2520,6 +2520,129 @@ mappings:
     comparison: money
     rationale: Same Michigan monthly individual DHS supplement amount for institutional living arrangements under RFT 248.
 
+  - legal_id: us-mi:policies/mdhhs/rft/248#independent_living_couple_state_ssi_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mi.mdhhs.ssp.payment.couple
+    parameter_key_path:
+      - INDEPENDENT_LIVING
+    period: month
+    unit: USD
+    comparison: money
+    result_multiplier: 0.5
+    rationale: Michigan RFT 248 states the independent-living couple payment as a total couple amount and per-person share; RuleSpec exposes the per-person share while PolicyEngine stores the full monthly couple amount.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#household_of_another_couple_state_ssi_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mi.mdhhs.ssp.payment.couple
+    parameter_key_path:
+      - HOUSEHOLD_OF_ANOTHER
+    period: month
+    unit: USD
+    comparison: money
+    result_multiplier: 0.5
+    rationale: Michigan RFT 248 states the household-of-another couple payment as a total couple amount and per-person share; RuleSpec exposes the per-person share while PolicyEngine stores the full monthly couple amount.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#domiciliary_care_couple_dhs_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mi.mdhhs.ssp.payment.couple
+    parameter_key_path:
+      - DOMICILIARY_CARE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Michigan monthly couple DHS supplement amount for domiciliary-care adult foster care under RFT 248.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#personal_care_couple_dhs_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mi.mdhhs.ssp.payment.couple
+    parameter_key_path:
+      - PERSONAL_CARE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Michigan monthly couple DHS supplement amount for personal-care adult foster care under RFT 248.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#home_for_aged_couple_dhs_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mi.mdhhs.ssp.payment.couple
+    parameter_key_path:
+      - HOME_FOR_AGED
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Michigan monthly couple DHS supplement amount for home-for-aged living arrangements under RFT 248.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#institution_couple_dhs_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mi.mdhhs.ssp.payment.couple
+    parameter_key_path:
+      - INSTITUTION
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Michigan monthly couple DHS supplement amount for institutional living arrangements under RFT 248.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#eligible_child_state_ssi_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Michigan RFT 248 includes an eligible-child State SSI Payment row; PolicyEngine's Michigan SSP parameter table does not expose a child living-arrangement category or one-to-one parameter.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#federal_ssi_benefit_rate
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Michigan RFT 248 repeats the federal SSI benefit rate as context for extended-care waiver calculations; federal SSI is modeled separately from Michigan SSP in PolicyEngine.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#extended_care_waiver_income_limit_multiplier
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Michigan RFT 248 uses this source-table helper multiplier to derive an extended-care waiver income limit; PolicyEngine's Michigan SSP surface does not expose the helper multiplier.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#extended_care_waiver_income_limit
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Michigan RFT 248 derives this extended-care waiver income limit from federal SSI context; PolicyEngine's Michigan SSP surface does not expose a one-to-one output for the derived limit.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#essential_person_payment
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Michigan RFT 248 includes an essential-person payment amount, but PolicyEngine's Michigan SSP model does not expose this optional contextual payment as a parameter or variable.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#adult_foster_care_individual_recipient_retained_allowance
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Michigan RFT 248 includes the adult foster care or home-for-aged recipient retained allowance; PolicyEngine's Michigan SSP model does not expose this retained-allowance row as a payment parameter or output.
+
+  - legal_id: us-mi:policies/mdhhs/rft/248#adult_foster_care_couple_recipient_retained_allowance
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Michigan RFT 248 includes the couple adult foster care or home-for-aged recipient retained allowance; PolicyEngine's Michigan SSP model does not expose this retained-allowance row as a payment parameter or output.
+
   - legal_id: us-mi:policies/mdhhs/rft/248#mi_ssp_person
     country: us
     program: ssi_state_supplement

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2552,6 +2552,41 @@ def test_policyengine_registry_is_legal_id_keyed():
     assert michigan_ssp_independent_living_mapping.parameter_key_path == (
         "INDEPENDENT_LIVING",
     )
+    michigan_ssp_couple_independent_living_mapping = registry.mapping_for_legal_id(
+        "us-mi:policies/mdhhs/rft/248#independent_living_couple_state_ssi_payment",
+        country="us",
+    )
+    assert michigan_ssp_couple_independent_living_mapping.mapping_type == (
+        "parameter_value"
+    )
+    assert (
+        michigan_ssp_couple_independent_living_mapping.policyengine_parameter
+        == "gov.states.mi.mdhhs.ssp.payment.couple"
+    )
+    assert michigan_ssp_couple_independent_living_mapping.parameter_key_path == (
+        "INDEPENDENT_LIVING",
+    )
+    assert michigan_ssp_couple_independent_living_mapping.result_multiplier == 0.5
+    michigan_ssp_couple_domiciliary_care_mapping = registry.mapping_for_legal_id(
+        "us-mi:policies/mdhhs/rft/248#domiciliary_care_couple_dhs_supplement",
+        country="us",
+    )
+    assert michigan_ssp_couple_domiciliary_care_mapping.mapping_type == (
+        "parameter_value"
+    )
+    assert (
+        michigan_ssp_couple_domiciliary_care_mapping.policyengine_parameter
+        == "gov.states.mi.mdhhs.ssp.payment.couple"
+    )
+    assert michigan_ssp_couple_domiciliary_care_mapping.parameter_key_path == (
+        "DOMICILIARY_CARE",
+    )
+    assert michigan_ssp_couple_domiciliary_care_mapping.result_multiplier is None
+    michigan_ssp_child_mapping = registry.mapping_for_legal_id(
+        "us-mi:policies/mdhhs/rft/248#eligible_child_state_ssi_payment",
+        country="us",
+    )
+    assert michigan_ssp_child_mapping.mapping_type == "not_comparable"
     michigan_ssp_person_mapping = registry.mapping_for_legal_id(
         "us-mi:policies/mdhhs/rft/248#mi_ssp_person",
         country="us",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.901"
+version = "0.2.902"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify the remaining Michigan RFT 248 SSP table outputs for PolicyEngine oracle coverage
- map couple payment cells to `gov.states.mi.mdhhs.ssp.payment.couple`, using `result_multiplier: 0.5` for the two per-person couple shares
- mark contextual/helper RFT rows as not comparable and bump axiom-encode to 0.2.902

## Tests
- `env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_rulespec_validation.py::test_policyengine_registry_is_legal_id_keyed -q`
- `env -u UV_FROZEN uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k "michigan_ssp or georgia_ssp or florida_oss or california_ssp" -q`
- `env -u UV_FROZEN uv run --extra dev ruff check tests/test_rulespec_validation.py src/axiom_encode/oracles/policyengine/registry.py`
- `git diff --check`
