### PR TITLE
Classify Washington SSP eligibility oracle outputs

### DIFF
--- a/changelog.d/wa-ssp-oracle-registry.fixed.md
+++ b/changelog.d/wa-ssp-oracle-registry.fixed.md
@@ -1,0 +1,1 @@
+Classify WAC 388-474 Washington SSP eligibility internals in the PolicyEngine oracle registry so source-level branch predicates do not block RuleSpec validation as unmapped.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1035"
+version = "0.2.1036"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1035"
+__version__ = "0.2.1036"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2135,6 +2135,38 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec encodes the current WAC 388-478-0055 source slice with local WAC 388-474 eligibility/category facts and an explicit deferred output for post-2024 medical-institution COLA. PolicyEngine's wa_ssp is a final person-level category wrapper over SSI eligibility, federal living arrangement, disabled-category timing, and a historical amount parameter schedule, so compare the encoded source components separately until the WAC 388-474 eligibility rules and historical WSR rate table are encoded.
 
+  - legal_id: us-wa:regulations/388/388-474/388-474-0012#individual_is_eligible_for_ssp_as_described
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: wa_ssp
+    candidate_priority: P4
+    rationale: RuleSpec exposes the source-level WAC 388-474-0012 SSP eligibility predicate. PolicyEngine's wa_ssp is a final payment variable that combines eligibility, payment-category selection, and historical amount schedules, so this predicate is not a one-to-one oracle target.
+
+  - legal_id: us-wa:regulations/388/388-474/388-474-0012#ssp_eligibility_based_on_developmental_disabilities_administration_determination
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: wa_ssp
+    candidate_priority: P4
+    rationale: RuleSpec exposes the WAC 388-474-0012(f) DDA-determination eligibility branch. PolicyEngine does not expose this branch separately from final Washington SSP payment eligibility and amount calculation.
+
+  - legal_id: us-wa:regulations/388/388-474/388-474-0012#ssp_eligibility_based_on_foster_child_brs_services
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: wa_ssp
+    candidate_priority: P4
+    rationale: RuleSpec exposes the WAC 388-474-0012(g) foster-child BRS eligibility branch. PolicyEngine does not expose this branch separately from final Washington SSP payment eligibility and amount calculation.
+
+  - legal_id: us-wa:regulations/388/388-474/388-474-0012#ssp_eligibility_based_on_ineligible_spouse_status
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    policyengine_variable: wa_ssp
+    candidate_priority: P4
+    rationale: RuleSpec exposes the WAC 388-474-0012(b) ineligible-spouse eligibility branch. PolicyEngine does not expose this branch separately from final Washington SSP payment eligibility and amount calculation.
+
   - legal_id: us:statutes/7/2014/e/6/A#snap_net_income_pre_shelter
     country: us
     program: snap

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -2740,6 +2740,18 @@ def test_policyengine_registry_is_legal_id_keyed():
     )
     assert michigan_ssp_person_mapping.mapping_type == "not_comparable"
     assert michigan_ssp_person_mapping.policyengine_variable == "mi_ssp_person"
+    wa_ssp_eligibility_mapping = registry.mapping_for_legal_id(
+        "us-wa:regulations/388/388-474/388-474-0012#individual_is_eligible_for_ssp_as_described",
+        country="us",
+    )
+    assert wa_ssp_eligibility_mapping.mapping_type == "not_comparable"
+    assert wa_ssp_eligibility_mapping.policyengine_variable == "wa_ssp"
+    wa_ssp_ineligible_spouse_mapping = registry.mapping_for_legal_id(
+        "us-wa:regulations/388/388-474/388-474-0012#ssp_eligibility_based_on_ineligible_spouse_status",
+        country="us",
+    )
+    assert wa_ssp_ineligible_spouse_mapping.mapping_type == "not_comparable"
+    assert wa_ssp_ineligible_spouse_mapping.policyengine_variable == "wa_ssp"
     section_2014c_net_failure_mapping = registry.mapping_for_legal_id(
         "us:statutes/7/2014/c#snap_net_income_exceeds_poverty_line",
         country="us",

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1035"
+version = "0.2.1036"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify WAC 388-474-0012 Washington SSP eligibility internals as known non-comparable in the PolicyEngine oracle registry
- add registry test assertions for representative WA SSP eligibility mappings
- document the registry fix in the changelog

## Validation
- `uv run python -m pytest tests/test_rulespec_validation.py -k policyengine_registry_is_legal_id_keyed`
- CI-shaped `axiom-encode oracle-coverage --root <tmpdir with rulespec-us symlink>` confirms WAC 388-474 outputs are known non-comparable and `medical_institution_monthly_ssp_base` is tested
- `uv run ruff check tests/test_rulespec_validation.py`
- `uv run ruff format --check tests/test_rulespec_validation.py`
- YAML parse check for `src/axiom_encode/oracles/policyengine/mappings/us.yaml`
- `git diff --check`
