### PR TITLE
Use upstream inputs for same-section alias tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.984"
+version = "0.2.985"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.984"
+__version__ = "0.2.985"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -33929,6 +33929,7 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
                 placeholder_repairs.extend(
                     _repair_formula_alias_output_test_inputs(
                         test_file=test_file,
+                        policy_repo_path=policy_repo_path,
                         generated_target_base=generated_target_base,
                         imported_target=imported_target,
                         alias_replacements=alias_replacements,
@@ -34434,7 +34435,24 @@ def _generated_test_values_equal(left: object, right: object) -> bool:
     right_decimal = _numeric_test_decimal(right)
     if left_decimal is not None and right_decimal is not None:
         return left_decimal == right_decimal
+    left_judgment = _judgment_test_bool(left)
+    right_judgment = _judgment_test_bool(right)
+    if left_judgment is not None and right_judgment is not None:
+        return left_judgment == right_judgment
     return left == right
+
+
+def _judgment_test_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if normalized in {"holds", "true"}:
+        return True
+    if normalized in {"not_holds", "false"}:
+        return False
+    return None
 
 
 def _numeric_test_decimal(value: object) -> Decimal | None:
@@ -34897,6 +34915,7 @@ def _add_imported_gate_test_overrides(
 def _repair_formula_alias_output_test_inputs(
     *,
     test_file: Path,
+    policy_repo_path: Path,
     generated_target_base: str,
     imported_target: str,
     alias_replacements: dict[str, str],
@@ -34922,6 +34941,7 @@ def _repair_formula_alias_output_test_inputs(
         case_repairs = _replace_alias_output_test_inputs_in_value(
             test_case,
             ref_replacements=ref_replacements,
+            policy_repo_path=policy_repo_path,
         )
         if not case_repairs:
             continue
@@ -34941,30 +34961,46 @@ def _replace_alias_output_test_inputs_in_value(
     value: object,
     *,
     ref_replacements: dict[str, str],
+    policy_repo_path: Path,
 ) -> list[str]:
     repairs: list[str] = []
     if isinstance(value, dict):
-        pending: dict[str, object] = {}
-        for key in list(value.keys()):
+        pending_desired_values: dict[str, object] = {}
+        matched_keys: dict[str, list[object]] = {}
+        for key, old_value in list(value.items()):
             key_text = str(key)
             new_ref = ref_replacements.get(key_text)
             if new_ref is None:
                 continue
-            old_value = value.pop(key)
-            if new_ref in value:
-                old_value = _combine_alias_test_input_values(value[new_ref], old_value)
-            if new_ref in pending:
+            if new_ref in pending_desired_values:
                 old_value = _combine_alias_test_input_values(
-                    pending[new_ref], old_value
+                    pending_desired_values[new_ref],
+                    old_value,
                 )
-            pending[new_ref] = old_value
-            repairs.append(f"{key_text}->{new_ref}")
-        value.update(pending)
+            pending_desired_values[new_ref] = old_value
+            matched_keys.setdefault(new_ref, []).append(key)
+        upstream_inputs_by_ref: dict[str, dict[object, object]] = {}
+        for new_ref, desired_value in pending_desired_values.items():
+            upstream_inputs = _producer_test_inputs_for_output_value(
+                new_ref,
+                desired_value,
+                policy_repo_path=policy_repo_path,
+            )
+            if upstream_inputs:
+                upstream_inputs_by_ref[new_ref] = upstream_inputs
+        for new_ref, upstream_inputs in upstream_inputs_by_ref.items():
+            for key in matched_keys.get(new_ref, []):
+                old_key = str(key)
+                value.pop(key, None)
+                repairs.append(f"{old_key}->{new_ref}")
+            for input_ref, input_value in upstream_inputs.items():
+                value.setdefault(input_ref, input_value)
         for nested in value.values():
             repairs.extend(
                 _replace_alias_output_test_inputs_in_value(
                     nested,
                     ref_replacements=ref_replacements,
+                    policy_repo_path=policy_repo_path,
                 )
             )
     elif isinstance(value, list):
@@ -34973,6 +35009,7 @@ def _replace_alias_output_test_inputs_in_value(
                 _replace_alias_output_test_inputs_in_value(
                     item,
                     ref_replacements=ref_replacements,
+                    policy_repo_path=policy_repo_path,
                 )
             )
     return repairs

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19915,6 +19915,7 @@ rules:
         policy_repo = tmp_path / "rulespec-us"
         cited_file = policy_repo / "statutes" / "26" / "3121" / "r.yaml"
         cited_file.parent.mkdir(parents=True)
+        cited_test_file = cited_file.with_name("r.test.yaml")
         cited_file.write_text(
             """format: rulespec/v1
 rules:
@@ -19930,6 +19931,21 @@ rules:
     versions:
       - effective_from: '1990-01-01'
         formula: certificate_of_election_by_religious_order_valid
+"""
+        )
+        cited_test_file.write_text(
+            """- name: election_in_effect_when_certificate_filed
+  period: 2026
+  input:
+    us:statutes/26/3121/r#input.certificate_filed: true
+  output:
+    us:statutes/26/3121/r#election_of_coverage_in_effect: holds
+- name: election_not_in_effect_when_certificate_not_filed
+  period: 2026
+  input:
+    us:statutes/26/3121/r#input.certificate_filed: false
+  output:
+    us:statutes/26/3121/r#election_of_coverage_in_effect: not_holds
 """
         )
         rules_file.write_text(
@@ -20010,8 +20026,9 @@ rules:
         )
         test_payload = yaml.safe_load(test_file.read_text())
         table_inputs = test_payload[0]["tables"]["Payment"][0]
+        assert table_inputs["us:statutes/26/3121/r#input.certificate_filed"] is True
         assert (
-            table_inputs["us:statutes/26/3121/r#election_of_coverage_in_effect"] is True
+            "us:statutes/26/3121/r#election_of_coverage_in_effect" not in table_inputs
         )
         assert (
             "us:statutes/26/3121/b/8#input."

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.984"
+version = "0.2.985"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- replace same-section alias test placeholders with upstream producer inputs instead of assigning imported computed outputs
- match boolean generated placeholders against Judgment producer outputs (`holds` / `not_holds`)
- bump axiom-encode to 0.2.985

## Tests
- `uv run ruff format src/axiom_encode/cli.py tests/test_cli.py`
- `uv run ruff check src/axiom_encode/cli.py tests/test_cli.py`
- `uv run pytest tests/test_cli.py -k "same_section_import_repair_replaces_qualified_cross_reference_alias or same_section_import_repair_promotes_non_operational_file_import or missing_same_section_import_repair_promotes_cfr_placeholder" -q`
- `uv run pytest tests/test_rulespec_validation.py -k "same_section_outside_subsection_scope_does_not_require_import or same_section_under_subsection_reference_requires_import" -q`
- `uv run pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`