### PR TITLE
Classify oracle helper scalar mappings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.981"
+version = "0.2.982"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.981"
+__version__ = "0.2.982"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -5658,6 +5658,54 @@ mappings:
     candidate_priority: P4
     rationale: PolicyEngine's aca_required_contribution_percentage computes the current-law indexed ACA applicable figure for a tax unit. This RuleSpec output is the unindexed section 36B(b)(3)(A) statutory formula, so 2026 oracle cases differ from PolicyEngine after Revenue Procedure indexing.
 
+  - legal_id: us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_percentage_band_scalar_limit
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.required_contribution_percentage.threshold
+    candidate_priority: P4
+    rationale: Revenue Procedure 2025-25 encodes the first ACA percentage-table income breakpoint as a standalone RuleSpec scalar helper. PolicyEngine stores the threshold table as an indexed parameter rather than exposing each scalar breakpoint as a one-to-one oracle target.
+
+  - legal_id: us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_percentage_band_scalar_limit_2
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.required_contribution_percentage.threshold
+    candidate_priority: P4
+    rationale: Revenue Procedure 2025-25 encodes the second ACA percentage-table income breakpoint as a standalone RuleSpec scalar helper. PolicyEngine stores the threshold table as an indexed parameter rather than exposing each scalar breakpoint as a one-to-one oracle target.
+
+  - legal_id: us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_percentage_band_scalar_limit_3
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.required_contribution_percentage.threshold
+    candidate_priority: P4
+    rationale: Revenue Procedure 2025-25 encodes the third ACA percentage-table income breakpoint as a standalone RuleSpec scalar helper. PolicyEngine stores the threshold table as an indexed parameter rather than exposing each scalar breakpoint as a one-to-one oracle target.
+
+  - legal_id: us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_percentage_band_scalar_limit_4
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.required_contribution_percentage.threshold
+    candidate_priority: P4
+    rationale: Revenue Procedure 2025-25 encodes the fourth ACA percentage-table income breakpoint as a standalone RuleSpec scalar helper. PolicyEngine stores the threshold table as an indexed parameter rather than exposing each scalar breakpoint as a one-to-one oracle target.
+
+  - legal_id: us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_percentage_band_scalar_limit_5
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.required_contribution_percentage.threshold
+    candidate_priority: P4
+    rationale: Revenue Procedure 2025-25 encodes the fifth ACA percentage-table income breakpoint as a standalone RuleSpec scalar helper. PolicyEngine stores the threshold table as an indexed parameter rather than exposing each scalar breakpoint as a one-to-one oracle target.
+
+  - legal_id: us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_percentage_band_scalar_limit_6
+    country: us
+    program: aca_ptc
+    mapping_type: not_comparable
+    policyengine_parameter: gov.aca.required_contribution_percentage.threshold
+    candidate_priority: P4
+    rationale: Revenue Procedure 2025-25 encodes the final ACA percentage-table income breakpoint as a standalone RuleSpec scalar helper. PolicyEngine stores the threshold table as an indexed parameter rather than exposing each scalar breakpoint as a one-to-one oracle target.
+
   - legal_id: us:policies/irs/rev-proc-2025-25/aca-ptc#applicable_percentage_band
     country: us
     program: aca_ptc
@@ -7108,6 +7156,12 @@ mappings:
     mapping_type: not_comparable
     rationale: PolicyEngine stores or ages the retirement earnings test exempt amounts rather than computing this 2026 SSA automatic determination as an oracle-comparable formula.
 
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#retirement_earnings_test_lower_annual_exempt_amount_scalar_limit
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: RuleSpec exposes the statutory twelve-month multiplier used to annualize the 2026 lower retirement earnings test monthly exempt amount. PolicyEngine stores or ages the final exempt amounts and does not expose this multiplier as a standalone oracle target.
+
   - legal_id: us:policies/ssa/retirement-earnings-test/2026#retirement_earnings_test_lower_annual_exempt_amount
     country: us
     program: tax
@@ -7119,6 +7173,12 @@ mappings:
     program: tax
     mapping_type: not_comparable
     rationale: PolicyEngine stores or ages the retirement earnings test exempt amounts rather than computing this 2026 SSA automatic determination as an oracle-comparable formula.
+
+  - legal_id: us:policies/ssa/retirement-earnings-test/2026#retirement_earnings_test_higher_annual_exempt_amount_scalar_limit
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: RuleSpec exposes the statutory twelve-month multiplier used to annualize the 2026 higher retirement earnings test monthly exempt amount. PolicyEngine stores or ages the final exempt amounts and does not expose this multiplier as a standalone oracle target.
 
   - legal_id: us:policies/ssa/retirement-earnings-test/2026#retirement_earnings_test_higher_annual_exempt_amount
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -111,6 +111,81 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_aca_ptc_rev_proc_scalar_helpers(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us/us/policies/irs/rev-proc-2025-25/aca-ptc.yaml",
+        """format: rulespec/v1
+rules:
+  - name: applicable_percentage_band_scalar_limit
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '1.33'
+  - name: applicable_percentage_band_scalar_limit_2
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '1.50'
+  - name: applicable_percentage_band_scalar_limit_3
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '2.00'
+  - name: applicable_percentage_band_scalar_limit_4
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '2.50'
+  - name: applicable_percentage_band_scalar_limit_5
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '3.00'
+  - name: applicable_percentage_band_scalar_limit_6
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '4.00'
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="aca_ptc")
+
+    assert report["total_outputs"] == 6
+    assert report["status_counts"] == {"known_not_comparable": 6}
+    assert {item["mapping_type"] for item in report["items"]} == {"not_comparable"}
+    assert {item["policyengine_parameter"] for item in report["items"]} == {
+        "gov.aca.required_contribution_percentage.threshold"
+    }
+
+
+def test_policyengine_coverage_classifies_retirement_earnings_annual_scalars(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us/us/policies/ssa/retirement-earnings-test/2026.yaml",
+        """format: rulespec/v1
+rules:
+  - name: retirement_earnings_test_lower_annual_exempt_amount_scalar_limit
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '12'
+  - name: retirement_earnings_test_higher_annual_exempt_amount_scalar_limit
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '12'
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["total_outputs"] == 2
+    assert report["status_counts"] == {"known_not_comparable": 2}
+    assert {item["mapping_type"] for item in report["items"]} == {"not_comparable"}
+
+
 def test_policyengine_coverage_classifies_head_start_45_cfr_1302_12(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us/us/regulations/45-cfr/1302/12.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.981"
+version = "0.2.982"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify ACA Rev. Proc. 2025-25 breakpoint scalar helpers as not directly comparable oracle targets
- classify SSA retirement earnings test annualization scalar helpers as not directly comparable oracle targets
- add coverage tests for both helper families

## Validation
- uv run pytest tests/test_policyengine_coverage.py -q
- uv run ruff check tests/test_policyengine_coverage.py
- uv run python - <<'PY'
from axiom_encode.oracles.policyengine.registry import load_policyengine_registry
issues = load_policyengine_registry().validate()
print('issues', len(issues))
raise SystemExit(1 if issues else 0)
PY
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program aca_ptc --fail-on-unmapped --fail-on-untested-comparable --limit 20
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tax --fail-on-unmapped --fail-on-untested-comparable --limit 20