### PR TITLE
Require upstream checks for lower-authority RuleSpec sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,20 @@ signature.
 ## Source pinning and staleness
 
 RuleSpec modules ground to legal text through
-`module.source_verification.corpus_citation_path`. The schema also accepts an
-optional `source_sha256` pin — the SHA-256 hex digest of the exact corpus
-provision text the module was encoded from — plus in-content
-`module.encoding_provenance` (`encoder`, `model`, `run_id`, `reviewed_by`)
-and `module.validation` (oracle, `matches`/`mismatches`/`pending` status,
-`last_run` date) blocks. All three are optional and inert at runtime.
+`module.source_verification.corpus_citation_path`. If that source is below
+statute/regulation authority, such as a policy manual, guidance page, form,
+CMS table, or state plan, validation requires
+`module.source_verification.upstream_source_check` with `status`,
+`checked_paths`, and `rationale`. The checked paths must include at least one
+statute/regulation corpus path or RuleSpec target that was checked before the
+lower source was encoded. This makes lower-authority sources reviewable instead
+of silently treating them as maximally upstream.
+
+The schema also accepts an optional `source_sha256` pin — the SHA-256 hex
+digest of the exact corpus provision text the module was encoded from — plus
+in-content `module.encoding_provenance` (`encoder`, `model`, `run_id`,
+`reviewed_by`) and `module.validation` (oracle, `matches`/`mismatches`/
+`pending` status, `last_run` date) blocks. These fields are inert at runtime.
 
 Check every pinned module in a jurisdiction checkout against a local
 `axiom-corpus` checkout:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1002"
+version = "0.2.1003"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1002"
+__version__ = "0.2.1003"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -4799,6 +4799,18 @@ RuleSpec requirements:
 - Include `module.summary: |-` with a concise exact audit excerpt, not the full source text when the source is more than a short paragraph. Corpus-backed validation reads the authoritative source from `corpus.provisions`; use the summary only to orient reviewers to the encoded provisions.
 - Do not emit `source_url`; RuleSpec source verification reads `corpus.provisions`, not raw PDFs or web pages.
 {corpus_rulespec_requirement.rstrip()}
+- If the corpus source path is below statute/regulation authority (for example
+  a `policy`, `manual`, `guidance`, `form`, table, CMS summary, or state plan),
+  do not treat it as adequate by default. First check statute/regulation
+  authority when provided in context. If the lower source remains the correct
+  source for the encoded value or rule, include
+  `module.source_verification.upstream_source_check` with `status`
+  (`checked_higher_authority`, `official_parameter_source`,
+  `delegated_parameter_source`, or `no_higher_authority_found`),
+  `checked_paths` listing at least one statute/regulation corpus path or
+  RuleSpec target that was checked, and `rationale` explaining why the lower
+  source is still used. If no higher-authority check is available, stop and
+  emit a typed request `upstream_source_check_required` instead of encoding.
 - Include `module.proof_validation.required: true` and add
   `metadata.proof.atoms` to every `parameter`, `derived`, and
   `derived_relation` rule. Each atom

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -6732,6 +6732,169 @@ def find_rule_source_metadata_issues(content: str) -> list[str]:
     return issues
 
 
+_PRIMARY_SOURCE_AUTHORITY_SEGMENTS = {
+    "act",
+    "acts",
+    "code",
+    "cfr",
+    "legislation",
+    "public-law",
+    "public-laws",
+    "regulation",
+    "regulations",
+    "statute",
+    "statutes",
+    "usc",
+}
+_LOWER_SOURCE_AUTHORITY_SEGMENTS = {
+    "form",
+    "forms",
+    "guidance",
+    "guide",
+    "guides",
+    "manual",
+    "manuals",
+    "plan",
+    "plans",
+    "policy",
+    "policies",
+    "state-plan",
+    "state-plans",
+    "state_plan",
+    "state_plans",
+    "table",
+    "tables",
+}
+_UPSTREAM_SOURCE_CHECK_STATUSES = {
+    "checked_higher_authority",
+    "delegated_parameter_source",
+    "no_higher_authority_found",
+    "official_parameter_source",
+}
+
+
+def find_upstream_source_authority_issues(content: str) -> list[str]:
+    """Require an upstream-authority audit before encoding lower sources.
+
+    Statutes and regulations can be encoded directly because they are
+    potentially maximally upstream for a computable rule. Implementation
+    sources such as manuals, guidance, state plans, forms, and CMS tables are
+    sometimes the right source, but only after checking higher authority first.
+    """
+    try:
+        payload = yaml.safe_load(content)
+    except (yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict) or payload.get("format") != "rulespec/v1":
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list) or not any(
+        _is_executable_rulespec_rule(rule) for rule in rules
+    ):
+        return []
+
+    source_verification = _source_verification_block(payload)
+    if source_verification is None:
+        return []
+    citation_paths, _source_label = _source_verification_source_fields(
+        source_verification
+    )
+    lower_authority_paths = tuple(
+        path for path in citation_paths if _source_path_requires_upstream_check(path)
+    )
+    if not lower_authority_paths:
+        return []
+
+    check = source_verification.get("upstream_source_check")
+    formatted_sources = _format_source_verification_paths(lower_authority_paths)
+    if not isinstance(check, dict):
+        return [
+            "Upstream source check required: "
+            f"{formatted_sources} is below statute/regulation authority. "
+            "Check statute/regulation sources first, then record "
+            "`module.source_verification.upstream_source_check` with "
+            "`status`, `checked_paths`, and `rationale`, or encode the "
+            "higher source instead."
+        ]
+
+    issues: list[str] = []
+    status = str(check.get("status") or "").strip()
+    if status not in _UPSTREAM_SOURCE_CHECK_STATUSES:
+        issues.append(
+            "Upstream source check status invalid: "
+            "`module.source_verification.upstream_source_check.status` must be "
+            "one of "
+            + ", ".join(
+                f"`{value}`" for value in sorted(_UPSTREAM_SOURCE_CHECK_STATUSES)
+            )
+            + "."
+        )
+
+    checked_paths = _source_check_paths(check.get("checked_paths"))
+    if not checked_paths:
+        issues.append(
+            "Upstream source check paths required: "
+            "`module.source_verification.upstream_source_check.checked_paths` "
+            "must list statute/regulation corpus paths or RuleSpec targets "
+            "that were checked before using the lower-authority source."
+        )
+    elif not any(
+        _source_reference_is_potentially_primary(path) for path in checked_paths
+    ):
+        issues.append(
+            "Upstream source check must include higher authority: "
+            "`module.source_verification.upstream_source_check.checked_paths` "
+            "must include at least one statute/regulation corpus path or "
+            "RuleSpec target."
+        )
+
+    rationale = str(check.get("rationale") or "").strip()
+    if len(rationale) < 20:
+        issues.append(
+            "Upstream source check rationale required: "
+            "`module.source_verification.upstream_source_check.rationale` must "
+            "explain why the lower-authority source is still the correct source "
+            "for this encoding."
+        )
+
+    return issues
+
+
+def _source_check_paths(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        text = value.strip()
+        return (text,) if text else ()
+    if not isinstance(value, list):
+        return ()
+    paths: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        text = item.strip()
+        if text:
+            paths.append(text)
+    return tuple(dict.fromkeys(paths))
+
+
+def _source_path_requires_upstream_check(path: str) -> bool:
+    segments = _source_reference_segments(path)
+    if segments & _PRIMARY_SOURCE_AUTHORITY_SEGMENTS:
+        return False
+    return bool(segments & _LOWER_SOURCE_AUTHORITY_SEGMENTS)
+
+
+def _source_reference_is_potentially_primary(reference: str) -> bool:
+    return bool(
+        _source_reference_segments(reference) & _PRIMARY_SOURCE_AUTHORITY_SEGMENTS
+    )
+
+
+def _source_reference_segments(reference: str) -> set[str]:
+    head = reference.split("#", 1)[0].strip().lower()
+    head = head.replace(":", "/")
+    return {segment for segment in re.split(r"[/\s]+", head) if segment}
+
+
 def _rulespec_rule_name(rule: dict[str, Any]) -> str:
     return str(rule.get("name") or "<unknown>").strip() or "<unknown>"
 
@@ -21361,6 +21524,7 @@ class ValidatorPipeline:
         issues.extend(find_deprecated_source_url_issues(content))
         issues.extend(find_source_claim_reference_issues(content))
         issues.extend(find_empty_rules_module_issues(content))
+        issues.extend(find_upstream_source_authority_issues(content))
         proof_issues = (
             validate_rulespec_proofs(
                 content,

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -199,6 +199,18 @@ Hard requirements:
 - If the source has an ingested corpus provision, include
   `module.source_verification.corpus_citation_path` or
   `module.source_verification.corpus_citation_paths`.
+- If the corpus source path is below statute/regulation authority (for example
+  a `policy`, `manual`, `guidance`, `form`, table, CMS summary, or state plan),
+  do not treat it as adequate by default. First check statute/regulation
+  authority when provided in context. If the lower source remains the correct
+  source for the encoded value or rule, include
+  `module.source_verification.upstream_source_check` with:
+  `status` (`checked_higher_authority`, `official_parameter_source`,
+  `delegated_parameter_source`, or `no_higher_authority_found`),
+  `checked_paths` listing at least one statute/regulation corpus path or
+  RuleSpec target that was checked, and `rationale` explaining why the lower
+  source is still used. If no higher-authority check is available, stop and
+  emit a typed request `upstream_source_check_required` instead of encoding.
 - If accepted source claims are supplied, include their IDs under
   `module.source_claims`; do not inline claim bodies, values, formulas,
   evidence, or review metadata in RuleSpec.

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -96,6 +96,7 @@ from axiom_encode.harness.validator_pipeline import (
     find_unused_import_issues,
     find_unused_modifier_parameter_issues,
     find_upstream_placement_issues,
+    find_upstream_source_authority_issues,
     find_versioned_derived_formula_issues,
     find_zero_branch_test_coverage_issues,
     repair_copied_cross_reference_summary,
@@ -1005,6 +1006,135 @@ rules:
     ]
 
 
+def test_upstream_source_authority_accepts_statute_source():
+    content = """format: rulespec/v1
+module:
+  summary: The standard is 20 hours.
+  source_verification:
+    corpus_citation_path: us/statute/7/2015
+rules:
+  - name: minimum_hours
+    kind: parameter
+    dtype: Count
+    source: 7 USC 2015(e)(4)
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '20'
+"""
+
+    assert find_upstream_source_authority_issues(content) == []
+
+
+def test_upstream_source_authority_rejects_lower_source_without_check():
+    content = """format: rulespec/v1
+module:
+  summary: CMS table states Georgia Medicaid child eligibility levels.
+  source_verification:
+    corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+rules:
+  - name: georgia_children_medicaid_ages_6_to_18_fpl_limit
+    kind: parameter
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row
+    versions:
+      - effective_from: '2023-12-01'
+        formula: '1.33'
+"""
+
+    issues = find_upstream_source_authority_issues(content)
+
+    assert issues == [
+        "Upstream source check required: "
+        "`us/form/cms/medicaid-chip-bhp-eligibility-levels` is below "
+        "statute/regulation authority. Check statute/regulation sources first, "
+        "then record "
+        "`module.source_verification.upstream_source_check` with `status`, "
+        "`checked_paths`, and `rationale`, or encode the higher source instead."
+    ]
+
+
+def test_upstream_source_authority_accepts_lower_source_with_audit():
+    content = """format: rulespec/v1
+module:
+  summary: CMS table states Georgia Medicaid child eligibility levels.
+  source_verification:
+    corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us/statute/42/1396a
+        - us/regulation/42/435/118
+      rationale: |-
+        Federal statute and regulation define the child Medicaid eligibility
+        category and state-plan requirement, while the CMS table is the
+        official published source for this state-specific effective FPL value.
+rules:
+  - name: georgia_children_medicaid_ages_6_to_18_fpl_limit
+    kind: parameter
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row
+    versions:
+      - effective_from: '2023-12-01'
+        formula: '1.33'
+"""
+
+    assert find_upstream_source_authority_issues(content) == []
+
+
+def test_upstream_source_authority_requires_checked_primary_path():
+    content = """format: rulespec/v1
+module:
+  summary: State manual states a TANF payment standard.
+  source_verification:
+    corpus_citation_path: us-ny/policy/otda/tanf-state-plan-2024-2026/standard-of-need-and-monthly-grant
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us-ny/policy/otda/tanf-state-plan-2024-2026
+      rationale: State plan checked before encoding this payment standard.
+rules:
+  - name: tanf_payment_standard
+    kind: parameter
+    dtype: Money
+    source: TANF state plan
+    versions:
+      - effective_from: '2024-01-01'
+        formula: '100'
+"""
+
+    issues = find_upstream_source_authority_issues(content)
+
+    assert issues == [
+        "Upstream source check must include higher authority: "
+        "`module.source_verification.upstream_source_check.checked_paths` must "
+        "include at least one statute/regulation corpus path or RuleSpec target."
+    ]
+
+
+def test_upstream_source_authority_requires_check_for_mixed_lower_sources():
+    content = """format: rulespec/v1
+module:
+  summary: Guidance restates the statutory value.
+  source_verification:
+    corpus_citation_paths:
+      - us/statute/7/2014
+      - us/guidance/usda/fns/snap-fy2026-cola/page-2
+rules:
+  - name: snap_guidance_amount
+    kind: parameter
+    dtype: Money
+    source: USDA guidance
+    versions:
+      - effective_from: '2025-10-01'
+        formula: '100'
+"""
+
+    issues = find_upstream_source_authority_issues(content)
+
+    assert len(issues) == 1
+    assert "`us/guidance/usda/fns/snap-fy2026-cola/page-2`" in issues[0]
+
+
 def test_missing_derived_companion_output_rejects_uncovered_derived_rule(tmp_path):
     policy_repo = tmp_path / "rulespec-us"
     rules_file = policy_repo / "statutes" / "7" / "2015" / "e.yaml"
@@ -1622,6 +1752,14 @@ module:
     The standard utility allowance is $451.
   source_verification:
     corpus_citation_path: us/guidance/example/sua
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us/statute/example/authority
+      rationale: |-
+        This fixture intentionally models a lower-authority source in CI after
+        checking a dummy statute path, so the test can focus on compile and
+        grounding behavior rather than source hierarchy validation.
 rules:
   - name: standard_utility_allowance_value
     kind: parameter
@@ -12237,6 +12375,14 @@ module:
   summary: The standard utility allowance is $451.
   source_verification:
     corpus_citation_path: us/guidance/example/sua
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us/statute/example/authority
+      rationale: |-
+        This fixture intentionally models a lower-authority source in CI after
+        checking a dummy statute path, so the test can focus on companion test
+        output behavior rather than source hierarchy validation.
 rules:
   - name: snap_standard_utility_allowance_value
     kind: parameter
@@ -12757,6 +12903,14 @@ module:
   summary: The policy rate is 0.2.
   source_verification:
     corpus_citation_path: us/guidance/example/rate
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us/statute/example/authority
+      rationale: |-
+        This fixture intentionally models a lower-authority source in CI after
+        checking a dummy statute path, so the test can focus on parameter-only
+        output comparison rather than source hierarchy validation.
 rules:
   - name: policy_rate
     kind: parameter
@@ -12805,6 +12959,14 @@ module:
     plus 218 for each additional person.
   source_verification:
     corpus_citation_path: us/guidance/example/allotments
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us/statute/example/authority
+      rationale: |-
+        This fixture intentionally models a lower-authority source in CI after
+        checking a dummy statute path, so the test can focus on indexed table
+        execution rather than source hierarchy validation.
 rules:
   - name: benefit_amount_table
     kind: parameter
@@ -12872,6 +13034,14 @@ module:
   summary: The maximum monthly allotments are 298 and 546.
   source_verification:
     corpus_citation_path: us/guidance/example/allotments
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us/statute/example/authority
+      rationale: |-
+        This fixture intentionally models a lower-authority source in CI after
+        checking a dummy statute path, so the test can focus on indexed
+        parameter output comparison rather than source hierarchy validation.
 rules:
   - name: benefit_amount_table
     kind: parameter
@@ -14865,7 +15035,13 @@ rules:
 
 def test_validator_pipeline_maps_in_memory_source_text_to_declared_corpus_path(
     tmp_path,
+    monkeypatch,
 ):
+    monkeypatch.setattr(
+        validator_pipeline,
+        "_fetch_corpus_source_text",
+        lambda _citation_path: None,
+    )
     source_text = (
         "Effective January 2026, the MSA assistance standard for a person living "
         "alone is $1,055.00."
@@ -23263,12 +23439,12 @@ rules:
 """
     )
     rules_file.with_name("rules.test.yaml").write_text(
-        """- name: kind_mismatch
+        """- name: text_expected_as_number
   period: 2024-01
   input: {}
   output:
     code_text: 1
-    count: "1"
+    count: 1
 """
     )
 
@@ -23284,8 +23460,22 @@ rules:
         "code_text" in issue and "expected integer 1, got text 1" in issue
         for issue in result.issues
     )
+
+    rules_file.with_name("rules.test.yaml").write_text(
+        """- name: integer_expected_as_text
+  period: 2024-01
+  input: {}
+  output:
+    code_text: "1"
+    count: "one"
+"""
+    )
+
+    result = pipeline._run_ci(rules_file)
+
+    assert result.passed is False
     assert any(
-        "count" in issue and "expected text 1, got integer 1" in issue
+        "count" in issue and "expected text one, got integer 1" in issue
         for issue in result.issues
     )
 
@@ -23433,6 +23623,14 @@ module:
     The standard utility allowance is $451.
   source_verification:
     corpus_citation_path: us/guidance/example/sua
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us/statute/example/authority
+      rationale: |-
+        This fixture intentionally models a lower-authority source in CI after
+        checking a dummy statute path, so the test can focus on numeric
+        grounding behavior rather than source hierarchy validation.
 rules:
   - name: snap_standard_utility_allowance_value
     kind: parameter

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1002"
+version = "0.2.1003"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a RuleSpec CI validator that requires an upstream source audit before executable rules can cite lower-authority sources like manuals, guidance, forms, CMS tables, policy pages, or state plans
- update encoder/eval prompt requirements and README docs for `module.source_verification.upstream_source_check`
- harden validator tests around lower-authority fixtures, local corpus isolation, and scalar mismatch assertions
- bump `axiom-encode` to `0.2.1003` so the encoder provenance guard records this prompt/validator change before generated RuleSpec can be applied

## Validation
- `uv run --extra dev python -m pytest tests/`
- `uv run --extra dev python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `uv run --extra dev python -m pytest tests/test_rulespec_validation.py`
- `uv run --extra dev python -m pytest tests/test_evals.py -k prompt --maxfail=1`
- `uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py src/axiom_encode/__init__.py README.md pyproject.toml`
- `env -u UV_FROZEN uv lock --check`
- `uv run --extra dev axiom-encode validate /Users/maxghenis/TheAxiomFoundation/rulespec-us/us-ga/policies/cms/georgia-medicaid-chip-bhp-eligibility-levels.yaml --skip-reviewers --json` fails as intended with `Upstream source check required` for `us/form/cms/medicaid-chip-bhp-eligibility-levels`
