### PR TITLE
Validate federal income tax Populace parity

### DIFF
--- a/changelog.d/bump-encoder-0-2-1033.changed.md
+++ b/changelog.d/bump-encoder-0-2-1033.changed.md
@@ -1,0 +1,1 @@
+Validate the final federal income-tax Populace oracle adapter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1032"
+version = "0.2.1033"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1032"
+__version__ = "0.2.1033"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -92,6 +92,8 @@ AOTC_PROGRAM_PATH = Path("statutes/26/25A.yaml")
 AOTC_BASE = "us:statutes/26/25A"
 NONREFUNDABLE_CREDITS_PROGRAM_PATH = Path("statutes/26/26.yaml")
 NONREFUNDABLE_CREDITS_BASE = "us:statutes/26/26"
+INCOME_TAX_PROGRAM_PATH = Path("statutes/26/6401.yaml")
+INCOME_TAX_BASE = "us:statutes/26/6401"
 SECTION_112_BASE = "us:statutes/26/112"
 SECTION_32_C_2_BASE = "us:statutes/26/32/c/2"
 SECTION_152_C_BASE = "us:statutes/26/152/c"
@@ -352,6 +354,16 @@ NONREFUNDABLE_CREDITS_OUTPUTS = {
         "pe": "income_tax_capped_non_refundable_credits",
     },
 }
+INCOME_TAX_OUTPUTS = {
+    "income_tax_refundable_credits": {
+        "axiom": f"{INCOME_TAX_BASE}#income_tax_refundable_credits",
+        "pe": "income_tax_refundable_credits",
+    },
+    "income_tax": {
+        "axiom": f"{INCOME_TAX_BASE}#income_tax",
+        "pe": "income_tax",
+    },
+}
 SURFACE_OUTPUTS = {
     "ctc": CTC_OUTPUTS,
     "standard-deduction": STANDARD_DEDUCTION_OUTPUTS,
@@ -361,6 +373,7 @@ SURFACE_OUTPUTS = {
     "cdcc": CDCC_OUTPUTS,
     "aotc": AOTC_OUTPUTS,
     "nonrefundable-credits": NONREFUNDABLE_CREDITS_OUTPUTS,
+    "income-tax": INCOME_TAX_OUTPUTS,
     **{surface: config["outputs"] for surface, config in PAYROLL_SURFACES.items()},
 }
 SURFACE_PROGRAM_PATHS = {
@@ -372,6 +385,7 @@ SURFACE_PROGRAM_PATHS = {
     "cdcc": CDCC_PROGRAM_PATH,
     "aotc": AOTC_PROGRAM_PATH,
     "nonrefundable-credits": NONREFUNDABLE_CREDITS_PROGRAM_PATH,
+    "income-tax": INCOME_TAX_PROGRAM_PATH,
     **{surface: config["program"] for surface, config in PAYROLL_SURFACES.items()},
 }
 
@@ -427,9 +441,12 @@ PE_TAX_UNIT_VARIABLES = tuple(
             "energy_efficient_home_improvement_credit",
             "filing_status",
             "foreign_tax_credit",
+            "income_tax",
             "income_tax_before_credits",
+            "income_tax_before_refundable_credits",
             "income_tax_capped_non_refundable_credits",
             "income_tax_non_refundable_credits",
+            "income_tax_refundable_credits",
             "income_tax_unavailable_non_refundable_credits",
             "min_head_spouse_earned",
             "net_capital_gain",
@@ -1083,6 +1100,8 @@ def build_axiom_request(
         return build_aotc_request(pe_data=pe_data, year=year)
     if surface == "nonrefundable-credits":
         return build_nonrefundable_credits_request(pe_data=pe_data, year=year)
+    if surface == "income-tax":
+        return build_income_tax_request(pe_data=pe_data, year=year)
     if surface in PAYROLL_SURFACES:
         return build_payroll_request(
             pe_data=pe_data,
@@ -1303,6 +1322,41 @@ def build_nonrefundable_credits_request(
                 "outputs": [
                     spec["axiom"] for spec in NONREFUNDABLE_CREDITS_OUTPUTS.values()
                 ],
+            }
+            for tax_unit_id in pe_data["tax_unit_ids"]
+        ],
+    }
+
+
+def build_income_tax_request(*, pe_data: dict[str, Any], year: int) -> dict[str, Any]:
+    interval = {
+        "period_kind": "tax_year",
+        "start": f"{year:04d}-01-01",
+        "end": f"{year:04d}-12-31",
+    }
+    inputs: list[dict[str, Any]] = []
+
+    for _idx, row in pe_data["tax_units"].iterrows():
+        tax_unit_id = int(row["tax_unit_id"])
+        entity_id = tax_entity_id(tax_unit_id)
+        for name, value in project_income_tax_inputs(row=row).items():
+            inputs.append(
+                input_record(
+                    f"{INCOME_TAX_BASE}#input.{name}",
+                    entity_id,
+                    interval,
+                    value,
+                )
+            )
+
+    return {
+        "mode": "explain",
+        "dataset": {"inputs": inputs, "relations": []},
+        "queries": [
+            {
+                "entity_id": tax_entity_id(tax_unit_id),
+                "period": interval,
+                "outputs": [spec["axiom"] for spec in INCOME_TAX_OUTPUTS.values()],
             }
             for tax_unit_id in pe_data["tax_unit_ids"]
         ],
@@ -2109,6 +2163,25 @@ def project_nonrefundable_credits_inputs(*, row: Any) -> dict[str, Any]:
     }
 
 
+def project_income_tax_inputs(*, row: Any) -> dict[str, Any]:
+    tax_before_refundable_credits = money(
+        row.get("income_tax_before_refundable_credits", 0)
+    )
+    return {
+        "credits_allowable_under_subpart_c_excluding_section_33_for_overpayment": (
+            money(row.get("income_tax_refundable_credits", 0))
+        ),
+        "nonresident_withholding_credit_treated_as_refundable_amount": 0.0,
+        "tax_imposed_by_subtitle_a_reduced_by_subparts_a_b_d_and_g_credits": (
+            tax_before_refundable_credits
+        ),
+        "amount_paid_as_tax": 0.0,
+        "no_tax_liability_in_respect_of_amount_paid": (
+            tax_before_refundable_credits == 0
+        ),
+    }
+
+
 def project_eitc_tax_unit_inputs(row: Any, persons: list[Any]) -> dict[str, Any]:
     filing_status = str(row["filing_status"])
     filing_status_numeric = filing_status_code(filing_status)
@@ -2806,6 +2879,12 @@ def compare_outputs(
             "boundary inputs. Individual component-credit correctness remains "
             "with each component surface until the full federal credit chain is "
             "encoded end-to-end.",
+            "Final income-tax projections run encoded 26 USC 6401 overpayment "
+            "math from PolicyEngine's before-refundable-credit liability and "
+            "refundable-credit aggregate. Section 33/nonresident withholding "
+            "credit treatment is zero for this PolicyEngine surface because "
+            "PolicyEngine's refundable-credit aggregate is configured from "
+            "Subpart C credits and does not include payment withholding.",
         ],
     )
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -17,7 +17,36 @@ surfaces:
   axiom_status: wired
   priority: P1
   rationale: Axiom encodes federal income tax liability surfaces and the PolicyEngine registry wires the final income-tax
-    comparison target; Populace validation is still required before claiming population-level parity.
+    comparison target; Populace validation verifies the final federal income-tax surface.
+  populace_validation:
+    status: validated
+    dataset: populace-us-2024 local H5
+    command: >-
+      AXIOM_POPULACE_US_2024_H5=/Users/maxghenis/.codex-artifacts/populace-us-fiscal-refresh-703bd81-no-oos-20260620/artifacts/populace_us_2024.h5
+      uv run --with policyengine-us --with policyengine-core==3.26.0
+      --with /Users/maxghenis/PolicyEngine/populace/packages/populace-data[us]
+      --with numpy --with pandas axiom-encode tax-populace-compare
+      --root /Users/maxghenis/TheAxiomFoundation
+      --rulespec-root /Users/maxghenis/TheAxiomFoundation/rulespec-us
+      --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/_worktrees/axiom-rules-engine-derived-versions-20260701
+      --year 2026 --populace-year 2024 --surface income-tax --sample-size 0
+      --fail-on-mismatch --json
+    last_run: '2026-07-01'
+    compared_persons: 160858
+    compared_tax_units: 87519
+    compared_values: 175038
+    mismatch_count: 0
+    outputs:
+    - output: income_tax_refundable_credits
+      compared: 87519
+      mismatches: 0
+      max_abs_diff: 0.0
+    - output: income_tax
+      compared: 87519
+      mismatches: 0
+      max_abs_diff: 0.0009307861328125
+    rationale: Full-population federal income-tax comparison passed with 87,519 tax units and 175,038 output values;
+      observed differences were below configured numeric tolerances.
 - country: us
   program_id: state_income_tax
   program_name: State income taxes

--- a/tests/test_policyengine_ecps_tax.py
+++ b/tests/test_policyengine_ecps_tax.py
@@ -16,6 +16,8 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     EITC_OUTPUTS,
     EMPLOYEE_OASDI_BASE,
     EMPLOYEE_OASDI_PROGRAM_PATH,
+    INCOME_TAX_BASE,
+    INCOME_TAX_OUTPUTS,
     NONREFUNDABLE_CREDITS_BASE,
     NONREFUNDABLE_CREDITS_OUTPUTS,
     OASDI_WAGE_BASE_BASE,
@@ -39,6 +41,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     build_contribution_and_benefit_base_request,
     build_ctc_request,
     build_eitc_request,
+    build_income_tax_request,
     build_nonrefundable_credits_request,
     build_oasdi_wage_base_request,
     build_payroll_request,
@@ -66,6 +69,7 @@ from axiom_encode.oracles.policyengine.ecps_tax import (
     project_eitc_relevant_investment_income,
     project_eitc_tax_unit_inputs,
     project_fica_wages,
+    project_income_tax_inputs,
     project_nonrefundable_credits_inputs,
     project_oasdi_wage_base_inputs,
     project_section_32_c_2_tax_unit_inputs,
@@ -1695,6 +1699,79 @@ def test_build_nonrefundable_credits_request_uses_tax_unit_inputs_and_outputs():
             )
         ]
         == "500.0"
+    )
+
+
+def test_project_income_tax_inputs_uses_6401_boundaries():
+    projected = project_income_tax_inputs(
+        row={
+            "income_tax_before_refundable_credits": 1_200,
+            "income_tax_refundable_credits": 300,
+        }
+    )
+
+    assert projected == {
+        "credits_allowable_under_subpart_c_excluding_section_33_for_overpayment": 300,
+        "nonresident_withholding_credit_treated_as_refundable_amount": 0.0,
+        "tax_imposed_by_subtitle_a_reduced_by_subparts_a_b_d_and_g_credits": 1_200,
+        "amount_paid_as_tax": 0.0,
+        "no_tax_liability_in_respect_of_amount_paid": False,
+    }
+
+
+def test_build_income_tax_request_uses_tax_unit_inputs_and_outputs():
+    pd = pytest.importorskip("pandas")
+    pe_data = {
+        "tax_units": pd.DataFrame(
+            [
+                {
+                    "tax_unit_id": 1,
+                    "income_tax_before_refundable_credits": 1_200,
+                    "income_tax_refundable_credits": 300,
+                }
+            ]
+        ),
+        "persons": pd.DataFrame([]),
+        "tax_unit_ids": [1],
+    }
+
+    request = build_income_tax_request(pe_data=pe_data, year=2026)
+
+    assert request["queries"] == [
+        {
+            "entity_id": "tax_unit_1",
+            "period": {
+                "period_kind": "tax_year",
+                "start": "2026-01-01",
+                "end": "2026-12-31",
+            },
+            "outputs": [spec["axiom"] for spec in INCOME_TAX_OUTPUTS.values()],
+        }
+    ]
+    assert request["dataset"]["relations"] == []
+    input_values = {
+        (item["name"], item["entity_id"]): item["value"]["value"]
+        for item in request["dataset"]["inputs"]
+    }
+    assert (
+        input_values[
+            (
+                f"{INCOME_TAX_BASE}#input."
+                "credits_allowable_under_subpart_c_excluding_section_33_for_overpayment",
+                "tax_unit_1",
+            )
+        ]
+        == "300.0"
+    )
+    assert (
+        input_values[
+            (
+                f"{INCOME_TAX_BASE}#input."
+                "tax_imposed_by_subtitle_a_reduced_by_subparts_a_b_d_and_g_credits",
+                "tax_unit_1",
+            )
+        ]
+        == "1200.0"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1032"
+version = "0.2.1033"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add the final federal `income-tax` PolicyEngine/Populace oracle surface for encoded 26 USC 6401 overpayment/refund math
- wire `income_tax_refundable_credits` and final `income_tax` comparisons through the tax Populace adapter
- record full local Populace validation for tax year 2026 / populace year 2024 with zero mismatches

## Validation
- `uv run pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`
- `uv run pytest tests/test_policyengine_ecps_tax.py -k 'income_tax or INCOME_TAX'`\n- `uv run pytest tests/test_policyengine_coverage.py -k 'populace or income_tax'`\n- `git diff --check`\n- full Populace run: `compared_persons=160858`, `compared_tax_units=87519`, `compared_values=175038`, `mismatch_count=0`; output max diffs: `income_tax_refundable_credits=0.0`, `income_tax=0.0009307861328125`