### PR TITLE
Add MA TAFDC infant benefit PolicyEngine oracle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.987"
+version = "0.2.988"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.987"
+__version__ = "0.2.988"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -25804,6 +25804,7 @@ print("BENCHMARK:" + json.dumps(result))
             ):
                 aliases.update(source_keys)
             aliases.update(adapter.unsupported_truthy_input_keys)
+            aliases.update(adapter.unsupported_falsy_input_keys)
             if adapter.state_code_from_boolean_input is not None:
                 aliases.add(adapter.state_code_from_boolean_input[0])
         return {alias.lower() for alias in aliases if alias}
@@ -25993,6 +25994,23 @@ print("BENCHMARK:" + json.dumps(result))
                     return (
                         False,
                         f"{reason}: {', '.join(sorted(unsupported_truthy_keys))}",
+                    )
+            if adapter is not None and adapter.unsupported_falsy_input_keys:
+                unsupported_falsy_keys = []
+                for key in adapter.unsupported_falsy_input_keys:
+                    value = self._rulespec_test_input_value(inputs, key)
+                    if value is None:
+                        continue
+                    if not bool(value):
+                        unsupported_falsy_keys.append(key)
+                if unsupported_falsy_keys:
+                    reason = adapter.unsupported_input_reason or (
+                        "RuleSpec test supplies inactive required facts that "
+                        "PolicyEngine US does not model"
+                    )
+                    return (
+                        False,
+                        f"{reason}: {', '.join(sorted(unsupported_falsy_keys))}",
                     )
         if country == "uk" and isinstance(expected, dict):
             return (

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -35,6 +35,7 @@ class PolicyEngineUSVarAdapter:
     annual_inverted_boolean_household_overrides: tuple[tuple[str, str], ...] = ()
     unsupported_input_keys: tuple[str, ...] = ()
     unsupported_input_patterns: tuple[str, ...] = ()
+    unsupported_falsy_input_keys: tuple[str, ...] = ()
     unsupported_truthy_input_keys: tuple[str, ...] = ()
     unsupported_input_reason: str | None = None
     default_state_code: str | None = None
@@ -412,6 +413,28 @@ PE_US_VAR_ADAPTERS = (
             ("assistance_unit_has_rent_allowance", "is_in_public_housing"),
         ),
         default_state_code="MA",
+    ),
+    PolicyEngineUSVarAdapter(
+        rule_names=("ma_tafdc_infant_benefit",),
+        pe_var="ma_tafdc_infant_benefit",
+        boolean_person_inputs=(
+            (
+                "payment_requested_within_six_months_following_birth_of_eligible_infant",
+                "ma_tafdc_eligible_infant",
+            ),
+        ),
+        unsupported_falsy_input_keys=(
+            "infant_equipment_not_available_from_any_other_source",
+            "crib_or_mattress_requested_for_newborn_infant",
+            "layette_requested_for_newborn_infant",
+        ),
+        unsupported_input_reason=(
+            "PolicyEngine Massachusetts TAFDC infant benefit models a flat "
+            "per-infant payment and does not expose the 106 CMR 705.600 "
+            "equipment-source or component-request conditions"
+        ),
+        default_state_code="MA",
+        target_person_role="child",
     ),
     PolicyEngineUSVarAdapter(
         rule_names=("oap_authorized_grant_payment_for_month",),

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -3540,6 +3540,17 @@ mappings:
     comparison: money
     rationale: Same Massachusetts TAFDC monthly payment-standard table, selecting the no-rent or with-rent column by assistance-unit rent-allowance status and applying the listed incremental amount for assistance units above size 10.
 
+  - legal_id: us-ma:regulations/106-cmr/705/600/block-1#ma_tafdc_infant_benefit
+    country: us
+    program: tanf
+    mapping_type: direct_variable
+    policyengine_variable: ma_tafdc_infant_benefit
+    entity: person
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Massachusetts TAFDC infant benefit comparison targets the one-infant subset where the 106 CMR 705.600 equipment-source and component-request conditions are all satisfied and the department-set crib or mattress plus layette rates total PolicyEngine's flat per-infant amount.
+
   - legal_id: us-az:programs/tanf/fy-2026#az_tanf
     country: us
     program: tanf

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -4356,6 +4356,50 @@ def test_policyengine_ma_tafdc_payment_standard_projects_household_rent_status(
     )
 
 
+def test_policyengine_ma_tafdc_infant_benefit_targets_child_subset(tmp_path):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+
+    script = pipeline._build_pe_us_scenario_script(
+        "ma_tafdc_infant_benefit",
+        {
+            "period": "2024-01",
+            "infant_equipment_not_available_from_any_other_source": True,
+            "payment_requested_within_six_months_following_birth_of_eligible_infant": True,
+            "crib_or_mattress_requested_for_newborn_infant": True,
+            "layette_requested_for_newborn_infant": True,
+            "department_set_crib_or_mattress_rate": 200,
+            "department_set_layette_rate": 100,
+        },
+        "2024",
+    )
+
+    assert "'state_code_str': {'2024': 'MA'}" in script
+    assert "'ma_tafdc_eligible_infant': {'2024': True}" in script
+    assert "result_index = 1" in script
+    assert ValidatorPipeline._is_projectable_pe_us_input_alias(
+        "infant_equipment_not_available_from_any_other_source",
+        "ma_tafdc_infant_benefit",
+    )
+
+    mappable, reason = pipeline._is_pe_test_mappable(
+        "us",
+        "ma_tafdc_infant_benefit",
+        {
+            "infant_equipment_not_available_from_any_other_source": False,
+            "payment_requested_within_six_months_following_birth_of_eligible_infant": True,
+            "crib_or_mattress_requested_for_newborn_infant": True,
+            "layette_requested_for_newborn_infant": True,
+        },
+        pe_var="ma_tafdc_infant_benefit",
+    )
+    assert mappable is False
+    assert "equipment-source or component-request conditions" in (reason or "")
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.987"
+version = "0.2.988"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a PolicyEngine oracle adapter for the MA TAFDC infant benefit
- map the legally comparable one-infant subset to ma_tafdc_infant_benefit
- mark 106 CMR 705.600 equipment-source and component-request branches unsupported where PE lacks the corresponding surface

## Validation
- uv run ruff check src/axiom_encode/oracles/policyengine/adapters.py src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py -k "ma_tafdc_infant_benefit or ma_tafdc_payment_standard"
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev python -m pytest tests/test_cli.py -k current_encoder_affecting_changes_are_behind_version_bump