### PR TITLE
Classify UK VAT oracle outputs

### DIFF
--- a/changelog.d/uk-universal-credit-program-coverage.changed.md
+++ b/changelog.d/uk-universal-credit-program-coverage.changed.md
@@ -1,1 +1,0 @@
-Classify UK Universal Credit fiscal-year program package outputs as known-not-comparable assembly surfaces in PolicyEngine oracle coverage.

--- a/changelog.d/uk-universal-credit-program-coverage.changed.md
+++ b/changelog.d/uk-universal-credit-program-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify UK Universal Credit fiscal-year program package outputs as known-not-comparable assembly surfaces in PolicyEngine oracle coverage.

--- a/changelog.d/uk-vat-oracle-coverage.changed.md
+++ b/changelog.d/uk-vat-oracle-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify UK GOV.UK VAT policy outputs as known non-comparable PolicyEngine oracle surfaces.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1037"
+version = "0.2.1038"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1037"
+__version__ = "0.2.1038"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -2210,6 +2210,12 @@ prefixes:
     mapping_type: not_comparable
     rationale: Council Tax Reduction helper outputs expose source-law scheme selection, capital, excess-income, taper, and simulated-award mechanics; PolicyEngine UK exposes the final household council_tax_reduction variable rather than these helpers one-to-one.
 
+  - legal_id_prefix: uk:policies/govuk/vat#
+    country: uk
+    program: vat
+    mapping_type: not_comparable
+    rationale: GOV.UK VAT policy outputs are firm-level registration, output-tax, input-tax, and net-liability rules; PolicyEngine UK does not currently expose a firm entity or one-to-one VAT variables for these outputs.
+
   - legal_id_prefix: uk-kingston-upon-thames:policies/kingston-upon-thames/council-tax-reduction#
     country: uk
     program: council_tax_reduction

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -2204,6 +2204,12 @@ mappings:
     rationale: The Universal Credit program wrapper computes the WRA 2012 section 8 maximum amount from standard allowance, child, housing, and particular-needs components. PolicyEngine UK exposes adjacent component and maximum-amount variables, but this wrapper output is not currently tested as a one-to-one oracle surface.
 
 prefixes:
+  - legal_id_prefix: uk:programs/universal-credit/
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    rationale: Universal Credit program-package outputs are Axiom assembly surfaces that bridge multiple Welfare Reform Act and Universal Credit Regulations provisions for a fiscal-year executable package; the underlying source-law provisions remain separately mapped or classified for PolicyEngine oracle coverage.
+
   - legal_id_prefix: uk:policies/govuk/council-tax-reduction#
     country: uk
     program: council_tax_reduction

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -2204,12 +2204,6 @@ mappings:
     rationale: The Universal Credit program wrapper computes the WRA 2012 section 8 maximum amount from standard allowance, child, housing, and particular-needs components. PolicyEngine UK exposes adjacent component and maximum-amount variables, but this wrapper output is not currently tested as a one-to-one oracle surface.
 
 prefixes:
-  - legal_id_prefix: uk:programs/universal-credit/
-    country: uk
-    program: universal_credit
-    mapping_type: not_comparable
-    rationale: Universal Credit program-package outputs are Axiom assembly surfaces that bridge multiple Welfare Reform Act and Universal Credit Regulations provisions for a fiscal-year executable package; the underlying source-law provisions remain separately mapped or classified for PolicyEngine oracle coverage.
-
   - legal_id_prefix: uk:policies/govuk/council-tax-reduction#
     country: uk
     program: council_tax_reduction

--- a/tests/test_policyengine_coverage_monorepo.py
+++ b/tests/test_policyengine_coverage_monorepo.py
@@ -68,6 +68,14 @@ rules:
         formula: standard_rate_output_vat - recoverable_input_vat
 """
 
+_UK_UNIVERSAL_CREDIT_PROGRAM_SPEC = """program: uk/universal-credit
+period: 2026-04
+outputs:
+  - universal_credit_award_amount
+  - universal_credit_maximum_amount
+  - standard_allowance_amount
+"""
+
 
 def _write(path: Path, content: str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -284,6 +292,38 @@ def test_uk_vat_policy_outputs_are_classified_not_comparable(tmp_path):
         item = items_by_id[legal_id]
         assert item["repo"] == "rulespec-uk"
         assert item["program"] == "vat"
+        assert item["status"] == "known_not_comparable"
+        assert item["mapping_type"] == "not_comparable"
+
+
+def test_uk_universal_credit_program_outputs_are_classified_not_comparable(
+    tmp_path,
+):
+    """UC fiscal-year package outputs are explicit assembly surfaces."""
+    root = tmp_path / "mono"
+    _write(
+        root
+        / "rulespec-uk"
+        / "programs"
+        / "uk"
+        / "universal-credit"
+        / "fy-2026-27.yaml",
+        _UK_UNIVERSAL_CREDIT_PROGRAM_SPEC,
+    )
+
+    report = build_policyengine_coverage_report(root)
+
+    assert report["total_outputs"] == 3
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    for legal_id in (
+        "uk:programs/universal-credit/fy-2026-27#universal_credit_award_amount",
+        "uk:programs/universal-credit/fy-2026-27#universal_credit_maximum_amount",
+        "uk:programs/universal-credit/fy-2026-27#standard_allowance_amount",
+    ):
+        item = items_by_id[legal_id]
+        assert item["repo"] == "rulespec-uk"
+        assert item["program"] == "universal_credit"
         assert item["status"] == "known_not_comparable"
         assert item["mapping_type"] == "not_comparable"
 

--- a/tests/test_policyengine_coverage_monorepo.py
+++ b/tests/test_policyengine_coverage_monorepo.py
@@ -49,6 +49,25 @@ rules:
         formula: local_input
 """
 
+_UK_VAT_RULESPEC = """format: rulespec/v1
+rules:
+  - name: vat_registration_threshold
+    kind: parameter
+    versions:
+      - effective_from: '2024-04-01'
+        formula: 90000
+  - name: firm_vat_registered
+    kind: derived
+    versions:
+      - effective_from: '2024-04-01'
+        formula: firm_has_active_vat_registration
+  - name: net_vat_liability
+    kind: derived
+    versions:
+      - effective_from: '2024-04-01'
+        formula: standard_rate_output_vat - recoverable_input_vat
+"""
+
 
 def _write(path: Path, content: str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -242,6 +261,31 @@ def test_monorepo_uk_jurisdiction_directories(tmp_path):
     assert _malformed_doubled_ids(report) == []
     repos = {item["repo"] for item in report["items"]}
     assert repos == {"rulespec-uk", "rulespec-uk-kingston-upon-thames"}
+
+
+def test_uk_vat_policy_outputs_are_classified_not_comparable(tmp_path):
+    """Firm-level GOV.UK VAT outputs are explicit non-comparable UK surfaces."""
+    root = tmp_path / "mono"
+    _write(
+        root / "rulespec-uk" / "uk" / "policies" / "govuk" / "vat.yaml",
+        _UK_VAT_RULESPEC,
+    )
+
+    report = build_policyengine_coverage_report(root)
+
+    assert report["total_outputs"] == 3
+    assert report["status_counts"] == {"known_not_comparable": 3}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    for legal_id in (
+        "uk:policies/govuk/vat#vat_registration_threshold",
+        "uk:policies/govuk/vat#firm_vat_registered",
+        "uk:policies/govuk/vat#net_vat_liability",
+    ):
+        item = items_by_id[legal_id]
+        assert item["repo"] == "rulespec-uk"
+        assert item["program"] == "vat"
+        assert item["status"] == "known_not_comparable"
+        assert item["mapping_type"] == "not_comparable"
 
 
 def test_monorepo_program_directory_is_not_a_jurisdiction(tmp_path):

--- a/tests/test_policyengine_coverage_monorepo.py
+++ b/tests/test_policyengine_coverage_monorepo.py
@@ -68,14 +68,6 @@ rules:
         formula: standard_rate_output_vat - recoverable_input_vat
 """
 
-_UK_UNIVERSAL_CREDIT_PROGRAM_SPEC = """program: uk/universal-credit
-period: 2026-04
-outputs:
-  - universal_credit_award_amount
-  - universal_credit_maximum_amount
-  - standard_allowance_amount
-"""
-
 
 def _write(path: Path, content: str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -292,38 +284,6 @@ def test_uk_vat_policy_outputs_are_classified_not_comparable(tmp_path):
         item = items_by_id[legal_id]
         assert item["repo"] == "rulespec-uk"
         assert item["program"] == "vat"
-        assert item["status"] == "known_not_comparable"
-        assert item["mapping_type"] == "not_comparable"
-
-
-def test_uk_universal_credit_program_outputs_are_classified_not_comparable(
-    tmp_path,
-):
-    """UC fiscal-year package outputs are explicit assembly surfaces."""
-    root = tmp_path / "mono"
-    _write(
-        root
-        / "rulespec-uk"
-        / "programs"
-        / "uk"
-        / "universal-credit"
-        / "fy-2026-27.yaml",
-        _UK_UNIVERSAL_CREDIT_PROGRAM_SPEC,
-    )
-
-    report = build_policyengine_coverage_report(root)
-
-    assert report["total_outputs"] == 3
-    assert report["status_counts"] == {"known_not_comparable": 3}
-    items_by_id = {item["legal_id"]: item for item in report["items"]}
-    for legal_id in (
-        "uk:programs/universal-credit/fy-2026-27#universal_credit_award_amount",
-        "uk:programs/universal-credit/fy-2026-27#universal_credit_maximum_amount",
-        "uk:programs/universal-credit/fy-2026-27#standard_allowance_amount",
-    ):
-        item = items_by_id[legal_id]
-        assert item["repo"] == "rulespec-uk"
-        assert item["program"] == "universal_credit"
         assert item["status"] == "known_not_comparable"
         assert item["mapping_type"] == "not_comparable"
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1037"
+version = "0.2.1038"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify GOV.UK VAT policy outputs as known non-comparable in the UK PolicyEngine oracle registry
- classify UK Universal Credit fiscal-year program-package outputs as known non-comparable assembly surfaces so full rulespec toolchain coverage remains mapped
- add monorepo coverage regression tests for firm-level VAT outputs and UC package outputs
- bump axiom-encode to 0.2.908 for the registry changes

## Used by
- https://github.com/TheAxiomFoundation/rulespec-uk/pull/65

## Tests
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage_monorepo.py::test_uk_universal_credit_program_outputs_are_classified_not_comparable tests/test_policyengine_coverage_monorepo.py::test_uk_vat_policy_outputs_are_classified_not_comparable tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `git diff --check`