### PR TITLE
Resolve country RuleSpec import files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.961"
+version = "0.2.962"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.961"
+__version__ = "0.2.962"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -15566,27 +15566,16 @@ def _expected_proof_import_hash(
         return "sha256:local"
 
     normalized = target.strip().strip("'\"")
-    match = re.match(r"^(?P<prefix>[a-z][a-z0-9_-]*):(?P<path>[^#]+)", normalized)
-    if match is None:
+    target_ref = _parse_rulespec_target(normalized)
+    if target_ref is None:
         return None
-    if match.group("prefix") != _repo_jurisdiction_prefix(repo_path):
+    if target_ref.prefix != _repo_jurisdiction_prefix(repo_path):
         return None
 
-    target_path = match.group("path").strip().strip("/")
-    if not target_path:
+    target_file = _resolve_rulespec_target_file(target_ref, repo_path)
+    if target_file is None or not target_file.exists():
         return None
-    target_relative = Path(target_path)
-    if target_relative.is_absolute() or any(
-        part in {"", ".", ".."} for part in target_relative.parts
-    ):
-        return None
-    if not target_path.endswith((".yaml", ".yml")):
-        target_relative = Path(f"{target_path}.yaml")
-
-    target_file = (repo_path / target_relative).resolve()
-    if not target_file.exists():
-        return None
-    if target_file == rules_file.resolve():
+    if target_file.resolve() == rules_file.resolve():
         return "sha256:local"
     return f"sha256:{hashlib.sha256(target_file.read_bytes()).hexdigest()}"
 
@@ -38797,12 +38786,24 @@ def _import_base_to_repo_file(import_base: str, *, repo_path: Path) -> Path | No
     if not normalized:
         return None
     if ":" in normalized:
+        target_ref = _parse_rulespec_target(normalized)
+        if target_ref is not None:
+            target_file = _resolve_rulespec_target_file(target_ref, repo_path)
+            if target_file is not None:
+                return target_file
         _, normalized = normalized.split(":", 1)
     if normalized.endswith((".yaml", ".yml")):
         relative = Path(normalized)
     else:
         relative = Path(f"{normalized}.yaml")
-    return repo_path / relative
+    candidates = [repo_path / relative]
+    prefix = _repo_jurisdiction_prefix(repo_path)
+    if relative.parts and relative.parts[0] in RULESPEC_SOURCE_ROOTS:
+        candidates.append(repo_path / prefix / relative)
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
 
 
 def _load_test_input_baseline(test_path: Path) -> dict[str, object]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,9 +41,11 @@ from axiom_encode.cli import (
     _ensure_generated_dependency_files_safe,
     _ensure_no_california_snap_sua_layout_collision,
     _ensure_no_unmanifested_preexisting_rulespec_changes,
+    _expected_proof_import_hash,
     _find_rulespec_dependents,
     _has_zero_output_test,
     _hoist_nested_test_tables,
+    _import_base_to_repo_file,
     _infer_missing_input_default,
     _inline_medicaid_magi_income_helpers,
     _insert_false_input_default,
@@ -15555,6 +15557,39 @@ rules:
         assert (
             _rulespec_anchor_base_for_output(repo_path, Path("statutes/5/5566.yaml"))
             == "us:statutes/5/5566"
+        )
+
+    def test_import_base_to_repo_file_resolves_country_content_root(self, tmp_path):
+        repo_path = tmp_path / "rulespec-us"
+        imported = repo_path / "us" / "statutes" / "26" / "3306" / "c" / "9.yaml"
+        imported.parent.mkdir(parents=True)
+        imported.write_text("format: rulespec/v1\nrules: []\n")
+
+        assert (
+            _import_base_to_repo_file(
+                "us:statutes/26/3306/c/9",
+                repo_path=repo_path,
+            )
+            == imported
+        )
+
+    def test_expected_proof_import_hash_resolves_country_content_root(self, tmp_path):
+        repo_path = tmp_path / "rulespec-us"
+        imported = repo_path / "us" / "statutes" / "26" / "3306" / "c" / "9.yaml"
+        target = repo_path / "us" / "statutes" / "26" / "3306" / "d.yaml"
+        imported.parent.mkdir(parents=True)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        imported.write_text("format: rulespec/v1\nrules: []\n")
+        target.write_text("format: rulespec/v1\nrules: []\n")
+
+        assert (
+            _expected_proof_import_hash(
+                "us:statutes/26/3306/c/9#railroad_employee_or_employee_representative_service_excepted_from_employment",
+                target_base="us:statutes/26/3306/d",
+                rules_file=target,
+                repo_path=repo_path,
+            )
+            == f"sha256:{_sha256_file(imported)}"
         )
 
     def test_judgment_positive_test_repair_uses_imported_companion_inputs(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.961"
+version = "0.2.962"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Resolve canonical RuleSpec imports through the shared country-aware target resolver in proof-hash repair paths
- Add country-level repo regression tests for import-file resolution and proof import hashes
- Bump axiom-encode to 0.2.962

## Tests
- uv run pytest tests/test_cli.py -k "country_content_root or proof_import_hashes or rulespec_anchor_base_for_output" -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- env -u UV_FROZEN uv lock --check