### PR TITLE
Fix zero-branch repair and Illinois AABD oracle

### DIFF
--- a/changelog.d/il-aabd-personal-allowance-oracle.changed.md
+++ b/changelog.d/il-aabd-personal-allowance-oracle.changed.md
@@ -1,0 +1,1 @@
+Add PolicyEngine oracle mapping support for Illinois AABD personal allowance tests.

--- a/changelog.d/zero-branch-sentinel-selector.fixed.md
+++ b/changelog.d/zero-branch-sentinel-selector.fixed.md
@@ -1,0 +1,1 @@
+Teach generated zero-branch test repair to exercise selector sentinel branches such as `band == -1`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.996"
+version = "0.2.997"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.997"
+version = "0.2.998"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.996"
+__version__ = "0.2.997"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.997"
+__version__ = "0.2.998"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -17389,6 +17389,15 @@ def _zero_branch_numeric_upper_bound_input_overrides(
         rules_payload=rules_payload,
     )
     for input_name in sorted(factual_inputs):
+        sentinel_selector_value = _numeric_sentinel_selector_zero_input_override(
+            input_name=input_name,
+            target_formula=target_formula,
+            rules_payload=rules_payload,
+            scalar_values=scalar_values,
+        )
+        if sentinel_selector_value is not None:
+            overrides[f"{target_base}#input.{input_name}"] = sentinel_selector_value
+            continue
         zero_branch_thresholds = _numeric_upper_bounds_returning_zero_for_input(
             input_name,
             formulas=[target_formula] if target_formula else [],
@@ -17412,6 +17421,84 @@ def _zero_branch_numeric_upper_bound_input_overrides(
             threshold
         )
     return overrides
+
+
+def _numeric_sentinel_selector_zero_input_override(
+    *,
+    input_name: str,
+    target_formula: str | None,
+    rules_payload: dict[str, object],
+    scalar_values: dict[str, float],
+) -> int | float | None:
+    if not target_formula:
+        return None
+    for selector_name in _sentinel_selector_zero_rule_names(target_formula):
+        selector_formula = _local_formula_for_rule(
+            output_name=selector_name,
+            rules_payload=rules_payload,
+        )
+        if not selector_formula:
+            continue
+        if not re.search(rf"\b{re.escape(input_name)}\b", selector_formula):
+            continue
+        if not _formula_can_return_numeric_sentinel(selector_formula, sentinel=-1):
+            continue
+        lower_edges = _numeric_lower_edge_values_for_input(
+            input_name,
+            formulas=[selector_formula],
+            scalar_values=scalar_values,
+        )
+        if not lower_edges:
+            continue
+        return _below_lower_edge_value(min(lower_edges))
+    return None
+
+
+def _sentinel_selector_zero_rule_names(formula: str) -> list[str]:
+    pattern = re.compile(
+        r"\b(?P<selector>[A-Za-z_][A-Za-z0-9_]*)\s*==\s*-1\s*:\s*0(?:\.0+)?\b"
+    )
+    names: list[str] = []
+    for match in pattern.finditer(formula):
+        selector = match["selector"]
+        if selector not in names:
+            names.append(selector)
+    return names
+
+
+def _formula_can_return_numeric_sentinel(formula: str, *, sentinel: int) -> bool:
+    sentinel_text = re.escape(str(sentinel))
+    return bool(re.search(rf"(?:^|[:\s]){sentinel_text}(?:\.0+)?\b", formula))
+
+
+def _numeric_lower_edge_values_for_input(
+    input_name: str,
+    *,
+    formulas: list[str],
+    scalar_values: dict[str, float],
+) -> list[float]:
+    rhs_pattern = r"(?P<rhs>-?\d+(?:\.\d+)?|[A-Za-z_][A-Za-z0-9_]*)"
+    left_pattern = re.compile(
+        rf"\b{re.escape(input_name)}\b\s*(?P<op>==|>=|>)\s*{rhs_pattern}"
+    )
+    right_pattern = re.compile(
+        rf"(?P<rhs>-?\d+(?:\.\d+)?|[A-Za-z_][A-Za-z0-9_]*)"
+        rf"\s*(?P<op>==|<=|<)\s*\b{re.escape(input_name)}\b"
+    )
+    thresholds: list[float] = []
+    for formula in formulas:
+        for pattern in (left_pattern, right_pattern):
+            for match in pattern.finditer(formula):
+                value = _numeric_formula_rhs_value(match["rhs"], scalar_values)
+                if value is not None:
+                    thresholds.append(value)
+    return thresholds
+
+
+def _below_lower_edge_value(threshold: float) -> int | float:
+    if threshold.is_integer():
+        return int(threshold) - 1
+    return threshold - max(1.0, abs(threshold) * 0.01)
 
 
 def _local_formula_for_rule(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -25805,6 +25805,7 @@ print("BENCHMARK:" + json.dumps(result))
                 aliases.update(source_keys)
             aliases.update(adapter.unsupported_truthy_input_keys)
             aliases.update(adapter.unsupported_falsy_input_keys)
+            aliases.update(adapter.projectable_input_keys)
             if adapter.state_code_from_boolean_input is not None:
                 aliases.add(adapter.state_code_from_boolean_input[0])
         return {alias.lower() for alias in aliases if alias}
@@ -26012,6 +26013,43 @@ print("BENCHMARK:" + json.dumps(result))
                         False,
                         f"{reason}: {', '.join(sorted(unsupported_falsy_keys))}",
                     )
+            if pe_var_name == "il_aabd_personal_allowance":
+                client_is_active = self._rulespec_test_input_value(
+                    inputs,
+                    "client_is_active",
+                )
+                client_is_bedfast = self._rulespec_test_input_value(
+                    inputs,
+                    "client_is_bedfast",
+                )
+                if client_is_active is not None and client_is_bedfast is not None:
+                    if not bool(client_is_active) and not bool(client_is_bedfast):
+                        return (
+                            False,
+                            "PolicyEngine Illinois AABD personal allowance treats "
+                            "non-bedfast clients as active and does not expose a "
+                            "source-level neither-active-nor-bedfast zero branch",
+                        )
+                    if bool(client_is_active) and bool(client_is_bedfast):
+                        return (
+                            False,
+                            "PolicyEngine Illinois AABD personal allowance uses "
+                            "bedfast status as the branch selector and does not "
+                            "represent simultaneous active and bedfast source facts",
+                        )
+                persons_eating_together = self._rulespec_test_input_value(
+                    inputs,
+                    "persons_eating_together_count",
+                )
+                if persons_eating_together is not None:
+                    with contextlib.suppress(TypeError, ValueError):
+                        if float(persons_eating_together) < 1:
+                            return (
+                                False,
+                                "PolicyEngine Illinois AABD personal allowance "
+                                "clips SPM-unit size to at least 1 and does not "
+                                "represent the source-level below-table zero branch",
+                            )
         if country == "uk" and isinstance(expected, dict):
             return (
                 False,

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -607,12 +607,8 @@ PE_US_VAR_ADAPTERS = (
         monthly=True,
         spm=True,
         default_state_code="IL",
-        direct_spm_overrides=(
-            ("persons_eating_together_count", "spm_unit_size"),
-        ),
-        monthly_boolean_person_inputs=(
-            ("client_is_bedfast", "il_aabd_is_bedfast"),
-        ),
+        direct_spm_overrides=(("persons_eating_together_count", "spm_unit_size"),),
+        monthly_boolean_person_inputs=(("client_is_bedfast", "il_aabd_is_bedfast"),),
         projectable_input_keys=("client_is_active",),
         unsupported_truthy_input_keys=("client_is_in_long_term_care",),
         unsupported_input_reason=(

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -33,6 +33,7 @@ class PolicyEngineUSVarAdapter:
     inverted_boolean_household_overrides: tuple[tuple[str, str], ...] = ()
     annual_direct_household_overrides: tuple[tuple[str, str], ...] = ()
     annual_inverted_boolean_household_overrides: tuple[tuple[str, str], ...] = ()
+    projectable_input_keys: tuple[str, ...] = ()
     unsupported_input_keys: tuple[str, ...] = ()
     unsupported_input_patterns: tuple[str, ...] = ()
     unsupported_falsy_input_keys: tuple[str, ...] = ()
@@ -598,6 +599,25 @@ PE_US_VAR_ADAPTERS = (
             "PolicyEngine California CAPI exposes the SPM-unit total and does "
             "not directly compare the person-level eligible-couple share or "
             "mixed CAPI/SSI-SSP couple branch"
+        ),
+    ),
+    PolicyEngineUSVarAdapter(
+        rule_names=("il_aabd_personal_allowance",),
+        pe_var="il_aabd_personal_allowance",
+        monthly=True,
+        spm=True,
+        default_state_code="IL",
+        direct_spm_overrides=(
+            ("persons_eating_together_count", "spm_unit_size"),
+        ),
+        monthly_boolean_person_inputs=(
+            ("client_is_bedfast", "il_aabd_is_bedfast"),
+        ),
+        projectable_input_keys=("client_is_active",),
+        unsupported_truthy_input_keys=("client_is_in_long_term_care",),
+        unsupported_input_reason=(
+            "PolicyEngine Illinois AABD personal allowance does not model the "
+            "DHS long-term-care personal allowance branch"
         ),
     ),
     PolicyEngineUSVarAdapter(

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -4314,6 +4314,16 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec applies the WAG 25-06-01 certification gate before returning a case-level grant-adjustment amount. PolicyEngine's `il_aabd_grant_amount` exposes the monthly grant parameter without this source-specific certification branch, so the ungated table output is the comparable oracle target.
 
+  - legal_id: us-il:policies/dhs/csmm/11-01-01/personal-allowance#il_aabd_personal_allowance
+    country: us
+    program: ssi_state_supplement
+    mapping_type: direct_variable
+    policyengine_variable: il_aabd_personal_allowance
+    period: month
+    unit: USD
+    comparison: money
+    rationale: RuleSpec and PolicyEngine both expose the Illinois AABD monthly personal allowance selected by active/bedfast status and persons eating together. Source cases using the long-term-care row or the below-table zero branch are excluded by the PE adapter because PolicyEngine's variable does not model those branches.
+
   - legal_id: us-wa:regulations/388/388-478/388-478-0035#cash_assistance_earned_income_limit_final_family_size_floor
     country: us
     program: tanf

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12394,9 +12394,7 @@ rules:
         self, tmp_path
     ):
         repo = tmp_path / "rulespec-us"
-        rules_file = (
-            tmp_path / "out" / "policies" / "dhs" / "csmm" / "11-01-01.yaml"
-        )
+        rules_file = tmp_path / "out" / "policies" / "dhs" / "csmm" / "11-01-01.yaml"
         test_file = rules_file.with_name("11-01-01.test.yaml")
         rules_file.parent.mkdir(parents=True)
         repo.mkdir()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12390,6 +12390,102 @@ rules:
             "us:regulations/388/388-450/388-450-0170#dependent_care_hours_band": 0
         }
 
+    def test_zero_branch_repair_uses_below_first_valid_selector_row_for_sentinel_zero(
+        self, tmp_path
+    ):
+        repo = tmp_path / "rulespec-us"
+        rules_file = (
+            tmp_path / "out" / "policies" / "dhs" / "csmm" / "11-01-01.yaml"
+        )
+        test_file = rules_file.with_name("11-01-01.test.yaml")
+        rules_file.parent.mkdir(parents=True)
+        repo.mkdir()
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: persons_eating_together_one
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '1'
+  - name: persons_eating_together_two
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '2'
+  - name: persons_eating_together_three
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '3'
+  - name: persons_eating_together_seven
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '7'
+  - name: persons_eating_together_eight
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '8'
+  - name: persons_eating_together_band
+    kind: derived
+    entity: Person
+    dtype: Integer
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if persons_eating_together == persons_eating_together_one: 0 else: if persons_eating_together == persons_eating_together_two: 1 else: if persons_eating_together >= persons_eating_together_three and persons_eating_together <= persons_eating_together_seven: 2 else: if persons_eating_together >= persons_eating_together_eight: 3 else: -1
+  - name: active_client_personal_allowance
+    kind: parameter
+    dtype: Money
+    indexed_by: persons_eating_together_band
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          0: 62.43
+          1: 57.25
+          2: 53.71
+          3: 52.91
+  - name: il_aabd_personal_allowance
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if persons_eating_together_band == -1: 0 else: active_client_personal_allowance[persons_eating_together_band]
+"""
+        )
+        test_file.write_text("[]\n")
+
+        repaired = _append_generated_zero_branch_tests_if_missing(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=repo,
+            relative_output=Path("policies/dhs/csmm/11-01-01.yaml"),
+            issues=[
+                "Zero branch test coverage missing: `il_aabd_personal_allowance` "
+                "has a formula branch that returns 0."
+            ],
+        )
+
+        assert repaired == ["auto_zero_il_aabd_personal_allowance"]
+        cases = yaml.safe_load(test_file.read_text())
+        assert cases[0]["input"] == {
+            "us:policies/dhs/csmm/11-01-01#input.persons_eating_together": 0
+        }
+        assert cases[0]["output"] == {
+            "us:policies/dhs/csmm/11-01-01#il_aabd_personal_allowance": 0
+        }
+
     def test_repair_zero_branch_tests_derives_hidden_zero_issues(
         self, capsys, tmp_path
     ):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2531,6 +2531,17 @@ def test_policyengine_registry_is_legal_id_keyed():
     assert ca_capi_mapping.mapping_type == "direct_variable"
     assert ca_capi_mapping.policyengine_variable == "ca_capi"
     assert ca_capi_mapping.result_multiplier is None
+    il_aabd_personal_allowance_mapping = registry.mapping_for_legal_id(
+        "us-il:policies/dhs/csmm/11-01-01/personal-allowance#il_aabd_personal_allowance",
+        country="us",
+    )
+    assert il_aabd_personal_allowance_mapping.mapping_type == "direct_variable"
+    assert (
+        il_aabd_personal_allowance_mapping.policyengine_variable
+        == "il_aabd_personal_allowance"
+    )
+    assert il_aabd_personal_allowance_mapping.period == "month"
+    assert il_aabd_personal_allowance_mapping.comparison == "money"
     colorado_ssp_grant_standard_mapping = registry.mapping_for_legal_id(
         "us-co:regulations/9-ccr-2503-5/3.546#and_cs_total_grant_standard",
         country="us",
@@ -4933,6 +4944,91 @@ def test_policyengine_ca_capi_blocks_person_level_couple_share(tmp_path):
     assert mappable is False
     assert "SPM-unit total" in (reason or "")
     assert "each_member_of_eligible_couple_receives_capi" in (reason or "")
+
+
+def test_policyengine_il_aabd_personal_allowance_adapter_projects_inputs(
+    tmp_path,
+):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    script = pipeline._build_pe_us_scenario_script(
+        "il_aabd_personal_allowance",
+        {
+            "period": "2024-01",
+            "us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_in_long_term_care": False,
+            "us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_active": False,
+            "us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_bedfast": True,
+            "us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.persons_eating_together_count": 8,
+        },
+        "2024",
+    )
+
+    assert "'state_code_str': {'2024': 'IL'}" in script
+    assert "'spm_unit_size': {'2024-01': 8}" in script
+    assert "'il_aabd_is_bedfast': {'2024-01': True}" in script
+    assert "calculate('il_aabd_personal_allowance', '2024-01')" in script
+
+
+def test_policyengine_il_aabd_personal_allowance_mappability(
+    tmp_path,
+):
+    pipeline = ValidatorPipeline(
+        policy_repo_path=tmp_path,
+        axiom_rules_path=AXIOM_RULES_PATH,
+        enable_oracles=False,
+    )
+    inputs = {
+        "period": "2024-01",
+        "us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_in_long_term_care": False,
+        "us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_active": True,
+        "us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_bedfast": False,
+        "us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.persons_eating_together_count": 4,
+    }
+
+    mappable, reason = pipeline._is_pe_test_mappable(
+        "us",
+        "il_aabd_personal_allowance",
+        inputs,
+        pe_var="il_aabd_personal_allowance",
+    )
+
+    assert mappable is True
+    assert reason is None
+
+    inputs[
+        "us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_in_long_term_care"
+    ] = True
+    mappable, reason = pipeline._is_pe_test_mappable(
+        "us",
+        "il_aabd_personal_allowance",
+        inputs,
+        pe_var="il_aabd_personal_allowance",
+    )
+
+    assert mappable is False
+    assert "long-term-care personal allowance branch" in (reason or "")
+
+    inputs[
+        "us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_in_long_term_care"
+    ] = False
+    inputs[
+        "us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.client_is_active"
+    ] = False
+    inputs[
+        "us-il:policies/dhs/csmm/11-01-01/personal-allowance#input.persons_eating_together_count"
+    ] = 0
+    mappable, reason = pipeline._is_pe_test_mappable(
+        "us",
+        "il_aabd_personal_allowance",
+        inputs,
+        pe_var="il_aabd_personal_allowance",
+    )
+
+    assert mappable is False
+    assert "neither-active-nor-bedfast zero branch" in (reason or "")
 
 
 def test_policyengine_medicare_adapter_projects_disability_inputs(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.997"
+version = "0.2.998"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.996"
+version = "0.2.997"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair generated zero-output tests for selector formulas whose zero branch is guarded by a sentinel band
- add PolicyEngine oracle mapping support for Illinois AABD personal allowance
- add regression coverage for Illinois AABD-style selectors and oracle projection/mappability
- bump axiom-encode to 0.2.997

## Tests
- uv run python -m pytest tests/test_cli.py -k 'zero_branch_repair_uses_below_first_valid_selector_row_for_sentinel_zero or zero_branch_repair_uses_upper_bound_input_for_band_selector or zero_branch_repair_uses_first_upper_bound_for_target_band_zero or encode_apply_auto_repairs_auto_zero_output_test_mismatches'
- uv run python -m pytest tests/test_rulespec_validation.py -k 'policyengine_registry or il_aabd_personal_allowance'
- uv run ruff check src/axiom_encode/oracles/policyengine/adapters.py src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- AXIOM_RULESPEC_REPO_ROOTS=/Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-il-aabd-personal-20260630 AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/axiom-corpus uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-il-aabd-personal-20260630/us-il/policies/dhs/csmm/11-01-01/personal-allowance.yaml --skip-reviewers --oracle policyengine --json
- AXIOM_RULESPEC_REPO_ROOTS=/Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-il-aabd-personal-20260630 AXIOM_CORPUS_ARTIFACT_ROOT=/Users/maxghenis/TheAxiomFoundation/axiom-corpus/data/corpus AXIOM_CORPUS_REPO=/Users/maxghenis/TheAxiomFoundation/axiom-corpus uv run axiom-encode test --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-il-aabd-personal-20260630/us-il /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-il-aabd-personal-20260630/us-il/policies/dhs/csmm/11-01-01/personal-allowance.test.yaml --json