### PR TITLE
Validate AOTC Populace parity

### DIFF
--- a/changelog.d/bump-encoder-0-2-1032.changed.md
+++ b/changelog.d/bump-encoder-0-2-1032.changed.md
@@ -1,0 +1,1 @@
+Validate the AOTC Populace oracle adapter against the full local Populace US dataset.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1031"
+version = "0.2.1032"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1031"
+__version__ = "0.2.1032"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -2034,13 +2034,14 @@ def project_aotc_person_inputs(
     person: Any,
     context: PersonProjectionContext,
 ) -> dict[str, Any]:
+    # PolicyEngine treats qualified_tuition_expenses as the amount eligible for
+    # the education-credit schedule. It does not expose a separate gross-tuition
+    # value that should be reduced again by educational assistance.
     return {
         "qualified_tuition_and_related_expenses": money(
             person.get("qualified_tuition_expenses", 0)
         ),
-        "excludable_educational_assistance": money(
-            person.get("educational_assistance", 0)
-        ),
+        "excludable_educational_assistance": 0.0,
         "is_taxpayer": context.is_head,
         "is_spouse": context.is_spouse,
         "is_tax_unit_dependent": context.is_tax_unit_dependent,
@@ -2791,12 +2792,15 @@ def compare_outputs(
             "the available nonrefundable-credit limit remain explicit upstream "
             "boundary inputs until those federal tax chains are encoded "
             "end-to-end.",
-            "AOTC projections run encoded 26 USC 25A math from Populace tuition, "
-            "educational-assistance, enrollment, credential, institution, "
-            "prior-claim, and SSN-card facts. Income tax before credits, CDCC, "
-            "and foreign tax credit remain explicit upstream boundary inputs "
-            "until the full federal credit-ordering chain is encoded "
-            "end-to-end.",
+            "AOTC projections run encoded 26 USC 25A math from "
+            "Populace/PolicyEngine adjusted qualified-tuition, enrollment, "
+            "credential, institution, prior-claim, and SSN-card facts. "
+            "Educational assistance is not subtracted a second time because "
+            "PolicyEngine exposes only the already creditable "
+            "qualified_tuition_expenses amount for this oracle surface. "
+            "Income tax before credits, CDCC, and foreign tax credit remain "
+            "explicit upstream boundary inputs until the full federal "
+            "credit-ordering chain is encoded end-to-end.",
             "Nonrefundable-credit projections run encoded 26 USC 26 aggregate "
             "sum and cap math from upstream credit components supplied as "
             "boundary inputs. Individual component-credit correctness remains "

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -2026,6 +2026,13 @@ surfaces:
   rationale: RuleSpec encodes current-law section 25A education credit surfaces and the PolicyEngine registry maps the American
     Opportunity Credit, refundable and nonrefundable AOTC components, Lifetime Learning Credit components, and education tax
     credit aggregate to exact PE variables for supported current-law cases.
+  populace_validation:
+    status: validated
+    command: AXIOM_POPULACE_US_2024_H5=/Users/maxghenis/.codex-artifacts/populace-us-fiscal-refresh-703bd81-no-oos-20260620/artifacts/populace_us_2024.h5 uv run --with policyengine-us --with policyengine-core==3.26.0 --with /Users/maxghenis/PolicyEngine/populace/packages/populace-data[us] --with numpy --with pandas axiom-encode tax-populace-compare --root /Users/maxghenis/TheAxiomFoundation --rulespec-root /Users/maxghenis/TheAxiomFoundation/rulespec-us --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-rules-engine-derived-versions-20260701 --year 2026 --populace-year 2024 --surface aotc --sample-size 0 --fail-on-mismatch --json
+    dataset: populace-us-2024 local H5
+    last_run: '2026-07-01'
+    rationale: Full-population AOTC comparison passed with 160,858 people, 87,519 tax units, 350,076 output values compared,
+      and 0 mismatches across American Opportunity Credit, refundable AOTC, nonrefundable AOTC, and education tax credits.
 - country: us
   program_id: clean_vehicle_credits
   program_name: Clean vehicle credits

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -1473,7 +1473,7 @@ def test_project_aotc_person_inputs_uses_ecps_education_leaves():
     )
 
     assert projected["qualified_tuition_and_related_expenses"] == 4_500
-    assert projected["excludable_educational_assistance"] == 500
+    assert projected["excludable_educational_assistance"] == 0
     assert projected["is_tax_unit_dependent"] is True
     assert projected["meets_higher_education_act_student_requirements"] is True
     assert projected["at_least_half_time_student"] is True

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1031"
+version = "0.2.1032"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Treat PolicyEngine/Populace qualified_tuition_expenses as the adjusted education-credit expense boundary for the AOTC oracle adapter instead of subtracting educational assistance a second time.
- Record full-population Populace validation for the AOTC/education-credit PE surface.

## Validation
- uv run pytest tests/test_policyengine_ecps_tax.py -k 'aotc or AOTC'
- uv run pytest tests/test_policyengine_coverage.py -k 'populace or education_tax_credit'
- AXIOM_POPULACE_US_2024_H5=/Users/maxghenis/.codex-artifacts/populace-us-fiscal-refresh-703bd81-no-oos-20260620/artifacts/populace_us_2024.h5 uv run --with policyengine-us --with policyengine-core==3.26.0 --with /Users/maxghenis/PolicyEngine/populace/packages/populace-data[us] --with numpy --with pandas axiom-encode tax-populace-compare --root /Users/maxghenis/TheAxiomFoundation --rulespec-root /Users/maxghenis/TheAxiomFoundation/rulespec-us --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-rules-engine-derived-versions-20260701 --year 2026 --populace-year 2024 --surface aotc --sample-size 0 --fail-on-mismatch --json

Full AOTC Populace result: 160,858 people, 87,519 tax units, 350,076 output values, 0 mismatches.