### PR TITLE
Repair Medicaid primary category composition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1019"
+version = "0.2.1020"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1017"
+version = "0.2.1018"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1020"
+version = "0.2.1021"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1009"
+version = "0.2.1010"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1011"
+version = "0.2.1012"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1016"
+version = "0.2.1017"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1013"
+version = "0.2.1014"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1014"
+version = "0.2.1015"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1018"
+version = "0.2.1019"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1010"
+version = "0.2.1011"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1012"
+version = "0.2.1013"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1015"
+version = "0.2.1016"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1018"
+__version__ = "0.2.1019"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1011"
+__version__ = "0.2.1012"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1017"
+__version__ = "0.2.1018"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1013"
+__version__ = "0.2.1014"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1020"
+__version__ = "0.2.1021"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1009"
+__version__ = "0.2.1010"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1019"
+__version__ = "0.2.1020"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1010"
+__version__ = "0.2.1011"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1015"
+__version__ = "0.2.1016"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1012"
+__version__ = "0.2.1013"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1014"
+__version__ = "0.2.1015"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1016"
+__version__ = "0.2.1017"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -8127,9 +8127,27 @@ def cmd_repair_medicaid_primary_category_composition(args):
             if _path_differs_from_original(path, originals.get(path))
         ]
     )
+    refresh_manifest_files: list[Path] = []
     if not changed_by_command:
-        print("No Medicaid primary category composition repairs found.")
-        return
+        for relative_output, group_files in manifest_groups:
+            applied_files = [path for path in group_files if path.exists()]
+            if not applied_files:
+                continue
+            if not _applied_manifest_matches_current_deterministic_repair(
+                repo_path=repo_path,
+                relative_output=relative_output,
+                applied_files=applied_files,
+                model=MEDICAID_PRIMARY_CATEGORY_REPAIR_MODEL,
+                axiom_encode_git=axiom_encode_git,
+                signing_key=signing_key,
+            ):
+                refresh_manifest_files.extend(applied_files)
+        if refresh_manifest_files:
+            changed_by_command = _unique_paths(refresh_manifest_files)
+        else:
+            print("No Medicaid primary category composition repairs found.")
+            return
+    refresh_only = bool(refresh_manifest_files)
 
     manifest_paths = _write_grouped_deterministic_repair_manifests(
         repo_path=repo_path,
@@ -8142,11 +8160,15 @@ def cmd_repair_medicaid_primary_category_composition(args):
     )
 
     changed_names = sorted(set(repaired_rules) | set(repaired_tests))
-    print("Applied Medicaid primary category composition repair")
-    if changed_names:
+    if refresh_only:
+        print("Refreshed Medicaid primary category composition repair manifest")
+    else:
+        print("Applied Medicaid primary category composition repair")
+    if changed_names and not refresh_only:
         print(f"changed_rules={', '.join(changed_names)}")
-    for path in changed_by_command:
-        print(f"changed={path.relative_to(repo_path)}")
+    if not refresh_only:
+        for path in changed_by_command:
+            print(f"changed={path.relative_to(repo_path)}")
     for manifest_path in manifest_paths:
         print(f"manifest={manifest_path}")
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -7517,6 +7517,9 @@ MEDICAID_MEDICALLY_NEEDY_MANDATORY_RULE = (
 MEDICAID_MEDICALLY_NEEDY_OPTIONAL_RULE = (
     "optional_medically_needy_medicaid_may_be_provided"
 )
+MEDICAID_OPTIONAL_SSI_EXCESS_EARNINGS_RULE = (
+    "optional_ssi_excess_earnings_medicaid_category_eligible"
+)
 MEDICAID_OPTIONAL_WORKING_DISABLED_RULE = (
     "optional_working_disabled_medicaid_category_eligible"
 )
@@ -8251,6 +8254,36 @@ def _repair_medicaid_primary_category_composition_rules(
         )
         changed.append(MEDICAID_OPTIONAL_WORKING_DISABLED_RULE)
 
+    if f"\n  - name: {MEDICAID_OPTIONAL_SSI_EXCESS_EARNINGS_RULE}\n" not in repaired:
+        rule_start = repaired.index("\n  - name: is_medicaid_eligible\n") + 1
+        optional_ssi_excess_earnings_rule = f"""  - name: {MEDICAID_OPTIONAL_SSI_EXCESS_EARNINGS_RULE}
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 USC 1396a(a)(10)(A)(ii)(XIII)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1396a/a/10
+              excerpt: "who are in families whose income is less than 250 percent of the income official poverty line ... and who but for earnings in excess of the limit established under section 1396d(q)(2)(B), would be considered to be receiving supplemental security income"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          state_elects_optional_coverage_for_ssi_excess_earnings_individuals
+          and not individual_described_in_mandatory_clause_i
+          and individual_would_be_considered_receiving_ssi_but_for_earnings
+          and family_income_as_fraction_of_poverty_line < optional_ssi_excess_earnings_family_income_limit_poverty_line_rate
+
+"""
+        repaired = (
+            repaired[:rule_start] + optional_ssi_excess_earnings_rule + repaired[rule_start:]
+        )
+        changed.append(MEDICAID_OPTIONAL_SSI_EXCESS_EARNINGS_RULE)
+
     rule_start = repaired.index("\n  - name: is_medicaid_eligible\n") + 1
     next_rule = repaired.find("\n  - name:", rule_start + 1)
     rule_end = next_rule if next_rule != -1 else len(repaired)
@@ -8296,6 +8329,7 @@ def _repair_medicaid_primary_category_composition_rules(
     if insertion_point not in repaired:
         insertion_point = "          or former_foster_care_child_medicaid_required\n"
     additions = [
+        f"          or {MEDICAID_OPTIONAL_SSI_EXCESS_EARNINGS_RULE}\n",
         f"          or {MEDICAID_OPTIONAL_WORKING_DISABLED_RULE}\n",
         f"          or {MEDICAID_OPTIONAL_YOUTH_RULE}\n",
         f"          or {MEDICAID_MEDICALLY_NEEDY_MANDATORY_RULE}\n",
@@ -8323,10 +8357,12 @@ _MEDICAID_PRIMARY_FALSE_INPUTS = {
     "us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option": False,
     "us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option": False,
     "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i": False,
+    "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_ssi_excess_earnings_individuals": False,
     "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_working_disabled_individuals": False,
     "us:statutes/42/1396a/a/10#input.individual_described_in_mandatory_clause_i": False,
     "us:statutes/42/1396a/a/10#input.individual_meets_income_and_resources_requirements_for_optional_category": False,
     "us:statutes/42/1396a/a/10#input.individual_would_be_considered_receiving_ssi_but_for_earnings": False,
+    "us:statutes/42/1396a/a/10#input.family_income_as_fraction_of_poverty_line": 3.0,
     "us:statutes/42/1396a/a/10#input.assets_resources_and_earned_or_unearned_income_do_not_exceed_state_established_limitations": False,
     "us:regulations/42-cfr/435/301#input.agency_chooses_medically_needy_option": False,
     "us:regulations/42-cfr/435/301#input.income_meets_applicable_medically_needy_standard": False,
@@ -8376,6 +8412,16 @@ _MEDICAID_PRIMARY_WORKING_DISABLED_TRUE_INPUTS = {
     "us:statutes/42/1396a/a/10#input.individual_described_in_mandatory_clause_i": False,
     "us:statutes/42/1396a/a/10#input.individual_would_be_considered_receiving_ssi_but_for_earnings": True,
     "us:statutes/42/1396a/a/10#input.assets_resources_and_earned_or_unearned_income_do_not_exceed_state_established_limitations": True,
+}
+
+_MEDICAID_PRIMARY_SSI_EXCESS_EARNINGS_TRUE_INPUTS = {
+    "us:statutes/42/1396a/a/10#input.individual_age_years": 72,
+    "us:statutes/42/1396a/m#input.individual_age_years": 72,
+    "us:statutes/42/1396d/a/i#input.individual_age_years": 72,
+    "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_ssi_excess_earnings_individuals": True,
+    "us:statutes/42/1396a/a/10#input.individual_described_in_mandatory_clause_i": False,
+    "us:statutes/42/1396a/a/10#input.individual_would_be_considered_receiving_ssi_but_for_earnings": True,
+    "us:statutes/42/1396a/a/10#input.family_income_as_fraction_of_poverty_line": 1.0,
 }
 
 
@@ -8453,6 +8499,21 @@ def _repair_medicaid_primary_category_composition_tests(
         }
         cases.append(working_disabled_case)
         changed.append("optional working disabled category eligible")
+
+    if "optional SSI excess earnings category eligible" not in names:
+        ssi_excess_case = copy.deepcopy(template)
+        ssi_excess_case["name"] = "optional SSI excess earnings category eligible"
+        inputs = ssi_excess_case.setdefault("input", {})
+        if not isinstance(inputs, dict):
+            raise ValueError("RuleSpec test input must be a mapping")
+        inputs.update(_MEDICAID_PRIMARY_FALSE_INPUTS)
+        inputs.update(_MEDICAID_PRIMARY_SSI_EXCESS_EARNINGS_TRUE_INPUTS)
+        ssi_excess_case["output"] = {
+            "us:statutes/42/1396a/a/10#optional_ssi_excess_earnings_medicaid_category_eligible": "holds",
+            "us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds",
+        }
+        cases.append(ssi_excess_case)
+        changed.append("optional SSI excess earnings category eligible")
 
     return _dump_rulespec_repair_yaml(cases), changed
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -7497,12 +7497,14 @@ MEDICAID_OPTIONAL_SENIOR_TARGET = (
 )
 MEDICAID_OPTIONAL_SENIOR_RULE = "is_optional_senior_or_disabled_for_medicaid"
 MEDICAID_YOUTH_RELATIVE = Path("statutes/42/1396d/a/i.yaml")
+MEDICAID_YOUTH_MODULE_TARGET = "us:statutes/42/1396d/a/i"
 MEDICAID_YOUTH_TARGET = (
     "us:statutes/42/1396d/a/i#youth_age_category_for_medical_assistance"
 )
 MEDICAID_YOUTH_RULE = "youth_age_category_for_medical_assistance"
 MEDICAID_OPTIONAL_YOUTH_RULE = "optional_youth_medicaid_category_eligible"
 MEDICAID_MEDICALLY_NEEDY_RELATIVE = Path("regulations/42-cfr/435/301.yaml")
+MEDICAID_MEDICALLY_NEEDY_MODULE_TARGET = "us:regulations/42-cfr/435/301"
 MEDICAID_MEDICALLY_NEEDY_MANDATORY_TARGET = (
     "us:regulations/42-cfr/435/301#mandatory_medically_needy_medicaid_required"
 )
@@ -8155,9 +8157,8 @@ def _repair_medicaid_primary_category_composition_rules(
     changed: list[str] = []
 
     imports_to_add = [
-        MEDICAID_YOUTH_TARGET,
-        MEDICAID_MEDICALLY_NEEDY_MANDATORY_TARGET,
-        MEDICAID_MEDICALLY_NEEDY_OPTIONAL_TARGET,
+        MEDICAID_YOUTH_MODULE_TARGET,
+        MEDICAID_MEDICALLY_NEEDY_MODULE_TARGET,
     ]
     module_marker = "\nmodule:\n"
     if module_marker not in repaired:
@@ -8279,7 +8280,10 @@ def _repair_medicaid_primary_category_composition_rules(
 
 
 _MEDICAID_PRIMARY_FALSE_INPUTS = {
-    "us:statutes/42/1396d/a/i#youth_age_category_for_medical_assistance": "not_holds",
+    "us:statutes/42/1396d/a/i#input.individual_age_years": 30,
+    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option": False,
+    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option": False,
+    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option": False,
     "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i": False,
     "us:statutes/42/1396a/a/10#input.individual_described_in_mandatory_clause_i": False,
     "us:statutes/42/1396a/a/10#input.individual_meets_income_and_resources_requirements_for_optional_category": False,
@@ -8301,7 +8305,10 @@ _MEDICAID_PRIMARY_FALSE_INPUTS = {
 }
 
 _MEDICAID_PRIMARY_YOUTH_TRUE_INPUTS = {
-    "us:statutes/42/1396d/a/i#youth_age_category_for_medical_assistance": "holds",
+    "us:statutes/42/1396d/a/i#input.individual_age_years": 20,
+    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option": False,
+    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option": False,
+    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option": False,
     "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i": True,
     "us:statutes/42/1396a/a/10#input.individual_described_in_mandatory_clause_i": False,
     "us:statutes/42/1396a/a/10#input.individual_meets_income_and_resources_requirements_for_optional_category": True,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -7517,6 +7517,9 @@ MEDICAID_MEDICALLY_NEEDY_MANDATORY_RULE = (
 MEDICAID_MEDICALLY_NEEDY_OPTIONAL_RULE = (
     "optional_medically_needy_medicaid_may_be_provided"
 )
+MEDICAID_OPTIONAL_WORKING_DISABLED_RULE = (
+    "optional_working_disabled_medicaid_category_eligible"
+)
 MEDICAID_PRIMARY_CATEGORY_REPAIR_MODEL = "medicaid-primary-category-composition-v1"
 
 MEDICAID_YOUTH_RULESPEC = """format: rulespec/v1
@@ -8216,6 +8219,38 @@ def _repair_medicaid_primary_category_composition_rules(
         repaired = repaired[:rule_start] + optional_youth_rule + repaired[rule_start:]
         changed.append(MEDICAID_OPTIONAL_YOUTH_RULE)
 
+    if f"\n  - name: {MEDICAID_OPTIONAL_WORKING_DISABLED_RULE}\n" not in repaired:
+        rule_start = repaired.index("\n  - name: is_medicaid_eligible\n") + 1
+        optional_working_disabled_rule = f"""  - name: {MEDICAID_OPTIONAL_WORKING_DISABLED_RULE}
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 USC 1396a(a)(10)(A)(ii)(XV)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1396a/a/10
+              excerpt: "who, but for earnings in excess of the limit established under section 1396d(q)(2)(B), would be considered to be receiving supplemental security income, who is at least 16, but less than 65, years of age, and whose assets, resources, and earned or unearned income (or both) do not exceed such limitations (if any) as the State may establish"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          state_elects_optional_coverage_for_working_disabled_individuals
+          and not individual_described_in_mandatory_clause_i
+          and individual_would_be_considered_receiving_ssi_but_for_earnings
+          and individual_age_years >= optional_working_disabled_minimum_age_years
+          and individual_age_years < optional_working_disabled_age_ceiling_years
+          and assets_resources_and_earned_or_unearned_income_do_not_exceed_state_established_limitations
+
+"""
+        repaired = (
+            repaired[:rule_start] + optional_working_disabled_rule + repaired[rule_start:]
+        )
+        changed.append(MEDICAID_OPTIONAL_WORKING_DISABLED_RULE)
+
     rule_start = repaired.index("\n  - name: is_medicaid_eligible\n") + 1
     next_rule = repaired.find("\n  - name:", rule_start + 1)
     rule_end = next_rule if next_rule != -1 else len(repaired)
@@ -8261,6 +8296,7 @@ def _repair_medicaid_primary_category_composition_rules(
     if insertion_point not in repaired:
         insertion_point = "          or former_foster_care_child_medicaid_required\n"
     additions = [
+        f"          or {MEDICAID_OPTIONAL_WORKING_DISABLED_RULE}\n",
         f"          or {MEDICAID_OPTIONAL_YOUTH_RULE}\n",
         f"          or {MEDICAID_MEDICALLY_NEEDY_MANDATORY_RULE}\n",
         f"          or {MEDICAID_MEDICALLY_NEEDY_OPTIONAL_RULE}\n",
@@ -8281,13 +8317,17 @@ def _repair_medicaid_primary_category_composition_rules(
 
 
 _MEDICAID_PRIMARY_FALSE_INPUTS = {
+    "us:statutes/42/1396a/a/10#input.individual_age_years": 30,
     "us:statutes/42/1396d/a/i#input.individual_age_years": 30,
     "us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option": False,
     "us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option": False,
     "us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option": False,
     "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i": False,
+    "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_working_disabled_individuals": False,
     "us:statutes/42/1396a/a/10#input.individual_described_in_mandatory_clause_i": False,
     "us:statutes/42/1396a/a/10#input.individual_meets_income_and_resources_requirements_for_optional_category": False,
+    "us:statutes/42/1396a/a/10#input.individual_would_be_considered_receiving_ssi_but_for_earnings": False,
+    "us:statutes/42/1396a/a/10#input.assets_resources_and_earned_or_unearned_income_do_not_exceed_state_established_limitations": False,
     "us:regulations/42-cfr/435/301#input.agency_chooses_medically_needy_option": False,
     "us:regulations/42-cfr/435/301#input.income_meets_applicable_medically_needy_standard": False,
     "us:regulations/42-cfr/435/301#input.incurred_medical_expenses_at_least_equal_to_income_standard_difference": False,
@@ -8326,6 +8366,16 @@ _MEDICAID_PRIMARY_MEDICALLY_NEEDY_TRUE_INPUTS = {
     "us:regulations/42-cfr/435/301#input.person_is_blind": False,
     "us:regulations/42-cfr/435/301#input.person_is_disabled": False,
     "us:regulations/42-cfr/435/301#input.person_is_parent_or_other_caretaker_relative": False,
+}
+
+_MEDICAID_PRIMARY_WORKING_DISABLED_TRUE_INPUTS = {
+    "us:statutes/42/1396a/a/10#input.individual_age_years": 40,
+    "us:statutes/42/1396a/m#input.individual_age_years": 40,
+    "us:statutes/42/1396d/a/i#input.individual_age_years": 40,
+    "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_working_disabled_individuals": True,
+    "us:statutes/42/1396a/a/10#input.individual_described_in_mandatory_clause_i": False,
+    "us:statutes/42/1396a/a/10#input.individual_would_be_considered_receiving_ssi_but_for_earnings": True,
+    "us:statutes/42/1396a/a/10#input.assets_resources_and_earned_or_unearned_income_do_not_exceed_state_established_limitations": True,
 }
 
 
@@ -8388,6 +8438,21 @@ def _repair_medicaid_primary_category_composition_tests(
         }
         cases.append(medically_needy_case)
         changed.append("optional medically needy category eligible")
+
+    if "optional working disabled category eligible" not in names:
+        working_disabled_case = copy.deepcopy(template)
+        working_disabled_case["name"] = "optional working disabled category eligible"
+        inputs = working_disabled_case.setdefault("input", {})
+        if not isinstance(inputs, dict):
+            raise ValueError("RuleSpec test input must be a mapping")
+        inputs.update(_MEDICAID_PRIMARY_FALSE_INPUTS)
+        inputs.update(_MEDICAID_PRIMARY_WORKING_DISABLED_TRUE_INPUTS)
+        working_disabled_case["output"] = {
+            "us:statutes/42/1396a/a/10#optional_working_disabled_medicaid_category_eligible": "holds",
+            "us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds",
+        }
+        cases.append(working_disabled_case)
+        changed.append("optional working disabled category eligible")
 
     return _dump_rulespec_repair_yaml(cases), changed
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1801,6 +1801,25 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_medicaid_optional_parser = subparsers.add_parser(
+        "repair-medicaid-optional-senior-composition",
+        help="Apply signed deterministic Medicaid optional senior/disabled composition repairs",
+    )
+    repair_medicaid_optional_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="rulespec-us repository root used for manifest signing",
+    )
+    repair_medicaid_optional_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_ny_snap_categorical_parser = subparsers.add_parser(
         "repair-new-york-snap-categorical-eligibility",
         help="Apply signed deterministic repairs for New York SNAP categorical eligibility",
@@ -2501,6 +2520,8 @@ def main():
         cmd_repair_georgia_cms_medicaid_availability(args)
     elif args.command == "repair-georgia-cms-effective-magi-limits":
         cmd_repair_georgia_cms_effective_magi_limits(args)
+    elif args.command == "repair-medicaid-optional-senior-composition":
+        cmd_repair_medicaid_optional_senior_composition(args)
     elif args.command == "repair-new-york-snap-categorical-eligibility":
         cmd_repair_new_york_snap_categorical_eligibility(args)
     elif args.command == "repair-new-york-snap-benefit-tests":
@@ -7446,6 +7467,337 @@ def _repair_georgia_cms_effective_magi_limit_tests(
             f"{rule['test_value']}\n"
         )
     return repaired, [rule["name"] for rule in missing]
+
+
+MEDICAID_A10_RELATIVE = Path("statutes/42/1396a/a/10.yaml")
+MEDICAID_A10_CITATION = "us/statute/42/1396a/a/10"
+MEDICAID_OPTIONAL_SENIOR_TARGET = (
+    "us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid"
+)
+MEDICAID_OPTIONAL_SENIOR_RULE = "is_optional_senior_or_disabled_for_medicaid"
+
+
+class _RulespecRepairDumper(yaml.SafeDumper):
+    pass
+
+
+def _rulespec_repair_str_representer(
+    dumper: yaml.SafeDumper, value: str
+) -> yaml.nodes.ScalarNode:
+    style = "|" if "\n" in value else None
+    return dumper.represent_scalar("tag:yaml.org,2002:str", value, style=style)
+
+
+_RulespecRepairDumper.add_representer(str, _rulespec_repair_str_representer)
+
+
+def _dump_rulespec_repair_yaml(payload: Any) -> str:
+    return yaml.dump(
+        payload,
+        Dumper=_RulespecRepairDumper,
+        sort_keys=False,
+        allow_unicode=False,
+        width=1000,
+    )
+
+
+def cmd_repair_medicaid_optional_senior_composition(args):
+    """Apply signed deterministic Medicaid optional senior/disabled composition."""
+    repo_path = Path(args.repo).resolve()
+    if _repo_jurisdiction_prefix(repo_path) != "us":
+        print(
+            "repair-medicaid-optional-senior-composition must run against "
+            f"rulespec-us; got {repo_path}"
+        )
+        sys.exit(1)
+
+    relative_output = MEDICAID_A10_RELATIVE
+    rules_file = repo_path / relative_output
+    test_file = _rulespec_test_path(rules_file)
+    medicaid_m_file = repo_path / "statutes/42/1396a/m.yaml"
+    if not rules_file.exists():
+        print(f"RuleSpec file not found: {rules_file}")
+        sys.exit(1)
+    if not test_file.exists():
+        print(f"RuleSpec companion test file not found: {test_file}")
+        sys.exit(1)
+    if not medicaid_m_file.exists():
+        print(f"Required optional-category RuleSpec file not found: {medicaid_m_file}")
+        sys.exit(1)
+
+    original_content = rules_file.read_text()
+    original_test_content = test_file.read_text()
+    optional_hash = _sha256_file(medicaid_m_file)
+    repaired_content, repaired_rules = (
+        _repair_medicaid_optional_senior_composition_rules(
+            original_content, optional_hash=optional_hash
+        )
+    )
+    repaired_test_content, repaired_tests = (
+        _repair_medicaid_optional_senior_composition_tests(original_test_content)
+    )
+    applied_files = [rules_file, test_file]
+    axiom_encode_git = None
+
+    if (
+        repaired_content == original_content
+        and repaired_test_content == original_test_content
+    ):
+        manifest_path = repo_path / _applied_encoding_manifest_path(relative_output)
+        if manifest_path.exists():
+            current_hashes = {
+                file.relative_to(repo_path).as_posix(): _sha256_file(file)
+                for file in applied_files
+            }
+            payload = json.loads(manifest_path.read_text())
+            manifest_hashes = {
+                item.get("path"): item.get("sha256")
+                for item in payload.get("applied_files", [])
+                if isinstance(item, dict)
+            }
+            if all(
+                manifest_hashes.get(path) == sha for path, sha in current_hashes.items()
+            ):
+                axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+                if (
+                    payload.get("axiom_encode_version") == __version__
+                    and payload.get("axiom_encode_git") == axiom_encode_git
+                ):
+                    print("No Medicaid optional senior composition repairs found.")
+                    return
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    if axiom_encode_git is None:
+        axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+    _ensure_no_unmanifested_preexisting_rulespec_changes(
+        repo_path,
+        [(relative_output, applied_files)],
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_root = Path(tmpdir)
+        generated_output = output_root / "deterministic-repair" / relative_output
+        generated_output.parent.mkdir(parents=True, exist_ok=True)
+        generated_output.write_text(repaired_content)
+        generated_test = _rulespec_test_path(generated_output)
+        generated_test.write_text(repaired_test_content)
+
+        rules_file.write_text(repaired_content)
+        test_file.write_text(repaired_test_content)
+
+        try:
+            validation = ValidatorPipeline(
+                policy_repo_path=repo_path,
+                axiom_rules_path=axiom_rules_path,
+                enable_oracles=False,
+                require_policy_proofs=True,
+            ).validate(rules_file, skip_reviewers=True)
+            if not validation.all_passed:
+                issues = [
+                    result.error
+                    for result in validation.results.values()
+                    if result.error
+                ]
+                print("Repair failed validation; restored original files.")
+                for issue in issues:
+                    print(f"- {issue}")
+                sys.exit(1)
+
+            test_failures = _rulespec_companion_test_failures(
+                test_file,
+                root=repo_path,
+                axiom_rules_path=axiom_rules_path,
+            )
+            if test_failures:
+                print("Repair failed companion tests; restored original files.")
+                for failure in test_failures[:20]:
+                    case_name = failure.get("case") or "<unknown case>"
+                    print(f"- {case_name}: {failure.get('message')}")
+                sys.exit(1)
+        finally:
+            validation_passed = "validation" in locals() and validation.all_passed
+            tests_passed = "test_failures" in locals() and not test_failures
+            if not validation_passed or not tests_passed:
+                rules_file.write_text(original_content)
+                test_file.write_text(original_test_content)
+
+        result = argparse.Namespace(
+            output_file=str(generated_output),
+            runner="deterministic-repair",
+            backend="deterministic",
+            model="medicaid-optional-senior-composition-v1",
+            tool="axiom-encode repair-medicaid-optional-senior-composition",
+            citation=MEDICAID_A10_CITATION,
+            generation_prompt_sha256=None,
+            trace_file=None,
+            context_manifest_file=None,
+        )
+        manifest_path = _write_applied_encoding_manifest(
+            result,
+            output_root=output_root,
+            policy_repo_path=repo_path,
+            relative_output=relative_output,
+            applied_files=applied_files,
+            run_id="deterministic-repair",
+            signing_key=signing_key,
+            axiom_encode_git=axiom_encode_git,
+        )
+
+    changed_names = sorted(set(repaired_rules) | set(repaired_tests))
+    print("Applied Medicaid optional senior composition repair")
+    if changed_names:
+        print(f"changed_rules={', '.join(changed_names)}")
+    print(f"changed={relative_output}")
+    print(f"changed={_rulespec_test_path(relative_output)}")
+    print(f"manifest={manifest_path}")
+
+
+def _repair_medicaid_optional_senior_composition_rules(
+    content: str, *, optional_hash: str
+) -> tuple[str, list[str]]:
+    if "\n  - name: is_medicaid_eligible\n" not in content:
+        raise ValueError("Missing is_medicaid_eligible rule")
+
+    repaired = content
+    changed: list[str] = []
+
+    if MEDICAID_OPTIONAL_SENIOR_TARGET not in repaired:
+        module_marker = "\nmodule:\n"
+        if module_marker not in repaired:
+            raise ValueError("RuleSpec payload must contain module section")
+        repaired = repaired.replace(
+            module_marker,
+            f"\n  - {MEDICAID_OPTIONAL_SENIOR_TARGET}{module_marker}",
+            1,
+        )
+        changed.append("is_medicaid_eligible")
+
+    source_marker = "    source: 42 USC 1396a(a)(10)(A)(i)\n"
+    if source_marker in repaired:
+        repaired = repaired.replace(
+            source_marker,
+            "    source: 42 USC 1396a(a)(10)(A)(i)-(ii)\n",
+            1,
+        )
+        if "is_medicaid_eligible" not in changed:
+            changed.append("is_medicaid_eligible")
+
+    rule_start = repaired.index("\n  - name: is_medicaid_eligible\n") + 1
+    next_rule = repaired.find("\n  - name:", rule_start + 1)
+    rule_end = next_rule if next_rule != -1 else len(repaired)
+    rule_text = repaired[rule_start:rule_end]
+
+    proof_atom = (
+        "          - path: versions[0].formula\n"
+        "            kind: import\n"
+        "            import:\n"
+        f"              target: {MEDICAID_OPTIONAL_SENIOR_TARGET}\n"
+        f"              output: {MEDICAID_OPTIONAL_SENIOR_RULE}\n"
+        f"              hash: sha256:{optional_hash}\n"
+    )
+    if MEDICAID_OPTIONAL_SENIOR_TARGET not in rule_text:
+        versions_marker = "    versions:\n"
+        if versions_marker not in rule_text:
+            raise ValueError("is_medicaid_eligible must have versions")
+        rule_text = rule_text.replace(
+            versions_marker,
+            proof_atom + versions_marker,
+            1,
+        )
+        repaired = repaired[:rule_start] + rule_text + repaired[rule_end:]
+        if "is_medicaid_eligible" not in changed:
+            changed.append("is_medicaid_eligible")
+
+    if f"or {MEDICAID_OPTIONAL_SENIOR_RULE}" not in repaired:
+        formula_marker = "          or former_foster_care_child_medicaid_required\n"
+        if formula_marker not in repaired:
+            raise ValueError("Missing Medicaid eligibility formula insertion point")
+        repaired = repaired.replace(
+            formula_marker,
+            formula_marker
+            + f"          or {MEDICAID_OPTIONAL_SENIOR_RULE}\n",
+            1,
+        )
+        if "is_medicaid_eligible" not in changed:
+            changed.append("is_medicaid_eligible")
+
+    return repaired, changed
+
+
+_MEDICAID_OPTIONAL_FALSE_INPUTS = {
+    "us:statutes/42/1396a/m#input.individual_age_years": 30,
+    "us:statutes/42/1396a/m#input.disabled_as_determined_under_section_1382c_a_3": False,
+    "us:statutes/42/1396a/m#input.income_determined_for_this_subsection": 999999,
+    "us:statutes/42/1396a/m#input.state_established_income_level_amount": 0,
+    "us:statutes/42/1396a/m#input.state_established_income_level_poverty_line_rate": 1.0,
+    "us:statutes/42/1396a/m#input.resources_determined_for_supplemental_security_income_program": 999999,
+    "us:statutes/42/1396a/m#input.maximum_resources_for_supplemental_security_income_program": 2000,
+    "us:statutes/42/1396a/m#input.state_provides_medical_assistance_to_individuals_not_described_in_subsection_a_10_A": False,
+    "us:statutes/42/1396a/m#input.state_elects_higher_resource_level_for_non_a10A_individuals": False,
+    "us:statutes/42/1396a/m#input.individual_not_described_in_subsection_a_10_A": False,
+    "us:statutes/42/1396a/m#input.state_optional_resource_level_amount_for_non_a10A_individuals": 2000,
+}
+
+
+_MEDICAID_OPTIONAL_TRUE_INPUTS = {
+    "us:statutes/42/1396a/m#input.individual_age_years": 65,
+    "us:statutes/42/1396a/m#input.disabled_as_determined_under_section_1382c_a_3": False,
+    "us:statutes/42/1396a/m#input.income_determined_for_this_subsection": 900,
+    "us:statutes/42/1396a/m#input.state_established_income_level_amount": 1000,
+    "us:statutes/42/1396a/m#input.state_established_income_level_poverty_line_rate": 1.0,
+    "us:statutes/42/1396a/m#input.resources_determined_for_supplemental_security_income_program": 1900,
+    "us:statutes/42/1396a/m#input.maximum_resources_for_supplemental_security_income_program": 2000,
+    "us:statutes/42/1396a/m#input.state_provides_medical_assistance_to_individuals_not_described_in_subsection_a_10_A": False,
+    "us:statutes/42/1396a/m#input.state_elects_higher_resource_level_for_non_a10A_individuals": False,
+    "us:statutes/42/1396a/m#input.individual_not_described_in_subsection_a_10_A": False,
+    "us:statutes/42/1396a/m#input.state_optional_resource_level_amount_for_non_a10A_individuals": 2000,
+}
+
+
+def _repair_medicaid_optional_senior_composition_tests(
+    content: str,
+) -> tuple[str, list[str]]:
+    cases = yaml.safe_load(content)
+    if not isinstance(cases, list):
+        raise ValueError("RuleSpec companion tests must be a list")
+
+    changed: list[str] = []
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        inputs = case.setdefault("input", {})
+        if not isinstance(inputs, dict):
+            raise ValueError("RuleSpec test input must be a mapping")
+        for key, value in _MEDICAID_OPTIONAL_FALSE_INPUTS.items():
+            if key not in inputs:
+                inputs[key] = value
+                changed.append(str(case.get("name") or "<unnamed>"))
+
+    names = {case.get("name") for case in cases if isinstance(case, dict)}
+    if "optional senior disabled category eligible" not in names:
+        template = None
+        for case in cases:
+            if (
+                isinstance(case, dict)
+                and case.get("name") == "no composed mandatory category eligible"
+            ):
+                template = copy.deepcopy(case)
+                break
+        if template is None:
+            raise ValueError("Missing no composed mandatory category eligible test")
+        template["name"] = "optional senior disabled category eligible"
+        inputs = template.setdefault("input", {})
+        if not isinstance(inputs, dict):
+            raise ValueError("RuleSpec test input must be a mapping")
+        inputs.update(_MEDICAID_OPTIONAL_TRUE_INPUTS)
+        template["output"] = {"us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds"}
+        cases.append(template)
+        changed.append("optional senior disabled category eligible")
+
+    return _dump_rulespec_repair_yaml(cases), changed
 
 
 def cmd_repair_georgia_cms_effective_magi_limits(args):

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -8306,6 +8306,7 @@ _MEDICAID_PRIMARY_FALSE_INPUTS = {
 }
 
 _MEDICAID_PRIMARY_YOUTH_TRUE_INPUTS = {
+    "us:statutes/42/1396a/m#input.individual_age_years": 20,
     "us:statutes/42/1396d/a/i#input.individual_age_years": 20,
     "us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option": False,
     "us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option": False,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1820,6 +1820,25 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_medicaid_primary_parser = subparsers.add_parser(
+        "repair-medicaid-primary-category-composition",
+        help="Apply signed deterministic Medicaid young-adult and medically-needy composition repairs",
+    )
+    repair_medicaid_primary_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="rulespec-us repository root used for manifest signing",
+    )
+    repair_medicaid_primary_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_ny_snap_categorical_parser = subparsers.add_parser(
         "repair-new-york-snap-categorical-eligibility",
         help="Apply signed deterministic repairs for New York SNAP categorical eligibility",
@@ -2522,6 +2541,8 @@ def main():
         cmd_repair_georgia_cms_effective_magi_limits(args)
     elif args.command == "repair-medicaid-optional-senior-composition":
         cmd_repair_medicaid_optional_senior_composition(args)
+    elif args.command == "repair-medicaid-primary-category-composition":
+        cmd_repair_medicaid_primary_category_composition(args)
     elif args.command == "repair-new-york-snap-categorical-eligibility":
         cmd_repair_new_york_snap_categorical_eligibility(args)
     elif args.command == "repair-new-york-snap-benefit-tests":
@@ -7475,6 +7496,192 @@ MEDICAID_OPTIONAL_SENIOR_TARGET = (
     "us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid"
 )
 MEDICAID_OPTIONAL_SENIOR_RULE = "is_optional_senior_or_disabled_for_medicaid"
+MEDICAID_YOUTH_RELATIVE = Path("statutes/42/1396d/a/i.yaml")
+MEDICAID_YOUTH_TARGET = (
+    "us:statutes/42/1396d/a/i#youth_age_category_for_medical_assistance"
+)
+MEDICAID_YOUTH_RULE = "youth_age_category_for_medical_assistance"
+MEDICAID_OPTIONAL_YOUTH_RULE = "optional_youth_medicaid_category_eligible"
+MEDICAID_MEDICALLY_NEEDY_RELATIVE = Path("regulations/42-cfr/435/301.yaml")
+MEDICAID_MEDICALLY_NEEDY_MANDATORY_TARGET = (
+    "us:regulations/42-cfr/435/301#mandatory_medically_needy_medicaid_required"
+)
+MEDICAID_MEDICALLY_NEEDY_OPTIONAL_TARGET = (
+    "us:regulations/42-cfr/435/301#optional_medically_needy_medicaid_may_be_provided"
+)
+MEDICAID_MEDICALLY_NEEDY_MANDATORY_RULE = (
+    "mandatory_medically_needy_medicaid_required"
+)
+MEDICAID_MEDICALLY_NEEDY_OPTIONAL_RULE = (
+    "optional_medically_needy_medicaid_may_be_provided"
+)
+MEDICAID_PRIMARY_CATEGORY_REPAIR_MODEL = "medicaid-primary-category-composition-v1"
+
+MEDICAID_YOUTH_RULESPEC = """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/1396d/a
+  summary: |-
+    Clause (i) includes individuals "under the age of 21, or, at the option of the State, under the age of 20, 19, or 18 as the State may choose."
+rules:
+  - name: default_youth_age_ceiling_years
+    kind: parameter
+    dtype: Count
+    source: 42 U.S.C. 1396d(a)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396d/a
+              excerpt: "under the age of 21"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          21
+
+  - name: state_option_youth_age_ceiling_20_years
+    kind: parameter
+    dtype: Count
+    source: 42 U.S.C. 1396d(a)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396d/a
+              excerpt: "at the option of the State, under the age of 20"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          20
+
+  - name: state_option_youth_age_ceiling_19_years
+    kind: parameter
+    dtype: Count
+    source: 42 U.S.C. 1396d(a)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396d/a
+              excerpt: "at the option of the State, under the age of ... 19"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          19
+
+  - name: state_option_youth_age_ceiling_18_years
+    kind: parameter
+    dtype: Count
+    source: 42 U.S.C. 1396d(a)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: parameter
+            source:
+              corpus_citation_path: us/statute/42/1396d/a
+              excerpt: "at the option of the State, under the age of ... 18"
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          18
+
+  - name: youth_age_category_for_medical_assistance
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 U.S.C. 1396d(a)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: definition
+            source:
+              corpus_citation_path: us/statute/42/1396d/a
+          - path: versions[0].formula
+            kind: parameter
+            import:
+              target: us:statutes/42/1396d/a/i#default_youth_age_ceiling_years
+              output: default_youth_age_ceiling_years
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: parameter
+            import:
+              target: us:statutes/42/1396d/a/i#state_option_youth_age_ceiling_20_years
+              output: state_option_youth_age_ceiling_20_years
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: parameter
+            import:
+              target: us:statutes/42/1396d/a/i#state_option_youth_age_ceiling_19_years
+              output: state_option_youth_age_ceiling_19_years
+              hash: sha256:local
+          - path: versions[0].formula
+            kind: parameter
+            import:
+              target: us:statutes/42/1396d/a/i#state_option_youth_age_ceiling_18_years
+              output: state_option_youth_age_ceiling_18_years
+              hash: sha256:local
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          (state_chooses_under_age_18_option and individual_age_years < state_option_youth_age_ceiling_18_years)
+          or (state_chooses_under_age_19_option and individual_age_years < state_option_youth_age_ceiling_19_years)
+          or (state_chooses_under_age_20_option and individual_age_years < state_option_youth_age_ceiling_20_years)
+          or (
+            not state_chooses_under_age_18_option
+            and not state_chooses_under_age_19_option
+            and not state_chooses_under_age_20_option
+            and individual_age_years < default_youth_age_ceiling_years
+          )
+"""
+
+MEDICAID_YOUTH_TEST = """- name: default_under_21_category_holds
+  period: 2026-01
+  input:
+    us:statutes/42/1396d/a/i#input.individual_age_years: 20
+    us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option: false
+    us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option: false
+    us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option: false
+  output:
+    us:statutes/42/1396d/a/i#youth_age_category_for_medical_assistance: holds
+- name: default_at_21_category_not_holds
+  period: 2026-01
+  input:
+    us:statutes/42/1396d/a/i#input.individual_age_years: 21
+    us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option: false
+    us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option: false
+    us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option: false
+  output:
+    us:statutes/42/1396d/a/i#youth_age_category_for_medical_assistance: not_holds
+- name: state_under_20_option_excludes_age_20
+  period: 2026-01
+  input:
+    us:statutes/42/1396d/a/i#input.individual_age_years: 20
+    us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option: false
+    us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option: false
+    us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option: true
+  output:
+    us:statutes/42/1396d/a/i#youth_age_category_for_medical_assistance: not_holds
+- name: state_under_18_option_includes_age_17
+  period: 2026-01
+  input:
+    us:statutes/42/1396d/a/i#input.individual_age_years: 17
+    us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option: true
+    us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option: false
+    us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option: false
+  output:
+    us:statutes/42/1396d/a/i#youth_age_category_for_medical_assistance: holds
+"""
 
 
 class _RulespecRepairDumper(yaml.SafeDumper):
@@ -7796,6 +8003,387 @@ def _repair_medicaid_optional_senior_composition_tests(
         template["output"] = {"us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds"}
         cases.append(template)
         changed.append("optional senior disabled category eligible")
+
+    return _dump_rulespec_repair_yaml(cases), changed
+
+
+def _sha256_text(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+def cmd_repair_medicaid_primary_category_composition(args):
+    """Apply signed deterministic Medicaid young-adult and medically-needy repairs."""
+    repo_path = Path(args.repo).resolve()
+    if _repo_jurisdiction_prefix(repo_path) != "us":
+        print(
+            "repair-medicaid-primary-category-composition must run against "
+            f"rulespec-us; got {repo_path}"
+        )
+        sys.exit(1)
+
+    rules_file = repo_path / MEDICAID_A10_RELATIVE
+    test_file = _rulespec_test_path(rules_file)
+    youth_file = repo_path / MEDICAID_YOUTH_RELATIVE
+    youth_test_file = _rulespec_test_path(youth_file)
+    medically_needy_file = repo_path / MEDICAID_MEDICALLY_NEEDY_RELATIVE
+    if not rules_file.exists():
+        print(f"RuleSpec file not found: {rules_file}")
+        sys.exit(1)
+    if not test_file.exists():
+        print(f"RuleSpec companion test file not found: {test_file}")
+        sys.exit(1)
+    if not medically_needy_file.exists():
+        print(f"Required medically needy RuleSpec file not found: {medically_needy_file}")
+        sys.exit(1)
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+    manifest_groups = [
+        (MEDICAID_YOUTH_RELATIVE, [youth_file, youth_test_file]),
+        (MEDICAID_A10_RELATIVE, [rules_file, test_file]),
+    ]
+    _ensure_no_unmanifested_preexisting_rulespec_changes(repo_path, manifest_groups)
+
+    original_content = rules_file.read_text()
+    original_test_content = test_file.read_text()
+    originals = {
+        rules_file: original_content,
+        test_file: original_test_content,
+        youth_file: youth_file.read_text() if youth_file.exists() else None,
+        youth_test_file: youth_test_file.read_text() if youth_test_file.exists() else None,
+    }
+
+    youth_hash = _sha256_text(MEDICAID_YOUTH_RULESPEC)
+    medically_needy_hash = _sha256_file(medically_needy_file)
+    repaired_content, repaired_rules = (
+        _repair_medicaid_primary_category_composition_rules(
+            original_content,
+            youth_hash=youth_hash,
+            medically_needy_hash=medically_needy_hash,
+        )
+    )
+    repaired_test_content, repaired_tests = (
+        _repair_medicaid_primary_category_composition_tests(original_test_content)
+    )
+
+    try:
+        youth_file.parent.mkdir(parents=True, exist_ok=True)
+        youth_file.write_text(MEDICAID_YOUTH_RULESPEC)
+        youth_test_file.write_text(MEDICAID_YOUTH_TEST)
+        rules_file.write_text(repaired_content)
+        test_file.write_text(repaired_test_content)
+
+        validation_pipeline = ValidatorPipeline(
+            policy_repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+            enable_oracles=False,
+            require_policy_proofs=True,
+        )
+        validation_issues: list[str] = []
+        for candidate in (youth_file, rules_file):
+            validation = validation_pipeline.validate(candidate, skip_reviewers=True)
+            if not validation.all_passed:
+                validation_issues.extend(
+                    result.error
+                    for result in validation.results.values()
+                    if result.error
+                )
+        if validation_issues:
+            raise RuntimeError(
+                "Validation failed after Medicaid primary category repair:\n"
+                + "\n".join(f"- {issue}" for issue in validation_issues)
+            )
+
+        test_issues = _companion_test_issues(
+            test_files=[youth_test_file, test_file],
+            repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+        )
+        if test_issues:
+            raise RuntimeError(
+                "Companion tests failed after Medicaid primary category repair:\n"
+                + "\n".join(f"- {issue}" for issue in test_issues)
+            )
+    except Exception:
+        _restore_original_files(originals)
+        raise
+
+    changed_by_command = _unique_paths(
+        [
+            path
+            for path in (youth_file, youth_test_file, rules_file, test_file)
+            if _path_differs_from_original(path, originals.get(path))
+        ]
+    )
+    if not changed_by_command:
+        print("No Medicaid primary category composition repairs found.")
+        return
+
+    manifest_paths = _write_grouped_deterministic_repair_manifests(
+        repo_path=repo_path,
+        signing_key=signing_key,
+        axiom_encode_git=axiom_encode_git,
+        manifest_groups=manifest_groups,
+        changed_files=changed_by_command,
+        model=MEDICAID_PRIMARY_CATEGORY_REPAIR_MODEL,
+        tool="axiom-encode repair-medicaid-primary-category-composition",
+    )
+
+    changed_names = sorted(set(repaired_rules) | set(repaired_tests))
+    print("Applied Medicaid primary category composition repair")
+    if changed_names:
+        print(f"changed_rules={', '.join(changed_names)}")
+    for path in changed_by_command:
+        print(f"changed={path.relative_to(repo_path)}")
+    for manifest_path in manifest_paths:
+        print(f"manifest={manifest_path}")
+
+
+def _repair_medicaid_primary_category_composition_rules(
+    content: str,
+    *,
+    youth_hash: str,
+    medically_needy_hash: str,
+) -> tuple[str, list[str]]:
+    if "\n  - name: is_medicaid_eligible\n" not in content:
+        raise ValueError("Missing is_medicaid_eligible rule")
+
+    repaired = content
+    changed: list[str] = []
+
+    imports_to_add = [
+        MEDICAID_YOUTH_TARGET,
+        MEDICAID_MEDICALLY_NEEDY_MANDATORY_TARGET,
+        MEDICAID_MEDICALLY_NEEDY_OPTIONAL_TARGET,
+    ]
+    module_marker = "\nmodule:\n"
+    if module_marker not in repaired:
+        raise ValueError("RuleSpec payload must contain module section")
+    missing_imports = [target for target in imports_to_add if target not in repaired]
+    if missing_imports:
+        repaired = repaired.replace(
+            module_marker,
+            "".join(f"  - {target}\n" for target in missing_imports)
+            + module_marker,
+            1,
+        )
+        changed.append("imports")
+
+    source_marker = "    source: 42 USC 1396a(a)(10)(A)(i)-(ii)\n"
+    if source_marker in repaired:
+        repaired = repaired.replace(
+            source_marker,
+            "    source: 42 USC 1396a(a)(10)(A)(i)-(ii), (C)\n",
+            1,
+        )
+        changed.append("is_medicaid_eligible")
+
+    if f"\n  - name: {MEDICAID_OPTIONAL_YOUTH_RULE}\n" not in repaired:
+        rule_start = repaired.index("\n  - name: is_medicaid_eligible\n") + 1
+        optional_youth_rule = f"""  - name: {MEDICAID_OPTIONAL_YOUTH_RULE}
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 USC 1396a(a)(10)(A)(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: formula
+            source:
+              corpus_citation_path: us/statute/42/1396a/a/10
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: {MEDICAID_YOUTH_TARGET}
+              output: {MEDICAID_YOUTH_RULE}
+              hash: sha256:{youth_hash}
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i
+          and not individual_described_in_mandatory_clause_i
+          and {MEDICAID_YOUTH_RULE}
+          and individual_meets_income_and_resources_requirements_for_optional_category
+
+"""
+        repaired = repaired[:rule_start] + optional_youth_rule + repaired[rule_start:]
+        changed.append(MEDICAID_OPTIONAL_YOUTH_RULE)
+
+    rule_start = repaired.index("\n  - name: is_medicaid_eligible\n") + 1
+    next_rule = repaired.find("\n  - name:", rule_start + 1)
+    rule_end = next_rule if next_rule != -1 else len(repaired)
+    rule_text = repaired[rule_start:rule_end]
+
+    proof_atoms = []
+    if MEDICAID_MEDICALLY_NEEDY_MANDATORY_TARGET not in rule_text:
+        proof_atoms.append(
+            (
+                MEDICAID_MEDICALLY_NEEDY_MANDATORY_TARGET,
+                MEDICAID_MEDICALLY_NEEDY_MANDATORY_RULE,
+                medically_needy_hash,
+            )
+        )
+    if MEDICAID_MEDICALLY_NEEDY_OPTIONAL_TARGET not in rule_text:
+        proof_atoms.append(
+            (
+                MEDICAID_MEDICALLY_NEEDY_OPTIONAL_TARGET,
+                MEDICAID_MEDICALLY_NEEDY_OPTIONAL_RULE,
+                medically_needy_hash,
+            )
+        )
+    if proof_atoms:
+        versions_marker = "    versions:\n"
+        if versions_marker not in rule_text:
+            raise ValueError("is_medicaid_eligible must have versions")
+        proof_text = ""
+        for target, output, digest in proof_atoms:
+            proof_text += (
+                "          - path: versions[0].formula\n"
+                "            kind: import\n"
+                "            import:\n"
+                f"              target: {target}\n"
+                f"              output: {output}\n"
+                f"              hash: sha256:{digest}\n"
+            )
+        rule_text = rule_text.replace(versions_marker, proof_text + versions_marker, 1)
+        repaired = repaired[:rule_start] + rule_text + repaired[rule_end:]
+        if "is_medicaid_eligible" not in changed:
+            changed.append("is_medicaid_eligible")
+
+    insertion_point = f"          or {MEDICAID_OPTIONAL_SENIOR_RULE}\n"
+    if insertion_point not in repaired:
+        insertion_point = "          or former_foster_care_child_medicaid_required\n"
+    additions = [
+        f"          or {MEDICAID_OPTIONAL_YOUTH_RULE}\n",
+        f"          or {MEDICAID_MEDICALLY_NEEDY_MANDATORY_RULE}\n",
+        f"          or {MEDICAID_MEDICALLY_NEEDY_OPTIONAL_RULE}\n",
+    ]
+    missing_additions = [line for line in additions if line not in repaired]
+    if missing_additions:
+        if insertion_point not in repaired:
+            raise ValueError("Missing Medicaid eligibility formula insertion point")
+        repaired = repaired.replace(
+            insertion_point,
+            insertion_point + "".join(missing_additions),
+            1,
+        )
+        if "is_medicaid_eligible" not in changed:
+            changed.append("is_medicaid_eligible")
+
+    return repaired, changed
+
+
+_MEDICAID_PRIMARY_FALSE_INPUTS = {
+    "us:statutes/42/1396d/a/i#input.individual_age_years": 30,
+    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option": False,
+    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option": False,
+    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option": False,
+    "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i": False,
+    "us:statutes/42/1396a/a/10#input.individual_described_in_mandatory_clause_i": False,
+    "us:statutes/42/1396a/a/10#input.individual_meets_income_and_resources_requirements_for_optional_category": False,
+    "us:regulations/42-cfr/435/301#input.agency_chooses_medically_needy_option": False,
+    "us:regulations/42-cfr/435/301#input.income_meets_applicable_medically_needy_standard": False,
+    "us:regulations/42-cfr/435/301#input.incurred_medical_expenses_at_least_equal_to_income_standard_difference": False,
+    "us:regulations/42-cfr/435/301#input.resources_meet_applicable_medically_needy_standard": False,
+    "us:regulations/42-cfr/435/301#input.person_is_pregnant": False,
+    "us:regulations/42-cfr/435/301#input.person_except_for_income_and_resources_would_be_mandatory_or_optional_categorically_needy_under_subpart_b_or_c": False,
+    "us:regulations/42-cfr/435/301#input.person_age": 30,
+    "us:regulations/42-cfr/435/301#input.person_except_for_income_and_resources_would_be_mandatory_categorically_needy_under_subpart_b": False,
+    "us:regulations/42-cfr/435/301#input.woman_received_medically_needy_medicaid_on_day_pregnancy_ends": False,
+    "us:regulations/42-cfr/435/301#input.month_is_within_extended_postpregnancy_period": False,
+    "us:regulations/42-cfr/435/301#input.person_is_parent_or_other_caretaker_relative": False,
+    "us:regulations/42-cfr/435/301#input.person_is_aged": False,
+    "us:regulations/42-cfr/435/301#input.person_is_blind": False,
+    "us:regulations/42-cfr/435/301#input.person_is_disabled": False,
+    "us:regulations/42-cfr/435/301#input.agency_provides_medicaid_to_any_individual_in_persons_optional_group": False,
+}
+
+_MEDICAID_PRIMARY_YOUTH_TRUE_INPUTS = {
+    "us:statutes/42/1396d/a/i#input.individual_age_years": 20,
+    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option": False,
+    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option": False,
+    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option": False,
+    "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i": True,
+    "us:statutes/42/1396a/a/10#input.individual_described_in_mandatory_clause_i": False,
+    "us:statutes/42/1396a/a/10#input.individual_meets_income_and_resources_requirements_for_optional_category": True,
+}
+
+_MEDICAID_PRIMARY_MEDICALLY_NEEDY_TRUE_INPUTS = {
+    "us:regulations/42-cfr/435/301#input.agency_chooses_medically_needy_option": True,
+    "us:regulations/42-cfr/435/301#input.income_meets_applicable_medically_needy_standard": True,
+    "us:regulations/42-cfr/435/301#input.incurred_medical_expenses_at_least_equal_to_income_standard_difference": False,
+    "us:regulations/42-cfr/435/301#input.resources_meet_applicable_medically_needy_standard": True,
+    "us:regulations/42-cfr/435/301#input.person_age": 65,
+    "us:regulations/42-cfr/435/301#input.person_is_aged": True,
+    "us:regulations/42-cfr/435/301#input.person_is_blind": False,
+    "us:regulations/42-cfr/435/301#input.person_is_disabled": False,
+    "us:regulations/42-cfr/435/301#input.person_is_parent_or_other_caretaker_relative": False,
+}
+
+
+def _repair_medicaid_primary_category_composition_tests(
+    content: str,
+) -> tuple[str, list[str]]:
+    cases = yaml.safe_load(content)
+    if not isinstance(cases, list):
+        raise ValueError("RuleSpec companion tests must be a list")
+
+    changed: list[str] = []
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        inputs = case.setdefault("input", {})
+        if not isinstance(inputs, dict):
+            raise ValueError("RuleSpec test input must be a mapping")
+        for key, value in _MEDICAID_PRIMARY_FALSE_INPUTS.items():
+            if key not in inputs:
+                inputs[key] = value
+                changed.append(str(case.get("name") or "<unnamed>"))
+
+    names = {case.get("name") for case in cases if isinstance(case, dict)}
+    template = None
+    for case in cases:
+        if (
+            isinstance(case, dict)
+            and case.get("name") == "no composed mandatory category eligible"
+        ):
+            template = case
+            break
+    if template is None:
+        raise ValueError("Missing no composed mandatory category eligible test")
+
+    if "optional youth category eligible" not in names:
+        youth_case = copy.deepcopy(template)
+        youth_case["name"] = "optional youth category eligible"
+        inputs = youth_case.setdefault("input", {})
+        if not isinstance(inputs, dict):
+            raise ValueError("RuleSpec test input must be a mapping")
+        inputs.update(_MEDICAID_PRIMARY_FALSE_INPUTS)
+        inputs.update(_MEDICAID_PRIMARY_YOUTH_TRUE_INPUTS)
+        youth_case["output"] = {
+            "us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds"
+        }
+        cases.append(youth_case)
+        changed.append("optional youth category eligible")
+
+    if "optional medically needy category eligible" not in names:
+        medically_needy_case = copy.deepcopy(template)
+        medically_needy_case["name"] = "optional medically needy category eligible"
+        inputs = medically_needy_case.setdefault("input", {})
+        if not isinstance(inputs, dict):
+            raise ValueError("RuleSpec test input must be a mapping")
+        inputs.update(_MEDICAID_PRIMARY_FALSE_INPUTS)
+        inputs.update(_MEDICAID_PRIMARY_MEDICALLY_NEEDY_TRUE_INPUTS)
+        medically_needy_case["output"] = {
+            "us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds"
+        }
+        cases.append(medically_needy_case)
+        changed.append("optional medically needy category eligible")
 
     return _dump_rulespec_repair_yaml(cases), changed
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -8279,10 +8279,7 @@ def _repair_medicaid_primary_category_composition_rules(
 
 
 _MEDICAID_PRIMARY_FALSE_INPUTS = {
-    "us:statutes/42/1396d/a/i#input.individual_age_years": 30,
-    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option": False,
-    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option": False,
-    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option": False,
+    "us:statutes/42/1396d/a/i#youth_age_category_for_medical_assistance": "not_holds",
     "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i": False,
     "us:statutes/42/1396a/a/10#input.individual_described_in_mandatory_clause_i": False,
     "us:statutes/42/1396a/a/10#input.individual_meets_income_and_resources_requirements_for_optional_category": False,
@@ -8304,10 +8301,7 @@ _MEDICAID_PRIMARY_FALSE_INPUTS = {
 }
 
 _MEDICAID_PRIMARY_YOUTH_TRUE_INPUTS = {
-    "us:statutes/42/1396d/a/i#input.individual_age_years": 20,
-    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option": False,
-    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option": False,
-    "us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option": False,
+    "us:statutes/42/1396d/a/i#youth_age_category_for_medical_assistance": "holds",
     "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i": True,
     "us:statutes/42/1396a/a/10#input.individual_described_in_mandatory_clause_i": False,
     "us:statutes/42/1396a/a/10#input.individual_meets_income_and_resources_requirements_for_optional_category": True,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -8167,7 +8167,8 @@ def _repair_medicaid_primary_category_composition_rules(
     if missing_imports:
         repaired = repaired.replace(
             module_marker,
-            "".join(f"  - {target}\n" for target in missing_imports)
+            "\n"
+            + "".join(f"  - {target}\n" for target in missing_imports)
             + module_marker,
             1,
         )

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -8366,6 +8366,7 @@ def _repair_medicaid_primary_category_composition_tests(
         inputs.update(_MEDICAID_PRIMARY_FALSE_INPUTS)
         inputs.update(_MEDICAID_PRIMARY_YOUTH_TRUE_INPUTS)
         youth_case["output"] = {
+            "us:statutes/42/1396a/a/10#optional_youth_medicaid_category_eligible": "holds",
             "us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds"
         }
         cases.append(youth_case)

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -7511,9 +7511,7 @@ MEDICAID_MEDICALLY_NEEDY_MANDATORY_TARGET = (
 MEDICAID_MEDICALLY_NEEDY_OPTIONAL_TARGET = (
     "us:regulations/42-cfr/435/301#optional_medically_needy_medicaid_may_be_provided"
 )
-MEDICAID_MEDICALLY_NEEDY_MANDATORY_RULE = (
-    "mandatory_medically_needy_medicaid_required"
-)
+MEDICAID_MEDICALLY_NEEDY_MANDATORY_RULE = "mandatory_medically_needy_medicaid_required"
 MEDICAID_MEDICALLY_NEEDY_OPTIONAL_RULE = (
     "optional_medically_needy_medicaid_may_be_provided"
 )
@@ -7932,8 +7930,7 @@ def _repair_medicaid_optional_senior_composition_rules(
             raise ValueError("Missing Medicaid eligibility formula insertion point")
         repaired = repaired.replace(
             formula_marker,
-            formula_marker
-            + f"          or {MEDICAID_OPTIONAL_SENIOR_RULE}\n",
+            formula_marker + f"          or {MEDICAID_OPTIONAL_SENIOR_RULE}\n",
             1,
         )
         if "is_medicaid_eligible" not in changed:
@@ -8041,7 +8038,9 @@ def cmd_repair_medicaid_primary_category_composition(args):
         print(f"RuleSpec companion test file not found: {test_file}")
         sys.exit(1)
     if not medically_needy_file.exists():
-        print(f"Required medically needy RuleSpec file not found: {medically_needy_file}")
+        print(
+            f"Required medically needy RuleSpec file not found: {medically_needy_file}"
+        )
         sys.exit(1)
 
     signing_key = _require_applied_encoding_manifest_signing_key()
@@ -8061,7 +8060,9 @@ def cmd_repair_medicaid_primary_category_composition(args):
         rules_file: original_content,
         test_file: original_test_content,
         youth_file: youth_file.read_text() if youth_file.exists() else None,
-        youth_test_file: youth_test_file.read_text() if youth_test_file.exists() else None,
+        youth_test_file: youth_test_file.read_text()
+        if youth_test_file.exists()
+        else None,
     }
 
     youth_hash = _sha256_text(MEDICAID_YOUTH_RULESPEC)
@@ -8250,7 +8251,9 @@ def _repair_medicaid_primary_category_composition_rules(
 
 """
         repaired = (
-            repaired[:rule_start] + optional_working_disabled_rule + repaired[rule_start:]
+            repaired[:rule_start]
+            + optional_working_disabled_rule
+            + repaired[rule_start:]
         )
         changed.append(MEDICAID_OPTIONAL_WORKING_DISABLED_RULE)
 
@@ -8280,7 +8283,9 @@ def _repair_medicaid_primary_category_composition_rules(
 
 """
         repaired = (
-            repaired[:rule_start] + optional_ssi_excess_earnings_rule + repaired[rule_start:]
+            repaired[:rule_start]
+            + optional_ssi_excess_earnings_rule
+            + repaired[rule_start:]
         )
         changed.append(MEDICAID_OPTIONAL_SSI_EXCESS_EARNINGS_RULE)
 
@@ -8466,7 +8471,7 @@ def _repair_medicaid_primary_category_composition_tests(
         inputs.update(_MEDICAID_PRIMARY_YOUTH_TRUE_INPUTS)
         youth_case["output"] = {
             "us:statutes/42/1396a/a/10#optional_youth_medicaid_category_eligible": "holds",
-            "us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds"
+            "us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds",
         }
         cases.append(youth_case)
         changed.append("optional youth category eligible")

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -768,33 +768,36 @@ def resolve_axiom_binary(workspace_root: Path, override: Path | None) -> Path:
 
 def axiom_rules_env(program: Path, workspace_root: Path) -> dict[str, str]:
     env = os.environ.copy()
+    active_roots: list[Path] = []
+    current_repo = program.resolve()
+    for parent in current_repo.parents:
+        if parent.name.startswith("rulespec-"):
+            active_roots.append(parent)
+            break
     roots = [
         workspace_root / "rulespec-us",
         workspace_root / "_axiom" / "rulespec-us",
         program.parent,
         program.parent.parent,
     ]
-    current_repo = program.resolve()
-    for parent in current_repo.parents:
-        if parent.name.startswith("rulespec-"):
-            roots.append(parent)
-            break
     roots.extend(sorted(workspace_root.glob("rulespec-*")))
     roots.extend(sorted((workspace_root / "_axiom").glob("rulespec-*")))
     existing = [path.resolve() for path in roots if path.exists()]
     configured = [
         Path(path).resolve()
-        for path in env.get("AXIOM_RULESPEC_REPO_ROOTS", "").split(":")
+        for path in env.get("AXIOM_RULESPEC_REPO_ROOTS", "").split(os.pathsep)
         if path
     ]
     unique_roots = []
     seen: set[Path] = set()
-    for path in [*configured, *existing]:
+    for path in [*active_roots, *configured, *existing]:
         if path in seen:
             continue
         seen.add(path)
         unique_roots.append(path)
-    env["AXIOM_RULESPEC_REPO_ROOTS"] = ":".join(str(path) for path in unique_roots)
+    env["AXIOM_RULESPEC_REPO_ROOTS"] = os.pathsep.join(
+        str(path) for path in unique_roots
+    )
     return env
 
 

--- a/src/axiom_encode/oracles/policyengine/medicaid_populace.py
+++ b/src/axiom_encode/oracles/policyengine/medicaid_populace.py
@@ -70,8 +70,7 @@ AXIOM_COMPONENT_OUTPUT_IDS = {
         "#optional_ssi_excess_earnings_medicaid_category_eligible"
     ),
     "working_disabled": (
-        "us:statutes/42/1396a/a/10"
-        "#optional_working_disabled_medicaid_category_eligible"
+        "us:statutes/42/1396a/a/10#optional_working_disabled_medicaid_category_eligible"
     ),
     "optional_senior_disabled": (
         "us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid"
@@ -596,12 +595,10 @@ def _project_case_inputs(
     inputs[
         "us:statutes/42/1396a/m#input.disabled_as_determined_under_section_1382c_a_3"
     ] = bool(optional_senior_disabled and numeric_age < 65)
-    inputs[
-        "us:statutes/42/1396a/m#input.income_determined_for_this_subsection"
-    ] = 0.5 if optional_senior_disabled else 2.0
-    inputs[
-        "us:statutes/42/1396a/m#input.state_established_income_level_amount"
-    ] = 1.0
+    inputs["us:statutes/42/1396a/m#input.income_determined_for_this_subsection"] = (
+        0.5 if optional_senior_disabled else 2.0
+    )
+    inputs["us:statutes/42/1396a/m#input.state_established_income_level_amount"] = 1.0
     inputs[
         "us:statutes/42/1396a/m#input.state_established_income_level_poverty_line_rate"
     ] = 1.0
@@ -637,15 +634,9 @@ def _project_case_inputs(
     young_adult = bool(young_adult_eligible)
     inputs["us:statutes/42/1396d/a/i#input.individual_age_years"] = numeric_age
     inputs["us:statutes/42/1396a/a/10#input.individual_age_years"] = numeric_age
-    inputs[
-        "us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option"
-    ] = False
-    inputs[
-        "us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option"
-    ] = False
-    inputs[
-        "us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option"
-    ] = False
+    inputs["us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option"] = False
+    inputs["us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option"] = False
+    inputs["us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option"] = False
     inputs[
         "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i"
     ] = young_adult
@@ -865,13 +856,11 @@ def load_policyengine_cases(
             medically_needy_eligible=str(values["medicaid_category"][index])
             == "MEDICALLY_NEEDY",
             working_disabled_buy_in_eligible=(
-                str(values["medicaid_category"][index])
-                == "WORKING_DISABLED_BUY_IN"
+                str(values["medicaid_category"][index]) == "WORKING_DISABLED_BUY_IN"
                 and str(states[index]) != "CA"
             ),
             ssi_excess_earnings_buy_in_eligible=(
-                str(values["medicaid_category"][index])
-                == "WORKING_DISABLED_BUY_IN"
+                str(values["medicaid_category"][index]) == "WORKING_DISABLED_BUY_IN"
                 and str(states[index]) == "CA"
             ),
             mandatory_subpart_b=mandatory_subpart_b,

--- a/src/axiom_encode/oracles/policyengine/medicaid_populace.py
+++ b/src/axiom_encode/oracles/policyengine/medicaid_populace.py
@@ -65,6 +65,10 @@ AXIOM_COMPONENT_OUTPUT_IDS = {
     "young_adult": (
         "us:statutes/42/1396a/a/10#optional_youth_medicaid_category_eligible"
     ),
+    "ssi_excess_earnings": (
+        "us:statutes/42/1396a/a/10"
+        "#optional_ssi_excess_earnings_medicaid_category_eligible"
+    ),
     "working_disabled": (
         "us:statutes/42/1396a/a/10"
         "#optional_working_disabled_medicaid_category_eligible"
@@ -478,6 +482,7 @@ def _project_case_inputs(
     senior_or_disabled_eligible: bool,
     medically_needy_eligible: bool,
     working_disabled_buy_in_eligible: bool,
+    ssi_excess_earnings_buy_in_eligible: bool,
     mandatory_subpart_b: bool,
     work_requirement_eligible: bool,
     medicare_eligible: bool,
@@ -652,12 +657,20 @@ def _project_case_inputs(
     ] = young_adult
 
     working_disabled = bool(working_disabled_buy_in_eligible)
+    ssi_excess_earnings = bool(ssi_excess_earnings_buy_in_eligible)
+    ssi_but_for_earnings = working_disabled or ssi_excess_earnings
+    inputs[
+        "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_ssi_excess_earnings_individuals"
+    ] = ssi_excess_earnings
     inputs[
         "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_working_disabled_individuals"
     ] = working_disabled
     inputs[
         "us:statutes/42/1396a/a/10#input.individual_would_be_considered_receiving_ssi_but_for_earnings"
-    ] = working_disabled
+    ] = ssi_but_for_earnings
+    inputs[
+        "us:statutes/42/1396a/a/10#input.family_income_as_fraction_of_poverty_line"
+    ] = 1.0 if ssi_excess_earnings else 3.0
     inputs[
         "us:statutes/42/1396a/a/10#input.assets_resources_and_earned_or_unearned_income_do_not_exceed_state_established_limitations"
     ] = working_disabled
@@ -851,8 +864,16 @@ def load_policyengine_cases(
             == "SENIOR_OR_DISABLED",
             medically_needy_eligible=str(values["medicaid_category"][index])
             == "MEDICALLY_NEEDY",
-            working_disabled_buy_in_eligible=str(values["medicaid_category"][index])
-            == "WORKING_DISABLED_BUY_IN",
+            working_disabled_buy_in_eligible=(
+                str(values["medicaid_category"][index])
+                == "WORKING_DISABLED_BUY_IN"
+                and str(states[index]) != "CA"
+            ),
+            ssi_excess_earnings_buy_in_eligible=(
+                str(values["medicaid_category"][index])
+                == "WORKING_DISABLED_BUY_IN"
+                and str(states[index]) == "CA"
+            ),
             mandatory_subpart_b=mandatory_subpart_b,
             work_requirement_eligible=bool(values["work"][index]),
             medicare_eligible=bool(values["medicare"][index]),

--- a/src/axiom_encode/oracles/policyengine/medicaid_populace.py
+++ b/src/axiom_encode/oracles/policyengine/medicaid_populace.py
@@ -625,9 +625,16 @@ def _project_case_inputs(
     ] = False
 
     young_adult = bool(young_adult_eligible)
-    inputs["us:statutes/42/1396d/a/i#youth_age_category_for_medical_assistance"] = (
-        "holds" if young_adult else "not_holds"
-    )
+    inputs["us:statutes/42/1396d/a/i#input.individual_age_years"] = numeric_age
+    inputs[
+        "us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option"
+    ] = False
+    inputs[
+        "us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option"
+    ] = False
+    inputs[
+        "us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option"
+    ] = False
     inputs[
         "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i"
     ] = young_adult

--- a/src/axiom_encode/oracles/policyengine/medicaid_populace.py
+++ b/src/axiom_encode/oracles/policyengine/medicaid_populace.py
@@ -173,6 +173,15 @@ def configure_parser(parser: argparse.ArgumentParser) -> argparse.ArgumentParser
         ),
     )
     parser.add_argument(
+        "--eligibility-only",
+        action="store_true",
+        help=(
+            "Request only the compared Medicaid eligibility output from Axiom. "
+            "Use this for full-population gates; omit it for sampled diagnostic "
+            "runs that need component outputs."
+        ),
+    )
+    parser.add_argument(
         "--populace-year",
         type=int,
         default=DEFAULT_US_POPULACE_YEAR,
@@ -872,6 +881,27 @@ def runtime_output_id_for_public_id(artifact: Path, public_id: str) -> str:
     )
 
 
+def axiom_output_ids_by_label(
+    artifact: Path,
+    *,
+    include_diagnostics: bool,
+) -> dict[str, str]:
+    outputs = {
+        "eligible": runtime_output_id_for_public_id(
+            artifact,
+            COMPARED_AXIOM_OUTPUT_ID,
+        )
+    }
+    if include_diagnostics:
+        outputs.update(
+            {
+                label: runtime_output_id_for_public_id(artifact, public_id)
+                for label, public_id in AXIOM_COMPONENT_OUTPUT_IDS.items()
+            }
+        )
+    return outputs
+
+
 def compare(
     cases: list[PersonCase],
     results: list[dict[str, Any]],
@@ -1034,15 +1064,10 @@ def main(args: argparse.Namespace | None = None) -> None:
         artifact = Path(tmp_dir) / "program.bin"
         print(f"Compiling {program}...", flush=True)
         compile_program(binary, program, artifact, env=env)
-        axiom_output_id_by_label = {
-            "eligible": runtime_output_id_for_public_id(
-                artifact, COMPARED_AXIOM_OUTPUT_ID
-            ),
-            **{
-                label: runtime_output_id_for_public_id(artifact, public_id)
-                for label, public_id in AXIOM_COMPONENT_OUTPUT_IDS.items()
-            },
-        }
+        axiom_output_id_by_label = axiom_output_ids_by_label(
+            artifact,
+            include_diagnostics=not args.eligibility_only,
+        )
         print(
             f"Resolved {COMPARED_AXIOM_OUTPUT_ID} to runtime output "
             f"{axiom_output_id_by_label['eligible']}.",

--- a/src/axiom_encode/oracles/policyengine/medicaid_populace.py
+++ b/src/axiom_encode/oracles/policyengine/medicaid_populace.py
@@ -65,6 +65,10 @@ AXIOM_COMPONENT_OUTPUT_IDS = {
     "young_adult": (
         "us:statutes/42/1396a/a/10#optional_youth_medicaid_category_eligible"
     ),
+    "working_disabled": (
+        "us:statutes/42/1396a/a/10"
+        "#optional_working_disabled_medicaid_category_eligible"
+    ),
     "optional_senior_disabled": (
         "us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid"
     ),
@@ -473,6 +477,7 @@ def _project_case_inputs(
     young_adult_eligible: bool,
     senior_or_disabled_eligible: bool,
     medically_needy_eligible: bool,
+    working_disabled_buy_in_eligible: bool,
     mandatory_subpart_b: bool,
     work_requirement_eligible: bool,
     medicare_eligible: bool,
@@ -626,6 +631,7 @@ def _project_case_inputs(
 
     young_adult = bool(young_adult_eligible)
     inputs["us:statutes/42/1396d/a/i#input.individual_age_years"] = numeric_age
+    inputs["us:statutes/42/1396a/a/10#input.individual_age_years"] = numeric_age
     inputs[
         "us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option"
     ] = False
@@ -644,6 +650,17 @@ def _project_case_inputs(
     inputs[
         "us:statutes/42/1396a/a/10#input.individual_meets_income_and_resources_requirements_for_optional_category"
     ] = young_adult
+
+    working_disabled = bool(working_disabled_buy_in_eligible)
+    inputs[
+        "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_working_disabled_individuals"
+    ] = working_disabled
+    inputs[
+        "us:statutes/42/1396a/a/10#input.individual_would_be_considered_receiving_ssi_but_for_earnings"
+    ] = working_disabled
+    inputs[
+        "us:statutes/42/1396a/a/10#input.assets_resources_and_earned_or_unearned_income_do_not_exceed_state_established_limitations"
+    ] = working_disabled
 
     medically_needy = bool(medically_needy_eligible)
     inputs[
@@ -834,6 +851,8 @@ def load_policyengine_cases(
             == "SENIOR_OR_DISABLED",
             medically_needy_eligible=str(values["medicaid_category"][index])
             == "MEDICALLY_NEEDY",
+            working_disabled_buy_in_eligible=str(values["medicaid_category"][index])
+            == "WORKING_DISABLED_BUY_IN",
             mandatory_subpart_b=mandatory_subpart_b,
             work_requirement_eligible=bool(values["work"][index]),
             medicare_eligible=bool(values["medicare"][index]),

--- a/src/axiom_encode/oracles/policyengine/medicaid_populace.py
+++ b/src/axiom_encode/oracles/policyengine/medicaid_populace.py
@@ -62,8 +62,17 @@ AXIOM_COMPONENT_OUTPUT_IDS = {
     "former_foster": (
         "us:regulations/42-cfr/435/150#former_foster_care_child_medicaid_required"
     ),
+    "young_adult": (
+        "us:statutes/42/1396a/a/10#optional_youth_medicaid_category_eligible"
+    ),
     "optional_senior_disabled": (
         "us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid"
+    ),
+    "medically_needy_mandatory": (
+        "us:regulations/42-cfr/435/301#mandatory_medically_needy_medicaid_required"
+    ),
+    "medically_needy_optional": (
+        "us:regulations/42-cfr/435/301#optional_medically_needy_medicaid_may_be_provided"
     ),
     "community_engagement": (
         "us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month"
@@ -461,7 +470,9 @@ def _project_case_inputs(
     adult_nfc: bool,
     adult_fc: bool,
     ssi_recipient: bool,
+    young_adult_eligible: bool,
     senior_or_disabled_eligible: bool,
+    medically_needy_eligible: bool,
     mandatory_subpart_b: bool,
     work_requirement_eligible: bool,
     medicare_eligible: bool,
@@ -613,6 +624,68 @@ def _project_case_inputs(
         "us:regulations/42-cfr/435/150#input.person_was_enrolled_in_medicaid_under_state_plan_or_1115_demonstration_upon_attaining_age_18"
     ] = False
 
+    young_adult = bool(young_adult_eligible)
+    inputs["us:statutes/42/1396d/a/i#input.individual_age_years"] = numeric_age
+    inputs[
+        "us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option"
+    ] = False
+    inputs[
+        "us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option"
+    ] = False
+    inputs[
+        "us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option"
+    ] = False
+    inputs[
+        "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i"
+    ] = young_adult
+    inputs[
+        "us:statutes/42/1396a/a/10#input.individual_described_in_mandatory_clause_i"
+    ] = bool(mandatory_subpart_b)
+    inputs[
+        "us:statutes/42/1396a/a/10#input.individual_meets_income_and_resources_requirements_for_optional_category"
+    ] = young_adult
+
+    medically_needy = bool(medically_needy_eligible)
+    inputs[
+        "us:regulations/42-cfr/435/301#input.agency_chooses_medically_needy_option"
+    ] = medically_needy
+    inputs[
+        "us:regulations/42-cfr/435/301#input.income_meets_applicable_medically_needy_standard"
+    ] = medically_needy
+    inputs[
+        "us:regulations/42-cfr/435/301#input.incurred_medical_expenses_at_least_equal_to_income_standard_difference"
+    ] = False
+    inputs[
+        "us:regulations/42-cfr/435/301#input.resources_meet_applicable_medically_needy_standard"
+    ] = medically_needy
+    inputs["us:regulations/42-cfr/435/301#input.person_is_pregnant"] = False
+    inputs[
+        "us:regulations/42-cfr/435/301#input.person_except_for_income_and_resources_would_be_mandatory_or_optional_categorically_needy_under_subpart_b_or_c"
+    ] = False
+    inputs["us:regulations/42-cfr/435/301#input.person_age"] = numeric_age
+    inputs[
+        "us:regulations/42-cfr/435/301#input.person_except_for_income_and_resources_would_be_mandatory_categorically_needy_under_subpart_b"
+    ] = False
+    inputs[
+        "us:regulations/42-cfr/435/301#input.woman_received_medically_needy_medicaid_on_day_pregnancy_ends"
+    ] = False
+    inputs[
+        "us:regulations/42-cfr/435/301#input.month_is_within_extended_postpregnancy_period"
+    ] = False
+    inputs[
+        "us:regulations/42-cfr/435/301#input.person_is_parent_or_other_caretaker_relative"
+    ] = False
+    inputs["us:regulations/42-cfr/435/301#input.person_is_aged"] = bool(
+        medically_needy and numeric_age >= 65
+    )
+    inputs["us:regulations/42-cfr/435/301#input.person_is_blind"] = False
+    inputs["us:regulations/42-cfr/435/301#input.person_is_disabled"] = bool(
+        medically_needy and numeric_age < 65
+    )
+    inputs[
+        "us:regulations/42-cfr/435/301#input.agency_provides_medicaid_to_any_individual_in_persons_optional_group"
+    ] = False
+
     inputs["us:statutes/42/1396a/xx#input.monthly_work_hours"] = (
         80 if work_requirement_eligible else 0
     )
@@ -755,8 +828,12 @@ def load_policyengine_cases(
             adult_nfc=bool(values["adult_nfc"][index]),
             adult_fc=bool(values["adult_fc"][index]),
             ssi_recipient=bool(values["ssi"][index]),
+            young_adult_eligible=str(values["medicaid_category"][index])
+            == "YOUNG_ADULT",
             senior_or_disabled_eligible=str(values["medicaid_category"][index])
             == "SENIOR_OR_DISABLED",
+            medically_needy_eligible=str(values["medicaid_category"][index])
+            == "MEDICALLY_NEEDY",
             mandatory_subpart_b=mandatory_subpart_b,
             work_requirement_eligible=bool(values["work"][index]),
             medicare_eligible=bool(values["medicare"][index]),

--- a/src/axiom_encode/oracles/policyengine/medicaid_populace.py
+++ b/src/axiom_encode/oracles/policyengine/medicaid_populace.py
@@ -62,6 +62,9 @@ AXIOM_COMPONENT_OUTPUT_IDS = {
     "former_foster": (
         "us:regulations/42-cfr/435/150#former_foster_care_child_medicaid_required"
     ),
+    "optional_senior_disabled": (
+        "us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid"
+    ),
     "community_engagement": (
         "us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month"
     ),
@@ -449,6 +452,7 @@ def _project_case_inputs(
     adult_nfc: bool,
     adult_fc: bool,
     ssi_recipient: bool,
+    senior_or_disabled_eligible: bool,
     mandatory_subpart_b: bool,
     work_requirement_eligible: bool,
     medicare_eligible: bool,
@@ -556,6 +560,39 @@ def _project_case_inputs(
     inputs[
         "us:regulations/42-cfr/435/120/ssi-mandatory-group#input.person_is_receiving_or_deemed_receiving_ssi"
     ] = bool(ssi_recipient)
+
+    optional_senior_disabled = bool(senior_or_disabled_eligible)
+    inputs["us:statutes/42/1396a/m#input.individual_age_years"] = numeric_age
+    inputs[
+        "us:statutes/42/1396a/m#input.disabled_as_determined_under_section_1382c_a_3"
+    ] = bool(optional_senior_disabled and numeric_age < 65)
+    inputs[
+        "us:statutes/42/1396a/m#input.income_determined_for_this_subsection"
+    ] = 0.5 if optional_senior_disabled else 2.0
+    inputs[
+        "us:statutes/42/1396a/m#input.state_established_income_level_amount"
+    ] = 1.0
+    inputs[
+        "us:statutes/42/1396a/m#input.state_established_income_level_poverty_line_rate"
+    ] = 1.0
+    inputs[
+        "us:statutes/42/1396a/m#input.resources_determined_for_supplemental_security_income_program"
+    ] = 1.0 if optional_senior_disabled else 3.0
+    inputs[
+        "us:statutes/42/1396a/m#input.maximum_resources_for_supplemental_security_income_program"
+    ] = 2.0
+    inputs[
+        "us:statutes/42/1396a/m#input.state_provides_medical_assistance_to_individuals_not_described_in_subsection_a_10_A"
+    ] = False
+    inputs[
+        "us:statutes/42/1396a/m#input.state_elects_higher_resource_level_for_non_a10A_individuals"
+    ] = False
+    inputs[
+        "us:statutes/42/1396a/m#input.individual_not_described_in_subsection_a_10_A"
+    ] = False
+    inputs[
+        "us:statutes/42/1396a/m#input.state_optional_resource_level_amount_for_non_a10A_individuals"
+    ] = 0.0
 
     inputs[
         "us:regulations/42-cfr/435/150#input.person_eligible_and_enrolled_for_mandatory_coverage_under_435_110_through_435_118_or_435_120_through_435_145"
@@ -709,6 +746,8 @@ def load_policyengine_cases(
             adult_nfc=bool(values["adult_nfc"][index]),
             adult_fc=bool(values["adult_fc"][index]),
             ssi_recipient=bool(values["ssi"][index]),
+            senior_or_disabled_eligible=str(values["medicaid_category"][index])
+            == "SENIOR_OR_DISABLED",
             mandatory_subpart_b=mandatory_subpart_b,
             work_requirement_eligible=bool(values["work"][index]),
             medicare_eligible=bool(values["medicare"][index]),
@@ -1041,7 +1080,8 @@ def main(args: argparse.Namespace | None = None) -> None:
             f"adult_fc={row['pe_adult_fc']} work={row['pe_work']} "
             f"axiom_child={row.get('axiom_child')} "
             f"axiom_adult={row.get('axiom_adult')} "
-            f"axiom_ssi={row.get('axiom_ssi')}"
+            f"axiom_ssi={row.get('axiom_ssi')} "
+            f"axiom_optional_senior_disabled={row.get('axiom_optional_senior_disabled')}"
         )
 
     if args.write_csv is not None:

--- a/src/axiom_encode/oracles/policyengine/medicaid_populace.py
+++ b/src/axiom_encode/oracles/policyengine/medicaid_populace.py
@@ -625,16 +625,9 @@ def _project_case_inputs(
     ] = False
 
     young_adult = bool(young_adult_eligible)
-    inputs["us:statutes/42/1396d/a/i#input.individual_age_years"] = numeric_age
-    inputs[
-        "us:statutes/42/1396d/a/i#input.state_chooses_under_age_18_option"
-    ] = False
-    inputs[
-        "us:statutes/42/1396d/a/i#input.state_chooses_under_age_19_option"
-    ] = False
-    inputs[
-        "us:statutes/42/1396d/a/i#input.state_chooses_under_age_20_option"
-    ] = False
+    inputs["us:statutes/42/1396d/a/i#youth_age_category_for_medical_assistance"] = (
+        "holds" if young_adult else "not_holds"
+    )
     inputs[
         "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i"
     ] = young_adult

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -197,6 +197,7 @@ from axiom_encode.cli import (
     cmd_repair_imported_test_inputs,
     cmd_repair_invalid_test_inputs,
     cmd_repair_judgment_positive_tests,
+    cmd_repair_medicaid_primary_category_composition,
     cmd_repair_missing_deferred_outputs,
     cmd_repair_missing_source_proofs,
     cmd_repair_mixed_derived_entity_output_tests,
@@ -25673,6 +25674,7 @@ rules:
         rules = """format: rulespec/v1
 imports:
   - us:regulations/42-cfr/435/110#parent_or_caretaker_relative_eligible
+  - us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid
 module:
   proof_validation:
     required: true
@@ -25914,6 +25916,118 @@ rules:
         }
         assert "optional working disabled category eligible" in changed_tests
         assert "optional SSI excess earnings category eligible" in changed_tests
+
+    def test_repair_medicaid_primary_category_refreshes_stale_manifest(self, tmp_path):
+        checkout = tmp_path / "rulespec-us"
+        _init_test_git_repo(checkout)
+        policy_repo = checkout / "us"
+        rules_file = policy_repo / "statutes/42/1396a/a/10.yaml"
+        test_file = policy_repo / "statutes/42/1396a/a/10.test.yaml"
+        medically_needy_file = policy_repo / "regulations/42-cfr/435/301.yaml"
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+imports:
+  - us:regulations/42-cfr/435/110#parent_or_caretaker_relative_eligible
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/1396a/a/10
+rules:
+  - name: is_medicaid_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 USC 1396a(a)(10)(A)(i)-(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/42/1396a/a/10
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          former_foster_care_child_medicaid_required
+          or is_optional_senior_or_disabled_for_medicaid
+"""
+        )
+        test_file.write_text(
+            """- name: no composed mandatory category eligible
+  period: 2027-01
+  input:
+    us:regulations/42-cfr/435/110#input.person_is_parent_or_caretaker_relative: false
+  output:
+    us:statutes/42/1396a/a/10#is_medicaid_eligible: not_holds
+"""
+        )
+        medically_needy_file.parent.mkdir(parents=True, exist_ok=True)
+        medically_needy_file.write_text("format: rulespec/v1\nrules: []\n")
+        _git(checkout, "add", ".")
+        _git(checkout, "commit", "-m", "initial")
+
+        args = SimpleNamespace(
+            repo=policy_repo,
+            axiom_rules_path=tmp_path / "axiom-rules-engine",
+        )
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is True
+
+            def validate(self, path, *, skip_reviewers):
+                assert path.suffix == ".yaml"
+                assert path.is_relative_to(policy_repo)
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        manifest = policy_repo / ".axiom/encoding-manifests/statutes/42/1396a/a/10.json"
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch("axiom_encode.cli._companion_test_issues", return_value=[]),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "old123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_medicaid_primary_category_composition(args)
+
+        first_payload = json.loads(manifest.read_text())
+        first_rules_content = rules_file.read_text()
+        first_test_content = test_file.read_text()
+        assert first_payload["axiom_encode_git"]["commit"] == "old123"
+        _git(checkout, "add", ".")
+        _git(checkout, "commit", "-m", "apply old repair")
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch("axiom_encode.cli._companion_test_issues", return_value=[]),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "new456", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_medicaid_primary_category_composition(args)
+
+        refreshed_payload = json.loads(manifest.read_text())
+        assert rules_file.read_text() == first_rules_content
+        assert test_file.read_text() == first_test_content
+        assert refreshed_payload["axiom_encode_git"]["commit"] == "new456"
+        assert [item["path"] for item in refreshed_payload["applied_files"]] == [
+            "statutes/42/1396a/a/10.yaml",
+            "statutes/42/1396a/a/10.test.yaml",
+        ]
 
     def test_repair_georgia_cms_medicaid_availability_writes_signed_manifest(
         self, tmp_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25830,19 +25830,12 @@ rules:
             )
         )
 
+        assert "optional_working_disabled_medicaid_category_eligible" in changed_rules
         assert (
-            "optional_working_disabled_medicaid_category_eligible" in changed_rules
+            "optional_ssi_excess_earnings_medicaid_category_eligible" in changed_rules
         )
-        assert (
-            "optional_ssi_excess_earnings_medicaid_category_eligible"
-            in changed_rules
-        )
-        assert (
-            "source: 42 USC 1396a(a)(10)(A)(ii)(XV)" in repaired_rules
-        )
-        assert (
-            "source: 42 USC 1396a(a)(10)(A)(ii)(XIII)" in repaired_rules
-        )
+        assert "source: 42 USC 1396a(a)(10)(A)(ii)(XV)" in repaired_rules
+        assert "source: 42 USC 1396a(a)(10)(A)(ii)(XIII)" in repaired_rules
         assert (
             "state_elects_optional_coverage_for_working_disabled_individuals"
             in repaired_rules
@@ -25860,8 +25853,7 @@ rules:
             in repaired_rules
         )
         assert (
-            "or optional_working_disabled_medicaid_category_eligible"
-            in repaired_rules
+            "or optional_working_disabled_medicaid_category_eligible" in repaired_rules
         )
 
     def test_repair_medicaid_primary_category_tests_add_working_disabled_case(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,6 +89,8 @@ from axiom_encode.cli import (
     _repair_half_unit_add_person_formulas,
     _repair_imported_rule_name_collisions,
     _repair_input_field_accesses_in_formulas,
+    _repair_medicaid_optional_senior_composition_rules,
+    _repair_medicaid_optional_senior_composition_tests,
     _repair_missing_entity_table_rows_for_row_ordered_outputs,
     _repair_missing_source_proof_atoms,
     _repair_mixed_derived_entity_output_tests,
@@ -25662,6 +25664,81 @@ rules:
         assert payload["axiom_encode_version"] == AXIOM_ENCODE_TEST_VERSION
         assert payload["axiom_encode_git"] == current_git
         assert payload["tool"] == "axiom-encode repair-snap-273-9-income-eligibility"
+
+    def test_repair_medicaid_optional_senior_composition_updates_rule_and_tests(
+        self,
+    ):
+        rules = """format: rulespec/v1
+imports:
+  - us:regulations/42-cfr/435/110#parent_or_caretaker_relative_eligible
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/1396a/a/10
+rules:
+  - name: is_medicaid_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 USC 1396a(a)(10)(A)(i)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/42/1396a/a/10
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          parent_or_caretaker_relative_eligible
+          or former_foster_care_child_medicaid_required
+"""
+        tests = """- name: no composed mandatory category eligible
+  period: 2027-01
+  input:
+    us:regulations/42-cfr/435/110#input.person_is_parent_or_caretaker_relative: false
+  output:
+    us:statutes/42/1396a/a/10#is_medicaid_eligible: not_holds
+"""
+
+        repaired_rules, changed_rules = (
+            _repair_medicaid_optional_senior_composition_rules(
+                rules, optional_hash="abc123"
+            )
+        )
+        repaired_tests, changed_tests = (
+            _repair_medicaid_optional_senior_composition_tests(tests)
+        )
+
+        assert changed_rules == ["is_medicaid_eligible"]
+        assert (
+            "us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid"
+            in repaired_rules
+        )
+        assert "source: 42 USC 1396a(a)(10)(A)(i)-(ii)" in repaired_rules
+        assert "hash: sha256:abc123" in repaired_rules
+        assert "or is_optional_senior_or_disabled_for_medicaid" in repaired_rules
+
+        parsed_tests = yaml.safe_load(repaired_tests)
+        assert [case["name"] for case in parsed_tests] == [
+            "no composed mandatory category eligible",
+            "optional senior disabled category eligible",
+        ]
+        baseline_inputs = parsed_tests[0]["input"]
+        assert (
+            baseline_inputs["us:statutes/42/1396a/m#input.individual_age_years"] == 30
+        )
+        optional_inputs = parsed_tests[1]["input"]
+        assert (
+            optional_inputs["us:statutes/42/1396a/m#input.individual_age_years"] == 65
+        )
+        assert parsed_tests[1]["output"] == {
+            "us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds"
+        }
+        assert "optional senior disabled category eligible" in changed_tests
 
     def test_repair_georgia_cms_medicaid_availability_writes_signed_manifest(
         self, tmp_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,6 +91,7 @@ from axiom_encode.cli import (
     _repair_input_field_accesses_in_formulas,
     _repair_medicaid_optional_senior_composition_rules,
     _repair_medicaid_optional_senior_composition_tests,
+    _repair_medicaid_primary_category_composition_rules,
     _repair_medicaid_primary_category_composition_tests,
     _repair_missing_entity_table_rows_for_row_ordered_outputs,
     _repair_missing_source_proof_atoms,
@@ -25770,6 +25771,118 @@ rules:
             "us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds",
         }
         assert "optional youth category eligible" in changed_tests
+
+    def test_repair_medicaid_primary_category_composes_working_disabled_category(
+        self,
+    ):
+        rules = """format: rulespec/v1
+imports:
+  - us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/1396a/a/10
+rules:
+  - name: optional_working_disabled_minimum_age_years
+    kind: parameter
+    dtype: Count
+    source: 42 USC 1396a(a)(10)(A)(ii)(XV)
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          16
+
+  - name: optional_working_disabled_age_ceiling_years
+    kind: parameter
+    dtype: Count
+    source: 42 USC 1396a(a)(10)(A)(ii)(XV)
+    versions:
+      - effective_from: '1974-01-01'
+        formula: |-
+          65
+
+  - name: is_medicaid_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 USC 1396a(a)(10)(A)(i)-(ii)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/42/1396a/a/10
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          former_foster_care_child_medicaid_required
+          or is_optional_senior_or_disabled_for_medicaid
+"""
+
+        repaired_rules, changed_rules = (
+            _repair_medicaid_primary_category_composition_rules(
+                rules,
+                youth_hash="youth-hash",
+                medically_needy_hash="mn-hash",
+            )
+        )
+
+        assert (
+            "optional_working_disabled_medicaid_category_eligible" in changed_rules
+        )
+        assert (
+            "source: 42 USC 1396a(a)(10)(A)(ii)(XV)" in repaired_rules
+        )
+        assert (
+            "state_elects_optional_coverage_for_working_disabled_individuals"
+            in repaired_rules
+        )
+        assert (
+            "and individual_would_be_considered_receiving_ssi_but_for_earnings"
+            in repaired_rules
+        )
+        assert (
+            "or optional_working_disabled_medicaid_category_eligible"
+            in repaired_rules
+        )
+
+    def test_repair_medicaid_primary_category_tests_add_working_disabled_case(self):
+        tests = """- name: no composed mandatory category eligible
+  period: 2027-01
+  input:
+    us:statutes/42/1396a/m#input.individual_age_years: 30
+  output:
+    us:statutes/42/1396a/a/10#is_medicaid_eligible: not_holds
+"""
+
+        repaired_tests, changed_tests = (
+            _repair_medicaid_primary_category_composition_tests(tests)
+        )
+
+        parsed_tests = yaml.safe_load(repaired_tests)
+        working_disabled_case = next(
+            case
+            for case in parsed_tests
+            if case["name"] == "optional working disabled category eligible"
+        )
+        inputs = working_disabled_case["input"]
+        assert inputs["us:statutes/42/1396a/a/10#input.individual_age_years"] == 40
+        assert inputs["us:statutes/42/1396a/m#input.individual_age_years"] == 40
+        assert inputs["us:statutes/42/1396d/a/i#input.individual_age_years"] == 40
+        assert (
+            inputs[
+                "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_working_disabled_individuals"
+            ]
+            is True
+        )
+        assert working_disabled_case["output"] == {
+            "us:statutes/42/1396a/a/10#optional_working_disabled_medicaid_category_eligible": "holds",
+            "us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds",
+        }
+        assert "optional working disabled category eligible" in changed_tests
 
     def test_repair_georgia_cms_medicaid_availability_writes_signed_manifest(
         self, tmp_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,6 +91,7 @@ from axiom_encode.cli import (
     _repair_input_field_accesses_in_formulas,
     _repair_medicaid_optional_senior_composition_rules,
     _repair_medicaid_optional_senior_composition_tests,
+    _repair_medicaid_primary_category_composition_tests,
     _repair_missing_entity_table_rows_for_row_ordered_outputs,
     _repair_missing_source_proof_atoms,
     _repair_mixed_derived_entity_output_tests,
@@ -25739,6 +25740,36 @@ rules:
             "us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds"
         }
         assert "optional senior disabled category eligible" in changed_tests
+
+    def test_repair_medicaid_primary_category_tests_keep_youth_age_inputs_consistent(
+        self,
+    ):
+        tests = """- name: no composed mandatory category eligible
+  period: 2027-01
+  input:
+    us:statutes/42/1396a/m#input.individual_age_years: 30
+  output:
+    us:statutes/42/1396a/a/10#is_medicaid_eligible: not_holds
+"""
+
+        repaired_tests, changed_tests = (
+            _repair_medicaid_primary_category_composition_tests(tests)
+        )
+
+        parsed_tests = yaml.safe_load(repaired_tests)
+        youth_case = next(
+            case
+            for case in parsed_tests
+            if case["name"] == "optional youth category eligible"
+        )
+        youth_inputs = youth_case["input"]
+        assert youth_inputs["us:statutes/42/1396a/m#input.individual_age_years"] == 20
+        assert youth_inputs["us:statutes/42/1396d/a/i#input.individual_age_years"] == 20
+        assert youth_case["output"] == {
+            "us:statutes/42/1396a/a/10#optional_youth_medicaid_category_eligible": "holds",
+            "us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds",
+        }
+        assert "optional youth category eligible" in changed_tests
 
     def test_repair_georgia_cms_medicaid_availability_writes_signed_manifest(
         self, tmp_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25834,14 +25834,29 @@ rules:
             "optional_working_disabled_medicaid_category_eligible" in changed_rules
         )
         assert (
+            "optional_ssi_excess_earnings_medicaid_category_eligible"
+            in changed_rules
+        )
+        assert (
             "source: 42 USC 1396a(a)(10)(A)(ii)(XV)" in repaired_rules
+        )
+        assert (
+            "source: 42 USC 1396a(a)(10)(A)(ii)(XIII)" in repaired_rules
         )
         assert (
             "state_elects_optional_coverage_for_working_disabled_individuals"
             in repaired_rules
         )
         assert (
+            "family_income_as_fraction_of_poverty_line < optional_ssi_excess_earnings_family_income_limit_poverty_line_rate"
+            in repaired_rules
+        )
+        assert (
             "and individual_would_be_considered_receiving_ssi_but_for_earnings"
+            in repaired_rules
+        )
+        assert (
+            "or optional_ssi_excess_earnings_medicaid_category_eligible"
             in repaired_rules
         )
         assert (
@@ -25882,7 +25897,31 @@ rules:
             "us:statutes/42/1396a/a/10#optional_working_disabled_medicaid_category_eligible": "holds",
             "us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds",
         }
+        ssi_excess_case = next(
+            case
+            for case in parsed_tests
+            if case["name"] == "optional SSI excess earnings category eligible"
+        )
+        ssi_inputs = ssi_excess_case["input"]
+        assert ssi_inputs["us:statutes/42/1396a/a/10#input.individual_age_years"] == 72
+        assert (
+            ssi_inputs[
+                "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_ssi_excess_earnings_individuals"
+            ]
+            is True
+        )
+        assert (
+            ssi_inputs[
+                "us:statutes/42/1396a/a/10#input.family_income_as_fraction_of_poverty_line"
+            ]
+            == 1.0
+        )
+        assert ssi_excess_case["output"] == {
+            "us:statutes/42/1396a/a/10#optional_ssi_excess_earnings_medicaid_category_eligible": "holds",
+            "us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds",
+        }
         assert "optional working disabled category eligible" in changed_tests
+        assert "optional SSI excess earnings category eligible" in changed_tests
 
     def test_repair_georgia_cms_medicaid_availability_writes_signed_manifest(
         self, tmp_path

--- a/tests/test_policyengine_ecps_snap.py
+++ b/tests/test_policyengine_ecps_snap.py
@@ -41,9 +41,7 @@ def test_set_input_value_updates_every_matching_legal_input():
     assert set(inputs.values()) == {4}
 
 
-def test_axiom_rules_env_prioritizes_active_rulespec_worktree(
-    monkeypatch, tmp_path
-):
+def test_axiom_rules_env_prioritizes_active_rulespec_worktree(monkeypatch, tmp_path):
     workspace = tmp_path / "workspace"
     stale_repo = workspace / "rulespec-us"
     active_repo = tmp_path / "worktrees" / "rulespec-us-medicaid-primary-categories"

--- a/tests/test_policyengine_ecps_snap.py
+++ b/tests/test_policyengine_ecps_snap.py
@@ -1,5 +1,6 @@
 import shutil
 from datetime import date
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -38,6 +39,29 @@ def test_set_input_value_updates_every_matching_legal_input():
     set_input_value(inputs, "household_size", 4)
 
     assert set(inputs.values()) == {4}
+
+
+def test_axiom_rules_env_prioritizes_active_rulespec_worktree(
+    monkeypatch, tmp_path
+):
+    workspace = tmp_path / "workspace"
+    stale_repo = workspace / "rulespec-us"
+    active_repo = tmp_path / "worktrees" / "rulespec-us-medicaid-primary-categories"
+    program = active_repo / "us" / "statutes" / "42" / "1396a" / "a" / "10.yaml"
+    stale_repo.mkdir(parents=True)
+    program.parent.mkdir(parents=True)
+    program.write_text("format: rulespec/v1\nrules: []\n", encoding="utf-8")
+    monkeypatch.setenv("AXIOM_RULESPEC_REPO_ROOTS", str(stale_repo))
+
+    env = ecps_snap.axiom_rules_env(program, workspace)
+
+    roots = [
+        Path(root)
+        for root in env["AXIOM_RULESPEC_REPO_ROOTS"].split(ecps_snap.os.pathsep)
+    ]
+    assert roots[0] == active_repo.resolve()
+    assert stale_repo.resolve() in roots
+    assert roots.index(active_repo.resolve()) < roots.index(stale_repo.resolve())
 
 
 def test_set_input_value_can_skip_optional_unknown_inputs():

--- a/tests/test_policyengine_medicaid_populace.py
+++ b/tests/test_policyengine_medicaid_populace.py
@@ -161,6 +161,7 @@ def test_project_case_inputs_uses_shared_income_projection_for_medicaid_imports(
         senior_or_disabled_eligible=False,
         medically_needy_eligible=False,
         working_disabled_buy_in_eligible=False,
+        ssi_excess_earnings_buy_in_eligible=False,
         mandatory_subpart_b=True,
         work_requirement_eligible=True,
         medicare_eligible=False,
@@ -205,6 +206,7 @@ def test_project_case_inputs_maps_senior_disabled_category_to_statutory_inputs()
         senior_or_disabled_eligible=True,
         medically_needy_eligible=False,
         working_disabled_buy_in_eligible=False,
+        ssi_excess_earnings_buy_in_eligible=False,
         mandatory_subpart_b=False,
         work_requirement_eligible=True,
         medicare_eligible=False,
@@ -250,6 +252,7 @@ def test_project_case_inputs_maps_young_adult_category_to_statutory_inputs():
         senior_or_disabled_eligible=False,
         medically_needy_eligible=False,
         working_disabled_buy_in_eligible=False,
+        ssi_excess_earnings_buy_in_eligible=False,
         mandatory_subpart_b=False,
         work_requirement_eligible=True,
         medicare_eligible=False,
@@ -289,6 +292,7 @@ def test_project_case_inputs_maps_working_disabled_category_to_statutory_inputs(
         senior_or_disabled_eligible=False,
         medically_needy_eligible=False,
         working_disabled_buy_in_eligible=True,
+        ssi_excess_earnings_buy_in_eligible=False,
         mandatory_subpart_b=False,
         work_requirement_eligible=True,
         medicare_eligible=False,
@@ -317,6 +321,58 @@ def test_project_case_inputs_maps_working_disabled_category_to_statutory_inputs(
     )
 
 
+def test_project_case_inputs_maps_ssi_excess_earnings_category_to_statutory_inputs():
+    inputs = medicaid_populace._project_case_inputs(
+        {},
+        age=72,
+        medicaid_income_level=0.25,
+        parent_nfc=False,
+        parent_fc=False,
+        pregnant_nfc=False,
+        pregnant_fc=False,
+        infant_fc=False,
+        young_child_fc=False,
+        older_child_eligible=False,
+        adult_nfc=False,
+        adult_fc=False,
+        ssi_recipient=False,
+        young_adult_eligible=False,
+        senior_or_disabled_eligible=False,
+        medically_needy_eligible=False,
+        working_disabled_buy_in_eligible=False,
+        ssi_excess_earnings_buy_in_eligible=True,
+        mandatory_subpart_b=False,
+        work_requirement_eligible=True,
+        medicare_eligible=True,
+    )
+
+    assert inputs["us:statutes/42/1396a/a/10#input.individual_age_years"] == 72
+    assert (
+        inputs[
+            "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_ssi_excess_earnings_individuals"
+        ]
+        is True
+    )
+    assert (
+        inputs[
+            "us:statutes/42/1396a/a/10#input.individual_would_be_considered_receiving_ssi_but_for_earnings"
+        ]
+        is True
+    )
+    assert (
+        inputs[
+            "us:statutes/42/1396a/a/10#input.family_income_as_fraction_of_poverty_line"
+        ]
+        == 1.0
+    )
+    assert (
+        inputs[
+            "us:statutes/42/1396a/a/10#input.assets_resources_and_earned_or_unearned_income_do_not_exceed_state_established_limitations"
+        ]
+        is False
+    )
+
+
 def test_project_case_inputs_maps_medically_needy_category_to_cfr_inputs():
     inputs = medicaid_populace._project_case_inputs(
         {},
@@ -336,6 +392,7 @@ def test_project_case_inputs_maps_medically_needy_category_to_cfr_inputs():
         senior_or_disabled_eligible=False,
         medically_needy_eligible=True,
         working_disabled_buy_in_eligible=False,
+        ssi_excess_earnings_buy_in_eligible=False,
         mandatory_subpart_b=False,
         work_requirement_eligible=True,
         medicare_eligible=False,

--- a/tests/test_policyengine_medicaid_populace.py
+++ b/tests/test_policyengine_medicaid_populace.py
@@ -109,6 +109,7 @@ def test_project_case_inputs_uses_shared_income_projection_for_medicaid_imports(
         adult_nfc=False,
         adult_fc=True,
         ssi_recipient=False,
+        senior_or_disabled_eligible=False,
         mandatory_subpart_b=True,
         work_requirement_eligible=True,
         medicare_eligible=False,
@@ -129,6 +130,48 @@ def test_project_case_inputs_uses_shared_income_projection_for_medicaid_imports(
     assert (
         inputs[
             "us:regulations/42-cfr/435/119#input.household_income_as_fraction_of_fpl"
+        ]
+        == 1.0
+    )
+
+
+def test_project_case_inputs_maps_senior_disabled_category_to_statutory_inputs():
+    inputs = medicaid_populace._project_case_inputs(
+        {},
+        age=64,
+        medicaid_income_level=0.25,
+        parent_nfc=False,
+        parent_fc=False,
+        pregnant_nfc=False,
+        pregnant_fc=False,
+        infant_fc=False,
+        young_child_fc=False,
+        older_child_eligible=False,
+        adult_nfc=False,
+        adult_fc=False,
+        ssi_recipient=False,
+        senior_or_disabled_eligible=True,
+        mandatory_subpart_b=False,
+        work_requirement_eligible=True,
+        medicare_eligible=False,
+    )
+
+    assert inputs["us:statutes/42/1396a/m#input.individual_age_years"] == 64
+    assert (
+        inputs[
+            "us:statutes/42/1396a/m#input.disabled_as_determined_under_section_1382c_a_3"
+        ]
+        is True
+    )
+    assert (
+        inputs[
+            "us:statutes/42/1396a/m#input.income_determined_for_this_subsection"
+        ]
+        == 0.5
+    )
+    assert (
+        inputs[
+            "us:statutes/42/1396a/m#input.resources_determined_for_supplemental_security_income_program"
         ]
         == 1.0
     )

--- a/tests/test_policyengine_medicaid_populace.py
+++ b/tests/test_policyengine_medicaid_populace.py
@@ -94,6 +94,54 @@ def test_runtime_output_id_for_public_id_resolves_branch_qualified_id(tmp_path: 
     )
 
 
+def test_axiom_output_ids_by_label_can_request_eligibility_only(
+    monkeypatch, tmp_path: Path
+):
+    artifact = tmp_path / "program.json"
+    artifact.write_text(
+        """
+        {
+          "program": {
+            "derived": [
+              {
+                "id": "us:statutes/42/1396a/a/10#is_medicaid_eligible",
+                "name": "is_medicaid_eligible"
+              },
+              {
+                "id": "us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid",
+                "name": "is_optional_senior_or_disabled_for_medicaid"
+              }
+            ]
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        medicaid_populace,
+        "AXIOM_COMPONENT_OUTPUT_IDS",
+        {
+            "optional_senior_disabled": (
+                "us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid"
+            )
+        },
+    )
+
+    assert medicaid_populace.axiom_output_ids_by_label(
+        artifact,
+        include_diagnostics=False,
+    ) == {
+        "eligible": "us:statutes/42/1396a/a/10#is_medicaid_eligible",
+    }
+    assert (
+        medicaid_populace.axiom_output_ids_by_label(
+            artifact,
+            include_diagnostics=True,
+        )["optional_senior_disabled"]
+        == "us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid"
+    )
+
+
 def test_project_case_inputs_uses_shared_income_projection_for_medicaid_imports():
     inputs = medicaid_populace._project_case_inputs(
         {},

--- a/tests/test_policyengine_medicaid_populace.py
+++ b/tests/test_policyengine_medicaid_populace.py
@@ -220,9 +220,7 @@ def test_project_case_inputs_maps_senior_disabled_category_to_statutory_inputs()
         is True
     )
     assert (
-        inputs[
-            "us:statutes/42/1396a/m#input.income_determined_for_this_subsection"
-        ]
+        inputs["us:statutes/42/1396a/m#input.income_determined_for_this_subsection"]
         == 0.5
     )
     assert (

--- a/tests/test_policyengine_medicaid_populace.py
+++ b/tests/test_policyengine_medicaid_populace.py
@@ -157,7 +157,9 @@ def test_project_case_inputs_uses_shared_income_projection_for_medicaid_imports(
         adult_nfc=False,
         adult_fc=True,
         ssi_recipient=False,
+        young_adult_eligible=False,
         senior_or_disabled_eligible=False,
+        medically_needy_eligible=False,
         mandatory_subpart_b=True,
         work_requirement_eligible=True,
         medicare_eligible=False,
@@ -198,7 +200,9 @@ def test_project_case_inputs_maps_senior_disabled_category_to_statutory_inputs()
         adult_nfc=False,
         adult_fc=False,
         ssi_recipient=False,
+        young_adult_eligible=False,
         senior_or_disabled_eligible=True,
+        medically_needy_eligible=False,
         mandatory_subpart_b=False,
         work_requirement_eligible=True,
         medicare_eligible=False,
@@ -223,6 +227,88 @@ def test_project_case_inputs_maps_senior_disabled_category_to_statutory_inputs()
         ]
         == 1.0
     )
+
+
+def test_project_case_inputs_maps_young_adult_category_to_statutory_inputs():
+    inputs = medicaid_populace._project_case_inputs(
+        {},
+        age=20,
+        medicaid_income_level=0.25,
+        parent_nfc=False,
+        parent_fc=False,
+        pregnant_nfc=False,
+        pregnant_fc=False,
+        infant_fc=False,
+        young_child_fc=False,
+        older_child_eligible=False,
+        adult_nfc=False,
+        adult_fc=False,
+        ssi_recipient=False,
+        young_adult_eligible=True,
+        senior_or_disabled_eligible=False,
+        medically_needy_eligible=False,
+        mandatory_subpart_b=False,
+        work_requirement_eligible=True,
+        medicare_eligible=False,
+    )
+
+    assert inputs["us:statutes/42/1396d/a/i#input.individual_age_years"] == 20
+    assert (
+        inputs[
+            "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i"
+        ]
+        is True
+    )
+    assert (
+        inputs[
+            "us:statutes/42/1396a/a/10#input.individual_meets_income_and_resources_requirements_for_optional_category"
+        ]
+        is True
+    )
+
+
+def test_project_case_inputs_maps_medically_needy_category_to_cfr_inputs():
+    inputs = medicaid_populace._project_case_inputs(
+        {},
+        age=44,
+        medicaid_income_level=0.25,
+        parent_nfc=False,
+        parent_fc=False,
+        pregnant_nfc=False,
+        pregnant_fc=False,
+        infant_fc=False,
+        young_child_fc=False,
+        older_child_eligible=False,
+        adult_nfc=False,
+        adult_fc=False,
+        ssi_recipient=False,
+        young_adult_eligible=False,
+        senior_or_disabled_eligible=False,
+        medically_needy_eligible=True,
+        mandatory_subpart_b=False,
+        work_requirement_eligible=True,
+        medicare_eligible=False,
+    )
+
+    assert (
+        inputs[
+            "us:regulations/42-cfr/435/301#input.agency_chooses_medically_needy_option"
+        ]
+        is True
+    )
+    assert (
+        inputs[
+            "us:regulations/42-cfr/435/301#input.income_meets_applicable_medically_needy_standard"
+        ]
+        is True
+    )
+    assert (
+        inputs[
+            "us:regulations/42-cfr/435/301#input.resources_meet_applicable_medically_needy_standard"
+        ]
+        is True
+    )
+    assert inputs["us:regulations/42-cfr/435/301#input.person_is_disabled"] is True
 
 
 def test_summarize_by_pe_category_counts_directional_mismatches():

--- a/tests/test_policyengine_medicaid_populace.py
+++ b/tests/test_policyengine_medicaid_populace.py
@@ -252,7 +252,10 @@ def test_project_case_inputs_maps_young_adult_category_to_statutory_inputs():
         medicare_eligible=False,
     )
 
-    assert inputs["us:statutes/42/1396d/a/i#input.individual_age_years"] == 20
+    assert (
+        inputs["us:statutes/42/1396d/a/i#youth_age_category_for_medical_assistance"]
+        == "holds"
+    )
     assert (
         inputs[
             "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i"

--- a/tests/test_policyengine_medicaid_populace.py
+++ b/tests/test_policyengine_medicaid_populace.py
@@ -160,6 +160,7 @@ def test_project_case_inputs_uses_shared_income_projection_for_medicaid_imports(
         young_adult_eligible=False,
         senior_or_disabled_eligible=False,
         medically_needy_eligible=False,
+        working_disabled_buy_in_eligible=False,
         mandatory_subpart_b=True,
         work_requirement_eligible=True,
         medicare_eligible=False,
@@ -203,6 +204,7 @@ def test_project_case_inputs_maps_senior_disabled_category_to_statutory_inputs()
         young_adult_eligible=False,
         senior_or_disabled_eligible=True,
         medically_needy_eligible=False,
+        working_disabled_buy_in_eligible=False,
         mandatory_subpart_b=False,
         work_requirement_eligible=True,
         medicare_eligible=False,
@@ -247,6 +249,7 @@ def test_project_case_inputs_maps_young_adult_category_to_statutory_inputs():
         young_adult_eligible=True,
         senior_or_disabled_eligible=False,
         medically_needy_eligible=False,
+        working_disabled_buy_in_eligible=False,
         mandatory_subpart_b=False,
         work_requirement_eligible=True,
         medicare_eligible=False,
@@ -262,6 +265,53 @@ def test_project_case_inputs_maps_young_adult_category_to_statutory_inputs():
     assert (
         inputs[
             "us:statutes/42/1396a/a/10#input.individual_meets_income_and_resources_requirements_for_optional_category"
+        ]
+        is True
+    )
+
+
+def test_project_case_inputs_maps_working_disabled_category_to_statutory_inputs():
+    inputs = medicaid_populace._project_case_inputs(
+        {},
+        age=41,
+        medicaid_income_level=0.25,
+        parent_nfc=False,
+        parent_fc=False,
+        pregnant_nfc=False,
+        pregnant_fc=False,
+        infant_fc=False,
+        young_child_fc=False,
+        older_child_eligible=False,
+        adult_nfc=False,
+        adult_fc=False,
+        ssi_recipient=False,
+        young_adult_eligible=False,
+        senior_or_disabled_eligible=False,
+        medically_needy_eligible=False,
+        working_disabled_buy_in_eligible=True,
+        mandatory_subpart_b=False,
+        work_requirement_eligible=True,
+        medicare_eligible=False,
+    )
+
+    assert inputs["us:statutes/42/1396a/a/10#input.individual_age_years"] == 41
+    assert inputs["us:statutes/42/1396a/m#input.individual_age_years"] == 41
+    assert inputs["us:statutes/42/1396d/a/i#input.individual_age_years"] == 41
+    assert (
+        inputs[
+            "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_working_disabled_individuals"
+        ]
+        is True
+    )
+    assert (
+        inputs[
+            "us:statutes/42/1396a/a/10#input.individual_would_be_considered_receiving_ssi_but_for_earnings"
+        ]
+        is True
+    )
+    assert (
+        inputs[
+            "us:statutes/42/1396a/a/10#input.assets_resources_and_earned_or_unearned_income_do_not_exceed_state_established_limitations"
         ]
         is True
     )
@@ -285,6 +335,7 @@ def test_project_case_inputs_maps_medically_needy_category_to_cfr_inputs():
         young_adult_eligible=False,
         senior_or_disabled_eligible=False,
         medically_needy_eligible=True,
+        working_disabled_buy_in_eligible=False,
         mandatory_subpart_b=False,
         work_requirement_eligible=True,
         medicare_eligible=False,

--- a/tests/test_policyengine_medicaid_populace.py
+++ b/tests/test_policyengine_medicaid_populace.py
@@ -252,10 +252,7 @@ def test_project_case_inputs_maps_young_adult_category_to_statutory_inputs():
         medicare_eligible=False,
     )
 
-    assert (
-        inputs["us:statutes/42/1396d/a/i#youth_age_category_for_medical_assistance"]
-        == "holds"
-    )
+    assert inputs["us:statutes/42/1396d/a/i#input.individual_age_years"] == 20
     assert (
         inputs[
             "us:statutes/42/1396a/a/10#input.state_elects_optional_coverage_for_reasonable_category_of_individuals_described_in_1396d_a_i"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1020"
+version = "0.2.1021"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1014"
+version = "0.2.1015"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1017"
+version = "0.2.1018"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1018"
+version = "0.2.1019"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1009"
+version = "0.2.1010"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1016"
+version = "0.2.1017"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1010"
+version = "0.2.1011"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1012"
+version = "0.2.1013"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1011"
+version = "0.2.1012"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1013"
+version = "0.2.1014"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1019"
+version = "0.2.1020"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1015"
+version = "0.2.1016"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add deterministic Medicaid primary category composition repairs to the encoder
- split federal optional working-disabled buy-in handling into clause XV and SSI-excess-earnings clause XIII paths
- extend the PolicyEngine Populace Medicaid oracle projection to map California working-disabled buy-in cases to the SSI-excess-earnings federal path

## Verification
- `uv run ruff check src/axiom_encode/cli.py src/axiom_encode/oracles/policyengine/medicaid_populace.py tests/test_cli.py tests/test_policyengine_medicaid_populace.py`
- `uv run python -m pytest tests/test_cli.py -k 'medicaid_primary_category'`
- `uv run python -m pytest tests/test_policyengine_medicaid_populace.py -k 'working_disabled or ssi_excess or young_adult or medically_needy'`
- generated RuleSpec repair passed full local Populace Medicaid parity: 572,780 compared, 0 mismatches

## Related
- Requires TheAxiomFoundation/axiom-rules-engine#59 for suffixed local worktree validation paths.
