### PR TITLE
Repair imported defaults in relation rows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.950"
+version = "0.2.951"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.950"
+__version__ = "0.2.951"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -38335,12 +38335,15 @@ def _complete_missing_imported_test_inputs(
 
     content = test_file.read_text()
     updated = content
+    current_base = _rulespec_base_for_file(rules_file, repo_path=repo_path)
+    relation_row_anchor_bases = [current_base] if current_base else None
     for input_name in sorted(missing_inputs):
         for input_ref in imported_inputs.get(input_name, []):
             updated = _insert_input_default_in_test_cases(
                 updated,
                 input_ref,
                 _infer_missing_input_default(input_name),
+                relation_row_anchor_bases=relation_row_anchor_bases,
             )
     for assignment in missing_assignments:
         entity_id = assignment.get("entity")
@@ -38354,6 +38357,12 @@ def _complete_missing_imported_test_inputs(
             input_names = sorted(imported_inputs)
         for input_name in input_names:
             for input_ref in imported_inputs.get(input_name, []):
+                updated = _insert_input_default_in_relation_rows_for_test_cases(
+                    updated,
+                    input_ref=input_ref,
+                    value=_infer_missing_input_default(input_name),
+                    relation_row_anchor_bases=relation_row_anchor_bases,
+                )
                 updated = _insert_input_default_in_table_entity_rows(
                     updated,
                     input_ref=input_ref,
@@ -38673,7 +38682,11 @@ def _infer_missing_input_default(input_name: str) -> object:
 
 
 def _insert_input_default_in_test_cases(
-    content: str, input_ref: str, value: object
+    content: str,
+    input_ref: str,
+    value: object,
+    *,
+    relation_row_anchor_bases: list[str] | None = None,
 ) -> str:
     """Insert an input default into every concrete test input block that needs it."""
     lines = content.splitlines(keepends=True)
@@ -38706,8 +38719,31 @@ def _insert_input_default_in_test_cases(
         indent = match.group("indent") + "  "
         newline = "\n" if lines[start].endswith("\n") else ""
         lines.insert(start + 1, f"{indent}{input_ref}: {rendered}{newline}")
-    lines = _insert_input_default_in_relation_rows(lines, input_ref, rendered)
+    lines = _insert_input_default_in_relation_rows(
+        lines,
+        input_ref,
+        rendered,
+        anchor_bases=relation_row_anchor_bases,
+    )
     return "".join(lines)
+
+
+def _insert_input_default_in_relation_rows_for_test_cases(
+    content: str,
+    *,
+    input_ref: str,
+    value: object,
+    relation_row_anchor_bases: list[str] | None = None,
+) -> str:
+    lines = content.splitlines(keepends=True)
+    lines = _expand_empty_inline_yaml_input_blocks(lines)
+    updated = _insert_input_default_in_relation_rows(
+        lines,
+        input_ref,
+        _format_yaml_scalar(value),
+        anchor_bases=relation_row_anchor_bases,
+    )
+    return "".join(updated)
 
 
 def _expand_empty_inline_yaml_input_blocks(lines: list[str]) -> list[str]:
@@ -38775,12 +38811,20 @@ def _insert_input_default_in_table_entity_rows(
 
 
 def _insert_input_default_in_relation_rows(
-    lines: list[str], input_ref: str, rendered_value: str
+    lines: list[str],
+    input_ref: str,
+    rendered_value: str,
+    *,
+    anchor_bases: list[str] | None = None,
 ) -> list[str]:
-    """Insert an input default into relation entity rows using the same module."""
+    """Insert an input default into relation entity rows sharing module anchors."""
     if "#input." not in input_ref:
         return lines
     input_base = input_ref.split("#input.", 1)[0]
+    row_anchor_bases = [input_base]
+    for anchor_base in anchor_bases or []:
+        if anchor_base and anchor_base not in row_anchor_bases:
+            row_anchor_bases.append(anchor_base)
 
     insertions: dict[int, list[str]] = {}
     remove_indices: set[int] = set()
@@ -38802,7 +38846,9 @@ def _insert_input_default_in_relation_rows(
                     break
                 item_end += 1
             item_text = "".join(lines[index:item_end])
-            if input_ref not in item_text and f"{input_base}#input." in item_text:
+            if input_ref not in item_text and any(
+                f"{anchor_base}#input." in item_text for anchor_base in row_anchor_bases
+            ):
                 carried_value, obsolete_line_indices = (
                     _similar_relation_row_input_value(
                         lines=lines,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21607,6 +21607,93 @@ rules:
             is False
         )
 
+    def test_complete_missing_imported_test_inputs_adds_relation_row_defaults(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        imported = policy_repo / "regulations/42-cfr/435/603/e.yaml"
+        dependent = policy_repo / "regulations/42-cfr/435/603/d.yaml"
+        dependent_test = policy_repo / "regulations/42-cfr/435/603/d.test.yaml"
+        imported.parent.mkdir(parents=True)
+        imported.write_text(
+            """format: rulespec/v1
+rules:
+  - name: magi_based_income
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-01-01'
+        formula: |-
+          if payment_is_income_under_section_36B_d_2_B_methodologies:
+            payment_amount
+          else:
+            0
+"""
+        )
+        dependent.write_text(
+            """format: rulespec/v1
+imports:
+  - us:regulations/42-cfr/435/603/e#magi_based_income
+rules:
+  - name: household_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2024-01-01'
+        formula: sum(member_of_individuals_household.magi_based_income)
+"""
+        )
+        dependent_test.write_text(
+            """- name: case_one
+  input:
+    us:regulations/42-cfr/435/603/d#input.federal_poverty_level_for_applicable_family_size: 20000
+    us:regulations/42-cfr/435/603/d#relation.member_of_individuals_household:
+    - us:regulations/42-cfr/435/603/d#input.expected_required_to_file_return_under_6012_a_1: true
+      us:regulations/42-cfr/435/603/d#input.included_in_household_of_natural_adopted_or_step_parent: false
+  output:
+    us:regulations/42-cfr/435/603/d#household_income: 0
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    error=(
+                        "Test case `case_one` execution failed: missing input "
+                        "`payment_is_income_under_section_36B_d_2_B_methodologies` "
+                        "for entity `case-1-us:regulations/42-cfr/435/603/d#relation.member_of_individuals_household-1` "
+                        "over 2024-01-01..2024-12-31"
+                    )
+                )
+            }
+        )
+
+        changed = _complete_missing_imported_test_inputs(
+            rules_file=dependent,
+            test_file=dependent_test,
+            repo_path=policy_repo,
+            validation=validation,
+        )
+
+        assert changed is True
+        payload = yaml.safe_load(dependent_test.read_text())
+        relation_rows = payload[0]["input"][
+            "us:regulations/42-cfr/435/603/d#relation.member_of_individuals_household"
+        ]
+        assert (
+            relation_rows[0][
+                "us:regulations/42-cfr/435/603/e#input.payment_is_income_under_section_36B_d_2_B_methodologies"
+            ]
+            is False
+        )
+        assert (
+            relation_rows[0]["us:regulations/42-cfr/435/603/e#input.payment_amount"]
+            == 0
+        )
+
     def test_repair_imported_test_inputs_writes_signed_manifest(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"
         imported = policy_repo / "statutes/26/1/h.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.950"
+version = "0.2.951"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- insert imported missing-input defaults into relation rows anchored by the generated module
- complete the imported input surface for relation rows when validation reports an entity-scoped imported input
- add a Medicaid-shaped regression for 42 CFR 435.603(d)/(e)

## Tests
- .venv/bin/python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::TestApplyDependencyValidation::test_complete_missing_imported_test_inputs_adds_relation_row_defaults -q
- .venv/bin/python -m pytest tests/test_cli.py::TestApplyDependencyValidation -k complete_missing_imported_test_inputs -q
- .venv/bin/ruff check src/axiom_encode/cli.py tests/test_cli.py src/axiom_encode/__init__.py
- .venv/bin/python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q