### PR TITLE
Fix country worktree source validation for encodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.907"
+version = "0.2.908"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.906"
+version = "0.2.907"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.906"
+__version__ = "0.2.907"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.907"
+__version__ = "0.2.908"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -35,6 +35,7 @@ from axiom_encode.repo_routing import (
     canonical_rulespec_repo_name,
     find_policy_repo_root,
     jurisdiction_content_dir,
+    jurisdiction_subdir_names,
     monorepo_alternative_path,
 )
 from axiom_encode.statute import (
@@ -350,11 +351,13 @@ _SECTION_CROSS_REFERENCE_PATTERN = re.compile(
     r"\d+(?:\.\d+)+(?:\s*(?:through|to|-|and|,)\s*\d+(?:\.\d+)+)*",
     re.IGNORECASE,
 )
+_LEADING_ZERO_MANUAL_SECTION_PATTERN = re.compile(r"\b0\d{3}\.\d{2}(?:\.\d{2})?\b")
 
 
 def _numeric_occurrence_source_text(source_text: str) -> str:
     """Drop citation-like cross-references before source numeric coverage checks."""
-    return _SECTION_CROSS_REFERENCE_PATTERN.sub("", source_text)
+    without_cross_references = _SECTION_CROSS_REFERENCE_PATTERN.sub("", source_text)
+    return _LEADING_ZERO_MANUAL_SECTION_PATTERN.sub("", without_cross_references)
 
 
 _UNREFERENCED_PROOF_IMPORT_RE = re.compile(
@@ -3145,6 +3148,7 @@ def evaluate_artifact(
             policyengine_country=policyengine_country,
             policyengine_rule_hint=policyengine_rule_hint,
             require_policy_proofs=True,
+            source_text=source_text,
         )
         compile_result = pipeline._run_compile_check(validation_file)
         ci_result = pipeline._run_ci(validation_file)
@@ -3623,22 +3627,43 @@ def _rulespec_validation_target(
         yield rulespec_file
         return
     relative = _relative_rulespec_source_path(rulespec_file)
-    if relative is None or not policy_repo_root.name.startswith("rulespec-"):
+    if relative is None:
         yield rulespec_file
         return
 
+    source_repo_root = policy_repo_root
+    if not source_repo_root.name.startswith("rulespec-"):
+        maybe_monorepo_root = source_repo_root.parent
+        if (
+            maybe_monorepo_root.name.startswith("rulespec-")
+            and source_repo_root.name in jurisdiction_subdir_names(maybe_monorepo_root)
+        ):
+            source_repo_root = maybe_monorepo_root
+        else:
+            yield rulespec_file
+            return
+
     with tempfile.TemporaryDirectory() as tmpdir:
         overlay_parent = Path(tmpdir)
-        for sibling in policy_repo_root.parent.glob("rulespec-*"):
-            if sibling.resolve() == policy_repo_root.resolve() or not sibling.is_dir():
+        for sibling in source_repo_root.parent.glob("rulespec-*"):
+            if sibling.resolve() == source_repo_root.resolve() or not sibling.is_dir():
                 continue
             sibling_target = overlay_parent / sibling.name
             try:
                 sibling_target.symlink_to(sibling.resolve(), target_is_directory=True)
             except OSError:
                 shutil.copytree(sibling, sibling_target, dirs_exist_ok=True)
-        overlay_repo = overlay_parent / policy_repo_root.name
-        shutil.copytree(policy_repo_root, overlay_repo)
+        overlay_repo_name = (
+            canonical_rulespec_repo_name(source_repo_root) or source_repo_root.name
+        )
+        overlay_repo = overlay_parent / overlay_repo_name
+        shutil.copytree(
+            source_repo_root,
+            overlay_repo,
+            ignore=shutil.ignore_patterns(
+                ".git", ".venv", "__pycache__", ".pytest_cache"
+            ),
+        )
         eval_workspaces_root = _nearby_eval_workspaces_root(rulespec_file)
         if eval_workspaces_root is not None:
             eval_overlay = overlay_parent / "_eval_workspaces"

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -3634,10 +3634,9 @@ def _rulespec_validation_target(
     source_repo_root = policy_repo_root
     if not source_repo_root.name.startswith("rulespec-"):
         maybe_monorepo_root = source_repo_root.parent
-        if (
-            maybe_monorepo_root.name.startswith("rulespec-")
-            and source_repo_root.name in jurisdiction_subdir_names(maybe_monorepo_root)
-        ):
+        if maybe_monorepo_root.name.startswith(
+            "rulespec-"
+        ) and source_repo_root.name in jurisdiction_subdir_names(maybe_monorepo_root):
             source_repo_root = maybe_monorepo_root
         else:
             yield rulespec_file

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -19344,9 +19344,7 @@ class ValidatorPipeline:
             )
         return env
 
-    def _source_texts_for_rulespec_content(
-        self, content: str
-    ) -> dict[str, str] | None:
+    def _source_texts_for_rulespec_content(self, content: str) -> dict[str, str] | None:
         """Map declared RuleSpec source paths to the in-memory source text, if any."""
         if self.source_text is None:
             return None

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -17181,7 +17181,11 @@ def _source_verification_text(
     return None
 
 
-def _extract_source_verification_text(content: str) -> str | None:
+def _extract_source_verification_text(
+    content: str,
+    *,
+    source_texts: dict[str, str] | None = None,
+) -> str | None:
     try:
         payload = yaml.safe_load(content)
     except (yaml.YAMLError, ValueError):
@@ -17199,6 +17203,7 @@ def _extract_source_verification_text(content: str) -> str | None:
     return _source_verification_text(
         citation_paths=citation_paths,
         source_label=source_label,
+        source_texts=source_texts,
     )
 
 
@@ -19300,6 +19305,7 @@ class ValidatorPipeline:
         policyengine_rule_hint: str | None = None,
         require_policy_proofs: bool = False,
         enforce_repository_layout: bool = True,
+        source_text: str | None = None,
     ):
         self.policy_repo_path = Path(policy_repo_path)
         self.axiom_rules_path = Path(axiom_rules_path)
@@ -19312,6 +19318,7 @@ class ValidatorPipeline:
         self.policyengine_rule_hint = policyengine_rule_hint
         self.require_policy_proofs = require_policy_proofs
         self.enforce_repository_layout = enforce_repository_layout
+        self.source_text = source_text
         self.policyengine_registry = load_policyengine_registry()
 
     def _log_event(
@@ -19336,6 +19343,33 @@ class ValidatorPipeline:
                 f"{rules_src}{os.pathsep}{existing}" if existing else str(rules_src)
             )
         return env
+
+    def _source_texts_for_rulespec_content(
+        self, content: str
+    ) -> dict[str, str] | None:
+        """Map declared RuleSpec source paths to the in-memory source text, if any."""
+        if self.source_text is None:
+            return None
+        try:
+            payload = yaml.safe_load(content)
+        except (yaml.YAMLError, ValueError):
+            return None
+        if not isinstance(payload, dict) or payload.get("format") != "rulespec/v1":
+            return None
+        source_verification = _source_verification_block(payload)
+        if source_verification is None:
+            return None
+        citation_paths, source_label = _source_verification_source_fields(
+            source_verification
+        )
+        if not citation_paths:
+            return None
+        source_texts = {
+            citation_path: self.source_text for citation_path in citation_paths
+        }
+        if source_label:
+            source_texts[source_label] = self.source_text
+        return source_texts
 
     def _rulespec_compile_env(self) -> dict[str, str]:
         """Build an env that can resolve canonical RuleSpec repo imports."""
@@ -20724,7 +20758,18 @@ class ValidatorPipeline:
         except Exception as exc:
             issues.append(f"Axiom rules engine compile failed: {exc}")
 
-        issues.extend(find_ungrounded_numeric_issues(content))
+        validation_source_texts = self._source_texts_for_rulespec_content(content)
+        validation_source_text = (
+            self.source_text
+            if self.source_text is not None
+            else _extract_source_verification_text(
+                content,
+                source_texts=validation_source_texts,
+            )
+        )
+        issues.extend(
+            find_ungrounded_numeric_issues(content, source_text=validation_source_text)
+        )
         issues.extend(find_deprecated_source_url_issues(content))
         issues.extend(find_source_claim_reference_issues(content))
         issues.extend(find_empty_rules_module_issues(content))
@@ -20740,7 +20785,11 @@ class ValidatorPipeline:
         issues.extend(find_structured_scale_parameter_issues(content))
         issues.extend(find_versioned_derived_formula_issues(content))
         issues.extend(find_upstream_placement_issues(content, rules_file=rules_file))
-        issues.extend(find_source_verification_issues(content))
+        issues.extend(
+            find_source_verification_issues(
+                content, source_texts=validation_source_texts
+            )
+        )
         issues.extend(find_source_condition_coverage_issues(content))
         issues.extend(find_anaphoric_scope_omission_issues(content))
         issues.extend(find_filtered_entity_dependency_issues(content))

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1594,6 +1594,90 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec encodes the one-time 1983 statutory dollar increase for couple SSI rates; PolicyEngine stores final monthly federal benefit-rate parameters rather than this source-specific transitional increase.
 
+  - legal_id: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_person_living_alone_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mn.dhs.msa.assistance_standard.amount
+    parameter_key: INDIVIDUAL_LIVING_ALONE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Minnesota Supplemental Aid monthly assistance standard for an individual living alone.
+
+  - legal_id: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_person_living_with_others_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mn.dhs.msa.assistance_standard.amount
+    parameter_key: INDIVIDUAL_LIVING_WITH_OTHERS
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Minnesota Supplemental Aid monthly assistance standard for an individual living with others.
+
+  - legal_id: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_married_couple_living_alone_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mn.dhs.msa.assistance_standard.amount
+    parameter_key: COUPLE_LIVING_ALONE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Minnesota Supplemental Aid monthly assistance standard for a married couple living alone.
+
+  - legal_id: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_married_couple_living_with_others_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mn.dhs.msa.assistance_standard.amount
+    parameter_key: COUPLE_LIVING_WITH_OTHERS
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Minnesota Supplemental Aid monthly assistance standard for a married couple living with others.
+
+  - legal_id: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_personal_needs_allowance
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.mn.dhs.msa.assistance_standard.amount
+    parameter_key: MEDICAID_FACILITY
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Minnesota Supplemental Aid facilities standard represented by the monthly personal-needs allowance.
+
+  - legal_id: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_pre_1994_married_couple_living_alone_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes Minnesota's pre-1994 married-couple living-alone standard. PolicyEngine's MSA assistance-standard parameter does not expose this grandfathered category as a separate cell.
+
+  - legal_id: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_pre_1994_married_couple_living_with_others_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes Minnesota's pre-1994 married-couple living-with-others standard. PolicyEngine's MSA assistance-standard parameter does not expose this grandfathered category as a separate cell.
+
+  - legal_id: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_living_alone_standard_applies
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the source-level Minnesota living-alone-standard predicate. PolicyEngine materializes this through its MSA payment-category calculation and does not expose the predicate as a one-to-one variable.
+
+  - legal_id: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#mn_msa_assistance_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: mn_msa_assistance_standard
+    candidate_priority: P4
+    rationale: The generated RuleSpec output composes a household-level assistance-standard branch from Combined Manual 0020.21. PolicyEngine's mn_msa_assistance_standard is a person-level payment-category surface that also includes categories not represented in this generated household output, so it should not be compared one-to-one.
+
   - legal_id: us:statutes/7/2014/e/6/A#snap_net_income_pre_shelter
     country: us
     program: snap

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3391,6 +3391,121 @@ class TestEvaluateArtifact:
             assert "rulespec-us-ny" in parts
             assert parts != policy_repo.parts
 
+    def test_validation_overlay_preserves_country_monorepo_state_shape(
+        self, tmp_path
+    ):
+        monorepo = tmp_path / "repos" / "rulespec-us"
+        policy_repo = monorepo / "us-mn"
+        policy_repo.mkdir(parents=True)
+        generated = (
+            tmp_path
+            / "out"
+            / "codex-gpt-5.5"
+            / "policies"
+            / "dhs"
+            / "combined-manual"
+            / "0020-21"
+            / "msa-assistance-standards-2026.yaml"
+        )
+        generated.parent.mkdir(parents=True)
+        generated.write_text("format: rulespec/v1\nrules: []\n")
+        generated.with_name("msa-assistance-standards-2026.test.yaml").write_text(
+            "[]\n"
+        )
+
+        with _rulespec_validation_target(generated, policy_repo) as validation_file:
+            validation_root = _validation_policy_repo_root(validation_file, policy_repo)
+
+            assert validation_file.parts[-6:] == (
+                "us-mn",
+                "policies",
+                "dhs",
+                "combined-manual",
+                "0020-21",
+                "msa-assistance-standards-2026.yaml",
+            )
+            assert validation_root.name == "us-mn"
+            assert validation_root.parent.name == "rulespec-us"
+            assert validation_file.with_name(
+                "msa-assistance-standards-2026.test.yaml"
+            ).exists()
+
+    def test_validation_overlay_uses_canonical_country_repo_name_for_worktrees(
+        self, tmp_path
+    ):
+        monorepo = tmp_path / "repos" / "rulespec-us-mn-msa-20260627"
+        policy_repo = monorepo / "us-mn"
+        policy_repo.mkdir(parents=True)
+        subprocess.run(["git", "init"], cwd=monorepo, check=True, capture_output=True)
+        subprocess.run(
+            [
+                "git",
+                "remote",
+                "add",
+                "origin",
+                "git@github.com:TheAxiomFoundation/rulespec-us.git",
+            ],
+            cwd=monorepo,
+            check=True,
+            capture_output=True,
+        )
+        generated = (
+            tmp_path
+            / "out"
+            / "codex-gpt-5.5"
+            / "policies"
+            / "dhs"
+            / "combined-manual"
+            / "0020-21"
+            / "msa-assistance-standards-2026.yaml"
+        )
+        generated.parent.mkdir(parents=True)
+        generated.write_text("format: rulespec/v1\nrules: []\n")
+
+        with _rulespec_validation_target(generated, policy_repo) as validation_file:
+            validation_root = _validation_policy_repo_root(validation_file, policy_repo)
+
+            assert validation_file.parts[-7:] == (
+                "rulespec-us",
+                "us-mn",
+                "policies",
+                "dhs",
+                "combined-manual",
+                "0020-21",
+                "msa-assistance-standards-2026.yaml",
+            )
+            assert validation_root.name == "us-mn"
+            assert validation_root.parent.name == "rulespec-us"
+
+    def test_passes_resolved_source_text_to_validation_pipeline(self, tmp_path):
+        policy_repo = tmp_path / "repos" / "rulespec-us"
+        policy_repo.mkdir(parents=True)
+        generated = tmp_path / "out" / "codex-gpt-5.5" / "a.yaml"
+        generated.parent.mkdir(parents=True)
+        generated.write_text("format: rulespec/v1\nrules: []\n")
+        source_text = "The official source states the standard is $1,055.00."
+        seen_source_texts: list[str | None] = []
+
+        def fake_compile(_pipeline, _path):
+            return ValidationResult("compile", passed=True)
+
+        def fake_ci(_pipeline, _path):
+            seen_source_texts.append(_pipeline.source_text)
+            return ValidationResult("ci", passed=True)
+
+        with (
+            patch.object(ValidatorPipeline, "_run_compile_check", fake_compile),
+            patch.object(ValidatorPipeline, "_run_ci", fake_ci),
+        ):
+            evaluate_artifact(
+                rulespec_file=generated,
+                policy_repo_root=policy_repo,
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+                source_text=source_text,
+            )
+
+        assert seen_source_texts == [source_text]
+
     def test_uses_fallback_source_text_for_grounding(self, tmp_path):
         rulespec_file = tmp_path / "24" / "a.yaml"
         rulespec_file.parent.mkdir(parents=True)
@@ -4614,6 +4729,49 @@ rules:
                     "Households shall receive an opportunity to participate within "
                     "thirty (30) calendar days. The office shall determine delay "
                     "cause as outlined in Sections 4.205.3 through 4.205.4."
+                ),
+            )
+
+        assert metrics.compile_pass
+        assert metrics.ci_pass
+        assert metrics.source_numeric_occurrence_count == 1
+        assert metrics.numeric_occurrence_issues == []
+
+    def test_numeric_occurrence_check_ignores_leading_zero_manual_sections(
+        self, tmp_path
+    ):
+        rulespec_file = tmp_path / "example.yaml"
+        rulespec_file.write_text(
+            """format: rulespec/v1
+module:
+  summary: Combined Manual 0020.21 sets the person living alone standard at $1,055.00.
+rules:
+  - name: mn_msa_person_living_alone_standard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 1055
+"""
+        )
+
+        compile_result = ValidationResult("compile", True, issues=[])
+        ci_result = ValidationResult("ci", True, issues=[])
+
+        with (
+            patch.object(
+                ValidatorPipeline, "_run_compile_check", return_value=compile_result
+            ),
+            patch.object(ValidatorPipeline, "_run_ci", return_value=ci_result),
+        ):
+            metrics = evaluate_artifact(
+                rulespec_file=rulespec_file,
+                policy_repo_root=tmp_path,
+                axiom_rules_path=Path("/tmp/axiom-rules-engine"),
+                source_text=(
+                    "Combined Manual 0020.21 provides: Person living alone "
+                    "$1,055.00."
                 ),
             )
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -3391,9 +3391,7 @@ class TestEvaluateArtifact:
             assert "rulespec-us-ny" in parts
             assert parts != policy_repo.parts
 
-    def test_validation_overlay_preserves_country_monorepo_state_shape(
-        self, tmp_path
-    ):
+    def test_validation_overlay_preserves_country_monorepo_state_shape(self, tmp_path):
         monorepo = tmp_path / "repos" / "rulespec-us"
         policy_repo = monorepo / "us-mn"
         policy_repo.mkdir(parents=True)
@@ -4770,8 +4768,7 @@ rules:
                 policy_repo_root=tmp_path,
                 axiom_rules_path=Path("/tmp/axiom-rules-engine"),
                 source_text=(
-                    "Combined Manual 0020.21 provides: Person living alone "
-                    "$1,055.00."
+                    "Combined Manual 0020.21 provides: Person living alone $1,055.00."
                 ),
             )
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -3343,6 +3343,55 @@ def test_policyengine_registry_classifies_medicaid_title_xix_statutory_helpers_n
         assert mapping.candidate_priority == "P4"
 
 
+def test_policyengine_registry_includes_minnesota_msa_assistance_standard_mappings():
+    registry = load_policyengine_registry()
+
+    living_alone_mapping = registry.mapping_for_legal_id(
+        "us-mn:policies/dhs/combined-manual/0020-21/"
+        "msa-assistance-standards-2026#msa_person_living_alone_standard",
+        country="us",
+    )
+    assert living_alone_mapping.mapping_type == "parameter_value"
+    assert (
+        living_alone_mapping.policyengine_parameter
+        == "gov.states.mn.dhs.msa.assistance_standard.amount"
+    )
+    assert living_alone_mapping.parameter_key == "INDIVIDUAL_LIVING_ALONE"
+
+    personal_needs_mapping = registry.mapping_for_legal_id(
+        "us-mn:policies/dhs/combined-manual/0020-21/"
+        "msa-assistance-standards-2026#msa_personal_needs_allowance",
+        country="us",
+    )
+    assert personal_needs_mapping.mapping_type == "parameter_value"
+    assert (
+        personal_needs_mapping.policyengine_parameter
+        == "gov.states.mn.dhs.msa.assistance_standard.amount"
+    )
+    assert personal_needs_mapping.parameter_key == "MEDICAID_FACILITY"
+
+    pre_1994_mapping = registry.mapping_for_legal_id(
+        "us-mn:policies/dhs/combined-manual/0020-21/"
+        "msa-assistance-standards-2026"
+        "#msa_pre_1994_married_couple_living_alone_standard",
+        country="us",
+    )
+    assert pre_1994_mapping.mapping_type == "not_comparable"
+    assert pre_1994_mapping.candidate_priority == "P4"
+
+    assistance_standard_mapping = registry.mapping_for_legal_id(
+        "us-mn:policies/dhs/combined-manual/0020-21/"
+        "msa-assistance-standards-2026#mn_msa_assistance_standard",
+        country="us",
+    )
+    assert assistance_standard_mapping.mapping_type == "not_comparable"
+    assert (
+        assistance_standard_mapping.policyengine_variable
+        == "mn_msa_assistance_standard"
+    )
+    assert assistance_standard_mapping.candidate_priority == "P4"
+
+
 def test_policyengine_registry_includes_acp_parameter_and_not_comparable_mappings():
     registry = load_policyengine_registry()
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -13985,10 +13985,13 @@ rules:
         )
         == source_text
     )
-    assert find_source_verification_issues(
-        content,
-        source_texts=source_texts,
-    ) == []
+    assert (
+        find_source_verification_issues(
+            content,
+            source_texts=source_texts,
+        )
+        == []
+    )
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
 
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -13890,6 +13890,59 @@ rules:
     assert find_ungrounded_numeric_issues(content) == []
 
 
+def test_validator_pipeline_maps_in_memory_source_text_to_declared_corpus_path(
+    tmp_path,
+):
+    source_text = (
+        "Effective January 2026, the MSA assistance standard for a person living "
+        "alone is $1,055.00."
+    )
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-mn/manual/dhs/combined-manual/msa-revised-sections-2026-01
+    values:
+      mn_msa_person_living_alone_standard: 1055
+rules:
+  - name: mn_msa_person_living_alone_standard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '1055'
+"""
+
+    assert find_source_verification_issues(content) == [
+        "Source verification source missing: "
+        "`us-mn/manual/dhs/combined-manual/msa-revised-sections-2026-01` "
+        "was not found in corpus.provisions."
+    ]
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path / "rulespec-us",
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+        source_text=source_text,
+    )
+    source_texts = pipeline._source_texts_for_rulespec_content(content)
+
+    assert source_texts == {
+        "us-mn/manual/dhs/combined-manual/msa-revised-sections-2026-01": source_text
+    }
+    assert (
+        validator_pipeline._extract_source_verification_text(
+            content,
+            source_texts=source_texts,
+        )
+        == source_text
+    )
+    assert find_source_verification_issues(
+        content,
+        source_texts=source_texts,
+    ) == []
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
 def test_source_verification_slices_local_parent_corpus_artifact(
     tmp_path,
     monkeypatch,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.906"
+version = "0.2.907"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.907"
+version = "0.2.908"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- preserve country-level RuleSpec repo shape when validating generated encodes from worktrees
- pass resolved in-memory source text into validation so newly ingested corpus sources can validate before merge
- add Minnesota MSA assistance-standard oracle mappings for PE parameter parity

## Tests
- env -u UV_FROZEN uv run --extra dev pytest tests/test_evals.py::TestEvaluateArtifact tests/test_rulespec_validation.py::test_validator_pipeline_maps_in_memory_source_text_to_declared_corpus_path tests/test_rulespec_validation.py::test_policyengine_registry_includes_minnesota_msa_assistance_standard_mappings -q
- env -u UV_FROZEN uv run --extra dev ruff check tests/test_rulespec_validation.py src/axiom_encode/harness/evals.py src/axiom_encode/harness/validator_pipeline.py