### PR TITLE
Support European numeric source grounding

### DIFF
--- a/changelog.d/european-decimal-grounding.fixed.md
+++ b/changelog.d/european-decimal-grounding.fixed.md
@@ -1,0 +1,1 @@
+Accept European comma-decimal source values with four decimal places while preserving comma thousands parsing for source-grounded RuleSpec validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1038"
+version = "0.2.1039"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1038"
+__version__ = "0.2.1039"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -573,6 +573,18 @@ SOURCE_TEXT_NUMBER_PATTERN = re.compile(
     r"(?:^|(?<=[\s$£€(\[,+\-−*/\"'`“”‘’]))"
     r"(-?(?:[\d,]+(?:\.\d+)?|\.\d+))\b"
 )
+EUROPEAN_DECIMAL_NUMBER_PATTERN = re.compile(
+    r"(?:^|(?<=[\s$£€(\[,+\-−*/\"'`“”‘’]))"
+    r"(-?(?:\d{1,3}(?:[.\u00a0\u202f]\d{3})+|\d+),(?:\d{1,2}|\d{4}))"
+    r"(?!\d)",
+    re.IGNORECASE,
+)
+EUROPEAN_THOUSANDS_NUMBER_PATTERN = re.compile(
+    r"(?:^|(?<=[\s$£€(\[,+\-−*/\"'`“”‘’]))"
+    r"(-?\d{1,3}(?:[.\u00a0\u202f ]\d{3})+)"
+    r"(?=\s*(?:euro|euros|eur\b|€|\bchildren?\b|\bpersons?\b|\bhouseholds?\b))",
+    re.IGNORECASE,
+)
 SOURCE_TEXT_RATIO_NUMBER_PATTERN = re.compile(
     r"(?<![\w.])(\d{1,3})\s*/\s*(\d{1,3})(?![\w/])"
 )
@@ -582,6 +594,19 @@ _SIMPLE_FRACTION_EXPRESSION = re.compile(
 _EXTRACTED_PARAMETER_SCALAR_COMPARISON = re.compile(
     r"^(?:(?P<left_name>[A-Za-z_][A-Za-z0-9_]*)\s*==\s*(?P<right_value>-?[\d,]+(?:\.\d+)?)|(?P<left_value>-?[\d,]+(?:\.\d+)?)\s*==\s*(?P<right_name>[A-Za-z_][A-Za-z0-9_]*))$"
 )
+
+
+def _normalize_grouped_thousands_number(raw: str) -> str:
+    return (
+        raw.replace(".", "")
+        .replace(" ", "")
+        .replace("\u00a0", "")
+        .replace("\u202f", "")
+    )
+
+
+def _normalize_european_decimal_number(raw: str) -> str:
+    return _normalize_grouped_thousands_number(raw).replace(",", ".")
 
 
 def _is_source_backed_simple_fraction_parameter(
@@ -730,7 +755,9 @@ _STRUCTURAL_SOURCE_LINE_PATTERN = re.compile(
     r"^[\(\[]?(?:\d+[A-Za-z]?|[ivxlcdm]+|[a-z])[\)\].]?$", re.IGNORECASE
 )
 _STRUCTURAL_SOURCE_HEADING_PATTERN = re.compile(
-    r"^(PART|CHAPTER|SCHEDULE|REGULATION|ARTICLE)\b", re.IGNORECASE
+    r"^(?:(?:PART|CHAPTER|SCHEDULE|REGULATION)\b|"
+    r"ARTICLE\b\s*(?:\d+[A-Za-z]?)?\s*$)",
+    re.IGNORECASE,
 )
 _STRUCTURAL_SOURCE_CITATION_PATTERN = re.compile(
     r"^\d+\s+[A-Z]{2,}(?:\s+\d+[A-Za-z0-9./-]*)+\s*$"
@@ -2643,6 +2670,20 @@ def extract_numbers_from_text(text: str) -> set[float]:
         numbers.add(value)
         occupied_spans.append(span)
 
+    for match in EUROPEAN_DECIMAL_NUMBER_PATTERN.finditer(text):
+        raw = _normalize_european_decimal_number(match.group(1))
+        with contextlib.suppress(ValueError):
+            numbers.add(float(raw))
+            occupied_spans.append(match.span(1))
+
+    for match in EUROPEAN_THOUSANDS_NUMBER_PATTERN.finditer(text):
+        if _span_overlaps(match.span(1), occupied_spans):
+            continue
+        raw = _normalize_grouped_thousands_number(match.group(1))
+        with contextlib.suppress(ValueError):
+            numbers.add(float(raw))
+            occupied_spans.append(match.span(1))
+
     for match in SOURCE_TEXT_NUMBER_PATTERN.finditer(text):
         if _span_overlaps(match.span(1), occupied_spans):
             continue
@@ -3150,6 +3191,26 @@ def extract_numeric_occurrences_from_text(text: str) -> list[float]:
             continue
         occurrences.append(value)
         spans.append(span)
+
+    for match in EUROPEAN_DECIMAL_NUMBER_PATTERN.finditer(cleaned):
+        span = match.span(1)
+        if _span_overlaps(span, spans):
+            continue
+        with contextlib.suppress(ValueError):
+            occurrences.append(
+                float(_normalize_european_decimal_number(match.group(1)))
+            )
+            spans.append(span)
+
+    for match in EUROPEAN_THOUSANDS_NUMBER_PATTERN.finditer(cleaned):
+        span = match.span(1)
+        if _span_overlaps(span, spans):
+            continue
+        with contextlib.suppress(ValueError):
+            occurrences.append(
+                float(_normalize_grouped_thousands_number(match.group(1)))
+            )
+            spans.append(span)
 
     for match in SOURCE_TEXT_NUMBER_PATTERN.finditer(cleaned):
         span = match.span(1)
@@ -17793,7 +17854,10 @@ def _find_source_text_value_issues(
             return []
         return issues
 
-    if _source_text_contains_scalar_value(normalized_text, expected_value):
+    if _source_text_contains_scalar_value(
+        normalized_text,
+        expected_value,
+    ) or _source_text_contains_numeric_value_equivalent(source_text, expected_value):
         return []
     return [
         "Source verification value missing: "
@@ -18613,6 +18677,13 @@ def _source_text_contains_scalar_value(text: str, value: Any) -> bool:
         )
         for value_text in value_texts
     )
+
+
+def _source_text_contains_numeric_value_equivalent(text: str, value: Any) -> bool:
+    numeric = _numeric_rule_value(value)
+    if numeric is None:
+        return False
+    return numeric_value_is_grounded(numeric[1], extract_numbers_from_text(text))
 
 
 def _source_text_contains_table_value_multiset(

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5684,6 +5684,156 @@ rules:
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
 
 
+def test_rulespec_grounding_accepts_european_thousands_separator_money():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be-bru/statute/example/article/9
+rules:
+  - name: brussels_family_benefits_social_supplement_low_income_upper_bound
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '31000'
+"""
+
+    source_text = "lorsque les revenus annuels du menage n'atteignent pas 31.000 euros"
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 31000 in extract_numbers_from_text(source_text)
+
+
+def test_rulespec_grounding_accepts_article_line_european_thousands_money():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be/statute/example/article/132
+rules:
+  - name: belgium_pit_two_children_tax_free_increase
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2025-01-01'
+        formula: '5110'
+"""
+
+    source_text = (
+        "Article 132, CIR 92 (revenus 2025) Le montant de base est majore "
+        "des supplements suivants pour personnes a charge: 2 degres pour "
+        "deux enfants: 5.110 euros (montant indexe)."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 5110 in extract_numbers_from_text(source_text)
+
+
+def test_rulespec_grounding_accepts_spaced_thousands_separator_money():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be/statute/example/article/14
+rules:
+  - name: belgium_social_integration_cohabitant_base_annual_amount
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '4400'
+"""
+
+    source_text = "1° 4 400 EUR pour toute personne cohabitant."
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 4400 in extract_numbers_from_text(source_text)
+
+
+def test_rulespec_grounding_accepts_european_decimal_money():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be/statute/example/article/6
+rules:
+  - name: belgium_grapa_base_annual_amount
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '6765.89'
+"""
+
+    source_text = "Le montant annuel s'eleve au maximum a 6.765,89 euros."
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 6765.89 in extract_numbers_from_text(source_text)
+
+
+def test_rulespec_grounding_accepts_european_decimal_money_table_cell():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be-bru/guidance/example/page-5
+rules:
+  - name: brussels_circulation_tax_cv_0_to_4_amount
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2026-07-01'
+        formula: '107.18'
+"""
+
+    source_text = "TARIFS (1) CC CV PK € 0 - 0,7 0 - 4 107,18 0,8 - 0,9 5 134,11"
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 107.18 in extract_numbers_from_text(source_text)
+
+
+def test_rulespec_grounding_accepts_european_decimal_coefficient():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be/statute/example/article/6
+rules:
+  - name: belgium_grapa_isolated_multiplier
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '1.5'
+"""
+
+    source_text = "Le coefficient 1,50 s'applique au montant vise au paragraphe 1er."
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 1.5 in extract_numbers_from_text(source_text)
+
+
+def test_rulespec_grounding_accepts_four_place_european_decimal_money():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be/statute/example/article/5
+rules:
+  - name: belgium_excise_beer_rate_per_hectolitre_degree_plato
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2026-06-30'
+        formula: '0.7933'
+"""
+
+    source_text = "La biere est soumise a un droit d'accise de 0,7933 EUR."
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 0.7933 in extract_numbers_from_text(source_text)
+
+
 def test_rulespec_grounding_does_not_trust_module_summary():
     content = """format: rulespec/v1
 module:
@@ -7123,6 +7273,65 @@ def test_numeric_occurrence_extraction_ignores_bare_dotted_regulatory_reference(
     )
 
     assert extract_numeric_occurrences_from_text(text) == [pytest.approx(0.0831)]
+
+
+def test_numeric_occurrence_extraction_accepts_european_thousands_money():
+    text = (
+        "Under article 9, income must be less than 45.000 euros. "
+        "Dotted legal reference 4.304.3 remains a citation."
+    )
+
+    assert extract_numeric_occurrences_from_text(text) == [45000.0]
+
+
+def test_numeric_occurrence_extraction_keeps_article_line_body_amount():
+    text = (
+        "Article 132, CIR 92 (revenus 2025) Le montant de base est majore "
+        "des supplements suivants pour personnes a charge: 2 degres pour "
+        "deux enfants: 5.110 euros (montant indexe)."
+    )
+
+    assert 5110.0 in extract_numeric_occurrences_from_text(text)
+
+
+def test_numeric_occurrence_extraction_accepts_spaced_thousands_money():
+    text = (
+        "Le montant annuel est 4 400 EUR. "
+        "Dotted legal reference 4.304.3 remains a citation."
+    )
+
+    assert extract_numeric_occurrences_from_text(text) == [4400.0]
+
+
+def test_numeric_occurrence_extraction_accepts_european_decimal_money():
+    text = (
+        "Le montant annuel s'eleve au maximum a 6.765,89 euros. "
+        "Dotted legal reference 4.304.3 remains a citation."
+    )
+
+    assert extract_numeric_occurrences_from_text(text) == [6765.89]
+
+
+def test_numeric_occurrence_extraction_accepts_european_decimal_money_table_cell():
+    text = "TARIFS (1) CC CV PK € 0 - 0,7 0 - 4 107,18 0,8 - 0,9 5 134,11"
+
+    values = extract_numeric_occurrences_from_text(text)
+
+    assert 107.18 in values
+    assert 134.11 in values
+    assert 1000.0 in extract_numbers_from_text("The limit is 1,000 dollars.")
+
+
+def test_numeric_occurrence_extraction_accepts_european_decimal_coefficient():
+    text = "Le coefficient 1,50 s'applique au montant vise au paragraphe 1er."
+
+    assert extract_numeric_occurrences_from_text(text) == [1.5]
+
+
+def test_numeric_occurrence_extraction_accepts_four_place_european_decimal_money():
+    text = "Le droit d'accise est 0,7933 EUR par hectolitre-degre Plato."
+
+    assert extract_numeric_occurrences_from_text(text) == [0.7933]
 
 
 def test_numeric_occurrence_extraction_ignores_section_symbol_reference():
@@ -15453,6 +15662,43 @@ rules:
         source_texts={
             "us/guidance/irs/rev-proc-2025-32/page-10": (
                 "The applicable rates are 10% and 12%."
+            )
+        },
+    )
+
+    assert issues == []
+
+
+def test_source_verification_accepts_european_decimal_source_values():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be/statute/example/article/6
+    values:
+      belgium_grapa_base_annual_amount: 7449.26
+      belgium_grapa_isolated_multiplier: 1.5
+rules:
+  - name: belgium_grapa_base_annual_amount
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '7449.26'
+  - name: belgium_grapa_isolated_multiplier
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '1.5'
+"""
+
+    issues = find_source_verification_issues(
+        content,
+        source_texts={
+            "be/statute/example/article/6": (
+                "Le montant annuel est remplace par 7.449,26 euros. "
+                "Le coefficient 1,50 s'applique au montant vise."
             )
         },
     )

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1038"
+version = "0.2.1039"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- parse European decimal and grouped-thousands numeric forms in source grounding
- keep dotted article/regulatory references from becoming false numeric evidence
- add Belgian-style grounding and occurrence extraction regression tests
- bump axiom-encode to 0.2.1039

## Checks
- uv run ruff format --check src/ tests/
- uv run ruff check .
- uv run --with pytest --with pytest-cov python -m pytest -q tests/test_rulespec_validation.py -k 'european or spaced_thousands or article_line'