### PR TITLE
Add Massachusetts TAFDC work expense oracle mapping

### DIFF
--- a/changelog.d/ma-tafdc-work-expense-oracle.fixed.md
+++ b/changelog.d/ma-tafdc-work-expense-oracle.fixed.md
@@ -1,0 +1,1 @@
+Add Massachusetts TAFDC work-related-expense oracle classifications.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.998"
+version = "0.2.999"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.998"
+__version__ = "0.2.999"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -3970,6 +3970,24 @@ mappings:
     comparison: money
     rationale: Massachusetts TAFDC infant benefit comparison targets the one-infant subset where the 106 CMR 705.600 equipment-source and component-request conditions are all satisfied and the department-set crib or mattress plus layette rates total PolicyEngine's flat per-infant amount.
 
+  - legal_id: us-ma:regulations/106-cmr/704/270/block-1#work_related_expense_deduction_monthly_amount
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ma.dta.tcap.deductions.work_related_expenses.amount
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Massachusetts TAFDC monthly work-related-expense deduction amount.
+
+  - legal_id: us-ma:regulations/106-cmr/704/270/block-1#ma_tafdc_work_related_expense_deduction_amount
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ma_tafdc_work_related_expense_deduction
+    candidate_priority: P4
+    rationale: Axiom's 106 CMR 704.270 rule applies the statutory employment, applicant/client, deemed-income, 100% earned-income-disregard, EAEDC restriction, and filing-unit membership conditions. PolicyEngine's ma_tafdc_work_related_expense_deduction exposes the flat amount parameter without these legal eligibility restrictions, so the conditional legal output is not a one-to-one oracle target.
+
   - legal_id: us-az:programs/tanf/fy-2026#az_tanf
     country: us
     program: tanf

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.998"
+version = "0.2.999"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add PolicyEngine oracle classifications for the Massachusetts TAFDC work-related-expense deduction
- map the generated amount parameter to `gov.states.ma.dta.tcap.deductions.work_related_expenses.amount`
- classify the conditional legal deduction output as non-comparable to PE's simplified variable
- bump axiom-encode to 0.2.999

## Validation
- `uv run ruff check src/ tests/`
- `uv run python -m pytest -q -o addopts='' tests/test_policyengine_coverage.py tests/test_policyengine_coverage_monorepo.py tests/test_policyengine_classifier.py` (389 passed)
- `uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-work-expense-20260630/us-ma/regulations/106-cmr/704/270/block-1.yaml --skip-reviewers --oracle policyengine --json` (PolicyEngine 1.0; 1 comparable, 1 passed, 0 failed)
- `uv run axiom-encode guard-generated --repo /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-work-expense-20260630`
