### PR TITLE
Classify SSI institutional oracle outputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1036"
+version = "0.2.1037"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1036"
+__version__ = "0.2.1037"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -20762,6 +20762,13 @@ prefixes:
     mapping_type: not_comparable
     rationale: Section 2014(g) resource-test intermediates (vehicle countable amount, fair-market-value threshold, indexed base-amount components, rounding increments) are internal pieces of PolicyEngine's asset-limit aggregation; PE exposes the final snap_assets and snap_asset_limit but not these per-vehicle and base-amount computation steps.
 
+  - legal_id_prefix: us:statutes/42/1382/e/1#
+    country: us
+    program: ssi
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: 42 USC 1382(e)(1) outputs are source-level institutional-eligibility, medical-facility cap, emergency-shelter, temporary-institutionalization, and inmate-reporting payment rules. PolicyEngine exposes final SSI eligibility and benefit amounts, not these statutory institutional exceptions, caps, and administrative payment predicates as one-to-one oracle variables.
+
   - legal_id_prefix: us:statutes/42/1396a/xx#
     country: us
     program: medicaid

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1036"
+version = "0.2.1037"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Add a PolicyEngine oracle prefix classification for 42 USC 1382(e)(1) SSI institutional outputs.
- Mark those institutional eligibility, medical-facility cap, emergency shelter, temporary institutionalization, and inmate-reporting payment outputs as source-level surfaces outside PE's one-to-one SSI oracle variables.
- Unblocks the generated RuleSpec addition by making the oracle coverage gate explicit instead of leaving the outputs unmapped.

## Checks
- `uv run pytest -q tests/test_policyengine_coverage_monorepo.py`
- SSI RuleSpec changed oracle coverage filter: 21 outputs, all `known_not_comparable`
