### PR TITLE
Classify Washington SSP PolicyEngine surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.990"
+version = "0.2.991"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.989"
+version = "0.2.990"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.989"
+__version__ = "0.2.990"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.990"
+__version__ = "0.2.991"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -16440,7 +16440,10 @@ def _append_oracle_parameter_tests_if_missing(
         appended_cases.append(
             {
                 "name": "_".join(case_name_parts),
-                "period": _oracle_parameter_test_period(effective_from),
+                "period": _oracle_parameter_test_period(
+                    effective_from,
+                    parameter_period=getattr(mapping, "period", None),
+                ),
                 "input": inputs,
                 "output": {legal_id: value},
             }
@@ -16484,11 +16487,10 @@ def _refresh_existing_oracle_parameter_test_inputs(
         )
         for input_name in sorted(factual_inputs)
     }
-    if not input_defaults:
-        return []
-
     registry = load_policyengine_registry()
-    mapped_parameter_outputs: dict[str, tuple[str, str | None]] = {}
+    mapped_parameter_outputs: dict[
+        str, tuple[str, str | None, str | dict[str, str] | None]
+    ] = {}
     for rule in rules:
         if not isinstance(rule, dict):
             continue
@@ -16502,9 +16504,18 @@ def _refresh_existing_oracle_parameter_test_inputs(
         if mapping is None or mapping.mapping_type != "parameter_value":
             continue
         index_name = _single_parameter_index_name(rule)
+        sample = _first_scalar_parameter_value(rule, indexed=index_name is not None)
+        expected_period: str | dict[str, str] | None = None
+        if sample is not None:
+            _, _, effective_from = sample
+            expected_period = _oracle_parameter_test_period(
+                effective_from,
+                parameter_period=getattr(mapping, "period", None),
+            )
         mapped_parameter_outputs[legal_id] = (
             rule_name,
             f"{target_base}#input.{index_name}" if index_name else None,
+            expected_period,
         )
     if not mapped_parameter_outputs:
         return []
@@ -16537,15 +16548,23 @@ def _refresh_existing_oracle_parameter_test_inputs(
         ]
         if not matching_output_specs:
             continue
-        matching_outputs = [rule_name for rule_name, _ in matching_output_specs]
+        matching_outputs = [rule_name for rule_name, _, _ in matching_output_specs]
         selector_input_refs = {
-            input_ref for _, input_ref in matching_output_specs if input_ref
+            input_ref for _, input_ref, _ in matching_output_specs if input_ref
         }
+        expected_periods = [
+            period for _, _, period in matching_output_specs if period is not None
+        ]
         inputs = case.get("input")
         if not isinstance(inputs, dict):
             inputs = {}
             case["input"] = inputs
         changed = False
+        if expected_periods:
+            expected_period = expected_periods[0]
+            if case.get("period") != expected_period:
+                case["period"] = expected_period
+                changed = True
         for input_ref, default_value in input_defaults.items():
             if input_ref in selector_input_refs:
                 continue
@@ -16658,7 +16677,11 @@ def _first_scalar_parameter_value(
     return None
 
 
-def _oracle_parameter_test_period(effective_from: str | None) -> dict[str, str]:
+def _oracle_parameter_test_period(
+    effective_from: str | None,
+    *,
+    parameter_period: str | None = None,
+) -> str | dict[str, str]:
     """Return a one-year period that is valid for a generated parameter test."""
     default = {
         "period_kind": "tax_year",
@@ -16673,6 +16696,8 @@ def _oracle_parameter_test_period(effective_from: str | None) -> dict[str, str]:
         return default
     if start.year < 1900:
         return default
+    if str(parameter_period or "").strip().lower() == "month":
+        return f"{start.year:04d}-{start.month:02d}"
     if start.month == 1 and start.day == 1:
         return {
             "period_kind": "tax_year",

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1697,6 +1697,69 @@ mappings:
     candidate_priority: P4
     rationale: The generated RuleSpec output composes a household-level assistance-standard branch from Combined Manual 0020.21. PolicyEngine's mn_msa_assistance_standard is a person-level payment-category surface that also includes categories not represented in this generated household output, so it should not be compared one-to-one.
 
+  - legal_id: us-wa:regulations/388/388-478/388-478-0055#fixed_monthly_ssp_rate_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.wa.dshs.ssp.amount
+    candidate_priority: P4
+    rationale: RuleSpec encodes the current WAC 388-478-0055 fixed monthly standard from the active source slice. PolicyEngine stores a historical Washington SSP STANDARD amount schedule, and the current-source encoding does not yet include the prior WSR rate history needed for a one-to-one parameter oracle.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0055#grandfathered_monthly_ssp_minimum
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the current WAC 388-478-0055 grandfathered-client lower bound. PolicyEngine's Washington SSP model does not expose separate grandfathered-client min/max cells.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0055#grandfathered_monthly_ssp_maximum
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the current WAC 388-478-0055 grandfathered-client upper bound. PolicyEngine's Washington SSP model does not expose separate grandfathered-client min/max cells.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0055#medical_institution_monthly_ssp_base
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.wa.dshs.ssp.amount
+    parameter_key: MEDICAL_INSTITUTION
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Washington SSP monthly medical-institution amount before the later annual PNA/COLA updates; both RuleSpec and PolicyEngine expose the July 2023 $70 base.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0055#federal_ssi_personal_needs_allowance
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the federal SSI personal-needs allowance referenced by WAC 388-478-0055(2)(c); PolicyEngine's Washington SSP surface stores the resulting state supplement amounts rather than this federal base allowance as a Washington parameter.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0055#fixed_monthly_ssp_rate_standard_applies
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: wa_ssp_payment_category
+    candidate_priority: P4
+    rationale: RuleSpec exposes the source-level branch predicate for WAC 388-478-0055(2)(a). PolicyEngine materializes this through its WA SSP category enum combined with SSI eligibility, living arrangement, age, blindness, disability, and marital-unit facts, so the predicate is not a one-to-one PE output.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0055#grandfathered_monthly_ssp_rate_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec computes the source-level grandfathered-client bounded payment from WAC 388-478-0055(2)(b). PolicyEngine's Washington SSP model does not expose a separate grandfathered-client final rate calculation.
+
+  - legal_id: us-wa:regulations/388/388-478/388-478-0055#wa_ssp
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: wa_ssp
+    candidate_priority: P4
+    rationale: RuleSpec encodes the current WAC 388-478-0055 source slice with local WAC 388-474 eligibility/category facts and an explicit deferred output for post-2024 medical-institution COLA. PolicyEngine's wa_ssp is a final person-level category wrapper over SSI eligibility, federal living arrangement, disabled-category timing, and a historical amount parameter schedule, so compare the encoded source components separately until the WAC 388-474 eligibility rules and historical WSR rate table are encoded.
+
   - legal_id: us:statutes/7/2014/e/6/A#snap_net_income_pre_shelter
     country: us
     program: snap

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1903,10 +1903,12 @@ surfaces:
   variable: wa_ssp
   source_type: state_implementation
   state: WA
-  axiom_status: deferred_jurisdiction
+  axiom_status: known_not_comparable
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: Axiom encodes current WAC 388-478-0055 SSP rate-standard components, including a comparable July 2023
+    medical-institution base amount and an explicit deferred output for post-2024 medical-institution COLA. PolicyEngine's
+    `wa_ssp` is a final person-level wrapper over WAC 388-474 eligibility/category facts and a historical amount schedule,
+    so compare source components separately until WAC 388-474 and the WSR rate history are encoded.
 - country: us
   program_id: social_security
   program_name: Social Security

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29347,6 +29347,174 @@ rules:
             "us-wa:regulations/388/388-478/388-478-0020#cash_assistance_maximum_monthly_payment_standard": 450
         }
 
+    def test_repair_oracle_parameter_tests_uses_month_for_monthly_parameters(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "us-wa/regulations/388/388-478/388-478-0055.yaml"
+        test_file = policy_repo / "us-wa/regulations/388/388-478/388-478-0055.test.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+rules:
+  - name: medical_institution_monthly_ssp_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    versions:
+      - effective_from: '2023-07-01'
+        formula: '70'
+"""
+        )
+        test_file.write_text(
+            """- name: existing
+  output:
+    us-wa:regulations/388/388-478/388-478-0055#some_other_output: 1
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo / "us-wa",
+            file=Path("regulations/388/388-478/388-478-0055.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakeRegistry:
+            def mapping_for_legal_id(self, legal_id, *, country=None):
+                assert country == "us"
+                if legal_id == (
+                    "us-wa:regulations/388/388-478/388-478-0055"
+                    "#medical_institution_monthly_ssp_base"
+                ):
+                    return SimpleNamespace(
+                        mapping_type="parameter_value", period="month"
+                    )
+                return None
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli.load_policyengine_registry",
+                return_value=FakeRegistry(),
+            ),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures", return_value=[]
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_oracle_parameter_tests(args)
+
+        payload = yaml.safe_load(test_file.read_text())
+        added = payload[-1]
+        assert added["name"] == "oracle_parameter_medical_institution_monthly_ssp_base"
+        assert added["period"] == "2023-07"
+        assert added["input"] == {}
+        assert added["output"] == {
+            "us-wa:regulations/388/388-478/388-478-0055#medical_institution_monthly_ssp_base": 70
+        }
+
+    def test_repair_oracle_parameter_tests_refreshes_existing_monthly_period(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = policy_repo / "us-wa/regulations/388/388-478/388-478-0055.yaml"
+        test_file = policy_repo / "us-wa/regulations/388/388-478/388-478-0055.test.yaml"
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+rules:
+  - name: medical_institution_monthly_ssp_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    versions:
+      - effective_from: '2023-07-01'
+        formula: '70'
+"""
+        )
+        test_file.write_text(
+            """- name: oracle_parameter_medical_institution_monthly_ssp_base
+  period:
+    period_kind: custom
+    name: policy_year
+    start: '2023-07-01'
+    end: '2024-06-30'
+  input: {}
+  output:
+    us-wa:regulations/388/388-478/388-478-0055#medical_institution_monthly_ssp_base: 70
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo / "us-wa",
+            file=Path("regulations/388/388-478/388-478-0055.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakeRegistry:
+            def mapping_for_legal_id(self, legal_id, *, country=None):
+                assert country == "us"
+                if legal_id == (
+                    "us-wa:regulations/388/388-478/388-478-0055"
+                    "#medical_institution_monthly_ssp_base"
+                ):
+                    return SimpleNamespace(
+                        mapping_type="parameter_value", period="month"
+                    )
+                return None
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli.load_policyengine_registry",
+                return_value=FakeRegistry(),
+            ),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures", return_value=[]
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_oracle_parameter_tests(args)
+
+        payload = yaml.safe_load(test_file.read_text())
+        assert len(payload) == 1
+        assert payload[0]["period"] == "2023-07"
+        assert payload[0]["output"] == {
+            "us-wa:regulations/388/388-478/388-478-0055#medical_institution_monthly_ssp_base": 70
+        }
+
     def test_repair_oracle_parameter_tests_replaces_empty_list_file(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"
         target = policy_repo / "statutes/42/18795a/c/3.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.989"
+version = "0.2.990"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.990"
+version = "0.2.991"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Washington SSP as a known-not-comparable PE program surface while mapping the July 2023 medical-institution SSP base as the one comparable PE parameter
- bump axiom-encode to 0.2.991
- make deterministic oracle-parameter repairs use month periods for monthly PE parameters, including already-generated oracle test cases

## Validation
- uv run python -m pytest tests/test_cli.py::TestApplyDependencyValidation::test_repair_oracle_parameter_tests_uses_month_for_monthly_parameters tests/test_cli.py::TestApplyDependencyValidation::test_repair_oracle_parameter_tests_refreshes_existing_monthly_period tests/test_policyengine_coverage.py -q
- uv run python -m pytest tests/test_policyengine_coverage.py -q
- registry validation: 0 issues