### PR TITLE
Gate incomplete PolicyEngine direct mappings

### DIFF
--- a/changelog.d/policyengine-incomplete-comparable.added.md
+++ b/changelog.d/policyengine-incomplete-comparable.added.md
@@ -1,0 +1,1 @@
+Added a PolicyEngine oracle coverage gate for direct mappings whose RuleSpec formulas still depend on unresolved upstream placeholder references.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1006"
+version = "0.2.1007"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1006"
+__version__ = "0.2.1007"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -719,6 +719,14 @@ def main():
         help="Exit non-zero when a comparable output is absent from companion tests",
     )
     oracle_coverage_parser.add_argument(
+        "--fail-on-incomplete-comparable",
+        action="store_true",
+        help=(
+            "Exit non-zero when a direct oracle mapping still depends on "
+            "unresolved upstream placeholder references"
+        ),
+    )
+    oracle_coverage_parser.add_argument(
         "--include-program-surfaces",
         action="store_true",
         help="Include PolicyEngine program-variable surface wiring coverage",
@@ -3828,6 +3836,9 @@ def cmd_oracle_coverage(args):
     fail_on_unvalidated_populace_surfaces = (
         getattr(args, "fail_on_unvalidated_populace_surfaces", False) is True
     )
+    fail_on_incomplete_comparable = (
+        getattr(args, "fail_on_incomplete_comparable", False) is True
+    )
     report = build_policyengine_coverage_report(
         root,
         program=args.program,
@@ -3836,6 +3847,7 @@ def cmd_oracle_coverage(args):
 
     unmapped = int(report["status_counts"].get("unmapped", 0))
     untested_comparable = int(report.get("untested_comparable", 0))
+    incomplete_comparable = int(report["status_counts"].get("incomplete_comparable", 0))
     pending_program_surfaces = int(
         (report.get("program_surfaces") or {}).get("active_pending_surfaces", 0)
     )
@@ -3845,6 +3857,7 @@ def cmd_oracle_coverage(args):
     should_fail = (
         (args.fail_on_unmapped and unmapped)
         or (args.fail_on_untested_comparable and untested_comparable)
+        or (fail_on_incomplete_comparable and incomplete_comparable)
         or (
             fail_on_pending_program_surfaces
             and include_program_surfaces
@@ -3867,6 +3880,7 @@ def cmd_oracle_coverage(args):
     print(f"Executable outputs: {report['total_outputs']}")
     print(f"Status: {_format_counter(report['status_counts'])}")
     print(f"Untested comparable outputs: {untested_comparable}")
+    print(f"Incomplete comparable outputs: {incomplete_comparable}")
     print(f"Programs: {_format_counter(report['program_counts'])}")
     if report.get("program_surfaces"):
         surfaces = report["program_surfaces"]
@@ -3931,6 +3945,21 @@ def cmd_oracle_coverage(args):
             print(f"  - {item['legal_id']}")
         if len(untested_items) > args.limit:
             print(f"  - ... {len(untested_items) - args.limit} more")
+
+    incomplete_items = [
+        item
+        for item in report["items"]
+        if item.get("status") == "incomplete_comparable"
+    ]
+    if incomplete_items:
+        print()
+        print(f"Incomplete comparable outputs (first {args.limit}):")
+        for item in incomplete_items[: args.limit]:
+            print(f"  - {item['legal_id']}")
+            for issue in (item.get("upstream_completeness_issues") or [])[:3]:
+                print(f"    - {issue}")
+        if len(incomplete_items) > args.limit:
+            print(f"  - ... {len(incomplete_items) - args.limit} more")
 
     program_surfaces = report.get("program_surfaces") or {}
     pending_surface_items = [

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -23,7 +23,12 @@ from axiom_encode.repo_routing import (
 from .registry import PolicyEngineMapping, load_policyengine_registry
 
 EXECUTABLE_RULE_KINDS = {"parameter", "derived", "derived_relation"}
-ORACLE_COVERAGE_STATUSES = {"comparable", "known_not_comparable", "unmapped"}
+ORACLE_COVERAGE_STATUSES = {
+    "comparable",
+    "incomplete_comparable",
+    "known_not_comparable",
+    "unmapped",
+}
 PROGRAM_SURFACE_STATUSES = {
     "deferred_jurisdiction",
     "input_only",
@@ -130,6 +135,51 @@ _US_STATE_VARIABLE_PREFIX_RE = re.compile(
 _INTERVAL_BOUND_HELPER_RE = re.compile(
     r"(^|_)(tier|band|bracket|interval|row)_(lower|upper)_bound$"
 )
+_FORMULA_IDENTIFIER_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")
+_QUOTED_STRING_RE = re.compile(r"('([^'\\]|\\.)*'|\"([^\"\\]|\\.)*\")")
+_RULESPEC_BUILTIN_IDENTIFIERS = {
+    "False",
+    "None",
+    "True",
+    "abs",
+    "all",
+    "and",
+    "any",
+    "ceil",
+    "count",
+    "count_where",
+    "else",
+    "false",
+    "floor",
+    "if",
+    "in",
+    "len",
+    "max",
+    "min",
+    "not",
+    "or",
+    "round",
+    "sum",
+    "sum_where",
+    "true",
+    "where",
+}
+_UPSTREAM_PLACEHOLDER_PATTERNS = tuple(
+    re.compile(pattern)
+    for pattern in (
+        r"(^|_)as_defined_in_",
+        r"(^|_)defined_(in|under)_",
+        r"(^|_)described_in_.*(section|subsection|paragraph|subparagraph|clause|subclause|part|subpart|title|chapter|act)",
+        r"(^|_)determined_(for|under|by)_",
+        r"(^|_)conditions_under_",
+        r"(^|_)state_elected_.*category",
+        r"(^|_)previous_mandatory_subclause",
+        r"(^|_)mandatory_subclauses",
+        r"(^|_)applicable_level",
+        r"^person_is_in_.*category",
+        r"^person_is_qualified_.*(beneficiary|group)",
+    )
+)
 POLICYBENCH_SOURCE_URL = "https://policybench.org/"
 POLICYBENCH_SNAPSHOT = "2026-06-14"
 POLICYBENCH_HOUSEHOLD_OUTPUT_WEIGHTS = {
@@ -208,6 +258,8 @@ class PolicyEngineCoverageItem:
     candidate_priority: str | None = None
     tested: bool = False
     test_output_count: int = 0
+    upstream_completeness_status: str | None = None
+    upstream_completeness_issues: tuple[str, ...] = ()
 
     def as_dict(self) -> dict[str, str | int | bool | None]:
         return {
@@ -226,6 +278,8 @@ class PolicyEngineCoverageItem:
             "candidate_priority": self.candidate_priority,
             "tested": self.tested,
             "test_output_count": self.test_output_count,
+            "upstream_completeness_status": self.upstream_completeness_status,
+            "upstream_completeness_issues": list(self.upstream_completeness_issues),
         }
 
 
@@ -827,6 +881,7 @@ def _iter_policyengine_coverage_items(
             rules = payload.get("rules")
             if not isinstance(rules, list):
                 continue
+            defined_identifiers = _rulespec_defined_identifiers(payload)
             test_output_counts = _rulespec_test_output_counts(rulespec_file)
             for rule in rules:
                 if not isinstance(rule, dict):
@@ -862,6 +917,7 @@ def _iter_policyengine_coverage_items(
                         rule=rule,
                         kind=kind,
                         mapping=mapping,
+                        defined_identifiers=defined_identifiers,
                         test_output_count=test_output_count,
                     )
                 )
@@ -1053,6 +1109,19 @@ def _candidate_from_coverage_item(
             recommendation=(
                 "Add this comparable output to the companion .test.yaml so CI "
                 "continues to exercise the oracle mapping."
+            ),
+        )
+
+    if status == "incomplete_comparable":
+        return _candidate_item(
+            item,
+            category="incomplete_comparable",
+            priority=_candidate_priority(item, "P1"),
+            recommendation=(
+                "Do not treat this direct PolicyEngine mapping as parity-ready "
+                "yet. Encode or import the unresolved primary-source "
+                "dependencies listed in upstream_completeness_issues, then "
+                "rerun coverage and Populace validation."
             ),
         )
 
@@ -1840,9 +1909,12 @@ def _coverage_item_from_mapping(
     rule: dict[str, Any],
     kind: str,
     mapping: PolicyEngineMapping | None,
+    defined_identifiers: set[str],
     test_output_count: int,
 ) -> PolicyEngineCoverageItem:
     file_path = _display_file_path(rulespec_file, root)
+    upstream_issues: tuple[str, ...] = ()
+    upstream_status: str | None = None
     if mapping is None:
         program = _infer_program_from_legal_id(legal_id, rule_name=rule_name)
         if _is_interval_bound_helper_rule(rule_name, rule):
@@ -1873,6 +1945,14 @@ def _coverage_item_from_mapping(
             legal_id, rule_name=rule_name
         )
         mapping_type = mapping.mapping_type
+        upstream_issues = _direct_mapping_upstream_completeness_issues(
+            rule=rule,
+            mapping=mapping,
+            defined_identifiers=defined_identifiers,
+        )
+        if upstream_issues:
+            status = "incomplete_comparable"
+            upstream_status = "needs_upstream_encoding"
     else:
         status = "known_not_comparable"
         program = mapping.program or _infer_program_from_legal_id(
@@ -1896,7 +1976,84 @@ def _coverage_item_from_mapping(
         candidate_priority=mapping.candidate_priority if mapping else None,
         tested=test_output_count > 0,
         test_output_count=test_output_count,
+        upstream_completeness_status=upstream_status,
+        upstream_completeness_issues=upstream_issues,
     )
+
+
+def _rulespec_defined_identifiers(payload: dict[str, Any]) -> set[str]:
+    """Return rule/import names available to formulas in one RuleSpec file."""
+    identifiers: set[str] = set()
+    raw_imports = payload.get("imports") or []
+    if isinstance(raw_imports, list):
+        for raw_import in raw_imports:
+            if not isinstance(raw_import, str):
+                continue
+            _, _, output_name = raw_import.partition("#")
+            if output_name:
+                identifiers.add(output_name.strip())
+
+    raw_rules = payload.get("rules") or []
+    if isinstance(raw_rules, list):
+        for rule in raw_rules:
+            if not isinstance(rule, dict):
+                continue
+            name = str(rule.get("name") or "").strip()
+            if name:
+                identifiers.add(name)
+    return identifiers
+
+
+def _direct_mapping_upstream_completeness_issues(
+    *,
+    rule: dict[str, Any],
+    mapping: PolicyEngineMapping,
+    defined_identifiers: set[str],
+) -> tuple[str, ...]:
+    """Flag direct PE mappings that still depend on broad upstream placeholders."""
+    if mapping.mapping_type != "direct_variable":
+        return ()
+
+    unresolved = sorted(
+        identifier
+        for identifier in _rule_formula_identifiers(rule)
+        if identifier not in defined_identifiers
+        and identifier not in _RULESPEC_BUILTIN_IDENTIFIERS
+    )
+    suspicious = [
+        identifier
+        for identifier in unresolved
+        if _is_upstream_placeholder_identifier(identifier)
+    ]
+    if not suspicious:
+        return ()
+    return tuple(
+        "Direct PolicyEngine mapping depends on unresolved upstream placeholder "
+        f"`{identifier}`; encode/import the primary source for that dependency "
+        "before treating this output as comparable."
+        for identifier in suspicious
+    )
+
+
+def _rule_formula_identifiers(rule: dict[str, Any]) -> set[str]:
+    identifiers: set[str] = set()
+    versions = rule.get("versions") or []
+    if not isinstance(versions, list):
+        return identifiers
+    for version in versions:
+        if not isinstance(version, dict):
+            continue
+        formula = version.get("formula")
+        if formula is None:
+            continue
+        text = _QUOTED_STRING_RE.sub(" ", str(formula))
+        identifiers.update(_FORMULA_IDENTIFIER_RE.findall(text))
+    return identifiers
+
+
+def _is_upstream_placeholder_identifier(identifier: str) -> bool:
+    lowered = identifier.lower()
+    return any(pattern.search(lowered) for pattern in _UPSTREAM_PLACEHOLDER_PATTERNS)
 
 
 def _is_interval_bound_helper_rule(rule_name: str, rule: dict[str, Any]) -> bool:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1949,6 +1949,51 @@ class TestCmdValidate:
         assert "Populace validation: not_configured=1" in output
         assert "29.86% is_medicaid_eligible: not_configured" in output
 
+    def test_oracle_coverage_fail_on_incomplete_comparable_exits_nonzero(
+        self, capsys, tmp_path
+    ):
+        args = MagicMock()
+        args.root = tmp_path
+        args.oracle = "policyengine"
+        args.program = None
+        args.limit = 25
+        args.fail_on_unmapped = False
+        args.fail_on_untested_comparable = False
+        args.fail_on_incomplete_comparable = True
+        args.include_program_surfaces = False
+        args.fail_on_pending_program_surfaces = False
+        args.fail_on_unvalidated_populace_surfaces = False
+        args.json = False
+
+        with patch(
+            "axiom_encode.cli.build_policyengine_coverage_report",
+            return_value={
+                "oracle": "policyengine",
+                "root": str(tmp_path),
+                "total_outputs": 1,
+                "status_counts": {"incomplete_comparable": 1},
+                "untested_comparable": 0,
+                "program_counts": {"medicaid": 1},
+                "repos": [],
+                "items": [
+                    {
+                        "legal_id": "us:statutes/42/1396a/a/10#is_medicaid_eligible",
+                        "status": "incomplete_comparable",
+                        "upstream_completeness_issues": [
+                            "Direct PolicyEngine mapping depends on unresolved upstream placeholder `person_is_in_other_mandatory_category_described_in_subparagraph_A_i`; encode/import the primary source for that dependency before treating this output as comparable."
+                        ],
+                    }
+                ],
+            },
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                cmd_oracle_coverage(args)
+
+        assert exc_info.value.code == 1
+        output = capsys.readouterr().out
+        assert "Incomplete comparable outputs: 1" in output
+        assert "us:statutes/42/1396a/a/10#is_medicaid_eligible" in output
+
     def test_oracle_candidates_prints_priority_queue(self, capsys, tmp_path):
         args = MagicMock()
         args.root = tmp_path

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -111,6 +111,44 @@ rules:
     )
 
 
+def test_direct_policyengine_mapping_with_upstream_placeholders_is_incomplete(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "us" / "statutes" / "42" / "1396a" / "a" / "10.yaml",
+        """format: rulespec/v1
+rules:
+  - name: is_medicaid_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          person_is_in_other_mandatory_category_described_in_subparagraph_A_i
+          or person_is_in_state_elected_optional_category_described_in_subparagraph_A_ii
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="medicaid")
+
+    assert report["status_counts"] == {"incomplete_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == ("us:statutes/42/1396a/a/10#is_medicaid_eligible")
+    assert item["status"] == "incomplete_comparable"
+    assert item["policyengine_variable"] == "is_medicaid_eligible"
+    assert item["upstream_completeness_status"] == "needs_upstream_encoding"
+    assert any(
+        "person_is_in_other_mandatory_category_described_in_subparagraph_A_i" in issue
+        for issue in item["upstream_completeness_issues"]
+    )
+
+    candidates = build_policyengine_candidate_report(tmp_path, program="medicaid")
+    assert candidates["items"][0]["category"] == "incomplete_comparable"
+    assert candidates["items"][0]["priority"] == "P1"
+
+
 def test_policyengine_coverage_classifies_aca_ptc_rev_proc_scalar_helpers(tmp_path):
     _write_rulespec_file(
         tmp_path / "rulespec-us/us/policies/irs/rev-proc-2025-25/aca-ptc.yaml",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1006"
+version = "0.2.1007"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add an `incomplete_comparable` PolicyEngine oracle coverage status for direct variable mappings whose RuleSpec formulas still depend on unresolved upstream/source-reference placeholders
- expose `upstream_completeness_status` and `upstream_completeness_issues` in coverage JSON and text output
- add `--fail-on-incomplete-comparable` so parity gates can fail before a direct mapping is treated as ready
- bump axiom-encode to 0.2.1007

## Why
Medicaid showed a direct mapping for `is_medicaid_eligible`, but the RuleSpec formula still depended on broad placeholders such as `income_determined_for_adult_expansion` and category references described only by upstream statute/regulation. That should not be allowed to count as PE parity.

## Validation
- `env -u UV_FROZEN uv lock --check`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev pytest tests/test_policyengine_coverage.py tests/test_policyengine_coverage_monorepo.py tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::TestCmdValidate::test_oracle_coverage_fail_on_incomplete_comparable_exits_nonzero -q` -> 382 passed
- `uv run --extra dev python -m towncrier build --draft --version 0.0.0`
- Expected failure proving the guard on current Medicaid surface:
  `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --oracle policyengine --program medicaid --include-program-surfaces --fail-on-incomplete-comparable --fail-on-pending-program-surfaces --fail-on-unvalidated-populace-surfaces --limit 10`
  - exits 1
  - reports `incomplete_comparable=1`
  - reports `us:statutes/42/1396a/a/10#is_medicaid_eligible`
