### PR TITLE
Classify Medicare PE surface boundary

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1030"
+version = "0.2.1031"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1030"
+__version__ = "0.2.1031"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -830,12 +830,10 @@ mappings:
   - legal_id: us:policies/cms/original-medicare-part-a-b#is_medicare_eligible
     country: us
     program: medicare
-    mapping_type: direct_variable
+    mapping_type: not_comparable
     policyengine_variable: is_medicare_eligible
-    entity: person
-    period: year
-    comparison: boolean
-    rationale: CMS's Original Medicare guidance backs the simplified PolicyEngine Medicare eligibility surface for age-based eligibility at 65 and disability-based automatic Medicare Part A and Part B enrollment after 24 months of Social Security disability benefits.
+    candidate_priority: P1
+    rationale: CMS's Original Medicare guidance backs the simplified age-65 and 24-month SSDI facts used by PolicyEngine, but it is not the maximally upstream legal boundary for Medicare entitlement. Primary 42 USC 426 conditions also require section 402 or railroad-retirement entitlement/application facts and include additional disability, railroad, government-employment, enrollment, and termination timing branches that PolicyEngine's is_medicare_eligible proxy does not expose.
 
   - legal_id: us:regulations/47-cfr/54/409#lifeline_income_limit_ratio
     country: us

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1944,10 +1944,14 @@ surfaces:
   coverage: US
   variable: is_medicare_eligible
   source_type: program
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom has primary-source 42 USC 426 Medicare entitlement slices plus CMS guidance parameters for the simplified
+    age-65 and 24-month SSDI facts. PolicyEngine's is_medicare_eligible variable is a simplified person-level proxy
+    using only age >= 65 or SSDI months >= 24, and does not expose the statutory section 402 entitlement,
+    railroad-retirement, government-employment application, enrollment, or termination-timing conditions needed for a
+    maximally upstream one-to-one RuleSpec oracle. Track the source-level statutory mappings separately instead of
+    claiming final Medicare PE parity from the guidance bridge.
 - country: us
   program_id: section_8
   program_name: Section 8

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1039,6 +1039,28 @@ def test_policyengine_program_surface_marks_wic_and_chip_final_eligibility_known
     )
 
 
+def test_policyengine_program_surface_marks_medicare_proxy_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="medicare")
+
+    medicare = {item["variable"]: item for item in report["items"]}[
+        "is_medicare_eligible"
+    ]
+    assert medicare["axiom_status"] == "known_not_comparable"
+    assert medicare["policybench_output"] == "person_level_medicare_eligibility"
+    assert medicare["policybench_household_weight"] == pytest.approx(10.74)
+    assert medicare["mapping_count"] >= 1
+    assert medicare["comparable_mapping_count"] == 0
+    assert (
+        "us:statutes/42/426/a/1#attained_age_65_requirement_satisfied"
+        in (medicare["legal_ids"])
+    )
+    assert (
+        "us:policies/cms/original-medicare-part-a-b#is_medicare_eligible"
+        in (medicare["legal_ids"])
+    )
+    assert report["actionable_surfaces"] == []
+
+
 def test_policyengine_registry_resolves_wic_and_chip_eligibility_prefixes():
     registry = load_policyengine_registry()
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1030"
+version = "0.2.1031"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- marks PolicyEngine's simplified Medicare eligibility variable as known-not-comparable instead of a pending final RuleSpec encoding target
- documents the source boundary: Axiom has 42 USC 426 statute-level slices, while PE exposes only an age/SSDI proxy
- adds coverage regression so the PolicyBench-weighted parity queue no longer treats the Medicare proxy as actionable final parity work

## Validation
- uv run --with pytest --with pytest-cov python -m pytest -q tests/test_policyengine_coverage.py --tb=short
- uv run --with pytest --with pytest-cov python -m pytest -q tests/test_cli.py -k "package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump" --tb=short