### PR TITLE
Repair same-section cross-reference aliases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.982"
+version = "0.2.983"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.982"
+__version__ = "0.2.983"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -34638,11 +34638,41 @@ _SAFE_IMPORT_OUTPUT_ALIAS_PREFIXES = {
 
 def _is_safe_import_output_alias(symbol: str, output: str) -> bool:
     if symbol == output or not symbol.endswith(f"_{output}"):
-        return False
+        return _is_safe_legal_cross_reference_output_alias(symbol, output)
     prefix = symbol[: -(len(output) + 1)].strip("_")
     if not prefix:
         return False
     return prefix in _SAFE_IMPORT_OUTPUT_ALIAS_PREFIXES
+
+
+def _is_safe_legal_cross_reference_output_alias(symbol: str, output: str) -> bool:
+    """Return whether a local cross-reference fact names a cited output plus qualifiers."""
+    symbol_tokens = _identifier_tokens(symbol)
+    output_tokens = _identifier_tokens(output)
+    if len(output_tokens) < 3 or len(symbol_tokens) <= len(output_tokens):
+        return False
+    if not any(
+        token in symbol_tokens
+        for token in ("clause", "paragraph", "section", "subparagraph", "subsection")
+    ):
+        return False
+    if symbol_tokens[0] != output_tokens[0]:
+        return False
+    return _ordered_subsequence(output_tokens, symbol_tokens)
+
+
+def _identifier_tokens(value: str) -> list[str]:
+    return [
+        token for token in re.sub(r"[^a-z0-9]+", "_", value.lower()).split("_") if token
+    ]
+
+
+def _ordered_subsequence(needles: list[str], haystack: list[str]) -> bool:
+    cursor = 0
+    for token in haystack:
+        if cursor < len(needles) and token == needles[cursor]:
+            cursor += 1
+    return cursor == len(needles)
 
 
 def _replace_rulespec_symbol_references(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -14852,6 +14852,12 @@ def _same_section_sibling_citation_requires_import(
         flags=re.IGNORECASE,
     ):
         return False
+    if re.search(
+        r"\b(?:for\s+purposes?\s+of|outside)\s*$",
+        prefix,
+        flags=re.IGNORECASE,
+    ):
+        return False
     triggers = list(
         re.finditer(
             r"\b(?:except|unless|subject\s+to|notwithstanding)\b",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19905,6 +19905,82 @@ rules:
             in rules_file.read_text()
         )
 
+    def test_same_section_import_repair_replaces_qualified_cross_reference_alias(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "codex-gpt-5.5" / "statutes/26/3121/b/8.yaml"
+        rules_file.parent.mkdir(parents=True)
+        policy_repo = tmp_path / "rulespec-us"
+        cited_file = policy_repo / "statutes" / "26" / "3121" / "r.yaml"
+        cited_file.parent.mkdir(parents=True)
+        cited_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: certificate_of_election_by_religious_order_valid
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: certificate_filed
+  - name: election_of_coverage_in_effect
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: certificate_of_election_by_religious_order_valid
+"""
+        )
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/26/3121/r
+rules:
+  - name: minister_or_religious_order_service_excluded_from_employment
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          service_performed_by_member_of_religious_order_in_exercise_of_duties_required_by_order
+          and not election_of_coverage_under_subsection_r_in_effect_with_respect_to_order
+          and not election_of_coverage_under_subsection_r_in_effect_with_respect_to_autonomous_subdivision
+"""
+        )
+        result = SimpleNamespace(
+            runner="codex-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = (
+            _try_repair_generated_missing_same_section_subsection_imports_for_apply(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                issues=[
+                    "statutes/26/3121/b/8.yaml: ci: Same-section subsection "
+                    "import not operational: source text cites `statutes/26/3121/r` "
+                    "in an exception/cross-reference clause, but the matching import "
+                    "does not bring a specific imported output into the formula."
+                ],
+            )
+        )
+
+        assert repaired == ["us:statutes/26/3121/r#election_of_coverage_in_effect"]
+        rules_text = rules_file.read_text()
+        assert (
+            "  - us:statutes/26/3121/r#election_of_coverage_in_effect\n" in rules_text
+        )
+        assert "and not election_of_coverage_in_effect\n" in rules_text
+        assert (
+            "election_of_coverage_under_subsection_r_in_effect_with_respect_to_order"
+            not in rules_text
+        )
+        assert (
+            "election_of_coverage_under_subsection_r_in_effect_with_respect_to_autonomous_subdivision"
+            not in rules_text
+        )
+
     def test_missing_same_section_import_repair_adds_medicaid_xx_formula_gate(
         self, tmp_path
     ):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -8858,6 +8858,61 @@ rules:
     assert "statutes/26/3121/y" in issues[0]
 
 
+def test_same_section_outside_subsection_scope_does_not_require_import(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    cited_file = repo / "statutes" / "26" / "3401" / "a.yaml"
+    cited_file.parent.mkdir(parents=True)
+    cited_file.write_text(
+        """format: rulespec/v1
+module:
+  status: deferred
+rules: []
+"""
+    )
+    rules_file = repo / "statutes" / "26" / "3401" / "d.yaml"
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  summary: |-
+    Employer means the person for whom an individual performs services as an
+    employee, except that, outside subsection (a), if that person lacks control
+    of wage payment, employer means the person having control of payment.
+rules:
+  - name: employer_for_subsection_a
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '0001-01-01'
+        formula: person_for_whom_individual_performs_services_as_employee
+  - name: employer
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Year
+    versions:
+      - effective_from: '0001-01-01'
+        formula: |-
+          (
+            person_for_whom_individual_performs_services_as_employee
+            and person_has_control_of_payment_of_wages
+          )
+          or person_having_control_of_payment_of_wages
+"""
+    )
+
+    assert (
+        find_missing_same_section_subsection_import_issues(
+            rules_file.read_text(),
+            rules_file=rules_file,
+            policy_repo_path=repo,
+        )
+        == []
+    )
+
+
 def test_same_section_nested_subsection_reference_uses_child_import(tmp_path):
     repo = tmp_path / "rulespec-us"
     cited_file = repo / "statutes" / "42" / "1396a" / "a" / "10.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.982"
+version = "0.2.983"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair same-section subsection imports when generated formulas use qualified local cross-reference aliases for the cited output
- avoid requiring executable same-section imports for scope carve-outs like "outside subsection (a)"
- bump axiom-encode to 0.2.983

## Tests
- uv run ruff check src/axiom_encode/cli.py src/axiom_encode/harness/validator_pipeline.py tests/test_cli.py tests/test_rulespec_validation.py
- uv run pytest tests/test_cli.py -k "same_section_import_repair_replaces_qualified_cross_reference_alias or same_section_import_repair_promotes_non_operational_file_import or missing_same_section_import_repair_promotes_cfr_placeholder" -q
- uv run pytest tests/test_rulespec_validation.py -k "same_section_outside_subsection_scope_does_not_require_import or same_section_under_subsection_reference_requires_import or regulation_subject_to_paragraph_reference_uses_source_verification_text" -q
- uv run pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q