### PR TITLE
Repair same-section alias test inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.983"
+version = "0.2.984"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.983"
+__version__ = "0.2.984"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -33926,6 +33926,14 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
                     repaired,
                     alias_replacements,
                 )
+                placeholder_repairs.extend(
+                    _repair_formula_alias_output_test_inputs(
+                        test_file=test_file,
+                        generated_target_base=generated_target_base,
+                        imported_target=imported_target,
+                        alias_replacements=alias_replacements,
+                    )
+                )
             referenced_outputs = _formula_referenced_rulespec_output_names(
                 repaired,
                 target_outputs,
@@ -34884,6 +34892,100 @@ def _add_imported_gate_test_overrides(
         yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
     )
     return repairs
+
+
+def _repair_formula_alias_output_test_inputs(
+    *,
+    test_file: Path,
+    generated_target_base: str,
+    imported_target: str,
+    alias_replacements: dict[str, str],
+) -> list[str]:
+    if not test_file.exists() or not alias_replacements:
+        return []
+    try:
+        test_payload = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    if not isinstance(test_payload, list):
+        return []
+
+    changed = False
+    repairs: list[str] = []
+    ref_replacements = {
+        f"{generated_target_base}#input.{alias}": f"{imported_target}#{output}"
+        for alias, output in alias_replacements.items()
+    }
+    for test_case in test_payload:
+        if not isinstance(test_case, dict):
+            continue
+        case_repairs = _replace_alias_output_test_inputs_in_value(
+            test_case,
+            ref_replacements=ref_replacements,
+        )
+        if not case_repairs:
+            continue
+        changed = True
+        case_name = str(test_case.get("name") or "<unnamed>")
+        repairs.extend(f"test:{case_name}:{repair}" for repair in case_repairs)
+
+    if not changed:
+        return []
+    test_file.write_text(
+        yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
+    )
+    return repairs
+
+
+def _replace_alias_output_test_inputs_in_value(
+    value: object,
+    *,
+    ref_replacements: dict[str, str],
+) -> list[str]:
+    repairs: list[str] = []
+    if isinstance(value, dict):
+        pending: dict[str, object] = {}
+        for key in list(value.keys()):
+            key_text = str(key)
+            new_ref = ref_replacements.get(key_text)
+            if new_ref is None:
+                continue
+            old_value = value.pop(key)
+            if new_ref in value:
+                old_value = _combine_alias_test_input_values(value[new_ref], old_value)
+            if new_ref in pending:
+                old_value = _combine_alias_test_input_values(
+                    pending[new_ref], old_value
+                )
+            pending[new_ref] = old_value
+            repairs.append(f"{key_text}->{new_ref}")
+        value.update(pending)
+        for nested in value.values():
+            repairs.extend(
+                _replace_alias_output_test_inputs_in_value(
+                    nested,
+                    ref_replacements=ref_replacements,
+                )
+            )
+    elif isinstance(value, list):
+        for item in value:
+            repairs.extend(
+                _replace_alias_output_test_inputs_in_value(
+                    item,
+                    ref_replacements=ref_replacements,
+                )
+            )
+    return repairs
+
+
+def _combine_alias_test_input_values(existing: object, incoming: object) -> bool:
+    return _test_input_object_truthy(existing) or _test_input_object_truthy(incoming)
+
+
+def _test_input_object_truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    return _test_input_value_truthy(str(value))
 
 
 def _repair_same_section_subsection_placeholder_references(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19910,6 +19910,7 @@ rules:
     ):
         output_root = tmp_path / "out"
         rules_file = output_root / "codex-gpt-5.5" / "statutes/26/3121/b/8.yaml"
+        test_file = rules_file.with_name("8.test.yaml")
         rules_file.parent.mkdir(parents=True)
         policy_repo = tmp_path / "rulespec-us"
         cited_file = policy_repo / "statutes" / "26" / "3121" / "r.yaml"
@@ -19947,6 +19948,20 @@ rules:
           and not election_of_coverage_under_subsection_r_in_effect_with_respect_to_autonomous_subdivision
 """
         )
+        test_file.write_text(
+            """- name: subsection_r_autonomous_subdivision_election_blocks_religious_order_member_branch
+  period: 2026
+  input: {}
+  tables:
+    Payment:
+      - us:statutes/26/3121/b/8#input.service_performed_by_member_of_religious_order_in_exercise_of_duties_required_by_order: true
+        us:statutes/26/3121/b/8#input.election_of_coverage_under_subsection_r_in_effect_with_respect_to_order: false
+        us:statutes/26/3121/b/8#input.election_of_coverage_under_subsection_r_in_effect_with_respect_to_autonomous_subdivision: true
+  output:
+    us:statutes/26/3121/b/8#minister_or_religious_order_service_excluded_from_employment:
+      - not_holds
+"""
+        )
         result = SimpleNamespace(
             runner="codex-gpt-5.5",
             output_file=str(rules_file),
@@ -19966,7 +19981,20 @@ rules:
             )
         )
 
-        assert repaired == ["us:statutes/26/3121/r#election_of_coverage_in_effect"]
+        assert repaired[0] == "us:statutes/26/3121/r#election_of_coverage_in_effect"
+        assert len(repaired) == 3
+        assert any(
+            "election_of_coverage_under_subsection_r_in_effect_with_respect_to_order"
+            in item
+            and item.endswith("->us:statutes/26/3121/r#election_of_coverage_in_effect")
+            for item in repaired
+        )
+        assert any(
+            "election_of_coverage_under_subsection_r_in_effect_with_respect_to_autonomous_subdivision"
+            in item
+            and item.endswith("->us:statutes/26/3121/r#election_of_coverage_in_effect")
+            for item in repaired
+        )
         rules_text = rules_file.read_text()
         assert (
             "  - us:statutes/26/3121/r#election_of_coverage_in_effect\n" in rules_text
@@ -19979,6 +20007,21 @@ rules:
         assert (
             "election_of_coverage_under_subsection_r_in_effect_with_respect_to_autonomous_subdivision"
             not in rules_text
+        )
+        test_payload = yaml.safe_load(test_file.read_text())
+        table_inputs = test_payload[0]["tables"]["Payment"][0]
+        assert (
+            table_inputs["us:statutes/26/3121/r#election_of_coverage_in_effect"] is True
+        )
+        assert (
+            "us:statutes/26/3121/b/8#input."
+            "election_of_coverage_under_subsection_r_in_effect_with_respect_to_order"
+            not in table_inputs
+        )
+        assert (
+            "us:statutes/26/3121/b/8#input."
+            "election_of_coverage_under_subsection_r_in_effect_with_respect_to_autonomous_subdivision"
+            not in table_inputs
         )
 
     def test_missing_same_section_import_repair_adds_medicaid_xx_formula_gate(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.983"
+version = "0.2.984"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- migrate generated alias test inputs when same-section repair replaces formula aliases with an imported output
- combine duplicate alias values with truthy semantics when multiple generated aliases map to one imported output
- bump axiom-encode to 0.2.984

## Tests
- uv run ruff format src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run pytest tests/test_cli.py -k "same_section_import_repair_replaces_qualified_cross_reference_alias or same_section_import_repair_promotes_non_operational_file_import or missing_same_section_import_repair_promotes_cfr_placeholder" -q
- uv run pytest tests/test_rulespec_validation.py -k "same_section_outside_subsection_scope_does_not_require_import or same_section_under_subsection_reference_requires_import" -q
- uv run pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q