### PR TITLE
Classify Minnesota MSA PE surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.988"
+version = "0.2.989"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.988"
+__version__ = "0.2.989"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1774,10 +1774,13 @@ surfaces:
   variable: mn_msa
   source_type: state_implementation
   state: MN
-  axiom_status: deferred_jurisdiction
+  axiom_status: known_not_comparable
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: RuleSpec encodes Minnesota Combined Manual 0020.21 MSA assistance-standard source parameters and the generated
+    household-level assistance-standard branch, with PolicyEngine parameter mappings for the comparable current-law cells.
+    PolicyEngine's final `mn_msa` surface composes person-level eligibility, payment categories, countable-income reductions,
+    special-needs amounts, guardian/conservator fees, representative-payee fees, housing assistance, and household aggregation,
+    so no single encoded source output is a one-to-one oracle target for the final aggregate.
 - country: us
   program_id: ssi_state_supplement
   program_name: Nebraska AABD

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1647,6 +1647,21 @@ def test_policyengine_program_surface_marks_michigan_ssp_known_not_comparable():
     assert "SPM-unit aggregate" in michigan_ssp["rationale"]
 
 
+def test_policyengine_program_surface_marks_minnesota_msa_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="mn_msa")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    minnesota_msa = items_by_variable["mn_msa"]
+
+    assert minnesota_msa["program_id"] == "ssi_state_supplement"
+    assert minnesota_msa["state"] == "MN"
+    assert minnesota_msa["axiom_status"] == "known_not_comparable"
+    assert minnesota_msa["policybench_output"] == "ssi"
+    assert minnesota_msa["policybench_household_weight"] > 0
+    assert "PolicyEngine parameter mappings" in minnesota_msa["rationale"]
+    assert "final `mn_msa` surface" in minnesota_msa["rationale"]
+
+
 def test_policyengine_program_surface_marks_florida_oss_known_not_comparable():
     report = build_policyengine_program_surface_report(program="fl_oss")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.988"
+version = "0.2.989"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark the final Minnesota MSA PolicyEngine program surface as known-not-comparable instead of deferred
- explain that Axiom has source-level MSA assistance-standard outputs and PE parameter mappings, but no one-to-one final `mn_msa` aggregate target
- add a regression test for the PolicyBench-weighted surface classification

## Tests
- `uv run ruff check tests/test_policyengine_coverage.py`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k "minnesota_msa or michigan_ssp or florida_oss"`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev python -m pytest tests/test_cli.py -k current_encoder_affecting_changes_are_behind_version_bump`
