### PR TITLE
Fill neutral Judgment branch inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.960"
+version = "0.2.961"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.960"
+__version__ = "0.2.961"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -17136,7 +17136,7 @@ def _positive_judgment_formula_input_assignments_for_formula(
 ) -> tuple[dict[str, object], set[str]]:
     disjuncts = _split_top_level_boolean_disjunction(formula)
     if len(disjuncts) > 1:
-        branch_results: list[tuple[dict[str, object], set[str]]] = []
+        branch_results: list[tuple[str, dict[str, object], set[str]]] = []
         for disjunct in disjuncts:
             branch_assignments, branch_protected_inputs = (
                 _positive_judgment_formula_input_assignments_for_formula(
@@ -17148,14 +17148,28 @@ def _positive_judgment_formula_input_assignments_for_formula(
                 )
             )
             if branch_assignments or branch_protected_inputs:
-                branch_results.append((branch_assignments, branch_protected_inputs))
+                branch_results.append(
+                    (disjunct, branch_assignments, branch_protected_inputs)
+                )
         legal_branch_results = [
             result
             for result in branch_results
-            if not _positive_judgment_assignments_use_forbidden_inputs(result[0])
+            if not _positive_judgment_assignments_use_forbidden_inputs(result[1])
         ]
         if legal_branch_results:
-            return min(legal_branch_results, key=lambda result: len(result[0]))
+            _chosen_disjunct, branch_assignments, branch_protected_inputs = min(
+                legal_branch_results,
+                key=lambda result: len(result[1]),
+            )
+            assignments = _neutral_unassigned_formula_input_assignments(
+                formula=formula,
+                rules_payload=rules_payload,
+                rules_by_name=rules_by_name,
+                imported_outputs=imported_outputs,
+                assigned_inputs=set(branch_assignments),
+            )
+            assignments.update(branch_assignments)
+            return assignments, branch_protected_inputs
 
     negated_group_spans = _negated_parenthesized_expression_spans(formula)
     positive_context_formula = _formula_with_spans_blank(
@@ -17250,6 +17264,26 @@ def _positive_judgment_formula_input_assignments_for_formula(
         )
 
     return assignments, protected_positive_inputs
+
+
+def _neutral_unassigned_formula_input_assignments(
+    *,
+    formula: str,
+    rules_payload: dict[str, object],
+    rules_by_name: dict[str, dict[str, object]],
+    imported_outputs: set[str],
+    assigned_inputs: set[str],
+) -> dict[str, object]:
+    defined_symbols = set(rules_by_name) | imported_outputs
+    assignments: dict[str, object] = {}
+    for identifier in sorted(_formula_identifiers(formula)):
+        if identifier in defined_symbols or identifier in assigned_inputs:
+            continue
+        assignments[identifier] = _default_generated_test_input_value(
+            identifier,
+            rules_payload=rules_payload,
+        )
+    return assignments
 
 
 def _positive_count_helper_input_assignments(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15529,7 +15529,11 @@ rules:
         assert repaired == ["auto_positive_treated_as_not_married_under_section_21"]
         auto_case = yaml.safe_load(test_file.read_text())[-1]
         assert auto_case["input"] == {
-            "us:statutes/26/21#input.legally_separated_under_decree": True
+            "us:statutes/26/21#input.filing_status": 0,
+            "us:statutes/26/21#input.furnishes_over_half_cost_of_household": False,
+            "us:statutes/26/21#input.legally_separated_under_decree": True,
+            "us:statutes/26/21#input.maintains_household_principal_abode_of_qualifying_individual_more_than_half_year": False,
+            "us:statutes/26/21#input.spouse_not_member_of_household_during_last_six_months": False,
         }
         assert auto_case["output"] == {
             "us:statutes/26/21#treated_as_not_married_under_section_21": "holds"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.960"
+version = "0.2.961"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Complete generated positive Judgment tests for top-level `or` formulas by filling neutral defaults for unchosen local formula inputs.
- Preserve the legal branch selection from #868 while satisfying proof-required explicit-input validation.
- Bump `axiom-encode` to `0.2.961` for the follow-up RuleSpec repair.

## Tests
- `uv run pytest tests/test_cli.py -k "judgment_positive_test_repair_prefers_legal_or_branch or judgment_positive_test_repair_strips_country_repo_root or rulespec_anchor_base_for_output or judgment_positive_test_repair_synthesizes_formula_inputs" -q`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `env -u UV_FROZEN uv lock --check`
