### PR TITLE
Map Medicaid PE surface to statute RuleSpec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.915"
+version = "0.2.916"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.915"
+__version__ = "0.2.916"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -104,52 +104,7 @@ mappings:
     candidate_priority: P4
     rationale: This RuleSpec output marks a qualified noncitizen whose Medicaid coverage is limited to emergency services by the five-year bar. PolicyEngine does not expose this limitation predicate as a separate Medicaid oracle target.
 
-  - legal_id: us:policies/hhs/medicaid/eligibility#child_ssi_deeming_age_ceiling_years
-    country: us
-    program: medicaid
-    mapping_type: not_comparable
-    candidate_priority: P4
-    rationale: This RuleSpec output is a statutory child age threshold used inside the Medicaid eligibility composition. PolicyEngine exposes final Medicaid eligibility, not this helper scalar as a one-to-one oracle target.
-
-  - legal_id: us:policies/hhs/medicaid/eligibility#specified_low_income_medicare_beneficiary_income_limit_poverty_line_rate
-    country: us
-    program: medicaid
-    mapping_type: not_comparable
-    candidate_priority: P4
-    rationale: This RuleSpec output is a Medicare Savings Program-adjacent statutory income-limit helper. PolicyEngine's Medicaid oracle surface is final eligibility and state/effective thresholds, not this source-level scalar.
-
-  - legal_id: us:policies/hhs/medicaid/eligibility#inpatient_hospital_durational_limit_exception_age_ceiling_years
-    country: us
-    program: medicaid
-    mapping_type: not_comparable
-    candidate_priority: P4
-    rationale: This RuleSpec output is a durational-limit exception age threshold for inpatient hospital services, not a person-level Medicaid eligibility result or exposed PolicyEngine Medicaid parameter.
-
-  - legal_id: us:policies/hhs/medicaid/eligibility#adult_expansion_mandatory_eligible
-    country: us
-    program: medicaid
-    mapping_type: not_comparable
-    policyengine_variable: is_medicaid_eligible
-    candidate_priority: P4
-    rationale: This RuleSpec output is the adult-expansion limb of the Medicaid eligibility composition. PolicyEngine exposes final Medicaid eligibility after all category, state, income, and immigration gates, not this limb as a one-to-one variable.
-
-  - legal_id: us:policies/hhs/medicaid/eligibility#former_foster_care_mandatory_eligible
-    country: us
-    program: medicaid
-    mapping_type: not_comparable
-    policyengine_variable: is_medicaid_eligible
-    candidate_priority: P4
-    rationale: This RuleSpec output is the former-foster-care limb of the Medicaid eligibility composition. PolicyEngine exposes final Medicaid eligibility, not this source-level mandatory-group branch separately.
-
-  - legal_id: us:policies/hhs/medicaid/eligibility#optional_group_eligible
-    country: us
-    program: medicaid
-    mapping_type: not_comparable
-    policyengine_variable: is_medicaid_eligible
-    candidate_priority: P4
-    rationale: This RuleSpec output is the state-elected optional-group limb of Medicaid eligibility. PolicyEngine exposes final Medicaid eligibility and does not expose this state-election branch as a separate oracle variable.
-
-  - legal_id: us:policies/hhs/medicaid/eligibility#is_medicaid_eligible
+  - legal_id: us:statutes/42/1396a/a/10#is_medicaid_eligible
     country: us
     program: medicaid
     mapping_type: direct_variable
@@ -207,6 +162,13 @@ mappings:
     mapping_type: not_comparable
     candidate_priority: P4
     rationale: This RuleSpec output is a federal medically-needy child age ceiling. PolicyEngine's comparable Medicaid surface is final eligibility and effective state thresholds, not this statutory scalar.
+
+  - legal_id: us:statutes/42/1396a/a/10#ssi_child_age_ceiling_years
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This RuleSpec output is the federal child age ceiling for an SSI-related mandatory Medicaid category in 42 USC 1396a(a)(10). PolicyEngine exposes final Medicaid eligibility, not this statutory helper scalar as a one-to-one oracle target.
 
   - legal_id: us:statutes/42/1396a/a/10#optional_adult_age_ceiling_years
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -179,71 +179,58 @@ rules:
 
 def test_policyengine_coverage_classifies_medicaid_policy_composite(tmp_path):
     _write_rulespec_file(
-        tmp_path / "rulespec-us/us/policies/hhs/medicaid/eligibility.yaml",
+        tmp_path / "rulespec-us/us/statutes/42/1396a/a/10.yaml",
         """format: rulespec/v1
 rules:
-  - name: child_ssi_deeming_age_ceiling_years
+  - name: adult_expansion_age_ceiling_years
     kind: parameter
-    versions:
-      - effective_from: '1974-01-01'
-        formula: 21
-  - name: specified_low_income_medicare_beneficiary_income_limit_poverty_line_rate
-    kind: parameter
-    versions:
-      - effective_from: '1995-01-01'
-        formula: 1.2
-  - name: inpatient_hospital_durational_limit_exception_age_ceiling_years
-    kind: parameter
-    versions:
-      - effective_from: '1974-01-01'
-        formula: 1
-  - name: adult_expansion_mandatory_eligible
-    kind: derived
     versions:
       - effective_from: '2014-01-01'
-        formula: adult_expansion_conditions_met
-  - name: former_foster_care_mandatory_eligible
-    kind: derived
+        formula: 65
+  - name: adult_expansion_income_limit_poverty_line_rate
+    kind: parameter
+    versions:
+      - effective_from: '2014-01-01'
+        formula: 1.33
+  - name: former_foster_care_age_ceiling_years
+    kind: parameter
     versions:
       - effective_from: '1974-01-01'
-        formula: former_foster_care_conditions_met
-  - name: optional_group_eligible
-    kind: derived
+        formula: 26
+  - name: former_foster_care_attainment_age_years
+    kind: parameter
     versions:
       - effective_from: '1974-01-01'
-        formula: optional_group_conditions_met
+        formula: 18
   - name: is_medicaid_eligible
     kind: derived
     versions:
       - effective_from: '2014-01-01'
-        formula: adult_expansion_mandatory_eligible or former_foster_care_mandatory_eligible or optional_group_eligible
+        formula: adult_expansion_conditions_met or former_foster_care_conditions_met
 """,
     )
     _write_rulespec_file(
-        tmp_path / "rulespec-us/us/policies/hhs/medicaid/eligibility.test.yaml",
+        tmp_path / "rulespec-us/us/statutes/42/1396a/a/10.test.yaml",
         """- name: medicaid composite covered
   period: 2024
   input:
-    us:policies/hhs/medicaid/eligibility#input.adult_expansion_conditions_met: true
-    us:policies/hhs/medicaid/eligibility#input.former_foster_care_conditions_met: false
-    us:policies/hhs/medicaid/eligibility#input.optional_group_conditions_met: false
+    us:statutes/42/1396a/a/10#input.adult_expansion_conditions_met: true
+    us:statutes/42/1396a/a/10#input.former_foster_care_conditions_met: false
   output:
-    us:policies/hhs/medicaid/eligibility#is_medicaid_eligible: holds
+    us:statutes/42/1396a/a/10#is_medicaid_eligible: holds
 """,
     )
 
     report = build_policyengine_coverage_report(tmp_path, program="medicaid")
 
-    assert report["total_outputs"] == 7
+    assert report["total_outputs"] == 5
     assert report["status_counts"] == {
         "comparable": 1,
-        "known_not_comparable": 6,
+        "known_not_comparable": 4,
     }
     assert report["untested_comparable"] == 0
     items_by_id = {item["legal_id"]: item for item in report["items"]}
-    final_surface = items_by_id[
-        "us:policies/hhs/medicaid/eligibility#is_medicaid_eligible"
-    ]
+    final_surface = items_by_id["us:statutes/42/1396a/a/10#is_medicaid_eligible"]
     assert final_surface["mapping_type"] == "direct_variable"
     assert final_surface["policyengine_variable"] == "is_medicaid_eligible"
     assert final_surface["tested"] is True
@@ -768,7 +755,7 @@ def test_policyengine_program_surface_includes_policybench_person_eligibility_su
     assert medicaid["program_id"] == "medicaid"
     assert medicaid["source_type"] == "eligibility"
     assert medicaid["axiom_status"] == "wired"
-    assert medicaid["mapping_count"] == 4
+    assert medicaid["mapping_count"] == 1
     assert medicaid["comparable_mapping_count"] == 1
     assert medicaid["policybench_output"] == "person_level_medicaid_eligibility"
     assert medicaid["policybench_household_weight"] == pytest.approx(29.86)
@@ -3674,6 +3661,11 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         value: 18
+  - name: ssi_child_age_ceiling_years
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        value: 18
   - name: optional_adult_age_ceiling_years
     kind: parameter
     versions:
@@ -3788,8 +3780,8 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path, program="medicaid")
 
-    assert report["total_outputs"] == 30
-    assert report["status_counts"] == {"known_not_comparable": 30}
+    assert report["total_outputs"] == 31
+    assert report["status_counts"] == {"known_not_comparable": 31}
     assert report["untested_comparable"] == 0
     assert {item["mapping_type"] for item in report["items"]} == {"not_comparable"}
     assert {item["candidate_priority"] for item in report["items"]} == {"P4"}

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.915"
+version = "0.2.916"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- move the Medicaid PE direct-variable mapping from the retired HHS wrapper to `us:statutes/42/1396a/a/10#is_medicaid_eligible`
- remove obsolete wrapper/helper mapping entries that no longer correspond to generated RuleSpec outputs
- add non-comparable coverage for the new statute-owned `ssi_child_age_ceiling_years` helper
- update coverage tests to use the statute path and a single comparable Medicaid PE mapping

## Validation
- `env -u UV_FROZEN uv run python - <<'PY' ... duplicate legal_id check ... PY`
- `env -u UV_FROZEN uv run --extra dev ruff check src/ tests/`
- `env -u UV_FROZEN uv run --extra dev ruff format --check src/ tests/`
- `env -u UV_FROZEN uv run --extra dev pytest tests/test_policyengine_coverage.py -k medicaid`
- `env -u UV_FROZEN uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- Medicaid coverage against rulespec-us PR #487: 236 outputs, 5 comparable, 231 known_not_comparable, 0 untested comparable; no unmapped/problem items; program surfaces remain `medicaid` out_of_scope and `is_medicaid_eligible` wired

## Unblocks
- TheAxiomFoundation/rulespec-us#487