### PR TITLE
Map Alabama SSP amount cells

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.995"
+version = "0.2.996"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.995"
+__version__ = "0.2.996"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -16759,6 +16759,10 @@ def _oracle_parameter_test_period(
     if start.year < 1900:
         return default
     if str(parameter_period or "").strip().lower() == "month":
+        if start.day != 1:
+            year = start.year + (1 if start.month == 12 else 0)
+            month = 1 if start.month == 12 else start.month + 1
+            return f"{year:04d}-{month:02d}"
         return f"{start.year:04d}-{start.month:02d}"
     if start.month == 1 and start.day == 1:
         return {

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -190,6 +190,7 @@ class PolicyEngineCoverageItem:
     mapping_type: str | None = None
     policyengine_variable: str | None = None
     policyengine_parameter: str | None = None
+    parameter_key: str | None = None
     rationale: str | None = None
     candidate_priority: str | None = None
     tested: bool = False
@@ -207,6 +208,7 @@ class PolicyEngineCoverageItem:
             "mapping_type": self.mapping_type,
             "policyengine_variable": self.policyengine_variable,
             "policyengine_parameter": self.policyengine_parameter,
+            "parameter_key": self.parameter_key,
             "rationale": self.rationale,
             "candidate_priority": self.candidate_priority,
             "tested": self.tested,
@@ -1730,6 +1732,7 @@ def _coverage_item_from_mapping(
         mapping_type=mapping_type,
         policyengine_variable=mapping.policyengine_variable if mapping else None,
         policyengine_parameter=mapping.policyengine_parameter if mapping else None,
+        parameter_key=mapping.parameter_key if mapping else None,
         rationale=mapping.rationale if mapping else None,
         candidate_priority=mapping.candidate_priority if mapping else None,
         tested=test_output_count > 0,

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1846,6 +1846,129 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec exposes a source-local monthly selector over Alaska DPA household type codes. PolicyEngine's final `ak_ssp` surface also composes eligibility, living-arrangement and claim-type projections, countable-income reduction, annualization, and person-level aggregation, so compare the encoded monthly row cells separately.
 
+  - legal_id: us-al:policies/dhr/ssp/state-supplement-payment-standard#fcmp_nursing_care_payment_monthly_amount
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.al.dhr.ssp.amount
+    parameter_key: FCMP_NURSING_CARE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Alabama monthly supplement amount for the FCMP Nursing Care row in Ala. Admin. Code attachment 660-2-4-.19a.
+
+  - legal_id: us-al:policies/dhr/ssp/state-supplement-payment-standard#nursing_care_supplement_payment_monthly_amount
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.al.dhr.ssp.amount
+    parameter_key: NURSING_CARE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Alabama monthly supplement amount for the Nursing Care Supplement row in Ala. Admin. Code attachment 660-2-4-.19a.
+
+  - legal_id: us-al:policies/dhr/ssp/state-supplement-payment-standard#personal_care_level_a_payment_monthly_amount
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.al.dhr.ssp.amount
+    parameter_key: IHC_LEVEL_A
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Alabama monthly supplement amount for the Personal Care Supplement Level A row in Ala. Admin. Code attachment 660-2-4-.19a.
+
+  - legal_id: us-al:policies/dhr/ssp/state-supplement-payment-standard#personal_care_level_b_payment_monthly_amount
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.al.dhr.ssp.amount
+    parameter_key: IHC_LEVEL_B
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Alabama monthly supplement amount for the Personal Care Supplement Level B row in Ala. Admin. Code attachment 660-2-4-.19a.
+
+  - legal_id: us-al:policies/dhr/ssp/state-supplement-payment-standard#foster_care_personal_or_nursing_care_supplement_payment_monthly_amount
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.al.dhr.ssp.amount
+    parameter_key: FOSTER_CARE
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Alabama monthly supplement amount for the Personal Care or Nursing Care Supplement in Foster Care row in Ala. Admin. Code attachment 660-2-4-.19a.
+
+  - legal_id: us-al:policies/dhr/ssp/state-supplement-payment-standard#cerebral_palsy_treatment_center_care_payment_monthly_amount
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.al.dhr.ssp.amount
+    parameter_key: CEREBRAL_PALSY
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Alabama monthly supplement amount for the Care in a Cerebral Palsy Treatment Center row in Ala. Admin. Code attachment 660-2-4-.19a.
+
+  - legal_id: us-al:policies/dhr/ssp/state-supplement-payment-standard#fcmp_nursing_care_maximum_budgeted
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the attachment 660-2-4-.19a Maximum Budgeted column for FCMP Nursing Care. PolicyEngine's Alabama SSP parameter stores payment monthly amounts and does not expose the separate maximum-budgeted column.
+
+  - legal_id: us-al:policies/dhr/ssp/state-supplement-payment-standard#nursing_care_supplement_maximum_budgeted
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the attachment 660-2-4-.19a Maximum Budgeted column for Nursing Care Supplement. PolicyEngine's Alabama SSP parameter stores payment monthly amounts and does not expose the separate maximum-budgeted column.
+
+  - legal_id: us-al:policies/dhr/ssp/state-supplement-payment-standard#personal_care_level_a_maximum_budgeted
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the attachment 660-2-4-.19a Maximum Budgeted column for Personal Care Level A. PolicyEngine's Alabama SSP parameter stores payment monthly amounts and does not expose the separate maximum-budgeted column.
+
+  - legal_id: us-al:policies/dhr/ssp/state-supplement-payment-standard#personal_care_level_b_maximum_budgeted
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the attachment 660-2-4-.19a Maximum Budgeted column for Personal Care Level B. PolicyEngine's Alabama SSP parameter stores payment monthly amounts and does not expose the separate maximum-budgeted column.
+
+  - legal_id: us-al:policies/dhr/ssp/state-supplement-payment-standard#foster_care_personal_or_nursing_care_supplement_maximum_budgeted
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the attachment 660-2-4-.19a Maximum Budgeted column for Foster Care supplement. PolicyEngine's Alabama SSP parameter stores payment monthly amounts and does not expose the separate maximum-budgeted column.
+
+  - legal_id: us-al:policies/dhr/ssp/state-supplement-payment-standard#cerebral_palsy_treatment_center_care_maximum_budgeted
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the attachment 660-2-4-.19a Maximum Budgeted column for Cerebral Palsy Treatment Center care. PolicyEngine's Alabama SSP parameter stores payment monthly amounts and does not expose the separate maximum-budgeted column.
+
+  - legal_id: us-al:policies/dhr/ssp/state-supplement-payment-standard#al_ssp
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: al_ssp
+    candidate_priority: P4
+    rationale: RuleSpec exposes a source-local monthly selector over attachment 660-2-4-.19a row predicates. PolicyEngine's final `al_ssp` surface also composes SSI eligibility, payment category, grandfathering, waiver, and skilled-nursing-facility predicates, so compare the encoded row amount cells separately until those eligibility and category rules are encoded.
+
+  - legal_id: us-al:policies/dhr/ssp/state-supplement-payment-standard#al_ssp_maximum_budgeted
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes a source-local selector over attachment 660-2-4-.19a Maximum Budgeted amounts. PolicyEngine's Alabama SSP surface does not expose that separate maximum-budgeted column.
+
   - legal_id: us-mn:policies/dhs/combined-manual/0020-21/msa-assistance-standards-2026#msa_person_living_alone_standard
     country: us
     program: ssi_state_supplement

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1559,10 +1559,12 @@ surfaces:
   variable: al_ssp
   source_type: state_implementation
   state: AL
-  axiom_status: deferred_jurisdiction
+  axiom_status: known_not_comparable
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: Axiom encodes Alabama Administrative Code attachment 660-2-4-.19a monthly state-supplement payment-standard
+    cells and maps those cells to PolicyEngine's Alabama SSP amount parameter. PolicyEngine's final `al_ssp` surface also
+    composes SSI eligibility, payment category, grandfathering, waiver, and skilled-nursing-facility predicates, so compare
+    encoded amount cells separately until Axiom has the equivalent final eligibility and benefit-composition surface.
 - country: us
   program_id: ssi_state_supplement
   program_name: California SSP

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29429,6 +29429,95 @@ rules:
             "us-wa:regulations/388/388-478/388-478-0055#medical_institution_monthly_ssp_base": 70
         }
 
+    def test_repair_oracle_parameter_tests_uses_next_month_for_midmonth_effective_date(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        target = (
+            policy_repo
+            / "us-al/policies/dhr/ssp/state-supplement-payment-standard.yaml"
+        )
+        test_file = (
+            policy_repo
+            / "us-al/policies/dhr/ssp/state-supplement-payment-standard.test.yaml"
+        )
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+rules:
+  - name: fcmp_nursing_care_payment_monthly_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    period: Month
+    versions:
+      - effective_from: '1995-03-31'
+        formula: '100'
+"""
+        )
+        test_file.write_text(
+            """- name: existing
+  output:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#some_other_output: 1
+"""
+        )
+        args = SimpleNamespace(
+            repo=policy_repo / "us-al",
+            file=Path("policies/dhr/ssp/state-supplement-payment-standard.yaml"),
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakeRegistry:
+            def mapping_for_legal_id(self, legal_id, *, country=None):
+                assert country == "us"
+                if legal_id == (
+                    "us-al:policies/dhr/ssp/state-supplement-payment-standard"
+                    "#fcmp_nursing_care_payment_monthly_amount"
+                ):
+                    return SimpleNamespace(
+                        mapping_type="parameter_value", period="month"
+                    )
+                return None
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch(
+                "axiom_encode.cli.load_policyengine_registry",
+                return_value=FakeRegistry(),
+            ),
+            patch(
+                "axiom_encode.cli._rulespec_companion_test_failures", return_value=[]
+            ),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_oracle_parameter_tests(args)
+
+        payload = yaml.safe_load(test_file.read_text())
+        added = payload[-1]
+        assert added["name"] == (
+            "oracle_parameter_fcmp_nursing_care_payment_monthly_amount"
+        )
+        assert added["period"] == "1995-04"
+        assert added["output"] == {
+            "us-al:policies/dhr/ssp/state-supplement-payment-standard#fcmp_nursing_care_payment_monthly_amount": 100
+        }
+
     def test_repair_oracle_parameter_tests_refreshes_existing_monthly_period(
         self, tmp_path
     ):

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1498,6 +1498,150 @@ def test_policyengine_program_surface_marks_alaska_ssp_known_not_comparable():
     assert "final benefit-composition surface" in ak_ssp["rationale"]
 
 
+def test_policyengine_coverage_maps_alabama_ssp_amount_cells(tmp_path):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-al"
+        / "policies/dhr/ssp/state-supplement-payment-standard.yaml",
+        """format: rulespec/v1
+rules:
+  - name: fcmp_nursing_care_payment_monthly_amount
+    kind: parameter
+    versions:
+      - effective_from: '1995-03-31'
+        formula: 100
+  - name: fcmp_nursing_care_maximum_budgeted
+    kind: parameter
+    versions:
+      - effective_from: '1995-03-31'
+        formula: 60
+  - name: nursing_care_supplement_payment_monthly_amount
+    kind: parameter
+    versions:
+      - effective_from: '1995-03-31'
+        formula: 60
+  - name: nursing_care_supplement_maximum_budgeted
+    kind: parameter
+    versions:
+      - effective_from: '1995-03-31'
+        formula: 60
+  - name: personal_care_level_a_payment_monthly_amount
+    kind: parameter
+    versions:
+      - effective_from: '1995-03-31'
+        formula: 60
+  - name: personal_care_level_a_maximum_budgeted
+    kind: parameter
+    versions:
+      - effective_from: '1995-03-31'
+        formula: 60
+  - name: personal_care_level_b_payment_monthly_amount
+    kind: parameter
+    versions:
+      - effective_from: '1995-03-31'
+        formula: 56
+  - name: personal_care_level_b_maximum_budgeted
+    kind: parameter
+    versions:
+      - effective_from: '1995-03-31'
+        formula: 56
+  - name: foster_care_personal_or_nursing_care_supplement_payment_monthly_amount
+    kind: parameter
+    versions:
+      - effective_from: '1995-03-31'
+        formula: 110
+  - name: foster_care_personal_or_nursing_care_supplement_maximum_budgeted
+    kind: parameter
+    versions:
+      - effective_from: '1995-03-31'
+        formula: 110
+  - name: cerebral_palsy_treatment_center_care_payment_monthly_amount
+    kind: parameter
+    versions:
+      - effective_from: '1995-03-31'
+        formula: 196
+  - name: cerebral_palsy_treatment_center_care_maximum_budgeted
+    kind: parameter
+    versions:
+      - effective_from: '1995-03-31'
+        formula: 196
+  - name: al_ssp
+    kind: derived
+    versions:
+      - effective_from: '1995-03-31'
+        formula: amount
+  - name: al_ssp_maximum_budgeted
+    kind: derived
+    versions:
+      - effective_from: '1995-03-31'
+        formula: amount
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-al"
+        / "policies/dhr/ssp/state-supplement-payment-standard.test.yaml",
+        """- name: alabama_ssp_payment_amount_cells
+  period: 2026-01
+  input: {}
+  output:
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#fcmp_nursing_care_payment_monthly_amount: 100
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#nursing_care_supplement_payment_monthly_amount: 60
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#personal_care_level_a_payment_monthly_amount: 60
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#personal_care_level_b_payment_monthly_amount: 56
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#foster_care_personal_or_nursing_care_supplement_payment_monthly_amount: 110
+    us-al:policies/dhr/ssp/state-supplement-payment-standard#cerebral_palsy_treatment_center_care_payment_monthly_amount: 196
+""",
+    )
+
+    report = build_policyengine_coverage_report(
+        tmp_path,
+        program="ssi_state_supplement",
+    )
+    items_by_name = {item["rule_name"]: item for item in report["items"]}
+
+    assert report["total_outputs"] == 14
+    assert report["status_counts"] == {
+        "comparable": 6,
+        "known_not_comparable": 8,
+    }
+    assert report["untested_comparable"] == 0
+    fcmp_amount = items_by_name["fcmp_nursing_care_payment_monthly_amount"]
+    assert fcmp_amount["policyengine_parameter"] == "gov.states.al.dhr.ssp.amount"
+    assert fcmp_amount["parameter_key"] == "FCMP_NURSING_CARE"
+    assert fcmp_amount["status"] == "comparable"
+    assert fcmp_amount["tested"] is True
+    assert (
+        items_by_name["cerebral_palsy_treatment_center_care_payment_monthly_amount"][
+            "parameter_key"
+        ]
+        == "CEREBRAL_PALSY"
+    )
+    assert items_by_name["al_ssp"]["policyengine_variable"] == "al_ssp"
+    assert items_by_name["al_ssp"]["status"] == "known_not_comparable"
+
+
+def test_policyengine_program_surface_marks_alabama_ssp_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="al_ssp")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    al_ssp = items_by_variable["al_ssp"]
+
+    assert al_ssp["program_id"] == "ssi_state_supplement"
+    assert al_ssp["state"] == "AL"
+    assert al_ssp["axiom_status"] == "known_not_comparable"
+    assert al_ssp["mapping_count"] >= 1
+    assert al_ssp["comparable_mapping_count"] == 0
+    assert (
+        "us-al:policies/dhr/ssp/state-supplement-payment-standard#al_ssp"
+        in al_ssp["legal_ids"]
+    )
+    assert "monthly state-supplement payment-standard cells" in al_ssp["rationale"]
+    assert "final `al_ssp` surface" in al_ssp["rationale"]
+
+
 def test_policyengine_program_surface_marks_illinois_tanf_known_not_comparable():
     report = build_policyengine_program_surface_report(program="il_tanf")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.995"
+version = "0.2.996"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map six Alabama SSP monthly amount cells to PolicyEngine's `gov.states.al.dhr.ssp.amount` parameter breakdown
- mark the source-local maximum-budgeted cells and final Alabama SSP selectors as known non-comparable for PE parity
- update the Alabama SSP program surface now that amount cells are covered but final eligibility/category composition remains separate
- expose `parameter_key` in oracle coverage output and fix monthly oracle parameter repair periods for mid-month effective dates

## Checks
- `uv run ruff check src/axiom_encode/cli.py src/axiom_encode/oracles/policyengine/coverage.py tests/test_cli.py tests/test_policyengine_coverage.py`
- `uv run ruff format src/axiom_encode/cli.py tests/test_cli.py tests/test_policyengine_coverage.py`
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k "alabama_ssp or alaska_ssp or georgia_ssp or minnesota_msa" -q`
- `uv run --extra dev python -m pytest tests/test_cli.py -k "repair_oracle_parameter_tests" -q`
