### PR TITLE
Repair imported output passthrough tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.945"
+version = "0.2.946"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.945"
+__version__ = "0.2.946"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -32294,6 +32294,22 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
                 target_outputs,
             )
             if referenced_outputs:
+                placeholder_repairs.extend(
+                    _add_imported_output_passthrough_test_overrides(
+                        test_file=test_file,
+                        rules_content=repaired,
+                        generated_target_base=(
+                            f"{jurisdiction}:"
+                            f"{_relative_rulespec_import_target(relative_output)}"
+                        ),
+                        imported_refs_by_output={
+                            referenced_output: (
+                                f"{imported_target}#{referenced_output}"
+                            )
+                            for referenced_output in referenced_outputs
+                        },
+                    )
+                )
                 source_hash = _sha256_file(target_file)
                 for referenced_output in referenced_outputs:
                     repaired = _ensure_rulespec_import(
@@ -32357,6 +32373,136 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
         return []
     rules_file.write_text(repaired)
     return added
+
+
+def _add_imported_output_passthrough_test_overrides(
+    *,
+    test_file: Path,
+    rules_content: str,
+    generated_target_base: str,
+    imported_refs_by_output: dict[str, str],
+) -> list[str]:
+    """Add test overrides for imported outputs used as passthrough values."""
+    if not test_file.exists() or not imported_refs_by_output:
+        return []
+    output_refs_by_rule = _passthrough_import_output_refs_by_rule(
+        rules_content,
+        imported_refs_by_output=imported_refs_by_output,
+    )
+    if not output_refs_by_rule:
+        return []
+    try:
+        test_payload = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    if not isinstance(test_payload, list):
+        return []
+
+    changed = False
+    repairs: list[str] = []
+    for test_case in test_payload:
+        if not isinstance(test_case, dict):
+            continue
+        inputs = test_case.get("input")
+        outputs = test_case.get("output")
+        if not isinstance(inputs, dict) or not isinstance(outputs, dict):
+            continue
+        input_keys = {str(key) for key in _mapping_keys_recursive(inputs)}
+        for rule_name, imported_ref in output_refs_by_rule.items():
+            expected = _test_output_value_for_rule(
+                outputs,
+                generated_target_base=generated_target_base,
+                rule_name=rule_name,
+            )
+            if expected is None or isinstance(expected, bool | str | list | dict):
+                continue
+            if imported_ref in input_keys:
+                continue
+            inputs[imported_ref] = expected
+            input_keys.add(imported_ref)
+            changed = True
+            case_name = str(test_case.get("name") or "<unnamed>")
+            repairs.append(f"test:{case_name}:{imported_ref}")
+
+    if not changed:
+        return []
+    test_file.write_text(
+        yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
+    )
+    return repairs
+
+
+def _passthrough_import_output_refs_by_rule(
+    rules_content: str,
+    *,
+    imported_refs_by_output: dict[str, str],
+) -> dict[str, str]:
+    try:
+        payload = yaml.safe_load(rules_content) or {}
+    except (ValueError, yaml.YAMLError):
+        return {}
+    rules = payload.get("rules") if isinstance(payload, dict) else None
+    if not isinstance(rules, list):
+        return {}
+    refs_by_rule: dict[str, str] = {}
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        rule_name = str(rule.get("name") or "").strip()
+        if not rule_name:
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        rule_refs: set[str] = set()
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            output_name = _passthrough_imported_output_name(
+                formula,
+                imported_outputs=list(imported_refs_by_output),
+            )
+            if output_name:
+                rule_refs.add(imported_refs_by_output[output_name])
+        if len(rule_refs) == 1:
+            refs_by_rule[rule_name] = next(iter(rule_refs))
+    return refs_by_rule
+
+
+def _passthrough_imported_output_name(
+    formula: str,
+    *,
+    imported_outputs: list[str],
+) -> str | None:
+    normalized = " ".join(formula.strip().split())
+    if not normalized:
+        return None
+    for output in imported_outputs:
+        token = re.escape(output)
+        if normalized == output:
+            return output
+        if re.fullmatch(rf"if\s+.+?:\s*0(?:\.0)?\s+else:\s*{token}", normalized):
+            return output
+        if re.fullmatch(rf"if\s+.+?:\s*{token}\s+else:\s*0(?:\.0)?", normalized):
+            return output
+    return None
+
+
+def _test_output_value_for_rule(
+    outputs: dict[object, object],
+    *,
+    generated_target_base: str,
+    rule_name: str,
+) -> object | None:
+    absolute_ref = f"{generated_target_base}#{rule_name}"
+    for candidate in (absolute_ref, rule_name):
+        key = _matching_mapping_key_by_rulespec_ref(outputs, candidate)
+        if key is not None:
+            return outputs[key]
+    return None
 
 
 def _rulespec_rule_output_names(rules_file: Path) -> list[str]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18989,6 +18989,7 @@ rules:
     ):
         output_root = tmp_path / "out"
         rules_file = output_root / "codex-gpt-5.5" / "regulations/42-cfr/435/603/d.yaml"
+        test_file = rules_file.with_name("d.test.yaml")
         rules_file.parent.mkdir(parents=True)
         policy_repo = tmp_path / "rulespec-us" / "us"
         cited_file = policy_repo / "regulations" / "42-cfr" / "435" / "603" / "e.yaml"
@@ -19032,6 +19033,14 @@ rules:
           household_member_counted_magi_based_income
 """
         )
+        test_file.write_text(
+            """- name: filer_income_counted
+  input:
+    us:regulations/42-cfr/435/603/d#input.household_member_income_excluded: false
+  output:
+    us:regulations/42-cfr/435/603/d#household_member_counted_magi_based_income: 1500
+"""
+        )
         result = SimpleNamespace(
             runner="codex-gpt-5.5",
             output_file=str(rules_file),
@@ -19052,12 +19061,25 @@ rules:
             )
         )
 
-        assert repaired == ["us:regulations/42-cfr/435/603/e#magi_based_income"]
+        assert repaired == [
+            "us:regulations/42-cfr/435/603/e#magi_based_income",
+            (
+                "test:filer_income_counted:"
+                "us:regulations/42-cfr/435/603/e#magi_based_income"
+            ),
+        ]
         rules_text = rules_file.read_text()
         assert "  - us:regulations/42-cfr/435/603/e#magi_based_income\n" in rules_text
         assert "else: magi_based_income\n" in rules_text
         assert "individual_magi_based_income" not in rules_text
         assert "          household_member_counted_magi_based_income\n" in rules_text
+        test_payload = yaml.safe_load(test_file.read_text())
+        assert (
+            test_payload[0]["input"][
+                "us:regulations/42-cfr/435/603/e#magi_based_income"
+            ]
+            == 1500
+        )
 
     def test_unsafe_formula_output_repair_defers_rules_and_tests(self, tmp_path):
         output_root = tmp_path / "out"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.945"
+version = "0.2.946"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add generated-test repair for passthrough formulas that depend on imported outputs
- cover the Medicaid MAGI same-section alias case with a regression
- bump axiom-encode to 0.2.946

## Tests
- .venv/bin/ruff format src/axiom_encode/cli.py tests/test_cli.py
- .venv/bin/ruff check src/axiom_encode/cli.py tests/test_cli.py src/axiom_encode/__init__.py
- .venv/bin/python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::TestCmdEncode::test_missing_same_section_import_repair_promotes_referenced_output_name tests/test_cli.py::TestCmdEncode::test_missing_same_section_import_repair_promotes_alias_output_name -q
- .venv/bin/python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q