### PR TITLE
Manifest full deterministic repair groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1022"
+version = "0.2.1023"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1022"
+__version__ = "0.2.1023"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -12687,11 +12687,12 @@ def _write_grouped_deterministic_repair_manifests(
     with tempfile.TemporaryDirectory() as tmpdir:
         output_root = Path(tmpdir)
         for relative_output, group_files in manifest_groups:
-            applied_files = [
-                path for path in group_files if path.resolve() in changed_file_set
-            ]
-            if not applied_files:
+            group_changed = any(
+                path.resolve() in changed_file_set for path in group_files
+            )
+            if not group_changed:
                 continue
+            applied_files = [path for path in group_files if path.exists()]
             generated_output = output_root / "deterministic-repair" / relative_output
             generated_output.parent.mkdir(parents=True, exist_ok=True)
             generated_output.write_text((repo_path / relative_output).read_text())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26039,6 +26039,40 @@ rules:
             "statutes/42/1396a/a/10.yaml",
             "statutes/42/1396a/a/10.test.yaml",
         ]
+        _git(checkout, "add", ".")
+        _git(checkout, "commit", "-m", "refresh manifest")
+
+        rules_file.write_text(
+            rules_file.read_text().replace(
+                "\n  - us:statutes/42/1396a/m\n",
+                "\n  - us:statutes/42/1396a/m#is_optional_senior_or_disabled_for_medicaid\n",
+            )
+        )
+        _git(checkout, "add", str(rules_file.relative_to(checkout)))
+        _git(checkout, "commit", "-m", "stale module import")
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch("axiom_encode.cli._companion_test_issues", return_value=[]),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "new789", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_medicaid_primary_category_composition(args)
+
+        repaired_payload = json.loads(manifest.read_text())
+        assert "\n  - us:statutes/42/1396a/m\n" in rules_file.read_text()
+        assert test_file.read_text() == first_test_content
+        assert repaired_payload["axiom_encode_git"]["commit"] == "new789"
+        assert [item["path"] for item in repaired_payload["applied_files"]] == [
+            "statutes/42/1396a/a/10.yaml",
+            "statutes/42/1396a/a/10.test.yaml",
+        ]
 
     def test_repair_georgia_cms_medicaid_availability_writes_signed_manifest(
         self, tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1022"
+version = "0.2.1023"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- include every existing file in a changed deterministic repair group when writing applied manifests
- add a Medicaid primary-category regression for repairing only the rules file while the generated companion test is already current
- bump axiom-encode to 0.2.1023

## Tests
- uv run ruff format --check src/ tests/
- uv run ruff check src/ tests/
- uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py -k 'medicaid_primary_category or grouped_deterministic_repair_manifests'