### PR TITLE
Classify Medicaid coverage helper oracle gaps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1023"
+version = "0.2.1024"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1023"
+__version__ = "0.2.1024"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -269,6 +269,27 @@ mappings:
     candidate_priority: P4
     rationale: This RuleSpec output is the lower age threshold for an optional working-disabled pathway. PolicyEngine does not expose that statutory helper separately from final Medicaid eligibility.
 
+  - legal_id: us:statutes/42/1396a/a/10#optional_ssi_excess_earnings_medicaid_category_eligible
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This RuleSpec output is a source-level optional Medicaid category branch under 42 USC 1396a(a)(10)(A)(ii)(XIII). PolicyEngine exposes final Medicaid eligibility and the separate section 1396a(m) optional senior-or-disabled pathway, not this SSI-excess-earnings optional branch as a one-to-one oracle variable.
+
+  - legal_id: us:statutes/42/1396a/a/10#optional_working_disabled_medicaid_category_eligible
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This RuleSpec output is a source-level optional Medicaid category branch under 42 USC 1396a(a)(10)(A)(ii)(XV). PolicyEngine exposes final Medicaid eligibility and the section 1396a(m) optional senior-or-disabled pathway, not this working-disabled optional branch as a one-to-one oracle variable.
+
+  - legal_id: us:statutes/42/1396a/a/10#optional_youth_medicaid_category_eligible
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: This RuleSpec output is a source-level State-option youth category branch under 42 USC 1396a(a)(10)(A)(ii) and 1396d(a)(i). PolicyEngine exposes final Medicaid eligibility and simplified young-adult category treatment, not this State-election branch as a one-to-one oracle variable.
+
   - legal_id: us:statutes/42/1396a/a/10#qualifying_individual_income_lower_bound_poverty_line_rate
     country: us
     program: medicaid
@@ -19017,6 +19038,13 @@ prefixes:
     candidate_priority: P4
     rationale: High-efficiency electric home rebate outputs not carrying exact parameter mappings are source-level eligible-entity, project, installer-payment, grant-administration, or anti-combination surfaces that PolicyEngine-US does not expose one-to-one.
 
+  - legal_id_prefix: us:statutes/42/1382b/a#
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 1382b(a) resource-exclusion outputs are source-level SSI resource exclusions and valuation helpers. PolicyEngine US exposes broad SSI countable resources and the final SSI resource test, not these individual statutory exclusion periods, caps, or per-asset valuation predicates as one-to-one oracle variables or parameters.
+
   - legal_id_prefix: us:policies/ed/fsa/2026-27-sai-pell-guide/
     country: us
     program: pell
@@ -20744,6 +20772,13 @@ prefixes:
     mapping_type: not_comparable
     candidate_priority: P4
     rationale: Section 1396a(m) optional senior-or-disabled income-level outputs are federal source-level eligibility, maximum-rate, state-plan, and medical-or-remedial-care methodology helpers. PolicyEngine US does not expose these optional-group statutory helpers as one-to-one Medicaid oracle variables or parameters.
+
+  - legal_id_prefix: us:statutes/42/1396d/a/i#
+    country: us
+    program: medicaid
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Section 1396d(a)(i) outputs encode the federal default and State-option youth age ceilings and the source-level youth medical-assistance category. PolicyEngine US exposes final Medicaid eligibility and simplified young-adult category treatment, not these State-option source helpers as one-to-one oracle variables or parameters.
 
   - legal_id_prefix: us:statutes/42/1396b/f#
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -4198,6 +4198,21 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         value: 16
+  - name: optional_ssi_excess_earnings_medicaid_category_eligible
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: true
+  - name: optional_working_disabled_medicaid_category_eligible
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: true
+  - name: optional_youth_medicaid_category_eligible
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: true
   - name: qualifying_individual_income_lower_bound_poverty_line_rate
     kind: parameter
     versions:
@@ -4218,6 +4233,37 @@ rules:
     versions:
       - effective_from: '2026-01-01'
         value: 1.2
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/42/1396d/a/i.yaml",
+        """format: rulespec/v1
+rules:
+  - name: default_youth_age_ceiling_years
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        value: 21
+  - name: state_option_youth_age_ceiling_20_years
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        value: 20
+  - name: state_option_youth_age_ceiling_19_years
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        value: 19
+  - name: state_option_youth_age_ceiling_18_years
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        value: 18
+  - name: youth_age_category_for_medical_assistance
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: true
 """,
     )
     _write_rulespec_file(
@@ -4282,8 +4328,70 @@ rules:
 
     report = build_policyengine_coverage_report(tmp_path, program="medicaid")
 
-    assert report["total_outputs"] == 31
-    assert report["status_counts"] == {"known_not_comparable": 31}
+    assert report["total_outputs"] == 39
+    assert report["status_counts"] == {"known_not_comparable": 39}
+    assert report["untested_comparable"] == 0
+    assert {item["mapping_type"] for item in report["items"]} == {"not_comparable"}
+    assert {item["candidate_priority"] for item in report["items"]} == {"P4"}
+
+
+def test_policyengine_coverage_classifies_ssi_resource_exclusion_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "statutes/42/1382b/a.yaml",
+        """format: rulespec/v1
+rules:
+  - name: alaska_native_stock_inalienability_exclusion_period_years
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        value: 20
+  - name: assistance_resource_exclusion_period_months
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        value: 9
+  - name: prior_underpayment_resource_exclusion_period_months
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        value: 9
+  - name: post_receipt_resource_exclusion_period_months
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        value: 9
+  - name: qualifying_gift_child_age_ceiling_years
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        value: 18
+  - name: annual_cash_gift_resource_exclusion_cap
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        value: 2000
+  - name: life_insurance_face_value_disregard_threshold
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        value: 1500
+  - name: life_insurance_policy_counted_resource_value
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: true
+  - name: qualifying_cash_gift_excluded_resource_amount
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: true
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="ssi")
+
+    assert report["total_outputs"] == 9
+    assert report["status_counts"] == {"known_not_comparable": 9}
     assert report["untested_comparable"] == 0
     assert {item["mapping_type"] for item in report["items"]} == {"not_comparable"}
     assert {item["candidate_priority"] for item in report["items"]} == {"P4"}

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1023"
+version = "0.2.1024"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Medicaid optional-category helper outputs and SSI 1382b(a) resource-exclusion helpers as known not comparable to PolicyEngine
- add coverage tests for the Medicaid and SSI surfaces that blocked rulespec-us PR #499
- bump axiom-encode to 0.2.1024 for deterministic RuleSpec toolchain pinning

## Verification
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py`
- `uv run ruff check pyproject.toml src/axiom_encode/__init__.py tests/test_policyengine_coverage.py`
- YAML parse of `src/axiom_encode/oracles/policyengine/mappings/us.yaml`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-medicaid-primary-categories-20260630 --json` => `{"comparable": 470, "known_not_comparable": 13311}` and no unmapped 1396a(a)(10), 1396d(a)(i), or 1382b(a) outputs
