### PR TITLE
Repair Colorado tax companion inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.955"
+version = "0.2.956"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.955"
+__version__ = "0.2.956"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10706,6 +10706,14 @@ COLORADO_TAX_SUBSECTION_2_MODIFIED_INCOME_IMPORT = (
 COLORADO_TAX_SUBSECTION_2_MODIFIED_INCOME_SYMBOL = (
     "federal_taxable_income_after_subsection_2_modifications"
 )
+COLORADO_TAX_SUBSECTION_2_LOCAL_TEST_INPUT = (
+    "us-co:statutes/39/39-22-104/1.5"
+    "#input.federal_taxable_income_after_subsection_2_modifications"
+)
+COLORADO_TAX_SUBSECTION_2_MODIFIED_INCOME_TARGET = (
+    "us-co:statutes/39/39-22-104/2"
+    "#federal_taxable_income_after_subsection_2_modifications"
+)
 COLORADO_TAX_VALIDATION_REPAIR_RELATIVE_OUTPUTS = (
     Path("statutes/39/39-22-104/1.5.yaml"),
     Path("statutes/39/39-22-104/1.7/a.yaml"),
@@ -10738,10 +10746,14 @@ def cmd_repair_colorado_tax_validation(args):
         args, "axiom_rules_path", None
     ) or _resolve_runtime_axiom_rules_checkout(repo_path)
 
-    content_manifest_groups = [
-        (relative_output, [content_repo_path / relative_output])
-        for relative_output in COLORADO_TAX_VALIDATION_REPAIR_RELATIVE_OUTPUTS
-    ]
+    content_manifest_groups = []
+    for relative_output in COLORADO_TAX_VALIDATION_REPAIR_RELATIVE_OUTPUTS:
+        rules_file = content_repo_path / relative_output
+        group_files = [rules_file]
+        companion = rules_file.with_name(f"{rules_file.stem}.test.yaml")
+        if companion.exists():
+            group_files.append(companion)
+        content_manifest_groups.append((relative_output, group_files))
     guard_manifest_groups = [
         (
             (content_repo_path / relative_output).relative_to(validation_repo_path),
@@ -10760,8 +10772,17 @@ def cmd_repair_colorado_tax_validation(args):
 
     try:
         changed: list[Path] = []
-        for rules_file in touched:
+        rules_files = [
+            content_repo_path / relative_output
+            for relative_output in COLORADO_TAX_VALIDATION_REPAIR_RELATIVE_OUTPUTS
+        ]
+        for rules_file in rules_files:
             changed.extend(_repair_colorado_tax_subsection_2_import(rules_file))
+            changed.extend(
+                _repair_colorado_tax_subsection_2_test_inputs(
+                    rules_file.with_name(f"{rules_file.stem}.test.yaml")
+                )
+            )
         changed = _unique_paths(changed)
         if not changed:
             print("No Colorado tax validation repairs found.")
@@ -10828,6 +10849,20 @@ def _repair_colorado_tax_subsection_2_import(rules_file: Path) -> list[Path]:
         return []
     rules_file.write_text(repaired)
     return [rules_file]
+
+
+def _repair_colorado_tax_subsection_2_test_inputs(test_file: Path) -> list[Path]:
+    if not test_file.exists():
+        return []
+    content = test_file.read_text()
+    repaired = content.replace(
+        COLORADO_TAX_SUBSECTION_2_LOCAL_TEST_INPUT,
+        COLORADO_TAX_SUBSECTION_2_MODIFIED_INCOME_TARGET,
+    )
+    if repaired == content:
+        return []
+    test_file.write_text(repaired)
+    return [test_file]
 
 
 def _rulespec_formula_references_symbol(content: str, symbol: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -73,6 +73,7 @@ from axiom_encode.cli import (
     _repair_colorado_snap_policy_composition,
     _repair_colorado_snap_program_tests,
     _repair_colorado_tax_subsection_2_import,
+    _repair_colorado_tax_subsection_2_test_inputs,
     _repair_embedded_scalar_literals,
     _repair_employer_scoped_entities,
     _repair_float_keyed_indexed_parameter_values,
@@ -11406,6 +11407,30 @@ rules:
         assert payload["imports"] == [
             "us-co:statutes/39/39-22-104/2#federal_taxable_income_after_subsection_2_modifications"
         ]
+
+    def test_repair_colorado_tax_subsection_2_rewrites_test_inputs(self, tmp_path):
+        test_file = tmp_path / "1.5.test.yaml"
+        test_file.write_text(
+            """- name: subsection_1_5_rate_applies_to_positive_modified_income
+  input:
+    us-co:statutes/39/39-22-104/1.5#input.federal_taxable_income_after_subsection_2_modifications: 100000
+  output:
+    us-co:statutes/39/39-22-104/1.5#subsection_1_5_individual_income_tax: 4750
+"""
+        )
+
+        assert _repair_colorado_tax_subsection_2_test_inputs(test_file) == [test_file]
+
+        content = test_file.read_text()
+        assert (
+            "us-co:statutes/39/39-22-104/2"
+            "#federal_taxable_income_after_subsection_2_modifications: 100000"
+            in content
+        )
+        assert (
+            "#input.federal_taxable_income_after_subsection_2_modifications"
+            not in content
+        )
 
     def test_repair_colorado_snap_2072_preserves_indentless_yaml(self, tmp_path):
         rules_file = tmp_path / "4.207.2.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.955"
+version = "0.2.956"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- include Colorado tax companion tests in the deterministic repair manifest groups
- rewrite the 39-22-104(1.5) companion test input from the local placeholder to the imported subsection (2) modified-income output
- bump axiom-encode to 0.2.956

## Tests
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run pytest tests/test_cli.py -k "colorado_tax_subsection_2" -q
- env -u UV_FROZEN uv lock --check