### PR TITLE
Allow definitional same-section references

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.951"
+version = "0.2.952"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.951"
+__version__ = "0.2.952"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -14743,6 +14743,12 @@ def _same_section_sibling_citation_requires_import(
         source_text.rfind(";", 0, citation_start),
     )
     prefix = source_text[sentence_start + 1 : citation_start]
+    if re.search(
+        r"\bas\s+defined\s+in\s*$",
+        prefix,
+        flags=re.IGNORECASE,
+    ):
+        return False
     triggers = list(
         re.finditer(
             r"\b(?:except|unless|subject\s+to|notwithstanding)\b",

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -9106,6 +9106,70 @@ rules:
     assert "regulations/42-cfr/435/602/c" in issues[0]
 
 
+def test_regulation_exception_clause_allows_defined_in_paragraph_reference(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us" / "us"
+    base = repo / "regulations" / "42-cfr" / "435" / "603"
+    for fragment, rule_name in (
+        ("d", "magi_based_household_income"),
+        ("i", "paragraph_i_exception_applies"),
+        ("j", "paragraph_j_exception_applies"),
+        ("k", "paragraph_k_exception_applies"),
+    ):
+        cited_file = base / f"{fragment}.yaml"
+        cited_file.parent.mkdir(parents=True, exist_ok=True)
+        cited_file.write_text(
+            f"""format: rulespec/v1
+rules:
+  - name: {rule_name}
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '0001-01-01'
+        formula: {rule_name}_input
+"""
+        )
+    rules_file = base / "c.yaml"
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    Except as specified in paragraphs (i), (j), and (k), the agency must determine
+    financial eligibility for Medicaid based on "household income" as defined in
+    paragraph (d).
+imports:
+  - us:regulations/42-cfr/435/603/i#paragraph_i_exception_applies
+  - us:regulations/42-cfr/435/603/j#paragraph_j_exception_applies
+  - us:regulations/42-cfr/435/603/k#paragraph_k_exception_applies
+rules:
+  - name: household_income_basis_required_for_medicaid_financial_eligibility
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          not paragraph_i_exception_applies
+          and not paragraph_j_exception_applies
+          and not paragraph_k_exception_applies
+          and agency_determines_financial_eligibility_using_household_income
+"""
+    )
+
+    assert (
+        find_missing_same_section_subsection_import_issues(
+            rules_file.read_text(),
+            rules_file=rules_file,
+            policy_repo_path=repo,
+        )
+        == []
+    )
+
+
 def test_same_section_import_check_slices_compact_cfr_parent_source(
     monkeypatch,
     tmp_path,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.951"
+version = "0.2.952"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- avoid treating same-section citations in `as defined in ...` phrases as operative exception dependencies
- add a Medicaid 42 CFR 435.603(c) regression covering true exception imports for paragraphs (i), (j), and (k) plus a non-operative definition reference to paragraph (d)
- bump axiom-encode to 0.2.952

## Tests
- `uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `uv run pytest tests/test_rulespec_validation.py -k "same_section or regulation_subject_to or exception_clause_allows_defined"`