### PR TITLE
Expose upstream placement duplicate repair

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.967"
+version = "0.2.968"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.967"
+__version__ = "0.2.968"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1338,6 +1338,31 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_upstream_duplicates_parser = subparsers.add_parser(
+        "repair-upstream-placement-duplicates",
+        help=(
+            "Apply signed deterministic repairs for executable rules that "
+            "duplicate upstream RuleSpec targets"
+        ),
+    )
+    repair_upstream_duplicates_parser.add_argument(
+        "file", type=Path, help="RuleSpec YAML file"
+    )
+    repair_upstream_duplicates_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="Rules repository root used for manifest signing",
+    )
+    repair_upstream_duplicates_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_missing_deferred_parser = subparsers.add_parser(
         "repair-missing-deferred-outputs",
         help="Apply signed deterministic repairs for source coverage gaps",
@@ -2377,6 +2402,8 @@ def main():
         cmd_repair_same_section_subsection_imports(args)
     elif args.command == "repair-child-fragment-reencoding":
         cmd_repair_child_fragment_reencoding(args)
+    elif args.command == "repair-upstream-placement-duplicates":
+        cmd_repair_upstream_placement_duplicates(args)
     elif args.command == "repair-missing-deferred-outputs":
         cmd_repair_missing_deferred_outputs(args)
     elif args.command == "repair-section-172-c-capacity":
@@ -10145,6 +10172,7 @@ def _cmd_repair_generated_validation_issues(
                     result=repair_args,
                     output_root=output_root,
                     repo_path=repair_repo_path,
+                    rules_repo_path=repo_path,
                     issues=pending_issues,
                 )
             )
@@ -10271,6 +10299,85 @@ def cmd_repair_child_fragment_reencoding(args):
         success_label="child-fragment re-encoding",
         repair=repair,
     )
+
+
+def cmd_repair_upstream_placement_duplicates(args):
+    """Apply signed deterministic repairs for copied upstream executable rules."""
+
+    def repair(context: argparse.Namespace) -> list[str]:
+        return _try_repair_generated_upstream_placement_duplicates_and_proofs_for_apply(
+            context.result,
+            output_root=context.output_root,
+            policy_repo_path=context.rules_repo_path,
+        )
+
+    _cmd_repair_generated_validation_issues(
+        args,
+        model="upstream-placement-duplicate-v1",
+        tool="axiom-encode repair-upstream-placement-duplicates",
+        no_repair_message="No upstream placement duplicate repairs found.",
+        success_label="upstream placement duplicate",
+        repair=repair,
+    )
+
+
+def _try_repair_generated_upstream_placement_duplicates_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+) -> list[str]:
+    try:
+        relative_output = _relative_generated_output_path(
+            result, output_root=output_root
+        )
+    except RuntimeError:
+        return []
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    try:
+        real_rules_file = Path(policy_repo_path) / relative_output
+        content_repo_path = find_policy_repo_root(
+            real_rules_file
+        ) or _generated_validation_repair_policy_repo_path(
+            Path(policy_repo_path), relative_output
+        )
+        content_relative_output = real_rules_file.relative_to(content_repo_path)
+    except ValueError:
+        content_repo_path = _generated_validation_repair_policy_repo_path(
+            Path(policy_repo_path), relative_output
+        )
+        content_relative_output = relative_output
+    return _repair_upstream_placement_duplicate_imports(
+        rules_file=rules_file,
+        test_file=_rulespec_test_path(rules_file),
+        repo_path=content_repo_path,
+        relative_output=content_relative_output,
+    )
+
+
+def _try_repair_generated_upstream_placement_duplicates_and_proofs_for_apply(
+    result,
+    *,
+    output_root: Path,
+    policy_repo_path: Path,
+) -> list[str]:
+    repaired = _try_repair_generated_upstream_placement_duplicates_for_apply(
+        result,
+        output_root=output_root,
+        policy_repo_path=policy_repo_path,
+    )
+    if not repaired:
+        return []
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    try:
+        content = rules_file.read_text()
+    except OSError:
+        return repaired
+    repaired_content, repaired_rules = _repair_missing_source_proof_atoms(content)
+    if repaired_content != content:
+        rules_file.write_text(repaired_content)
+        repaired.extend(f"proof:{name}" for name in repaired_rules)
+    return repaired
 
 
 _CHILD_FRAGMENT_REENCODING_ISSUE_PATTERN = re.compile(
@@ -37492,11 +37599,21 @@ def _repair_upstream_placement_duplicate_imports(
     if not isinstance(rules, list):
         return []
 
-    content_repo_path = _rulespec_apply_content_root(repo_path, relative_output)
+    content_repo_path = _generated_validation_repair_policy_repo_path(
+        repo_path, relative_output
+    )
+    relative_parts = relative_output.parts
+    if (
+        len(relative_parts) >= 2
+        and relative_parts[1] in RULESPEC_SOURCE_ROOTS
+        and relative_parts[0] == _repo_jurisdiction_prefix(content_repo_path)
+    ):
+        relative_output = Path(*relative_parts[1:])
+    target_rules_file = content_repo_path / relative_output
     duplicate_targets_by_name, duplicate_indexes = (
         _upstream_placement_duplicate_targets(
             rules=rules,
-            rules_file=rules_file,
+            rules_file=target_rules_file,
             repo_path=content_repo_path,
         )
     )

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -13596,6 +13596,8 @@ def find_imported_deferred_branch_composition_issues(
             imported_tokens = _purpose_surface_tokens(imported_symbol)
             if len(imported_tokens) < 2:
                 continue
+            if _is_scalar_modifier_import_symbol(imported_symbol):
+                continue
             for record in deferred_outputs:
                 output = (
                     str(record.get("output") or "").strip()
@@ -13658,6 +13660,11 @@ def find_imported_deferred_branch_composition_issues(
                 continue
             break
     return issues
+
+
+def _is_scalar_modifier_import_symbol(symbol: str) -> bool:
+    normalized = _normalize_identifier(symbol)
+    return normalized.endswith(("_rate", "_percentage", "_percent", "_ratio"))
 
 
 def _purpose_specific_prefix(symbol: str) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,6 +157,8 @@ from axiom_encode.cli import (
     _try_repair_generated_unresolved_local_test_outputs_for_apply,
     _try_repair_generated_unsafe_formula_outputs_for_apply,
     _try_repair_generated_unsupported_entity_outputs_for_apply,
+    _try_repair_generated_upstream_placement_duplicates_and_proofs_for_apply,
+    _try_repair_generated_upstream_placement_duplicates_for_apply,
     _unit_scoped_person_definition_issue_names,
     _validate_generated_encoding_in_policy_overlay,
     _write_applied_encoding_manifest,
@@ -18632,6 +18634,160 @@ rules:
         assert test_cases[0]["output"] == {
             "us:policies/hhs/medicaid/eligibility#is_medicaid_eligible": "holds"
         }
+
+    def test_generated_upstream_placement_duplicate_repair_uses_real_content_target(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        output_root = tmp_path / "generated"
+        upstream_file = policy_repo / "us/statutes/7/2014/e/2/B.yaml"
+        generated_file = output_root / "us/statutes/7/2014/e/2.yaml"
+        generated_test_file = output_root / "us/statutes/7/2014/e/2.test.yaml"
+        upstream_file.parent.mkdir(parents=True)
+        generated_file.parent.mkdir(parents=True)
+        upstream_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: snap_earned_income_deduction_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.20
+"""
+        )
+        generated_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: snap_earned_income_deduction_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.20
+  - name: snap_earned_income_deduction
+    kind: derived
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '1990-01-01'
+        formula: snap_countable_earned_income * snap_earned_income_deduction_rate
+"""
+        )
+        generated_test_file.write_text(
+            """- name: earned_income_case
+  period: 2026-01
+  input:
+    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 100
+  output:
+    us:statutes/7/2014/e/2#snap_earned_income_deduction_rate: 0.20
+    us:statutes/7/2014/e/2#snap_earned_income_deduction: 20
+"""
+        )
+
+        repaired = _try_repair_generated_upstream_placement_duplicates_for_apply(
+            SimpleNamespace(output_file=str(generated_file)),
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+        )
+
+        rules_payload = yaml.safe_load(generated_file.read_text())
+        test_cases = yaml.safe_load(generated_test_file.read_text())
+        assert repaired == ["snap_earned_income_deduction_rate"]
+        assert rules_payload["imports"] == [
+            "us:statutes/7/2014/e/2/B#snap_earned_income_deduction_rate"
+        ]
+        assert [rule["name"] for rule in rules_payload["rules"]] == [
+            "snap_earned_income_deduction"
+        ]
+        assert test_cases[0]["output"] == {
+            "us:statutes/7/2014/e/2#snap_earned_income_deduction": 20
+        }
+
+    def test_generated_upstream_placement_duplicate_repair_adds_remaining_proofs(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        output_root = tmp_path / "generated"
+        upstream_file = policy_repo / "us/statutes/7/2014/e/2/B.yaml"
+        generated_file = output_root / "us/statutes/7/2014/e/2.yaml"
+        generated_test_file = output_root / "us/statutes/7/2014/e/2.test.yaml"
+        upstream_file.parent.mkdir(parents=True)
+        generated_file.parent.mkdir(parents=True)
+        upstream_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: snap_earned_income_deduction_rate
+    kind: parameter
+    dtype: Rate
+    source: 7 USC 2014(e)(2)(B)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/7/2014
+              excerpt: "20 percent of all earned income"
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.20
+"""
+        )
+        generated_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/7/2014
+rules:
+  - name: snap_earned_income_deduction_rate
+    kind: parameter
+    dtype: Rate
+    source: 7 USC 2014(e)(2)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          0.20
+  - name: snap_earned_income_deduction
+    kind: derived
+    dtype: Money
+    period: Month
+    source: 7 USC 2014(e)(2)
+    versions:
+      - effective_from: '1990-01-01'
+        formula: snap_countable_earned_income * snap_earned_income_deduction_rate
+"""
+        )
+        generated_test_file.write_text(
+            """- name: earned_income_case
+  period: 2026-01
+  input:
+    us:statutes/7/2014/e/2#input.snap_countable_earned_income: 100
+  output:
+    us:statutes/7/2014/e/2#snap_earned_income_deduction_rate: 0.20
+    us:statutes/7/2014/e/2#snap_earned_income_deduction: 20
+"""
+        )
+
+        repaired = (
+            _try_repair_generated_upstream_placement_duplicates_and_proofs_for_apply(
+                SimpleNamespace(output_file=str(generated_file)),
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+            )
+        )
+
+        rules_payload = yaml.safe_load(generated_file.read_text())
+        assert repaired == [
+            "snap_earned_income_deduction_rate",
+            "proof:snap_earned_income_deduction",
+        ]
+        assert rules_payload["module"]["proof_validation"]["required"] is True
+        assert rules_payload["rules"][0]["name"] == "snap_earned_income_deduction"
+        assert rules_payload["rules"][0]["metadata"]["proof"]["atoms"]
 
     def test_upstream_placement_duplicate_repair_restates_duplicate_only_module(
         self, tmp_path

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -24244,3 +24244,45 @@ rules:
         )
         == []
     )
+
+
+def test_imported_deferred_branch_composition_allows_rate_modifier_import(tmp_path):
+    policy_repo = tmp_path / "rulespec-us"
+    child = policy_repo / "us/statutes/7/2014/e/2/B.yaml"
+    child.parent.mkdir(parents=True)
+    child.write_text(
+        """format: rulespec/v1
+module:
+  deferred_outputs:
+    - output: us:statutes/7/2014/e/2/B#snap_earned_income_deduction
+      reason: Subparagraph (B) deduction amount is deferred because paragraph (C) states an exception.
+rules:
+  - name: snap_earned_income_deduction_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2008-10-01'
+        formula: 0.20
+"""
+    )
+    rules_file = policy_repo / "us/statutes/7/2014/e/2.yaml"
+    content = """format: rulespec/v1
+imports:
+  - us:statutes/7/2014/e/2/B#snap_earned_income_deduction_rate
+rules:
+  - name: snap_earned_income_deduction
+    kind: derived
+    dtype: Money
+    versions:
+      - effective_from: '2008-10-01'
+        formula: snap_earned_income_subject_to_deduction * snap_earned_income_deduction_rate
+"""
+
+    assert (
+        find_imported_deferred_branch_composition_issues(
+            content,
+            rules_file=rules_file,
+            policy_repo_path=policy_repo,
+        )
+        == []
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.967"
+version = "0.2.968"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a signed repair command for generated upstream-placement duplicate failures
- make the repair use the real RuleSpec content target when operating on country-repo paths
- repair any proof atoms exposed after the duplicate import is removed
- allow scalar modifier imports like *_rate in the deferred-branch composition validator

## Verification
- uv run pytest tests/test_rulespec_validation.py -k "deferred_branch_composition or deferred_purpose_specific" -q
- uv run pytest tests/test_cli.py -k "upstream_placement_duplicate or child_fragment_reencoding or proof_import_hashes" -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- env -u UV_FROZEN uv lock --check
- signed repair smoke test on temp rulespec-us copy for us/statutes/7/2014/e/2.yaml