### PR TITLE
Repair alias same-section output imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.944"
+version = "0.2.945"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.944"
+__version__ = "0.2.945"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -32279,8 +32279,19 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
                 )
             )
         else:
+            target_outputs = _rulespec_rule_output_names(target_file)
+            alias_replacements = _formula_alias_rulespec_output_replacements(
+                repaired,
+                target_outputs,
+            )
+            if alias_replacements:
+                repaired = _replace_rulespec_symbol_references(
+                    repaired,
+                    alias_replacements,
+                )
             referenced_outputs = _formula_referenced_rulespec_output_names(
-                repaired, _rulespec_rule_output_names(target_file)
+                repaired,
+                target_outputs,
             )
             if referenced_outputs:
                 source_hash = _sha256_file(target_file)
@@ -32394,6 +32405,70 @@ def _formula_referenced_rulespec_output_names(
         if any(pattern.search(formula) for formula in formulas):
             referenced.append(output)
     return referenced
+
+
+def _formula_alias_rulespec_output_replacements(
+    content: str,
+    target_outputs: list[str],
+) -> dict[str, str]:
+    if not target_outputs:
+        return {}
+    try:
+        payload = yaml.safe_load(content) or {}
+    except (ValueError, yaml.YAMLError):
+        return {}
+    rules = payload.get("rules") if isinstance(payload, dict) else None
+    if not isinstance(rules, list):
+        return {}
+    local_outputs = {
+        str(rule.get("name") or "").strip()
+        for rule in rules
+        if isinstance(rule, dict) and str(rule.get("name") or "").strip()
+    }
+    formulas: list[str] = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if isinstance(formula, str):
+                formulas.append(formula)
+    replacements: dict[str, str] = {}
+    sorted_outputs = sorted(target_outputs, key=len, reverse=True)
+    for formula in formulas:
+        for match in re.finditer(
+            r"(?<![A-Za-z0-9_])([A-Za-z_][A-Za-z0-9_]*)(?![A-Za-z0-9_])",
+            formula,
+        ):
+            symbol = match.group(1)
+            if symbol in local_outputs:
+                continue
+            for output in sorted_outputs:
+                if symbol != output and symbol.endswith(f"_{output}"):
+                    replacements[symbol] = output
+                    break
+    return replacements
+
+
+def _replace_rulespec_symbol_references(
+    content: str,
+    replacements: dict[str, str],
+) -> str:
+    if not replacements:
+        return content
+    pattern = re.compile(
+        r"(?<![A-Za-z0-9_])("
+        + "|".join(
+            re.escape(symbol) for symbol in sorted(replacements, key=len, reverse=True)
+        )
+        + r")(?![A-Za-z0-9_])"
+    )
+    return pattern.sub(lambda match: replacements[match.group(1)], content)
 
 
 def _single_rulespec_rule_output_name(rules_file: Path) -> str | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18984,6 +18984,81 @@ rules:
             "target: us:regulations/42-cfr/435/603/e#magi_based_income"
         ) in rules_text
 
+    def test_missing_same_section_import_repair_promotes_alias_output_name(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "codex-gpt-5.5" / "regulations/42-cfr/435/603/d.yaml"
+        rules_file.parent.mkdir(parents=True)
+        policy_repo = tmp_path / "rulespec-us" / "us"
+        cited_file = policy_repo / "regulations" / "42-cfr" / "435" / "603" / "e.yaml"
+        cited_file.parent.mkdir(parents=True)
+        cited_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: payment_excluded_from_magi_based_income
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '0001-01-01'
+        formula: payment_is_excluded
+  - name: magi_based_income
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if payment_is_income: payment_amount else: 0
+"""
+        )
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  summary: Household income uses MAGI-based income except as provided in paragraph (e).
+rules:
+  - name: household_member_counted_magi_based_income
+    kind: derived
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          if household_member_income_excluded: 0 else: individual_magi_based_income
+  - name: household_income_before_fpl_disregard
+    kind: derived
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          household_member_counted_magi_based_income
+"""
+        )
+        result = SimpleNamespace(
+            runner="codex-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = (
+            _try_repair_generated_missing_same_section_subsection_imports_for_apply(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                issues=[
+                    "regulations/42-cfr/435/603/d.yaml: ci: Same-section "
+                    "subsection import missing: source text cites "
+                    "`regulations/42-cfr/435/603/e` in an "
+                    "exception/cross-reference clause, but the file does not "
+                    "import it."
+                ],
+            )
+        )
+
+        assert repaired == ["us:regulations/42-cfr/435/603/e#magi_based_income"]
+        rules_text = rules_file.read_text()
+        assert "  - us:regulations/42-cfr/435/603/e#magi_based_income\n" in rules_text
+        assert "else: magi_based_income\n" in rules_text
+        assert "individual_magi_based_income" not in rules_text
+        assert "          household_member_counted_magi_based_income\n" in rules_text
+
     def test_unsafe_formula_output_repair_defers_rules_and_tests(self, tmp_path):
         output_root = tmp_path / "out"
         rules_file = output_root / "openai-gpt-5.5" / "statutes/26/3201.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.944"
+version = "0.2.945"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- detect generated formula aliases that end with a cited same-section output name, such as individual_magi_based_income for magi_based_income
- rewrite those aliases to the imported output while excluding local generated rule names
- add a regression for the Medicaid 42 CFR 435.603(d) alias repair case
- bump axiom-encode to 0.2.945

## Tests
- ruff format src/axiom_encode/cli.py tests/test_cli.py
- ruff check src/axiom_encode/cli.py tests/test_cli.py src/axiom_encode/__init__.py
- python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::TestCmdEncode::test_missing_same_section_import_repair_promotes_alias_output_name -q