### PR TITLE
Add Massachusetts TAFDC child support oracle mapping

### DIFF
--- a/changelog.d/ma-tafdc-child-support-oracle.fixed.md
+++ b/changelog.d/ma-tafdc-child-support-oracle.fixed.md
@@ -1,0 +1,1 @@
+Add PolicyEngine oracle metadata for the Massachusetts TAFDC absent-parent income disregard.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.999"
+version = "0.2.1000"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.999"
+__version__ = "0.2.1000"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -3988,6 +3988,24 @@ mappings:
     candidate_priority: P4
     rationale: Axiom's 106 CMR 704.270 rule applies the statutory employment, applicant/client, deemed-income, 100% earned-income-disregard, EAEDC restriction, and filing-unit membership conditions. PolicyEngine's ma_tafdc_work_related_expense_deduction exposes the flat amount parameter without these legal eligibility restrictions, so the conditional legal output is not a one-to-one oracle target.
 
+  - legal_id: us-ma:regulations/106-cmr/704/230/block-1#ma_tafdc_monthly_absent_parent_income_disregard
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ma.dta.tcap.deductions.child_support_received
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Massachusetts TAFDC monthly absent-parent income disregard amount, represented in PolicyEngine as the child-support-received deduction parameter.
+
+  - legal_id: us-ma:regulations/106-cmr/704/230/block-1#ma_tafdc_child_support_deduction
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ma_tafdc_child_support_deduction
+    candidate_priority: P4
+    rationale: Axiom's 106 CMR 704.230 rule applies only to income from an absent parent for a child included in the TAFDC assistance unit and distinguishes income received directly or paid to DOR. PolicyEngine's ma_tafdc_child_support_deduction uses a generic alimony-income proxy and the flat child-support parameter, so the conditional legal output is not a one-to-one oracle target.
+
   - legal_id: us-az:programs/tanf/fy-2026#az_tanf
     country: us
     program: tanf

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.999"
+version = "0.2.1000"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Map the Massachusetts TAFDC absent-parent income disregard amount to PolicyEngine's child-support-received deduction parameter
- Classify the full conditional TAFDC child-support deduction as not directly comparable because PolicyEngine uses a generic alimony-income proxy and does not model the 106 CMR 704.230 assistance-unit/DOR receipt boundary
- Bump axiom-encode to 0.2.1000 and add a changelog note

## Validation
- uv run ruff check src/ tests/
- uv run --extra dev python -m pytest -q -o addopts='' tests/test_policyengine_coverage.py tests/test_policyengine_coverage_monorepo.py tests/test_policyengine_classifier.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-child-support-20260630 --oracle policyengine --limit 20
- uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-child-support-20260630/us-ma/regulations/106-cmr/704/230/block-1.yaml --oracle policyengine --skip-reviewers --json