### PR TITLE
Anchor WIC and CHIP eligibility surfaces

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.912"
+version = "0.2.913"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.912"
+__version__ = "0.2.913"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -18948,6 +18948,7 @@ prefixes:
     country: us
     program: wic
     mapping_type: not_comparable
+    policyengine_variable: is_wic_eligible
     candidate_priority: P4
     rationale: 7 CFR 246.7(c)-(e) encodes WIC certification, residency, identity, income-screening, adjunctive eligibility, pregnancy-documentation, nutritional-risk, and State/local agency workflow predicates. PolicyEngine-US exposes final WIC eligibility and benefit surfaces, not these certification-procedure helper outputs as one-to-one oracle targets; exact mappings should be added only for later composed WIC eligibility or parameter outputs that share PolicyEngine's variable boundary.
 
@@ -20100,6 +20101,14 @@ prefixes:
     mapping_type: not_comparable
     candidate_priority: P4
     rationale: Section 1396a(l) qualified pregnant woman and child outputs are federal source-level age-band, postpartum-period, income-rate, resource-option, and waiver-state helpers. PolicyEngine US exposes final Medicaid eligibility and effective state/category thresholds, not these statutory helper outputs as one-to-one oracle variables or parameters.
+
+  - legal_id_prefix: us:statutes/42/1397jj/b/1#
+    country: us
+    program: chip
+    mapping_type: not_comparable
+    candidate_priority: P4
+    policyengine_variable: is_chip_eligible
+    rationale: Section 1397jj(b)(1) targeted-low-income-child outputs are source-level CHIP eligibility prerequisites. PolicyEngine's is_chip_eligible variable is a final person-level category aggregate over child, standard pregnant, and FCEP paths, so this section-level source surface is adjacent rather than one-to-one; exact child-helper mappings continue to classify individual outputs.
 
   - legal_id_prefix: us:regulations/42-cfr/431/213#
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -778,15 +778,35 @@ def test_policyengine_program_surface_marks_wic_and_chip_final_eligibility_known
     report = build_policyengine_program_surface_report()
 
     items_by_variable = {item["variable"]: item for item in report["items"]}
-    assert items_by_variable["is_wic_eligible"]["axiom_status"] == (
-        "known_not_comparable"
-    )
-    assert items_by_variable["is_chip_eligible"]["axiom_status"] == (
-        "known_not_comparable"
-    )
+    wic = items_by_variable["is_wic_eligible"]
+    chip = items_by_variable["is_chip_eligible"]
+    assert wic["axiom_status"] == "known_not_comparable"
+    assert wic["mapping_count"] >= 1
+    assert wic["comparable_mapping_count"] == 0
+    assert "us:regulations/7-cfr/246/7/" in wic["legal_ids"]
+    assert chip["axiom_status"] == "known_not_comparable"
+    assert chip["mapping_count"] >= 1
+    assert chip["comparable_mapping_count"] == 0
+    assert "us:statutes/42/1397jj/b/1#" in chip["legal_ids"]
     assert {item["variable"] for item in report["actionable_surfaces"]}.isdisjoint(
         {"is_wic_eligible", "is_chip_eligible"}
     )
+
+
+def test_policyengine_registry_resolves_wic_and_chip_eligibility_prefixes():
+    registry = load_policyengine_registry()
+
+    expected_prefix_mappings = {
+        "us:regulations/7-cfr/246/7/local_agency_certification_helper": "is_wic_eligible",
+        "us:statutes/42/1397jj/b/1#future_chip_source_helper": "is_chip_eligible",
+    }
+    for legal_id, variable in expected_prefix_mappings.items():
+        mapping = registry.mapping_for_legal_id(legal_id, country="us")
+
+        assert mapping is not None
+        assert mapping.match_type == "prefix"
+        assert mapping.mapping_type == "not_comparable"
+        assert mapping.policyengine_variable == variable
 
 
 def test_policyengine_program_surface_local_tax_credit_uses_local_weight(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.912"
+version = "0.2.913"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- anchor final PE WIC eligibility to the existing 7 CFR 246.7 prefix as known-not-comparable
- add a CHIP section-level prefix for final `is_chip_eligible` while leaving exact child-helper mappings in place
- assert WIC/CHIP program surfaces have registry mappings and that concrete legal IDs resolve through real prefix mappings
- bump axiom-encode to 0.2.913

## Validation
- `AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program wic --json` -> 15 known_not_comparable, 0 untested_comparable
- `AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program chip --json` -> 1 comparable, 14 known_not_comparable, 0 untested_comparable
- `env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage.py -q` -> 354 passed
- `env -u UV_FROZEN uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
- `env -u UV_FROZEN uv run --extra dev ruff check src/axiom_encode tests/test_policyengine_coverage.py tests/test_cli.py`
- `env -u UV_FROZEN uv run --extra dev ruff format --check src/axiom_encode tests`
- `env -u UV_FROZEN uv run python -m compileall -q src/axiom_encode`
- `git diff --check`

## Review cycle
- Independent review found the first CHIP prefix was under `mappings:` instead of `prefixes:`. Fixed by moving it to `prefixes:` and adding direct prefix-resolution coverage.
- Second independent review was clean.

## Notes
This does not encode imputed PE amounts in RuleSpec. These final PE eligibility surfaces remain `known_not_comparable`; the registry now records adjacent legal anchors so the PE parity dashboard no longer treats them as unmapped.