### PR TITLE
Normalize Medicaid optional category module import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1021"
+version = "0.2.1022"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1021"
+__version__ = "0.2.1022"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -7492,9 +7492,8 @@ def _repair_georgia_cms_effective_magi_limit_tests(
 
 MEDICAID_A10_RELATIVE = Path("statutes/42/1396a/a/10.yaml")
 MEDICAID_A10_CITATION = "us/statute/42/1396a/a/10"
-MEDICAID_OPTIONAL_SENIOR_TARGET = (
-    "us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid"
-)
+MEDICAID_OPTIONAL_SENIOR_MODULE_TARGET = "us:statutes/42/1396a/m"
+MEDICAID_OPTIONAL_SENIOR_TARGET = f"{MEDICAID_OPTIONAL_SENIOR_MODULE_TARGET}#is_optional_senior_or_disabled_for_medicaid"
 MEDICAID_OPTIONAL_SENIOR_RULE = "is_optional_senior_or_disabled_for_medicaid"
 MEDICAID_YOUTH_RELATIVE = Path("statutes/42/1396d/a/i.yaml")
 MEDICAID_YOUTH_MODULE_TARGET = "us:statutes/42/1396d/a/i"
@@ -7877,16 +7876,21 @@ def _repair_medicaid_optional_senior_composition_rules(
     repaired = content
     changed: list[str] = []
 
-    if MEDICAID_OPTIONAL_SENIOR_TARGET not in repaired:
-        module_marker = "\nmodule:\n"
-        if module_marker not in repaired:
-            raise ValueError("RuleSpec payload must contain module section")
-        repaired = repaired.replace(
-            module_marker,
-            f"\n  - {MEDICAID_OPTIONAL_SENIOR_TARGET}{module_marker}",
-            1,
-        )
-        changed.append("is_medicaid_eligible")
+    optional_module_line = f"  - {MEDICAID_OPTIONAL_SENIOR_MODULE_TARGET}\n"
+    optional_specific_line = f"  - {MEDICAID_OPTIONAL_SENIOR_TARGET}\n"
+    if optional_module_line not in repaired:
+        if optional_specific_line in repaired:
+            repaired = repaired.replace(optional_specific_line, optional_module_line, 1)
+        else:
+            module_marker = "\nmodule:\n"
+            if module_marker not in repaired:
+                raise ValueError("RuleSpec payload must contain module section")
+            repaired = repaired.replace(
+                module_marker,
+                f"\n{optional_module_line}{module_marker}",
+                1,
+            )
+        changed.append("imports")
 
     source_marker = "    source: 42 USC 1396a(a)(10)(A)(i)\n"
     if source_marker in repaired:
@@ -8186,13 +8190,21 @@ def _repair_medicaid_primary_category_composition_rules(
     changed: list[str] = []
 
     imports_to_add = [
+        MEDICAID_OPTIONAL_SENIOR_MODULE_TARGET,
         MEDICAID_YOUTH_MODULE_TARGET,
         MEDICAID_MEDICALLY_NEEDY_MODULE_TARGET,
     ]
     module_marker = "\nmodule:\n"
     if module_marker not in repaired:
         raise ValueError("RuleSpec payload must contain module section")
-    missing_imports = [target for target in imports_to_add if target not in repaired]
+    optional_module_line = f"  - {MEDICAID_OPTIONAL_SENIOR_MODULE_TARGET}\n"
+    optional_specific_line = f"  - {MEDICAID_OPTIONAL_SENIOR_TARGET}\n"
+    if optional_module_line not in repaired and optional_specific_line in repaired:
+        repaired = repaired.replace(optional_specific_line, optional_module_line, 1)
+        changed.append("imports")
+    missing_imports = [
+        target for target in imports_to_add if f"  - {target}\n" not in repaired
+    ]
     if missing_imports:
         repaired = repaired.replace(
             module_marker,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25717,7 +25717,12 @@ rules:
             _repair_medicaid_optional_senior_composition_tests(tests)
         )
 
-        assert changed_rules == ["is_medicaid_eligible"]
+        assert changed_rules == ["imports", "is_medicaid_eligible"]
+        assert "\n  - us:statutes/42/1396a/m\n" in repaired_rules
+        assert (
+            "\n  - us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid\n"
+            not in repaired_rules
+        )
         assert (
             "us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid"
             in repaired_rules
@@ -25856,6 +25861,11 @@ rules:
         )
         assert (
             "or optional_working_disabled_medicaid_category_eligible" in repaired_rules
+        )
+        assert "\n  - us:statutes/42/1396a/m\n" in repaired_rules
+        assert (
+            "\n  - us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid\n"
+            not in repaired_rules
         )
 
     def test_repair_medicaid_primary_category_tests_add_working_disabled_case(self):
@@ -26003,6 +26013,7 @@ rules:
         first_rules_content = rules_file.read_text()
         first_test_content = test_file.read_text()
         assert first_payload["axiom_encode_git"]["commit"] == "old123"
+        assert "\n  - us:statutes/42/1396a/m\n" in first_rules_content
         _git(checkout, "add", ".")
         _git(checkout, "commit", "-m", "apply old repair")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1021"
+version = "0.2.1022"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- make Medicaid deterministic repairs import the optional senior/disabled module, not only the exported output
- keep specific output references in proof atoms for provenance
- add regression assertions for generated Medicaid imports

## Tests
- uv run ruff format --check src/ tests/
- uv run ruff check src/ tests/
- uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py -k 'medicaid_optional_senior_composition or medicaid_primary_category'