### PR TITLE
Constrain import alias repair

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.949"
+version = "0.2.950"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.949"
+__version__ = "0.2.950"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -33196,10 +33196,39 @@ def _formula_alias_rulespec_output_replacements(
             if symbol in local_outputs:
                 continue
             for output in sorted_outputs:
-                if symbol != output and symbol.endswith(f"_{output}"):
+                if _is_safe_import_output_alias(symbol, output):
                     replacements[symbol] = output
                     break
     return replacements
+
+
+_SAFE_IMPORT_OUTPUT_ALIAS_PREFIXES = {
+    "applicant",
+    "candidate",
+    "child",
+    "claimant",
+    "dependent",
+    "household_member",
+    "individual",
+    "member",
+    "parent",
+    "payee",
+    "payer",
+    "payment",
+    "person",
+    "recipient",
+    "spouse",
+    "taxpayer",
+}
+
+
+def _is_safe_import_output_alias(symbol: str, output: str) -> bool:
+    if symbol == output or not symbol.endswith(f"_{output}"):
+        return False
+    prefix = symbol[: -(len(output) + 1)].strip("_")
+    if not prefix:
+        return False
+    return prefix in _SAFE_IMPORT_OUTPUT_ALIAS_PREFIXES
 
 
 def _replace_rulespec_symbol_references(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19281,6 +19281,13 @@ rules:
       - effective_from: '0001-01-01'
         formula: |-
           household_member_counted_magi_based_income
+  - name: fpl_five_percentage_point_disregard_applies
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          determining_eligibility_using_magi_based_income
 """
         )
         test_file.write_text(
@@ -19322,6 +19329,7 @@ rules:
         assert "  - us:regulations/42-cfr/435/603/e#magi_based_income\n" in rules_text
         assert "else: magi_based_income\n" in rules_text
         assert "individual_magi_based_income" not in rules_text
+        assert "determining_eligibility_using_magi_based_income\n" in rules_text
         assert "          household_member_counted_magi_based_income\n" in rules_text
         test_payload = yaml.safe_load(test_file.read_text())
         assert (

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.949"
+version = "0.2.950"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- make same-section imported-output alias promotion conservative so condition facts are not collapsed into imported scalar outputs
- keep entity/role-style aliases such as `individual_magi_based_income` eligible for repair
- bump axiom-encode to 0.2.950

## Validation
- `.venv/bin/python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::TestCmdEncode::test_missing_same_section_import_repair_promotes_alias_output_name -q`
- `.venv/bin/ruff check src/axiom_encode/cli.py tests/test_cli.py src/axiom_encode/__init__.py`
- `.venv/bin/python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
