### PR TITLE
Classify Kansas TANF proration helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.903"
+version = "0.2.904"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.903"
+__version__ = "0.2.904"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -18592,6 +18592,14 @@ prefixes:
     candidate_priority: P4
     rationale: Kansas KEESM 7411 outputs decompose source-local TANF basic allowances, shelter groups, Table I and Table II shelter-percentage selection, and budgetary-standard calculations. PolicyEngine-US exposes adjacent Kansas TANF maximum-benefit and final-benefit surfaces keyed by its own assistance-unit size and parameterization, not these source-specific KEESM 7411 legal helper boundaries one-to-one.
 
+  - legal_id_prefix: us-ks:policies/dcf/keesm/keesm7400/cash-proration-rounding#
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ks_tanf
+    candidate_priority: P4
+    rationale: Kansas KEESM 7401 and 7402 outputs decompose source-local cash-assistance proration, inclusive application-month day counting, proration exceptions, and cash payment rounding over a monthly cash-benefit input. PolicyEngine-US exposes adjacent Kansas TANF final-benefit and maximum-benefit surfaces, but does not expose this source-specific proration and rounding helper boundary one-to-one.
+
   - legal_id_prefix: us-la:policies/dcfs/economic-independence/b-640-fitap-income-limits-398921#
     country: us
     program: tanf

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.903"
+version = "0.2.904"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Kansas KEESM 7400 cash proration/rounding helper outputs as known not comparable to PolicyEngine
- keeps the adjacent PE surface tied to `ks_tanf` while documenting that PE does not expose these source-local helper boundaries one-to-one
- bumps axiom-encode to 0.2.904 because the mapping catalog is covered by the version-provenance guard
- unblocks TheAxiomFoundation/rulespec-us#481 oracle coverage

## Validation
- `git diff --check`
- `env -u UV_FROZEN uv lock --check`
- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ks-tanf-oracle-20260627 --extra dev pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ks-tanf-oracle-20260627 --extra dev pytest tests/test_policyengine_coverage.py -q`
- `env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ks-tanf-oracle-20260627 --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ks-tanf-7400-20260627 --fail-on-unmapped`