### PR TITLE
Repair negated sum_where predicates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.946"
+version = "0.2.947"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.946"
+__version__ = "0.2.947"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -20815,6 +20815,34 @@ def cmd_encode(args):
                     )
                     outcome["overlay_validation_success"] = bool(can_apply)
             if not can_apply:
+                repaired_negated_sum_where_predicates = (
+                    _try_repair_generated_negated_sum_where_predicates_for_apply(
+                        result,
+                        output_root=args.output,
+                        issues=apply_issues,
+                    )
+                )
+                if repaired_negated_sum_where_predicates:
+                    outcome["auto_repaired_negated_sum_where_predicates"] = (
+                        repaired_negated_sum_where_predicates
+                    )
+                    print(
+                        "  apply=auto_repaired_negated_sum_where_predicates:"
+                        + ",".join(repaired_negated_sum_where_predicates)
+                    )
+                    can_apply, apply_issues, supplemental_files = (
+                        _validate_generated_encoding_in_policy_overlay(
+                            result,
+                            output_root=args.output,
+                            policy_repo_path=policy_repo_path,
+                            axiom_rules_path=axiom_rules_path,
+                            validate_dependents=not bool(
+                                getattr(args, "apply_target_only", False)
+                            ),
+                        )
+                    )
+                    outcome["overlay_validation_success"] = bool(can_apply)
+            if not can_apply:
                 repaired_unit_scoped_definitions = (
                     _try_repair_generated_unit_scoped_person_definition_for_apply(
                         result,
@@ -22190,6 +22218,24 @@ def _try_repair_generated_negated_comparisons_for_apply(
 
     rules_file = Path(str(getattr(result, "output_file", "") or ""))
     return _rewrite_negated_comparison_formulas(rules_file)
+
+
+def _try_repair_generated_negated_sum_where_predicates_for_apply(
+    result,
+    *,
+    output_root: Path,
+    issues: list[str],
+) -> list[str]:
+    """Promote inline negated sum_where predicates to named helpers."""
+    if not any(_issue_mentions_negated_sum_where_predicate(issue) for issue in issues):
+        return []
+    try:
+        _relative_generated_output_path(result, output_root=output_root)
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    return _rewrite_negated_sum_where_predicates(rules_file)
 
 
 def _try_repair_generated_judgment_numeric_comparisons_for_apply(
@@ -25313,6 +25359,188 @@ def _rewrite_negated_comparison_formula(formula: str) -> str:
         return f"{left} {_INVERTED_COMPARISON_OPERATORS[op]} {right}"
 
     return _NEGATED_COMPARISON_PATTERN.sub(_replace, str(formula))
+
+
+_NEGATED_SUM_WHERE_PREDICATE_PATTERN = re.compile(
+    r"sum_where\(\s*"
+    r"(?P<relation>[A-Za-z_][A-Za-z0-9_]*)\s*,\s*"
+    r"(?P<amount>[A-Za-z_][A-Za-z0-9_]*)\s*,\s*"
+    r"not\s+(?P<predicate>[A-Za-z_][A-Za-z0-9_]*)\s*"
+    r"\)"
+)
+
+
+def _issue_mentions_negated_sum_where_predicate(issue: str) -> bool:
+    text = str(issue).lower()
+    return "sum_where arg 3 must be a variable name" in text
+
+
+def _rewrite_negated_sum_where_predicates(rules_file: Path) -> list[str]:
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    rules_by_name = {
+        str(rule.get("name")).strip(): rule
+        for rule in rules
+        if isinstance(rule, dict)
+        and isinstance(rule.get("name"), str)
+        and str(rule.get("name")).strip()
+    }
+    existing_names = set(rules_by_name)
+    helper_by_predicate: dict[str, str] = {}
+    repaired: list[str] = []
+
+    for rule in list(rules):
+        if not isinstance(rule, dict):
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        rule_changed = False
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if not isinstance(formula, str):
+                continue
+            updated = _replace_negated_sum_where_predicates_in_formula(
+                formula,
+                rules=rules,
+                rules_by_name=rules_by_name,
+                existing_names=existing_names,
+                helper_by_predicate=helper_by_predicate,
+            )
+            if updated != formula:
+                version["formula"] = updated
+                rule_changed = True
+        if rule_changed:
+            repaired.append(str(rule.get("name") or "formula_rule"))
+
+    if not repaired:
+        return []
+
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repaired
+
+
+def _replace_negated_sum_where_predicates_in_formula(
+    formula: str,
+    *,
+    rules: list[Any],
+    rules_by_name: dict[str, Any],
+    existing_names: set[str],
+    helper_by_predicate: dict[str, str],
+) -> str:
+    def _replace(match: re.Match[str]) -> str:
+        relation = match.group("relation")
+        amount = match.group("amount")
+        predicate = match.group("predicate")
+        helper_name = helper_by_predicate.get(predicate)
+        if helper_name is None:
+            predicate_rule = rules_by_name.get(predicate)
+            if not isinstance(predicate_rule, dict):
+                return match.group(0)
+            helper_name = _negated_sum_where_helper_name(predicate, existing_names)
+            helper_rule = _negated_sum_where_predicate_rule(
+                predicate_rule,
+                name=helper_name,
+                predicate=predicate,
+            )
+            insert_at = rules.index(predicate_rule) + 1
+            rules.insert(insert_at, helper_rule)
+            rules_by_name[helper_name] = helper_rule
+            existing_names.add(helper_name)
+            helper_by_predicate[predicate] = helper_name
+        return f"sum_where({relation}, {amount}, {helper_name})"
+
+    return _NEGATED_SUM_WHERE_PREDICATE_PATTERN.sub(_replace, formula)
+
+
+def _negated_sum_where_helper_name(predicate: str, existing_names: set[str]) -> str:
+    if predicate.endswith("_excluded"):
+        base = f"{predicate.removesuffix('_excluded')}_included"
+    else:
+        base = f"not_{predicate}"
+    return _unique_generated_rule_name(base, existing_names)
+
+
+def _negated_sum_where_predicate_rule(
+    predicate_rule: dict[str, Any],
+    *,
+    name: str,
+    predicate: str,
+) -> dict[str, Any]:
+    helper: dict[str, Any] = {
+        "name": name,
+        "kind": "derived",
+        "entity": predicate_rule.get("entity"),
+        "dtype": "Judgment",
+        "period": predicate_rule.get("period"),
+        "source": predicate_rule.get("source"),
+        "metadata": {
+            "proof": {
+                "atoms": [
+                    _source_atom_for_negated_sum_where_predicate(predicate_rule),
+                ]
+            }
+        },
+        "versions": [
+            {
+                "effective_from": _first_effective_from(predicate_rule),
+                "formula": f"not {predicate}",
+            }
+        ],
+    }
+    if not helper["entity"]:
+        helper.pop("entity", None)
+    if not helper["period"]:
+        helper.pop("period", None)
+    if not helper["source"]:
+        helper.pop("source", None)
+    return helper
+
+
+def _first_effective_from(rule: dict[str, Any]) -> str:
+    versions = rule.get("versions")
+    if isinstance(versions, list):
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            effective_from = version.get("effective_from")
+            if isinstance(effective_from, str) and effective_from.strip():
+                return effective_from.strip()
+    return "0001-01-01"
+
+
+def _source_atom_for_negated_sum_where_predicate(
+    rule: dict[str, Any],
+) -> dict[str, Any]:
+    proof = rule.get("metadata", {}).get("proof")
+    atoms = proof.get("atoms") if isinstance(proof, dict) else None
+    if isinstance(atoms, list):
+        for atom in atoms:
+            if not isinstance(atom, dict):
+                continue
+            source = atom.get("source")
+            if isinstance(source, dict):
+                return {
+                    "path": "versions[0].formula",
+                    "kind": "formula",
+                    "source": dict(source),
+                }
+    return {
+        "path": "versions[0].formula",
+        "kind": "formula",
+    }
 
 
 def _rewrite_judgment_numeric_comparisons(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -136,6 +136,7 @@ from axiom_encode.cli import (
     _try_repair_generated_missing_same_section_subsection_imports_for_apply,
     _try_repair_generated_mixed_missing_deferred_outputs_for_apply,
     _try_repair_generated_negated_comparisons_for_apply,
+    _try_repair_generated_negated_sum_where_predicates_for_apply,
     _try_repair_generated_nonoperative_source_coverage_for_apply,
     _try_repair_generated_parameter_only_companion_tests_for_apply,
     _try_repair_generated_policyengine_oracle_inputs_for_apply,
@@ -7527,6 +7528,90 @@ rules:
         )
         assert payload["rules"][1]["versions"][0]["formula"] == (
             "if other_status == 0: 0 else: 100"
+        )
+
+    def test_negated_sum_where_predicate_repair_adds_named_helper(self, tmp_path):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "runner" / "medicaid.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/regulation/42/435/603/d
+rules:
+- name: household_member_income_excluded
+  kind: derived
+  entity: Person
+  dtype: Judgment
+  period: Year
+  source: 42 CFR 435.603(d)(2)
+  metadata:
+    proof:
+      atoms:
+      - path: versions[0].formula
+        kind: exception
+        source:
+          corpus_citation_path: us/regulation/42/435/603/d
+  versions:
+  - effective_from: '0001-01-01'
+    formula: non_filing_child
+- name: household_member_counted_magi_based_income
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  versions:
+  - effective_from: '0001-01-01'
+    formula: |-
+      if household_member_income_excluded: 0 else: magi_based_income
+- name: member_of_individuals_household
+  kind: data_relation
+  data_relation:
+    predicate: member_of_individuals_household
+    arity: 2
+- name: household_income_before_fpl_disregard
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  unit: USD
+  versions:
+  - effective_from: '0001-01-01'
+    formula: |-
+      sum_where(member_of_individuals_household, household_member_counted_magi_based_income, not household_member_income_excluded)
+"""
+        )
+        result = SimpleNamespace(output_file=rules_file, runner="runner")
+
+        repaired = _try_repair_generated_negated_sum_where_predicates_for_apply(
+            result,
+            output_root=output_root,
+            issues=[
+                "compile: Axiom rules engine compile failed: formula lower error: "
+                "sum_where arg 3 must be a variable name"
+            ],
+        )
+
+        assert repaired == ["household_income_before_fpl_disregard"]
+        payload = yaml.safe_load(rules_file.read_text())
+        helper = payload["rules"][1]
+        assert helper["name"] == "household_member_income_included"
+        assert helper["kind"] == "derived"
+        assert helper["entity"] == "Person"
+        assert helper["dtype"] == "Judgment"
+        assert helper["period"] == "Year"
+        assert (
+            helper["versions"][0]["formula"] == "not household_member_income_excluded"
+        )
+        aggregate_formula = payload["rules"][4]["versions"][0]["formula"]
+        assert aggregate_formula == (
+            "sum_where("
+            "member_of_individuals_household, "
+            "household_member_counted_magi_based_income, "
+            "household_member_income_included"
+            ")"
         )
 
     def test_rewrite_judgment_conditionals_updates_formula(self, tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.946"
+version = "0.2.947"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add an apply-time repair for generated `sum_where(..., not predicate)` formulas rejected by the rules engine
- promote the negated predicate to a named derived Judgment helper and rewrite the aggregate to use that helper
- bump axiom-encode to 0.2.947

## Tests
- `.venv/bin/ruff check src/axiom_encode/cli.py tests/test_cli.py src/axiom_encode/__init__.py`
- `.venv/bin/python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_cli.py::TestCmdEncode::test_negated_sum_where_predicate_repair_adds_named_helper -q`
- smoke-tested repair against the failed 42 CFR 435.603(d) generated candidate