### PR TITLE
Add Arizona TANF oracle surface mapping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.908"
+version = "0.2.909"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.908"
+__version__ = "0.2.909"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -3494,6 +3494,14 @@ mappings:
     comparison: rate
     rationale: Same Arizona TANF base income-limit rate for parent or non-parent caretaker relative self-and-child cases.
 
+  - legal_id: us-az:programs/tanf/fy-2026#az_tanf
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: az_tanf
+    candidate_priority: P4
+    rationale: Axiom's Arizona Cash Assistance wrapper composes DES FAA5 payment-standard, needy-family, prospective-eligibility, and eligible-no-pay issuance rules, including the under-$10 no-pay boundary. PolicyEngine's az_tanf is a final monthly SPM-unit benefit gated by PE's demographic, immigration, resource, and income graph and does not share the DES eligible-no-pay issuance boundary, so this is not a one-to-one oracle target yet.
+
   - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_thirty_dollar_earned_income_disregard
     country: us
     program: tanf

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -374,10 +374,11 @@ surfaces:
   state: AZ
   axiom_status: known_not_comparable
   priority: P1
-  rationale: Current RuleSpec repos include tested Arizona Cash Assistance payment-standard, needy-family, benefit-determination,
-    earned-income-deduction, and resource/income legal slices. Those outputs are DES FAA5 source slices, while PolicyEngine's az_tanf
-    is a final annualized TANF benefit variable built from PE's own TANF graph; do not treat it as a direct one-to-one oracle target
-    until Axiom has an equivalent final Arizona Cash Assistance benefit surface or PE exposes compatible helper boundaries.
+  rationale: Current RuleSpec repos include a runnable us-az/tanf FY 2026 composition over tested Arizona Cash Assistance
+    payment-standard, needy-family, prospective-eligibility, and eligible-no-pay legal slices. The wrapper is source-faithful
+    to the DES FAA5 under-$10 eligible-no-pay issuance branch, while PolicyEngine's az_tanf is a final monthly SPM-unit benefit
+    built from PE's own demographic, immigration, resource, and income graph; do not treat it as a direct one-to-one oracle target
+    until both runtimes expose the same final Arizona Cash Assistance boundary.
 - country: us
   program_id: tanf
   program_name: Oklahoma TANF

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1521,6 +1521,22 @@ def test_policyengine_program_surface_marks_georgia_tanf_known_not_comparable():
     assert "final monthly TANF benefit variable" in georgia_tanf["rationale"]
 
 
+def test_policyengine_program_surface_marks_arizona_tanf_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    arizona_tanf = items_by_variable["az_tanf"]
+
+    assert arizona_tanf["program_id"] == "tanf"
+    assert arizona_tanf["state"] == "AZ"
+    assert arizona_tanf["axiom_status"] == "known_not_comparable"
+    assert arizona_tanf["mapping_count"] == 1
+    assert arizona_tanf["comparable_mapping_count"] == 0
+    assert "us-az:programs/tanf/fy-2026#az_tanf" in arizona_tanf["legal_ids"]
+    assert "runnable us-az/tanf FY 2026 composition" in arizona_tanf["rationale"]
+    assert "eligible-no-pay" in arizona_tanf["rationale"]
+
+
 def test_policyengine_program_surface_marks_florida_tca_known_not_comparable():
     report = build_policyengine_program_surface_report(program="tanf")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.908"
+version = "0.2.909"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary\n- add an explicit non-comparable PolicyEngine oracle mapping for the Arizona TANF wrapper surface\n- update the AZ TANF program-surface rationale to reference the runnable FY 2026 composition and DES eligible-no-pay boundary\n- add regression coverage that the surface report carries the wrapper legal ID\n\n## Tests\n- env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage.py -q\n- AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root <tmp rulespec-us symlink> --program tanf --limit 80\n- AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root <tmp rulespec-us symlink> --include-program-surfaces --json