### PR TITLE
Validate structure repairs against content root

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.964"
+version = "0.2.965"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.964"
+__version__ = "0.2.965"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10072,11 +10072,14 @@ def _cmd_repair_generated_validation_issues(
     test_file = _rulespec_test_path(rules_file)
     original_content = rules_file.read_text()
     original_test_content = test_file.read_text() if test_file.exists() else None
+    repair_repo_path = _generated_validation_repair_policy_repo_path(
+        repo_path, relative_output
+    )
     axiom_rules_path = getattr(
         args, "axiom_rules_path", None
     ) or _resolve_runtime_axiom_rules_checkout(repo_path)
     pipeline = ValidatorPipeline(
-        policy_repo_path=repo_path,
+        policy_repo_path=repair_repo_path,
         axiom_rules_path=axiom_rules_path,
         enable_oracles=False,
         require_policy_proofs=True,
@@ -10089,9 +10092,6 @@ def _cmd_repair_generated_validation_issues(
         print(no_repair_message)
         return
 
-    repair_repo_path = _generated_validation_repair_policy_repo_path(
-        repo_path, relative_output
-    )
     with tempfile.TemporaryDirectory() as tmpdir:
         output_root = Path(tmpdir)
         repair_args = _validation_issue_repair_args(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19055,6 +19055,7 @@ rules:
 
         class FakePipeline:
             def __init__(self, **kwargs):
+                assert kwargs["policy_repo_path"] == policy_repo / "us"
                 assert kwargs["require_policy_proofs"] is True
 
             def validate(self, path, *, skip_reviewers):
@@ -19131,6 +19132,7 @@ rules:
 
         class FakePipeline:
             def __init__(self, **kwargs):
+                assert kwargs["policy_repo_path"] == policy_repo / "us"
                 assert kwargs["require_policy_proofs"] is True
 
             def validate(self, path, *, skip_reviewers):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.964"
+version = "0.2.965"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- validate generated validation repairs against the derived country content root instead of the repository root
- keep signed manifest writing rooted at the RuleSpec repository
- bump axiom-encode to 0.2.965

## Tests
- uv run pytest tests/test_cli.py -k "same_section_subsection_imports or missing_deferred_output" -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- env -u UV_FROZEN uv lock --check