### PR TITLE
Repair local missing test input defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.977"
+version = "0.2.978"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.977"
+__version__ = "0.2.978"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -39765,13 +39765,27 @@ def _complete_missing_imported_test_inputs(
     missing_inputs = {assignment["input"] for assignment in missing_assignments}
     if not missing_inputs:
         return False
-    imported_inputs = _imported_input_refs_by_name(rules_file, repo_path=repo_path)
+    current_base = _rulespec_base_for_file(rules_file, repo_path=repo_path)
+    local_input_refs: dict[str, list[str]] = {}
+    if current_base:
+        with contextlib.suppress(OSError, ValueError, yaml.YAMLError):
+            for input_name in sorted(
+                _local_factual_input_names_from_rules_content(rules_file.read_text())
+            ):
+                _append_unique_input_ref(
+                    local_input_refs,
+                    input_name,
+                    f"{current_base}#input.{input_name}",
+                )
+    imported_inputs = _merge_imported_input_refs_by_name(
+        local_input_refs,
+        _imported_input_refs_by_name(rules_file, repo_path=repo_path),
+    )
     if not imported_inputs:
         return False
 
     content = test_file.read_text()
     updated = content
-    current_base = _rulespec_base_for_file(rules_file, repo_path=repo_path)
     relation_row_anchor_bases = [current_base] if current_base else None
     for input_name in sorted(missing_inputs):
         for input_ref in imported_inputs.get(input_name, []):
@@ -39935,7 +39949,7 @@ def _collect_imported_input_refs_by_name(
 
 def _rulespec_base_for_file(rules_file: Path, *, repo_path: Path) -> str:
     try:
-        relative = rules_file.relative_to(repo_path)
+        relative = _relative_to_rulespec_apply_content_root(rules_file, repo_path)
     except ValueError:
         return ""
     return (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -115,6 +115,7 @@ from axiom_encode.cli import (
     _rewrite_judgment_numeric_comparisons,
     _rulespec_anchor_base_for_output,
     _rulespec_apply_content_root,
+    _rulespec_base_for_file,
     _rulespec_scalar_matches,
     _scoped_source_text_for_encode_source_id,
     _sha256_file,
@@ -22629,6 +22630,67 @@ rules: []
         assert (
             "us:statutes/26/1402/b#input.net_earnings_from_self_employment: 0"
             in dependent_test.read_text()
+        )
+
+    def test_complete_missing_imported_test_inputs_adds_local_defaults(self, tmp_path):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "statutes/26/24/d.yaml"
+        target_test = policy_repo / "statutes/26/24/d.test.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+rules:
+  - name: ctc_phase_in_earned_income_base
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          earned_income_before_section_112_election
+"""
+        )
+        target_test.write_text(
+            """- name: phase_in_case
+  input: {}
+  output:
+    us:statutes/26/24/d#ctc_phase_in_earned_income_base: 0
+"""
+        )
+        validation = SimpleNamespace(
+            results={
+                "ci": SimpleNamespace(
+                    error=(
+                        "Test case `phase_in_case` execution failed: "
+                        "missing input `earned_income_before_section_112_election`"
+                    )
+                )
+            }
+        )
+
+        changed = _complete_missing_imported_test_inputs(
+            rules_file=target,
+            test_file=target_test,
+            repo_path=policy_repo,
+            validation=validation,
+        )
+
+        assert changed is True
+        assert (
+            "us:statutes/26/24/d#input.earned_income_before_section_112_election: 0"
+            in target_test.read_text()
+        )
+
+    def test_rulespec_base_for_file_uses_country_content_root(self, tmp_path):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "us/statutes/26/24/d.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text("format: rulespec/v1\nrules: []\n")
+
+        assert (
+            _rulespec_base_for_file(target, repo_path=policy_repo)
+            == "us:statutes/26/24/d"
         )
 
     def test_complete_missing_imported_test_inputs_adds_table_entity_defaults(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.977"
+version = "0.2.978"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- include local factual inputs when auto-filling missing proof-test defaults
- fix country-layout RuleSpec base refs so repairs emit us:statutes/... instead of us:us/statutes/...
- bump axiom-encode to 0.2.978

## Tests
- uv run pytest tests/test_cli.py -k "complete_missing_imported_test_inputs_adds_local_defaults or rulespec_base_for_file_uses_country_content_root or complete_missing_imported_test_inputs_adds_transitive_deferred_defaults or proof_import_hashes_removes_unknown_test_outputs" -q
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- env -u UV_FROZEN uv lock --check