### PR TITLE
Allow same-section pre-limit outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.985"
+version = "0.2.986"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.985"
+__version__ = "0.2.986"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -14595,6 +14595,11 @@ def find_missing_same_section_subsection_import_issues(
             fragment=fragment,
         ):
             continue
+        if payload is not None and _pre_limit_outputs_cover_same_section_dependency(
+            payload,
+            fragment=fragment,
+        ):
+            continue
         if _transitive_imports_cover_path_static(
             imports,
             import_base,
@@ -14774,6 +14779,42 @@ def _deferred_output_targets_same_section_dependency(
             ):
                 return True
     return False
+
+
+def _pre_limit_outputs_cover_same_section_dependency(
+    payload: dict[str, Any],
+    *,
+    fragment: str,
+) -> bool:
+    """Return whether rule outputs explicitly defer applying a cited same-section limit."""
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return False
+    suffixes = _same_section_pre_limit_output_suffixes(fragment)
+    if not suffixes:
+        return False
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        name = str(rule.get("name") or "").strip().lower()
+        if name and any(name.endswith(suffix) for suffix in suffixes):
+            return True
+    return False
+
+
+def _same_section_pre_limit_output_suffixes(fragment: str) -> set[str]:
+    parts = [
+        part.strip().lower()
+        for part in fragment.split("/")
+        if re.fullmatch(r"[a-z0-9]+", part.strip().lower())
+    ]
+    if not parts:
+        return set()
+    suffix_stem = "_".join(parts)
+    return {
+        f"_before_subsection_{suffix_stem}_limit",
+        f"_before_paragraph_{suffix_stem}_limit",
+    }
 
 
 def _direct_same_section_sibling_import_symbol_issue(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -9006,6 +9006,44 @@ rules:
     )
 
 
+def test_same_section_subject_to_reference_allows_pre_limit_output(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    cited_file = repo / "statutes" / "26" / "3121" / "a" / "1.yaml"
+    cited_file.parent.mkdir(parents=True)
+    cited_file.write_text("format: rulespec/v1\nrules: []\n")
+    rules_file = repo / "statutes" / "26" / "3121" / "i.yaml"
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    rules_file.write_text(
+        """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/statute/26/3121/i
+  summary: |-
+    Uniformed-services remuneration includes only specified basic pay,
+    subject to subsection (a)(1).
+rules:
+  - name: uniformed_service_remuneration_included_before_subsection_a_1_limit
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: basic_pay_described_in_chapter_3_and_section_1009_of_title_37
+"""
+    )
+
+    assert (
+        find_missing_same_section_subsection_import_issues(
+            rules_file.read_text(),
+            rules_file=rules_file,
+            policy_repo_path=repo,
+        )
+        == []
+    )
+
+
 def test_same_section_reference_allows_empty_deferred_fallback(tmp_path):
     repo = tmp_path / "rulespec-us"
     cited_file = repo / "statutes" / "26" / "3121" / "j.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.985"
+version = "0.2.986"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- allow same-section subject-to citations when the encoded rule explicitly emits a pre-application limit output
- add suffix detection for before-subsection and before-paragraph limit outputs
- bump axiom-encode to 0.2.986

## Tests
- uv run ruff format src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- uv run pytest tests/test_rulespec_validation.py -k same_section_subject_to_reference_allows_pre_limit_output-or-same_section_outside_subsection_scope_does_not_require_import-or-same_section_under_subsection_reference_requires_import-or-regulation_subject_to_paragraph_reference_rejects_bare_import -q
- uv run pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- axiom-encode validate --skip-reviewers --json us/statutes/26/3121/b/8.yaml us/statutes/26/3121/i.yaml us/statutes/26/3401/d.yaml us/statutes/26/45A.yaml us/statutes/42/1396a/e.yaml