### PR TITLE
Classify Kansas TANF program surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.909"
+version = "0.2.910"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.909"
+__version__ = "0.2.910"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -3502,6 +3502,38 @@ mappings:
     candidate_priority: P4
     rationale: Axiom's Arizona Cash Assistance wrapper composes DES FAA5 payment-standard, needy-family, prospective-eligibility, and eligible-no-pay issuance rules, including the under-$10 no-pay boundary. PolicyEngine's az_tanf is a final monthly SPM-unit benefit gated by PE's demographic, immigration, resource, and income graph and does not share the DES eligible-no-pay issuance boundary, so this is not a one-to-one oracle target yet.
 
+  - legal_id: us-ks:programs/tanf/fy-2026#ks_tanf_maximum_benefit
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ks_tanf_maximum_benefit
+    candidate_priority: P4
+    rationale: The Kansas TANF program wrapper exposes the KEESM 7411 budgetary-standard output from Axiom's shelter-group and Table I/II legal path. PolicyEngine-US exposes an adjacent ks_tanf_maximum_benefit using its own SPM-unit size and parameterization, so this program bridge is not a one-to-one oracle target.
+
+  - legal_id: us-ks:programs/tanf/fy-2026#ks_tanf_before_proration
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ks_tanf
+    candidate_priority: P4
+    rationale: The Kansas TANF program wrapper's pre-proration amount is the encoded KEESM 7411 maximum benefit before the broader income/resource eligibility path is encoded. PolicyEngine-US ks_tanf applies PE eligibility gates and subtracts countable income, so this bridge is not directly comparable.
+
+  - legal_id: us-ks:programs/tanf/fy-2026#ks_tanf_prorated_cash_benefit
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ks_tanf
+    candidate_priority: P4
+    rationale: The Kansas TANF program wrapper's prorated cash-benefit bridge applies KEESM 7401 proration to the currently encoded maximum-benefit path before final cash rounding. PolicyEngine-US ks_tanf does not expose KEESM 7401 proration and also includes PE eligibility and countable-income logic, so this is not a one-to-one oracle target.
+
+  - legal_id: us-ks:programs/tanf/fy-2026#ks_tanf
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ks_tanf
+    candidate_priority: P4
+    rationale: The Kansas TANF program wrapper composes KEESM 7411 maximum benefit with KEESM 7401/7402 cash proration and rounding, but does not yet encode countable income, income/resource eligibility, demographic eligibility, or immigration eligibility. PolicyEngine-US ks_tanf applies those PE graph gates and a maximum-benefit-minus-countable-income formula, so this surface is currently known not comparable.
+
   - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_thirty_dollar_earned_income_disregard
     country: us
     program: tanf

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -555,10 +555,13 @@ surfaces:
   variable: ks_tanf
   source_type: state_implementation
   state: KS
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Current RuleSpec repos include a Kansas TANF FY 2026 program wrapper that composes KEESM 7411
+    budgetary standards with KEESM 7401/7402 cash proration and rounding. The wrapper intentionally remains
+    incomplete for countable income, income/resource eligibility, demographic eligibility, and immigration
+    eligibility, while PolicyEngine-US ks_tanf applies those PE graph gates and a maximum-benefit-minus-countable-income
+    formula. The surface is therefore known and reviewed, but not a one-to-one oracle target yet.
 - country: us
   program_id: tanf
   program_name: Hawaii TANF

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -276,6 +276,45 @@ outputs:
     assert payment_standard["candidate_priority"] == "P4"
 
 
+def test_policyengine_coverage_classifies_kansas_tanf_program_outputs(tmp_path):
+    checkout = tmp_path / "rulespec-us"
+    _write_rulespec_file(
+        checkout / "programs/us-ks/tanf/fy-2026.yaml",
+        """program: us-ks/tanf
+period: 2026-01
+outputs:
+  - ks_tanf_maximum_benefit
+  - ks_tanf_before_proration
+  - ks_tanf_prorated_cash_benefit
+  - ks_tanf
+""",
+    )
+
+    report = build_policyengine_coverage_report(checkout, program="tanf")
+
+    assert report["total_outputs"] == 4
+    assert report["status_counts"] == {"known_not_comparable": 4}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    maximum_benefit = items_by_id["us-ks:programs/tanf/fy-2026#ks_tanf_maximum_benefit"]
+    final_benefit = items_by_id["us-ks:programs/tanf/fy-2026#ks_tanf"]
+    assert maximum_benefit["policyengine_variable"] == "ks_tanf_maximum_benefit"
+    assert final_benefit["policyengine_variable"] == "ks_tanf"
+    assert {item["candidate_priority"] for item in items_by_id.values()} == {"P4"}
+    registry = load_policyengine_registry()
+    final_mapping = registry.mapping_for_legal_id(
+        "us-ks:programs/tanf/fy-2026#ks_tanf",
+        country="us",
+    )
+    assert final_mapping.match_type == "exact"
+    assert (
+        registry.mapping_for_legal_id(
+            "us-ks:programs/tanf/fy-2026#ks_tanf_extra",
+            country="us",
+        )
+        is None
+    )
+
+
 def test_policyengine_candidates_classify_program_spec_adjacent_targets(tmp_path):
     checkout = tmp_path / "rulespec-us"
     _write_rulespec_file(
@@ -1535,6 +1574,22 @@ def test_policyengine_program_surface_marks_arizona_tanf_known_not_comparable():
     assert "us-az:programs/tanf/fy-2026#az_tanf" in arizona_tanf["legal_ids"]
     assert "runnable us-az/tanf FY 2026 composition" in arizona_tanf["rationale"]
     assert "eligible-no-pay" in arizona_tanf["rationale"]
+
+
+def test_policyengine_program_surface_marks_kansas_tanf_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    kansas_tanf = items_by_variable["ks_tanf"]
+
+    assert kansas_tanf["program_id"] == "tanf"
+    assert kansas_tanf["state"] == "KS"
+    assert kansas_tanf["axiom_status"] == "known_not_comparable"
+    assert kansas_tanf["mapping_count"] >= 4
+    assert kansas_tanf["comparable_mapping_count"] == 0
+    assert "us-ks:programs/tanf/fy-2026#ks_tanf" in kansas_tanf["legal_ids"]
+    assert "Kansas TANF FY 2026 program wrapper" in kansas_tanf["rationale"]
+    assert "countable income" in kansas_tanf["rationale"]
 
 
 def test_policyengine_program_surface_marks_florida_tca_known_not_comparable():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.909"
+version = "0.2.910"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Kansas TANF FY 2026 program wrapper outputs as known not comparable to PolicyEngine surfaces
- mark the Kansas TANF program surface as known_not_comparable with rationale tied to the missing income/resource/eligibility path
- bump axiom-encode to 0.2.910 and add focused coverage tests

## Local checks
- env -u UV_FROZEN uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_kansas_tanf_program_outputs tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_kansas_tanf_known_not_comparable -q
- env -u UV_FROZEN uv run --extra dev ruff check pyproject.toml src/axiom_encode scripts tests/test_policyengine_coverage.py tests/test_cli.py
- env -u UV_FROZEN uv run --extra dev ruff format --check src tests
- KS TANF coverage against rulespec-us wrapper: 293 outputs, 22 comparable, 271 known_not_comparable, 0 unmapped, 0 untested comparable

## Review cycle
- Independent read-only review found the KS program output rows were accidentally under prefix mappings. Fixed by moving them to exact mappings and adding a regression that `#ks_tanf_extra` does not match.