### PR TITLE
Add Minnesota MFIP upstream-source repair

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1039"
+version = "0.2.1040"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1040"
+version = "0.2.1041"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1040"
+__version__ = "0.2.1041"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1039"
+__version__ = "0.2.1040"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -1380,6 +1380,25 @@ def main():
         help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
     )
 
+    repair_minnesota_mfip_parser = subparsers.add_parser(
+        "repair-minnesota-mfip-upstream-source-check",
+        help="Apply a signed deterministic upstream-source audit for Minnesota MFIP",
+    )
+    repair_minnesota_mfip_parser.add_argument(
+        "--repo",
+        type=Path,
+        default=Path.cwd(),
+        help="rulespec-us repository root used for manifest signing",
+    )
+    repair_minnesota_mfip_parser.add_argument(
+        "--axiom-rules-engine-path",
+        dest="axiom_rules_path",
+        metavar="AXIOM_RULES_ENGINE_PATH",
+        type=Path,
+        default=None,
+        help="Path to axiom-rules-engine repo (defaults to sibling checkout)",
+    )
+
     repair_child_fragment_parser = subparsers.add_parser(
         "repair-child-fragment-reencoding",
         help=(
@@ -2530,6 +2549,8 @@ def main():
         cmd_repair_same_section_subsection_imports(args)
     elif args.command == "repair-source-child-corpus-paths":
         cmd_repair_source_child_corpus_paths(args)
+    elif args.command == "repair-minnesota-mfip-upstream-source-check":
+        cmd_repair_minnesota_mfip_upstream_source_check(args)
     elif args.command == "repair-child-fragment-reencoding":
         cmd_repair_child_fragment_reencoding(args)
     elif args.command == "repair-upstream-placement-duplicates":
@@ -4507,6 +4528,28 @@ ARIZONA_SNAP_BENEFIT_RELATIVE = Path(
     "policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount.yaml"
 )
 
+MINNESOTA_MFIP_UPSTREAM_SOURCE_CHECK_MODEL = (
+    "minnesota-mfip-upstream-source-check-v1"
+)
+MINNESOTA_MFIP_RELATIVE_OUTPUT = Path(
+    "us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml"
+)
+MINNESOTA_MFIP_MANUAL_SOURCE = "us-mn/manual/dhs/combined-manual/current/page-944"
+MINNESOTA_MFIP_UPSTREAM_SOURCE_CHECK_BLOCK = """    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us-mn/statute/142G.16
+        - us-mn/statute/142G.17
+        - us-mn/statute/256P.03
+      rationale: |-
+        Minnesota statutes define the MFIP income/payment calculation,
+        transitional standard, family wage level, and earned-income disregard.
+        The DHS Combined Manual remains the official implementation source for
+        this module's operational grant procedure, including applicant
+        proration, recoupment, and cash/food issuance against the published
+        standards.
+"""
+
 
 def cmd_repair_colorado_snap_federal_refs(args):
     """Apply signed deterministic repairs for Colorado SNAP federal ref drift."""
@@ -5013,6 +5056,148 @@ def cmd_repair_arizona_snap_composition(args):
             print(f"changed={path.relative_to(repo_path)}")
     for manifest_path in manifest_paths:
         print(f"manifest={manifest_path}")
+
+
+def cmd_repair_minnesota_mfip_upstream_source_check(args):
+    """Apply a signed deterministic upstream-source audit for Minnesota MFIP."""
+    repo_path = Path(args.repo).resolve()
+    if _repo_jurisdiction_prefix(repo_path) != "us":
+        print(
+            "repair-minnesota-mfip-upstream-source-check must run against "
+            f"rulespec-us; got {repo_path}"
+        )
+        sys.exit(1)
+
+    relative_output = MINNESOTA_MFIP_RELATIVE_OUTPUT
+    rules_file = repo_path / relative_output
+    test_file = _rulespec_test_path(rules_file)
+    if not rules_file.exists():
+        print(f"RuleSpec file not found: {rules_file}")
+        sys.exit(1)
+
+    manifest_groups = [(relative_output, [rules_file, test_file])]
+    try:
+        _ensure_no_unmanifested_preexisting_rulespec_changes(
+            repo_path,
+            manifest_groups,
+        )
+    except RuntimeError as exc:
+        print(str(exc))
+        sys.exit(1)
+
+    signing_key = _require_applied_encoding_manifest_signing_key()
+    axiom_encode_git = _require_clean_axiom_encode_git_provenance()
+    axiom_rules_path = getattr(
+        args, "axiom_rules_path", None
+    ) or _resolve_runtime_axiom_rules_checkout(repo_path)
+
+    originals = {
+        path: path.read_text() if path.exists() else None
+        for path in (rules_file, test_file)
+    }
+    try:
+        changed = _repair_minnesota_mfip_upstream_source_check_file(rules_file)
+        refresh_manifest = False
+        if not changed:
+            if not _applied_manifest_matches_current_deterministic_repair(
+                repo_path=repo_path,
+                relative_output=relative_output,
+                applied_files=[path for path in (rules_file, test_file) if path.exists()],
+                model=MINNESOTA_MFIP_UPSTREAM_SOURCE_CHECK_MODEL,
+                axiom_encode_git=axiom_encode_git,
+                signing_key=signing_key,
+            ):
+                refresh_manifest = True
+            else:
+                print("No Minnesota MFIP upstream-source repairs found.")
+                return
+
+        validation = ValidatorPipeline(
+            policy_repo_path=repo_path,
+            axiom_rules_path=axiom_rules_path,
+            enable_oracles=False,
+            require_policy_proofs=False,
+        ).validate(rules_file, skip_reviewers=True)
+        if not validation.all_passed:
+            issues = [
+                result.error for result in validation.results.values() if result.error
+            ]
+            raise RuntimeError("\n".join(issues) or "validation failed")
+
+        if test_file.exists():
+            test_issues = _companion_test_issues(
+                test_files=[test_file],
+                repo_path=repo_path,
+                axiom_rules_path=axiom_rules_path,
+            )
+            if test_issues:
+                raise RuntimeError(
+                    "Companion tests failed after Minnesota MFIP upstream-source "
+                    "repair:\n" + "\n".join(f"- {issue}" for issue in test_issues)
+                )
+    except Exception:
+        _restore_original_files(originals)
+        raise
+
+    changed_by_command = _unique_paths(
+        [
+            path
+            for path in (rules_file, test_file)
+            if _path_differs_from_original(path, originals.get(path))
+        ]
+    )
+    refresh_only = not changed_by_command and refresh_manifest
+    if refresh_only:
+        changed_by_command = [path for path in (rules_file, test_file) if path.exists()]
+    if not changed_by_command:
+        print("No Minnesota MFIP upstream-source repairs found.")
+        return
+
+    manifest_paths = _write_grouped_deterministic_repair_manifests(
+        repo_path=repo_path,
+        signing_key=signing_key,
+        axiom_encode_git=axiom_encode_git,
+        manifest_groups=manifest_groups,
+        changed_files=changed_by_command,
+        model=MINNESOTA_MFIP_UPSTREAM_SOURCE_CHECK_MODEL,
+        tool="axiom-encode repair-minnesota-mfip-upstream-source-check",
+    )
+
+    if refresh_only:
+        print("Refreshed Minnesota MFIP upstream-source repair manifest")
+    else:
+        print("Applied Minnesota MFIP upstream-source repair")
+        for path in changed_by_command:
+            print(f"changed={path.relative_to(repo_path)}")
+    for manifest_path in manifest_paths:
+        print(f"manifest={manifest_path}")
+
+
+def _repair_minnesota_mfip_upstream_source_check_file(rules_file: Path) -> bool:
+    content = rules_file.read_text()
+    if MINNESOTA_MFIP_UPSTREAM_SOURCE_CHECK_BLOCK in content:
+        return False
+    if "\n    upstream_source_check:\n" in f"\n{content}":
+        raise RuntimeError(
+            "Minnesota MFIP RuleSpec already has a different upstream_source_check"
+        )
+
+    source_line = f"    corpus_citation_path: {MINNESOTA_MFIP_MANUAL_SOURCE}\n"
+    marker = "  source_verification:\n" + source_line
+    if marker not in content:
+        raise RuntimeError(
+            "Minnesota MFIP RuleSpec does not have the expected manual "
+            f"source_verification path: {MINNESOTA_MFIP_MANUAL_SOURCE}"
+        )
+
+    rules_file.write_text(
+        content.replace(
+            marker,
+            marker + MINNESOTA_MFIP_UPSTREAM_SOURCE_CHECK_BLOCK,
+            1,
+        )
+    )
+    return True
 
 
 def _applied_manifest_matches_current_deterministic_repair(
@@ -12992,10 +13177,7 @@ def _write_grouped_deterministic_repair_manifests(
                 backend="deterministic",
                 model=model,
                 tool=tool,
-                citation=(
-                    f"{_repo_jurisdiction_prefix(repo_path)}:"
-                    f"{_relative_rulespec_import_target(relative_output)}"
-                ),
+                citation=_rulespec_anchor_base_for_output(repo_path, relative_output),
                 generation_prompt_sha256=None,
                 trace_file=None,
                 context_manifest_file=None,

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -4528,9 +4528,7 @@ ARIZONA_SNAP_BENEFIT_RELATIVE = Path(
     "policies/des/faa5/na-eligibility-and-benefit-determination/benefit-amount.yaml"
 )
 
-MINNESOTA_MFIP_UPSTREAM_SOURCE_CHECK_MODEL = (
-    "minnesota-mfip-upstream-source-check-v1"
-)
+MINNESOTA_MFIP_UPSTREAM_SOURCE_CHECK_MODEL = "minnesota-mfip-upstream-source-check-v1"
 MINNESOTA_MFIP_RELATIVE_OUTPUT = Path(
     "us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml"
 )
@@ -5102,7 +5100,9 @@ def cmd_repair_minnesota_mfip_upstream_source_check(args):
             if not _applied_manifest_matches_current_deterministic_repair(
                 repo_path=repo_path,
                 relative_output=relative_output,
-                applied_files=[path for path in (rules_file, test_file) if path.exists()],
+                applied_files=[
+                    path for path in (rules_file, test_file) if path.exists()
+                ],
                 model=MINNESOTA_MFIP_UPSTREAM_SOURCE_CHECK_MODEL,
                 axiom_encode_git=axiom_encode_git,
                 signing_key=signing_key,

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -651,10 +651,17 @@ surfaces:
   variable: mn_mfip
   source_type: state_implementation
   state: MN
-  axiom_status: pending_rulespec_encoding
+  axiom_status: wired
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom encodes the Minnesota Combined Manual MFIP total grant, applicant-proration, recoupment, and cash/food
+    issuance split, with a direct legal-ID mapping from the cash portion issued as cash to PolicyEngine's monthly mn_mfip
+    surface. The RuleSpec module records the higher-authority check against Minnesota Statutes 142G.16, 142G.17, and
+    256P.03 before relying on DHS manual operational procedure.
+  populace_validation:
+    status: pending_validator
+    command: uv run axiom-encode us-populace-compare --variable mn_mfip --sample-size 1 --state MN --json
+    rationale: The current US Populace comparator exits with "No PolicyEngine US adapter is configured for mn_mfip";
+      add the Minnesota MFIP adapter before claiming Populace-verified parity.
 - country: us
   program_id: tanf
   program_name: Tennessee Families First

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -94,6 +94,7 @@ from axiom_encode.cli import (
     _repair_medicaid_optional_senior_composition_tests,
     _repair_medicaid_primary_category_composition_rules,
     _repair_medicaid_primary_category_composition_tests,
+    _repair_minnesota_mfip_upstream_source_check_file,
     _repair_missing_entity_table_rows_for_row_ordered_outputs,
     _repair_missing_source_proof_atoms,
     _repair_mixed_derived_entity_output_tests,
@@ -199,6 +200,7 @@ from axiom_encode.cli import (
     cmd_repair_invalid_test_inputs,
     cmd_repair_judgment_positive_tests,
     cmd_repair_medicaid_primary_category_composition,
+    cmd_repair_minnesota_mfip_upstream_source_check,
     cmd_repair_missing_deferred_outputs,
     cmd_repair_missing_source_proofs,
     cmd_repair_mixed_derived_entity_output_tests,
@@ -11063,6 +11065,120 @@ rules:
             "policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.yaml",
             "policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.test.yaml",
         ]
+
+    def test_repair_minnesota_mfip_source_check_writes_signed_manifest(
+        self, tmp_path
+    ):
+        policy_repo = tmp_path / "rulespec-us"
+        _init_test_git_repo(policy_repo)
+        target = (
+            policy_repo
+            / "us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml"
+        )
+        target.parent.mkdir(parents=True)
+        target.write_text(
+            """format: rulespec/v1
+module:
+  kind: source
+  source_verification:
+    corpus_citation_path: us-mn/manual/dhs/combined-manual/current/page-944
+  summary: Minnesota MFIP grant calculation.
+rules:
+  - name: final_total_mfip_grant
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2025-10-01'
+        formula: max(0, total_mfip_grant_before_proration)
+"""
+        )
+        test_file = target.with_name("mfip-total-grant.test.yaml")
+        test_file.write_text(
+            """- name: no_income_example
+  period: 2026-01
+  input: {}
+  output:
+    us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#final_total_mfip_grant: 0
+"""
+        )
+        _git(policy_repo, "add", ".")
+        _git(policy_repo, "commit", "-m", "initial")
+
+        class FakePipeline:
+            def __init__(self, **kwargs):
+                assert kwargs["require_policy_proofs"] is False
+
+            def validate(self, path, *, skip_reviewers):
+                assert path == target.resolve()
+                assert skip_reviewers is True
+                return SimpleNamespace(all_passed=True, results={})
+
+        with (
+            patch("axiom_encode.cli.ValidatorPipeline", FakePipeline),
+            patch("axiom_encode.cli._companion_test_issues", return_value=[]),
+            patch(
+                "axiom_encode.cli._require_clean_axiom_encode_git_provenance",
+                return_value={"commit": "abc123", "dirty_tracked": False},
+            ),
+            patch.dict(
+                os.environ,
+                {APPLIED_ENCODING_SIGNING_KEY_ENV: TEST_APPLY_SIGNING_KEY},
+            ),
+        ):
+            cmd_repair_minnesota_mfip_upstream_source_check(
+                SimpleNamespace(
+                    repo=policy_repo,
+                    axiom_rules_path=tmp_path / "axiom-rules-engine",
+                )
+            )
+
+        content = target.read_text()
+        assert "upstream_source_check:" in content
+        assert "us-mn/statute/142G.16" in content
+        assert "us-mn/statute/142G.17" in content
+        assert "us-mn/statute/256P.03" in content
+        manifest = (
+            policy_repo
+            / ".axiom/encoding-manifests/us-mn/policies/dhs/combined-manual/"
+            "0022-12/mfip-total-grant.json"
+        )
+        payload = json.loads(manifest.read_text())
+        assert payload["schema_version"] == APPLIED_ENCODING_MANIFEST_SCHEMA
+        assert payload["citation"] == (
+            "us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant"
+        )
+        assert payload["model"] == "minnesota-mfip-upstream-source-check-v1"
+        assert payload["tool"] == (
+            "axiom-encode repair-minnesota-mfip-upstream-source-check"
+        )
+        assert [applied_file["path"] for applied_file in payload["applied_files"]] == [
+            "us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.yaml",
+            "us-mn/policies/dhs/combined-manual/0022-12/mfip-total-grant.test.yaml",
+        ]
+
+    def test_minnesota_mfip_source_check_rejects_conflicting_existing_block(
+        self, tmp_path
+    ):
+        target = tmp_path / "mfip-total-grant.yaml"
+        target.write_text(
+            """format: rulespec/v1
+module:
+  kind: source
+  source_verification:
+    corpus_citation_path: us-mn/manual/dhs/combined-manual/current/page-944
+    upstream_source_check:
+      status: no_higher_authority_found
+      checked_paths: []
+      rationale: stale
+rules: []
+"""
+        )
+
+        with pytest.raises(RuntimeError, match="different upstream_source_check"):
+            _repair_minnesota_mfip_upstream_source_check_file(target)
 
     def test_repair_new_york_snap_categorical_eligibility_adds_final_outputs(self):
         rules = """format: rulespec/v1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11066,9 +11066,7 @@ rules:
             "policies/des/faa5/na-eligibility-and-benefit-determination/fy-2026-benefit-calculation.test.yaml",
         ]
 
-    def test_repair_minnesota_mfip_source_check_writes_signed_manifest(
-        self, tmp_path
-    ):
+    def test_repair_minnesota_mfip_source_check_writes_signed_manifest(self, tmp_path):
         policy_repo = tmp_path / "rulespec-us"
         _init_test_git_repo(policy_repo)
         target = (

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2104,17 +2104,13 @@ def test_policyengine_program_surface_marks_minnesota_mfip_wired_pending_populac
     assert minnesota_mfip["comparable_mapping_count"] == 1
     assert (
         "us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#"
-        "mfip_cash_portion_issued_as_cash"
-        in minnesota_mfip["legal_ids"]
+        "mfip_cash_portion_issued_as_cash" in minnesota_mfip["legal_ids"]
     )
-    assert (
-        minnesota_mfip["populace_validation_status"]
-        == "pending_validator"
-    )
+    assert minnesota_mfip["populace_validation_status"] == "pending_validator"
     assert "mn_mfip" in minnesota_mfip["populace_validation_command"]
-    assert "No PolicyEngine US adapter" in minnesota_mfip[
-        "populace_validation_rationale"
-    ]
+    assert (
+        "No PolicyEngine US adapter" in minnesota_mfip["populace_validation_rationale"]
+    )
 
 
 def test_policyengine_program_surface_marks_florida_tca_known_not_comparable():

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2091,6 +2091,32 @@ def test_policyengine_program_surface_marks_kansas_tanf_known_not_comparable():
     assert "countable income" in kansas_tanf["rationale"]
 
 
+def test_policyengine_program_surface_marks_minnesota_mfip_wired_pending_populace_validator():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    minnesota_mfip = items_by_variable["mn_mfip"]
+
+    assert minnesota_mfip["program_id"] == "tanf"
+    assert minnesota_mfip["state"] == "MN"
+    assert minnesota_mfip["axiom_status"] == "wired"
+    assert minnesota_mfip["mapping_count"] == 3
+    assert minnesota_mfip["comparable_mapping_count"] == 1
+    assert (
+        "us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#"
+        "mfip_cash_portion_issued_as_cash"
+        in minnesota_mfip["legal_ids"]
+    )
+    assert (
+        minnesota_mfip["populace_validation_status"]
+        == "pending_validator"
+    )
+    assert "mn_mfip" in minnesota_mfip["populace_validation_command"]
+    assert "No PolicyEngine US adapter" in minnesota_mfip[
+        "populace_validation_rationale"
+    ]
+
+
 def test_policyengine_program_surface_marks_florida_tca_known_not_comparable():
     report = build_policyengine_program_surface_report(program="tanf")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1040"
+version = "0.2.1041"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1039"
+version = "0.2.1040"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add deterministic repair command for Minnesota MFIP upstream source checks
- fix country-level deterministic repair manifest citation anchors
- mark Minnesota MFIP as wired but pending a Populace adapter instead of claiming full validation

## Validation
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run pytest tests/test_cli.py -k 'minnesota_mfip or rulespec_anchor_base_for_output or arizona_snap_composition'
- uv run pytest tests/test_cli.py -k 'package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump or minnesota_mfip or rulespec_anchor_base_for_output or arizona_snap_composition'
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/cli.py
- uv run pytest tests/test_policyengine_coverage.py -k 'minnesota_mfip or program_surface_report_accepts_populace_validation_metadata'
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tanf --include-program-surfaces --json
- uv run axiom-encode cloud-queue --root /Users/maxghenis/TheAxiomFoundation --program tanf --json