### PR TITLE
Add MA TAFDC PolicyEngine oracle adapter

### DIFF
--- a/changelog.d/ma-tafdc-household-oracle.added.md
+++ b/changelog.d/ma-tafdc-household-oracle.added.md
@@ -1,0 +1,1 @@
+Add PolicyEngine oracle support for household-level scenario overrides and Massachusetts TAFDC payment-standard comparisons.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.986"
+version = "0.2.987"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.986"
+__version__ = "0.2.987"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -25784,6 +25784,10 @@ print("BENCHMARK:" + json.dumps(result))
                 *adapter.monthly_person_inputs,
                 *adapter.boolean_person_inputs,
                 *adapter.monthly_boolean_person_inputs,
+                *adapter.direct_household_overrides,
+                *adapter.inverted_boolean_household_overrides,
+                *adapter.annual_direct_household_overrides,
+                *adapter.annual_inverted_boolean_household_overrides,
             ):
                 aliases.add(source_key)
             for _target_key, _operation, source_keys in (
@@ -27063,6 +27067,38 @@ print(f'RESULT:{{float(value)}}')
             household_extra_parts.append(
                 f"'state_group_str': {{'{year}': {repr(inputs['state_group'])}}}"
             )
+        if adapter is not None:
+            household_override_period = period if is_monthly else year
+            for rule_key, pe_key in adapter.direct_household_overrides:
+                value = self._rulespec_test_input_value(inputs, rule_key)
+                if value is None:
+                    continue
+                household_extra_parts.append(
+                    f"'{pe_key}': "
+                    f"{{'{household_override_period}': {pe_literal(value)}}}"
+                )
+            for rule_key, pe_key in adapter.inverted_boolean_household_overrides:
+                value = self._rulespec_test_input_value(inputs, rule_key)
+                if value is None:
+                    continue
+                household_extra_parts.append(
+                    f"'{pe_key}': "
+                    f"{{'{household_override_period}': {pe_literal(not bool(value))}}}"
+                )
+            for rule_key, pe_key in adapter.annual_direct_household_overrides:
+                value = self._rulespec_test_input_value(inputs, rule_key)
+                if value is None:
+                    continue
+                household_extra_parts.append(
+                    f"'{pe_key}': {{'{year}': {pe_literal(value)}}}"
+                )
+            for rule_key, pe_key in adapter.annual_inverted_boolean_household_overrides:
+                value = self._rulespec_test_input_value(inputs, rule_key)
+                if value is None:
+                    continue
+                household_extra_parts.append(
+                    f"'{pe_key}': {{'{year}': {pe_literal(not bool(value))}}}"
+                )
         household_extra = ", ".join(household_extra_parts)
 
         if adapter is not None and adapter.parameter_path is not None:

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -29,6 +29,10 @@ class PolicyEngineUSVarAdapter:
     derived_spm_overrides: tuple[tuple[str, str, tuple[str, ...]], ...] = ()
     annual_direct_spm_overrides: tuple[tuple[str, str], ...] = ()
     annual_derived_spm_overrides: tuple[tuple[str, str, tuple[str, ...]], ...] = ()
+    direct_household_overrides: tuple[tuple[str, str], ...] = ()
+    inverted_boolean_household_overrides: tuple[tuple[str, str], ...] = ()
+    annual_direct_household_overrides: tuple[tuple[str, str], ...] = ()
+    annual_inverted_boolean_household_overrides: tuple[tuple[str, str], ...] = ()
     unsupported_input_keys: tuple[str, ...] = ()
     unsupported_input_patterns: tuple[str, ...] = ()
     unsupported_truthy_input_keys: tuple[str, ...] = ()
@@ -397,6 +401,17 @@ PE_US_VAR_ADAPTERS = (
         spm=True,
         annual_direct_spm_overrides=(("family_size", "spm_unit_size"),),
         default_state_code="CO",
+    ),
+    PolicyEngineUSVarAdapter(
+        rule_names=("ma_tafdc_payment_standard",),
+        pe_var="ma_tafdc_payment_standard",
+        monthly=True,
+        spm=True,
+        annual_direct_spm_overrides=(("assistance_unit_size", "spm_unit_size"),),
+        annual_inverted_boolean_household_overrides=(
+            ("assistance_unit_has_rent_allowance", "is_in_public_housing"),
+        ),
+        default_state_code="MA",
     ),
     PolicyEngineUSVarAdapter(
         rule_names=("oap_authorized_grant_payment_for_month",),

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -3529,6 +3529,17 @@ mappings:
     comparison: rate
     rationale: Same Arizona TANF base income-limit rate for parent or non-parent caretaker relative self-and-child cases.
 
+  - legal_id: us-ma:regulations/106-cmr/704/410-420-table/block-1#ma_tafdc_payment_standard
+    country: us
+    program: tanf
+    mapping_type: direct_variable
+    policyengine_variable: ma_tafdc_payment_standard
+    entity: spm_unit
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Massachusetts TAFDC monthly payment-standard table, selecting the no-rent or with-rent column by assistance-unit rent-allowance status and applying the listed incremental amount for assistance units above size 10.
+
   - legal_id: us-az:programs/tanf/fy-2026#az_tanf
     country: us
     program: tanf

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -4328,6 +4328,34 @@ def test_policyengine_snap_net_income_annualizes_housing_cost(tmp_path):
     assert "'housing_cost': {'2026-01':" not in script
 
 
+def test_policyengine_ma_tafdc_payment_standard_projects_household_rent_status(
+    tmp_path,
+):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+
+    script = pipeline._build_pe_us_scenario_script(
+        "ma_tafdc_payment_standard",
+        {
+            "period": "2024-09",
+            "assistance_unit_size": 3,
+            "assistance_unit_has_rent_allowance": False,
+        },
+        "2024",
+    )
+
+    assert "'state_code_str': {'2024': 'MA'}" in script
+    assert "'spm_unit_size': {'2024': 3}" in script
+    assert "'is_in_public_housing': {'2024': True}" in script
+    assert ValidatorPipeline._is_projectable_pe_us_input_alias(
+        "assistance_unit_has_rent_allowance",
+        "ma_tafdc_payment_standard",
+    )
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.986"
+version = "0.2.987"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add household-level PolicyEngine scenario overrides, including annual household overrides
- map the Massachusetts TAFDC payment-standard RuleSpec output to PolicyEngine `ma_tafdc_payment_standard`
- add regression coverage for MA TAFDC SPM-unit and household input projection

## Validation
- `uv run python -m pytest tests/test_rulespec_validation.py -k ma_tafdc_payment_standard_projects_household_rent_status`
- `uv run python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run ruff check src/axiom_encode/oracles/policyengine/adapters.py src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- With this branch on `PYTHONPATH`, the MA TAFDC RuleSpec file passes PolicyEngine oracle validation at 3/3 comparable tests.