### PR TITLE
Anchor New York TANF program surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.914"
+version = "0.2.915"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.914"
+__version__ = "0.2.915"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2944,6 +2944,14 @@ mappings:
     candidate_priority: P4
     rationale: Axiom's Colorado Works FY 2026 program bridge exposes the encoded basic cash assistance grant before pregnancy allowance. PolicyEngine's co_tanf is a final TANF benefit surface built from PE's own Colorado Works graph, so the bridge is adjacent PE coverage but not a one-to-one oracle until the remaining Colorado Works eligibility, allowance, and procedural gates are composed.
 
+  - legal_id: us-ny:programs/tanf/fy-2026#ny_tanf
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ny_tanf
+    candidate_priority: P4
+    rationale: Axiom's New York TANF FY 2026 program bridge composes the encoded State Plan standard-of-need, grant, home-energy, shelter-cap, asset, and income-disregard legal slices. PolicyEngine's ny_tanf is a final annual TANF benefit surface with its own graph and older parameterization, while Axiom's shelter table remains partially deferred, so this bridge is adjacent PE coverage but not a one-to-one oracle target.
+
   - legal_id: us-ca:regulations/cdss/eas/49/49-055#ca_capi
     country: us
     program: ssi_state_supplement
@@ -18900,7 +18908,7 @@ prefixes:
     program: tanf
     mapping_type: not_comparable
     candidate_priority: P4
-    rationale: New York TANF State Plan outputs are source-specific OTDA cash-assistance eligibility, income-disregard, standard-of-need, grant, home-energy, and shelter schedule mechanics. PolicyEngine-US does not expose these State Plan provision boundaries as one-to-one TANF oracle outputs; direct comparison should wait for a New York TANF adapter that targets the same state source slices.
+    rationale: New York TANF State Plan outputs are source-specific OTDA cash-assistance eligibility, income-disregard, standard-of-need, grant, home-energy, and shelter schedule mechanics. PolicyEngine-US does not expose these State Plan provision boundaries as one-to-one TANF oracle outputs; compare the Axiom FY 2026 program bridge separately until PE exposes compatible helper boundaries or the final legal behavior matches.
 
   - legal_id_prefix: us-ny:policies/tax/it-201-instructions/nyc-school-tax-credit-rate-reduction#
     country: us

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -271,10 +271,10 @@ surfaces:
   state: NY
   axiom_status: known_not_comparable
   priority: P1
-  rationale: Current RuleSpec repos include a runnable us-ny/tanf FY 2026 composition over tested State Plan standard-of-need,
-    grant, home-energy, shelter-cap, asset, and income-disregard legal slices. Direct oracle comparison should wait for a
-    New York TANF adapter that targets the same source-faithful monthly boundaries; PolicyEngine's ny_tanf is a final annual
-    program variable with its own graph and older parameterization, and the Axiom shelter table remains partially deferred.
+  rationale: Axiom now has a country-level New York TANF FY 2026 program bridge over tested State Plan standard-of-need,
+    grant, home-energy, shelter-cap, asset, and income-disregard legal slices. That bridge remains source-slice coverage,
+    while PolicyEngine's ny_tanf is a final annual program variable with its own graph and older parameterization; keep
+    as known-not-comparable until the Axiom shelter table is complete and the final legal behavior matches PE-compatible boundaries.
 - country: us
   program_id: tanf
   program_name: Massachusetts TAFDC

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -315,6 +315,35 @@ outputs:
     )
 
 
+def test_policyengine_coverage_classifies_new_york_tanf_program_output(tmp_path):
+    checkout = tmp_path / "rulespec-us"
+    _write_rulespec_file(
+        checkout / "programs/us-ny/tanf/fy-2026.yaml",
+        """program: us-ny/tanf
+period: 2026-01
+outputs:
+  - ny_tanf
+""",
+    )
+
+    report = build_policyengine_coverage_report(checkout, program="tanf")
+
+    assert report["total_outputs"] == 1
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == "us-ny:programs/tanf/fy-2026#ny_tanf"
+    assert item["repo"] == "rulespec-us"
+    assert item["file"] == "programs/us-ny/tanf/fy-2026.yaml"
+    assert item["kind"] == "program_output"
+    assert item["program"] == "tanf"
+    assert item["rule_name"] == "ny_tanf"
+    assert item["status"] == "known_not_comparable"
+    assert item["mapping_type"] == "not_comparable"
+    assert item["policyengine_variable"] == "ny_tanf"
+    assert item["candidate_priority"] == "P4"
+    assert "not a one-to-one oracle target" in item["rationale"]
+
+
 def test_policyengine_candidates_classify_program_spec_adjacent_targets(tmp_path):
     checkout = tmp_path / "rulespec-us"
     _write_rulespec_file(
@@ -1620,6 +1649,22 @@ def test_policyengine_program_surface_marks_arizona_tanf_known_not_comparable():
     assert "us-az:programs/tanf/fy-2026#az_tanf" in arizona_tanf["legal_ids"]
     assert "runnable us-az/tanf FY 2026 composition" in arizona_tanf["rationale"]
     assert "eligible-no-pay" in arizona_tanf["rationale"]
+
+
+def test_policyengine_program_surface_marks_new_york_tanf_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    new_york_tanf = items_by_variable["ny_tanf"]
+
+    assert new_york_tanf["program_id"] == "tanf"
+    assert new_york_tanf["state"] == "NY"
+    assert new_york_tanf["axiom_status"] == "known_not_comparable"
+    assert new_york_tanf["mapping_count"] == 1
+    assert new_york_tanf["comparable_mapping_count"] == 0
+    assert "us-ny:programs/tanf/fy-2026#ny_tanf" in new_york_tanf["legal_ids"]
+    assert "New York TANF FY 2026 program bridge" in new_york_tanf["rationale"]
+    assert "shelter table" in new_york_tanf["rationale"]
 
 
 def test_policyengine_program_surface_marks_kansas_tanf_known_not_comparable():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.914"
+version = "0.2.915"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Add an exact `not_comparable` PolicyEngine oracle anchor for `us-ny:programs/tanf/fy-2026#ny_tanf`.
- Keep PE `ny_tanf` explicitly non-comparable: Axiom has a country-level NY TANF FY 2026 source-slice bridge, while PE exposes a final annual TANF benefit surface with its own graph/older parameterization.
- Add tests for both the program-surface report and the generated program-spec coverage item so this cannot be counted as a comparable oracle.
- Bump `axiom-encode` to `0.2.915`.

## Validation
- `env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage.py -q` (`357 passed`)
- `env -u UV_FROZEN uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
- `env -u UV_FROZEN uv run --extra dev ruff check src/axiom_encode tests/test_policyengine_coverage.py tests/test_cli.py`
- `env -u UV_FROZEN uv run --extra dev ruff format --check src/axiom_encode tests`
- `env -u UV_FROZEN uv run python -m compileall -q src/axiom_encode`
- `git diff --check`
- `AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus env -u UV_FROZEN uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tanf --include-program-surfaces --json`
  - TANF: `343` outputs, `22` comparable, `321` known-not-comparable, `0` untested comparable.
  - `ny_tanf`: `known_not_comparable`, `mapping_count=1`, `comparable_mapping_count=0`.

## Review cycle
- Independent read-only review found one test gap: the exact program-spec coverage path was not directly asserted.
- Added `test_policyengine_coverage_classifies_new_york_tanf_program_output`.
- Re-review found no remaining actionable issues and specifically confirmed the diff does not imply PE final/imputed values are Axiom law or a comparable oracle.
