### PR TITLE
Classify Alaska ATAP oracle bridge

### DIFF
--- a/changelog.d/ak-atap-oracle-coverage.changed.md
+++ b/changelog.d/ak-atap-oracle-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify Alaska ATAP PolicyEngine oracle surfaces as known non-comparable and bump axiom-encode to 0.2.1042.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1041"
+version = "0.2.1042"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1041"
+__version__ = "0.2.1042"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -4073,6 +4073,70 @@ mappings:
     candidate_priority: P4
     rationale: Axiom's Arizona Cash Assistance wrapper composes DES FAA5 payment-standard, needy-family, prospective-eligibility, and eligible-no-pay issuance rules, including the under-$10 no-pay boundary. PolicyEngine's az_tanf is a final monthly SPM-unit benefit gated by PE's demographic, immigration, resource, and income graph and does not share the DES eligible-no-pay issuance boundary, so this is not a one-to-one oracle target yet.
 
+  - legal_id: us-ak:programs/tanf/fy-2026#ak_atap_need_standard
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_need_standard
+    candidate_priority: P4
+    rationale: Axiom's Alaska ATAP FY 2026 bridge exposes the DPA adult-included need-standard table and each-additional amount from the official 2026 standards. PolicyEngine's ak_atap_need_standard also blends the pregnant-woman branch and PE SPM-unit composition, while Axiom has not yet composed all ATAP assistance-unit variants at the program surface, so this is adjacent but not a one-to-one oracle target.
+
+  - legal_id: us-ak:programs/tanf/fy-2026#ak_atap_gross_income_limit
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_gross_income_limit
+    candidate_priority: P4
+    rationale: Axiom's Alaska ATAP FY 2026 bridge exposes the source table's adult-included 185 percent standard. PolicyEngine derives ak_atap_gross_income_limit from its broader ak_atap_need_standard graph, including PE's pregnant-woman branch and SPM-unit projection, so this bridge output is not yet an exact oracle target.
+
+  - legal_id: us-ak:programs/tanf/fy-2026#ak_atap_maximum_payment
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_maximum_payment
+    candidate_priority: P4
+    rationale: Axiom's Alaska ATAP FY 2026 bridge exposes the official adult-included maximum-payment table and each-additional amount from Alaska DPA standards. PolicyEngine's ak_atap_maximum_payment uses a simplified dependent-count formula with a separate pregnant-woman branch, so this source-table bridge is adjacent rather than directly comparable.
+
+  - legal_id: us-ak:programs/tanf/fy-2026#ak_atap_resources_eligible
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_resources_eligible
+    candidate_priority: P4
+    rationale: Axiom's Alaska ATAP FY 2026 bridge applies 7 AAC 45.280 resource limits using nonexempt resources valued under the Alaska regulation and the age-60 higher limit. PolicyEngine's resource helper is projected through PE's SPM-unit resource graph, so the bridge remains an adjacent legal eligibility surface until the same resource inputs are wired.
+
+  - legal_id: us-ak:programs/tanf/fy-2026#ak_atap_childcare_deduction
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_childcare_deduction
+    candidate_priority: P4
+    rationale: Axiom's Alaska ATAP FY 2026 bridge encodes 7 AAC 45.485 child and incapacitated-parent care disregards, including the 7 AAC 45.495 and 45.500 exception inputs. PolicyEngine models only a dependent-child childcare-expense cap, so the Axiom output is source-faithful but not a one-to-one oracle target.
+
+  - legal_id: us-ak:programs/tanf/fy-2026#ak_atap_countable_unearned_income
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_countable_unearned_income
+    candidate_priority: P4
+    rationale: Axiom's Alaska ATAP FY 2026 bridge encodes the 7 AAC 45.400 cash child-support timing, recipient-retention, noncash-payment, repayment, and noncooperation rules. PolicyEngine subtracts a generic child-support exclusion from gross unearned income, so this legal child-support surface is adjacent rather than directly comparable.
+
+  - legal_id: us-ak:programs/tanf/fy-2026#ak_atap_eligible
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_eligible
+    candidate_priority: P4
+    rationale: Axiom's Alaska ATAP FY 2026 bridge currently composes 7 AAC 45.470 income eligibility with source-level resource, gross-income, countable-income, and other-eligibility inputs. PolicyEngine's ak_atap_eligible adds PE federal TANF demographic and immigration projections and separate helper tests, so this bridge is not a direct oracle target until those legal gates are encoded and wired.
+
+  - legal_id: us-ak:programs/tanf/fy-2026#ak_atap
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap
+    candidate_priority: P4
+    rationale: Axiom's Alaska ATAP FY 2026 bridge preserves 7 AAC 45.525 payment mechanics, including low-shelter-cost reduction and the under-$10 payment rule, while the current source set still lacks full earned-income deduction composition, nonfinancial gates, low-shelter calculation, and non-adult-included variants. PolicyEngine's ak_atap omits several Alaska ATAP features and uses PE's SPM-unit graph, so this is progress toward parity but not a one-to-one oracle yet.
+
   - legal_id: us-ks:programs/tanf/fy-2026#ks_tanf_maximum_benefit
     country: us
     program: tanf

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -868,10 +868,13 @@ surfaces:
   variable: ak_atap
   source_type: state_implementation
   state: AK
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Current RuleSpec repos include an Alaska ATAP FY 2026 program bridge over official DPA adult-included
+    standards and tested 7 AAC 45.280, 45.400, 45.470, 45.485, and 45.525 legal slices. The bridge remains incomplete
+    for earned-income deductions, nonfinancial eligibility, low-shelter-cost reduction, and non-adult-included assistance-unit
+    variants, while PolicyEngine's ak_atap is a final monthly SPM-unit benefit built from PE's simplified ATAP graph; keep
+    as known-not-comparable until the remaining legal gates are encoded and a final adapter matches PE-compatible boundaries.
 - country: us
   program_id: tanf
   program_name: Iowa FIP

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2059,6 +2059,22 @@ def test_policyengine_program_surface_marks_arizona_tanf_known_not_comparable():
     assert "eligible-no-pay" in arizona_tanf["rationale"]
 
 
+def test_policyengine_program_surface_marks_alaska_atap_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    alaska_atap = items_by_variable["ak_atap"]
+
+    assert alaska_atap["program_id"] == "tanf"
+    assert alaska_atap["state"] == "AK"
+    assert alaska_atap["axiom_status"] == "known_not_comparable"
+    assert alaska_atap["mapping_count"] == 1
+    assert alaska_atap["comparable_mapping_count"] == 0
+    assert "us-ak:programs/tanf/fy-2026#ak_atap" in alaska_atap["legal_ids"]
+    assert "Alaska ATAP FY 2026 program bridge" in alaska_atap["rationale"]
+    assert "earned-income deductions" in alaska_atap["rationale"]
+
+
 def test_policyengine_program_surface_marks_new_york_tanf_known_not_comparable():
     report = build_policyengine_program_surface_report(program="tanf")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1041"
+version = "0.2.1042"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add P4 PolicyEngine oracle mappings for the Alaska ATAP FY 2026 program bridge outputs
- mark the AK ATAP program surface known-not-comparable until remaining legal gates and adapter boundaries are complete
- add a regression test for the AK ATAP TANF surface classification

## Checks
- uv run pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ak-atap-20260701 --program tanf --include-program-surfaces --json