### PR TITLE
Validate Colorado repair artifacts only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.957"
+version = "0.2.958"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.957"
+__version__ = "0.2.958"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10802,7 +10802,7 @@ def cmd_repair_colorado_tax_validation(args):
             require_policy_proofs=True,
         )
         validation_issues: list[str] = []
-        for rules_file in touched:
+        for rules_file in rules_files:
             validation = pipeline.validate(rules_file, skip_reviewers=True)
             if validation.all_passed:
                 continue

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -171,6 +171,7 @@ from axiom_encode.cli import (
     cmd_oracle_coverage,
     cmd_repair_arizona_snap_composition,
     cmd_repair_bare_snapunit_entities,
+    cmd_repair_colorado_tax_validation,
     cmd_repair_current_year_final_amounts,
     cmd_repair_delegated_policy_settings,
     cmd_repair_embedded_scalar_literals,
@@ -11440,6 +11441,86 @@ rules:
             "#input.federal_taxable_income_after_subsection_2_modifications"
             not in content
         )
+
+    def test_repair_colorado_tax_validation_validates_only_rulespec_artifacts(
+        self, tmp_path
+    ):
+        repo_path = tmp_path / "rulespec-us"
+        content_root = repo_path / "us-co"
+        target_dir = content_root / "statutes/39/39-22-104"
+        target_dir.mkdir(parents=True)
+        for relative_output in (
+            "1.5.yaml",
+            "1.7/a.yaml",
+            "1.7/b.yaml",
+            "1.7/c.yaml",
+        ):
+            rules_file = target_dir / relative_output
+            rules_file.parent.mkdir(parents=True, exist_ok=True)
+            rules_file.write_text(
+                """format: rulespec/v1
+module:
+  summary: Colorado income tax
+rules:
+- name: subsection_1_5_individual_income_tax
+  kind: derived
+  entity: Person
+  dtype: Money
+  period: Year
+  versions:
+  - effective_from: '1999-01-01'
+    formula: max(0, federal_taxable_income_after_subsection_2_modifications)
+"""
+            )
+        companion = target_dir / "1.5.test.yaml"
+        companion.write_text(
+            """- name: subsection_1_5_rate_applies_to_positive_modified_income
+  input:
+    us-co:statutes/39/39-22-104/1.5#input.federal_taxable_income_after_subsection_2_modifications: 100000
+  output:
+    us-co:statutes/39/39-22-104/1.5#subsection_1_5_individual_income_tax: 100000
+"""
+        )
+        validated_paths: list[Path] = []
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                pass
+
+            def validate(self, rules_file, skip_reviewers=False):
+                validated_paths.append(Path(rules_file))
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch(
+                "axiom_encode.cli._require_applied_encoding_manifest_signing_key",
+                return_value=TEST_APPLY_SIGNING_KEY,
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123"},
+            ),
+            patch(
+                "axiom_encode.cli._ensure_no_unmanifested_preexisting_rulespec_changes"
+            ),
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli._write_grouped_deterministic_repair_manifests",
+                return_value=[],
+            ),
+        ):
+            cmd_repair_colorado_tax_validation(
+                SimpleNamespace(repo=repo_path, axiom_rules_path=tmp_path)
+            )
+
+        assert companion not in validated_paths
+        assert set(validated_paths) == {
+            content_root / "statutes/39/39-22-104/1.5.yaml",
+            content_root / "statutes/39/39-22-104/1.7/a.yaml",
+            content_root / "statutes/39/39-22-104/1.7/b.yaml",
+            content_root / "statutes/39/39-22-104/1.7/c.yaml",
+        }
+        assert "#input.federal_taxable_income: 100000" in companion.read_text()
 
     def test_repair_colorado_snap_2072_preserves_indentless_yaml(self, tmp_path):
         rules_file = tmp_path / "4.207.2.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.957"
+version = "0.2.958"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- validate only RuleSpec artifacts during the Colorado tax repair command
- keep companion `.test.yaml` files in deterministic manifest groups without sending them through artifact compile validation
- bump axiom-encode to 0.2.958 for RuleSpec toolchain pinning

## Verification
- `uv run pytest tests/test_cli.py -k "colorado_tax" -q`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `env -u UV_FROZEN uv lock --check`
