### PR TITLE
Anchor Colorado TANF program surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.913"
+version = "0.2.914"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.913"
+__version__ = "0.2.914"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2936,6 +2936,14 @@ mappings:
     candidate_priority: P4
     rationale: Axiom's WIC 11450 monthly aid payment is the family-level legal payment formula after state income exemptions and special-needs inputs. PolicyEngine's ca_tanf is an annual SPM-unit final benefit gated through PE's demographic, resource, vehicle-value, and immigration-proration graph, so this is an adjacent final cash-benefit surface rather than a one-to-one oracle target.
 
+  - legal_id: us-co:programs/tanf/fy-2026#co_tanf
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: co_tanf
+    candidate_priority: P4
+    rationale: Axiom's Colorado Works FY 2026 program bridge exposes the encoded basic cash assistance grant before pregnancy allowance. PolicyEngine's co_tanf is a final TANF benefit surface built from PE's own Colorado Works graph, so the bridge is adjacent PE coverage but not a one-to-one oracle until the remaining Colorado Works eligibility, allowance, and procedural gates are composed.
+
   - legal_id: us-ca:regulations/cdss/eas/49/49-055#ca_capi
     country: us
     program: ssi_state_supplement

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -224,10 +224,10 @@ surfaces:
   state: CO
   axiom_status: known_not_comparable
   priority: P1
-  rationale: Current RuleSpec repos include tested Colorado Works basic-cash-assistance, earned-income-disregard, grant-standard,
-    and time-limit legal slices. Those outputs are source-specific legal boundaries, while PolicyEngine's co_tanf is a final monthly
-    benefit variable built from PE's own TANF graph and parameter table; do not treat it as a direct one-to-one oracle target until
-    Axiom has an equivalent final Colorado Works benefit surface or PE exposes compatible helper boundaries.
+  rationale: Axiom now has a country-level Colorado Works FY 2026 program bridge for the encoded basic-cash-assistance
+    grant before pregnancy allowance. That bridge remains source-slice coverage, while PolicyEngine's co_tanf
+    is a final monthly benefit variable built from PE's own Colorado Works graph and parameter table; keep as
+    known-not-comparable until the remaining Colorado Works eligibility, allowance, and procedural gates are composed.
 - country: us
   program_id: tanf
   program_name: DC TANF

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -577,6 +577,14 @@ surfaces:
                     policyengine_variable="employee_payroll_tax",
                 )
             ],
+            "co_tanf": [
+                PolicyEngineMapping(
+                    legal_id="us-co:programs/tanf/fy-2026#co_tanf",
+                    country="us",
+                    mapping_type="not_comparable",
+                    policyengine_variable="co_tanf",
+                )
+            ],
         }
     )
 
@@ -607,7 +615,8 @@ surfaces:
     assert items_by_variable["aca_ptc"]["mapping_count"] == 1
     assert items_by_variable["aca_ptc"]["comparable_mapping_count"] == 0
     assert items_by_variable["co_tanf"]["axiom_status"] == "known_not_comparable"
-    assert items_by_variable["co_tanf"]["mapping_count"] == 0
+    assert items_by_variable["co_tanf"]["mapping_count"] == 1
+    assert items_by_variable["co_tanf"]["comparable_mapping_count"] == 0
     assert items_by_variable["employee_payroll_tax"]["axiom_status"] == "out_of_scope"
     assert items_by_variable["employee_payroll_tax"]["mapping_count"] == 1
     assert items_by_variable["employee_payroll_tax"]["comparable_mapping_count"] == 0
@@ -1579,6 +1588,22 @@ def test_policyengine_program_surface_marks_georgia_tanf_known_not_comparable():
     assert "us-ga:policies/dfcs/tanf/" in georgia_tanf["legal_ids"]
     assert "Georgia TANF assistance-standard" in georgia_tanf["rationale"]
     assert "final monthly TANF benefit variable" in georgia_tanf["rationale"]
+
+
+def test_policyengine_program_surface_marks_colorado_tanf_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    colorado_tanf = items_by_variable["co_tanf"]
+
+    assert colorado_tanf["program_id"] == "tanf"
+    assert colorado_tanf["state"] == "CO"
+    assert colorado_tanf["axiom_status"] == "known_not_comparable"
+    assert colorado_tanf["mapping_count"] >= 1
+    assert colorado_tanf["comparable_mapping_count"] == 0
+    assert "us-co:programs/tanf/fy-2026#co_tanf" in colorado_tanf["legal_ids"]
+    assert "Colorado Works FY 2026 program bridge" in colorado_tanf["rationale"]
+    assert "before pregnancy allowance" in colorado_tanf["rationale"]
 
 
 def test_policyengine_program_surface_marks_arizona_tanf_known_not_comparable():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.913"
+version = "0.2.914"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a not-comparable PolicyEngine oracle anchor for the merged rulespec-us Colorado TANF FY 2026 bridge
- update the CO TANF program-surface rationale to reflect the source-slice bridge without treating PE's final benefit as comparable
- add coverage tests for the registry overlay and live CO TANF program surface

Depends on merged rulespec-us PR: https://github.com/TheAxiomFoundation/rulespec-us/pull/486 (commit 3e67b2a2)

## Validation
- Independent read-only review: no actionable findings
- env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage.py -q
- env -u UV_FROZEN uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- env -u UV_FROZEN uv run --extra dev ruff check src/axiom_encode tests/test_policyengine_coverage.py tests/test_cli.py
- env -u UV_FROZEN uv run --extra dev ruff format --check src/axiom_encode tests
- env -u UV_FROZEN uv run python -m compileall -q src/axiom_encode
- git diff --check
- AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tanf --json