### PR TITLE
Fix repair import insertion for country roots

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.965"
+version = "0.2.966"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.965"
+__version__ = "0.2.966"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10843,7 +10843,15 @@ def _ensure_rulespec_import(content: str, import_item: str) -> str:
     lines = content.splitlines(keepends=True)
     for index, line in enumerate(lines):
         if re.match(r"^imports:\s*$", line):
-            lines.insert(index + 1, f"  - {import_item}\n")
+            item_indent = "  "
+            for following in lines[index + 1 :]:
+                if not following.strip():
+                    continue
+                item_match = re.match(r"^(\s*)-\s+", following)
+                if item_match:
+                    item_indent = item_match.group(1)
+                break
+            lines.insert(index + 1, f"{item_indent}- {import_item}\n")
             return "".join(lines)
     insert_at = 1 if lines and re.match(r"^format:\s*", lines[0]) else 0
     lines.insert(insert_at, f"imports:\n  - {import_item}\n")

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -18995,6 +18995,17 @@ def _monorepo_rulespec_repo_alias(
     return alias_parent, canonical_name
 
 
+def _is_canonical_monorepo_content_root(policy_repo_path: Path) -> bool:
+    """Return true for a country content root inside its canonical checkout."""
+    policy_root = Path(policy_repo_path).resolve()
+    monorepo_root = policy_root.parent
+    if not monorepo_root.name.startswith("rulespec-"):
+        return False
+    if policy_root.name not in jurisdiction_subdir_names(monorepo_root):
+        return False
+    return canonical_rulespec_repo_name(monorepo_root) == monorepo_root.name
+
+
 def _rulespec_repo_alias_parent_for_root(
     rulespec_root: Path,
     canonical_name: str | None,
@@ -19035,6 +19046,8 @@ def _canonical_rulespec_compile_path(
         except ValueError:
             return rules_file
         return monorepo_alias_parent / monorepo_canonical_name / relative
+    if _is_canonical_monorepo_content_root(policy_repo_path):
+        return rules_file
 
     alias_parent = _rulespec_repo_alias_parent(policy_repo_path)
     canonical_name = canonical_rulespec_repo_name(policy_repo_path)
@@ -19858,9 +19871,10 @@ class ValidatorPipeline:
         if monorepo_alias is not None:
             monorepo_alias_parent, _monorepo_canonical_name = monorepo_alias
             roots.append(monorepo_alias_parent)
-        alias_parent = _rulespec_repo_alias_parent(self.policy_repo_path)
-        if alias_parent is not None:
-            roots.append(alias_parent)
+        if not _is_canonical_monorepo_content_root(self.policy_repo_path):
+            alias_parent = _rulespec_repo_alias_parent(self.policy_repo_path)
+            if alias_parent is not None:
+                roots.append(alias_parent)
         roots.append(self.policy_repo_path)
         existing_roots = env.get("AXIOM_RULESPEC_REPO_ROOTS", "")
         if existing_roots:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ from axiom_encode.cli import (
     _ensure_generated_dependency_files_safe,
     _ensure_no_california_snap_sua_layout_collision,
     _ensure_no_unmanifested_preexisting_rulespec_changes,
+    _ensure_rulespec_import,
     _expected_proof_import_hash,
     _find_rulespec_dependents,
     _has_zero_output_test,
@@ -249,6 +250,33 @@ def test_package_version_metadata_matches_pyproject():
 
     assert pyproject["project"]["version"] == AXIOM_ENCODE_TEST_VERSION
     assert lock_version == AXIOM_ENCODE_TEST_VERSION
+
+
+def test_ensure_rulespec_import_preserves_unindented_import_list():
+    content = """format: rulespec/v1
+imports:
+- us:statutes/26/3121/n#member_of_uniformed_service
+module:
+  proof_validation:
+    required: true
+rules: []
+"""
+
+    repaired = _ensure_rulespec_import(
+        content,
+        "us:statutes/26/3121/a/1",
+    )
+
+    assert (
+        "imports:\n"
+        "- us:statutes/26/3121/a/1\n"
+        "- us:statutes/26/3121/n#member_of_uniformed_service\n"
+    ) in repaired
+    payload = yaml.safe_load(repaired)
+    assert payload["imports"] == [
+        "us:statutes/26/3121/a/1",
+        "us:statutes/26/3121/n#member_of_uniformed_service",
+    ]
 
 
 def test_current_encoder_affecting_changes_are_behind_version_bump():

--- a/tests/test_repo_routing.py
+++ b/tests/test_repo_routing.py
@@ -97,6 +97,28 @@ def test_canonical_compile_path_keeps_monorepo_jurisdiction_under_country_alias(
     assert compile_path.resolve() == rules_file.resolve()
 
 
+def test_canonical_compile_path_keeps_canonical_country_content_root_segment(
+    tmp_path,
+):
+    checkout = tmp_path / "rulespec-us"
+    _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")
+    policy_root = checkout / "us"
+    rules_file = policy_root / "statutes" / "26" / "3121" / "i.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text("format: rulespec/v1\nrules: []\n")
+
+    compile_path = _canonical_rulespec_compile_path(rules_file, policy_root)
+
+    assert compile_path == rules_file
+    assert compile_path.parts[-5:] == (
+        "us",
+        "statutes",
+        "26",
+        "3121",
+        "i.yaml",
+    )
+
+
 def test_compile_env_exposes_monorepo_for_jurisdiction_subdir(tmp_path):
     checkout = tmp_path / "rulespec-us-clean.abcd"
     _init_checkout(checkout, "https://github.com/TheAxiomFoundation/rulespec-us.git")

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.965"
+version = "0.2.966"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- preserve existing YAML list indentation when deterministic repairs insert RuleSpec imports
- avoid aliasing canonical country content roots such as rulespec-us/us to a path that drops the country segment
- bump axiom-encode to 0.2.966

## Tests
- uv run pytest tests/test_repo_routing.py tests/test_cli.py -k "canonical_compile_path or ensure_rulespec_import or same_section_subsection_imports or missing_deferred_output" -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- env -u UV_FROZEN uv lock --check