### PR TITLE
Classify UK Universal Credit program outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.910"
+version = "0.2.911"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.910"
+__version__ = "0.2.911"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -2094,6 +2094,113 @@ mappings:
     comparison: bool
     rationale: Same Universal Credit childcare work-condition predicate, with the Populace oracle projecting person-level adult work status into the Regulation 32 claimant and other-member work leaves.
 
+  - legal_id: uk:programs/universal-credit/fy-2026-27#amount_included_under_section_10_responsibility_for_children_and_young_persons
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    policyengine_variable: uc_child_element
+    candidate_priority: P4
+    rationale: The Universal Credit program wrapper composes child and disabled-child amounts across benefit-unit children. PolicyEngine UK exposes adjacent child element variables and parameters, while the Populace oracle currently compares the constituent source-law outputs rather than this program-boundary aggregate.
+
+  - legal_id: uk:programs/universal-credit/fy-2026-27#amount_included_under_section_11_housing_costs
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    policyengine_variable: uc_housing_costs_element
+    candidate_priority: P4
+    rationale: The Universal Credit program wrapper adds renter and owner-occupier housing-cost schedule outputs from the encoded regulations. PolicyEngine UK exposes downstream UC housing outcomes rather than this WRA 2012 section 11 bridge as a one-to-one oracle surface.
+
+  - legal_id: uk:programs/universal-credit/fy-2026-27#amount_included_under_section_12_other_particular_needs_or_circumstances
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    policyengine_variable: uc_maximum_amount
+    candidate_priority: P4
+    rationale: The Universal Credit program wrapper combines LCWRA, carer, and childcare element bridges. PolicyEngine UK exposes nearby element outputs, but there is not yet a tested program-boundary oracle adapter for this section 12 composite.
+
+  - legal_id: uk:programs/universal-credit/fy-2026-27#carer_element
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    policyengine_variable: uc_carer_element
+    candidate_priority: P4
+    rationale: The program wrapper's carer element output is a branch-selected program amount backed by Regulation 36 parameter rows already mapped at the source-law level. PolicyEngine UK stores the parameter branches rather than this program-output boundary.
+
+  - legal_id: uk:programs/universal-credit/fy-2026-27#child_element_amount
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    policyengine_variable: uc_child_element
+    candidate_priority: P4
+    rationale: The program wrapper's child element amount is a branch-selected program amount backed by Regulation 36 parameter rows already mapped at the source-law level. PolicyEngine UK stores the parameter branches rather than this program-output boundary.
+
+  - legal_id: uk:programs/universal-credit/fy-2026-27#childcare_costs_element_amount
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    policyengine_variable: uc_childcare_element
+    candidate_priority: P4
+    rationale: The Universal Credit program wrapper computes a childcare element bridge from relevant childcare charges and caps. PolicyEngine UK exposes adjacent childcare element outcomes, but the current oracle surface does not test this program-boundary calculation one-to-one.
+
+  - legal_id: uk:programs/universal-credit/fy-2026-27#childcare_costs_element_maximum_amount
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    policyengine_variable: uc_maximum_childcare_element_amount
+    candidate_priority: P4
+    rationale: The program wrapper's childcare maximum amount is a branch-selected program amount backed by Regulation 36 childcare cap parameter rows already mapped at the source-law level. PolicyEngine UK stores the parameter branches rather than this program-output boundary.
+
+  - legal_id: uk:programs/universal-credit/fy-2026-27#disabled_child_additional_amount
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    policyengine_variable: uc_individual_disabled_child_element
+    candidate_priority: P4
+    rationale: The program wrapper's disabled child additional amount is a branch-selected program amount backed by Regulation 36 parameter rows already mapped at the source-law level. PolicyEngine UK stores the parameter branches rather than this program-output boundary.
+
+  - legal_id: uk:programs/universal-credit/fy-2026-27#lcwra_element_amount
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    policyengine_variable: uc_LCWRA_element
+    candidate_priority: P4
+    rationale: The program wrapper's LCWRA element amount is a branch-selected program amount backed by Regulation 36 parameter rows already mapped at the source-law level. PolicyEngine UK stores the parameter branches rather than this program-output boundary.
+
+  - legal_id: uk:programs/universal-credit/fy-2026-27#standard_allowance_amount
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    policyengine_variable: uc_standard_allowance
+    candidate_priority: P4
+    rationale: The program wrapper's standard allowance amount is a branch-selected program amount backed by Regulation 36 parameter rows already mapped at the source-law level. PolicyEngine UK stores the parameter branches rather than this program-output boundary.
+
+  - legal_id: uk:programs/universal-credit/fy-2026-27#universal_credit_award_amount
+    country: uk
+    program: universal_credit
+    mapping_type: derived_expression
+    expression: max(uc_maximum_amount - uc_income_reduction, 0)
+    entity: benunit
+    period: month
+    unit: GBP
+    comparison: money
+    rationale: Same WRA 2012 section 8 award formula as the source-law mapping, comparing the pre-take-up and pre-benefit-cap expression from uc_maximum_amount and uc_income_reduction.
+
+  - legal_id: uk:programs/universal-credit/fy-2026-27#universal_credit_award_deduction_from_maximum_amount
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    policyengine_variable: uc_income_reduction
+    candidate_priority: P4
+    rationale: The Universal Credit program wrapper sums prescribed earned and unearned income deductions. PolicyEngine UK exposes adjacent income-reduction outputs, but there is not yet a tested Populace adapter for this program-boundary deduction composite.
+
+  - legal_id: uk:programs/universal-credit/fy-2026-27#universal_credit_maximum_amount
+    country: uk
+    program: universal_credit
+    mapping_type: not_comparable
+    policyengine_variable: uc_maximum_amount
+    candidate_priority: P4
+    rationale: The Universal Credit program wrapper computes the WRA 2012 section 8 maximum amount from standard allowance, child, housing, and particular-needs components. PolicyEngine UK exposes adjacent component and maximum-amount variables, but this wrapper output is not currently tested as a one-to-one oracle surface.
+
 prefixes:
   - legal_id_prefix: uk:policies/govuk/council-tax-reduction#
     country: uk

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -15466,6 +15466,71 @@ rules:
     assert item["mapping_type"] == "not_comparable"
 
 
+def test_universal_credit_program_wrapper_outputs_are_classified(tmp_path):
+    outputs = [
+        "amount_included_under_section_10_responsibility_for_children_and_young_persons",
+        "amount_included_under_section_11_housing_costs",
+        "amount_included_under_section_12_other_particular_needs_or_circumstances",
+        "carer_element",
+        "child_element_amount",
+        "childcare_costs_element_amount",
+        "childcare_costs_element_maximum_amount",
+        "disabled_child_additional_amount",
+        "lcwra_element_amount",
+        "standard_allowance_amount",
+        "universal_credit_award_amount",
+        "universal_credit_award_deduction_from_maximum_amount",
+        "universal_credit_maximum_amount",
+    ]
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "programs/uk/universal-credit/fy-2026-27.yaml",
+        "program: uk/universal-credit\n"
+        "period: 2026-04\n"
+        "outputs:\n" + "\n".join(f"  - {output}" for output in outputs) + "\n",
+    )
+
+    report = build_policyengine_coverage_report(
+        tmp_path,
+        program="universal_credit",
+    )
+
+    assert report["total_outputs"] == len(outputs)
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": len(outputs) - 1,
+    }
+    assert report["untested_comparable"] == 1
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    final_award = items_by_id[
+        "uk:programs/universal-credit/fy-2026-27#universal_credit_award_amount"
+    ]
+    assert final_award["program"] == "universal_credit"
+    assert final_award["status"] == "comparable"
+    assert final_award["mapping_type"] == "derived_expression"
+    assert final_award["tested"] is False
+    maximum_amount = items_by_id[
+        "uk:programs/universal-credit/fy-2026-27#universal_credit_maximum_amount"
+    ]
+    assert maximum_amount["status"] == "known_not_comparable"
+    assert maximum_amount["policyengine_variable"] == "uc_maximum_amount"
+    assert maximum_amount["candidate_priority"] == "P4"
+
+    registry = load_policyengine_registry()
+    final_mapping = registry.mapping_for_legal_id(
+        "uk:programs/universal-credit/fy-2026-27#universal_credit_award_amount",
+        country="uk",
+    )
+    assert final_mapping is not None
+    assert final_mapping.match_type == "exact"
+    assert (
+        registry.mapping_for_legal_id(
+            "uk:programs/universal-credit/fy-2026-27#universal_credit_award_amount_extra",
+            country="uk",
+        )
+        is None
+    )
+
+
 def test_council_tax_reduction_policy_surface_is_classified(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-uk" / "policies/govuk/council-tax-reduction.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.910"
+version = "0.2.911"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify UK Universal Credit FY 2026-27 program wrapper outputs in the PolicyEngine oracle registry
- expose the final WRA 2012 section 8 award as the same derived expression used by the source-law mapping
- mark the remaining 12 wrapper/branch outputs as reviewed known-not-comparable, with adjacent PolicyEngine variables recorded for candidate triage
- add a regression covering all 13 wrapper outputs and exact-match behavior
- bump axiom-encode to 0.2.911

## Local checks
- env -u UV_FROZEN uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py::test_universal_credit_program_wrapper_outputs_are_classified -q
- env -u UV_FROZEN uv run --extra dev ruff check pyproject.toml src/axiom_encode scripts tests/test_policyengine_coverage.py tests/test_cli.py
- env -u UV_FROZEN uv run --extra dev ruff format --check src tests
- AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus env -u UV_FROZEN uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-uk-uc-program-mappings-20260627 --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --include-program-surfaces --json

## Coverage result
- total_outputs: 14705
- comparable: 594
- known_not_comparable: 14111
- unmapped: 0
- untested_comparable: 1

The one untested comparable output is uk:programs/universal-credit/fy-2026-27#universal_credit_award_amount; this PR intentionally surfaces it as comparable rather than hiding it as non-comparable. A follow-up should add program-boundary oracle test support for program spec outputs.

## Review cycle
- First independent review found the final UC award should reuse the existing comparable section 8 expression and adjacent PE targets should be recorded.
- Fixed both findings.
- Second independent review reported no actionable findings.
