### PR TITLE
Resolve source relation values through imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.968"
+version = "0.2.969"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.968"
+__version__ = "0.2.969"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -18825,7 +18825,8 @@ def _find_source_relation_value_verification_issues(
         ]
 
     target_values, target_symbols, load_issue = _extract_source_relation_target_values(
-        target_file
+        target_file,
+        policy_repo_path=policy_repo_path,
     )
     if load_issue is not None:
         return [
@@ -19069,15 +19070,64 @@ def _canonical_rulespec_compile_path(
 
 def _extract_source_relation_target_values(
     target_file: Path,
+    *,
+    policy_repo_path: Path | None = None,
+    seen: set[Path] | None = None,
 ) -> tuple[dict[str, Any], set[str], str | None]:
     """Extract scalar/table parameter values from a canonical RuleSpec file."""
+    resolved_target = target_file.resolve() if target_file.exists() else target_file
+    if seen is None:
+        seen = set()
+    if resolved_target in seen:
+        return {}, set(), None
+    seen.add(resolved_target)
     try:
         payload = yaml.safe_load(target_file.read_text())
     except (OSError, yaml.YAMLError, ValueError) as exc:
         return {}, set(), f"{target_file} could not be read as RuleSpec YAML: {exc}"
     if not isinstance(payload, dict) or payload.get("format") != "rulespec/v1":
         return {}, set(), f"{target_file} is not a RuleSpec v1 file"
-    return _extract_rulespec_parameter_values(payload, source_label=str(target_file))
+    values, symbols, load_issue = _extract_rulespec_parameter_values(
+        payload,
+        source_label=str(target_file),
+    )
+    if load_issue is not None:
+        return values, symbols, load_issue
+
+    imports = payload.get("imports")
+    if not isinstance(imports, list):
+        return values, symbols, None
+    for raw_import in imports:
+        if not isinstance(raw_import, str):
+            continue
+        import_ref = _parse_rulespec_target(raw_import)
+        if import_ref is None:
+            continue
+        import_file = _resolve_rulespec_target_file(
+            import_ref,
+            policy_repo_path,
+        )
+        if import_file is None:
+            continue
+        imported_values, imported_symbols, import_issue = (
+            _extract_source_relation_target_values(
+                import_file,
+                policy_repo_path=policy_repo_path,
+                seen=seen,
+            )
+        )
+        if import_issue is not None:
+            return values, symbols, import_issue
+        if import_ref.symbol:
+            symbols.add(import_ref.symbol)
+            if import_ref.symbol in imported_values:
+                values.setdefault(import_ref.symbol, imported_values[import_ref.symbol])
+            continue
+        for imported_symbol in imported_symbols:
+            symbols.add(imported_symbol)
+        for imported_name, imported_value in imported_values.items():
+            values.setdefault(imported_name, imported_value)
+    return values, symbols, None
 
 
 def _extract_rulespec_parameter_values(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -22598,6 +22598,69 @@ rules:
     assert pipeline._run_ci(rules_file).passed is True
 
 
+def test_rulespec_ci_verifies_source_relation_values_from_target_imports(tmp_path):
+    if not AXIOM_RULES_ENGINE_BINARY.exists():
+        pytest.skip("local axiom-rules-engine binary is not built")
+
+    us_root = tmp_path / "rulespec-us"
+    child_file = us_root / "statutes/7/2014/e/2/B.yaml"
+    child_file.parent.mkdir(parents=True)
+    child_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: snap_earned_income_deduction_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2008-10-01'
+        formula: '0.20'
+"""
+    )
+    target_file = us_root / "statutes/7/2014/e/2.yaml"
+    target_file.write_text(
+        """format: rulespec/v1
+imports:
+  - us:statutes/7/2014/e/2/B#snap_earned_income_deduction_rate
+rules:
+  - name: snap_earned_income_deduction
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2008-10-01'
+        formula: snap_earned_income_subject_to_deduction * snap_earned_income_deduction_rate
+"""
+    )
+
+    co_root = tmp_path / "rulespec-us-co"
+    rules_file = co_root / "regulations/10-ccr-2506-1/4.407.2.yaml"
+    rules_file.parent.mkdir(parents=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: restates_earned_income_deduction
+    kind: source_relation
+    source_relation:
+      type: restates
+      target: us:statutes/7/2014/e/2#snap_earned_income_deduction
+      authority: federal
+    verification:
+      values:
+        snap_earned_income_deduction_rate: 0.20
+"""
+    )
+
+    pipeline = ValidatorPipeline(
+        policy_repo_path=co_root,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+
+    assert pipeline._run_ci(rules_file).passed is True
+
+
 def test_rulespec_ci_rejects_source_relation_value_mismatch(tmp_path):
     if not AXIOM_RULES_ENGINE_BINARY.exists():
         pytest.skip("local axiom-rules-engine binary is not built")

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.968"
+version = "0.2.969"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- resolve source-relation verification values through RuleSpec imports on the target module
- preserve target rule checks while allowing imported scalar/table values like SNAP deduction rates
- bump axiom-encode to 0.2.969

## Verification
- uv run pytest tests/test_rulespec_validation.py -k "source_relation_values" -q
- uv run pytest tests/test_rulespec_validation.py -k "deferred_branch_composition or deferred_purpose_specific" -q
- uv run pytest tests/test_cli.py -k "upstream_placement_duplicate or child_fragment_reencoding or proof_import_hashes" -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- env -u UV_FROZEN uv lock --check
- local validation passes for rulespec-us/us-co/regulations/10-ccr-2506-1/4.407.2.yaml