### PR TITLE
Keep pending PE surfaces pending despite mappings

### DIFF
--- a/changelog.d/program-surface-pending-status.fixed.md
+++ b/changelog.d/program-surface-pending-status.fixed.md
@@ -1,0 +1,1 @@
+Prevent PolicyEngine program-surface reports from upgrading explicitly pending manifest entries to wired solely because a legal-ID mapping exists.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1005"
+version = "0.2.1006"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1005"
+__version__ = "0.2.1006"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -35,6 +35,12 @@ PROGRAM_SURFACE_STATUSES = {
     "pending_source_ingestion",
     "wired",
 }
+PENDING_PROGRAM_SURFACE_STATUSES = {
+    "deferred_jurisdiction",
+    "pending_oracle_mapping",
+    "pending_rulespec_encoding",
+    "pending_source_ingestion",
+}
 PROGRAM_SURFACE_LIFECYCLES = {"active", "inactive", "sunset", "historical"}
 POPULACE_VALIDATION_STATUSES = {
     "validated",
@@ -572,14 +578,10 @@ def build_policyengine_program_surface_report(
         for surface in surfaces
         if surface.lifecycle == "active" and surface.priority
     )
-    unwired_statuses = {
-        "deferred_jurisdiction",
-        "pending_oracle_mapping",
-        "pending_rulespec_encoding",
-        "pending_source_ingestion",
-    }
     pending_surfaces = [
-        surface for surface in surfaces if surface.axiom_status in unwired_statuses
+        surface
+        for surface in surfaces
+        if surface.axiom_status in PENDING_PROGRAM_SURFACE_STATUSES
     ]
     active_pending_surfaces = [
         surface for surface in pending_surfaces if surface.lifecycle == "active"
@@ -1343,7 +1345,7 @@ def _load_policyengine_program_surface_manifest(
                 f"{', '.join(missing)}: {path}"
             )
         status = str(raw_surface.get("axiom_status"))
-        if status not in PROGRAM_SURFACE_STATUSES - {"wired"}:
+        if status not in PROGRAM_SURFACE_STATUSES:
             raise ValueError(
                 f"Unsupported PolicyEngine surface status for "
                 f"{raw_surface.get('variable')}: {status}"
@@ -1423,7 +1425,9 @@ def _program_surface_item_from_payload(
         if not mapping.comparable and mapping.candidate_priority != "P4"
     )
     manifest_status = str(payload["axiom_status"])
-    if comparable_mapping_count:
+    if manifest_status in PENDING_PROGRAM_SURFACE_STATUSES:
+        axiom_status = manifest_status
+    elif comparable_mapping_count:
         axiom_status = "wired"
     elif final_non_comparable_mapping_count and manifest_status in {
         "pending_oracle_mapping",

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -14,10 +14,10 @@ surfaces:
   coverage: US
   variable: income_tax
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: wired
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom encodes federal income tax liability surfaces and the PolicyEngine registry wires the final income-tax
+    comparison target; Populace validation is still required before claiming population-level parity.
 - country: us
   program_id: state_income_tax
   program_name: State income taxes
@@ -1605,7 +1605,7 @@ surfaces:
   variable: co_state_supplement
   source_type: state_implementation
   state: CO
-  axiom_status: pending_rulespec_encoding
+  axiom_status: wired
   priority: P1
   rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
     before claiming parity.
@@ -2009,7 +2009,7 @@ surfaces:
   coverage: US
   variable: american_opportunity_credit
   source_type: program
-  axiom_status: pending_oracle_mapping
+  axiom_status: wired
   priority: P1
   rationale: RuleSpec encodes current-law section 25A education credit surfaces and the PolicyEngine registry maps the American
     Opportunity Credit, refundable and nonrefundable AOTC components, Lifetime Learning Credit components, and education tax
@@ -2102,10 +2102,10 @@ surfaces:
   coverage: CO
   variable: co_oap
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: wired
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Colorado OAP grant payment rules are encoded and wired to PolicyEngine's CO OAP surface; Populace validation
+    is still required before claiming population-level parity.
 - country: us
   program_id: co_chp
   program_name: Colorado CHP
@@ -2183,7 +2183,7 @@ surfaces:
   state: CA
   variable: ca_capi
   source_type: program
-  axiom_status: pending_oracle_mapping
+  axiom_status: wired
   priority: P2
   rationale: California CDSS EAS Chapter 49 CAPI benefit determination is encoded in RuleSpec and wired through an
     exact final-benefit oracle mapping; coverage promotes this surface to wired when the mapping is present in the

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -586,9 +586,9 @@ surfaces:
     policyengine_status: complete
     coverage: US
     variable: income_tax
-    axiom_status: pending_rulespec_encoding
+    axiom_status: wired
     priority: P1
-    rationale: Should be overridden by the legal-ID registry.
+    rationale: Manifest explicitly claims the legal-ID registry wiring.
   - country: us
     program_id: wic
     program_name: WIC
@@ -606,7 +606,7 @@ surfaces:
     policyengine_status: complete
     coverage: US
     variable: aca_ptc
-    axiom_status: pending_rulespec_encoding
+    axiom_status: known_not_comparable
     priority: P1
     rationale: Encoded but not comparable to PE's aggregate legal boundary.
   - country: us
@@ -746,9 +746,9 @@ surfaces:
     policyengine_status: complete
     coverage: US
     variable: income_tax
-    axiom_status: pending_rulespec_encoding
+    axiom_status: wired
     priority: P1
-    rationale: Should be overridden by the legal-ID registry.
+    rationale: Manifest explicitly claims the legal-ID registry wiring.
     populace_validation:
       status: validated
       command: axiom-encode tax-populace-compare --variable income_tax --year 2024
@@ -928,7 +928,7 @@ def test_policyengine_program_surface_includes_policybench_person_eligibility_su
 
     assert medicaid["program_id"] == "medicaid"
     assert medicaid["source_type"] == "eligibility"
-    assert medicaid["axiom_status"] == "wired"
+    assert medicaid["axiom_status"] == "pending_rulespec_encoding"
     assert medicaid["mapping_count"] == 1
     assert medicaid["comparable_mapping_count"] == 1
     assert medicaid["policybench_output"] == "person_level_medicaid_eligibility"
@@ -968,9 +968,11 @@ def test_policyengine_program_surface_medicaid_filter_prioritizes_eligibility():
     assert report["total_surfaces"] == 2
     assert report["status_counts"] == {
         "out_of_scope": 1,
-        "wired": 1,
+        "pending_rulespec_encoding": 1,
     }
-    assert report["actionable_surfaces"] == []
+    assert [item["variable"] for item in report["actionable_surfaces"]] == [
+        "is_medicaid_eligible"
+    ]
 
 
 def test_policyengine_program_surface_marks_wic_and_chip_final_eligibility_known_not_comparable():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1005"
+version = "0.2.1006"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- keep explicit pending program-surface manifest statuses from being promoted to wired solely because a legal-ID mapping exists
- allow explicit `wired` manifest entries and mark known wired tax/benefit surfaces accordingly
- keep Medicaid eligibility actionable as pending instead of treating it as a wired surface missing Populace validation

## Tests
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `env -u UV_FROZEN uv lock --check`
- `uv run --extra dev towncrier build --draft --version 0.0.0`
- `uv run --extra dev pytest tests/test_policyengine_coverage.py -q`
- `uv run --extra dev pytest tests/`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --oracle policyengine --program medicaid --include-program-surfaces --fail-on-pending-program-surfaces --fail-on-unvalidated-populace-surfaces` (expected exit 1; reports `is_medicaid_eligible` as active pending and `unvalidated_populace=0`)
