### PR TITLE
Prefer legal Judgment positive branches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.959"
+version = "0.2.960"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.959"
+__version__ = "0.2.960"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -12797,10 +12797,7 @@ def cmd_repair_tax_filing_status_branches(args):
             backend="deterministic",
             model="tax-filing-status-branch-v1",
             tool="axiom-encode repair-tax-filing-status-branches",
-            citation=(
-                f"{_repo_jurisdiction_prefix(repo_path)}:"
-                f"{_relative_rulespec_import_target(relative_output)}"
-            ),
+            citation=_rulespec_anchor_base_for_output(repo_path, relative_output),
             generation_prompt_sha256=None,
             trace_file=None,
             context_manifest_file=None,
@@ -13076,10 +13073,7 @@ def cmd_repair_tax_status_components(args):
             backend="deterministic",
             model="tax-status-component-v1",
             tool="axiom-encode repair-tax-status-components",
-            citation=(
-                f"{_repo_jurisdiction_prefix(repo_path)}:"
-                f"{_relative_rulespec_import_target(relative_output)}"
-            ),
+            citation=_rulespec_anchor_base_for_output(repo_path, relative_output),
             generation_prompt_sha256=None,
             trace_file=None,
             context_manifest_file=None,
@@ -17067,6 +17061,71 @@ def _positive_judgment_formula_input_assignments(
     return assignments
 
 
+_FORBIDDEN_GENERATED_JUDGMENT_INPUTS = {"filing_status", "tax_filing_status"}
+
+
+def _positive_judgment_assignments_use_forbidden_inputs(
+    assignments: dict[str, object],
+) -> bool:
+    return any(
+        input_name in _FORBIDDEN_GENERATED_JUDGMENT_INPUTS for input_name in assignments
+    )
+
+
+def _split_top_level_boolean_disjunction(formula: str) -> list[str]:
+    stripped_formula = _strip_balanced_outer_parentheses(formula.strip())
+    branches: list[str] = []
+    depth = 0
+    quote: str | None = None
+    branch_start = 0
+    index = 0
+    while index < len(stripped_formula):
+        char = stripped_formula[index]
+        if quote:
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            continue
+        if char in "([{":
+            depth += 1
+            index += 1
+            continue
+        if char in ")]}":
+            if depth:
+                depth -= 1
+            index += 1
+            continue
+        if (
+            depth == 0
+            and stripped_formula.startswith("or", index)
+            and _is_word_operator_at(stripped_formula, index, len("or"))
+        ):
+            branch = stripped_formula[branch_start:index].strip()
+            if branch:
+                branches.append(_strip_balanced_outer_parentheses(branch))
+            index += len("or")
+            branch_start = index
+            continue
+        index += 1
+    final_branch = stripped_formula[branch_start:].strip()
+    if final_branch:
+        branches.append(_strip_balanced_outer_parentheses(final_branch))
+    return [branch for branch in branches if branch]
+
+
+def _is_word_operator_at(text: str, start: int, length: int) -> bool:
+    before = text[start - 1] if start > 0 else " "
+    after_index = start + length
+    after = text[after_index] if after_index < len(text) else " "
+    return not (before.isalnum() or before == "_") and not (
+        after.isalnum() or after == "_"
+    )
+
+
 def _positive_judgment_formula_input_assignments_for_formula(
     *,
     formula: str,
@@ -17075,6 +17134,29 @@ def _positive_judgment_formula_input_assignments_for_formula(
     imported_outputs: set[str],
     seen_rules: set[str],
 ) -> tuple[dict[str, object], set[str]]:
+    disjuncts = _split_top_level_boolean_disjunction(formula)
+    if len(disjuncts) > 1:
+        branch_results: list[tuple[dict[str, object], set[str]]] = []
+        for disjunct in disjuncts:
+            branch_assignments, branch_protected_inputs = (
+                _positive_judgment_formula_input_assignments_for_formula(
+                    formula=disjunct,
+                    rules_payload=rules_payload,
+                    rules_by_name=rules_by_name,
+                    imported_outputs=imported_outputs,
+                    seen_rules=seen_rules,
+                )
+            )
+            if branch_assignments or branch_protected_inputs:
+                branch_results.append((branch_assignments, branch_protected_inputs))
+        legal_branch_results = [
+            result
+            for result in branch_results
+            if not _positive_judgment_assignments_use_forbidden_inputs(result[0])
+        ]
+        if legal_branch_results:
+            return min(legal_branch_results, key=lambda result: len(result[0]))
+
     negated_group_spans = _negated_parenthesized_expression_spans(formula)
     positive_context_formula = _formula_with_spans_blank(
         formula,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15488,6 +15488,53 @@ rules:
             "us:statutes/5/5566#agency_determination_conclusive_as_to_dependency": "holds"
         }
 
+    def test_judgment_positive_test_repair_prefers_legal_or_branch(self, tmp_path):
+        repo_path = tmp_path / "rulespec-us"
+        rules_file = repo_path / "statutes" / "26" / "21.yaml"
+        test_file = repo_path / "statutes" / "26" / "21.test.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: treated_as_not_married_under_section_21
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          legally_separated_under_decree
+          or (
+              filing_status == 2
+              and maintains_household_principal_abode_of_qualifying_individual_more_than_half_year
+              and furnishes_over_half_cost_of_household
+              and spouse_not_member_of_household_during_last_six_months
+          )
+"""
+        )
+        test_file.write_text("[]\n")
+
+        repaired = _append_generated_judgment_positive_tests_if_missing(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=repo_path,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+            relative_output=Path("statutes/26/21.yaml"),
+            issues=[
+                "Judgment rule missing positive companion output coverage: "
+                "`us:statutes/26/21#treated_as_not_married_under_section_21` "
+                "is not asserted as `holds` by the companion `.test.yaml` file."
+            ],
+        )
+
+        assert repaired == ["auto_positive_treated_as_not_married_under_section_21"]
+        auto_case = yaml.safe_load(test_file.read_text())[-1]
+        assert auto_case["input"] == {
+            "us:statutes/26/21#input.legally_separated_under_decree": True
+        }
+        assert auto_case["output"] == {
+            "us:statutes/26/21#treated_as_not_married_under_section_21": "holds"
+        }
+
     def test_rulespec_anchor_base_for_output_uses_country_relative_root(self, tmp_path):
         repo_path = tmp_path / "rulespec-us"
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.959"
+version = "0.2.960"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Prefer positive Judgment repair branches that avoid generated legal-classification inputs such as `filing_status`.
- Split top-level boolean `or` formulas so deterministic positive companions can use the shortest legal factual branch.
- Use the shared country-aware RuleSpec anchor helper for two remaining signed repair manifest citations.

## Tests
- `uv run pytest tests/test_cli.py -k "judgment_positive_test_repair_prefers_legal_or_branch or judgment_positive_test_repair_strips_country_repo_root or rulespec_anchor_base_for_output or judgment_positive_test_repair_synthesizes_formula_inputs" -q`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `env -u UV_FROZEN uv lock --check`
