### PR TITLE
Load local Populace artifacts before HF fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,13 @@ add `--fail-on-mismatch` in CI when exact parity is expected, or
 `--min-match-rate` when a documented upstream oracle gap makes a population
 threshold more appropriate.
 
+Populace oracle commands prefer a local engine-native H5 artifact before using
+the `populace-data` package loader. To force a local dataset, set the most
+specific available environment variable, for example
+`AXIOM_POPULACE_US_2024_H5=/path/to/populace_us_2024.h5`. The loader also
+checks `AXIOM_POPULACE_US_H5`, `AXIOM_POPULACE_H5`,
+`AXIOM_POPULACE_DATASET`, and `AXIOM_POPULACE_DATA_PATH`.
+
 Add `--external-oracle snapscreener` for a diagnostic comparison against the
 public SnapScreener browser calculator. The command fetches or uses a local
 `api.js`, records its SHA256 in stdout, and adds SnapScreener result columns to

--- a/changelog.d/local-populace-artifact.changed.md
+++ b/changelog.d/local-populace-artifact.changed.md
@@ -1,0 +1,1 @@
+Load Populace oracle datasets from local H5 artifacts before falling back to the `populace-data` Hugging Face client.

--- a/docs/policyengine-oracle-registry.md
+++ b/docs/policyengine-oracle-registry.md
@@ -196,6 +196,12 @@ date. Use `pending_validator`, `blocked`, or `not_applicable` only with a
 concrete rationale. CI jobs that want to forbid unvalidated wired program
 surfaces can use:
 
+Populace comparison commands load a local engine-native H5 artifact first when
+one is available, including cached `policyengine/populace-*` snapshots. Set
+`AXIOM_POPULACE_US_2024_H5`, `AXIOM_POPULACE_US_H5`, `AXIOM_POPULACE_H5`,
+`AXIOM_POPULACE_DATASET`, or `AXIOM_POPULACE_DATA_PATH` to pin validation to a
+specific local artifact.
+
 ```bash
 axiom-encode oracle-coverage \
   --root /path/to/workspace \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1004"
+version = "0.2.1005"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1004"
+__version__ = "0.2.1005"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/population.py
+++ b/src/axiom_encode/oracles/policyengine/population.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from importlib import import_module
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +12,15 @@ DEFAULT_UK_POPULACE_YEAR = 2023
 DEFAULT_LOCAL_POPULACE_DATA_PACKAGE = (
     Path.home() / "PolicyEngine" / "populace" / "packages" / "populace-data"
 )
+DEFAULT_HUGGINGFACE_CACHE_ROOT = Path.home() / ".cache" / "huggingface" / "hub"
+DEFAULT_POPULACE_YEARS = {
+    "us": DEFAULT_US_POPULACE_YEAR,
+    "uk": DEFAULT_UK_POPULACE_YEAR,
+}
+POLICYENGINE_DATASET_CLASSES = {
+    "us": ("policyengine_us.data", "USSingleYearDataset"),
+    "uk": ("policyengine_uk.data", "UKSingleYearDataset"),
+}
 
 
 def load_populace_dataset(
@@ -20,6 +30,24 @@ def load_populace_dataset(
     command: str,
 ) -> Any:
     """Load a published Populace artifact as a PolicyEngine dataset."""
+    country = country.lower()
+    try:
+        local_artifact = local_populace_artifact_path(country, year=year)
+    except FileNotFoundError as exc:
+        raise SystemExit(str(exc)) from exc
+    if local_artifact is not None:
+        try:
+            return load_policyengine_dataset_artifact(country, local_artifact)
+        except ImportError as exc:  # pragma: no cover - optional runtime dependency
+            raise SystemExit(
+                policyengine_dataset_install_message(country, command)
+            ) from exc
+        except Exception as exc:  # pragma: no cover - depends on external dataset shape
+            raise SystemExit(
+                f"Failed to load local Populace {country.upper()} artifact "
+                f"{local_artifact}: {exc}"
+            ) from exc
+
     try:
         from populace.data import load
     except ImportError as exc:  # pragma: no cover - optional runtime dependency
@@ -33,6 +61,19 @@ def load_populace_dataset(
         raise SystemExit(
             f"Failed to load Populace {country.upper()} {year_label} dataset: {exc}"
         ) from exc
+
+
+def load_policyengine_dataset_artifact(country: str, path: Path) -> Any:
+    """Load a local Populace H5 artifact using its PolicyEngine dataset class."""
+    country = country.lower()
+    dataset_spec = POLICYENGINE_DATASET_CLASSES.get(country)
+    if dataset_spec is None:
+        raise ValueError(
+            f"No PolicyEngine dataset loader is configured for {country!r}."
+        )
+    module_name, class_name = dataset_spec
+    dataset_class = getattr(import_module(module_name), class_name)
+    return dataset_class(file_path=str(path))
 
 
 def population_table(dataset: Any, name: str) -> Any:
@@ -55,9 +96,109 @@ def local_dataset_path(value: str | None) -> Path | None:
     return None
 
 
+def local_populace_artifact_path(
+    country: str,
+    *,
+    year: int | None = None,
+    cache_root: Path | None = None,
+) -> Path | None:
+    """Return the local Populace H5 artifact for ``country`` when available."""
+    country = country.lower()
+    resolved_year = year or DEFAULT_POPULACE_YEARS.get(country)
+    for env_var in local_populace_artifact_env_vars(country, resolved_year):
+        override = os.environ.get(env_var)
+        if not override:
+            continue
+        path = Path(override).expanduser()
+        if not path.exists():
+            raise FileNotFoundError(
+                f"{env_var} points to a missing Populace artifact: {path}"
+            )
+        return path
+    if resolved_year is None:
+        return None
+    return huggingface_cache_populace_artifact(
+        country,
+        populace_artifact_filename(country, resolved_year),
+        cache_root=cache_root,
+    )
+
+
+def local_populace_artifact_env_vars(country: str, year: int | None) -> tuple[str, ...]:
+    country_token = country.upper().replace("-", "_")
+    names: list[str] = []
+    if year is not None:
+        names.append(f"AXIOM_POPULACE_{country_token}_{year}_H5")
+    names.extend(
+        [
+            f"AXIOM_POPULACE_{country_token}_H5",
+            "AXIOM_POPULACE_H5",
+            "AXIOM_POPULACE_DATASET",
+            "AXIOM_POPULACE_DATA_PATH",
+        ]
+    )
+    return tuple(names)
+
+
+def populace_artifact_filename(country: str, year: int) -> str:
+    return f"populace_{country.lower()}_{int(year)}.h5"
+
+
+def huggingface_cache_populace_artifact(
+    country: str,
+    filename: str,
+    *,
+    cache_root: Path | None = None,
+) -> Path | None:
+    """Resolve a Populace artifact already present in the Hugging Face cache."""
+    root = cache_root or DEFAULT_HUGGINGFACE_CACHE_ROOT
+    repo_cache = root / f"datasets--policyengine--populace-{country.lower()}"
+    snapshots = repo_cache / "snapshots"
+    refs = repo_cache / "refs"
+    for ref in huggingface_cache_refs(refs):
+        try:
+            revision = ref.read_text().strip()
+        except OSError:
+            continue
+        if not revision:
+            continue
+        candidate = snapshots / revision / filename
+        if candidate.exists():
+            return candidate
+    if not snapshots.exists():
+        return None
+    candidates = [path for path in snapshots.glob(f"*/{filename}") if path.exists()]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda path: path.stat().st_mtime)
+
+
+def huggingface_cache_refs(refs: Path) -> tuple[Path, ...]:
+    if not refs.exists():
+        return ()
+    main = refs / "main"
+    others = sorted(
+        (path for path in refs.iterdir() if path.is_file() and path != main),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    if main.exists():
+        return (main, *others)
+    return tuple(others)
+
+
 def populace_install_message(country: str, command: str) -> str:
     return (
         "Populace validation requires populace-data and the matching "
+        "PolicyEngine country engine. Run with: "
+        f"uv run --with {populace_data_requirement(country)} "
+        f"axiom-encode {command}"
+    )
+
+
+def policyengine_dataset_install_message(country: str, command: str) -> str:
+    return (
+        "Populace validation found a local artifact but requires the matching "
         "PolicyEngine country engine. Run with: "
         f"uv run --with {populace_data_requirement(country)} "
         f"axiom-encode {command}"

--- a/tests/test_policyengine_population.py
+++ b/tests/test_policyengine_population.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from axiom_encode.oracles.policyengine import population
+
+
+def test_local_populace_artifact_prefers_specific_env(monkeypatch, tmp_path):
+    artifact = tmp_path / "populace_us_2024.h5"
+    artifact.write_text("")
+    monkeypatch.setenv("AXIOM_POPULACE_US_2024_H5", str(artifact))
+
+    assert population.local_populace_artifact_path("US", year=2024) == artifact
+
+
+def test_local_populace_artifact_rejects_missing_env_override(monkeypatch, tmp_path):
+    missing = tmp_path / "missing.h5"
+    monkeypatch.setenv("AXIOM_POPULACE_US_H5", str(missing))
+
+    with pytest.raises(FileNotFoundError, match="AXIOM_POPULACE_US_H5"):
+        population.local_populace_artifact_path("us", year=2024)
+
+
+def test_load_populace_dataset_exits_for_missing_env_override(monkeypatch, tmp_path):
+    missing = tmp_path / "missing.h5"
+    monkeypatch.setenv("AXIOM_POPULACE_US_H5", str(missing))
+
+    with pytest.raises(SystemExit, match="AXIOM_POPULACE_US_H5"):
+        population.load_populace_dataset(
+            "us",
+            year=2024,
+            command="tax-populace-compare",
+        )
+
+
+def test_local_populace_artifact_reads_huggingface_cache_ref(tmp_path):
+    cache_root = tmp_path / "hub"
+    repo = cache_root / "datasets--policyengine--populace-us"
+    snapshot = repo / "snapshots" / "abc123"
+    snapshot.mkdir(parents=True)
+    artifact = snapshot / "populace_us_2024.h5"
+    artifact.write_text("")
+    refs = repo / "refs"
+    refs.mkdir()
+    (refs / "main").write_text("abc123\n")
+
+    assert (
+        population.local_populace_artifact_path(
+            "us",
+            year=2024,
+            cache_root=cache_root,
+        )
+        == artifact
+    )
+
+
+def test_load_populace_dataset_uses_local_engine_dataset_without_populace_data(
+    monkeypatch, tmp_path
+):
+    artifact = tmp_path / "populace_us_2024.h5"
+    artifact.write_text("")
+    monkeypatch.setenv("AXIOM_POPULACE_US_2024_H5", str(artifact))
+    imports: list[str] = []
+
+    class FakeDataset:
+        def __init__(self, *, file_path: str):
+            self.file_path = file_path
+
+    def fake_import_module(name: str) -> SimpleNamespace:
+        imports.append(name)
+        return SimpleNamespace(USSingleYearDataset=FakeDataset)
+
+    monkeypatch.setattr(population, "import_module", fake_import_module)
+
+    dataset = population.load_populace_dataset(
+        "us",
+        year=2024,
+        command="tax-populace-compare",
+    )
+
+    assert dataset.file_path == str(artifact)
+    assert imports == ["policyengine_us.data"]

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1004"
+version = "0.2.1005"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- resolve local Populace H5 artifacts from env overrides or cached policyengine/populace-* snapshots before using `populace.data.load`
- load local artifacts through the country PolicyEngine dataset classes, so local Populace can be used without a Hugging Face call
- document local artifact env vars and add population-loader tests

## Tests
- `uv run --extra dev pytest tests/test_policyengine_population.py -q`
- `uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `env -u UV_FROZEN uv lock --check`
- `uv run --extra dev towncrier build --draft --version 0.0.0`
- `HF_HUB_OFFLINE=1 uv run --extra dev python - <<PY ... local_populace_artifact_path("us", year=2024) ... PY`
- `uv run --extra dev pytest tests/` (2415 passed, 25 skipped)