### PR TITLE
Add child-fragment reencoding repair

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.966"
+version = "0.2.967"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.966"
+__version__ = "0.2.967"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1313,6 +1313,31 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_child_fragment_parser = subparsers.add_parser(
+        "repair-child-fragment-reencoding",
+        help=(
+            "Apply signed deterministic repairs for parent files that re-encode "
+            "child fragment outputs"
+        ),
+    )
+    repair_child_fragment_parser.add_argument(
+        "file", type=Path, help="RuleSpec YAML file"
+    )
+    repair_child_fragment_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="Rules repository root used for manifest signing",
+    )
+    repair_child_fragment_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_missing_deferred_parser = subparsers.add_parser(
         "repair-missing-deferred-outputs",
         help="Apply signed deterministic repairs for source coverage gaps",
@@ -2350,6 +2375,8 @@ def main():
         cmd_repair_unreferenced_proof_imports(args)
     elif args.command == "repair-same-section-subsection-imports":
         cmd_repair_same_section_subsection_imports(args)
+    elif args.command == "repair-child-fragment-reencoding":
+        cmd_repair_child_fragment_reencoding(args)
     elif args.command == "repair-missing-deferred-outputs":
         cmd_repair_missing_deferred_outputs(args)
     elif args.command == "repair-section-172-c-capacity":
@@ -10091,6 +10118,8 @@ def _cmd_repair_generated_validation_issues(
     if not before_issues:
         print(no_repair_message)
         return
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
 
     with tempfile.TemporaryDirectory() as tmpdir:
         output_root = Path(tmpdir)
@@ -10168,9 +10197,6 @@ def _cmd_repair_generated_validation_issues(
                 print(f"- {issue}")
             sys.exit(1)
 
-        signing_key = _require_applied_encoding_manifest_signing_key()
-        axiom_encode_git = _require_clean_axiom_encode_git_provenance()
-
         repair_args.citation = _rulespec_anchor_base_for_output(
             repo_path, relative_output
         )
@@ -10215,6 +10241,278 @@ def cmd_repair_same_section_subsection_imports(args):
         success_label="same-section subsection import",
         repair=repair,
     )
+
+
+def cmd_repair_child_fragment_reencoding(args):
+    """Apply signed deterministic repairs for parent child-fragment aliases."""
+
+    def repair(context: argparse.Namespace) -> list[str]:
+        repaired = _try_repair_generated_proof_import_hashes_for_apply(
+            context.result,
+            output_root=context.output_root,
+            policy_repo_path=context.repo_path,
+            issues=context.issues,
+        )
+        repaired.extend(
+            _try_repair_generated_child_fragment_reencoding_for_apply(
+                context.result,
+                output_root=context.output_root,
+                policy_repo_path=context.repo_path,
+                issues=context.issues,
+            )
+        )
+        return repaired
+
+    _cmd_repair_generated_validation_issues(
+        args,
+        model="child-fragment-reencoding-v1",
+        tool="axiom-encode repair-child-fragment-reencoding",
+        no_repair_message="No child-fragment re-encoding repairs found.",
+        success_label="child-fragment re-encoding",
+        repair=repair,
+    )
+
+
+_CHILD_FRAGMENT_REENCODING_ISSUE_PATTERN = re.compile(
+    r"Child fragment re-encoded: .*? uses child-local input\(s\) "
+    r"(?P<inputs>.+?) also used by `(?P<child_path>[^`]+)` without importing "
+    r"a terminal child output\. Import and compose the child (?P<child_hint>.+?) "
+    r"instead of copying the child formula or factual inputs"
+)
+
+
+def _try_repair_generated_child_fragment_reencoding_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+    issues: list[str],
+) -> list[str]:
+    parsed_issues = [
+        parsed
+        for issue in issues
+        if (parsed := _parse_child_fragment_reencoding_issue(str(issue))) is not None
+    ]
+    if not parsed_issues:
+        return []
+    try:
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
+    except RuntimeError:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    return _repair_child_fragment_reencoding_aliases(
+        rules_file=rules_file,
+        policy_repo_path=policy_repo_path,
+        relative_output=relative_output,
+        parsed_issues=parsed_issues,
+    )
+
+
+def _parse_child_fragment_reencoding_issue(
+    issue: str,
+) -> tuple[tuple[str, ...], str] | None:
+    match = _CHILD_FRAGMENT_REENCODING_ISSUE_PATTERN.search(issue)
+    if match is None:
+        return None
+    shared_inputs = tuple(re.findall(r"`([^`]+)`", match.group("inputs")))
+    child_refs = tuple(
+        _normalize_rulespec_child_hint_ref(ref)
+        for ref in re.findall(r"`([^`]+)`", match.group("child_hint"))
+        if "#" in ref
+    )
+    if not shared_inputs or len(child_refs) != 1:
+        return None
+    return shared_inputs, child_refs[0]
+
+
+def _normalize_rulespec_child_hint_ref(ref: str) -> str:
+    normalized = ref.strip().strip("'\"")
+    match = re.match(
+        r"^(?P<prefix>[a-z]{2}(?:-[a-z0-9_]+)*):(?P=prefix)/(?P<rest>.+)$",
+        normalized,
+    )
+    if match is not None:
+        return f"{match.group('prefix')}:{match.group('rest')}"
+    return normalized
+
+
+def _repair_child_fragment_reencoding_aliases(
+    *,
+    rules_file: Path,
+    policy_repo_path: Path,
+    relative_output: Path,
+    parsed_issues: list[tuple[tuple[str, ...], str]],
+) -> list[str]:
+    """Rewrite parent aliases that copy child-local symbols to terminal imports."""
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return []
+
+    imports = payload.get("imports")
+    if imports is None:
+        imports = []
+        payload["imports"] = imports
+    if not isinstance(imports, list):
+        return []
+
+    repaired: list[str] = []
+    for shared_inputs, child_ref in parsed_issues:
+        child_name = child_ref.rsplit("#", 1)[1].strip()
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", child_name):
+            continue
+
+        shared = set(shared_inputs)
+        pending_repaired: list[str] = []
+        for rule in rules:
+            if not isinstance(rule, dict):
+                continue
+            rule_name = str(rule.get("name") or "")
+            if not rule_name:
+                continue
+            rewrote = _rewrite_exact_rule_formula_and_proof_alias(
+                rule,
+                aliases=shared,
+                child_ref=child_ref,
+                child_name=child_name,
+                replacement=child_name,
+            )
+            if not rewrote:
+                continue
+            pending_repaired.append(f"{rule_name}->{child_name}")
+        if not pending_repaired:
+            continue
+        if child_ref not in imports:
+            imports.append(child_ref)
+            repaired.append(f"import:{child_ref}")
+        repaired.extend(pending_repaired)
+
+    if not repaired:
+        return []
+
+    content = yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
+    content, removed_imports = _prune_unused_imports(content)
+    for removed in removed_imports:
+        repaired.append(f"remove_unused_import:{removed}")
+    target_base = _relative_output_to_anchor(
+        relative_output,
+        policy_repo_path=policy_repo_path,
+    )
+    content, hash_repairs = _repair_proof_import_hashes(
+        content,
+        target_base=target_base,
+        rules_file=rules_file,
+        repo_path=policy_repo_path,
+    )
+    for index in range(hash_repairs):
+        repaired.append(f"hash[{index}]")
+    rules_file.write_text(content)
+    return repaired
+
+
+def _rewrite_exact_rule_formula_alias(
+    rule: dict[str, object],
+    *,
+    aliases: set[str],
+    replacement: str,
+) -> bool:
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return False
+    changed = False
+    for version in versions:
+        if not isinstance(version, dict):
+            continue
+        formula = version.get("formula")
+        if not isinstance(formula, str):
+            continue
+        if formula.strip() not in aliases:
+            continue
+        version["formula"] = replacement
+        changed = True
+    return changed
+
+
+def _rewrite_exact_rule_formula_and_proof_alias(
+    rule: dict[str, object],
+    *,
+    aliases: set[str],
+    child_ref: str,
+    child_name: str,
+    replacement: str,
+) -> bool:
+    """Rewrite a generated direct alias only when its proof can be rewired."""
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return False
+    alias_versions: list[dict[str, object]] = []
+    for version in versions:
+        if not isinstance(version, dict):
+            continue
+        formula = version.get("formula")
+        if not isinstance(formula, str):
+            continue
+        if formula.strip() in aliases:
+            alias_versions.append(version)
+    if not alias_versions:
+        return False
+    if not _rewrite_rule_proof_import_alias(
+        rule,
+        aliases=aliases,
+        child_ref=child_ref,
+        child_name=child_name,
+    ):
+        return False
+    for version in alias_versions:
+        version["formula"] = replacement
+    return True
+
+
+def _rewrite_rule_proof_import_alias(
+    rule: dict[str, object],
+    *,
+    aliases: set[str],
+    child_ref: str,
+    child_name: str,
+) -> bool:
+    metadata = rule.get("metadata")
+    proof = (
+        metadata.get("proof")
+        if isinstance(metadata, dict) and isinstance(metadata.get("proof"), dict)
+        else rule.get("proof")
+    )
+    if not isinstance(proof, dict):
+        return False
+    atoms = proof.get("atoms")
+    if not isinstance(atoms, list):
+        return False
+    changed = False
+    for atom in atoms:
+        if not isinstance(atom, dict):
+            continue
+        imported = atom.get("import")
+        if not isinstance(imported, dict):
+            continue
+        output = str(imported.get("output") or "").strip()
+        target = str(imported.get("target") or "").strip()
+        target_name = target.rsplit("#", 1)[1] if "#" in target else ""
+        if output not in aliases and target_name not in aliases:
+            continue
+        imported["target"] = child_ref
+        imported["output"] = child_name
+        imported["hash"] = "sha256:local"
+        changed = True
+    return changed
 
 
 def cmd_repair_missing_deferred_outputs(args):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,6 +54,7 @@ from axiom_encode.cli import (
     _looks_like_absolute_rulespec_output_target,
     _medicaid_magi_income_helper_issue_names,
     _normalize_top_level_parameter_values_to_versions,
+    _parse_child_fragment_reencoding_issue,
     _parse_child_numeric_reencoding_issue,
     _person_scoped_definition_issue_names,
     _promote_boolean_comparison_predicates_to_judgment,
@@ -66,6 +67,7 @@ from axiom_encode.cli import (
     _repair_bare_indexed_parameter_references,
     _repair_california_snap_policy_composition,
     _repair_california_snap_program_tests,
+    _repair_child_fragment_reencoding_aliases,
     _repair_child_numeric_reencoding_parent_aliases,
     _repair_colorado_snap_401,
     _repair_colorado_snap_401_tests,
@@ -2479,6 +2481,116 @@ rules:
         assert payload["module"]["deferred_outputs"][0]["source_values"] == [
             "us:statutes/26/36B/b#required_contribution_monthly_fraction"
         ]
+
+    def test_repairs_child_fragment_reencoding_parent_aliases(self, tmp_path):
+        repo = tmp_path / "rulespec-us"
+        rules_file = tmp_path / "out" / "codex-test-model" / "statutes/42/426.yaml"
+        child_a2 = repo / "statutes/42/426/a/2.yaml"
+        child_d = repo / "statutes/42/426/d.yaml"
+        rules_file.parent.mkdir(parents=True)
+        child_a2.parent.mkdir(parents=True)
+        child_d.parent.mkdir(parents=True, exist_ok=True)
+        child_a2.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/42/426/d#qualified_railroad_retirement_beneficiary
+rules:
+  - name: railroad_retirement_beneficiary_alternative_satisfied
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          qualified_railroad_retirement_beneficiary
+"""
+        )
+        child_d.write_text(
+            """format: rulespec/v1
+rules:
+  - name: qualified_railroad_retirement_beneficiary
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          certified_by_railroad_retirement_board
+"""
+        )
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/42/426/d#qualified_railroad_retirement_beneficiary
+rules:
+  - name: qualified_railroad_retirement_beneficiary_status
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/426/d#qualified_railroad_retirement_beneficiary
+              output: qualified_railroad_retirement_beneficiary
+              hash: sha256:old
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          qualified_railroad_retirement_beneficiary
+"""
+        )
+        issue = (
+            "Child fragment re-encoded: `426.yaml` uses child-local input(s) "
+            "`qualified_railroad_retirement_beneficiary` also used by "
+            "`statutes/42/426/a/2.yaml` without importing a terminal child output. "
+            "Import and compose the child output "
+            "`us:us/statutes/42/426/a/2#railroad_retirement_beneficiary_alternative_satisfied` "
+            "instead of copying the child formula or factual inputs."
+        )
+        parsed_issue = _parse_child_fragment_reencoding_issue(issue)
+
+        assert parsed_issue == (
+            ("qualified_railroad_retirement_beneficiary",),
+            "us:statutes/42/426/a/2#railroad_retirement_beneficiary_alternative_satisfied",
+        )
+
+        repaired = _repair_child_fragment_reencoding_aliases(
+            rules_file=rules_file,
+            policy_repo_path=repo,
+            relative_output=Path("statutes/42/426.yaml"),
+            parsed_issues=[parsed_issue],
+        )
+
+        assert repaired == [
+            "import:us:statutes/42/426/a/2#railroad_retirement_beneficiary_alternative_satisfied",
+            "qualified_railroad_retirement_beneficiary_status->railroad_retirement_beneficiary_alternative_satisfied",
+            "remove_unused_import:us:statutes/42/426/d#qualified_railroad_retirement_beneficiary",
+            "hash[0]",
+        ]
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["imports"] == [
+            "us:statutes/42/426/a/2#railroad_retirement_beneficiary_alternative_satisfied"
+        ]
+        rule = payload["rules"][0]
+        assert (
+            rule["versions"][0]["formula"]
+            == "railroad_retirement_beneficiary_alternative_satisfied"
+        )
+        proof_import = rule["metadata"]["proof"]["atoms"][0]["import"]
+        assert (
+            proof_import["target"]
+            == "us:statutes/42/426/a/2#railroad_retirement_beneficiary_alternative_satisfied"
+        )
+        assert proof_import["output"] == (
+            "railroad_retirement_beneficiary_alternative_satisfied"
+        )
+        assert proof_import["hash"] == f"sha256:{_sha256_file(child_a2)}"
 
     def test_executes_companion_tests_success_json(self, capsys, tmp_path):
         repo = self._write_rulespec_with_test(tmp_path, expected_benefit=15)

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.966"
+version = "0.2.967"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a signed deterministic repair command for parent files that re-encode child fragment outputs
- preflight signed-repair provenance before mutating target files
- bump axiom-encode to 0.2.967

## Validation
- uv run pytest tests/test_cli.py -k "child_fragment_reencoding or child_numeric_reencoding or same_section_subsection_imports or proof_import_hashes" -q
- uv run pytest tests/test_repo_routing.py tests/test_cli.py -k "canonical_compile_path or ensure_rulespec_import or child_fragment_reencoding or proof_import_hashes" -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/ && env -u UV_FROZEN uv lock --check
- signed throwaway repair of rulespec-us us/statutes/42/426.yaml, followed by targeted validation passing