### PR TITLE
Require Populace evidence for PE surface parity

### DIFF
--- a/changelog.d/populace-surface-validation-gate.changed.md
+++ b/changelog.d/populace-surface-validation-gate.changed.md
@@ -1,0 +1,1 @@
+Track Populace validation status for PolicyEngine program surfaces and add a failing oracle-coverage gate for active wired surfaces that lack validated Populace evidence.

--- a/docs/policyengine-oracle-registry.md
+++ b/docs/policyengine-oracle-registry.md
@@ -178,6 +178,31 @@ axiom-encode oracle-coverage \
   --fail-on-untested-comparable
 ```
 
+For PolicyEngine program-surface parity, a legal-ID mapping is not enough. Active
+surfaces that the report classifies as `wired` still require a Populace-backed
+comparison before they can be treated as PE-parity-complete. The program-surface
+manifest can record this under `populace_validation`:
+
+```yaml
+populace_validation:
+  status: validated
+  command: axiom-encode tax-populace-compare --variable income_tax --year 2024
+  dataset: populace-us-2024
+  last_run: '2026-06-30'
+```
+
+`validated` entries must cite a Populace comparison command, dataset, and run
+date. Use `pending_validator`, `blocked`, or `not_applicable` only with a
+concrete rationale. CI jobs that want to forbid unvalidated wired program
+surfaces can use:
+
+```bash
+axiom-encode oracle-coverage \
+  --root /path/to/workspace \
+  --include-program-surfaces \
+  --fail-on-unvalidated-populace-surfaces
+```
+
 ## Candidate Triage
 
 Use the candidate command to turn coverage into a priority queue:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1003"
+version = "0.2.1004"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1003"
+__version__ = "0.2.1004"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -732,6 +732,14 @@ def main():
         ),
     )
     oracle_coverage_parser.add_argument(
+        "--fail-on-unvalidated-populace-surfaces",
+        action="store_true",
+        help=(
+            "Exit non-zero when an included active wired PolicyEngine program "
+            "surface lacks validated Populace comparison metadata"
+        ),
+    )
+    oracle_coverage_parser.add_argument(
         "--json", action="store_true", help="Output as JSON"
     )
 
@@ -3817,6 +3825,9 @@ def cmd_oracle_coverage(args):
     fail_on_pending_program_surfaces = (
         getattr(args, "fail_on_pending_program_surfaces", False) is True
     )
+    fail_on_unvalidated_populace_surfaces = (
+        getattr(args, "fail_on_unvalidated_populace_surfaces", False) is True
+    )
     report = build_policyengine_coverage_report(
         root,
         program=args.program,
@@ -3828,6 +3839,9 @@ def cmd_oracle_coverage(args):
     pending_program_surfaces = int(
         (report.get("program_surfaces") or {}).get("active_pending_surfaces", 0)
     )
+    unvalidated_populace_surfaces = int(
+        (report.get("program_surfaces") or {}).get("unvalidated_populace_surfaces", 0)
+    )
     should_fail = (
         (args.fail_on_unmapped and unmapped)
         or (args.fail_on_untested_comparable and untested_comparable)
@@ -3835,6 +3849,11 @@ def cmd_oracle_coverage(args):
             fail_on_pending_program_surfaces
             and include_program_surfaces
             and pending_program_surfaces
+        )
+        or (
+            fail_on_unvalidated_populace_surfaces
+            and include_program_surfaces
+            and unvalidated_populace_surfaces
         )
     )
     if args.json:
@@ -3856,12 +3875,18 @@ def cmd_oracle_coverage(args):
             f"{surfaces['total_surfaces']} "
             f"status={_format_counter(surfaces['status_counts'])} "
             f"pending={surfaces['pending_surfaces']} "
-            f"active_pending={surfaces.get('active_pending_surfaces', 0)}"
+            f"active_pending={surfaces.get('active_pending_surfaces', 0)} "
+            f"unvalidated_populace={surfaces.get('unvalidated_populace_surfaces', 0)}"
         )
         print(
             "PolicyEngine surface priorities: "
             f"{_format_counter(surfaces['priority_counts'])}"
         )
+        if surfaces.get("populace_validation_counts"):
+            print(
+                "PolicyEngine Populace validation: "
+                f"{_format_counter(surfaces['populace_validation_counts'])}"
+            )
         policybench = surfaces.get("policybench")
         if policybench:
             print(
@@ -3936,6 +3961,29 @@ def cmd_oracle_coverage(args):
             )
         if len(pending_surface_items) > args.limit:
             print(f"  - ... {len(pending_surface_items) - args.limit} more")
+
+    unvalidated_populace_items = (report.get("program_surfaces") or {}).get(
+        "unvalidated_populace_items"
+    ) or []
+    if unvalidated_populace_items:
+        print()
+        print(
+            "Active wired PolicyEngine program surfaces without Populace "
+            f"validation (first {args.limit}):"
+        )
+        for item in unvalidated_populace_items[: args.limit]:
+            state = f" [{item['state']}]" if item.get("state") else ""
+            weight = item.get("policybench_household_weight")
+            weight_prefix = (
+                f"{weight:.2f}% " if isinstance(weight, (int, float)) else ""
+            )
+            print(
+                f"  - {weight_prefix}{item['variable']}{state}: "
+                f"{item.get('populace_validation_status') or 'not_configured'} "
+                f"({item['program_id']})"
+            )
+        if len(unvalidated_populace_items) > args.limit:
+            print(f"  - ... {len(unvalidated_populace_items) - args.limit} more")
 
     sys.exit(1 if should_fail else 0)
 

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -36,6 +36,13 @@ PROGRAM_SURFACE_STATUSES = {
     "wired",
 }
 PROGRAM_SURFACE_LIFECYCLES = {"active", "inactive", "sunset", "historical"}
+POPULACE_VALIDATION_STATUSES = {
+    "validated",
+    "pending_validator",
+    "not_applicable",
+    "not_configured",
+    "blocked",
+}
 POLICYENGINE_CLOUD_QUEUE_SCHEMA = "axiom-encode/policyengine-cloud-queue/v1"
 POLICYENGINE_CLOUD_RUN_ARTIFACT_SCHEMA = (
     "axiom-encode/policyengine-cloud-run-artifact/v1"
@@ -281,6 +288,11 @@ class PolicyEngineProgramSurfaceItem:
     legal_ids: tuple[str, ...] = ()
     policybench_output: str | None = None
     policybench_household_weight: float | None = None
+    populace_validation_status: str = "not_configured"
+    populace_validation_command: str | None = None
+    populace_validation_dataset: str | None = None
+    populace_validation_last_run: str | None = None
+    populace_validation_rationale: str | None = None
 
     def as_dict(self) -> dict[str, str | int | float | list[str] | None]:
         return {
@@ -303,6 +315,11 @@ class PolicyEngineProgramSurfaceItem:
             "legal_ids": list(self.legal_ids),
             "policybench_output": self.policybench_output,
             "policybench_household_weight": self.policybench_household_weight,
+            "populace_validation_status": self.populace_validation_status,
+            "populace_validation_command": self.populace_validation_command,
+            "populace_validation_dataset": self.populace_validation_dataset,
+            "populace_validation_last_run": self.populace_validation_last_run,
+            "populace_validation_rationale": self.populace_validation_rationale,
         }
 
 
@@ -567,6 +584,15 @@ def build_policyengine_program_surface_report(
     active_pending_surfaces = [
         surface for surface in pending_surfaces if surface.lifecycle == "active"
     ]
+    unvalidated_populace_surfaces = [
+        surface
+        for surface in surfaces
+        if _surface_requires_populace_validation(surface)
+        and surface.populace_validation_status != "validated"
+    ]
+    populace_validation_counts = Counter(
+        surface.populace_validation_status for surface in surfaces
+    )
     actionable_surfaces = sorted(
         active_pending_surfaces,
         key=lambda surface: (
@@ -596,9 +622,32 @@ def build_policyengine_program_surface_report(
         },
         "pending_surfaces": len(pending_surfaces),
         "active_pending_surfaces": len(active_pending_surfaces),
+        "unvalidated_populace_surfaces": len(unvalidated_populace_surfaces),
+        "populace_validation_counts": dict(sorted(populace_validation_counts.items())),
+        "unvalidated_populace_items": [
+            surface.as_dict()
+            for surface in sorted(
+                unvalidated_populace_surfaces,
+                key=lambda surface: (
+                    -(surface.policybench_household_weight or 0.0),
+                    _candidate_priority_rank(surface.priority or ""),
+                    surface.category,
+                    surface.coverage,
+                    surface.program_id,
+                    surface.variable,
+                ),
+            )
+        ],
         "actionable_surfaces": [surface.as_dict() for surface in actionable_surfaces],
         "items": [surface.as_dict() for surface in surfaces],
     }
+
+
+def _surface_requires_populace_validation(
+    surface: PolicyEngineProgramSurfaceItem,
+) -> bool:
+    """Return whether a PE-facing surface needs population-level parity evidence."""
+    return surface.lifecycle == "active" and surface.axiom_status == "wired"
 
 
 def _cloud_queue_item_from_program_surface(
@@ -1313,7 +1362,50 @@ def _load_policyengine_program_surface_manifest(
                 "surfaces P1/P2 and demote historical, inactive, or sunset "
                 "surfaces."
             )
+        _validate_populace_validation(raw_surface, path=path)
     return payload
+
+
+def _validate_populace_validation(raw_surface: dict[str, Any], *, path: Path) -> None:
+    raw_validation = raw_surface.get("populace_validation")
+    if raw_validation is None:
+        return
+    variable = raw_surface.get("variable")
+    if not isinstance(raw_validation, dict):
+        raise ValueError(
+            f"PolicyEngine surface {variable} populace_validation must be an object: "
+            f"{path}"
+        )
+    status = str(raw_validation.get("status") or "")
+    if status not in POPULACE_VALIDATION_STATUSES:
+        raise ValueError(
+            f"Unsupported PolicyEngine surface Populace validation status for "
+            f"{variable}: {status}"
+        )
+    if status == "validated":
+        missing = [
+            key
+            for key in ("command", "dataset", "last_run")
+            if not str(raw_validation.get(key) or "").strip()
+        ]
+        if missing:
+            raise ValueError(
+                f"Validated PolicyEngine surface {variable} missing "
+                f"populace_validation {', '.join(missing)}: {path}"
+            )
+        command = str(raw_validation.get("command") or "")
+        if "populace" not in command:
+            raise ValueError(
+                f"Validated PolicyEngine surface {variable} must cite a Populace "
+                f"comparison command: {path}"
+            )
+    if status in {"blocked", "not_applicable", "pending_validator"}:
+        rationale = str(raw_validation.get("rationale") or "").strip()
+        if len(rationale) < 20:
+            raise ValueError(
+                f"PolicyEngine surface {variable} Populace validation status "
+                f"{status} requires a rationale: {path}"
+            )
 
 
 def _program_surface_item_from_payload(
@@ -1345,6 +1437,7 @@ def _program_surface_item_from_payload(
         payload,
         legal_ids=legal_ids,
     )
+    populace_validation = _populace_validation_fields(payload)
     return PolicyEngineProgramSurfaceItem(
         country=country,
         program_id=str(payload["program_id"]),
@@ -1369,7 +1462,35 @@ def _program_surface_item_from_payload(
             if policybench_output
             else None
         ),
+        populace_validation_status=populace_validation["status"],
+        populace_validation_command=populace_validation.get("command"),
+        populace_validation_dataset=populace_validation.get("dataset"),
+        populace_validation_last_run=populace_validation.get("last_run"),
+        populace_validation_rationale=populace_validation.get("rationale"),
     )
+
+
+def _populace_validation_fields(payload: dict[str, Any]) -> dict[str, str | None]:
+    raw_validation = payload.get("populace_validation")
+    if not isinstance(raw_validation, dict):
+        return {"status": "not_configured"}
+    status = str(raw_validation.get("status") or "not_configured")
+    if status not in POPULACE_VALIDATION_STATUSES:
+        status = "not_configured"
+    return {
+        "status": status,
+        "command": _optional_text(raw_validation.get("command")),
+        "dataset": _optional_text(raw_validation.get("dataset")),
+        "last_run": _optional_text(raw_validation.get("last_run")),
+        "rationale": _optional_text(raw_validation.get("rationale")),
+    }
+
+
+def _optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
 
 
 def _policybench_output_for_program_surface(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1892,6 +1892,63 @@ class TestCmdValidate:
         assert "PolicyEngine program surfaces: 1" in output
         assert "wic: pending_rulespec_encoding" in output
 
+    def test_oracle_coverage_fail_on_unvalidated_populace_surfaces_exits_nonzero(
+        self, capsys, tmp_path
+    ):
+        args = MagicMock()
+        args.root = tmp_path
+        args.oracle = "policyengine"
+        args.program = None
+        args.limit = 25
+        args.fail_on_unmapped = False
+        args.fail_on_untested_comparable = False
+        args.include_program_surfaces = True
+        args.fail_on_pending_program_surfaces = False
+        args.fail_on_unvalidated_populace_surfaces = True
+        args.json = False
+
+        with patch(
+            "axiom_encode.cli.build_policyengine_coverage_report",
+            return_value={
+                "oracle": "policyengine",
+                "root": str(tmp_path),
+                "total_outputs": 0,
+                "status_counts": {},
+                "untested_comparable": 0,
+                "program_counts": {},
+                "repos": [],
+                "items": [],
+                "program_surfaces": {
+                    "total_surfaces": 1,
+                    "status_counts": {"wired": 1},
+                    "priority_counts": {"P1": 1},
+                    "pending_surfaces": 0,
+                    "active_pending_surfaces": 0,
+                    "unvalidated_populace_surfaces": 1,
+                    "populace_validation_counts": {"not_configured": 1},
+                    "unvalidated_populace_items": [
+                        {
+                            "variable": "is_medicaid_eligible",
+                            "axiom_status": "wired",
+                            "program_id": "medicaid",
+                            "state": None,
+                            "policybench_household_weight": 29.86,
+                            "populace_validation_status": "not_configured",
+                        }
+                    ],
+                    "items": [],
+                },
+            },
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_oracle_coverage(args)
+
+        assert exc_info.value.code == 1
+        output = capsys.readouterr().out
+        assert "unvalidated_populace=1" in output
+        assert "Populace validation: not_configured=1" in output
+        assert "29.86% is_medicaid_eligible: not_configured" in output
+
     def test_oracle_candidates_prints_priority_queue(self, capsys, tmp_path):
         args = MagicMock()
         args.root = tmp_path

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -696,11 +696,20 @@ surfaces:
     assert report["active_priority_counts"] == {"P1": 6}
     assert report["pending_surfaces"] == 1
     assert report["active_pending_surfaces"] == 1
+    assert report["unvalidated_populace_surfaces"] == 1
+    assert report["populace_validation_counts"] == {"not_configured": 6}
+    assert [item["variable"] for item in report["unvalidated_populace_items"]] == [
+        "income_tax"
+    ]
     assert [item["variable"] for item in report["actionable_surfaces"]] == ["wic"]
     items_by_variable = {item["variable"]: item for item in report["items"]}
     assert items_by_variable["income_tax"]["axiom_status"] == "wired"
     assert items_by_variable["income_tax"]["lifecycle"] == "active"
     assert items_by_variable["income_tax"]["mapping_count"] == 1
+    assert (
+        items_by_variable["income_tax"]["populace_validation_status"]
+        == "not_configured"
+    )
     assert items_by_variable["wic"]["axiom_status"] == "pending_rulespec_encoding"
     assert items_by_variable["aca_ptc"]["axiom_status"] == "known_not_comparable"
     assert items_by_variable["aca_ptc"]["mapping_count"] == 1
@@ -718,6 +727,96 @@ surfaces:
     assert items_by_variable["employee_payroll_tax"][
         "policybench_household_weight"
     ] == pytest.approx(15.65)
+
+
+def test_policyengine_program_surface_report_accepts_populace_validation_metadata(
+    tmp_path,
+):
+    manifest = tmp_path / "program_surfaces.yaml"
+    manifest.write_text(
+        """source:
+  repository: PolicyEngine/policyengine-us
+  ref: test
+  path: policyengine_us/programs.yaml
+surfaces:
+  - country: us
+    program_id: federal_income_tax
+    program_name: Federal income taxes
+    category: Taxes
+    policyengine_status: complete
+    coverage: US
+    variable: income_tax
+    axiom_status: pending_rulespec_encoding
+    priority: P1
+    rationale: Should be overridden by the legal-ID registry.
+    populace_validation:
+      status: validated
+      command: axiom-encode tax-populace-compare --variable income_tax --year 2024
+      dataset: populace-us-2024
+      last_run: '2026-06-30'
+""",
+        encoding="utf-8",
+    )
+    registry = _ProgramSurfaceRegistry(
+        {
+            "income_tax": [
+                PolicyEngineMapping(
+                    legal_id="us:statutes/26/6401#income_tax",
+                    country="us",
+                    mapping_type="direct_variable",
+                    policyengine_variable="income_tax",
+                )
+            ],
+        }
+    )
+
+    report = build_policyengine_program_surface_report(
+        manifest_path=manifest,
+        registry=registry,
+    )
+
+    assert report["status_counts"] == {"wired": 1}
+    assert report["unvalidated_populace_surfaces"] == 0
+    assert report["populace_validation_counts"] == {"validated": 1}
+    item = report["items"][0]
+    assert item["populace_validation_status"] == "validated"
+    assert item["populace_validation_dataset"] == "populace-us-2024"
+    assert "tax-populace-compare" in item["populace_validation_command"]
+
+
+def test_policyengine_program_surface_rejects_incomplete_validated_populace_metadata(
+    tmp_path,
+):
+    manifest = tmp_path / "program_surfaces.yaml"
+    manifest.write_text(
+        """source:
+  repository: PolicyEngine/policyengine-us
+  ref: test
+  path: policyengine_us/programs.yaml
+surfaces:
+  - country: us
+    program_id: federal_income_tax
+    program_name: Federal income taxes
+    category: Taxes
+    policyengine_status: complete
+    coverage: US
+    variable: income_tax
+    axiom_status: pending_rulespec_encoding
+    priority: P1
+    rationale: Claims validation without the required evidence fields.
+    populace_validation:
+      status: validated
+      command: axiom-encode oracle-coverage --program tax
+      dataset: populace-us-2024
+""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="missing populace_validation last_run"):
+        build_policyengine_program_surface_report(
+            manifest_path=manifest,
+            registry=_ProgramSurfaceRegistry({}),
+        )
 
 
 def test_policyengine_program_surface_report_sorts_actionable_by_policybench_weight(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1003"
+version = "0.2.1004"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Add `populace_validation` metadata to PolicyEngine program surfaces and validate the evidence shape.
- Add `axiom-encode oracle-coverage --fail-on-unvalidated-populace-surfaces` so active wired surfaces cannot be treated as PE-parity-complete without Populace comparison evidence.
- Document the gate and add regression coverage for accepted/rejected Populace validation metadata.

## Evidence
- Current Medicaid surface now fails the new gate as intended: `is_medicaid_eligible` is wired but `not_configured` for Populace validation.

## Tests
- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py tests/test_cli.py -k "policyengine_program_surface or oracle_coverage_fail_on_unvalidated or oracle_coverage_fail_on_pending"`
- `uv run --extra dev python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py tests/test_cli.py -k "policyengine_program_surface or oracle_coverage_fail_on_unvalidated or oracle_coverage_fail_on_pending or current_encoder_affecting_changes_are_behind_version_bump"`
- `uv run --extra dev ruff check src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/cli.py tests/test_policyengine_coverage.py tests/test_cli.py docs/policyengine-oracle-registry.md pyproject.toml src/axiom_encode/__init__.py`
- `uv run --extra dev ruff format --check src/axiom_encode/oracles/policyengine/coverage.py src/axiom_encode/cli.py tests/test_policyengine_coverage.py tests/test_cli.py`
- `env -u UV_FROZEN uv lock --check`
- `uv run --extra dev python -m towncrier build --draft --version 0.0.0`
- Expected failure evidence: `uv run --extra dev axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --include-program-surfaces --program medicaid --fail-on-unvalidated-populace-surfaces`
