### PR TITLE
Repair companion missing-input completion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.980"
+version = "0.2.981"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.980"
+__version__ = "0.2.981"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10905,26 +10905,27 @@ def cmd_repair_companion_test_references(args):
             issues=issues,
         )
         completed_missing_inputs = False
+        missing_input_failures = failures
         if rewritten_inputs or removed_inputs or removed_outputs:
-            followup_failures = _rulespec_companion_test_failures(
+            missing_input_failures = _rulespec_companion_test_failures(
                 test_file,
                 root=repo_path,
                 axiom_rules_path=axiom_rules_path,
             )
-            if followup_failures:
-                completed_missing_inputs = _complete_missing_imported_test_inputs(
-                    rules_file=rules_file,
-                    test_file=test_file,
-                    repo_path=repo_path,
-                    validation=SimpleNamespace(
-                        results={
-                            f"companion_{index}": SimpleNamespace(
-                                error=str(failure.get("message") or "")
-                            )
-                            for index, failure in enumerate(followup_failures)
-                        }
-                    ),
-                )
+        if missing_input_failures:
+            completed_missing_inputs = _complete_missing_imported_test_inputs(
+                rules_file=rules_file,
+                test_file=test_file,
+                repo_path=repo_path,
+                validation=SimpleNamespace(
+                    results={
+                        f"companion_{index}": SimpleNamespace(
+                            error=_companion_failure_validation_error(failure)
+                        )
+                        for index, failure in enumerate(missing_input_failures)
+                    }
+                ),
+            )
         if (
             not rewritten_inputs
             and not removed_inputs
@@ -10987,6 +10988,16 @@ def cmd_repair_companion_test_references(args):
     print(f"Applied companion test reference repair to {relative_output}")
     print(f"repaired={', '.join(sorted(set(repaired_refs)))}")
     print(f"manifest={manifest_path}")
+
+
+def _companion_failure_validation_error(failure: dict[str, object]) -> str:
+    message = str(failure.get("message") or "")
+    case_name = str(failure.get("case") or "").strip()
+    if not case_name or not message:
+        return message
+    if message.startswith(f"{case_name}:") or message.startswith("Test case `"):
+        return message
+    return f"{case_name}: {message}"
 
 
 _SECTION_172_C_IMPORT = (
@@ -40244,6 +40255,7 @@ def _infer_missing_input_default(input_name: str) -> object:
     numeric_markers = (
         "amount",
         "base",
+        "compensation",
         "count",
         "cost",
         "costs",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -183,6 +183,7 @@ from axiom_encode.cli import (
     cmd_repair_arizona_snap_composition,
     cmd_repair_bare_snapunit_entities,
     cmd_repair_colorado_tax_validation,
+    cmd_repair_companion_test_references,
     cmd_repair_current_year_final_amounts,
     cmd_repair_delegated_policy_settings,
     cmd_repair_embedded_scalar_literals,
@@ -22783,6 +22784,110 @@ rules:
             in repaired
         )
 
+    def test_repair_companion_test_references_adds_missing_defaults_with_case(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        imported = policy_repo / "us/statutes/26/32/c/2.yaml"
+        dependent = policy_repo / "us/statutes/26/24/d.yaml"
+        dependent_test = policy_repo / "us/statutes/26/24/d.test.yaml"
+        imported.parent.mkdir(parents=True)
+        dependent.parent.mkdir(parents=True, exist_ok=True)
+        imported.write_text(
+            """format: rulespec/v1
+rules:
+  - name: earned_income_before_section_112_election
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          employee_compensation_includible_in_gross_income
+          + net_earnings_from_self_employment_after_self_employment_tax_deduction
+"""
+        )
+        dependent.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/32/c/2#earned_income_before_section_112_election
+rules:
+  - name: ctc_phase_in_earned_income_base
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          earned_income_before_section_112_election
+"""
+        )
+        dependent_test.write_text(
+            """- name: phase_in_case
+  input:
+    us:statutes/26/32/c/2#input.employee_compensation_includible_in_gross_income: 20000
+  output:
+    us:statutes/26/24/d#ctc_phase_in_earned_income_base: 0
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo,
+            file=Path("us/statutes/26/24/d.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+        failure_sequence = iter(
+            [
+                [
+                    {
+                        "case": "phase_in_case",
+                        "message": (
+                            "missing input "
+                            "`net_earnings_from_self_employment_after_self_employment_tax_deduction` "
+                            "for entity `case` over 2026-01-01..2026-12-31"
+                        ),
+                    }
+                ],
+                [],
+                [],
+            ]
+        )
+
+        def fake_companion_failures(test_file, *, root, axiom_rules_path):
+            assert test_file == dependent_test.resolve()
+            assert root == policy_repo.resolve()
+            assert axiom_rules_path == tmp_path / "axiom-rules-engine"
+            return next(failure_sequence)
+
+        with (
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures",
+                side_effect=fake_companion_failures,
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_companion_test_references(args)
+
+        assert (
+            "us:statutes/26/32/c/2#input.net_earnings_from_self_employment_after_self_employment_tax_deduction: 0"
+            in dependent_test.read_text()
+        )
+        manifest = policy_repo / ".axiom/encoding-manifests/us/statutes/26/24/d.json"
+        payload = json.loads(manifest.read_text())
+        assert payload["tool"] == "axiom-encode repair-companion-test-references"
+        assert [item["path"] for item in payload["applied_files"]] == [
+            "us/statutes/26/24/d.yaml",
+            "us/statutes/26/24/d.test.yaml",
+        ]
+
     def test_rulespec_base_for_file_uses_country_content_root(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"
         target = policy_repo / "us/statutes/26/24/d.yaml"
@@ -28626,6 +28731,7 @@ rules:
             "incapacitated_adult_care_expenses",
             "above_the_line_deductions",
             "income_tax_refundable_credits",
+            "penal_institution_service_compensation",
         ],
     )
     def test_missing_input_default_treats_plural_numeric_markers_as_numeric(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.980"
+version = "0.2.981"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- feed companion failure case names into missing-input completion so case-scoped runtime errors are repairable
- retry missing-input completion after stale references are removed or rewritten
- treat compensation inputs as numeric defaults when generating missing imported test inputs

## Tests
- uv run pytest tests/test_cli.py -k "missing_input_default or repair_companion_test_references_adds_missing_defaults_with_case or companion_reference_cleanup_can_add_new_import_defaults" -q
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py
- env -u UV_FROZEN uv lock --check

## Validation
- Verified signed repair succeeds on rulespec-us us/statutes/26/24/d.yaml
- Verified axiom-encode validate us/statutes/26/24/d.yaml --skip-reviewers --json passes