### PR TITLE
Classify Massachusetts TAFDC income test

### DIFF
--- a/changelog.d/ma-tafdc-income-test-oracle.fixed.md
+++ b/changelog.d/ma-tafdc-income-test-oracle.fixed.md
@@ -1,0 +1,1 @@
+Classify the Massachusetts TAFDC income-test rule against the PolicyEngine oracle registry.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1001"
+version = "0.2.1002"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1001"
+__version__ = "0.2.1002"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -3988,6 +3988,14 @@ mappings:
     candidate_priority: P4
     rationale: Axiom's 106 CMR 704.270 rule applies the statutory employment, applicant/client, deemed-income, 100% earned-income-disregard, EAEDC restriction, and filing-unit membership conditions. PolicyEngine's ma_tafdc_work_related_expense_deduction exposes the flat amount parameter without these legal eligibility restrictions, so the conditional legal output is not a one-to-one oracle target.
 
+  - legal_id: us-ma:regulations/106-cmr/704/260/block-1#ma_tafdc_financial_eligible
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ma_tafdc_financial_eligible
+    candidate_priority: P4
+    rationale: Axiom's 106 CMR 704.260 rule applies the source-law income test against the applicable Need Standard and treats income equal to that standard as eligible after excluding noncountable income, Full Employment Program wages, and the listed disregards. PolicyEngine's ma_tafdc_financial_eligible uses PE's own income graph and a strict less-than comparison against ma_tafdc_payment_standard, so the legal output is adjacent TAFDC coverage rather than a one-to-one oracle target.
+
   - legal_id: us-ma:regulations/106-cmr/704/230/block-1#ma_tafdc_monthly_absent_parent_income_disregard
     country: us
     program: tanf

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2829,6 +2829,46 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_massachusetts_tafdc_income_test(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "us-ma/regulations/106-cmr/704/260/block-1.yaml",
+        """format: rulespec/v1
+rules:
+  - name: ma_tafdc_financial_eligible
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '0001-01-01'
+        formula: countable_income <= applicable_need_standard
+""",
+    )
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-ma/regulations/106-cmr/704/260/block-1.test.yaml",
+        """- name: eligible_at_need_standard
+  period: 2026-01
+  output:
+    us-ma:regulations/106-cmr/704/260/block-1#ma_tafdc_financial_eligible: holds
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tanf")
+
+    assert report["untested_comparable"] == 0
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == (
+        "us-ma:regulations/106-cmr/704/260/block-1#ma_tafdc_financial_eligible"
+    )
+    assert item["program"] == "tanf"
+    assert item["status"] == "known_not_comparable"
+    assert item["mapping_type"] == "not_comparable"
+    assert item["policyengine_variable"] == "ma_tafdc_financial_eligible"
+    assert item["candidate_priority"] == "P4"
+    assert "strict less-than comparison" in item["rationale"]
+
+
 def test_policyengine_coverage_classifies_washington_tanf_wac_components(tmp_path):
     _write_rulespec_file(
         tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1001"
+version = "0.2.1002"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify the new 106 CMR 704.260 Massachusetts TAFDC income-test output as known-not-comparable against PolicyEngine
- document the strict less-than / source-law less-than-or-equal boundary difference in the registry rationale
- add a coverage regression and bump axiom-encode to 0.2.1002

## Verification
- uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/
- uv run --extra dev python -m pytest -q -o addopts='' tests/test_policyengine_coverage.py -k 'massachusetts_tafdc_income_test or arizona_tanf_exact_parameters'
- uv run --extra dev python -m pytest -q -o addopts='' tests/test_policyengine_coverage.py tests/test_policyengine_coverage_monorepo.py tests/test_policyengine_classifier.py
- uv run --project /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-encode-ma-tafdc-income-test-oracle-20260630 axiom-encode validate us-ma/regulations/106-cmr/704/260/block-1.yaml --oracle policyengine --skip-reviewers --require-oracle-classification --json
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ma-tafdc-income-test-20260630 --oracle policyengine --program tanf --json
