### PR TITLE
Track program oracle test evidence

### DIFF
--- a/changelog.d/program-oracle-test-evidence.fixed.md
+++ b/changelog.d/program-oracle-test-evidence.fixed.md
@@ -1,0 +1,1 @@
+Treat explicitly referenced source-law tests as evidence for comparable program-wrapper oracle outputs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1000"
+version = "0.2.1001"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1000"
+__version__ = "0.2.1001"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -7,7 +7,7 @@ import importlib.util
 import os
 import re
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -369,10 +369,9 @@ def build_policyengine_coverage_report(
     duplicate_outputs_collapsed = len(raw_items) - len(
         {item.legal_id for item in raw_items}
     )
-    items = sorted(
-        _dedupe_coverage_items_by_legal_id(raw_items),
-        key=lambda item: item.legal_id,
-    )
+    deduped_items = _dedupe_coverage_items_by_legal_id(raw_items)
+    evidence_items = _apply_test_evidence_mappings(deduped_items, registry)
+    items = sorted(evidence_items, key=lambda item: item.legal_id)
     if program:
         programs = _program_filter_values(program)
         items = [item for item in items if item.program in programs]
@@ -816,6 +815,41 @@ def _iter_policyengine_coverage_items(
                     )
                 )
     return items
+
+
+def _apply_test_evidence_mappings(
+    items: list[PolicyEngineCoverageItem],
+    registry,
+) -> list[PolicyEngineCoverageItem]:
+    """Mark outputs tested when their mapping points to tested source outputs."""
+    test_output_counts_by_id = {item.legal_id: item.test_output_count for item in items}
+    out: list[PolicyEngineCoverageItem] = []
+    for item in items:
+        prefix, _, _ = item.legal_id.partition(":")
+        mapping = registry.mapping_for_legal_id(
+            item.legal_id,
+            country=_country_from_rulespec_prefix(prefix),
+        )
+        if not mapping or not mapping.tested_by_legal_ids:
+            out.append(item)
+            continue
+        evidence_count = sum(
+            test_output_counts_by_id.get(evidence_legal_id, 0)
+            for evidence_legal_id in set(mapping.tested_by_legal_ids)
+            if evidence_legal_id != item.legal_id
+        )
+        if evidence_count <= 0:
+            out.append(item)
+            continue
+        total_count = item.test_output_count + evidence_count
+        out.append(
+            replace(
+                item,
+                tested=total_count > 0,
+                test_output_count=total_count,
+            )
+        )
+    return out
 
 
 def _iter_program_spec_coverage_items(

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -2183,6 +2183,8 @@ mappings:
     period: month
     unit: GBP
     comparison: money
+    tested_by_legal_ids:
+      - uk:statutes/ukpga/2012/5/8#universal_credit_award_amount
     rationale: Same WRA 2012 section 8 award formula as the source-law mapping, comparing the pre-take-up and pre-benefit-cap expression from uc_maximum_amount and uc_income_reduction.
 
   - legal_id: uk:programs/universal-credit/fy-2026-27#universal_credit_award_deduction_from_maximum_amount

--- a/src/axiom_encode/oracles/policyengine/registry.py
+++ b/src/axiom_encode/oracles/policyengine/registry.py
@@ -53,6 +53,7 @@ class PolicyEngineMapping:
     rationale: str | None = None
     candidate_priority: str | None = None
     aliases: tuple[str, ...] = ()
+    tested_by_legal_ids: tuple[str, ...] = ()
 
     @property
     def comparable(self) -> bool:
@@ -235,6 +236,12 @@ class PolicyEngineOracleRegistry:
                     "Unsupported PolicyEngine candidate_priority for "
                     f"{legal_id}: {mapping.candidate_priority}"
                 )
+            for evidence_legal_id in mapping.tested_by_legal_ids:
+                if ":" not in evidence_legal_id or "#" not in evidence_legal_id:
+                    issues.append(
+                        "PolicyEngine tested_by_legal_ids entries must be "
+                        f"canonical legal IDs: {legal_id} -> {evidence_legal_id}"
+                    )
         return issues
 
 
@@ -292,6 +299,11 @@ def _mapping_from_payload(payload: dict[str, Any]) -> PolicyEngineMapping:
         aliases = ()
     if isinstance(aliases, str):
         aliases = (aliases,)
+    tested_by_legal_ids = payload.get("tested_by_legal_ids", ())
+    if tested_by_legal_ids is None:
+        tested_by_legal_ids = ()
+    if isinstance(tested_by_legal_ids, str):
+        tested_by_legal_ids = (tested_by_legal_ids,)
     parameter_keys = payload.get("parameter_keys", ())
     if parameter_keys is None:
         parameter_keys = ()
@@ -340,4 +352,5 @@ def _mapping_from_payload(payload: dict[str, Any]) -> PolicyEngineMapping:
         rationale=payload.get("rationale"),
         candidate_priority=payload.get("candidate_priority"),
         aliases=tuple(str(alias) for alias in aliases),
+        tested_by_legal_ids=tuple(str(legal_id) for legal_id in tested_by_legal_ids),
     )

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -15932,6 +15932,51 @@ def test_universal_credit_program_wrapper_outputs_are_classified(tmp_path):
         )
         is None
     )
+    assert final_mapping.tested_by_legal_ids == (
+        "uk:statutes/ukpga/2012/5/8#universal_credit_award_amount",
+    )
+
+
+def test_universal_credit_program_wrapper_counts_source_test_evidence(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "programs/uk/universal-credit/fy-2026-27.yaml",
+        "program: uk/universal-credit\n"
+        "period: 2026-04\n"
+        "outputs:\n"
+        "  - universal_credit_award_amount\n",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "uk/statutes/ukpga/2012/5/8.yaml",
+        """format: rulespec/v1
+rules:
+  - name: universal_credit_award_amount
+    kind: derived
+    versions:
+      - effective_from: '0001-01-01'
+        formula: max(0, universal_credit_maximum_amount - universal_credit_amounts_to_be_deducted)
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "uk/statutes/ukpga/2012/5/8.test.yaml",
+        """- name: source_award_amount_is_tested
+  period: 2026-04
+  output:
+    uk:statutes/ukpga/2012/5/8#universal_credit_award_amount: 1000
+""",
+    )
+
+    report = build_policyengine_coverage_report(
+        tmp_path,
+        program="universal_credit",
+    )
+
+    assert report["untested_comparable"] == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    final_award = items_by_id[
+        "uk:programs/universal-credit/fy-2026-27#universal_credit_award_amount"
+    ]
+    assert final_award["tested"] is True
+    assert final_award["test_output_count"] == 1
 
 
 def test_council_tax_reduction_policy_surface_is_classified(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1000"
+version = "0.2.1001"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add tested_by_legal_ids to PolicyEngine oracle mappings
- count referenced source-law tests as evidence for comparable program-wrapper outputs
- annotate the UK Universal Credit program wrapper so coverage no longer reports an untested comparable when the source-law WRA section 8 output is tested

## Verification
- uv run ruff check src/axiom_encode/oracles/policyengine/registry.py src/axiom_encode/oracles/policyengine/coverage.py tests/test_policyengine_coverage.py
- uv run --extra dev python -m pytest -q -o addopts='' tests/test_policyengine_coverage.py -k 'universal_credit_program_wrapper or source_test_evidence or alias_counts'
- uv run --extra dev python -m pytest -q -o addopts='' tests/test_policyengine_coverage.py tests/test_policyengine_coverage_monorepo.py tests/test_policyengine_classifier.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --oracle policyengine --include-program-surfaces --json (untested_comparable: 0)
