### PR TITLE
Relax same-section validation for fallback modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.953"
+version = "0.2.954"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.953"
+__version__ = "0.2.954"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -8017,14 +8017,10 @@ def find_empty_rules_module_issues(content: str) -> list[str]:
     payload = _rulespec_payload(content)
     if payload is None:
         return []
+    if _rulespec_module_is_empty_fallback(payload):
+        return []
     rules = payload.get("rules")
     if not isinstance(rules, list) or rules:
-        return []
-    module = payload.get("module")
-    status = ""
-    if isinstance(module, dict):
-        status = str(module.get("status") or "").strip().lower()
-    if status in {"deferred", "entity_not_supported"}:
         return []
     return [
         "Empty RuleSpec module invalid: `rules: []` requires explicit "
@@ -14539,16 +14535,6 @@ def find_missing_same_section_subsection_import_issues(
     policy_repo_path: Path,
 ) -> list[str]:
     """Require imports for cited same-section siblings used as carve-outs."""
-    source_text = _extract_source_verification_text(
-        content
-    ) or extract_embedded_source_text(content)
-    if not source_text or not re.search(
-        r"\b(?:except|unless|subject\s+to)\b",
-        source_text,
-        flags=re.IGNORECASE,
-    ):
-        return []
-
     same_section_path = _same_section_path_parts_for_file(
         rules_file,
         policy_repo_path,
@@ -14556,16 +14542,28 @@ def find_missing_same_section_subsection_import_issues(
     if same_section_path is None:
         return []
     root, section_parts, current_fragments = same_section_path
+    payload = _rulespec_payload(content)
+    if payload is not None and _rulespec_module_is_empty_fallback(payload):
+        return []
+    source_text = _same_section_dependency_source_text(
+        content,
+        payload=payload,
+        same_section_path=same_section_path,
+    )
+    if not source_text or not re.search(
+        r"\b(?:except|unless|subject\s+to)\b",
+        source_text,
+        flags=re.IGNORECASE,
+    ):
+        return []
     import_items = _extract_import_items_from_content(content)
     imports = {
         _normalize_rulespec_import_path_static(import_path)
         for import_path in import_items
     }
     formula_texts: list[str] = []
-    with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
-        payload = yaml.safe_load(content)
-        if isinstance(payload, dict):
-            formula_texts = _rulespec_formula_texts(payload)
+    if payload is not None:
+        formula_texts = _rulespec_formula_texts(payload)
     formula_text = "\n".join(formula_texts)
 
     issues: list[str] = []
@@ -14577,7 +14575,7 @@ def find_missing_same_section_subsection_import_issues(
         ):
             continue
         if (
-            fragment.lower() in {part.lower() for part in current_fragments}
+            _same_section_citation_is_current_path(fragment, current_fragments)
             or fragment in seen
         ):
             continue
@@ -14616,6 +14614,104 @@ def find_missing_same_section_subsection_import_issues(
             "subsection instead of modeling its requirements as a local fact."
         )
     return issues
+
+
+def _same_section_dependency_source_text(
+    content: str,
+    *,
+    payload: dict[str, Any] | None,
+    same_section_path: tuple[str, tuple[str, ...], tuple[str, ...]],
+) -> str:
+    root, section_parts, current_fragments = same_section_path
+    if payload is not None:
+        source_verification = _source_verification_block(payload)
+        if source_verification is not None:
+            citation_paths, _source_label = _source_verification_source_fields(
+                source_verification
+            )
+            scoped_paths = tuple(
+                citation_path
+                for citation_path in citation_paths
+                if _corpus_citation_path_covers_rules_file_scope(
+                    citation_path,
+                    root=root,
+                    section_parts=section_parts,
+                    current_fragments=current_fragments,
+                )
+            )
+            if scoped_paths:
+                source_text = _source_verification_text(
+                    citation_paths=scoped_paths,
+                    source_label=", ".join(scoped_paths),
+                )
+                if source_text:
+                    return source_text
+    return extract_embedded_source_text(content)
+
+
+def _corpus_citation_path_covers_rules_file_scope(
+    citation_path: str,
+    *,
+    root: str,
+    section_parts: tuple[str, ...],
+    current_fragments: tuple[str, ...],
+) -> bool:
+    parts = tuple(
+        part.strip().lower()
+        for part in citation_path.strip().strip("/").split("/")
+        if part.strip()
+    )
+    source_kind = "statute" if root == "statutes" else "regulation"
+    if source_kind not in parts:
+        return False
+    source_index = parts.index(source_kind)
+    source_parts = parts[source_index + 1 :]
+    normalized_section_parts = _corpus_section_parts_for_rulespec_path(
+        root,
+        section_parts,
+    )
+    if source_parts[: len(normalized_section_parts)] != normalized_section_parts:
+        return False
+    source_fragments = source_parts[len(normalized_section_parts) :]
+    normalized_current_fragments = tuple(part.lower() for part in current_fragments)
+    return (
+        len(source_fragments) >= len(normalized_current_fragments)
+        and source_fragments[: len(normalized_current_fragments)]
+        == normalized_current_fragments
+    )
+
+
+def _corpus_section_parts_for_rulespec_path(
+    root: str,
+    section_parts: tuple[str, ...],
+) -> tuple[str, ...]:
+    if root == "regulations" and section_parts and section_parts[0].endswith("-cfr"):
+        return (section_parts[0].removesuffix("-cfr").lower(),) + tuple(
+            part.lower() for part in section_parts[1:]
+        )
+    return tuple(part.lower() for part in section_parts)
+
+
+def _rulespec_module_is_empty_fallback(payload: dict[str, Any]) -> bool:
+    rules = payload.get("rules")
+    if not isinstance(rules, list) or rules:
+        return False
+    module = payload.get("module")
+    status = ""
+    if isinstance(module, dict):
+        status = str(module.get("status") or "").strip().lower()
+    return status in {"deferred", "entity_not_supported"}
+
+
+def _same_section_citation_is_current_path(
+    fragment: str,
+    current_fragments: tuple[str, ...],
+) -> bool:
+    cited_parts = tuple(part.lower() for part in fragment.split("/") if part)
+    current_parts = tuple(part.lower() for part in current_fragments)
+    if cited_parts == current_parts:
+        return True
+    return len(cited_parts) == 1 and cited_parts[0] in current_parts
 
 
 def _deferred_outputs_cover_same_section_dependency(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -8951,6 +8951,150 @@ rules:
     )
 
 
+def test_same_section_reference_allows_empty_deferred_fallback(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    cited_file = repo / "statutes" / "26" / "3121" / "j.yaml"
+    cited_file.parent.mkdir(parents=True)
+    cited_file.write_text("format: rulespec/v1\nrules: []\n")
+    rules_file = repo / "statutes" / "26" / "3121" / "a.yaml"
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  status: deferred
+  summary: |-
+    Wages means all remuneration for employment, except that the term shall not
+    include remuneration for covered transportation service under subsection (j).
+  deferred_outputs:
+    - output: us:statutes/26/3121/a#wages
+      reason: The complete wages definition depends on enumerated exclusions.
+rules: []
+"""
+    )
+
+    assert (
+        find_missing_same_section_subsection_import_issues(
+            rules_file.read_text(),
+            rules_file=rules_file,
+            policy_repo_path=repo,
+        )
+        == []
+    )
+
+
+def test_same_section_reference_allows_empty_entity_not_supported_fallback(tmp_path):
+    repo = tmp_path / "rulespec-us" / "us"
+    cited_file = repo / "regulations" / "7-cfr" / "275" / "11" / "b" / "1" / "iii.yaml"
+    cited_file.parent.mkdir(parents=True)
+    cited_file.write_text("format: rulespec/v1\nrules: []\n")
+    rules_file = repo / "regulations" / "7-cfr" / "275" / "11.yaml"
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  status: entity_not_supported
+  summary: |-
+    The agency must complete quality control review activity, except that the
+    sample frame in paragraph (b)(1)(iii) is separately specified.
+rules: []
+"""
+    )
+
+    assert (
+        find_missing_same_section_subsection_import_issues(
+            rules_file.read_text(),
+            rules_file=rules_file,
+            policy_repo_path=repo,
+        )
+        == []
+    )
+
+
+def test_same_section_reference_allows_nested_self_citation(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "statutes" / "26" / "104" / "a" / "4.yaml"
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    Gross income does not include amounts received under subsection (a)(4),
+    except in the case of amounts attributable to contributions by the employer.
+rules:
+  - name: service_injury_pension_exclusion_applies
+    kind: derived
+    entity: Payment
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: payment_received_under_subsection_a_4
+"""
+    )
+
+    assert (
+        find_missing_same_section_subsection_import_issues(
+            rules_file.read_text(),
+            rules_file=rules_file,
+            policy_repo_path=repo,
+        )
+        == []
+    )
+
+
+def test_same_section_import_check_ignores_broad_parent_source_for_child_file(
+    monkeypatch,
+    tmp_path,
+):
+    repo_parent = tmp_path / "repos"
+    corpus_repo = repo_parent / "axiom-corpus"
+    monkeypatch.setenv("AXIOM_CORPUS_REPO", str(corpus_repo))
+    validator_pipeline._fetch_corpus_source_text.cache_clear()
+    validator_pipeline._fetch_local_corpus_source_text.cache_clear()
+    _write_local_corpus_provision(
+        repo_parent,
+        "us-co/statute/39/39-22-104",
+        "(1.5) Subject to subsection (2), income is taxed.\n\n"
+        "(4)(y) A qualified individual's military retirement benefits may be "
+        "subtracted up to the stated cap.",
+    )
+    repo = repo_parent / "rulespec-us" / "us-co"
+    cited_file = repo / "statutes" / "39" / "39-22-104" / "2.yaml"
+    cited_file.parent.mkdir(parents=True, exist_ok=True)
+    cited_file.write_text("format: rulespec/v1\nrules: []\n")
+    rules_file = repo / "statutes" / "39" / "39-22-104" / "4" / "y.yaml"
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-co/statute/39/39-22-104
+  summary: |-
+    Section 39-22-104(4)(y) subtracts qualified military retirement benefits
+    included in federal adjusted gross income, subject to stated dollar caps.
+rules:
+  - name: military_retirement_benefits_subtraction
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2019-01-01'
+        formula: military_retirement_benefits_included_in_federal_adjusted_gross_income
+"""
+    )
+
+    assert (
+        find_missing_same_section_subsection_import_issues(
+            rules_file.read_text(),
+            rules_file=rules_file,
+            policy_repo_path=repo,
+        )
+        == []
+    )
+
+
 def test_regulation_subject_to_paragraph_reference_requires_import(tmp_path):
     repo = tmp_path / "rulespec-us" / "us"
     cited_file = repo / "regulations" / "42-cfr" / "435" / "602" / "c.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.953"
+version = "0.2.954"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- skip same-section import enforcement for explicit empty fallback modules (`deferred` / `entity_not_supported`)
- avoid treating nested self-citations like subsection `(a)(4)` as missing same-section imports
- only use `source_verification` text for same-section dependency checks when the citation path is scoped to the RuleSpec file; broad parent citations fall back to the module summary
- bump package version to `0.2.954`

## Validation
- `uv run pytest tests/test_rulespec_validation.py -k "same_section" -q`
- `uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py src/axiom_encode/__init__.py`
- `env -u UV_FROZEN uv lock --check`
- spot-checked representative RuleSpec files:
  - `us-co/statutes/39/39-22-104/4/y.yaml` passes
  - `us-co/statutes/39/39-22-104/3/a.yaml` passes
  - `us-co/statutes/39/39-22-104/1.5.yaml` still fails as a real missing import
  - `us/statutes/7/2015/d/2/C.yaml` still fails as a real non-operational import
