### PR TITLE
Route cloud queue to country RuleSpec repos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.904"
+version = "0.2.905"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.904"
+__version__ = "0.2.905"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -662,8 +662,9 @@ def _cloud_queue_item_from_program_surface(
 
 
 def canonical_rulespec_repo_name_from_prefix(prefix: str) -> str:
-    """Return the legacy per-jurisdiction RuleSpec repo name for a prefix."""
-    return f"rulespec-{prefix}"
+    """Return the country-level RuleSpec repo name for a jurisdiction prefix."""
+    country = prefix.split("-", 1)[0].lower()
+    return f"rulespec-{country}"
 
 
 def _cloud_queue_oracle_expectation(action: str) -> str:

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -843,6 +843,18 @@ surfaces:
     priority: P1
     rationale: Needs source ingestion first.
   - country: us
+    program_id: tanf
+    program_name: Alabama TANF
+    category: Benefits
+    policyengine_status: complete
+    coverage: AL
+    variable: al_tanf
+    source_type: state_implementation
+    state: AL
+    axiom_status: pending_rulespec_encoding
+    priority: P1
+    rationale: Needs governing law encoding.
+  - country: us
     program_id: snap
     program_name: Montana SNAP
     category: Benefits
@@ -878,9 +890,9 @@ surfaces:
         report["run_artifact_schema"]
         == "axiom-encode/policyengine-cloud-run-artifact/v1"
     )
-    assert report["total_items"] == 2
+    assert report["total_items"] == 3
     assert report["action_counts"] == {
-        "encode_rulespec": 1,
+        "encode_rulespec": 2,
         "ingest_source": 1,
     }
     items_by_variable = {
@@ -893,6 +905,13 @@ surfaces:
     assert new_tax_surface["target_prefix"] == "us"
     assert "repo:rulespec-us" in new_tax_surface["lock_scopes"]
     assert new_tax_surface["oracle_expectation"].startswith("encode source-law output")
+
+    al_tanf = items_by_variable["al_tanf"]
+    assert al_tanf["action"] == "encode_rulespec"
+    assert al_tanf["target_repo"] == "rulespec-us"
+    assert al_tanf["target_prefix"] == "us-al"
+    assert "repo:rulespec-us" in al_tanf["lock_scopes"]
+    assert "target-prefix:us-al" in al_tanf["lock_scopes"]
 
     az_ccap = items_by_variable["az_ccap"]
     assert az_ccap["action"] == "ingest_source"
@@ -934,7 +953,7 @@ surfaces:
     assert report["total_items"] == 1
     item = report["items"][0]
     assert item["action"] == "bootstrap_jurisdiction"
-    assert item["target_repo"] == "rulespec-us-mt"
+    assert item["target_repo"] == "rulespec-us"
     assert item["target_prefix"] == "us-mt"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.904"
+version = "0.2.905"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary\n- route PolicyEngine cloud queue RuleSpec work to country-level repos such as rulespec-us\n- preserve jurisdiction target_prefix locks like us-al for path/fan-out isolation\n- add cloud queue regression coverage for state encode and deferred jurisdiction items\n- bump axiom-encode to 0.2.905\n\n## Tests\n- env -u UV_FROZEN uv run --extra dev pytest -q tests/test_policyengine_coverage.py -k 'cloud_queue'\n- env -u UV_FROZEN uv run python - <<'PY' ... version consistency check\n- git diff --check