### PR TITLE
Map Alaska SSP source intermediates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.994"
+version = "0.2.995"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.994"
+__version__ = "0.2.995"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1613,6 +1613,111 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec encodes the one-time 1983 statutory dollar increase for couple SSI rates; PolicyEngine stores final monthly federal benefit-rate parameters rather than this source-specific transitional increase.
 
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#a_individual_apa_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Alaska DPA source-level APA gross payment standard for an A Individual row. PolicyEngine stores net state supplement payment-standard cells after subtracting the federal SSI amount, not this APA gross-standard intermediate.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#b_individual_apa_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Alaska DPA source-level APA gross payment standard for a B Individual row. PolicyEngine stores net state supplement payment-standard cells after subtracting the federal SSI amount, not this APA gross-standard intermediate.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#alh_individual_apa_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Alaska DPA source-level APA gross payment standard for an ALH Individual row. PolicyEngine stores net state supplement payment-standard cells after subtracting the federal SSI amount, not this APA gross-standard intermediate.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#a_couple_one_eligible_apa_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Alaska DPA source-level APA gross payment standard for an A Couple with one eligible individual. PolicyEngine stores net state supplement payment-standard cells after subtracting the federal SSI amount, not this APA gross-standard intermediate.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#b_couple_one_eligible_apa_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Alaska DPA source-level APA gross payment standard for a B Couple with one eligible individual. PolicyEngine stores net state supplement payment-standard cells after subtracting the federal SSI amount, not this APA gross-standard intermediate.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#alh_couple_one_eligible_apa_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Alaska DPA source-level APA gross payment standard for an ALH Couple with one eligible individual. PolicyEngine stores net state supplement payment-standard cells after subtracting the federal SSI amount, not this APA gross-standard intermediate.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#a_couple_both_eligible_apa_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Alaska DPA source-level APA gross payment standard for an A Couple with both individuals eligible. PolicyEngine stores net state supplement payment-standard cells after subtracting the federal SSI amount, not this APA gross-standard intermediate.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#b_couple_both_eligible_apa_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Alaska DPA source-level APA gross payment standard for a B Couple with both individuals eligible. PolicyEngine stores net state supplement payment-standard cells after subtracting the federal SSI amount, not this APA gross-standard intermediate.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#alh_couple_both_eligible_apa_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Alaska DPA source-level APA gross payment standard for an ALH Couple with both individuals eligible. PolicyEngine stores net state supplement payment-standard cells after subtracting the federal SSI amount, not this APA gross-standard intermediate.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#eligible_institution_apa_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Alaska DPA source-level APA gross payment standard for the eligible institution row. PolicyEngine stores net state supplement payment-standard cells after subtracting the federal SSI amount, not this APA gross-standard intermediate.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#a_individual_ssi_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Alaska DPA source table's federal SSI payment standard for an A Individual row as an input to the state supplement calculation. PolicyEngine's Alaska SSP table stores the net state supplement, while federal SSI rates are represented on the separate SSI surface.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#b_individual_ssi_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Alaska DPA source table's federal SSI payment standard for a B Individual row as an input to the state supplement calculation. PolicyEngine's Alaska SSP table stores the net state supplement, while federal SSI rates are represented on the separate SSI surface.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#a_couple_both_eligible_ssi_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Alaska DPA source table's federal SSI payment standard for an A Couple with both individuals eligible as an input to the state supplement calculation. PolicyEngine's Alaska SSP table stores the net state supplement, while federal SSI rates are represented on the separate SSI surface.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#b_couple_both_eligible_ssi_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Alaska DPA source table's federal SSI payment standard for a B Couple with both individuals eligible as an input to the state supplement calculation. PolicyEngine's Alaska SSP table stores the net state supplement, while federal SSI rates are represented on the separate SSI surface.
+
+  - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#eligible_institution_ssi_payment_standard
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Alaska DPA source table's federal SSI payment standard for the eligible institution row as an input to the state supplement calculation. PolicyEngine's Alaska SSP table stores the net state supplement, while federal SSI rates are represented on the separate SSI surface.
+
   - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#a_individual_monthly_state_supplement
     country: us
     program: ssi_state_supplement

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.994"
+version = "0.2.995"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Alaska APA/SSI gross-standard source intermediates as not comparable to PolicyEngine SSP outputs
- bump axiom-encode to 0.2.995 so downstream RuleSpec CI can pin the mapping

## Tests
- uv run ruff check src/ tests/test_policyengine_coverage.py
- uv run ruff format --check src/ tests/test_policyengine_coverage.py
- uv run python -m pytest tests/test_policyengine_coverage.py -k "alaska_ssp or california_ssp or georgia_ssp or minnesota_msa" -q
- uv run python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ak-ssp-20260630 --fail-on-unmapped --fail-on-untested-comparable --limit 50