### PR TITLE
Fix country RuleSpec repair target anchors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.958"
+version = "0.2.959"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.958"
+__version__ = "0.2.959"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -9479,10 +9479,7 @@ def cmd_repair_judgment_positive_tests(args):
             backend="deterministic",
             model="judgment-positive-test-v1",
             tool="axiom-encode repair-judgment-positive-tests",
-            citation=(
-                f"{_repo_jurisdiction_prefix(repo_path)}:"
-                f"{_relative_rulespec_import_target(relative_output)}"
-            ),
+            citation=_rulespec_anchor_base_for_output(repo_path, relative_output),
             generation_prompt_sha256=None,
             trace_file=None,
             context_manifest_file=None,
@@ -9727,10 +9724,7 @@ def cmd_repair_proof_import_hashes(args):
         print(f"RuleSpec file {rules_file} is not under repo {repo_path}")
         sys.exit(1)
 
-    target_base = (
-        f"{_repo_jurisdiction_prefix(repo_path)}:"
-        f"{_relative_rulespec_import_target(relative_output)}"
-    )
+    target_base = _rulespec_anchor_base_for_output(repo_path, relative_output)
     test_file = _rulespec_test_path(rules_file)
     original_test_content = test_file.read_text() if test_file.exists() else None
     original_content = rules_file.read_text()
@@ -12850,10 +12844,7 @@ def cmd_repair_tax_status_components(args):
     except ValueError:
         print(f"RuleSpec file {rules_file} is not under repo {repo_path}")
         sys.exit(1)
-    target_base = (
-        f"{_repo_jurisdiction_prefix(repo_path)}:"
-        f"{_relative_rulespec_import_target(relative_output)}"
-    )
+    target_base = _rulespec_anchor_base_for_output(repo_path, relative_output)
     is_section_151_target = relative_output == Path("statutes/26/151.yaml")
 
     test_file = _rulespec_test_path(rules_file)
@@ -16034,10 +16025,7 @@ def _append_exception_positive_companion_tests_if_missing(
     if not isinstance(test_payload, list):
         return []
 
-    target_base = (
-        f"{_repo_jurisdiction_prefix(repo_path)}:"
-        f"{_relative_rulespec_import_target(relative_output)}"
-    )
+    target_base = _rulespec_anchor_base_for_output(repo_path, relative_output)
     repaired: list[str] = []
     existing_case_names = {
         str(test_case.get("name") or "").strip()
@@ -16808,10 +16796,7 @@ def _append_generated_judgment_positive_tests_if_missing(
     if not isinstance(test_payload, list):
         return []
 
-    target_base = (
-        f"{_repo_jurisdiction_prefix(repo_path)}:"
-        f"{_relative_rulespec_import_target(relative_output)}"
-    )
+    target_base = _rulespec_anchor_base_for_output(repo_path, relative_output)
     existing_case_names = {
         str(test_case.get("name") or "").strip()
         for test_case in test_payload
@@ -39135,6 +39120,18 @@ def _find_rulespec_dependents(
 
 def _relative_rulespec_import_target(relative_output: Path) -> str:
     return relative_output.with_suffix("").as_posix()
+
+
+def _rulespec_anchor_base_for_output(repo_path: Path, relative_output: Path) -> str:
+    target_path = relative_output.with_suffix("")
+    parts = target_path.parts
+    if len(parts) > 1 and parts[0] not in RULESPEC_SOURCE_ROOTS:
+        jurisdiction = parts[0]
+        target = Path(*parts[1:]).as_posix()
+    else:
+        jurisdiction = _repo_jurisdiction_prefix(repo_path)
+        target = target_path.as_posix()
+    return f"{jurisdiction}:{target}"
 
 
 def _rulespec_file_imports_target(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,6 +108,7 @@ from axiom_encode.cli import (
     _rewrite_import_output_test_input_refs,
     _rewrite_judgment_conditional_formulas,
     _rewrite_judgment_numeric_comparisons,
+    _rulespec_anchor_base_for_output,
     _rulespec_apply_content_root,
     _rulespec_scalar_matches,
     _scoped_source_text_for_encode_source_id,
@@ -15440,6 +15441,69 @@ rules:
         assert (
             "us:statutes/26/3303#input.account_maintained_for_employer"
             not in synthesized["input"]
+        )
+
+    def test_judgment_positive_test_repair_strips_country_repo_root(self, tmp_path):
+        repo_path = tmp_path / "rulespec-us"
+        rules_file = repo_path / "us" / "statutes" / "5" / "5566.yaml"
+        test_file = repo_path / "us" / "statutes" / "5" / "5566.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: agency_determination_conclusive_as_to_dependency
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          head_or_designee_made_determination_necessary_to_administer_subchapter
+          and determination_is_as_to_fact_of_dependency_under_subchapter
+"""
+        )
+        test_file.write_text("[]\n")
+
+        repaired = _append_generated_judgment_positive_tests_if_missing(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=repo_path,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            relative_output=Path("us/statutes/5/5566.yaml"),
+            issues=[
+                "Judgment rule missing positive companion output coverage: "
+                "`us:statutes/5/5566#agency_determination_conclusive_as_to_dependency` "
+                "is not asserted as `holds` by the companion `.test.yaml` file."
+            ],
+        )
+
+        assert repaired == [
+            "auto_positive_agency_determination_conclusive_as_to_dependency"
+        ]
+        auto_case = yaml.safe_load(test_file.read_text())[-1]
+        assert auto_case["input"] == {
+            "us:statutes/5/5566#input.determination_is_as_to_fact_of_dependency_under_subchapter": True,
+            "us:statutes/5/5566#input.head_or_designee_made_determination_necessary_to_administer_subchapter": True,
+        }
+        assert auto_case["output"] == {
+            "us:statutes/5/5566#agency_determination_conclusive_as_to_dependency": "holds"
+        }
+
+    def test_rulespec_anchor_base_for_output_uses_country_relative_root(self, tmp_path):
+        repo_path = tmp_path / "rulespec-us"
+
+        assert (
+            _rulespec_anchor_base_for_output(repo_path, Path("us/statutes/5/5566.yaml"))
+            == "us:statutes/5/5566"
+        )
+        assert (
+            _rulespec_anchor_base_for_output(
+                repo_path, Path("us-co/statutes/39/39-22-104/1.5.yaml")
+            )
+            == "us-co:statutes/39/39-22-104/1.5"
+        )
+        assert (
+            _rulespec_anchor_base_for_output(repo_path, Path("statutes/5/5566.yaml"))
+            == "us:statutes/5/5566"
         )
 
     def test_judgment_positive_test_repair_uses_imported_companion_inputs(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.958"
+version = "0.2.959"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a shared country-aware RuleSpec anchor helper for repair commands
- use it for judgment, proof-import, tax-status, and exception companion repairs so country-level paths do not become `us:us/...`
- add regression coverage for `rulespec-us/us/...` and subjurisdiction paths

## Tests
- `uv run pytest tests/test_cli.py -k "judgment_positive_test_repair_strips_country_repo_root or rulespec_anchor_base_for_output or judgment_positive_test_repair_synthesizes_formula_inputs" -q`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `env -u UV_FROZEN uv lock --check`