### PR TITLE
Repair import output placeholder rows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.948"
+version = "0.2.949"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.948"
+__version__ = "0.2.949"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -17604,16 +17604,17 @@ def _remove_generated_import_output_input_placeholders(
         f"{_repo_jurisdiction_prefix(repo_path)}:"
         f"{_relative_rulespec_import_target(relative_output)}"
     )
-    imported_outputs = _imported_output_names(rules_file)
-    if not imported_outputs:
+    imported_output_refs = _imported_output_refs_by_name(rules_file)
+    if not imported_output_refs:
         return []
     invalid_refs = _invalid_input_refs_from_issues(issues)
-    removable_refs = {
-        ref
+    replacements_by_ref = {
+        ref: imported_output_refs[output_name]
         for ref in invalid_refs
         if ref.startswith(f"{target_base}#input.")
-        and ref.split("#input.", 1)[1] in imported_outputs
+        and (output_name := ref.split("#input.", 1)[1]) in imported_output_refs
     }
+    removable_refs = set(replacements_by_ref)
     if not removable_refs:
         return []
 
@@ -17629,7 +17630,11 @@ def _remove_generated_import_output_input_placeholders(
         if not isinstance(test_case, dict):
             continue
         inputs = test_case.get("input")
-        if _remove_mapping_keys_recursive(inputs, removable_refs):
+        if _replace_import_output_placeholders_with_upstream_inputs(
+            inputs,
+            placeholder_refs=replacements_by_ref,
+            policy_repo_path=repo_path,
+        ):
             changed = True
     if not changed:
         return []
@@ -18237,6 +18242,24 @@ def _imported_output_names(rules_file: Path) -> set[str]:
     except (OSError, ValueError, yaml.YAMLError):
         return set()
     return _imported_output_names_from_payload(payload)
+
+
+def _imported_output_refs_by_name(rules_file: Path) -> dict[str, str]:
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, ValueError, yaml.YAMLError):
+        return {}
+    imports = payload.get("imports") if isinstance(payload, dict) else None
+    if not isinstance(imports, list):
+        return {}
+    refs_by_name: dict[str, str] = {}
+    for raw_import in imports:
+        if not isinstance(raw_import, str) or "#" not in raw_import:
+            continue
+        fragment = raw_import.rsplit("#", 1)[1].strip()
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", fragment):
+            refs_by_name.setdefault(fragment, raw_import)
+    return refs_by_name
 
 
 def _imported_output_names_from_payload(payload: object) -> set[str]:
@@ -32771,6 +32794,45 @@ def _replace_computed_output_test_inputs_with_upstream_inputs(
         yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
     )
     return repairs
+
+
+def _replace_import_output_placeholders_with_upstream_inputs(
+    value: object,
+    *,
+    placeholder_refs: dict[str, str],
+    policy_repo_path: Path,
+) -> bool:
+    changed = False
+    if isinstance(value, dict):
+        for key in list(value.keys()):
+            key_text = str(key)
+            imported_ref = placeholder_refs.get(key_text)
+            if imported_ref is not None:
+                desired = value.pop(key)
+                upstream_inputs = _producer_test_inputs_for_output_value(
+                    imported_ref,
+                    desired,
+                    policy_repo_path=policy_repo_path,
+                )
+                for input_ref, input_value in upstream_inputs.items():
+                    value.setdefault(input_ref, input_value)
+                changed = True
+                continue
+            if _replace_import_output_placeholders_with_upstream_inputs(
+                value[key],
+                placeholder_refs=placeholder_refs,
+                policy_repo_path=policy_repo_path,
+            ):
+                changed = True
+    elif isinstance(value, list):
+        for item in value:
+            if _replace_import_output_placeholders_with_upstream_inputs(
+                item,
+                placeholder_refs=placeholder_refs,
+                policy_repo_path=policy_repo_path,
+            ):
+                changed = True
+    return changed
 
 
 def _replace_computed_output_inputs_in_value(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,6 +128,7 @@ from axiom_encode.cli import (
     _try_repair_generated_delegated_policy_settings_for_apply,
     _try_repair_generated_embedded_scalar_literals_for_apply,
     _try_repair_generated_empty_test_outputs_for_apply,
+    _try_repair_generated_import_output_inputs_for_apply,
     _try_repair_generated_import_target_prefix_typos_for_apply,
     _try_repair_generated_invalid_source_relation_types_for_apply,
     _try_repair_generated_judgment_conditionals_for_apply,
@@ -16287,6 +16288,90 @@ rules:
         assert imported_output_ref not in inputs
         assert inputs["us:regulations/42-cfr/435/603/e#input.payment_is_income"] is True
         assert inputs["us:regulations/42-cfr/435/603/e#input.payment_amount"] == 500
+
+    def test_encode_apply_replaces_local_import_output_placeholder_rows(self, tmp_path):
+        output_root = tmp_path / "out"
+        runner = "codex-test-model"
+        output_file = output_root / runner / "regulations/42-cfr/435/603/d.yaml"
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:regulations/42-cfr/435/603/e#magi_based_income
+rules:
+  - name: household_income_before_fpl_disregard
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: sum(member_of_individuals_household.magi_based_income)
+"""
+        )
+        test_file = output_file.with_name("d.test.yaml")
+        local_placeholder = "us:regulations/42-cfr/435/603/d#input.magi_based_income"
+        imported_payment_amount = "us:regulations/42-cfr/435/603/e#input.payment_amount"
+        imported_payment_is_income = (
+            "us:regulations/42-cfr/435/603/e#input.payment_is_income"
+        )
+        test_file.write_text(
+            f"""- name: household_member_income
+  period: 2026
+  input:
+    us:regulations/42-cfr/435/603/d#relation.member_of_individuals_household:
+      - {local_placeholder}: 500
+  output:
+    us:regulations/42-cfr/435/603/d#household_income_before_fpl_disregard: 500
+"""
+        )
+
+        policy_repo = tmp_path / "rulespec-us"
+        producer_file = policy_repo / "regulations/42-cfr/435/603/e.yaml"
+        producer_file.parent.mkdir(parents=True)
+        producer_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: magi_based_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: if payment_is_income: payment_amount else: 0
+"""
+        )
+        producer_file.with_name("e.test.yaml").write_text(
+            """- name: ordinary_income_counts
+  period: 2026-01
+  input:
+    us:regulations/42-cfr/435/603/e#input.payment_is_income: true
+    us:regulations/42-cfr/435/603/e#input.payment_amount: 1200
+  output:
+    us:regulations/42-cfr/435/603/e#magi_based_income: 1200
+"""
+        )
+
+        repaired = _try_repair_generated_import_output_inputs_for_apply(
+            SimpleNamespace(output_file=str(output_file), runner=runner),
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "regulations/42-cfr/435/603/d.yaml: ci: Test case "
+                "`household_member_income` execution failed: input "
+                f"`{local_placeholder}` does not resolve to an input slot"
+            ],
+        )
+
+        assert repaired == [local_placeholder]
+        test_payload = yaml.safe_load(test_file.read_text())
+        row = test_payload[0]["input"][
+            "us:regulations/42-cfr/435/603/d#relation.member_of_individuals_household"
+        ][0]
+        assert local_placeholder not in row
+        assert row[imported_payment_is_income] is True
+        assert row[imported_payment_amount] == 500
 
     def test_encode_apply_removes_invalid_imported_test_inputs(self, capsys, tmp_path):
         args = self._make_args(tmp_path, backend="codex", sync=False)

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.948"
+version = "0.2.949"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- translate local imported-output test placeholders into producer upstream inputs instead of only deleting them
- apply the repair recursively so relation rows generated by the encoder get valid inputs before validation
- bump axiom-encode to 0.2.949

## Validation
- `.venv/bin/python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::TestCmdEncode::test_encode_apply_replaces_computed_output_test_inputs_with_upstream_inputs tests/test_cli.py::TestCmdEncode::test_encode_apply_replaces_local_import_output_placeholder_rows -q`
- `.venv/bin/ruff check src/axiom_encode/cli.py tests/test_cli.py src/axiom_encode/__init__.py`
- `.venv/bin/python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
