### PR TITLE
Map Alaska SSP payment-standard oracle cells

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.993"
+version = "0.2.994"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.993"
+__version__ = "0.2.994"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1613,6 +1613,134 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec encodes the one-time 1983 statutory dollar increase for couple SSI rates; PolicyEngine stores final monthly federal benefit-rate parameters rather than this source-specific transitional increase.
 
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#a_individual_monthly_state_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.ssp.payment_standard
+    parameter_key_path:
+      - INDEPENDENT
+      - INDIVIDUAL
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Alaska monthly state supplement for an APA A Individual (A1E), represented by PolicyEngine's independent individual SSP payment-standard cell.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#b_individual_monthly_state_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.ak.dpa.ssp.payment_standard
+    candidate_priority: P4
+    rationale: Alaska DPA's 2026 APA and SSI standards imply a B Individual state supplement of 1031 - 662.67 = 368.33; PolicyEngine's household-of-another individual cell currently stores 368, so this cell should be treated as a PolicyEngine parameter discrepancy rather than forced into an oracle pass.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#alh_individual_monthly_state_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.ssp.payment_standard
+    parameter_key_path:
+      - ASSISTED_LIVING
+      - INDIVIDUAL
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Alaska monthly state supplement for an APA ALH Individual (H1E), represented by PolicyEngine's assisted-living individual SSP payment-standard cell.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#a_couple_one_eligible_monthly_state_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.ssp.payment_standard
+    parameter_key_path:
+      - INDEPENDENT
+      - COUPLE_ONE_ELIGIBLE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Alaska monthly state supplement for an APA A Couple, one eligible (A2S), represented by PolicyEngine's independent one-eligible-couple SSP payment-standard cell.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#b_couple_one_eligible_monthly_state_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.ak.dpa.ssp.payment_standard
+    candidate_priority: P4
+    rationale: Alaska DPA's 2026 APA and SSI standards imply a B Couple, one eligible state supplement of 1127 - 662.67 = 464.33; PolicyEngine's household-of-another one-eligible-couple cell currently stores 464, so this cell should be treated as a PolicyEngine parameter discrepancy rather than forced into an oracle pass.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#alh_couple_one_eligible_monthly_state_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.ssp.payment_standard
+    parameter_key_path:
+      - ASSISTED_LIVING
+      - COUPLE_ONE_ELIGIBLE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Alaska monthly state supplement for an APA ALH Couple, one eligible (H2S), represented by PolicyEngine's assisted-living one-eligible-couple SSP payment-standard cell.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#a_couple_both_eligible_monthly_state_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.ssp.payment_standard
+    parameter_key_path:
+      - INDEPENDENT
+      - COUPLE_BOTH_ELIGIBLE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Alaska monthly state supplement for an APA A Couple, both eligible (A2C), represented by PolicyEngine's independent both-eligible-couple SSP payment-standard cell.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#b_couple_both_eligible_monthly_state_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.ssp.payment_standard
+    parameter_key_path:
+      - HOUSEHOLD_OF_ANOTHER
+      - COUPLE_BOTH_ELIGIBLE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Alaska monthly state supplement for an APA B Couple, both eligible (B2C), represented by PolicyEngine's household-of-another both-eligible-couple SSP payment-standard cell.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#alh_couple_both_eligible_monthly_state_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.ssp.payment_standard
+    parameter_key_path:
+      - ASSISTED_LIVING
+      - COUPLE_BOTH_ELIGIBLE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Alaska monthly state supplement for an APA ALH Couple, both eligible (H2C), represented by PolicyEngine's assisted-living both-eligible-couple SSP payment-standard cell.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#eligible_institution_monthly_state_supplement
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.ssp.payment_standard
+    parameter_key_path:
+      - MEDICAID_FACILITY
+      - INDIVIDUAL
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Alaska monthly state supplement for an eligible institution (NHP), represented by PolicyEngine's Medicaid-facility individual SSP payment-standard cell.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#ak_ssp_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: ak_ssp
+    candidate_priority: P4
+    rationale: RuleSpec exposes a source-local monthly selector over Alaska DPA household type codes. PolicyEngine's final `ak_ssp` surface also composes eligibility, living-arrangement and claim-type projections, countable-income reduction, annualization, and person-level aggregation, so compare the encoded monthly row cells separately.
+
   - legal_id: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_person_living_alone_standard
     country: us
     program: ssi_state_supplement

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1543,10 +1543,12 @@ surfaces:
   variable: ak_ssp
   source_type: state_implementation
   state: AK
-  axiom_status: deferred_jurisdiction
+  axiom_status: known_not_comparable
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: Axiom encodes Alaska DPA's 2026 APA and SSI standards and the source-derived monthly state-supplement payment-standard
+    cells. PolicyEngine's final `ak_ssp` surface also composes eligibility, federal living-arrangement/claim-type facts,
+    countable-income reduction, annualization, and person-level aggregation, so compare encoded payment-standard cells separately
+    until Axiom has the equivalent final benefit-composition surface.
 - country: us
   program_id: ssi_state_supplement
   program_name: Alabama SSP

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1479,6 +1479,25 @@ def test_policyengine_program_surface_marks_california_ssp_known_not_comparable(
     assert "annual SPM-unit final amount" in ca_ssp["rationale"]
 
 
+def test_policyengine_program_surface_marks_alaska_ssp_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="ak_ssp")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    ak_ssp = items_by_variable["ak_ssp"]
+
+    assert ak_ssp["program_id"] == "ssi_state_supplement"
+    assert ak_ssp["state"] == "AK"
+    assert ak_ssp["axiom_status"] == "known_not_comparable"
+    assert ak_ssp["mapping_count"] >= 1
+    assert ak_ssp["comparable_mapping_count"] == 0
+    assert (
+        "us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#ak_ssp_payment_standard"
+        in ak_ssp["legal_ids"]
+    )
+    assert "payment-standard cells" in ak_ssp["rationale"]
+    assert "final benefit-composition surface" in ak_ssp["rationale"]
+
+
 def test_policyengine_program_surface_marks_illinois_tanf_known_not_comparable():
     report = build_policyengine_program_surface_report(program="il_tanf")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.993"
+version = "0.2.994"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Map Alaska SSP payment-standard row outputs to PolicyEngine parameter cells where source-derived amounts match.
- Mark the final `ak_ssp` PE surface as known-not-comparable because RuleSpec currently exposes source-local monthly row selection, while PE composes eligibility, living arrangement/claim type, income reduction, annualization, and person aggregation.
- Track the two household-of-another cents discrepancies as non-comparable PE parameter discrepancies; filed PolicyEngine/policyengine-us#8789.

## Validation
- `uv run ruff check src/ tests/test_policyengine_coverage.py`
- `uv run python -m pytest tests/test_policyengine_coverage.py -k "alaska_ssp or california_ssp or georgia_ssp or minnesota_msa" -q`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ak-ssp-20260630 --include-program-surfaces --program ssi_state_supplement --limit 80`
