### PR TITLE
Parse companion missing-input failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.979"
+version = "0.2.980"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.979"
+__version__ = "0.2.980"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -39368,7 +39368,7 @@ def _repair_dependent_proof_import_hashes(
 
 
 _MISSING_INPUT_RE = re.compile(
-    r"Test case `(?P<case>[^`]+)` execution failed: "
+    r"(?:Test case `)?(?P<case>[^`:]+)`?(?: execution failed)?: "
     r"missing input `(?P<input>[^`]+)`"
     r"(?: for entity `(?P<entity>[^`]+)`)?"
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22755,9 +22755,9 @@ rules:
                 results={
                     "ci": SimpleNamespace(
                         error=(
-                            "Test case `phase_in_case` execution failed: "
-                            "missing input "
-                            "`net_earnings_from_self_employment_after_self_employment_tax_deduction`"
+                            "phase_in_case: missing input "
+                            "`net_earnings_from_self_employment_after_self_employment_tax_deduction` "
+                            "for entity `case` over 2026-01-01..2026-12-31"
                         )
                     )
                 }

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.979"
+version = "0.2.980"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- parse companion-test missing-input messages that use the case-name prefix shape
- cover the live entity-suffixed missing-input message in the companion cleanup test
- bump axiom-encode to 0.2.980

## Tests
- uv run pytest tests/test_cli.py -k "companion_reference_cleanup_can_add_new_import_defaults or complete_missing_imported_test_inputs_adds_local_defaults or rulespec_base_for_file_uses_country_content_root" -q
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- env -u UV_FROZEN uv lock --check