### PR TITLE
Promote same-section output-name imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.943"
+version = "0.2.944"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.943"
+__version__ = "0.2.944"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -32261,6 +32261,7 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
         imported_target = f"{jurisdiction}:{target}"
         before = repaired
         placeholder_repairs: list[str] = []
+        referenced_outputs: list[str] = []
         if imported_output is not None:
             import_item = f"{imported_target}#{imported_output}"
             repaired = _ensure_rulespec_import(repaired, import_item)
@@ -32278,37 +32279,60 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
                 )
             )
         else:
-            imported_outputs = _rulespec_judgment_rule_output_names(target_file)
-            if len(imported_outputs) > 1:
-                candidate, placeholder_repairs = (
-                    _repair_same_section_subsection_multi_output_placeholder_references(
+            referenced_outputs = _formula_referenced_rulespec_output_names(
+                repaired, _rulespec_rule_output_names(target_file)
+            )
+            if referenced_outputs:
+                source_hash = _sha256_file(target_file)
+                for referenced_output in referenced_outputs:
+                    repaired = _ensure_rulespec_import(
                         repaired,
-                        test_file=test_file,
-                        target_base=f"{jurisdiction}:{target}",
-                        target_outputs=imported_outputs,
-                        target_file=target_file,
-                        generated_target_base=(
-                            f"{jurisdiction}:"
-                            f"{_relative_rulespec_import_target(relative_output)}"
-                        ),
+                        f"{imported_target}#{referenced_output}",
                     )
-                )
-                if placeholder_repairs:
-                    repaired = candidate
-                    for imported_output_name in imported_outputs:
-                        repaired = _ensure_rulespec_import(
+                    repaired = _ensure_import_proof_atoms_for_formula_symbol(
+                        repaired,
+                        symbol=referenced_output,
+                        target=f"{imported_target}#{referenced_output}",
+                        output=referenced_output,
+                        source_hash=source_hash,
+                    )
+            if not referenced_outputs:
+                imported_outputs = _rulespec_judgment_rule_output_names(target_file)
+                if len(imported_outputs) > 1:
+                    candidate, placeholder_repairs = (
+                        _repair_same_section_subsection_multi_output_placeholder_references(
                             repaired,
-                            f"{imported_target}#{imported_output_name}",
+                            test_file=test_file,
+                            target_base=f"{jurisdiction}:{target}",
+                            target_outputs=imported_outputs,
+                            target_file=target_file,
+                            generated_target_base=(
+                                f"{jurisdiction}:"
+                                f"{_relative_rulespec_import_target(relative_output)}"
+                            ),
                         )
+                    )
+                    if placeholder_repairs:
+                        repaired = candidate
+                        for imported_output_name in imported_outputs:
+                            repaired = _ensure_rulespec_import(
+                                repaired,
+                                f"{imported_target}#{imported_output_name}",
+                            )
+                    else:
+                        import_item = imported_target
+                        repaired = _ensure_rulespec_import(repaired, import_item)
                 else:
                     import_item = imported_target
                     repaired = _ensure_rulespec_import(repaired, import_item)
-            else:
-                import_item = imported_target
-                repaired = _ensure_rulespec_import(repaired, import_item)
         if repaired != before:
             if imported_output is not None:
                 added.append(f"{imported_target}#{imported_output}")
+            elif referenced_outputs:
+                added.extend(
+                    f"{imported_target}#{referenced_output}"
+                    for referenced_output in referenced_outputs
+                )
             elif placeholder_repairs:
                 added.extend(
                     f"{imported_target}#{imported_output_name}"
@@ -32322,6 +32346,54 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
         return []
     rules_file.write_text(repaired)
     return added
+
+
+def _rulespec_rule_output_names(rules_file: Path) -> list[str]:
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    rules = payload.get("rules") if isinstance(payload, dict) else None
+    if not isinstance(rules, list):
+        return []
+    return [
+        str(rule.get("name") or "").strip()
+        for rule in rules
+        if isinstance(rule, dict) and str(rule.get("name") or "").strip()
+    ]
+
+
+def _formula_referenced_rulespec_output_names(
+    content: str, target_outputs: list[str]
+) -> list[str]:
+    if not target_outputs:
+        return []
+    try:
+        payload = yaml.safe_load(content) or {}
+    except (ValueError, yaml.YAMLError):
+        return []
+    rules = payload.get("rules") if isinstance(payload, dict) else None
+    if not isinstance(rules, list):
+        return []
+    formulas: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if isinstance(formula, str):
+                formulas.append(formula)
+    referenced: list[str] = []
+    for output in target_outputs:
+        pattern = re.compile(rf"(?<![A-Za-z0-9_]){re.escape(output)}(?![A-Za-z0-9_])")
+        if any(pattern.search(formula) for formula in formulas):
+            referenced.append(output)
+    return referenced
 
 
 def _single_rulespec_rule_output_name(rules_file: Path) -> str | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18914,6 +18914,76 @@ rules:
         ) in test_text
         assert "conditions_of_paragraph_d_2_are_satisfied" not in test_text
 
+    def test_missing_same_section_import_repair_promotes_referenced_output_name(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "codex-gpt-5.5" / "regulations/42-cfr/435/603/d.yaml"
+        rules_file.parent.mkdir(parents=True)
+        policy_repo = tmp_path / "rulespec-us" / "us"
+        cited_file = policy_repo / "regulations" / "42-cfr" / "435" / "603" / "e.yaml"
+        cited_file.parent.mkdir(parents=True)
+        cited_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: payment_excluded_from_magi_based_income
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '0001-01-01'
+        formula: payment_is_excluded
+  - name: magi_based_income
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if payment_is_income: payment_amount else: 0
+"""
+        )
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  summary: Household income uses MAGI-based income except as provided in paragraph (e).
+rules:
+  - name: household_member_counted_magi_based_income
+    kind: derived
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if household_member_income_excluded: 0 else: magi_based_income
+"""
+        )
+        result = SimpleNamespace(
+            runner="codex-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = (
+            _try_repair_generated_missing_same_section_subsection_imports_for_apply(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                issues=[
+                    "regulations/42-cfr/435/603/d.yaml: ci: Same-section "
+                    "subsection import missing: source text cites "
+                    "`regulations/42-cfr/435/603/e` in an "
+                    "exception/cross-reference clause, but the file does not "
+                    "import it."
+                ],
+            )
+        )
+
+        assert repaired == ["us:regulations/42-cfr/435/603/e#magi_based_income"]
+        rules_text = rules_file.read_text()
+        assert "  - us:regulations/42-cfr/435/603/e#magi_based_income\n" in rules_text
+        assert "  - us:regulations/42-cfr/435/603/e\n" not in rules_text
+        assert (
+            "target: us:regulations/42-cfr/435/603/e#magi_based_income"
+        ) in rules_text
+
     def test_unsafe_formula_output_repair_defers_rules_and_tests(self, tmp_path):
         output_root = tmp_path / "out"
         rules_file = output_root / "openai-gpt-5.5" / "statutes/26/3201.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.943"
+version = "0.2.944"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- promote same-section cross-reference repairs to specific referenced output imports when the generated formula already references an output name
- add proof atoms for those promoted output imports
- bump axiom-encode to 0.2.944

## Tests
- ruff check src/axiom_encode/cli.py tests/test_cli.py src/axiom_encode/__init__.py
- python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::TestCmdEncode::test_missing_same_section_import_repair_promotes_referenced_output_name tests/test_cli.py::TestCmdEncode::test_missing_same_section_import_repair_promotes_cfr_multi_output_placeholder tests/test_cli.py::TestCmdEncode::test_missing_same_section_import_repair_promotes_cfr_placeholder -q