### PR TITLE
Iterate validation structure repairs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.963"
+version = "0.2.964"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.963"
+__version__ = "0.2.964"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10107,45 +10107,69 @@ def _cmd_repair_generated_validation_issues(
             generated_test = _rulespec_test_path(generated_output)
             generated_test.write_text(original_test_content)
 
-        repaired_items = repair(
-            argparse.Namespace(
-                result=repair_args,
-                output_root=output_root,
-                repo_path=repair_repo_path,
-                issues=before_issues,
+        pending_issues = before_issues
+        repaired_items: list[str] = []
+        after_validation = before_validation
+        for _ in range(20):
+            pass_items = repair(
+                argparse.Namespace(
+                    result=repair_args,
+                    output_root=output_root,
+                    repo_path=repair_repo_path,
+                    issues=pending_issues,
+                )
             )
-        )
-        if not repaired_items:
-            print(no_repair_message)
-            return
+            if not pass_items:
+                if not repaired_items:
+                    print(no_repair_message)
+                    return
+                rules_file.write_text(original_content)
+                if original_test_content is not None:
+                    test_file.write_text(original_test_content)
+                print("Repair failed validation; restored original file.")
+                for issue in pending_issues:
+                    print(f"- {issue}")
+                sys.exit(1)
+            repaired_items.extend(pass_items)
 
-        repaired_content = generated_output.read_text()
-        repaired_test_content = (
-            _rulespec_test_path(generated_output).read_text()
-            if original_test_content is not None
-            else None
-        )
+            repaired_content = generated_output.read_text()
+            repaired_test_content = (
+                _rulespec_test_path(generated_output).read_text()
+                if original_test_content is not None
+                else None
+            )
+            rules_file.write_text(repaired_content)
+            if repaired_test_content is not None:
+                test_file.write_text(repaired_test_content)
 
-        signing_key = _require_applied_encoding_manifest_signing_key()
-        axiom_encode_git = _require_clean_axiom_encode_git_provenance()
-        rules_file.write_text(repaired_content)
-        if repaired_test_content is not None:
-            test_file.write_text(repaired_test_content)
-
-        after_validation = pipeline.validate(rules_file, skip_reviewers=True)
-        if not after_validation.all_passed:
-            rules_file.write_text(original_content)
-            if original_test_content is not None:
-                test_file.write_text(original_test_content)
-            issues = [
+            after_validation = pipeline.validate(rules_file, skip_reviewers=True)
+            if after_validation.all_passed:
+                break
+            pending_issues = [
                 result.error
                 for result in after_validation.results.values()
                 if result.error
             ]
-            print("Repair failed validation; restored original file.")
-            for issue in issues:
+        else:
+            rules_file.write_text(original_content)
+            if original_test_content is not None:
+                test_file.write_text(original_test_content)
+            print("Repair failed validation after 20 passes; restored original file.")
+            for issue in pending_issues:
                 print(f"- {issue}")
             sys.exit(1)
+
+        if not after_validation.all_passed:
+            rules_file.write_text(original_content)
+            if original_test_content is not None:
+                test_file.write_text(original_test_content)
+            print("Repair failed validation; restored original file.")
+            for issue in pending_issues:
+                print(f"- {issue}")
+            sys.exit(1)
+
+        signing_key = _require_applied_encoding_manifest_signing_key()
+        axiom_encode_git = _require_clean_axiom_encode_git_provenance()
 
         repair_args.citation = _rulespec_anchor_base_for_output(
             repo_path, relative_output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19136,21 +19136,38 @@ rules:
             def validate(self, path, *, skip_reviewers):
                 assert path == target.resolve()
                 assert skip_reviewers is True
-                if "deferred_outputs:" in target.read_text():
-                    return SimpleNamespace(all_passed=True, results={})
-                return SimpleNamespace(
-                    all_passed=False,
-                    results={
-                        "ci": SimpleNamespace(
-                            error=(
-                                "Source sub-paragraph coverage missing: "
-                                "26 USC 26(b) ('Regular tax liability For "
-                                "purposes of this part') has no rule citing it "
-                                "and no entry in `module.deferred_outputs`."
+                target_text = target.read_text()
+                if "us:statutes/26/26/b#" not in target_text:
+                    return SimpleNamespace(
+                        all_passed=False,
+                        results={
+                            "ci": SimpleNamespace(
+                                error=(
+                                    "Source sub-paragraph coverage missing: "
+                                    "26 USC 26(b) ('Regular tax liability For "
+                                    "purposes of this part') has no rule citing it "
+                                    "and no entry in `module.deferred_outputs`."
+                                )
                             )
-                        )
-                    },
-                )
+                        },
+                    )
+                if "us:statutes/26/26/c#" not in target_text:
+                    return SimpleNamespace(
+                        all_passed=False,
+                        results={
+                            "ci": SimpleNamespace(
+                                error=(
+                                    "Source sub-paragraph coverage missing: "
+                                    "26 USC 26(c) ('Tentative minimum tax For "
+                                    "purposes of this part') has no rule citing it "
+                                    "and no entry in `module.deferred_outputs`."
+                                )
+                            )
+                        },
+                    )
+                if "deferred_outputs:" in target_text:
+                    return SimpleNamespace(all_passed=True, results={})
+                raise AssertionError("expected deferred outputs to be added")
 
         with (
             patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
@@ -19168,6 +19185,7 @@ rules:
         payload = yaml.safe_load(target.read_text())
         deferred_outputs = payload["module"]["deferred_outputs"]
         assert deferred_outputs[0]["output"].startswith("us:statutes/26/26/b#")
+        assert deferred_outputs[1]["output"].startswith("us:statutes/26/26/c#")
         manifest = policy_repo / ".axiom/encoding-manifests/us/statutes/26/26.json"
         manifest_payload = json.loads(manifest.read_text())
         assert manifest_payload["model"] == "missing-deferred-output-v1"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.963"
+version = "0.2.964"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- make signed validation-structure repairs iterate over fresh validator issues until the target passes
- preserve restore-on-failure behavior when no further deterministic repair is available
- extend the missing-deferred-output test to cover sequential 26(b)/26(c) repairs

## Tests
- uv run pytest tests/test_cli.py -k "same_section_subsection_imports or missing_deferred_output" -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- env -u UV_FROZEN uv lock --check