### PR TITLE
Add Medicaid Populace parity comparator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1007"
+version = "0.2.1008"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1008"
+version = "0.2.1009"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1008"
+__version__ = "0.2.1009"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1007"
+__version__ = "0.2.1008"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -36730,14 +36730,12 @@ def _try_repair_generated_imported_output_test_mismatches_for_apply(
 
     rules_file = Path(str(getattr(result, "output_file", "") or ""))
     test_file = _rulespec_test_path(rules_file)
-    repaired_positive_imports = (
-        _repair_positive_imported_judgment_composition_tests(
-            rules_file=rules_file,
-            test_file=test_file,
-            policy_repo_path=policy_repo_path,
-            relative_output=relative_output,
-            issues=issues,
-        )
+    repaired_positive_imports = _repair_positive_imported_judgment_composition_tests(
+        rules_file=rules_file,
+        test_file=test_file,
+        policy_repo_path=policy_repo_path,
+        relative_output=relative_output,
+        issues=issues,
     )
     if repaired_positive_imports:
         return repaired_positive_imports
@@ -36959,13 +36957,9 @@ def _harmonize_imported_judgment_branch_inputs(
             del inputs[direct_key]
             repairs.append(f"test:{case_name}:remove:{direct_key}")
 
-    for fragment, (producer_ref, desired_value) in sorted(
-        desired_by_fragment.items()
-    ):
+    for fragment, (producer_ref, desired_value) in sorted(desired_by_fragment.items()):
         matching_keys = [
-            key
-            for key in list(inputs)
-            if _rulespec_test_key_fragment(key) == fragment
+            key for key in list(inputs) if _rulespec_test_key_fragment(key) == fragment
         ]
         exact_key = _matching_mapping_key_by_rulespec_ref(inputs, producer_ref)
         if exact_key is None:
@@ -37038,9 +37032,7 @@ def _imported_judgment_positive_branches_for_rule(
                 branch_names.append(part)
             if not branch_names:
                 continue
-            branches.append(
-                tuple(imported_refs_by_name[name] for name in branch_names)
-            )
+            branches.append(tuple(imported_refs_by_name[name] for name in branch_names))
     return branches
 
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -151,6 +151,12 @@ from .oracles.policyengine.efrs_uk import (
 from .oracles.policyengine.efrs_uk import (
     main_hbai_coverage as run_uk_populace_hbai_coverage,
 )
+from .oracles.policyengine.medicaid_populace import (
+    configure_parser as configure_medicaid_populace_compare_parser,
+)
+from .oracles.policyengine.medicaid_populace import (
+    main as run_medicaid_populace_compare,
+)
 from .oracles.policyengine.registry import load_policyengine_registry
 from .oracles.policyengine.snap_readiness import build_snap_readiness_report
 from .repo_routing import (
@@ -877,6 +883,12 @@ def main():
         help="Compare federal tax RuleSpec output against PolicyEngine over Populace",
     )
     configure_tax_populace_compare_parser(tax_populace_compare_parser)
+
+    medicaid_populace_compare_parser = subparsers.add_parser(
+        "medicaid-populace-compare",
+        help="Compare Medicaid RuleSpec eligibility against PolicyEngine over Populace",
+    )
+    configure_medicaid_populace_compare_parser(medicaid_populace_compare_parser)
 
     uk_populace_compare_parser = subparsers.add_parser(
         "uk-populace-compare",
@@ -2396,6 +2408,8 @@ def main():
         sys.exit(run_snap_populace_compare(args))
     elif args.command in {"tax-populace-compare", "tax-ecps-compare"}:
         sys.exit(run_tax_populace_compare(args))
+    elif args.command == "medicaid-populace-compare":
+        sys.exit(run_medicaid_populace_compare(args))
     elif args.command in {"uk-populace-compare", "uk-efrs-compare"}:
         sys.exit(run_uk_populace_compare(args))
     elif args.command in {"uk-populace-coverage", "uk-efrs-coverage"}:

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -10000,6 +10000,7 @@ def cmd_repair_proof_import_hashes(args):
                 validation=validation,
             )
             repaired_output_cases = _repair_imported_output_test_mismatches(
+                rules_file=rules_file,
                 test_file=test_file,
                 policy_repo_path=repo_path,
                 relative_output=relative_output,
@@ -10863,6 +10864,7 @@ def cmd_repair_imported_test_inputs(args):
             validation=validation,
         )
         repaired_output_cases = _repair_imported_output_test_mismatches(
+            rules_file=rules_file,
             test_file=test_file,
             policy_repo_path=repo_path,
             relative_output=relative_output,
@@ -11438,6 +11440,32 @@ def _ensure_rulespec_import(content: str, import_item: str) -> str:
     insert_at = 1 if lines and re.match(r"^format:\s*", lines[0]) else 0
     lines.insert(insert_at, f"imports:\n  - {import_item}\n")
     return "".join(lines)
+
+
+def _remove_rulespec_import(content: str, import_item: str) -> str:
+    repaired_lines: list[str] = []
+    in_imports = False
+    imports_indent = 0
+    for line in content.splitlines(keepends=True):
+        imports_match = re.match(r"^(\s*)imports:\s*$", line)
+        if imports_match:
+            in_imports = True
+            imports_indent = len(imports_match.group(1))
+            repaired_lines.append(line)
+            continue
+        if in_imports:
+            stripped = line.strip()
+            if stripped:
+                indent = len(line) - len(line.lstrip())
+                item_match = re.match(r"^\s*-\s+(.+?)\s*$", line)
+                if item_match and indent >= imports_indent:
+                    item = _strip_yaml_scalar_quotes(item_match.group(1).strip())
+                    if item == import_item:
+                        continue
+                elif indent <= imports_indent:
+                    in_imports = False
+        repaired_lines.append(line)
+    return "".join(repaired_lines)
 
 
 def _replace_section_172_c_placeholder_test_inputs(content: str) -> str:
@@ -30225,6 +30253,14 @@ def _try_repair_generated_unsafe_formula_outputs_for_apply(
         for rule in rules
         if isinstance(rule, dict) and str(rule.get("name") or "")
     }
+    for rule_name in list(seed_rules):
+        reasons = set(issue_reasons.get(rule_name, []))
+        rule = rules_by_name.get(rule_name)
+        if reasons != {"flattened_thresholded_rate"} or not isinstance(rule, dict):
+            continue
+        if _generated_rule_is_imported_judgment_composition(rule, payload=payload):
+            seed_rules.discard(rule_name)
+            issue_reasons.pop(rule_name, None)
     unresolved_import_symbols = _unexported_import_symbols_for_missing_inputs(
         rules_file=rules_file,
         policy_repo_path=policy_repo_path,
@@ -30620,6 +30656,50 @@ def _generated_rule_formula_identifiers(rule: dict[str, Any]) -> set[str]:
         if isinstance(formula, str):
             identifiers.update(_formula_identifiers(formula))
     return identifiers - _RULESPEC_FORMULA_BUILTINS
+
+
+def _generated_rule_is_imported_judgment_composition(
+    rule: dict[str, Any],
+    *,
+    payload: dict[str, Any],
+) -> bool:
+    if str(rule.get("dtype") or "").strip().lower() != "judgment":
+        return False
+    imported_symbols = _rulespec_import_fragments_from_payload(payload)
+    if not imported_symbols:
+        return False
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return False
+    saw_formula = False
+    for version in versions:
+        if not isinstance(version, dict):
+            continue
+        formula = version.get("formula")
+        if not isinstance(formula, str) or not formula.strip():
+            continue
+        saw_formula = True
+        formula_without_literals = _formula_without_string_literals(formula)
+        if re.search(r"[<>=*/+\-:,\[\]{}]", formula_without_literals):
+            return False
+        identifiers = _formula_identifiers(formula)
+        if not identifiers or identifiers - imported_symbols:
+            return False
+    return saw_formula
+
+
+def _rulespec_import_fragments_from_payload(payload: dict[str, Any]) -> set[str]:
+    imports = payload.get("imports")
+    if not isinstance(imports, list):
+        return set()
+    fragments: set[str] = set()
+    for raw_import in imports:
+        if not isinstance(raw_import, str) or "#" not in raw_import:
+            continue
+        fragment = raw_import.rsplit("#", 1)[1].strip()
+        if fragment:
+            fragments.add(fragment)
+    return fragments
 
 
 def _deferred_output_target_for_generated_rule(
@@ -34092,7 +34172,8 @@ def _try_repair_generated_computed_output_test_inputs_for_apply(
 
 _MISSING_SAME_SECTION_SUBSECTION_IMPORT_RE = re.compile(
     r"Same-section subsection import "
-    r"(?:missing: source text cites (?:subsection\s+)?|not operational: source text cites )"
+    r"(?P<issue_kind>missing|not operational): source text cites "
+    r"(?:subsection\s+)?"
     r"`(?P<target>(?:statutes|regulations)/[^`]+)`"
 )
 
@@ -34133,6 +34214,7 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
         match = _MISSING_SAME_SECTION_SUBSECTION_IMPORT_RE.search(str(issue))
         if match is None:
             continue
+        issue_kind = match.group("issue_kind")
         target = match.group("target").strip().strip("/")
         if target.endswith((".yaml", ".yml")):
             target = Path(target).with_suffix("").as_posix()
@@ -34156,10 +34238,12 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
         placeholder_repairs: list[str] = []
         referenced_outputs: list[str] = []
         subject_to_outputs: list[str] = []
+        subject_to_proof_rule_name: str | None = None
         subject_to_proof_path: str | None = None
         if imported_output is not None:
             import_item = f"{imported_target}#{imported_output}"
             repaired = _ensure_rulespec_import(repaired, import_item)
+            repaired = _remove_rulespec_import(repaired, imported_target)
             repaired, placeholder_repairs = (
                 _repair_same_section_subsection_placeholder_references(
                     repaired,
@@ -34214,6 +34298,7 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
                         repaired,
                         f"{imported_target}#{referenced_output}",
                     )
+                    repaired = _remove_rulespec_import(repaired, imported_target)
                     repaired = _ensure_import_proof_atoms_for_formula_symbol(
                         repaired,
                         symbol=referenced_output,
@@ -34228,6 +34313,7 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
                         candidate,
                         subject_to_outputs,
                         subject_to_repairs,
+                        subject_to_proof_rule_name,
                         subject_to_proof_path,
                     ) = _repair_same_section_subsection_subject_to_output_gate(
                         repaired,
@@ -34243,10 +34329,17 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
                                 repaired,
                                 f"{imported_target}#{subject_to_output}",
                             )
-                            if subject_to_proof_path is not None:
+                            repaired = _remove_rulespec_import(
+                                repaired,
+                                imported_target,
+                            )
+                            if (
+                                subject_to_proof_rule_name is not None
+                                and subject_to_proof_path is not None
+                            ):
                                 repaired = _ensure_rule_import_proof_atom(
                                     repaired,
-                                    rule_name="is_medicaid_eligible",
+                                    rule_name=subject_to_proof_rule_name,
                                     target=f"{imported_target}#{subject_to_output}",
                                     output=subject_to_output,
                                     source_hash=source_hash,
@@ -34269,10 +34362,16 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
                                     test_file=test_file,
                                     policy_repo_path=policy_repo_path,
                                     generated_target_base=generated_target_base,
-                                    rule_name="is_medicaid_eligible",
+                                    rule_name=subject_to_proof_rule_name
+                                    or "is_medicaid_eligible",
                                     imported_ref=(
                                         f"{imported_target}#{subject_to_output}"
                                     ),
+                                    stale_input_names=[
+                                        repair.split("->", 1)[0]
+                                        for repair in subject_to_repairs
+                                        if "->" in repair
+                                    ],
                                 )
                             )
                     else:
@@ -34293,12 +34392,20 @@ def _try_repair_generated_missing_same_section_subsection_imports_for_apply(
                                     repaired,
                                     f"{imported_target}#{imported_output_name}",
                                 )
+                                repaired = _remove_rulespec_import(
+                                    repaired,
+                                    imported_target,
+                                )
                         else:
-                            import_item = imported_target
-                            repaired = _ensure_rulespec_import(repaired, import_item)
+                            if issue_kind != "not operational":
+                                import_item = imported_target
+                                repaired = _ensure_rulespec_import(
+                                    repaired, import_item
+                                )
                 else:
-                    import_item = imported_target
-                    repaired = _ensure_rulespec_import(repaired, import_item)
+                    if issue_kind != "not operational":
+                        import_item = imported_target
+                        repaired = _ensure_rulespec_import(repaired, import_item)
         if repaired != before:
             if imported_output is not None:
                 added.append(f"{imported_target}#{imported_output}")
@@ -35015,6 +35122,11 @@ def _rulespec_judgment_rule_output_names(rules_file: Path) -> list[str]:
 _MEDICAID_1396A_XX_COMMUNITY_ENGAGEMENT_OUTPUT = (
     "demonstrated_community_engagement_for_month"
 )
+_MEDICAID_1396A_XX_SUBJECT_TO_PLACEHOLDERS = (
+    "adult_expansion_subject_to_xx",
+    "adult_expansion_subject_to_subsection_xx_satisfied",
+    "adult_expansion_subject_to_subsections_k_and_xx_satisfied",
+)
 _MEDICAID_ADULT_EXPANSION_INCOME_LIMIT_LINE = (
     "and income_determined_for_adult_expansion <= "
     "adult_expansion_income_limit_poverty_line_rate * poverty_line_for_family_size"
@@ -35026,20 +35138,16 @@ def _repair_same_section_subsection_subject_to_output_gate(
     *,
     target: str,
     target_outputs: list[str],
-) -> tuple[str, list[str], list[str], str | None]:
+) -> tuple[str, list[str], list[str], str | None, str | None]:
     if target != "statutes/42/1396a/xx":
-        return content, [], [], None
+        return content, [], [], None, None
     output = _MEDICAID_1396A_XX_COMMUNITY_ENGAGEMENT_OUTPUT
     if output not in target_outputs:
-        return content, [], [], None
+        return content, [], [], None, None
 
-    rule_match = re.search(
-        r"(?ms)^  - name: is_medicaid_eligible\n.*?(?=^  - name: |\Z)",
-        content,
+    rule_pattern = re.compile(
+        r"(?ms)^  - name: (?P<rule_name>[A-Za-z_][A-Za-z0-9_]*)\n.*?(?=^  - name: |\Z)"
     )
-    if rule_match is None:
-        return content, [], [], None
-    rule_block = rule_match.group(0)
     version_pattern = re.compile(
         r"(?ms)"
         r"(?P<version>"
@@ -35048,46 +35156,116 @@ def _repair_same_section_subsection_subject_to_output_gate(
         r"(?P<formula>(?:^          .*(?:\n|$))+)"
         r")"
     )
-    for version_index, version_match in enumerate(version_pattern.finditer(rule_block)):
-        formula_text = version_match.group("formula")
-        formula_lines = formula_text.splitlines()
-        if output in formula_text:
-            continue
-        if not any(
-            line.strip() == _MEDICAID_ADULT_EXPANSION_INCOME_LIMIT_LINE
-            for line in formula_lines
+    for rule_match in rule_pattern.finditer(content):
+        rule_name = rule_match.group("rule_name")
+        rule_block = rule_match.group(0)
+        for version_index, version_match in enumerate(
+            version_pattern.finditer(rule_block)
         ):
-            continue
-        gated_lines: list[str] = []
-        inserted_gate = False
-        for line in formula_lines:
-            gated_lines.append(line)
-            if line.strip() != _MEDICAID_ADULT_EXPANSION_INCOME_LIMIT_LINE:
+            formula_text = version_match.group("formula")
+            formula_lines = formula_text.splitlines()
+            if output in formula_text:
                 continue
-            indentation = line[: len(line) - len(line.lstrip())]
-            gated_lines.append(f"{indentation}and {output}")
-            inserted_gate = True
-        if not inserted_gate:
-            continue
-        gated_formula = "\n".join(gated_lines) + "\n"
-        repaired_rule_block = (
-            rule_block[: version_match.start("formula")]
-            + gated_formula
-            + rule_block[version_match.end("formula") :]
-        )
-        repaired = (
-            content[: rule_match.start()]
-            + repaired_rule_block
-            + content[rule_match.end() :]
-        )
-        proof_path = f"versions[{version_index}].formula"
-        return (
-            repaired,
-            [output],
-            [f"adult_expansion_subject_to_xx->{output}"],
-            proof_path,
-        )
-    return content, [], [], None
+            replaced_formula = formula_text
+            placeholder_repairs: list[str] = []
+            for placeholder in _MEDICAID_1396A_XX_SUBJECT_TO_PLACEHOLDERS:
+                updated_formula = re.sub(
+                    rf"\b{re.escape(placeholder)}\b",
+                    output,
+                    replaced_formula,
+                )
+                if updated_formula == replaced_formula:
+                    continue
+                replaced_formula = updated_formula
+                placeholder_repairs.append(f"{placeholder}->{output}")
+            if placeholder_repairs:
+                repaired_rule_block = (
+                    rule_block[: version_match.start("formula")]
+                    + replaced_formula
+                    + rule_block[version_match.end("formula") :]
+                )
+                repaired = (
+                    content[: rule_match.start()]
+                    + repaired_rule_block
+                    + content[rule_match.end() :]
+                )
+                proof_path = f"versions[{version_index}].formula"
+                return repaired, [output], placeholder_repairs, rule_name, proof_path
+
+            gated_lines: list[str] = []
+            inserted_imported_adult_group_gate = False
+            for line in formula_lines:
+                stripped = line.strip()
+                indentation = line[: len(line) - len(line.lstrip())]
+                if stripped == "adult_group_eligible":
+                    gated_lines.append(
+                        f"{indentation}(adult_group_eligible and {output})"
+                    )
+                    inserted_imported_adult_group_gate = True
+                    continue
+                if stripped == "or adult_group_eligible":
+                    gated_lines.append(
+                        f"{indentation}or (adult_group_eligible and {output})"
+                    )
+                    inserted_imported_adult_group_gate = True
+                    continue
+                gated_lines.append(line)
+            if inserted_imported_adult_group_gate:
+                gated_formula = "\n".join(gated_lines) + "\n"
+                repaired_rule_block = (
+                    rule_block[: version_match.start("formula")]
+                    + gated_formula
+                    + rule_block[version_match.end("formula") :]
+                )
+                repaired = (
+                    content[: rule_match.start()]
+                    + repaired_rule_block
+                    + content[rule_match.end() :]
+                )
+                proof_path = f"versions[{version_index}].formula"
+                return (
+                    repaired,
+                    [output],
+                    [f"adult_expansion_subject_to_xx->{output}"],
+                    rule_name,
+                    proof_path,
+                )
+            if not any(
+                line.strip() == _MEDICAID_ADULT_EXPANSION_INCOME_LIMIT_LINE
+                for line in formula_lines
+            ):
+                continue
+            gated_lines = []
+            inserted_gate = False
+            for line in formula_lines:
+                gated_lines.append(line)
+                if line.strip() != _MEDICAID_ADULT_EXPANSION_INCOME_LIMIT_LINE:
+                    continue
+                indentation = line[: len(line) - len(line.lstrip())]
+                gated_lines.append(f"{indentation}and {output}")
+                inserted_gate = True
+            if not inserted_gate:
+                continue
+            gated_formula = "\n".join(gated_lines) + "\n"
+            repaired_rule_block = (
+                rule_block[: version_match.start("formula")]
+                + gated_formula
+                + rule_block[version_match.end("formula") :]
+            )
+            repaired = (
+                content[: rule_match.start()]
+                + repaired_rule_block
+                + content[rule_match.end() :]
+            )
+            proof_path = f"versions[{version_index}].formula"
+            return (
+                repaired,
+                [output],
+                [f"adult_expansion_subject_to_xx->{output}"],
+                rule_name,
+                proof_path,
+            )
+    return content, [], [], None, None
 
 
 def _add_imported_gate_test_overrides(
@@ -35097,6 +35275,7 @@ def _add_imported_gate_test_overrides(
     generated_target_base: str,
     rule_name: str,
     imported_ref: str,
+    stale_input_names: list[str] | None = None,
 ) -> list[str]:
     if not test_file.exists():
         return []
@@ -35109,6 +35288,11 @@ def _add_imported_gate_test_overrides(
 
     changed = False
     repairs: list[str] = []
+    stale_input_refs = {
+        f"{generated_target_base}#input.{input_name}"
+        for input_name in (stale_input_names or [])
+        if input_name
+    }
     for test_case in test_payload:
         if not isinstance(test_case, dict):
             continue
@@ -35134,6 +35318,12 @@ def _add_imported_gate_test_overrides(
         )
         if not upstream_inputs:
             continue
+        removed_stale_inputs = False
+        if stale_input_refs:
+            removed_stale_inputs = _remove_mapping_keys_recursive(
+                inputs,
+                stale_input_refs,
+            )
 
         current_period_start = _test_period_start_date(test_case.get("period"))
         upstream_period_start = _test_period_start_date(upstream_period)
@@ -35150,7 +35340,7 @@ def _add_imported_gate_test_overrides(
             for input_ref, input_value in upstream_inputs.items()
             if str(input_ref) not in input_keys
         ]
-        if not missing_inputs and not period_changed:
+        if not missing_inputs and not period_changed and not removed_stale_inputs:
             continue
         for input_ref, input_value in missing_inputs:
             inputs[input_ref] = input_value
@@ -36526,7 +36716,19 @@ def _try_repair_generated_imported_output_test_mismatches_for_apply(
 
     rules_file = Path(str(getattr(result, "output_file", "") or ""))
     test_file = _rulespec_test_path(rules_file)
+    repaired_positive_imports = (
+        _repair_positive_imported_judgment_composition_tests(
+            rules_file=rules_file,
+            test_file=test_file,
+            policy_repo_path=policy_repo_path,
+            relative_output=relative_output,
+            issues=issues,
+        )
+    )
+    if repaired_positive_imports:
+        return repaired_positive_imports
     return _repair_imported_output_test_mismatches(
+        rules_file=rules_file,
         test_file=test_file,
         policy_repo_path=policy_repo_path,
         relative_output=relative_output,
@@ -36591,8 +36793,326 @@ def _try_repair_generated_conditional_vacuity_tests_for_apply(
     )
 
 
+def _repair_positive_imported_judgment_composition_tests(
+    *,
+    rules_file: Path,
+    test_file: Path,
+    policy_repo_path: Path,
+    relative_output: Path,
+    issues: list[str],
+) -> list[str]:
+    if not rules_file.exists() or not test_file.exists() or not issues:
+        return []
+
+    try:
+        rules_payload = yaml.safe_load(rules_file.read_text()) or {}
+        test_payload = yaml.safe_load(test_file.read_text()) or []
+    except (OSError, ValueError, yaml.YAMLError):
+        return []
+    if not isinstance(rules_payload, dict) or not isinstance(test_payload, list):
+        return []
+
+    anchor = _relative_output_to_anchor(
+        relative_output, policy_repo_path=policy_repo_path
+    )
+    rules_by_name = _rules_by_name_from_payload(rules_payload)
+    imported_refs_by_name = _imported_output_refs_by_name(rules_file)
+    if not imported_refs_by_name:
+        return []
+
+    positive_mismatches: dict[str, set[str]] = defaultdict(set)
+    for issue in issues:
+        parsed = _parse_generated_test_output_mismatch(str(issue))
+        if parsed is None:
+            continue
+        case_name, output_ref, actual_value = parsed
+        if actual_value != "not_holds":
+            continue
+        if not _rulespec_ref_matches_base(output_ref, anchor):
+            continue
+        output_name = output_ref.rsplit("#", 1)[-1]
+        rule = rules_by_name.get(output_name)
+        if not isinstance(rule, dict):
+            continue
+        if not _generated_rule_is_imported_judgment_composition(
+            rule,
+            payload=rules_payload,
+        ):
+            continue
+        positive_mismatches[case_name].add(output_ref)
+    if not positive_mismatches:
+        return []
+
+    changed = False
+    repairs: list[str] = []
+    for test_case in test_payload:
+        if not isinstance(test_case, dict):
+            continue
+        case_name = str(test_case.get("name") or "").strip()
+        output_refs = positive_mismatches.get(case_name)
+        if not output_refs:
+            continue
+        inputs = test_case.get("input")
+        outputs = test_case.get("output")
+        if not isinstance(inputs, dict) or not isinstance(outputs, dict):
+            continue
+        for output_ref in sorted(output_refs):
+            output_key = _matching_mapping_key_by_rulespec_ref(outputs, output_ref)
+            if output_key is None:
+                continue
+            if _normalized_generated_test_scalar(outputs[output_key]) != "holds":
+                continue
+            output_name = output_ref.rsplit("#", 1)[-1]
+            rule = rules_by_name.get(output_name)
+            if not isinstance(rule, dict):
+                continue
+            branch = _best_imported_judgment_branch_for_test_case(
+                rule=rule,
+                imported_refs_by_name=imported_refs_by_name,
+                inputs=inputs,
+                policy_repo_path=policy_repo_path,
+            )
+            if not branch:
+                continue
+            branch_repairs = _harmonize_imported_judgment_branch_inputs(
+                inputs,
+                branch=branch,
+                case_name=case_name,
+                policy_repo_path=policy_repo_path,
+            )
+            if branch_repairs is None:
+                return []
+            if not branch_repairs:
+                continue
+            repairs.extend(branch_repairs)
+            changed = True
+
+    if not changed:
+        return []
+    test_file.write_text(
+        yaml.safe_dump(test_payload, sort_keys=False, allow_unicode=False)
+    )
+    return repairs
+
+
+def _harmonize_imported_judgment_branch_inputs(
+    inputs: dict[object, object],
+    *,
+    branch: tuple[str, ...],
+    case_name: str,
+    policy_repo_path: Path,
+) -> list[str] | None:
+    """Make a generated positive test satisfy an imported Judgment branch.
+
+    Imported Judgment outputs are computed by the producer RuleSpec file. A
+    generated consumer test therefore has to set the producer's factual inputs,
+    not assign the imported output directly.
+    """
+    desired_by_fragment: dict[str, tuple[str, object]] = {}
+    direct_imported_keys: list[object] = []
+
+    for imported_ref in branch:
+        direct_key = _matching_mapping_key_by_rulespec_ref(inputs, imported_ref)
+        if direct_key is not None:
+            if _normalized_generated_test_scalar(inputs[direct_key]) != "holds":
+                return None
+            direct_imported_keys.append(direct_key)
+
+        producer_inputs = _producer_test_inputs_for_output_value(
+            imported_ref,
+            "holds",
+            policy_repo_path=policy_repo_path,
+        )
+        if not producer_inputs:
+            return None
+        for producer_ref, producer_value in producer_inputs.items():
+            producer_ref_text = str(producer_ref)
+            fragment = _rulespec_test_key_fragment(producer_ref_text)
+            existing = desired_by_fragment.get(fragment)
+            if existing is not None and not _generated_test_values_equal(
+                existing[1],
+                producer_value,
+            ):
+                return None
+            desired_by_fragment[fragment] = (
+                producer_ref_text,
+                copy.deepcopy(producer_value),
+            )
+
+    repairs: list[str] = []
+    for direct_key in direct_imported_keys:
+        if direct_key in inputs:
+            del inputs[direct_key]
+            repairs.append(f"test:{case_name}:remove:{direct_key}")
+
+    for fragment, (producer_ref, desired_value) in sorted(
+        desired_by_fragment.items()
+    ):
+        matching_keys = [
+            key
+            for key in list(inputs)
+            if _rulespec_test_key_fragment(key) == fragment
+        ]
+        exact_key = _matching_mapping_key_by_rulespec_ref(inputs, producer_ref)
+        if exact_key is None:
+            inputs[producer_ref] = copy.deepcopy(desired_value)
+            repairs.append(f"test:{case_name}:{producer_ref}")
+            matching_keys.append(producer_ref)
+            exact_key = producer_ref
+        for key in matching_keys:
+            if not _generated_test_values_equal(inputs[key], desired_value):
+                inputs[key] = copy.deepcopy(desired_value)
+                repairs.append(f"test:{case_name}:{key}={fragment}")
+
+    return repairs
+
+
+def _best_imported_judgment_branch_for_test_case(
+    *,
+    rule: dict[str, object],
+    imported_refs_by_name: dict[str, str],
+    inputs: dict[object, object],
+    policy_repo_path: Path,
+) -> tuple[str, ...]:
+    branches = _imported_judgment_positive_branches_for_rule(
+        rule,
+        imported_refs_by_name=imported_refs_by_name,
+    )
+    best_branch: tuple[str, ...] = ()
+    best_score = 0
+    for branch in branches:
+        score = _imported_judgment_branch_test_score(
+            branch,
+            inputs=inputs,
+            policy_repo_path=policy_repo_path,
+        )
+        if score > best_score:
+            best_score = score
+            best_branch = branch
+    return best_branch
+
+
+def _imported_judgment_positive_branches_for_rule(
+    rule: dict[str, object],
+    *,
+    imported_refs_by_name: dict[str, str],
+) -> list[tuple[str, ...]]:
+    versions = rule.get("versions")
+    if not isinstance(versions, list):
+        return []
+    imported_names = set(imported_refs_by_name)
+    branches: list[tuple[str, ...]] = []
+    for version in versions:
+        if not isinstance(version, dict):
+            continue
+        formula = version.get("formula")
+        if not isinstance(formula, str) or not formula.strip():
+            continue
+        for raw_branch in _split_top_level_boolean_operator(formula, "or"):
+            branch = _strip_balanced_outer_parentheses(raw_branch)
+            if re.search(r"\bnot\b", branch):
+                continue
+            branch_names: list[str] = []
+            for raw_part in _split_top_level_boolean_operator(branch, "and"):
+                part = _strip_balanced_outer_parentheses(raw_part)
+                if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", part):
+                    branch_names = []
+                    break
+                if part not in imported_names:
+                    branch_names = []
+                    break
+                branch_names.append(part)
+            if not branch_names:
+                continue
+            branches.append(
+                tuple(imported_refs_by_name[name] for name in branch_names)
+            )
+    return branches
+
+
+def _split_top_level_boolean_operator(expression: str, operator: str) -> list[str]:
+    normalized_operator = operator.strip().lower()
+    if normalized_operator not in {"and", "or"}:
+        return [expression.strip()]
+    parts: list[str] = []
+    depth = 0
+    start = 0
+    for match in re.finditer(r"\b(?:and|or)\b|[()]", expression):
+        token = match.group(0)
+        if token == "(":
+            depth += 1
+            continue
+        if token == ")":
+            depth = max(0, depth - 1)
+            continue
+        if depth == 0 and token.lower() == normalized_operator:
+            parts.append(expression[start : match.start()].strip())
+            start = match.end()
+    parts.append(expression[start:].strip())
+    return [part for part in parts if part]
+
+
+def _strip_balanced_outer_parentheses(expression: str) -> str:
+    stripped = expression.strip()
+    while stripped.startswith("(") and stripped.endswith(")"):
+        depth = 0
+        wraps = True
+        for index, char in enumerate(stripped):
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0 and index != len(stripped) - 1:
+                    wraps = False
+                    break
+            if depth < 0:
+                wraps = False
+                break
+        if not wraps or depth != 0:
+            break
+        stripped = stripped[1:-1].strip()
+    return stripped
+
+
+def _imported_judgment_branch_test_score(
+    branch: tuple[str, ...],
+    *,
+    inputs: dict[object, object],
+    policy_repo_path: Path,
+) -> int:
+    score = 0
+    for imported_ref in branch:
+        direct_key = _matching_mapping_key_by_rulespec_ref(inputs, imported_ref)
+        if direct_key is not None:
+            if _normalized_generated_test_scalar(inputs[direct_key]) != "holds":
+                return -1
+            score += 100
+            continue
+        producer_inputs = _producer_test_inputs_for_output_value(
+            imported_ref,
+            "holds",
+            policy_repo_path=policy_repo_path,
+        )
+        if not producer_inputs:
+            continue
+        matched = 0
+        for producer_ref, producer_value in producer_inputs.items():
+            input_key = _matching_mapping_key_by_rulespec_ref(
+                inputs,
+                str(producer_ref),
+            )
+            if input_key is None:
+                continue
+            if not _generated_test_values_equal(inputs[input_key], producer_value):
+                return -1
+            matched += 1
+        score += matched
+    return score
+
+
 def _repair_imported_output_test_mismatches(
     *,
+    rules_file: Path | None = None,
     test_file: Path,
     policy_repo_path: Path,
     relative_output: Path,
@@ -36607,6 +37127,20 @@ def _repair_imported_output_test_mismatches(
         return []
     if not isinstance(test_payload, list):
         return []
+
+    imported_composition_rules: set[str] = set()
+    if rules_file is not None and rules_file.exists():
+        try:
+            rules_payload = yaml.safe_load(rules_file.read_text()) or {}
+        except (OSError, ValueError, yaml.YAMLError):
+            rules_payload = {}
+        if isinstance(rules_payload, dict):
+            for name, rule in _rules_by_name_from_payload(rules_payload).items():
+                if _generated_rule_is_imported_judgment_composition(
+                    rule,
+                    payload=rules_payload,
+                ):
+                    imported_composition_rules.add(name)
 
     anchor = _relative_output_to_anchor(
         relative_output, policy_repo_path=policy_repo_path
@@ -36645,6 +37179,13 @@ def _repair_imported_output_test_mismatches(
         for output_ref, actual_value in replacements.items():
             output_key = _matching_mapping_key_by_rulespec_ref(outputs, output_ref)
             if output_key is None:
+                return []
+            output_name = output_ref.rsplit("#", 1)[-1]
+            if (
+                output_name in imported_composition_rules
+                and actual_value == "not_holds"
+                and _normalized_generated_test_scalar(outputs[output_key]) == "holds"
+            ):
                 return []
             if outputs[output_key] != actual_value:
                 outputs[output_key] = actual_value
@@ -36874,7 +37415,7 @@ def _parse_generated_test_output_mismatch(
     issue: str,
 ) -> tuple[str, str, object] | None:
     match = re.search(
-        r"Test case\s+`?(?P<case>[^\s`]+)`?\s+"
+        r"Test case\s+(?:`(?P<case_quoted>[^`]+)`|(?P<case>[^\s`]+))\s+"
         r"output\s+`?(?P<output>[^\s`]+)`?\s+"
         r"expected\s+\w+\s+.+?,\s+got\s+"
         r"(?P<kind>\w+)\s+(?P<value>-?(?:\d+(?:\.\d+)?|true|false))\.?$",
@@ -36886,18 +37427,20 @@ def _parse_generated_test_output_mismatch(
             value = _rulespec_mismatch_actual_value(match["kind"], match["value"])
         except (InvalidOperation, ValueError):
             return None
-        return match["case"].strip(), match["output"].strip(), value
+        case = (match["case_quoted"] or match["case"]).strip()
+        return case, match["output"].strip(), value
 
     judgment_match = re.search(
-        r"Test case\s+`?(?P<case>[^\s`]+)`?\s+"
+        r"Test case\s+(?:`(?P<case_quoted>[^`]+)`|(?P<case>[^\s`]+))\s+"
         r"output\s+`?(?P<output>[^\s`]+)`?\s+"
         r"expected\s+\w+,\s+got\s+(?P<value>holds|not_holds)\.?$",
         issue,
         flags=re.IGNORECASE,
     )
     if judgment_match:
+        case = (judgment_match["case_quoted"] or judgment_match["case"]).strip()
         return (
-            judgment_match["case"].strip(),
+            case,
             judgment_match["output"].strip(),
             judgment_match["value"].strip().lower(),
         )

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -204,6 +204,38 @@ _CODEX_DEFAULT_IDLE_TIMEOUT_SECONDS = 300
 _CODEX_LONG_SOURCE_CHAR_THRESHOLD = 40_000
 _CODEX_LONG_SOURCE_TIMEOUT_SECONDS = 1800
 _CODEX_LONG_SOURCE_IDLE_TIMEOUT_SECONDS = 900
+_POLICYENGINE_HINT_BROAD_PLACEHOLDER_RE = re.compile(
+    r"\b(?:"
+    r"person_is_described_in_[A-Za-z0-9_]*"
+    r"|person_is_not_described_in_or_enrolled_under_[A-Za-z0-9_]*"
+    r"|person_is_in_[A-Za-z0-9_]*category[A-Za-z0-9_]*"
+    r"|person_[A-Za-z0-9_]*listed_state_plan[A-Za-z0-9_]*"
+    r"|person_[A-Za-z0-9_]*(?:mandatory|optional|cost_sharing|ssi_related)"
+    r"[A-Za-z0-9_]*group[A-Za-z0-9_]*"
+    r"|person_[A-Za-z0-9_]*(?:subparagraph|subclause|subsection|section)"
+    r"[A-Za-z0-9_]*"
+    r"|person_[A-Za-z0-9_]*as_defined_in_[A-Za-z0-9_]*"
+    r"|person_covered_by_[A-Za-z0-9_]*(?:category|subparagraph)[A-Za-z0-9_]*"
+    r"|person_is_qualified_[A-Za-z0-9_]*group[A-Za-z0-9_]*"
+    r"|income_(?:as_)?determined_(?:under|for)_[A-Za-z0-9_]*"
+    r"|[A-Za-z0-9_]*subsection_[A-Za-z0-9_]*requirements"
+    r"(?:_[A-Za-z0-9_]+)?_satisfied"
+    r"|[A-Za-z0-9_]*subject_to_subsections?_[A-Za-z0-9_]*_satisfied"
+    r")\b"
+)
+_RULESPEC_FORMULA_IDENTIFIER_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\b")
+_RULESPEC_FORMULA_KEYWORDS = frozenset(
+    {
+        "and",
+        "else",
+        "false",
+        "if",
+        "in",
+        "not",
+        "or",
+        "true",
+    }
+)
 
 
 def _matching_numeric_occurrence_count(
@@ -3336,6 +3368,10 @@ def evaluate_artifact(
         content,
         source_text,
     )
+    policyengine_hint_upstream_issues = _policyengine_hint_upstream_composition_issues(
+        content,
+        policyengine_rule_hint,
+    )
     ci_issues = []
     seen_ci_issues: set[str] = set()
     for issue in (
@@ -3343,6 +3379,7 @@ def evaluate_artifact(
         + ungrounded_numeric_issues
         + numeric_occurrence_issues
         + admin_agency_aggregate_issues
+        + policyengine_hint_upstream_issues
     ):
         if issue in seen_ci_issues:
             continue
@@ -3353,6 +3390,7 @@ def evaluate_artifact(
         and not ungrounded_numeric_issues
         and not numeric_occurrence_issues
         and not admin_agency_aggregate_issues
+        and not policyengine_hint_upstream_issues
     )
 
     return EvalArtifactMetrics(
@@ -4734,9 +4772,39 @@ Return ONLY raw RuleSpec YAML for `{target_file_name}`. Do not include fences or
 
     target_hint = ""
     if policyengine_rule_hint:
+        policyengine_context_exports_section = _format_policyengine_hint_context_exports(
+            context_files,
+        )
         target_hint = f"""
 Preferred principal output:
 - Name the main derived rule `{policyengine_rule_hint}` unless the source clearly defines a different canonical concept.
+- Treat `{policyengine_rule_hint}` as a required oracle-facing surface. Do not
+  put `{policyengine_rule_hint}` under `module.deferred_outputs[]` merely
+  because the source is broad or cites many sibling provisions when an
+  executable formula can be composed from source-stated facts, scalar
+  parameters, or imported primary-source RuleSpec exports supplied in context.
+- If the hinted output would otherwise depend on broad placeholders such as
+  `person_is_described_in_*`, `person_is_in_*_category`, `*_determined_for_*`,
+  `*_mandatory_subclauses*`, or `person_is_qualified_*_group`, first look for
+  the primary statute/regulation export in copied context and import that
+  concrete output instead of leaving the broad phrase as a local boundary
+  input. Defer only the specific unavailable branch, not the whole hinted
+  output, when the remaining branches are executable and source-grounded.
+- For an aggregate/composite hinted output, first enumerate the executable
+  `dtype: Judgment` exports already visible in copied context that match the
+  source's listed categories or branches. Compose `{policyengine_rule_hint}` as
+  a disjunction/conjunction of those imported exports plus only the local
+  conditions the current source itself newly states. Do not create broad local
+  inputs such as `person_covered_by_*category`,
+  `person_covered_by_*subparagraph`, `person_is_described_in_previous_*`,
+  `person_is_not_described_in_or_enrolled_under_*`, or
+  `income_determined_under_*` when a copied primary-source RuleSpec file
+  exports the corresponding concrete category, income methodology, or branch.
+- If a listed branch has no executable primary-source export in copied context,
+  split that branch out: either encode the upstream source first, or omit/defer
+  only that branch with exact provenance. Do not let the oracle-facing hinted
+  rule depend on an aggregate leaf input merely to make the formula executable.
+{policyengine_context_exports_section.rstrip()}
 - Keep oracle-comparable tests at that named semantic level; do not assert only helper parameters or documentary scalars.
 - Keep `.test.yaml` inputs oracle-comparable: prefer the oracle's direct component facts over inverted household proxy inputs, preserve direct component surfaces when available, and assert the canonical RuleSpec output whose local name is `{policyengine_rule_hint}` in every non-empty `output:` mapping.
 - When PolicyEngine can compare the output but cannot consume the source-level
@@ -5793,6 +5861,48 @@ def _format_context_file_listing(
         f"- inspect `{item.workspace_path}`; import target `{item.import_path}`"
         f"{hash_detail}{export_detail}{details}{kind}"
     )
+
+
+def _format_policyengine_hint_context_exports(
+    context_files: list[EvalContextFile],
+    *,
+    max_exports: int = 40,
+) -> str:
+    """Return PE-hint scoped executable context exports for prompt guidance."""
+    export_lines: list[str] = []
+    for item in context_files:
+        if item.kind.endswith("_test_context"):
+            continue
+        surfaces = _context_file_executable_surfaces(item.source_path)
+        for name, surface in sorted(surfaces.items()):
+            dtype = str(surface.get("dtype") or "").strip()
+            if dtype != "Judgment":
+                continue
+            kind = str(surface.get("kind") or "").strip()
+            entity = str(surface.get("entity") or "").strip()
+            details = ", ".join(
+                part
+                for part in [
+                    f"kind={kind}" if kind else "",
+                    f"entity={entity}" if entity else "",
+                    f"dtype={dtype}",
+                ]
+                if part
+            )
+            export_lines.append(f"- `{item.import_path}#{name}` ({details})")
+    if not export_lines:
+        return ""
+    rendered = export_lines[:max_exports]
+    if len(export_lines) > max_exports:
+        rendered.append(
+            f"- ... {len(export_lines) - max_exports} additional Judgment exports omitted"
+        )
+    return """
+Executable Judgment exports visible in copied context for the hinted output.
+Prefer these exact imports before creating any local branch/category/status
+placeholder for the oracle-facing output:
+{lines}
+""".format(lines="\n".join(rendered))
 
 
 _CANONICAL_CONCEPT_TOKEN_RE = re.compile(r"[a-z][a-z0-9_]*")
@@ -9738,6 +9848,94 @@ def _canonical_rulespec_target_for_path(rulespec_path: Path | None) -> str | Non
     if relative.suffix in {".yaml", ".yml"}:
         relative = relative.with_suffix("")
     return f"{prefix}:{relative.as_posix()}"
+
+
+def _policyengine_hint_upstream_composition_issues(
+    rulespec_content: str,
+    policyengine_rule_hint: str | None,
+) -> list[str]:
+    """Flag PE-hinted surfaces that still rely on broad upstream placeholders."""
+    if not policyengine_rule_hint:
+        return []
+    with contextlib.suppress(yaml.YAMLError, TypeError, ValueError):
+        payload = yaml.safe_load(rulespec_content)
+        if not isinstance(payload, dict):
+            return []
+        issues: list[str] = []
+        module = payload.get("module")
+        deferred_outputs = (
+            module.get("deferred_outputs") if isinstance(module, dict) else None
+        )
+        if isinstance(deferred_outputs, list):
+            for deferred_output in deferred_outputs:
+                if not isinstance(deferred_output, dict):
+                    continue
+                output = str(deferred_output.get("output", "")).strip()
+                if output == policyengine_rule_hint or output.endswith(
+                    f"#{policyengine_rule_hint}"
+                ):
+                    issues.append(
+                        "PolicyEngine hinted output "
+                        f"`{policyengine_rule_hint}` is deferred; compose it from "
+                        "available primary-source RuleSpec exports, or defer only "
+                        "specific unavailable branches."
+                    )
+        rules = payload.get("rules")
+        if not isinstance(rules, list):
+            return issues
+        rules_by_name = {
+            rule.get("name"): rule
+            for rule in rules
+            if isinstance(rule, dict) and isinstance(rule.get("name"), str)
+        }
+        rule = rules_by_name.get(policyengine_rule_hint)
+        if not isinstance(rule, dict):
+            return issues
+
+        placeholders: set[str] = set()
+        visited: set[str] = set()
+        pending = [policyengine_rule_hint]
+        while pending:
+            rule_name = pending.pop()
+            if rule_name in visited:
+                continue
+            visited.add(rule_name)
+            rule = rules_by_name.get(rule_name)
+            if not isinstance(rule, dict):
+                continue
+            versions = rule.get("versions")
+            if not isinstance(versions, list):
+                continue
+            for version in versions:
+                if not isinstance(version, dict):
+                    continue
+                formula = version.get("formula")
+                if not isinstance(formula, str):
+                    continue
+                placeholders.update(
+                    match.group(0)
+                    for match in _POLICYENGINE_HINT_BROAD_PLACEHOLDER_RE.finditer(
+                        formula
+                    )
+                )
+                for identifier in _RULESPEC_FORMULA_IDENTIFIER_RE.findall(formula):
+                    if identifier in _RULESPEC_FORMULA_KEYWORDS:
+                        continue
+                    if identifier not in rules_by_name or identifier in visited:
+                        continue
+                    pending.append(identifier)
+        if placeholders:
+            issues.append(
+                "PolicyEngine hinted output "
+                f"`{policyengine_rule_hint}` uses broad upstream placeholder(s) "
+                f"{', '.join(f'`{item}`' for item in sorted(placeholders))}. "
+                "Import concrete primary-source RuleSpec outputs already present "
+                "in context, encode the upstream source first, or defer only the "
+                "specific unavailable branch instead of making the PE surface "
+                "depend on aggregate leaf inputs."
+            )
+        return issues
+    return []
 
 
 def _policyengine_hint_test_output_key(

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -4772,8 +4772,10 @@ Return ONLY raw RuleSpec YAML for `{target_file_name}`. Do not include fences or
 
     target_hint = ""
     if policyengine_rule_hint:
-        policyengine_context_exports_section = _format_policyengine_hint_context_exports(
-            context_files,
+        policyengine_context_exports_section = (
+            _format_policyengine_hint_context_exports(
+                context_files,
+            )
         )
         target_hint = f"""
 Preferred principal output:

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -16309,9 +16309,7 @@ def _imported_rate_source_is_thresholded(content: str, rate_name: str) -> bool:
 
 def _identifier_has_rate_token(identifier: str) -> bool:
     """Return whether an identifier names a rate as a token, not a substring."""
-    tokens = {
-        token for token in _normalize_identifier(identifier).split("_") if token
-    }
+    tokens = {token for token in _normalize_identifier(identifier).split("_") if token}
     return bool(tokens.intersection({"rate", "rates"}))
 
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -16307,6 +16307,14 @@ def _imported_rate_source_is_thresholded(content: str, rate_name: str) -> bool:
     )
 
 
+def _identifier_has_rate_token(identifier: str) -> bool:
+    """Return whether an identifier names a rate as a token, not a substring."""
+    tokens = {
+        token for token in _normalize_identifier(identifier).split("_") if token
+    }
+    return bool(tokens.intersection({"rate", "rates"}))
+
+
 _SOURCE_STATED_COMPOSITE_RATE_PATTERN = re.compile(
     r"\b(?:one-half|half|sum)\b[\s\S]{0,160}\b"
     r"rates?\s+imposed\s+by\b"
@@ -22366,7 +22374,7 @@ class ValidatorPipeline:
         imported_rate_sources: dict[str, str] = {}
         for import_item in self._extract_import_items(content):
             fragment = self._import_item_fragment(import_item)
-            if not fragment or "rate" not in fragment.lower():
+            if not fragment or not _identifier_has_rate_token(fragment):
                 continue
             import_file = _resolve_rulespec_import_file_static(
                 import_item,

--- a/src/axiom_encode/oracles/policyengine/medicaid_populace.py
+++ b/src/axiom_encode/oracles/policyengine/medicaid_populace.py
@@ -13,6 +13,7 @@ import csv
 import json
 import subprocess
 import tempfile
+from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -907,6 +908,66 @@ def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
         writer.writerows(rows)
 
 
+def summarize_by_pe_category(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    summary: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {
+            "category": "",
+            "compared": 0,
+            "pe_eligible": 0,
+            "axiom_eligible": 0,
+            "mismatches": 0,
+            "pe_true_axiom_false": 0,
+            "pe_false_axiom_true": 0,
+        }
+    )
+    for row in rows:
+        category = str(row["pe_medicaid_category"])
+        item = summary[category]
+        item["category"] = category
+        item["compared"] += 1
+        if row["pe_is_medicaid_eligible"]:
+            item["pe_eligible"] += 1
+        if row["axiom_is_medicaid_eligible"]:
+            item["axiom_eligible"] += 1
+        if not row["match"]:
+            item["mismatches"] += 1
+            if row["pe_is_medicaid_eligible"]:
+                item["pe_true_axiom_false"] += 1
+            else:
+                item["pe_false_axiom_true"] += 1
+    return sorted(
+        summary.values(),
+        key=lambda item: (
+            -int(item["mismatches"]),
+            -int(item["pe_eligible"]),
+            str(item["category"]),
+        ),
+    )
+
+
+def print_category_summary(rows: list[dict[str, Any]]) -> None:
+    category_rows = summarize_by_pe_category(rows)
+    if not category_rows:
+        return
+    print("PE Medicaid category summary:", flush=True)
+    for item in category_rows:
+        compared = int(item["compared"])
+        mismatches = int(item["mismatches"])
+        match_rate = (compared - mismatches) / compared if compared else 1.0
+        print(
+            "  "
+            f"{item['category']}: compared={compared:,}; "
+            f"pe_eligible={int(item['pe_eligible']):,}; "
+            f"axiom_eligible={int(item['axiom_eligible']):,}; "
+            f"mismatches={mismatches:,}; match_rate={match_rate:.2%}; "
+            "pe_true_axiom_false="
+            f"{int(item['pe_true_axiom_false']):,}; "
+            "pe_false_axiom_true="
+            f"{int(item['pe_false_axiom_true']):,}",
+            flush=True,
+        )
+
+
 def main(args: argparse.Namespace | None = None) -> None:
     if args is None:
         args = parse_args()
@@ -969,6 +1030,7 @@ def main(args: argparse.Namespace | None = None) -> None:
         f"Compared {len(rows):,} people; matches={matches:,}; "
         f"mismatches={mismatches:,}; match_rate={match_rate:.2%}."
     )
+    print_category_summary(rows)
     for row in [row for row in rows if not row["match"]][: args.max_differences]:
         print(
             "DIFF "

--- a/src/axiom_encode/oracles/policyengine/medicaid_populace.py
+++ b/src/axiom_encode/oracles/policyengine/medicaid_populace.py
@@ -1,0 +1,1001 @@
+"""Compare Medicaid RuleSpec eligibility against PolicyEngine over Populace.
+
+This command runs the real Axiom rules engine over Populace-derived person
+records.  Its initial projection maps PolicyEngine's Medicaid component
+predicates into the corresponding RuleSpec source inputs so residual
+differences identify surface-composition gaps, not missing microdata plumbing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from axiom_encode.oracles.policyengine.ecps_snap import (
+    Period,
+    axiom_rules_env,
+    compile_program,
+    load_base_inputs,
+    month_period,
+    output_to_python,
+    outputs_by_reference,
+    resolve_axiom_binary,
+    resolve_test_template_path,
+    resolve_workspace_root,
+    scalar_value,
+)
+from axiom_encode.oracles.policyengine.population import (
+    DEFAULT_US_POPULACE_YEAR,
+    load_populace_dataset,
+    populace_data_requirement,
+)
+
+try:
+    import numpy as np
+except ImportError:  # pragma: no cover - exercised only without optional oracle deps
+    np = None
+
+try:
+    import pandas as pd
+except ImportError:  # pragma: no cover - exercised only without optional oracle deps
+    pd = None
+
+
+COMPARED_POLICYENGINE_OUTPUT = "is_medicaid_eligible"
+COMPARED_AXIOM_OUTPUT_ID = "us:statutes/42/1396a/a/10#is_medicaid_eligible"
+AXIOM_COMPONENT_OUTPUT_IDS = {
+    "parent": "us:regulations/42-cfr/435/110#parent_or_caretaker_relative_eligible",
+    "pregnant": "us:regulations/42-cfr/435/116#pregnant_woman_eligible",
+    "child": "us:regulations/42-cfr/435/118#infants_and_children_eligible",
+    "adult": "us:regulations/42-cfr/435/119#adult_group_eligible",
+    "ssi": (
+        "us:regulations/42-cfr/435/120/ssi-mandatory-group"
+        "#medicaid_required_for_ssi_mandatory_group"
+    ),
+    "former_foster": (
+        "us:regulations/42-cfr/435/150"
+        "#former_foster_care_child_medicaid_required"
+    ),
+    "community_engagement": (
+        "us:statutes/42/1396a/xx"
+        "#demonstrated_community_engagement_for_month"
+    ),
+}
+DEFAULT_PROGRAM_RELATIVE_PATH = Path("us/statutes/42/1396a/a/10.yaml")
+STATE_FIPS_BY_CODE = {
+    "AL": 1,
+    "AK": 2,
+    "AZ": 4,
+    "AR": 5,
+    "CA": 6,
+    "CO": 8,
+    "CT": 9,
+    "DE": 10,
+    "DC": 11,
+    "FL": 12,
+    "GA": 13,
+    "HI": 15,
+    "ID": 16,
+    "IL": 17,
+    "IN": 18,
+    "IA": 19,
+    "KS": 20,
+    "KY": 21,
+    "LA": 22,
+    "ME": 23,
+    "MD": 24,
+    "MA": 25,
+    "MI": 26,
+    "MN": 27,
+    "MS": 28,
+    "MO": 29,
+    "MT": 30,
+    "NE": 31,
+    "NV": 32,
+    "NH": 33,
+    "NJ": 34,
+    "NM": 35,
+    "NY": 36,
+    "NC": 37,
+    "ND": 38,
+    "OH": 39,
+    "OK": 40,
+    "OR": 41,
+    "PA": 42,
+    "RI": 44,
+    "SC": 45,
+    "SD": 46,
+    "TN": 47,
+    "TX": 48,
+    "UT": 49,
+    "VT": 50,
+    "VA": 51,
+    "WA": 53,
+    "WV": 54,
+    "WI": 55,
+    "WY": 56,
+}
+
+
+@dataclass
+class PersonCase:
+    person_index: int
+    state: str
+    inputs: dict[str, Any]
+    pe_outputs: dict[str, Any]
+
+
+def configure_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    parser.add_argument("--year", type=int, default=2027)
+    parser.add_argument("--month", type=int, default=1)
+    parser.add_argument(
+        "--state",
+        default=None,
+        help="Optional two-letter state code filter.",
+    )
+    parser.add_argument(
+        "--sample-size",
+        type=int,
+        default=None,
+        help="Limit after filtering. Omit to run all matching Populace people.",
+    )
+    parser.add_argument(
+        "--pre-sample-households",
+        type=int,
+        default=None,
+        help=(
+            "Subset the local Populace household sample before constructing "
+            "PolicyEngine. This preserves whole households and avoids building "
+            "the full Medicaid graph for smoke tests."
+        ),
+    )
+    parser.add_argument(
+        "--positive-only",
+        action="store_true",
+        help="Only compare people PolicyEngine marks Medicaid-eligible.",
+    )
+    parser.add_argument(
+        "--projection",
+        choices=("policyengine-components",),
+        default="policyengine-components",
+        help=(
+            "Projection mode. policyengine-components maps PE category "
+            "component predicates into RuleSpec source inputs to isolate final "
+            "surface-composition differences."
+        ),
+    )
+    parser.add_argument(
+        "--populace-year",
+        type=int,
+        default=DEFAULT_US_POPULACE_YEAR,
+        help="Published US Populace dataset year to load.",
+    )
+    parser.add_argument(
+        "--program",
+        type=Path,
+        default=None,
+        help="Override the Medicaid RuleSpec program file.",
+    )
+    parser.add_argument(
+        "--test-template",
+        type=Path,
+        default=None,
+        help="Override the companion test template used for base input defaults.",
+    )
+    parser.add_argument(
+        "--axiom-binary",
+        type=Path,
+        default=None,
+        help="Path to the axiom-rules-engine binary.",
+    )
+    parser.add_argument(
+        "--workspace-root",
+        type=Path,
+        default=None,
+        help="Workspace containing axiom-rules-engine and rulespec-us.",
+    )
+    parser.add_argument("--write-csv", type=Path, default=None)
+    parser.add_argument("--max-differences", type=int, default=20)
+    parser.add_argument(
+        "--fail-on-mismatch",
+        action="store_true",
+        help="Exit nonzero when any compared row mismatches.",
+    )
+    parser.add_argument(
+        "--min-match-rate",
+        type=float,
+        default=None,
+        help="Exit nonzero when the match rate is below this threshold.",
+    )
+    return parser
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    configure_parser(parser)
+    return parser.parse_args()
+
+
+def require_numpy() -> None:
+    if np is None:
+        raise SystemExit(
+            "numpy is required. Run with: "
+            "uv run --with numpy --with policyengine-core==3.26.0 --with "
+            f"{populace_data_requirement('us')} axiom-encode "
+            "medicaid-populace-compare"
+        )
+
+
+def require_pandas() -> None:
+    if pd is None:
+        raise SystemExit(
+            "pandas is required. Run with: "
+            "uv run --with pandas --with numpy --with policyengine-core==3.26.0 "
+            f"--with {populace_data_requirement('us')} axiom-encode "
+            "medicaid-populace-compare"
+        )
+
+
+def array(values: Any) -> np.ndarray:
+    require_numpy()
+    if hasattr(values, "to_numpy"):
+        return values.to_numpy()
+    if hasattr(values, "values"):
+        return np.asarray(values.values)
+    return np.asarray(values)
+
+
+def calculate(sim: Any, name: str, period: str | int) -> np.ndarray:
+    return array(sim.calculate(name, period=period))
+
+
+def calculate_or_default(
+    sim: Any, name: str, period: str | int, default: Any, size: int
+) -> np.ndarray:
+    try:
+        return calculate(sim, name, period)
+    except Exception:
+        return np.full(size, default)
+
+
+def resolve_program_path(workspace_root: Path, override: Path | None) -> Path:
+    if override is not None:
+        return override.resolve()
+    cwd_program = Path.cwd() / DEFAULT_PROGRAM_RELATIVE_PATH
+    if cwd_program.exists():
+        return cwd_program.resolve()
+    return (workspace_root / "rulespec-us" / DEFAULT_PROGRAM_RELATIVE_PATH).resolve()
+
+
+def _policyengine_import_error_message(exc: BaseException) -> str:
+    message = str(exc)
+    if "mixes computation modes" in message:
+        return (
+            "policyengine-us could not be imported because policyengine-core is "
+            "too new for this checkout. Run the oracle with "
+            "`--with policyengine-core==3.26.0`, or refresh the PE-US checkout "
+            "and lockfile together."
+        )
+    return (
+        "policyengine-us is required. Run with: "
+        "uv run --with policyengine-core==3.26.0 --with "
+        f"{populace_data_requirement('us')} --with numpy axiom-encode "
+        "medicaid-populace-compare"
+    )
+
+
+def _person_state_codes(sim: Any, period: int, count: int) -> np.ndarray:
+    household_ids = calculate(sim, "household_id", period)
+    household_states = calculate(sim, "state_code_str", period).astype(str)
+    state_by_household_id = {
+        int(household_id): str(state)
+        for household_id, state in zip(household_ids, household_states, strict=False)
+    }
+    person_household_ids = calculate_or_default(
+        sim,
+        "person_household_id",
+        period,
+        -1,
+        count,
+    )
+    return np.asarray(
+        [state_by_household_id.get(int(household_id), "") for household_id in person_household_ids]
+    )
+
+
+def _empty_like(df: pd.DataFrame) -> pd.DataFrame:
+    return df.iloc[0:0].copy()
+
+
+def _subset_table_by_ids(
+    dataset: Any,
+    *,
+    table_name: str,
+    id_column: str,
+    ids: set[Any],
+) -> pd.DataFrame:
+    table = getattr(dataset, table_name)
+    if table.empty or id_column not in table:
+        return _empty_like(table)
+    return table[table[id_column].isin(ids)].copy().reset_index(drop=True)
+
+
+def _household_state_mask(household: pd.DataFrame, state_filter: str | None) -> Any:
+    if state_filter is None:
+        return pd.Series(True, index=household.index)
+    state = state_filter.upper()
+    if "state_code_str" in household:
+        return household["state_code_str"].astype(str).str.upper() == state
+    if "state_code" in household:
+        return household["state_code"].astype(str).str.upper() == state
+    if "state_fips" in household:
+        state_fips = STATE_FIPS_BY_CODE.get(state)
+        if state_fips is None:
+            raise SystemExit(f"Unsupported state code for pre-sampling: {state}")
+        return household["state_fips"].astype(int) == state_fips
+    return pd.Series(True, index=household.index)
+
+
+def pre_sample_households(
+    dataset: Any,
+    *,
+    household_count: int,
+    state_filter: str | None,
+) -> Any:
+    """Return a fresh dataset containing complete selected households."""
+    require_pandas()
+    if household_count <= 0:
+        raise SystemExit("--pre-sample-households must be positive.")
+    person = dataset.person
+    household = dataset.household
+    if "household_id" not in household:
+        raise SystemExit("Populace household table is missing household_id.")
+    if "person_household_id" not in person:
+        raise SystemExit("Populace person table is missing person_household_id.")
+
+    candidate_households = household[_household_state_mask(household, state_filter)]
+    selected_household_ids = set(
+        candidate_households["household_id"].head(household_count)
+    )
+    sampled_household = (
+        household[household["household_id"].isin(selected_household_ids)]
+        .copy()
+        .reset_index(drop=True)
+    )
+    sampled_person = (
+        person[person["person_household_id"].isin(selected_household_ids)]
+        .copy()
+        .reset_index(drop=True)
+    )
+    if sampled_person.empty:
+        raise SystemExit(
+            "Pre-sampling selected no Populace people. Check --state and "
+            "--pre-sample-households."
+        )
+
+    sampled_tax_unit = _subset_table_by_ids(
+        dataset,
+        table_name="tax_unit",
+        id_column="tax_unit_id",
+        ids=set(sampled_person["person_tax_unit_id"])
+        if "person_tax_unit_id" in sampled_person
+        else set(),
+    )
+    sampled_spm_unit = _subset_table_by_ids(
+        dataset,
+        table_name="spm_unit",
+        id_column="spm_unit_id",
+        ids=set(sampled_person["person_spm_unit_id"])
+        if "person_spm_unit_id" in sampled_person
+        else set(),
+    )
+    sampled_family = _subset_table_by_ids(
+        dataset,
+        table_name="family",
+        id_column="family_id",
+        ids=set(sampled_person["person_family_id"])
+        if "person_family_id" in sampled_person
+        else set(),
+    )
+    sampled_marital_unit = _subset_table_by_ids(
+        dataset,
+        table_name="marital_unit",
+        id_column="marital_unit_id",
+        ids=set(sampled_person["person_marital_unit_id"])
+        if "person_marital_unit_id" in sampled_person
+        else set(),
+    )
+    return dataset.__class__(
+        person=sampled_person,
+        household=sampled_household,
+        tax_unit=sampled_tax_unit,
+        spm_unit=sampled_spm_unit,
+        family=sampled_family,
+        marital_unit=sampled_marital_unit,
+        time_period=int(dataset.time_period),
+    )
+
+
+def _threshold_inputs_from_component(
+    *,
+    eligible: bool,
+    low: float = 0.50,
+    high: float = 2.00,
+    threshold: float = 1.00,
+) -> tuple[float, float]:
+    return (low, threshold) if eligible else (high, threshold)
+
+
+def _project_case_inputs(
+    base_inputs: dict[str, Any],
+    *,
+    age: float,
+    medicaid_income_level: float,
+    parent_nfc: bool,
+    parent_fc: bool,
+    pregnant_nfc: bool,
+    pregnant_fc: bool,
+    infant_fc: bool,
+    young_child_fc: bool,
+    older_child_eligible: bool,
+    adult_nfc: bool,
+    adult_fc: bool,
+    ssi_recipient: bool,
+    mandatory_subpart_b: bool,
+    work_requirement_eligible: bool,
+    medicare_eligible: bool,
+) -> dict[str, Any]:
+    inputs = dict(base_inputs)
+    numeric_age = float(age)
+    for key in (
+        "us:regulations/42-cfr/435/118#input.person_age",
+        "us:regulations/42-cfr/435/119#input.person_age",
+        "us:regulations/42-cfr/435/150#input.person_age",
+    ):
+        inputs[key] = numeric_age
+
+    inputs["us:regulations/42-cfr/435/110#input.person_is_parent_or_caretaker_relative"] = bool(
+        parent_nfc
+    )
+    inputs[
+        "us:regulations/42-cfr/435/110#input.person_is_spouse_of_parent_or_caretaker_relative_living_with_them"
+    ] = False
+    inputs[
+        "us:regulations/42-cfr/435/110#input.household_income_at_or_below_state_plan_income_standard"
+    ] = bool(parent_fc)
+
+    pregnant_full_eligible = bool(pregnant_nfc and pregnant_fc)
+    pregnant_limit = _threshold_inputs_from_component(
+        eligible=pregnant_full_eligible
+    )[1]
+    child_component_eligible = bool(
+        (numeric_age < 1 and infant_fc)
+        or (1 <= numeric_age <= 5 and young_child_fc)
+        or older_child_eligible
+    )
+    adult_full_eligible = bool(adult_nfc and adult_fc)
+    # The current rules engine run request addresses inputs by name within the
+    # compiled program. Several imported Medicaid modules use this same local
+    # input name, so use one synthetic income projection for all of them.
+    shared_income_fraction = 1.0 if (
+        pregnant_full_eligible or child_component_eligible or adult_full_eligible
+    ) else 2.0
+
+    _, child_limit = _threshold_inputs_from_component(
+        eligible=child_component_eligible,
+        threshold=1.33,
+    )
+    inputs["us:regulations/42-cfr/435/116#input.person_is_pregnant"] = bool(
+        pregnant_nfc
+    )
+    inputs[
+        "us:regulations/42-cfr/435/116#input.household_income_as_fraction_of_fpl"
+    ] = shared_income_fraction
+    inputs[
+        "us:regulations/42-cfr/435/116#input.state_plan_pregnant_women_income_standard_fpl_ratio"
+    ] = pregnant_limit
+    inputs[
+        "us:regulations/42-cfr/435/116#input.state_plan_full_medicaid_applicable_income_limit_fpl_ratio"
+    ] = pregnant_limit
+
+    inputs[
+        "us:regulations/42-cfr/435/118#input.household_income_as_fraction_of_fpl"
+    ] = shared_income_fraction
+    inputs[
+        "us:regulations/42-cfr/435/118#input.state_had_authorizing_legislation_for_higher_infant_income_standard"
+    ] = bool(infant_fc)
+    inputs[
+        "us:regulations/42-cfr/435/118#input.state_plan_authorized_infant_income_standard_fpl_ratio"
+    ] = child_limit
+    inputs[
+        "us:regulations/42-cfr/435/118#input.state_plan_age_group_grandfathered_income_standard_fpl_ratio"
+    ] = child_limit
+    inputs[
+        "us:regulations/42-cfr/435/118#input.state_plan_child_income_standard_fpl_ratio"
+    ] = child_limit
+
+    inputs["us:regulations/42-cfr/435/119#input.person_is_pregnant"] = bool(
+        pregnant_nfc
+    )
+    inputs[
+        "us:regulations/42-cfr/435/119#input.person_entitled_to_or_enrolled_in_medicare_part_a_or_b"
+    ] = bool(medicare_eligible)
+    inputs[
+        "us:regulations/42-cfr/435/119#input.person_eligible_and_enrolled_for_mandatory_medicaid_under_subpart_b"
+    ] = bool(mandatory_subpart_b)
+    inputs[
+        "us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl"
+    ] = shared_income_fraction
+    inputs["us:regulations/42-cfr/435/119#input.person_is_parent_or_caretaker_relative"] = bool(
+        parent_nfc
+    )
+    inputs[
+        "us:regulations/42-cfr/435/119#input.person_lives_with_dependent_child_under_age_threshold"
+    ] = False
+    inputs["us:regulations/42-cfr/435/119#input.dependent_child_receiving_medicaid"] = True
+    inputs["us:regulations/42-cfr/435/119#input.dependent_child_receiving_chip"] = False
+    inputs[
+        "us:regulations/42-cfr/435/119#input.dependent_child_enrolled_in_minimum_essential_coverage"
+    ] = True
+
+    inputs[
+        "us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_aged_blind_or_disabled"
+    ] = bool(ssi_recipient)
+    inputs[
+        "us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_receiving_or_deemed_receiving_ssi"
+    ] = bool(ssi_recipient)
+
+    inputs[
+        "us:regulations/42-cfr/435/150#input.person_eligible_and_enrolled_for_mandatory_coverage_under_435_110_through_435_118_or_435_120_through_435_145"
+    ] = bool(mandatory_subpart_b)
+    inputs[
+        "us:regulations/42-cfr/435/150#input.person_was_in_foster_care_under_state_or_tribe_responsibility_upon_attaining_age_18"
+    ] = False
+    inputs[
+        "us:regulations/42-cfr/435/150#input.person_was_enrolled_in_medicaid_under_state_plan_or_1115_demonstration_upon_attaining_age_18"
+    ] = False
+
+    inputs["us:statutes/42/1396a/xx#input.monthly_work_hours"] = (
+        80 if work_requirement_eligible else 0
+    )
+    inputs["us:statutes/42/1396a/xx#input.monthly_income"] = 0
+    inputs[
+        "us:statutes/42/1396a/xx#input.was_described_in_subsection_a_10_A_i_I_through_VII_for_part_or_all_of_month"
+    ] = bool(mandatory_subpart_b)
+    inputs[
+        "us:statutes/42/1396a/xx#input.was_under_age_19_for_part_or_all_of_month"
+    ] = numeric_age < 19
+    inputs[
+        "us:statutes/42/1396a/xx#input.was_entitled_to_or_enrolled_for_medicare_part_a_or_b_for_part_or_all_of_month"
+    ] = bool(medicare_eligible)
+    return inputs
+
+
+def load_policyengine_cases(
+    *,
+    base_inputs: dict[str, Any],
+    period: Period,
+    state_filter: str | None,
+    sample_size: int | None,
+    pre_sample_households_count: int | None,
+    positive_only: bool,
+    populace_year: int,
+) -> list[PersonCase]:
+    try:
+        from policyengine_us import Microsimulation
+    except Exception as exc:  # pragma: no cover - depends on optional deps
+        raise SystemExit(_policyengine_import_error_message(exc)) from exc
+
+    print(f"Loading PolicyEngine Populace US {populace_year} dataset...", flush=True)
+    dataset = load_populace_dataset(
+        "us",
+        year=populace_year,
+        command="medicaid-populace-compare",
+    )
+    if pre_sample_households_count is not None:
+        dataset = pre_sample_households(
+            dataset,
+            household_count=pre_sample_households_count,
+            state_filter=state_filter,
+        )
+        print(
+            "Pre-sampled "
+            f"{len(dataset.household):,} households and {len(dataset.person):,} "
+            "people before constructing PolicyEngine.",
+            flush=True,
+        )
+    print("Constructing PolicyEngine simulation...", flush=True)
+    sim = Microsimulation(dataset=dataset)
+
+    year = period.year
+    print(f"Calculating PolicyEngine {COMPARED_POLICYENGINE_OUTPUT}...", flush=True)
+    pe_eligible = calculate(sim, COMPARED_POLICYENGINE_OUTPUT, year).astype(bool)
+    count = len(pe_eligible)
+    states = _person_state_codes(sim, year, count)
+    mask = np.ones(count, dtype=bool)
+    if state_filter:
+        mask &= states == state_filter.upper()
+    if positive_only:
+        mask &= pe_eligible
+    indices = np.flatnonzero(mask)
+    if sample_size is not None:
+        indices = indices[:sample_size]
+
+    print(f"Projecting {len(indices):,} Populace people...", flush=True)
+    values = {
+        "age": calculate(sim, "age", year),
+        "medicaid_income_level": calculate(sim, "medicaid_income_level", year),
+        "medicaid_category": calculate(sim, "medicaid_category", year),
+        "parent_fc": calculate(sim, "is_parent_for_medicaid_fc", year).astype(bool),
+        "parent_nfc": calculate(sim, "is_parent_for_medicaid_nfc", year).astype(bool),
+        "pregnant_nfc": calculate(sim, "is_pregnant_for_medicaid_nfc", year).astype(
+            bool
+        ),
+        "pregnant_fc": calculate(sim, "is_pregnant_for_medicaid_fc", year).astype(bool),
+        "infant_fc": calculate(sim, "is_infant_for_medicaid_fc", year).astype(bool),
+        "young_child_fc": calculate(sim, "is_young_child_for_medicaid_fc", year).astype(bool),
+        "older_child": calculate(sim, "is_older_child_for_medicaid", year).astype(bool),
+        "adult_nfc": calculate(sim, "is_adult_for_medicaid_nfc", year).astype(bool),
+        "adult_fc": calculate(sim, "is_adult_for_medicaid_fc", year).astype(bool),
+        "ssi": calculate(sim, "is_ssi_recipient_for_medicaid", year).astype(bool),
+        "medicare": calculate_or_default(
+            sim, "is_medicare_eligible", year, False, count
+        ).astype(bool),
+        "work": calculate_or_default(
+            sim,
+            "medicaid_work_requirement_eligible",
+            year,
+            True,
+            count,
+        ).astype(bool),
+        "immigration": calculate_or_default(
+            sim,
+            "is_medicaid_immigration_status_eligible",
+            year,
+            True,
+            count,
+        ).astype(bool),
+        "ca_ffyp": calculate_or_default(
+            sim, "ca_ffyp_eligible", year, False, count
+        ).astype(bool),
+        "il_hbi": calculate_or_default(
+            sim, "il_hbi_eligible", year, False, count
+        ).astype(bool),
+    }
+
+    cases: list[PersonCase] = []
+    for raw_index in indices:
+        index = int(raw_index)
+        age = float(values["age"][index])
+        child_mandatory = bool(
+            (age < 1 and values["infant_fc"][index])
+            or (1 <= age <= 5 and values["young_child_fc"][index])
+            or values["older_child"][index]
+        )
+        mandatory_subpart_b = bool(
+            values["parent_fc"][index]
+            and values["parent_nfc"][index]
+            or values["pregnant_fc"][index]
+            and values["pregnant_nfc"][index]
+            or child_mandatory
+            or values["older_child"][index]
+            or values["ssi"][index]
+        )
+        inputs = _project_case_inputs(
+            base_inputs,
+            age=age,
+            medicaid_income_level=float(values["medicaid_income_level"][index]),
+            parent_nfc=bool(values["parent_nfc"][index]),
+            parent_fc=bool(values["parent_fc"][index]),
+            pregnant_nfc=bool(values["pregnant_nfc"][index]),
+            pregnant_fc=bool(values["pregnant_fc"][index]),
+            infant_fc=bool(values["infant_fc"][index]),
+            young_child_fc=bool(values["young_child_fc"][index]),
+            older_child_eligible=bool(values["older_child"][index]),
+            adult_nfc=bool(values["adult_nfc"][index]),
+            adult_fc=bool(values["adult_fc"][index]),
+            ssi_recipient=bool(values["ssi"][index]),
+            mandatory_subpart_b=mandatory_subpart_b,
+            work_requirement_eligible=bool(values["work"][index]),
+            medicare_eligible=bool(values["medicare"][index]),
+        )
+        cases.append(
+            PersonCase(
+                person_index=index,
+                state=str(states[index]),
+                inputs=inputs,
+                pe_outputs={
+                    COMPARED_POLICYENGINE_OUTPUT: bool(pe_eligible[index]),
+                    "age": float(values["age"][index]),
+                    "medicaid_income_level": float(
+                        values["medicaid_income_level"][index]
+                    ),
+                    "medicaid_category": str(values["medicaid_category"][index]),
+                    "is_parent_for_medicaid_nfc": bool(
+                        values["parent_nfc"][index]
+                    ),
+                    "is_parent_for_medicaid_fc": bool(values["parent_fc"][index]),
+                    "is_pregnant_for_medicaid_nfc": bool(
+                        values["pregnant_nfc"][index]
+                    ),
+                    "is_pregnant_for_medicaid_fc": bool(
+                        values["pregnant_fc"][index]
+                    ),
+                    "is_infant_for_medicaid_fc": bool(values["infant_fc"][index]),
+                    "is_young_child_for_medicaid_fc": bool(
+                        values["young_child_fc"][index]
+                    ),
+                    "is_older_child_for_medicaid": bool(
+                        values["older_child"][index]
+                    ),
+                    "is_adult_for_medicaid_nfc": bool(values["adult_nfc"][index]),
+                    "is_adult_for_medicaid_fc": bool(values["adult_fc"][index]),
+                    "is_ssi_recipient_for_medicaid": bool(values["ssi"][index]),
+                    "is_medicare_eligible": bool(values["medicare"][index]),
+                    "medicaid_work_requirement_eligible": bool(
+                        values["work"][index]
+                    ),
+                    "projected_mandatory_subpart_b": mandatory_subpart_b,
+                    "is_medicaid_immigration_status_eligible": bool(
+                        values["immigration"][index]
+                    ),
+                    "ca_ffyp_eligible": bool(values["ca_ffyp"][index]),
+                    "il_hbi_eligible": bool(values["il_hbi"][index]),
+                },
+            )
+        )
+    return cases
+
+
+def run_axiom_person_cases(
+    *,
+    binary: Path,
+    artifact: Path,
+    cases: list[PersonCase],
+    period: Period,
+    env: dict[str, str],
+    axiom_output_ids: list[str],
+) -> list[dict[str, Any]]:
+    interval = {"start": period.start.isoformat(), "end": period.end.isoformat()}
+    period_json = {
+        "period_kind": "month",
+        "start": period.start.isoformat(),
+        "end": period.end.isoformat(),
+        "name": period.label,
+    }
+    inputs: list[dict[str, Any]] = []
+    queries: list[dict[str, Any]] = []
+    for case in cases:
+        entity_id = f"person-{case.person_index}"
+        for name, value in case.inputs.items():
+            inputs.append(
+                {
+                    "name": name,
+                    "entity": "Person",
+                    "entity_id": entity_id,
+                    "interval": interval,
+                    "value": scalar_value(value),
+                }
+            )
+        queries.append(
+            {
+                "entity_id": entity_id,
+                "period": period_json,
+                "outputs": axiom_output_ids,
+            }
+        )
+
+    request = {
+        "mode": "fast",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": queries,
+    }
+    result = subprocess.run(
+        [str(binary), "run-compiled", "--artifact", str(artifact)],
+        input=json.dumps(request),
+        text=True,
+        capture_output=True,
+        check=False,
+        env=env,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip())
+    payload = json.loads(result.stdout)
+    return payload["results"]
+
+
+def runtime_output_id_for_public_id(artifact: Path, public_id: str) -> str:
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    public_name = public_id.rsplit("#", 1)[-1]
+    program = payload.get("program") if isinstance(payload, dict) else {}
+    derived = program.get("derived") if isinstance(program, dict) else []
+    matches = [
+        str(output["id"])
+        for output in derived
+        if isinstance(output, dict)
+        and output.get("id")
+        and (
+            output.get("name") == public_name
+            or str(output.get("id")).endswith(f"#{public_name}")
+        )
+    ]
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        raise RuntimeError(f"Compiled artifact does not expose {public_id}.")
+    raise RuntimeError(
+        f"Compiled artifact exposes multiple outputs matching {public_id}: "
+        + ", ".join(matches)
+    )
+
+
+def compare(
+    cases: list[PersonCase],
+    results: list[dict[str, Any]],
+    *,
+    axiom_output_id_by_label: dict[str, str],
+) -> list[dict[str, Any]]:
+    axiom_output_id = axiom_output_id_by_label["eligible"]
+    rows: list[dict[str, Any]] = []
+    for case, result in zip(cases, results, strict=True):
+        raw_outputs = result.get("outputs", {})
+        output_references = outputs_by_reference(raw_outputs)
+        if axiom_output_id not in output_references:
+            raise ValueError(
+                f"Axiom result for person {case.person_index} is missing "
+                f"{axiom_output_id}"
+            )
+        axiom_value = output_to_python(output_references[axiom_output_id])
+        axiom_holds = axiom_value == "holds" or axiom_value is True
+        pe_holds = bool(case.pe_outputs[COMPARED_POLICYENGINE_OUTPUT])
+        row = {
+            "person_index": case.person_index,
+            "state": case.state,
+            "pe_is_medicaid_eligible": pe_holds,
+            "axiom_is_medicaid_eligible": axiom_holds,
+            "match": axiom_holds == pe_holds,
+            "pe_immigration_status_eligible": case.pe_outputs[
+                "is_medicaid_immigration_status_eligible"
+            ],
+            "pe_ca_ffyp_eligible": case.pe_outputs["ca_ffyp_eligible"],
+            "pe_il_hbi_eligible": case.pe_outputs["il_hbi_eligible"],
+            "pe_age": case.pe_outputs["age"],
+            "pe_medicaid_income_level": case.pe_outputs["medicaid_income_level"],
+            "pe_medicaid_category": case.pe_outputs["medicaid_category"],
+            "pe_parent_nfc": case.pe_outputs["is_parent_for_medicaid_nfc"],
+            "pe_parent_fc": case.pe_outputs["is_parent_for_medicaid_fc"],
+            "pe_pregnant_nfc": case.pe_outputs["is_pregnant_for_medicaid_nfc"],
+            "pe_pregnant_fc": case.pe_outputs["is_pregnant_for_medicaid_fc"],
+            "pe_infant_fc": case.pe_outputs["is_infant_for_medicaid_fc"],
+            "pe_young_child_fc": case.pe_outputs["is_young_child_for_medicaid_fc"],
+            "pe_older_child": case.pe_outputs["is_older_child_for_medicaid"],
+            "pe_adult_nfc": case.pe_outputs["is_adult_for_medicaid_nfc"],
+            "pe_adult_fc": case.pe_outputs["is_adult_for_medicaid_fc"],
+            "pe_ssi": case.pe_outputs["is_ssi_recipient_for_medicaid"],
+            "pe_medicare": case.pe_outputs["is_medicare_eligible"],
+            "pe_work": case.pe_outputs["medicaid_work_requirement_eligible"],
+            "projected_mandatory_subpart_b": case.pe_outputs[
+                "projected_mandatory_subpart_b"
+            ],
+        }
+        for label, output_id in axiom_output_id_by_label.items():
+            if label == "eligible":
+                continue
+            value = output_references.get(output_id)
+            rows_value = None
+            if value is not None:
+                python_value = output_to_python(value)
+                rows_value = python_value == "holds" or python_value is True
+            row[f"axiom_{label}"] = rows_value
+        rows.append(row)
+    return rows
+
+
+def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    with path.open("w", newline="", encoding="utf-8") as file:
+        writer = csv.DictWriter(file, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main(args: argparse.Namespace | None = None) -> None:
+    if args is None:
+        args = parse_args()
+    workspace_root = resolve_workspace_root(args.workspace_root)
+    program = resolve_program_path(workspace_root, args.program)
+    test_template = resolve_test_template_path(program, args.test_template)
+    binary = resolve_axiom_binary(workspace_root, args.axiom_binary)
+    if not program.exists():
+        raise SystemExit(f"RuleSpec program not found: {program}")
+    if not test_template.exists():
+        raise SystemExit(f"RuleSpec test template not found: {test_template}")
+    if not binary.exists():
+        raise SystemExit(f"axiom-rules-engine binary not found: {binary}")
+
+    period = month_period(args.year, args.month)
+    base_inputs = load_base_inputs(test_template)
+    cases = load_policyengine_cases(
+        base_inputs=base_inputs,
+        period=period,
+        state_filter=args.state,
+        sample_size=args.sample_size,
+        pre_sample_households_count=args.pre_sample_households,
+        positive_only=args.positive_only,
+        populace_year=args.populace_year,
+    )
+    env = axiom_rules_env(program, workspace_root)
+    with tempfile.TemporaryDirectory(prefix="medicaid-pe-populace-") as tmp_dir:
+        artifact = Path(tmp_dir) / "program.bin"
+        print(f"Compiling {program}...", flush=True)
+        compile_program(binary, program, artifact, env=env)
+        axiom_output_id_by_label = {
+            "eligible": runtime_output_id_for_public_id(
+                artifact, COMPARED_AXIOM_OUTPUT_ID
+            ),
+            **{
+                label: runtime_output_id_for_public_id(artifact, public_id)
+                for label, public_id in AXIOM_COMPONENT_OUTPUT_IDS.items()
+            },
+        }
+        print(
+            f"Resolved {COMPARED_AXIOM_OUTPUT_ID} to runtime output "
+            f"{axiom_output_id_by_label['eligible']}.",
+            flush=True,
+        )
+        print(f"Running Axiom for {len(cases):,} people...", flush=True)
+        results = run_axiom_person_cases(
+            binary=binary,
+            artifact=artifact,
+            cases=cases,
+            period=period,
+            env=env,
+            axiom_output_ids=list(axiom_output_id_by_label.values()),
+        )
+
+    rows = compare(cases, results, axiom_output_id_by_label=axiom_output_id_by_label)
+    matches = sum(1 for row in rows if row["match"])
+    mismatches = len(rows) - matches
+    match_rate = matches / len(rows) if rows else 1.0
+    print(
+        f"Compared {len(rows):,} people; matches={matches:,}; "
+        f"mismatches={mismatches:,}; match_rate={match_rate:.2%}."
+    )
+    for row in [row for row in rows if not row["match"]][: args.max_differences]:
+        print(
+            "DIFF "
+            f"person_index={row['person_index']} state={row['state']} "
+            f"pe={row['pe_is_medicaid_eligible']} "
+            f"axiom={row['axiom_is_medicaid_eligible']} "
+            f"immigration_ok={row['pe_immigration_status_eligible']} "
+            f"ca_ffyp={row['pe_ca_ffyp_eligible']} "
+            f"il_hbi={row['pe_il_hbi_eligible']} "
+            f"category={row['pe_medicaid_category']} "
+            f"adult_fc={row['pe_adult_fc']} work={row['pe_work']} "
+            f"axiom_child={row.get('axiom_child')} "
+            f"axiom_adult={row.get('axiom_adult')} "
+            f"axiom_ssi={row.get('axiom_ssi')}"
+        )
+
+    if args.write_csv is not None:
+        write_csv(args.write_csv, rows)
+        print(f"Wrote {args.write_csv}", flush=True)
+
+    if args.min_match_rate is not None and match_rate < args.min_match_rate:
+        raise SystemExit(
+            f"Match rate {match_rate:.1%} is below required {args.min_match_rate:.1%}"
+        )
+    if args.fail_on_mismatch and mismatches:
+        raise SystemExit(f"{mismatches} Medicaid Populace rows mismatched")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/axiom_encode/oracles/policyengine/medicaid_populace.py
+++ b/src/axiom_encode/oracles/policyengine/medicaid_populace.py
@@ -60,12 +60,10 @@ AXIOM_COMPONENT_OUTPUT_IDS = {
         "#medicaid_required_for_ssi_mandatory_group"
     ),
     "former_foster": (
-        "us:regulations/42-cfr/435/150"
-        "#former_foster_care_child_medicaid_required"
+        "us:regulations/42-cfr/435/150#former_foster_care_child_medicaid_required"
     ),
     "community_engagement": (
-        "us:statutes/42/1396a/xx"
-        "#demonstrated_community_engagement_for_month"
+        "us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month"
     ),
 }
 DEFAULT_PROGRAM_RELATIVE_PATH = Path("us/statutes/42/1396a/a/10.yaml")
@@ -306,7 +304,10 @@ def _person_state_codes(sim: Any, period: int, count: int) -> np.ndarray:
         count,
     )
     return np.asarray(
-        [state_by_household_id.get(int(household_id), "") for household_id in person_household_ids]
+        [
+            state_by_household_id.get(int(household_id), "")
+            for household_id in person_household_ids
+        ]
     )
 
 
@@ -461,9 +462,9 @@ def _project_case_inputs(
     ):
         inputs[key] = numeric_age
 
-    inputs["us:regulations/42-cfr/435/110#input.person_is_parent_or_caretaker_relative"] = bool(
-        parent_nfc
-    )
+    inputs[
+        "us:regulations/42-cfr/435/110#input.person_is_parent_or_caretaker_relative"
+    ] = bool(parent_nfc)
     inputs[
         "us:regulations/42-cfr/435/110#input.person_is_spouse_of_parent_or_caretaker_relative_living_with_them"
     ] = False
@@ -472,9 +473,9 @@ def _project_case_inputs(
     ] = bool(parent_fc)
 
     pregnant_full_eligible = bool(pregnant_nfc and pregnant_fc)
-    pregnant_limit = _threshold_inputs_from_component(
-        eligible=pregnant_full_eligible
-    )[1]
+    pregnant_limit = _threshold_inputs_from_component(eligible=pregnant_full_eligible)[
+        1
+    ]
     child_component_eligible = bool(
         (numeric_age < 1 and infant_fc)
         or (1 <= numeric_age <= 5 and young_child_fc)
@@ -484,9 +485,11 @@ def _project_case_inputs(
     # The current rules engine run request addresses inputs by name within the
     # compiled program. Several imported Medicaid modules use this same local
     # input name, so use one synthetic income projection for all of them.
-    shared_income_fraction = 1.0 if (
-        pregnant_full_eligible or child_component_eligible or adult_full_eligible
-    ) else 2.0
+    shared_income_fraction = (
+        1.0
+        if (pregnant_full_eligible or child_component_eligible or adult_full_eligible)
+        else 2.0
+    )
 
     _, child_limit = _threshold_inputs_from_component(
         eligible=child_component_eligible,
@@ -533,13 +536,15 @@ def _project_case_inputs(
     inputs[
         "us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl"
     ] = shared_income_fraction
-    inputs["us:regulations/42-cfr/435/119#input.person_is_parent_or_caretaker_relative"] = bool(
-        parent_nfc
-    )
+    inputs[
+        "us:regulations/42-cfr/435/119#input.person_is_parent_or_caretaker_relative"
+    ] = bool(parent_nfc)
     inputs[
         "us:regulations/42-cfr/435/119#input.person_lives_with_dependent_child_under_age_threshold"
     ] = False
-    inputs["us:regulations/42-cfr/435/119#input.dependent_child_receiving_medicaid"] = True
+    inputs["us:regulations/42-cfr/435/119#input.dependent_child_receiving_medicaid"] = (
+        True
+    )
     inputs["us:regulations/42-cfr/435/119#input.dependent_child_receiving_chip"] = False
     inputs[
         "us:regulations/42-cfr/435/119#input.dependent_child_enrolled_in_minimum_essential_coverage"
@@ -640,7 +645,9 @@ def load_policyengine_cases(
         ),
         "pregnant_fc": calculate(sim, "is_pregnant_for_medicaid_fc", year).astype(bool),
         "infant_fc": calculate(sim, "is_infant_for_medicaid_fc", year).astype(bool),
-        "young_child_fc": calculate(sim, "is_young_child_for_medicaid_fc", year).astype(bool),
+        "young_child_fc": calculate(sim, "is_young_child_for_medicaid_fc", year).astype(
+            bool
+        ),
         "older_child": calculate(sim, "is_older_child_for_medicaid", year).astype(bool),
         "adult_nfc": calculate(sim, "is_adult_for_medicaid_nfc", year).astype(bool),
         "adult_fc": calculate(sim, "is_adult_for_medicaid_fc", year).astype(bool),
@@ -718,30 +725,20 @@ def load_policyengine_cases(
                         values["medicaid_income_level"][index]
                     ),
                     "medicaid_category": str(values["medicaid_category"][index]),
-                    "is_parent_for_medicaid_nfc": bool(
-                        values["parent_nfc"][index]
-                    ),
+                    "is_parent_for_medicaid_nfc": bool(values["parent_nfc"][index]),
                     "is_parent_for_medicaid_fc": bool(values["parent_fc"][index]),
-                    "is_pregnant_for_medicaid_nfc": bool(
-                        values["pregnant_nfc"][index]
-                    ),
-                    "is_pregnant_for_medicaid_fc": bool(
-                        values["pregnant_fc"][index]
-                    ),
+                    "is_pregnant_for_medicaid_nfc": bool(values["pregnant_nfc"][index]),
+                    "is_pregnant_for_medicaid_fc": bool(values["pregnant_fc"][index]),
                     "is_infant_for_medicaid_fc": bool(values["infant_fc"][index]),
                     "is_young_child_for_medicaid_fc": bool(
                         values["young_child_fc"][index]
                     ),
-                    "is_older_child_for_medicaid": bool(
-                        values["older_child"][index]
-                    ),
+                    "is_older_child_for_medicaid": bool(values["older_child"][index]),
                     "is_adult_for_medicaid_nfc": bool(values["adult_nfc"][index]),
                     "is_adult_for_medicaid_fc": bool(values["adult_fc"][index]),
                     "is_ssi_recipient_for_medicaid": bool(values["ssi"][index]),
                     "is_medicare_eligible": bool(values["medicare"][index]),
-                    "medicaid_work_requirement_eligible": bool(
-                        values["work"][index]
-                    ),
+                    "medicaid_work_requirement_eligible": bool(values["work"][index]),
                     "projected_mandatory_subpart_b": mandatory_subpart_b,
                     "is_medicaid_immigration_status_eligible": bool(
                         values["immigration"][index]

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -153,6 +153,14 @@ surfaces:
   priority: P1
   rationale: PolicyBench scores this direct person-level Medicaid eligibility variable. Axiom has source-level category and
     state-parameter rules, but still needs a PE-facing eligibility composite before claiming parity.
+  populace_validation:
+    status: blocked
+    command: axiom-encode medicaid-populace-compare --program /path/to/rulespec-us/us/statutes/42/1396a/a/10.yaml --workspace-root /path/to/workspace --pre-sample-households 150 --sample-size 50
+    dataset: populace-us-2024 local H5
+    last_run: '2026-06-30'
+    rationale: CA and IL Populace smoke comparisons run against the real Axiom rules engine still show PE SENIOR_OR_DISABLED
+      rows as PE-eligible and Axiom-ineligible. Close optional aged/blind/disabled Medicaid from federal primary sources
+      plus maximally-upstream state-set income and resource standards before marking this surface validated.
 - country: us
   program_id: chip
   program_name: CHIP

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15070,13 +15070,10 @@ rules:
         assert "us:regulations/42-cfr/435/119#adult_group_eligible" not in inputs
         assert (
             "us:statutes/42/1396a/xx"
-            "#demonstrated_community_engagement_for_month"
-            not in inputs
+            "#demonstrated_community_engagement_for_month" not in inputs
         )
         assert (
-            test_payload[0]["output"][
-                "us:statutes/42/1396a/a/10#is_medicaid_eligible"
-            ]
+            test_payload[0]["output"]["us:statutes/42/1396a/a/10#is_medicaid_eligible"]
             == "holds"
         )
 
@@ -20780,8 +20777,7 @@ rules:
         assert "us:statutes/42/1396a/xx#input.monthly_work_hours: 80" in test_text
         assert (
             "us:statutes/42/1396a/a/10#input."
-            "adult_expansion_subject_to_subsections_k_and_xx_satisfied"
-            not in test_text
+            "adult_expansion_subject_to_subsections_k_and_xx_satisfied" not in test_text
         )
 
     def test_not_operational_same_section_import_repair_does_not_add_broad_import(
@@ -21360,9 +21356,7 @@ rules:
         self, tmp_path
     ):
         output_root = tmp_path / "out"
-        rules_file = (
-            output_root / "codex-gpt-5.5" / "statutes/42/1396a/a/10.yaml"
-        )
+        rules_file = output_root / "codex-gpt-5.5" / "statutes/42/1396a/a/10.yaml"
         test_file = rules_file.with_name("10.test.yaml")
         rules_file.parent.mkdir(parents=True)
         policy_repo = tmp_path / "rulespec-us"
@@ -21415,9 +21409,7 @@ rules:
         payload = yaml.safe_load(rules_file.read_text())
         assert payload["module"].get("deferred_outputs") is None
         assert [
-            rule["name"]
-            for rule in payload["rules"]
-            if isinstance(rule, dict)
+            rule["name"] for rule in payload["rules"] if isinstance(rule, dict)
         ] == ["is_medicaid_eligible"]
         assert "is_medicaid_eligible" in test_file.read_text()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,6 +139,7 @@ from axiom_encode.cli import (
     _try_repair_generated_empty_test_outputs_for_apply,
     _try_repair_generated_import_output_inputs_for_apply,
     _try_repair_generated_import_target_prefix_typos_for_apply,
+    _try_repair_generated_imported_output_test_mismatches_for_apply,
     _try_repair_generated_invalid_source_relation_types_for_apply,
     _try_repair_generated_judgment_conditionals_for_apply,
     _try_repair_generated_judgment_numeric_comparisons_for_apply,
@@ -14938,6 +14939,147 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_imported_output_repair_satisfies_positive_judgment_composition(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "codex-gpt-5.5" / "statutes/42/1396a/a/10.yaml"
+        test_file = rules_file.with_name("10.test.yaml")
+        rules_file.parent.mkdir(parents=True)
+        policy_repo = tmp_path / "rulespec-us"
+        parent_file = policy_repo / "us" / "regulations/42-cfr/435/110.yaml"
+        adult_file = policy_repo / "us" / "regulations/42-cfr/435/119.yaml"
+        engagement_file = policy_repo / "us" / "statutes/42/1396a/xx.yaml"
+        for path, output_name, formula in [
+            (
+                parent_file,
+                "parent_or_caretaker_relative_eligible",
+                "person_is_parent_or_caretaker_relative",
+            ),
+            (
+                adult_file,
+                "adult_group_eligible",
+                "household_income_as_fraction_of_fpl <= 1.38",
+            ),
+            (
+                engagement_file,
+                "demonstrated_community_engagement_for_month",
+                "monthly_work_hours >= 80",
+            ),
+        ]:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                f"""format: rulespec/v1
+rules:
+  - name: {output_name}
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-01-01'
+        formula: {formula}
+"""
+            )
+        parent_file.with_suffix(".test.yaml").write_text(
+            """- name: parent eligible
+  input:
+    us:regulations/42-cfr/435/110#input.person_is_parent_or_caretaker_relative: true
+  output:
+    us:regulations/42-cfr/435/110#parent_or_caretaker_relative_eligible: holds
+"""
+        )
+        adult_file.with_suffix(".test.yaml").write_text(
+            """- name: adult group eligible
+  input:
+    us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl: 1.0
+  output:
+    us:regulations/42-cfr/435/119#adult_group_eligible: holds
+"""
+        )
+        engagement_file.with_suffix(".test.yaml").write_text(
+            """- name: work hours satisfy monthly engagement
+  input:
+    us:statutes/42/1396a/xx#input.monthly_work_hours: 80
+  output:
+    us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month: holds
+"""
+        )
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:regulations/42-cfr/435/110#parent_or_caretaker_relative_eligible
+  - us:regulations/42-cfr/435/119#adult_group_eligible
+  - us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month
+rules:
+  - name: is_medicaid_eligible
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          parent_or_caretaker_relative_eligible
+          or (adult_group_eligible and demonstrated_community_engagement_for_month)
+"""
+        )
+        test_file.write_text(
+            """- name: adult expansion group eligible
+  input:
+    us:regulations/42-cfr/435/110#input.person_is_parent_or_caretaker_relative: false
+    us:regulations/42-cfr/435/110#input.household_income_as_fraction_of_fpl: 2.0
+    us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl: 1.0
+    us:statutes/42/1396a/xx#input.monthly_work_hours: 80
+  output:
+    us:statutes/42/1396a/a/10#is_medicaid_eligible: holds
+"""
+        )
+        result = SimpleNamespace(
+            runner="codex-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = _try_repair_generated_imported_output_test_mismatches_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "statutes/42/1396a/a/10.yaml: ci: Test case "
+                "`adult expansion group eligible` output "
+                "us:statutes/42/1396a/a/10#is_medicaid_eligible "
+                "expected holds, got not_holds."
+            ],
+        )
+
+        assert repaired == [
+            "test:adult expansion group eligible:"
+            "us:regulations/42-cfr/435/110"
+            "#input.household_income_as_fraction_of_fpl="
+            "input.household_income_as_fraction_of_fpl"
+        ]
+        test_payload = yaml.safe_load(test_file.read_text())
+        inputs = test_payload[0]["input"]
+        assert (
+            inputs[
+                "us:regulations/42-cfr/435/110"
+                "#input.household_income_as_fraction_of_fpl"
+            ]
+            == 1.0
+        )
+        assert (
+            "us:regulations/42-cfr/435/110#parent_or_caretaker_relative_eligible"
+            not in inputs
+        )
+        assert "us:regulations/42-cfr/435/119#adult_group_eligible" not in inputs
+        assert (
+            "us:statutes/42/1396a/xx"
+            "#demonstrated_community_engagement_for_month"
+            not in inputs
+        )
+        assert (
+            test_payload[0]["output"][
+                "us:statutes/42/1396a/a/10#is_medicaid_eligible"
+            ]
+            == "holds"
+        )
+
     def test_encode_apply_retries_unsafe_deferral_after_positive_repair(
         self, capsys, tmp_path
     ):
@@ -20385,6 +20527,335 @@ rules:
             not in test_file.read_text()
         )
 
+    def test_missing_same_section_import_repair_gates_imported_adult_group(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "codex-gpt-5.5" / "statutes/42/1396a/a/10.yaml"
+        test_file = rules_file.with_name("10.test.yaml")
+        rules_file.parent.mkdir(parents=True)
+        policy_repo = tmp_path / "rulespec-us"
+        cited_file = policy_repo / "us" / "statutes" / "42" / "1396a" / "xx.yaml"
+        cited_file.parent.mkdir(parents=True)
+        cited_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: demonstrated_community_engagement_for_month
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-12-31'
+        formula: community_engagement_met_by_activity_or_income
+  - name: specified_excluded_individual
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-12-31'
+        formula: person_has_exclusion
+"""
+        )
+        cited_file.with_suffix(".test.yaml").write_text(
+            """- name: work hours satisfy monthly engagement
+  period: 2027-01
+  input:
+    us:statutes/42/1396a/xx#input.monthly_work_hours: 80
+  output:
+    us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month: holds
+"""
+        )
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/42/1396a/xx
+  - us:regulations/42-cfr/435/119#adult_group_eligible
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: is_medicaid_eligible
+    kind: derived
+    dtype: Judgment
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/119#adult_group_eligible
+              output: adult_group_eligible
+              hash: sha256:local
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          parent_or_caretaker_relative_eligible
+          or adult_group_eligible
+          or former_foster_care_child_medicaid_required
+"""
+        )
+        test_file.write_text(
+            """- name: adult group eligibility makes medical assistance available
+  period: 2024-01
+  input:
+    us:regulations/42-cfr/435/119#input.person_age: 40
+  output:
+    us:statutes/42/1396a/a/10#is_medicaid_eligible: holds
+"""
+        )
+        result = SimpleNamespace(
+            runner="codex-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = (
+            _try_repair_generated_missing_same_section_subsection_imports_for_apply(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                issues=[
+                    "statutes/42/1396a/a/10.yaml: ci: Same-section subsection "
+                    "import not operational: source text cites `statutes/42/1396a/xx` "
+                    "in an exception/cross-reference clause, but the matching import "
+                    "does not bring a specific imported output into the formula."
+                ],
+            )
+        )
+
+        assert repaired == [
+            ("us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month"),
+            (
+                "adult_expansion_subject_to_xx"
+                "->demonstrated_community_engagement_for_month"
+            ),
+            (
+                "test:adult group eligibility makes medical assistance available:"
+                "us:statutes/42/1396a/xx"
+                "#demonstrated_community_engagement_for_month"
+            ),
+        ]
+        rules_text = rules_file.read_text()
+        assert (
+            "  - us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month\n"
+        ) in rules_text
+        assert "  - us:statutes/42/1396a/xx\n" not in rules_text
+        assert (
+            "          or (adult_group_eligible "
+            "and demonstrated_community_engagement_for_month)\n"
+        ) in rules_text
+        assert "path: versions[0].formula" in rules_text
+        assert (
+            "target: us:statutes/42/1396a/xx"
+            "#demonstrated_community_engagement_for_month"
+        ) in rules_text
+        test_text = test_file.read_text()
+        assert "period: 2027-01" in test_text
+        assert "us:statutes/42/1396a/xx#input.monthly_work_hours: 80" in test_text
+
+    def test_not_operational_same_section_import_repair_replaces_medicaid_xx_placeholder_in_adult_group(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "codex-gpt-5.5" / "statutes/42/1396a/a/10.yaml"
+        test_file = rules_file.with_name("10.test.yaml")
+        rules_file.parent.mkdir(parents=True)
+        policy_repo = tmp_path / "rulespec-us"
+        cited_file = policy_repo / "us" / "statutes" / "42" / "1396a" / "xx.yaml"
+        cited_file.parent.mkdir(parents=True)
+        cited_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: demonstrated_community_engagement_for_month
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-12-31'
+        formula: community_engagement_met_by_activity_or_income
+  - name: specified_excluded_individual
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-12-31'
+        formula: person_has_exclusion
+"""
+        )
+        cited_file.with_suffix(".test.yaml").write_text(
+            """- name: work hours satisfy monthly engagement
+  period: 2027-01
+  input:
+    us:statutes/42/1396a/xx#input.monthly_work_hours: 80
+  output:
+    us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month: holds
+"""
+        )
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/42/1396a/xx
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: adult_expansion_group
+    kind: derived
+    dtype: Judgment
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/42/1396a/a/10
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          age < adult_expansion_age_ceiling_years
+          and adult_expansion_subject_to_subsections_k_and_xx_satisfied
+  - name: is_medicaid_eligible
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          adult_expansion_group
+"""
+        )
+        test_file.write_text(
+            """- name: adult expansion eligible below income limit
+  period: 2024-01
+  input:
+    us:statutes/42/1396a/a/10#input.age: 40
+    us:statutes/42/1396a/a/10#input.adult_expansion_subject_to_subsections_k_and_xx_satisfied: true
+  output:
+    us:statutes/42/1396a/a/10#adult_expansion_group: holds
+    us:statutes/42/1396a/a/10#is_medicaid_eligible: holds
+"""
+        )
+        result = SimpleNamespace(
+            runner="codex-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = (
+            _try_repair_generated_missing_same_section_subsection_imports_for_apply(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                issues=[
+                    "statutes/42/1396a/a/10.yaml: ci: Same-section subsection "
+                    "import not operational: source text cites `statutes/42/1396a/xx` "
+                    "in an exception/cross-reference clause, but the matching import "
+                    "does not bring a specific imported output into the formula."
+                ],
+            )
+        )
+
+        assert repaired == [
+            "us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month",
+            (
+                "adult_expansion_subject_to_subsections_k_and_xx_satisfied"
+                "->demonstrated_community_engagement_for_month"
+            ),
+            (
+                "test:adult expansion eligible below income limit:"
+                "us:statutes/42/1396a/xx"
+                "#demonstrated_community_engagement_for_month"
+            ),
+        ]
+        rules_text = rules_file.read_text()
+        assert (
+            "  - us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month\n"
+            in rules_text
+        )
+        assert "  - us:statutes/42/1396a/xx\n" not in rules_text
+        assert (
+            "and adult_expansion_subject_to_subsections_k_and_xx_satisfied"
+            not in rules_text
+        )
+        assert "and demonstrated_community_engagement_for_month\n" in rules_text
+        assert (
+            "target: us:statutes/42/1396a/xx"
+            "#demonstrated_community_engagement_for_month"
+        ) in rules_text
+        test_text = test_file.read_text()
+        assert "period: 2027-01" in test_text
+        assert "us:statutes/42/1396a/xx#input.monthly_work_hours: 80" in test_text
+        assert (
+            "us:statutes/42/1396a/a/10#input."
+            "adult_expansion_subject_to_subsections_k_and_xx_satisfied"
+            not in test_text
+        )
+
+    def test_not_operational_same_section_import_repair_does_not_add_broad_import(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = output_root / "codex-gpt-5.5" / "statutes/42/1396a/a/10.yaml"
+        rules_file.parent.mkdir(parents=True)
+        policy_repo = tmp_path / "rulespec-us"
+        cited_file = policy_repo / "us" / "statutes" / "42" / "1396a" / "xx.yaml"
+        cited_file.parent.mkdir(parents=True)
+        cited_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: demonstrated_community_engagement_for_month
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-12-31'
+        formula: community_engagement_met_by_activity_or_income
+  - name: specified_excluded_individual
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-12-31'
+        formula: person_has_exclusion
+"""
+        )
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month
+module:
+  proof_validation:
+    required: true
+  deferred_outputs:
+    - output: us:statutes/42/1396a/a/10/a#is_medicaid_eligible
+      reason: Deferred after validation.
+rules:
+  - name: adult_expansion_income_limit_poverty_line_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2014-01-01'
+        formula: '1.33'
+"""
+        )
+        result = SimpleNamespace(
+            runner="codex-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = (
+            _try_repair_generated_missing_same_section_subsection_imports_for_apply(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                issues=[
+                    "statutes/42/1396a/a/10.yaml: ci: Same-section subsection "
+                    "import not operational: source text cites `statutes/42/1396a/xx` "
+                    "in an exception/cross-reference clause, but the matching import "
+                    "does not bring a specific imported output into the formula."
+                ],
+            )
+        )
+
+        assert repaired == []
+        rules_text = rules_file.read_text()
+        assert (
+            "  - us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month\n"
+            in rules_text
+        )
+        assert "  - us:statutes/42/1396a/xx\n" not in rules_text
+
     def test_missing_same_section_import_repair_promotes_cfr_placeholder(
         self, tmp_path
     ):
@@ -20884,6 +21355,71 @@ rules:
             record["output"] for record in payload["module"]["deferred_outputs"]
         ] == repaired
         assert test_cases == []
+
+    def test_unsafe_formula_output_repair_keeps_imported_judgment_composition(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = (
+            output_root / "codex-gpt-5.5" / "statutes/42/1396a/a/10.yaml"
+        )
+        test_file = rules_file.with_name("10.test.yaml")
+        rules_file.parent.mkdir(parents=True)
+        policy_repo = tmp_path / "rulespec-us"
+        policy_repo.mkdir()
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:regulations/42-cfr/435/110#parent_or_caretaker_relative_eligible
+  - us:regulations/42-cfr/435/119#adult_group_eligible
+  - us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: is_medicaid_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    source: 42 USC 1396a(a)(10)(A)
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          parent_or_caretaker_relative_eligible
+          or (adult_group_eligible and demonstrated_community_engagement_for_month)
+"""
+        )
+        test_file.write_text(
+            """- name: adult group with community engagement
+  output:
+    us:statutes/42/1396a/a/10#is_medicaid_eligible: holds
+"""
+        )
+        result = SimpleNamespace(
+            runner="codex-gpt-5.5",
+            output_file=str(rules_file),
+        )
+
+        repaired = _try_repair_generated_unsafe_formula_outputs_for_apply(
+            result,
+            output_root=output_root,
+            policy_repo_path=policy_repo,
+            issues=[
+                "statutes/42/1396a/a/10.yaml: ci: Flattened thresholded "
+                "imported rate: `is_medicaid_eligible` uses imported "
+                "`adult_group_eligible`."
+            ],
+        )
+
+        assert repaired == []
+        payload = yaml.safe_load(rules_file.read_text())
+        assert payload["module"].get("deferred_outputs") is None
+        assert [
+            rule["name"]
+            for rule in payload["rules"]
+            if isinstance(rule, dict)
+        ] == ["is_medicaid_eligible"]
+        assert "is_medicaid_eligible" in test_file.read_text()
 
     def test_unsafe_formula_output_repair_defers_cross_reference_placeholders(
         self, tmp_path

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -39,6 +39,7 @@ from axiom_encode.harness.evals import (
     _normalize_nonannual_test_period_value,
     _normalize_test_case_value,
     _normalize_test_periods_to_effective_dates,
+    _policyengine_hint_upstream_composition_issues,
     _post_openai_eval_request,
     _prepare_codex_eval_home,
     _prompt_corpus_citation_path,
@@ -11438,12 +11439,36 @@ class TestSourceEval:
             mode="cold",
             extra_context_paths=[],
         )
+        context_source = tmp_path / "adult-group.yaml"
+        context_source.write_text(
+            """format: rulespec/v1
+rules:
+  - name: adult_group_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    versions:
+      - effective_from: '2024-01-01'
+        formula: age >= 19
+""",
+            encoding="utf-8",
+        )
+        workspace_context = workspace.root / "context" / "adult-group.yaml"
+        workspace_context.parent.mkdir(parents=True)
+        workspace_context.write_text(context_source.read_text(), encoding="utf-8")
+        context_file = EvalContextFile(
+            source_path=str(context_source),
+            workspace_path="context/adult-group.yaml",
+            import_path="us:regulations/42-cfr/435/119",
+            kind="allowed_context",
+        )
 
         prompt = _build_eval_prompt(
             "uksi/2013/376/regulation/36/3",
             "cold",
             workspace,
-            [],
+            [context_file],
             target_file_name="example.yaml",
             include_tests=True,
             runner_backend="openai",
@@ -11451,6 +11476,12 @@ class TestSourceEval:
         )
 
         assert "uc_standard_allowance_single_claimant_aged_under_25" in prompt
+        assert "Treat `uc_standard_allowance_single_claimant_aged_under_25` as a required oracle-facing surface" in prompt
+        assert "Do not" in prompt
+        assert "module.deferred_outputs[]" in prompt
+        assert "import that" in prompt
+        assert "concrete output instead of leaving the broad phrase" in prompt
+        assert "person_is_in_*_category" in prompt
         assert "Keep `.test.yaml` inputs oracle-comparable" in prompt
         assert (
             "Prefer a contemporary monthly `.test.yaml` period like `2022-01` or `2024-01`"
@@ -11470,10 +11501,110 @@ class TestSourceEval:
         assert "assert that canonical copied output" in prompt
         assert "key the test by that id rather than the friendly local name" in prompt
         assert "Key inputs by their resolving legal RuleSpec target too" in prompt
+        assert "For an aggregate/composite hinted output" in prompt
+        assert "first enumerate the executable" in prompt
+        assert "Executable Judgment exports visible in copied context" in prompt
+        assert "us:regulations/42-cfr/435/119#adult_group_eligible" in prompt
+        assert "person_covered_by_*category" in prompt
+        assert "Do not let the oracle-facing hinted" in prompt
         assert (
             "avoid pre-2015 historical periods that PolicyEngine US cannot evaluate"
             in prompt
         )
+
+    def test_policyengine_hint_upstream_composition_flags_broad_placeholders(self):
+        content = """
+format: rulespec/v1
+module:
+  deferred_outputs:
+    - output: us:statutes/42/1396a/a/10#other_surface
+      reason: not relevant
+rules:
+  - name: is_medicaid_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 USC 1396a(a)(10)
+    versions:
+      - effective_from: '2024-01-01'
+        formula: |-
+          adult_group_eligible
+          or person_covered_by_other_mandatory_subparagraph_A_i_category
+          or person_is_described_in_previous_mandatory_subclause
+          or income_as_determined_under_subsection_e_14 <= income_limit
+"""
+
+        issues = _policyengine_hint_upstream_composition_issues(
+            content,
+            "is_medicaid_eligible",
+        )
+
+        assert len(issues) == 1
+        assert "broad upstream placeholder" in issues[0]
+        assert "person_covered_by_other_mandatory_subparagraph_A_i_category" in issues[0]
+        assert "person_is_described_in_previous_mandatory_subclause" in issues[0]
+        assert "income_as_determined_under_subsection_e_14" in issues[0]
+
+    def test_policyengine_hint_upstream_composition_flags_transitive_placeholders(self):
+        content = """
+format: rulespec/v1
+rules:
+  - name: adult_expansion_mandatory_group_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 USC 1396a(a)(10)(A)(i)(VIII)
+    versions:
+      - effective_from: '2024-01-01'
+        formula: |-
+          not person_is_described_in_previous_mandatory_subclause
+          and income_determined_for_adult_expansion <= income_limit
+          and adult_expansion_subject_to_subsections_k_and_xx_satisfied
+  - name: is_medicaid_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 USC 1396a(a)(10)
+    versions:
+      - effective_from: '2024-01-01'
+        formula: |-
+          person_receives_aid_or_assistance_under_listed_state_plan
+          or person_meets_ssi_related_mandatory_group
+          or adult_expansion_mandatory_group_eligible
+"""
+
+        issues = _policyengine_hint_upstream_composition_issues(
+            content,
+            "is_medicaid_eligible",
+        )
+
+        assert len(issues) == 1
+        assert "person_receives_aid_or_assistance_under_listed_state_plan" in issues[0]
+        assert "person_meets_ssi_related_mandatory_group" in issues[0]
+        assert "person_is_described_in_previous_mandatory_subclause" in issues[0]
+        assert "income_determined_for_adult_expansion" in issues[0]
+        assert "adult_expansion_subject_to_subsections_k_and_xx_satisfied" in issues[0]
+
+    def test_policyengine_hint_upstream_composition_flags_deferred_hint(self):
+        content = """
+format: rulespec/v1
+module:
+  deferred_outputs:
+    - output: us:statutes/42/1396a/a/10#is_medicaid_eligible
+      reason: broad source
+rules: []
+"""
+
+        issues = _policyengine_hint_upstream_composition_issues(
+            content,
+            "is_medicaid_eligible",
+        )
+
+        assert len(issues) == 1
+        assert "is deferred" in issues[0]
 
     def test_build_eval_prompt_includes_sets_source_metadata_guidance(self, tmp_path):
         runner = parse_runner_spec("openai:gpt-5.4")

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -11476,7 +11476,10 @@ rules:
         )
 
         assert "uc_standard_allowance_single_claimant_aged_under_25" in prompt
-        assert "Treat `uc_standard_allowance_single_claimant_aged_under_25` as a required oracle-facing surface" in prompt
+        assert (
+            "Treat `uc_standard_allowance_single_claimant_aged_under_25` as a required oracle-facing surface"
+            in prompt
+        )
         assert "Do not" in prompt
         assert "module.deferred_outputs[]" in prompt
         assert "import that" in prompt
@@ -11542,7 +11545,9 @@ rules:
 
         assert len(issues) == 1
         assert "broad upstream placeholder" in issues[0]
-        assert "person_covered_by_other_mandatory_subparagraph_A_i_category" in issues[0]
+        assert (
+            "person_covered_by_other_mandatory_subparagraph_A_i_category" in issues[0]
+        )
         assert "person_is_described_in_previous_mandatory_subclause" in issues[0]
         assert "income_as_determined_under_subsection_e_14" in issues[0]
 

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -969,6 +969,9 @@ def test_policyengine_program_surface_includes_policybench_person_eligibility_su
     assert medicaid["axiom_status"] == "pending_rulespec_encoding"
     assert medicaid["mapping_count"] == 1
     assert medicaid["comparable_mapping_count"] == 1
+    assert medicaid["populace_validation_status"] == "blocked"
+    assert "medicaid-populace-compare" in medicaid["populace_validation_command"]
+    assert "SENIOR_OR_DISABLED" in medicaid["populace_validation_rationale"]
     assert medicaid["policybench_output"] == "person_level_medicaid_eligibility"
     assert medicaid["policybench_household_weight"] == pytest.approx(29.86)
 

--- a/tests/test_policyengine_medicaid_populace.py
+++ b/tests/test_policyengine_medicaid_populace.py
@@ -132,3 +132,49 @@ def test_project_case_inputs_uses_shared_income_projection_for_medicaid_imports(
         ]
         == 1.0
     )
+
+
+def test_summarize_by_pe_category_counts_directional_mismatches():
+    rows = [
+        {
+            "pe_medicaid_category": "SENIOR_OR_DISABLED",
+            "pe_is_medicaid_eligible": True,
+            "axiom_is_medicaid_eligible": False,
+            "match": False,
+        },
+        {
+            "pe_medicaid_category": "SENIOR_OR_DISABLED",
+            "pe_is_medicaid_eligible": True,
+            "axiom_is_medicaid_eligible": True,
+            "match": True,
+        },
+        {
+            "pe_medicaid_category": "ADULT",
+            "pe_is_medicaid_eligible": False,
+            "axiom_is_medicaid_eligible": True,
+            "match": False,
+        },
+    ]
+
+    summary = medicaid_populace.summarize_by_pe_category(rows)
+
+    assert summary == [
+        {
+            "category": "SENIOR_OR_DISABLED",
+            "compared": 2,
+            "pe_eligible": 2,
+            "axiom_eligible": 1,
+            "mismatches": 1,
+            "pe_true_axiom_false": 1,
+            "pe_false_axiom_true": 0,
+        },
+        {
+            "category": "ADULT",
+            "compared": 1,
+            "pe_eligible": 0,
+            "axiom_eligible": 1,
+            "mismatches": 1,
+            "pe_true_axiom_false": 0,
+            "pe_false_axiom_true": 1,
+        },
+    ]

--- a/tests/test_policyengine_medicaid_populace.py
+++ b/tests/test_policyengine_medicaid_populace.py
@@ -1,0 +1,134 @@
+from pathlib import Path
+
+import pytest
+
+from axiom_encode.oracles.policyengine import medicaid_populace
+
+
+class FakeUSDataset:
+    def __init__(
+        self,
+        *,
+        person,
+        household,
+        tax_unit,
+        spm_unit=None,
+        family=None,
+        marital_unit=None,
+        time_period=2024,
+    ):
+        self.person = person
+        self.household = household
+        self.tax_unit = tax_unit
+        self.spm_unit = spm_unit
+        self.family = family
+        self.marital_unit = marital_unit
+        self.time_period = str(time_period)
+
+
+def test_pre_sample_households_preserves_whole_state_households():
+    pd = pytest.importorskip("pandas")
+    dataset = FakeUSDataset(
+        household=pd.DataFrame(
+            {
+                "household_id": [1, 2, 3],
+                "state_fips": [36, 6, 6],
+            }
+        ),
+        person=pd.DataFrame(
+            {
+                "person_id": [10, 20, 21, 30],
+                "person_household_id": [1, 2, 2, 3],
+                "person_tax_unit_id": [100, 200, 200, 300],
+                "person_spm_unit_id": [1000, 2000, 2000, 3000],
+                "person_family_id": [10000, 20000, 20000, 30000],
+                "person_marital_unit_id": [100000, 200000, 200001, 300000],
+            }
+        ),
+        tax_unit=pd.DataFrame({"tax_unit_id": [100, 200, 300]}),
+        spm_unit=pd.DataFrame({"spm_unit_id": [1000, 2000, 3000]}),
+        family=pd.DataFrame({"family_id": [10000, 20000, 30000]}),
+        marital_unit=pd.DataFrame(
+            {"marital_unit_id": [100000, 200000, 200001, 300000]}
+        ),
+    )
+
+    sampled = medicaid_populace.pre_sample_households(
+        dataset,
+        household_count=1,
+        state_filter="CA",
+    )
+
+    assert sampled.household["household_id"].tolist() == [2]
+    assert sampled.person["person_id"].tolist() == [20, 21]
+    assert sampled.tax_unit["tax_unit_id"].tolist() == [200]
+    assert sampled.spm_unit["spm_unit_id"].tolist() == [2000]
+    assert sampled.family["family_id"].tolist() == [20000]
+    assert sampled.marital_unit["marital_unit_id"].tolist() == [200000, 200001]
+
+
+def test_runtime_output_id_for_public_id_resolves_branch_qualified_id(tmp_path: Path):
+    artifact = tmp_path / "program.json"
+    artifact.write_text(
+        """
+        {
+          "program": {
+            "derived": [
+              {
+                "id": "us-medicaid-branch:us/statutes/42/1396a/a/10#is_medicaid_eligible",
+                "name": "is_medicaid_eligible"
+              }
+            ]
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    assert (
+        medicaid_populace.runtime_output_id_for_public_id(
+            artifact,
+            "us:statutes/42/1396a/a/10#is_medicaid_eligible",
+        )
+        == "us-medicaid-branch:us/statutes/42/1396a/a/10#is_medicaid_eligible"
+    )
+
+
+def test_project_case_inputs_uses_shared_income_projection_for_medicaid_imports():
+    inputs = medicaid_populace._project_case_inputs(
+        {},
+        age=10,
+        medicaid_income_level=0.25,
+        parent_nfc=False,
+        parent_fc=False,
+        pregnant_nfc=False,
+        pregnant_fc=False,
+        infant_fc=False,
+        young_child_fc=False,
+        older_child_eligible=True,
+        adult_nfc=False,
+        adult_fc=True,
+        ssi_recipient=False,
+        mandatory_subpart_b=True,
+        work_requirement_eligible=True,
+        medicare_eligible=False,
+    )
+
+    assert (
+        inputs[
+            "us:regulations/42-cfr/435/116#input.household_income_as_fraction_of_fpl"
+        ]
+        == 1.0
+    )
+    assert (
+        inputs[
+            "us:regulations/42-cfr/435/118#input.household_income_as_fraction_of_fpl"
+        ]
+        == 1.0
+    )
+    assert (
+        inputs[
+            "us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl"
+        ]
+        == 1.0
+    )

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -11154,6 +11154,53 @@ rules:
     assert "additional_medicare_tax_rate" in issues[0]
 
 
+def test_flattened_thresholded_imported_rate_ignores_rate_substring(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    imported_file = repo / "statutes" / "42" / "1396a" / "xx.yaml"
+    rules_file = repo / "statutes" / "42" / "1396a" / "a" / "10.yaml"
+    imported_file.parent.mkdir(parents=True)
+    rules_file.parent.mkdir(parents=True, exist_ok=True)
+    imported_file.write_text(
+        """format: rulespec/v1
+rules:
+  - name: demonstrated_community_engagement_for_month
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-12-31'
+        formula: monthly_work_hours >= community_engagement_hours_threshold
+  - name: community_engagement_hours_threshold
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-12-31'
+        formula: 80
+"""
+    )
+    rules_file.write_text(
+        """format: rulespec/v1
+imports:
+  - us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month
+rules:
+  - name: is_medicaid_eligible
+    kind: derived
+    dtype: Judgment
+    versions:
+      - effective_from: '2026-12-31'
+        formula: adult_group_eligible and demonstrated_community_engagement_for_month
+"""
+    )
+    pipeline = ValidatorPipeline(
+        policy_repo_path=repo,
+        axiom_rules_path=tmp_path / "axiom-rules-engine",
+        enable_oracles=False,
+    )
+
+    issues = pipeline._check_flattened_thresholded_imported_rates(rules_file)
+
+    assert issues == []
+
+
 def test_thresholded_imported_rate_allows_excess_amount_formula(tmp_path):
     repo = tmp_path / "rulespec-us"
     imported_file = repo / "statutes" / "26" / "3101" / "b" / "2.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1007"
+version = "0.2.1008"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1008"
+version = "0.2.1009"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair PE-hinted Medicaid composition handling in encoder output application
- add a real Axiom vs PolicyEngine Medicaid Populace comparator using local Populace data and axiom-rules-engine
- summarize Medicaid Populace mismatches by PE category so residual category gaps are visible

## Validation
- uv run ruff check src/axiom_encode/cli.py src/axiom_encode/oracles/policyengine/medicaid_populace.py tests/test_policyengine_medicaid_populace.py
- uv run --with pandas pytest tests/test_policyengine_medicaid_populace.py
- CA and IL Medicaid Populace smoke comparisons using local Populace H5 and real axiom-rules-engine