### PR TITLE
Map Georgia TANF RuleSpec outputs to PE registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.911"
+version = "0.2.912"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.911"
+__version__ = "0.2.912"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -18743,6 +18743,14 @@ prefixes:
     candidate_priority: P4
     rationale: Colorado Works basic-cash-assistance composition outputs are Axiom assembly points across encoded 9 CCR 2503-6 Section 3.606.1 and 3.606.2 provisions. PolicyEngine-US does not expose this exact composed monthly TANF legal slice one-to-one; direct oracle comparison should wait for an adapter that targets the same Colorado Works source boundaries and updated grant parameters.
 
+  - legal_id_prefix: us-ga:policies/dfcs/tanf/
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ga_tanf
+    candidate_priority: P4
+    rationale: Georgia DFCS TANF manual outputs decompose source-level assistance standards, gross and net income tests, countable-income construction, work and dependent-care deductions, resource/income eligibility, and cash-assistance benefit slices. PolicyEngine-US exposes ga_tanf as a final monthly SPM-unit benefit built from PE's own eligibility graph and parameter tables, so these legal outputs are adjacent TANF coverage but not one-to-one oracle targets unless a narrower exact mapping overrides this prefix.
+
   - legal_id_prefix: us-ks:policies/dcf/keesm/keesm7410#
     country: us
     program: tanf

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1554,8 +1554,9 @@ def test_policyengine_program_surface_marks_georgia_tanf_known_not_comparable():
     assert georgia_tanf["program_id"] == "tanf"
     assert georgia_tanf["state"] == "GA"
     assert georgia_tanf["axiom_status"] == "known_not_comparable"
-    assert georgia_tanf["mapping_count"] == 0
+    assert georgia_tanf["mapping_count"] >= 1
     assert georgia_tanf["comparable_mapping_count"] == 0
+    assert "us-ga:policies/dfcs/tanf/" in georgia_tanf["legal_ids"]
     assert "Georgia TANF assistance-standard" in georgia_tanf["rationale"]
     assert "final monthly TANF benefit variable" in georgia_tanf["rationale"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.911"
+version = "0.2.912"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Georgia DFCS TANF RuleSpec outputs under the TANF PE oracle surface with a non-comparable prefix mapping to adjacent `ga_tanf`
- keep GA TANF known-not-comparable, since PE exposes a final SPM-unit benefit and these Axiom outputs are source-level legal slices
- bump axiom-encode to 0.2.912 and update the GA TANF program-surface test

## Validation
- TANF oracle coverage: 342 outputs; `rulespec-us-ga` now contributes 49 known-not-comparable outputs; `untested_comparable` remains 0
- `env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_georgia_tanf_known_not_comparable -q`
- `env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage.py -k "georgia_tanf or arizona_tanf or kansas_tanf or colorado_tanf" -q`
- `env -u UV_FROZEN uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
- `env -u UV_FROZEN uv run --extra dev ruff check src/axiom_encode tests/test_policyengine_coverage.py tests/test_cli.py`
- `env -u UV_FROZEN uv run --extra dev ruff format --check src/axiom_encode tests`
- `env -u UV_FROZEN uv run python -m compileall -q src/axiom_encode`

## Review
- Independent review completed cleanly; no exact-comparable overclaim or required test gap found. Residual risk is future semantic drift if a specific GA output later becomes exactly comparable, which should use a narrower exact override above the prefix.
