### PR TITLE
Repair Colorado tax companion test inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.956"
+version = "0.2.957"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.956"
+__version__ = "0.2.957"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10710,9 +10710,16 @@ COLORADO_TAX_SUBSECTION_2_LOCAL_TEST_INPUT = (
     "us-co:statutes/39/39-22-104/1.5"
     "#input.federal_taxable_income_after_subsection_2_modifications"
 )
-COLORADO_TAX_SUBSECTION_2_MODIFIED_INCOME_TARGET = (
+COLORADO_TAX_SUBSECTION_2_FEDERAL_TAXABLE_INCOME_INPUT = (
+    "us-co:statutes/39/39-22-104/2#input.federal_taxable_income"
+)
+COLORADO_TAX_SUBSECTION_2_ADDITIONS_INPUT = (
     "us-co:statutes/39/39-22-104/2"
-    "#federal_taxable_income_after_subsection_2_modifications"
+    "#input.additions_to_federal_taxable_income_provided_in_subsection_3"
+)
+COLORADO_TAX_SUBSECTION_2_SUBTRACTIONS_INPUT = (
+    "us-co:statutes/39/39-22-104/2"
+    "#input.subtractions_from_federal_taxable_income_provided_in_subsection_4"
 )
 COLORADO_TAX_VALIDATION_REPAIR_RELATIVE_OUTPUTS = (
     Path("statutes/39/39-22-104/1.5.yaml"),
@@ -10855,14 +10862,27 @@ def _repair_colorado_tax_subsection_2_test_inputs(test_file: Path) -> list[Path]
     if not test_file.exists():
         return []
     content = test_file.read_text()
-    repaired = content.replace(
-        COLORADO_TAX_SUBSECTION_2_LOCAL_TEST_INPUT,
-        COLORADO_TAX_SUBSECTION_2_MODIFIED_INCOME_TARGET,
+    repaired = re.sub(
+        rf"(?m)^(?P<indent>\s*){re.escape(COLORADO_TAX_SUBSECTION_2_LOCAL_TEST_INPUT)}:\s*(?P<value>[^\n]+)$",
+        _colorado_tax_subsection_2_input_replacement,
+        content,
     )
     if repaired == content:
         return []
     test_file.write_text(repaired)
     return [test_file]
+
+
+def _colorado_tax_subsection_2_input_replacement(match: re.Match[str]) -> str:
+    indent = match.group("indent")
+    value = match.group("value").strip()
+    return "\n".join(
+        (
+            f"{indent}{COLORADO_TAX_SUBSECTION_2_FEDERAL_TAXABLE_INCOME_INPUT}: {value}",
+            f"{indent}{COLORADO_TAX_SUBSECTION_2_ADDITIONS_INPUT}: 0",
+            f"{indent}{COLORADO_TAX_SUBSECTION_2_SUBTRACTIONS_INPUT}: 0",
+        )
+    )
 
 
 def _rulespec_formula_references_symbol(content: str, symbol: str) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11424,7 +11424,16 @@ rules:
         content = test_file.read_text()
         assert (
             "us-co:statutes/39/39-22-104/2"
-            "#federal_taxable_income_after_subsection_2_modifications: 100000"
+            "#input.federal_taxable_income: 100000" in content
+        )
+        assert (
+            "us-co:statutes/39/39-22-104/2"
+            "#input.additions_to_federal_taxable_income_provided_in_subsection_3: 0"
+            in content
+        )
+        assert (
+            "us-co:statutes/39/39-22-104/2"
+            "#input.subtractions_from_federal_taxable_income_provided_in_subsection_4: 0"
             in content
         )
         assert (

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.956"
+version = "0.2.957"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- rewrite Colorado subsection 1.5 companion test values into subsection (2) upstream inputs instead of computed outputs
- bump axiom-encode to 0.2.957 for RuleSpec toolchain pinning

## Verification
- `uv run pytest tests/test_cli.py -k "colorado_tax_subsection_2" -q`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `env -u UV_FROZEN uv lock --check`
