### PR TITLE
Use producer inputs for Medicaid import gate tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.973"
+version = "0.2.974"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.973"
+__version__ = "0.2.974"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -33852,6 +33852,7 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
                             placeholder_repairs.extend(
                                 _add_imported_gate_test_overrides(
                                     test_file=test_file,
+                                    policy_repo_path=policy_repo_path,
                                     generated_target_base=(
                                         f"{jurisdiction}:"
                                         f"{_relative_rulespec_import_target(relative_output)}"
@@ -34585,6 +34586,7 @@ def _repair_same_section_subsection_subject_to_output_gate(
 def _add_imported_gate_test_overrides(
     *,
     test_file: Path,
+    policy_repo_path: Path,
     generated_target_base: str,
     rule_name: str,
     imported_ref: str,
@@ -34616,9 +34618,25 @@ def _add_imported_gate_test_overrides(
             is None
         ):
             continue
-        if imported_ref in {str(key) for key in _mapping_keys_recursive(inputs)}:
+        upstream_inputs = _producer_test_inputs_for_output_value(
+            imported_ref,
+            "holds",
+            policy_repo_path=policy_repo_path,
+        )
+        if not upstream_inputs:
             continue
-        inputs[imported_ref] = True
+
+        input_keys = {str(key) for key in _mapping_keys_recursive(inputs)}
+        missing_inputs = [
+            (input_ref, input_value)
+            for input_ref, input_value in upstream_inputs.items()
+            if str(input_ref) not in input_keys
+        ]
+        if not missing_inputs:
+            continue
+        for input_ref, input_value in missing_inputs:
+            inputs[input_ref] = input_value
+            input_keys.add(str(input_ref))
         changed = True
         case_name = str(test_case.get("name") or "<unnamed>")
         repairs.append(f"test:{case_name}:{imported_ref}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19929,6 +19929,18 @@ rules:
         formula: person_has_exclusion
 """
         )
+        cited_file.with_suffix(".test.yaml").write_text(
+            """- name: work hours satisfy monthly engagement
+  period: 2027-01
+  input:
+    us:statutes/42/1396a/xx#input.monthly_work_hours: 80
+    us:statutes/42/1396a/xx#input.monthly_community_service_hours: 0
+    us:statutes/42/1396a/xx#input.monthly_work_program_hours: 0
+    us:statutes/42/1396a/xx#input.enrolled_in_educational_program_at_least_half_time: false
+  output:
+    us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month: holds
+"""
+        )
         rules_file.write_text(
             """format: rulespec/v1
 imports:
@@ -20029,8 +20041,12 @@ rules:
             "#demonstrated_community_engagement_for_month"
         ) in rules_text
         assert (
-            "us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month: true"
+            "us:statutes/42/1396a/xx#input.monthly_work_hours: 80"
         ) in test_file.read_text()
+        assert (
+            "us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month: true"
+            not in test_file.read_text()
+        )
 
     def test_missing_same_section_import_repair_promotes_cfr_placeholder(
         self, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.973"
+version = "0.2.974"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- copy producer test inputs for the Medicaid community-engagement import gate instead of adding the derived imported output as a test input
- keep the same generated repair marker while making the repaired tests executable by the real rules engine
- bump axiom-encode to 0.2.974

## Validation
- uv run pytest tests/test_cli.py -k "same_section_import_repair or source_child_corpus_path_repair or proof_import_hashes" -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- env -u UV_FROZEN uv lock --check