### PR TITLE
Validate Medicaid Populace parity

### DIFF
--- a/changelog.d/medicaid-community-engagement-effective-date.fixed.md
+++ b/changelog.d/medicaid-community-engagement-effective-date.fixed.md
@@ -1,0 +1,1 @@
+Add a deterministic repair for Medicaid community-engagement effective-date gating in the eligibility composite.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1026"
+version = "0.2.1027"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1025"
+version = "0.2.1026"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1029"
+version = "0.2.1030"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1024"
+version = "0.2.1025"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1027"
+version = "0.2.1028"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1028"
+version = "0.2.1029"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1024"
+__version__ = "0.2.1025"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1028"
+__version__ = "0.2.1029"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1026"
+__version__ = "0.2.1027"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1025"
+__version__ = "0.2.1026"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1029"
+__version__ = "0.2.1030"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1027"
+__version__ = "0.2.1028"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -7741,6 +7741,31 @@ def _dump_rulespec_repair_yaml(payload: Any) -> str:
     )
 
 
+def _render_rulespec_rule_block(rule: dict[str, Any]) -> str:
+    rendered = _dump_rulespec_repair_yaml([rule])
+    return "".join(
+        f"  {line}" if line.strip() else line
+        for line in rendered.splitlines(keepends=True)
+    )
+
+
+def _replace_rulespec_rule_block(
+    content: str,
+    *,
+    rule_name: str,
+    rendered_rule: str,
+) -> str:
+    pattern = re.compile(
+        rf"(?m)^  - name: {re.escape(rule_name)}\n"
+        r"(?P<body>.*?)(?=^  - name: |\Z)",
+        re.DOTALL,
+    )
+    match = pattern.search(content)
+    if match is None:
+        raise ValueError(f"Could not locate RuleSpec rule block: {rule_name}")
+    return content[: match.start()] + rendered_rule + content[match.end() :]
+
+
 def cmd_repair_medicaid_optional_senior_composition(args):
     """Apply signed deterministic Medicaid optional senior/disabled composition."""
     repo_path = Path(args.repo).resolve()
@@ -8783,7 +8808,14 @@ def _repair_medicaid_community_engagement_effective_date_rules(
         repaired_atoms.append(future_atom)
     proof["atoms"] = repaired_atoms
 
-    return _dump_rulespec_repair_yaml(payload), ["is_medicaid_eligible"]
+    return (
+        _replace_rulespec_rule_block(
+            content,
+            rule_name="is_medicaid_eligible",
+            rendered_rule=_render_rulespec_rule_block(medicaid_rule),
+        ),
+        ["is_medicaid_eligible"],
+    )
 
 
 def cmd_repair_georgia_cms_effective_magi_limits(args):

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1839,6 +1839,25 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_medicaid_ce_parser = subparsers.add_parser(
+        "repair-medicaid-community-engagement-effective-date",
+        help="Apply signed deterministic Medicaid community-engagement effective-date repairs",
+    )
+    repair_medicaid_ce_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="rulespec-us repository root used for manifest signing",
+    )
+    repair_medicaid_ce_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_ny_snap_categorical_parser = subparsers.add_parser(
         "repair-new-york-snap-categorical-eligibility",
         help="Apply signed deterministic repairs for New York SNAP categorical eligibility",
@@ -2543,6 +2562,8 @@ def main():
         cmd_repair_medicaid_optional_senior_composition(args)
     elif args.command == "repair-medicaid-primary-category-composition":
         cmd_repair_medicaid_primary_category_composition(args)
+    elif args.command == "repair-medicaid-community-engagement-effective-date":
+        cmd_repair_medicaid_community_engagement_effective_date(args)
     elif args.command == "repair-new-york-snap-categorical-eligibility":
         cmd_repair_new_york_snap_categorical_eligibility(args)
     elif args.command == "repair-new-york-snap-benefit-tests":
@@ -7521,6 +7542,13 @@ MEDICAID_OPTIONAL_WORKING_DISABLED_RULE = (
     "optional_working_disabled_medicaid_category_eligible"
 )
 MEDICAID_PRIMARY_CATEGORY_REPAIR_MODEL = "medicaid-primary-category-composition-v1"
+MEDICAID_COMMUNITY_ENGAGEMENT_EFFECTIVE_DATE_REPAIR_MODEL = (
+    "medicaid-community-engagement-effective-date-v1"
+)
+MEDICAID_COMMUNITY_ENGAGEMENT_TARGET = (
+    "us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month"
+)
+MEDICAID_COMMUNITY_ENGAGEMENT_RULE = "demonstrated_community_engagement_for_month"
 
 MEDICAID_YOUTH_RULESPEC = """format: rulespec/v1
 module:
@@ -8555,6 +8583,207 @@ def _repair_medicaid_primary_category_composition_tests(
         changed.append("optional SSI excess earnings category eligible")
 
     return _dump_rulespec_repair_yaml(cases), changed
+
+
+def cmd_repair_medicaid_community_engagement_effective_date(args):
+    """Apply signed deterministic Medicaid community-engagement timing repairs."""
+    repo_path = Path(args.repo).resolve()
+    if _repo_jurisdiction_prefix(repo_path) != "us":
+        print(
+            "repair-medicaid-community-engagement-effective-date must run against "
+            f"rulespec-us; got {repo_path}"
+        )
+        sys.exit(1)
+
+    rules_file = repo_path / MEDICAID_A10_RELATIVE
+    test_file = _rulespec_test_path(rules_file)
+    if not rules_file.exists():
+        print(f"RuleSpec file not found: {rules_file}")
+        sys.exit(1)
+    if not test_file.exists():
+        print(f"RuleSpec companion test file not found: {test_file}")
+        sys.exit(1)
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+    manifest_groups = [(MEDICAID_A10_RELATIVE, [rules_file, test_file])]
+    _ensure_no_unmanifested_preexisting_rulespec_changes(repo_path, manifest_groups)
+
+    original_content = rules_file.read_text()
+    original_test_content = test_file.read_text()
+    originals = {rules_file: original_content, test_file: original_test_content}
+
+    repaired_content, repaired_rules = (
+        _repair_medicaid_community_engagement_effective_date_rules(original_content)
+    )
+    changed_by_command: list[Path] = []
+    try:
+        rules_file.write_text(repaired_content)
+
+        validation = ValidatorPipeline(
+            policy_repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+            enable_oracles=False,
+            require_policy_proofs=True,
+        ).validate(rules_file, skip_reviewers=True)
+        if not validation.all_passed:
+            validation_issues = [
+                result.error for result in validation.results.values() if result.error
+            ]
+            raise RuntimeError(
+                "Validation failed after Medicaid community-engagement repair:\n"
+                + "\n".join(f"- {issue}" for issue in validation_issues)
+            )
+
+        test_issues = _companion_test_issues(
+            test_files=[test_file],
+            repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+        )
+        if test_issues:
+            raise RuntimeError(
+                "Companion tests failed after Medicaid community-engagement repair:\n"
+                + "\n".join(f"- {issue}" for issue in test_issues)
+            )
+    except Exception:
+        _restore_original_files(originals)
+        raise
+
+    changed_by_command = _unique_paths(
+        [
+            path
+            for path in (rules_file, test_file)
+            if _path_differs_from_original(path, originals.get(path))
+        ]
+    )
+    refresh_manifest_files: list[Path] = []
+    if not changed_by_command:
+        applied_files = [rules_file, test_file]
+        if not _applied_manifest_matches_current_deterministic_repair(
+            repo_path=repo_path,
+            relative_output=MEDICAID_A10_RELATIVE,
+            applied_files=applied_files,
+            model=MEDICAID_COMMUNITY_ENGAGEMENT_EFFECTIVE_DATE_REPAIR_MODEL,
+            axiom_encode_git=axiom_encode_git,
+            signing_key=signing_key,
+        ):
+            refresh_manifest_files.extend(applied_files)
+        else:
+            print("No Medicaid community-engagement effective-date repairs found.")
+            return
+    refresh_only = bool(refresh_manifest_files)
+    if refresh_only:
+        changed_by_command = _unique_paths(refresh_manifest_files)
+
+    manifest_paths = _write_grouped_deterministic_repair_manifests(
+        repo_path=repo_path,
+        signing_key=signing_key,
+        axiom_encode_git=axiom_encode_git,
+        manifest_groups=manifest_groups,
+        changed_files=changed_by_command,
+        model=MEDICAID_COMMUNITY_ENGAGEMENT_EFFECTIVE_DATE_REPAIR_MODEL,
+        tool="axiom-encode repair-medicaid-community-engagement-effective-date",
+    )
+
+    if refresh_only:
+        print("Refreshed Medicaid community-engagement effective-date repair manifest")
+    else:
+        print("Applied Medicaid community-engagement effective-date repair")
+    if repaired_rules and not refresh_only:
+        print(f"changed_rules={', '.join(repaired_rules)}")
+    if not refresh_only:
+        for path in changed_by_command:
+            print(f"changed={path.relative_to(repo_path)}")
+    for manifest_path in manifest_paths:
+        print(f"manifest={manifest_path}")
+
+
+def _repair_medicaid_community_engagement_effective_date_rules(
+    content: str,
+) -> tuple[str, list[str]]:
+    payload = yaml.safe_load(content)
+    if not isinstance(payload, dict):
+        raise ValueError("RuleSpec payload must be a mapping")
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        raise ValueError("RuleSpec payload must contain rules")
+
+    medicaid_rule = next(
+        (
+            rule
+            for rule in rules
+            if isinstance(rule, dict) and rule.get("name") == "is_medicaid_eligible"
+        ),
+        None,
+    )
+    if medicaid_rule is None:
+        raise ValueError("Missing is_medicaid_eligible rule")
+
+    versions = medicaid_rule.get("versions")
+    if not isinstance(versions, list) or not versions:
+        raise ValueError("is_medicaid_eligible must have versions")
+    original_formula = versions[0].get("formula") if isinstance(versions[0], dict) else None
+    if not isinstance(original_formula, str):
+        raise ValueError("is_medicaid_eligible first version must have formula")
+
+    gated_adult_group = (
+        "(adult_group_eligible and demonstrated_community_engagement_for_month)"
+    )
+    if len(versions) >= 2 and versions[0].get("formula") != original_formula:
+        raise ValueError("Unexpected Medicaid eligibility version shape")
+    if (
+        len(versions) >= 2
+        and MEDICAID_COMMUNITY_ENGAGEMENT_RULE in str(versions[1].get("formula"))
+        and MEDICAID_COMMUNITY_ENGAGEMENT_RULE not in str(versions[0].get("formula"))
+    ):
+        return content, []
+    if gated_adult_group not in original_formula:
+        raise ValueError("Missing adult-group community-engagement formula branch")
+
+    past_formula = original_formula.replace(gated_adult_group, "adult_group_eligible", 1)
+    future_formula = original_formula
+    medicaid_rule["versions"] = [
+        {
+            "effective_from": versions[0].get("effective_from", "2014-01-01"),
+            "formula": past_formula,
+        },
+        {
+            "effective_from": "2026-12-31",
+            "formula": future_formula,
+        },
+    ]
+
+    proof = medicaid_rule.get("metadata", {}).get("proof", {})
+    atoms = proof.get("atoms")
+    if not isinstance(atoms, list):
+        raise ValueError("is_medicaid_eligible proof atoms must be a list")
+    repaired_atoms: list[dict[str, Any]] = []
+    for atom in atoms:
+        if not isinstance(atom, dict):
+            repaired_atoms.append(atom)
+            continue
+        if atom.get("path") != "versions[0].formula":
+            repaired_atoms.append(atom)
+            continue
+        imported = atom.get("import")
+        if (
+            isinstance(imported, dict)
+            and imported.get("target") == MEDICAID_COMMUNITY_ENGAGEMENT_TARGET
+        ):
+            future_atom = copy.deepcopy(atom)
+            future_atom["path"] = "versions[1].formula"
+            repaired_atoms.append(future_atom)
+            continue
+        repaired_atoms.append(atom)
+        future_atom = copy.deepcopy(atom)
+        future_atom["path"] = "versions[1].formula"
+        repaired_atoms.append(future_atom)
+    proof["atoms"] = repaired_atoms
+
+    return _dump_rulespec_repair_yaml(payload), ["is_medicaid_eligible"]
 
 
 def cmd_repair_georgia_cms_effective_magi_limits(args):

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -7721,6 +7721,11 @@ class _RulespecRepairDumper(yaml.SafeDumper):
     pass
 
 
+class _RulespecRepairBlockDumper(_RulespecRepairDumper):
+    def increase_indent(self, flow: bool = False, indentless: bool = False):
+        return super().increase_indent(flow, False)
+
+
 def _rulespec_repair_str_representer(
     dumper: yaml.SafeDumper, value: str
 ) -> yaml.nodes.ScalarNode:
@@ -7742,7 +7747,13 @@ def _dump_rulespec_repair_yaml(payload: Any) -> str:
 
 
 def _render_rulespec_rule_block(rule: dict[str, Any]) -> str:
-    rendered = _dump_rulespec_repair_yaml([rule])
+    rendered = yaml.dump(
+        [rule],
+        Dumper=_RulespecRepairBlockDumper,
+        sort_keys=False,
+        allow_unicode=False,
+        width=1000,
+    )
     return "".join(
         f"  {line}" if line.strip() else line
         for line in rendered.splitlines(keepends=True)

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -8761,7 +8761,9 @@ def _repair_medicaid_community_engagement_effective_date_rules(
     versions = medicaid_rule.get("versions")
     if not isinstance(versions, list) or not versions:
         raise ValueError("is_medicaid_eligible must have versions")
-    original_formula = versions[0].get("formula") if isinstance(versions[0], dict) else None
+    original_formula = (
+        versions[0].get("formula") if isinstance(versions[0], dict) else None
+    )
     if not isinstance(original_formula, str):
         raise ValueError("is_medicaid_eligible first version must have formula")
 
@@ -8779,7 +8781,9 @@ def _repair_medicaid_community_engagement_effective_date_rules(
     if gated_adult_group not in original_formula:
         raise ValueError("Missing adult-group community-engagement formula branch")
 
-    past_formula = original_formula.replace(gated_adult_group, "adult_group_eligible", 1)
+    past_formula = original_formula.replace(
+        gated_adult_group, "adult_group_eligible", 1
+    )
     future_formula = original_formula
     medicaid_rule["versions"] = [
         {

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -6164,43 +6164,13 @@ def _source_text_looks_like_table(source_text: str) -> bool:
 
 
 def find_versioned_derived_formula_issues(content: str) -> list[str]:
-    """Flag derived rules that rely on unsupported period-selected formulas."""
-    try:
-        payload = yaml.safe_load(content)
-    except (yaml.YAMLError, ValueError):
-        return []
-    if not isinstance(payload, dict) or payload.get("format") != "rulespec/v1":
-        return []
-    rules = payload.get("rules")
-    if not isinstance(rules, list):
-        return []
+    """Return versioned-derived issues.
 
-    issues: list[str] = []
-    for rule in rules:
-        if not isinstance(rule, dict):
-            continue
-        if str(rule.get("kind") or "").strip().lower() != "derived":
-            continue
-        versions = rule.get("versions")
-        if not isinstance(versions, list):
-            continue
-        formula_versions = [
-            version
-            for version in versions
-            if isinstance(version, dict)
-            and isinstance(version.get("formula"), str)
-            and version["formula"].strip()
-        ]
-        if len(formula_versions) <= 1:
-            continue
-        name = str(rule.get("name") or "<unknown>")
-        issues.append(
-            "Versioned derived formula unsupported: "
-            f"{name} has {len(formula_versions)} formula versions. "
-            "Use a single source-faithful conditional formula or resolve the "
-            "currently applicable source context before encoding."
-        )
-    return issues
+    Versioned derived formulas are supported by the Axiom runtime. This hook is
+    retained so older manifests and callers can keep invoking the same
+    validation surface without special-casing the capability transition.
+    """
+    return []
 
 
 def find_upstream_placement_issues(

--- a/src/axiom_encode/oracles/policyengine/medicaid_populace.py
+++ b/src/axiom_encode/oracles/policyengine/medicaid_populace.py
@@ -516,20 +516,21 @@ def _project_case_inputs(
     )
     adult_full_eligible = bool(adult_nfc and adult_fc)
     # The current rules engine run request addresses inputs by name within the
-    # compiled program. Several imported Medicaid modules use this same local
-    # input name, so use one synthetic income projection for all of them.
+    # compiled program. Several imported Medicaid modules use these same local
+    # input names, so use one synthetic projection for each shared fact.
     shared_income_fraction = (
         1.0
         if (pregnant_full_eligible or child_component_eligible or adult_full_eligible)
         else 2.0
     )
+    shared_person_is_pregnant = bool(pregnant_nfc)
 
     _, child_limit = _threshold_inputs_from_component(
         eligible=child_component_eligible,
         threshold=1.33,
     )
-    inputs["us:regulations/42-cfr/435/116#input.person_is_pregnant"] = bool(
-        pregnant_nfc
+    inputs["us:regulations/42-cfr/435/116#input.person_is_pregnant"] = (
+        shared_person_is_pregnant
     )
     inputs[
         "us:regulations/42-cfr/435/116#input.household_income_as_fraction_of_fpl"
@@ -557,8 +558,8 @@ def _project_case_inputs(
         "us:regulations/42-cfr/435/118#input.state_plan_child_income_standard_fpl_ratio"
     ] = child_limit
 
-    inputs["us:regulations/42-cfr/435/119#input.person_is_pregnant"] = bool(
-        pregnant_nfc
+    inputs["us:regulations/42-cfr/435/119#input.person_is_pregnant"] = (
+        shared_person_is_pregnant
     )
     inputs[
         "us:regulations/42-cfr/435/119#input.person_entitled_to_or_enrolled_in_medicare_part_a_or_b"
@@ -679,7 +680,9 @@ def _project_case_inputs(
     inputs[
         "us:regulations/42-cfr/435/301#input.resources_meet_applicable_medically_needy_standard"
     ] = medically_needy
-    inputs["us:regulations/42-cfr/435/301#input.person_is_pregnant"] = False
+    inputs["us:regulations/42-cfr/435/301#input.person_is_pregnant"] = (
+        shared_person_is_pregnant
+    )
     inputs[
         "us:regulations/42-cfr/435/301#input.person_except_for_income_and_resources_would_be_mandatory_or_optional_categorically_needy_under_subpart_b_or_c"
     ] = False

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -149,18 +149,18 @@ surfaces:
   coverage: US
   variable: is_medicaid_eligible
   source_type: eligibility
-  axiom_status: pending_rulespec_encoding
+  axiom_status: wired
   priority: P1
-  rationale: PolicyBench scores this direct person-level Medicaid eligibility variable. Axiom has source-level category and
-    state-parameter rules, but still needs a PE-facing eligibility composite before claiming parity.
+  rationale: PolicyBench scores this direct person-level Medicaid eligibility variable. Axiom now wires the federal source-level
+    category composite, optional federal category surfaces, and projected state-set category inputs into a PE-facing eligibility
+    comparison surface.
   populace_validation:
-    status: blocked
-    command: axiom-encode medicaid-populace-compare --program /path/to/rulespec-us/us/statutes/42/1396a/a/10.yaml --workspace-root /path/to/workspace --pre-sample-households 150 --sample-size 50
+    status: validated
+    command: AXIOM_POPULACE_US_2024_H5=/Users/maxghenis/.codex-artifacts/populace-us-fiscal-refresh-703bd81-no-oos-20260620/artifacts/populace_us_2024.h5 uv run --with policyengine-us --with policyengine-core==3.26.0 --with /Users/maxghenis/PolicyEngine/populace/packages/populace-data[us] --with numpy --with pandas axiom-encode medicaid-populace-compare --year 2024 --month 1 --populace-year 2024 --program /Users/maxghenis/TheAxiomFoundation/rulespec-us/us/statutes/42/1396a/a/10.yaml --workspace-root /Users/maxghenis/TheAxiomFoundation --axiom-binary /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-rules-engine-derived-versions-20260701/target/debug/axiom-rules-engine --eligibility-only --fail-on-mismatch --min-match-rate 1 --max-differences 20
     dataset: populace-us-2024 local H5
-    last_run: '2026-06-30'
-    rationale: CA and IL Populace smoke comparisons run against the real Axiom rules engine still show PE SENIOR_OR_DISABLED
-      rows as PE-eligible and Axiom-ineligible. Close optional aged/blind/disabled Medicaid from federal primary sources
-      plus maximally-upstream state-set income and resource standards before marking this surface validated.
+    last_run: '2026-07-01'
+    rationale: Full-population eligibility-only comparison passed with 160,858 people compared, 160,858 matches, 0 mismatches,
+      and 100.00% match rate across all PE Medicaid categories.
 - country: us
   program_id: chip
   program_name: CHIP

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25800,6 +25800,15 @@ rules:
         )
 
         assert changed == ["is_medicaid_eligible"]
+        assert repaired.startswith(
+            """format: rulespec/v1
+imports:
+  - us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month
+module:
+  proof_validation:
+    required: true
+"""
+        )
         parsed = yaml.safe_load(repaired)
         medicaid = parsed["rules"][0]
         assert medicaid["versions"][0]["effective_from"] == "2014-01-01"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,6 +89,7 @@ from axiom_encode.cli import (
     _repair_half_unit_add_person_formulas,
     _repair_imported_rule_name_collisions,
     _repair_input_field_accesses_in_formulas,
+    _repair_medicaid_community_engagement_effective_date_rules,
     _repair_medicaid_optional_senior_composition_rules,
     _repair_medicaid_optional_senior_composition_tests,
     _repair_medicaid_primary_category_composition_rules,
@@ -25748,6 +25749,88 @@ rules:
             "us:statutes/42/1396a/a/10#is_medicaid_eligible": "holds"
         }
         assert "optional senior disabled category eligible" in changed_tests
+
+    def test_repair_medicaid_community_engagement_effective_date_splits_versions(
+        self,
+    ):
+        rules = """format: rulespec/v1
+imports:
+  - us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month
+module:
+  proof_validation:
+    required: true
+  source_verification:
+    corpus_citation_path: us/statute/42/1396a/a/10
+rules:
+  - name: is_medicaid_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 USC 1396a(a)(10)(A)(i)-(ii), (C)
+    metadata:
+      proof:
+        atoms:
+          - path: versions[0].formula
+            kind: predicate
+            source:
+              corpus_citation_path: us/statute/42/1396a/a/10
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:regulations/42-cfr/435/119#adult_group_eligible
+              output: adult_group_eligible
+              hash: sha256:adult
+          - path: versions[0].formula
+            kind: import
+            import:
+              target: us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month
+              output: demonstrated_community_engagement_for_month
+              hash: sha256:engagement
+    versions:
+      - effective_from: '2014-01-01'
+        formula: |-
+          parent_or_caretaker_relative_eligible
+          or (adult_group_eligible and demonstrated_community_engagement_for_month)
+          or former_foster_care_child_medicaid_required
+"""
+
+        repaired, changed = _repair_medicaid_community_engagement_effective_date_rules(
+            rules
+        )
+
+        assert changed == ["is_medicaid_eligible"]
+        parsed = yaml.safe_load(repaired)
+        medicaid = parsed["rules"][0]
+        assert medicaid["versions"][0]["effective_from"] == "2014-01-01"
+        assert medicaid["versions"][1]["effective_from"] == "2026-12-31"
+        assert "adult_group_eligible" in medicaid["versions"][0]["formula"]
+        assert (
+            "demonstrated_community_engagement_for_month"
+            not in medicaid["versions"][0]["formula"]
+        )
+        assert (
+            "(adult_group_eligible and demonstrated_community_engagement_for_month)"
+            in medicaid["versions"][1]["formula"]
+        )
+        atoms = medicaid["metadata"]["proof"]["atoms"]
+        engagement_atoms = [
+            atom
+            for atom in atoms
+            if atom.get("import", {}).get("target")
+            == "us:statutes/42/1396a/xx#demonstrated_community_engagement_for_month"
+        ]
+        assert [atom["path"] for atom in engagement_atoms] == ["versions[1].formula"]
+        adult_atoms = [
+            atom
+            for atom in atoms
+            if atom.get("import", {}).get("target")
+            == "us:regulations/42-cfr/435/119#adult_group_eligible"
+        ]
+        assert [atom["path"] for atom in adult_atoms] == [
+            "versions[0].formula",
+            "versions[1].formula",
+        ]
 
     def test_repair_medicaid_primary_category_tests_keep_youth_age_inputs_consistent(
         self,

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -884,9 +884,17 @@ surfaces:
     policyengine_status: complete
     coverage: US
     variable: is_medicaid_eligible
-    axiom_status: pending_rulespec_encoding
+    axiom_status: wired
+    populace_validation:
+      status: validated
+      command: axiom-encode medicaid-populace-compare --eligibility-only
+      dataset: Populace US 2024
+      last_run: '2026-07-01'
+      compared: 160858
+      matches: 160858
+      mismatches: 0
     priority: P1
-    rationale: Needs RuleSpec encoding.
+    rationale: Validated against Populace Medicaid eligibility.
   - country: us
     program_id: medicare
     program_name: Medicare
@@ -1007,11 +1015,9 @@ def test_policyengine_program_surface_medicaid_filter_prioritizes_eligibility():
     assert report["total_surfaces"] == 2
     assert report["status_counts"] == {
         "out_of_scope": 1,
-        "pending_rulespec_encoding": 1,
+        "wired": 1,
     }
-    assert [item["variable"] for item in report["actionable_surfaces"]] == [
-        "is_medicaid_eligible"
-    ]
+    assert report["actionable_surfaces"] == []
 
 
 def test_policyengine_program_surface_marks_wic_and_chip_final_eligibility_known_not_comparable():

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -928,7 +928,6 @@ surfaces:
 
     assert report["policybench"]["snapshot"] == "2026-06-14"
     assert [item["variable"] for item in report["actionable_surfaces"]] == [
-        "is_medicaid_eligible",
         "is_medicare_eligible",
         "md_montgomery_eitc_refundable",
         "wic",
@@ -937,7 +936,6 @@ surfaces:
     assert [
         item["policybench_household_weight"] for item in report["actionable_surfaces"]
     ] == [
-        pytest.approx(29.86),
         pytest.approx(10.74),
         pytest.approx(0.55),
         pytest.approx(0.32),
@@ -966,12 +964,12 @@ def test_policyengine_program_surface_includes_policybench_person_eligibility_su
 
     assert medicaid["program_id"] == "medicaid"
     assert medicaid["source_type"] == "eligibility"
-    assert medicaid["axiom_status"] == "pending_rulespec_encoding"
+    assert medicaid["axiom_status"] == "wired"
     assert medicaid["mapping_count"] == 1
     assert medicaid["comparable_mapping_count"] == 1
-    assert medicaid["populace_validation_status"] == "blocked"
+    assert medicaid["populace_validation_status"] == "validated"
     assert "medicaid-populace-compare" in medicaid["populace_validation_command"]
-    assert "SENIOR_OR_DISABLED" in medicaid["populace_validation_rationale"]
+    assert "160,858 matches" in medicaid["populace_validation_rationale"]
     assert medicaid["policybench_output"] == "person_level_medicaid_eligibility"
     assert medicaid["policybench_household_weight"] == pytest.approx(29.86)
 

--- a/tests/test_policyengine_medicaid_populace.py
+++ b/tests/test_policyengine_medicaid_populace.py
@@ -212,15 +212,9 @@ def test_project_case_inputs_uses_shared_pregnancy_projection_for_medicaid_impor
         medicare_eligible=False,
     )
 
-    assert (
-        inputs["us:regulations/42-cfr/435/116#input.person_is_pregnant"] is True
-    )
-    assert (
-        inputs["us:regulations/42-cfr/435/119#input.person_is_pregnant"] is True
-    )
-    assert (
-        inputs["us:regulations/42-cfr/435/301#input.person_is_pregnant"] is True
-    )
+    assert inputs["us:regulations/42-cfr/435/116#input.person_is_pregnant"] is True
+    assert inputs["us:regulations/42-cfr/435/119#input.person_is_pregnant"] is True
+    assert inputs["us:regulations/42-cfr/435/301#input.person_is_pregnant"] is True
 
 
 def test_project_case_inputs_maps_senior_disabled_category_to_statutory_inputs():

--- a/tests/test_policyengine_medicaid_populace.py
+++ b/tests/test_policyengine_medicaid_populace.py
@@ -187,6 +187,42 @@ def test_project_case_inputs_uses_shared_income_projection_for_medicaid_imports(
     )
 
 
+def test_project_case_inputs_uses_shared_pregnancy_projection_for_medicaid_imports():
+    inputs = medicaid_populace._project_case_inputs(
+        {},
+        age=35,
+        medicaid_income_level=0.25,
+        parent_nfc=False,
+        parent_fc=True,
+        pregnant_nfc=True,
+        pregnant_fc=True,
+        infant_fc=False,
+        young_child_fc=False,
+        older_child_eligible=False,
+        adult_nfc=True,
+        adult_fc=True,
+        ssi_recipient=False,
+        young_adult_eligible=False,
+        senior_or_disabled_eligible=False,
+        medically_needy_eligible=False,
+        working_disabled_buy_in_eligible=False,
+        ssi_excess_earnings_buy_in_eligible=False,
+        mandatory_subpart_b=True,
+        work_requirement_eligible=True,
+        medicare_eligible=False,
+    )
+
+    assert (
+        inputs["us:regulations/42-cfr/435/116#input.person_is_pregnant"] is True
+    )
+    assert (
+        inputs["us:regulations/42-cfr/435/119#input.person_is_pregnant"] is True
+    )
+    assert (
+        inputs["us:regulations/42-cfr/435/301#input.person_is_pregnant"] is True
+    )
+
+
 def test_project_case_inputs_maps_senior_disabled_category_to_statutory_inputs():
     inputs = medicaid_populace._project_case_inputs(
         {},

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -891,7 +891,7 @@ rules:
     ]
 
 
-def test_versioned_derived_formula_rejects_multiple_formula_versions():
+def test_versioned_derived_formula_allows_multiple_formula_versions():
     content = """format: rulespec/v1
 rules:
   - name: savers_credit_gross_contributions
@@ -918,9 +918,7 @@ rules:
 
     issues = find_versioned_derived_formula_issues(content)
 
-    assert len(issues) == 1
-    assert "savers_credit_gross_contributions has 2 formula versions" in issues[0]
-    assert "Versioned derived formula unsupported" in issues[0]
+    assert issues == []
 
 
 def test_rule_source_metadata_rejects_executable_rules_without_rule_source():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1027"
+version = "0.2.1028"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1028"
+version = "0.2.1029"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1024"
+version = "0.2.1025"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1025"
+version = "0.2.1026"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1026"
+version = "0.2.1027"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1029"
+version = "0.2.1030"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- fix the Medicaid Populace oracle projection so imported pregnancy inputs share the same projected person pregnancy flag instead of colliding with later category-specific imports
- mark the Medicaid PE surface as wired and validated against full Populace 2024 eligibility parity
- bump axiom-encode to 0.2.1029 for the oracle validation change

## Validation
- `uv run ruff check src/axiom_encode/oracles/policyengine/medicaid_populace.py tests/test_policyengine_medicaid_populace.py tests/test_policyengine_coverage.py`
- `uv run --with pytest --with pytest-cov python -m pytest -q tests/test_cli.py -k "package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump" --tb=short`
- `uv run --with pytest --with pytest-cov python -m pytest -q tests/test_policyengine_medicaid_populace.py -k "shared_pregnancy_projection or shared_income_projection or medically_needy" --tb=short`
- `axiom-encode medicaid-populace-compare --year 2024 --month 1 --populace-year 2024 --program /Users/maxghenis/TheAxiomFoundation/rulespec-us/us/statutes/42/1396a/a/10.yaml --workspace-root /Users/maxghenis/TheAxiomFoundation --axiom-binary /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-rules-engine-derived-versions-20260701/target/debug/axiom-rules-engine --eligibility-only --fail-on-mismatch --min-match-rate 1 --max-differences 20`
  - Compared 160,858 people; matches=160,858; mismatches=0; match_rate=100.00%
