### PR TITLE
Classify UK VAT Act firm outputs for oracle coverage

### DIFF
--- a/changelog.d/uk-vat-oracle-coverage.changed.md
+++ b/changelog.d/uk-vat-oracle-coverage.changed.md
@@ -1,1 +1,1 @@
-Classify UK GOV.UK VAT policy outputs as known non-comparable PolicyEngine oracle surfaces.
+Classify UK GOV.UK VAT policy and VAT Act firm-level outputs as known non-comparable PolicyEngine oracle surfaces.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1042"
+version = "0.2.1043"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1042"
+__version__ = "0.2.1043"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/uk.yaml
@@ -2203,6 +2203,41 @@ mappings:
     candidate_priority: P4
     rationale: The Universal Credit program wrapper computes the WRA 2012 section 8 maximum amount from standard allowance, child, housing, and particular-needs components. PolicyEngine UK exposes adjacent component and maximum-amount variables, but this wrapper output is not currently tested as a one-to-one oracle surface.
 
+  - legal_id: uk:statutes/ukpga/1994/23/2#standard_rate_of_vat
+    country: uk
+    program: vat
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Value Added Tax Act 1994 section 2 is encoded for Axiom firm-level VAT microsimulation. PolicyEngine UK does not currently expose a firm entity or a registered one-to-one VAT Act oracle surface for this output.
+
+  - legal_id: uk:statutes/ukpga/1994/23/24#output_tax_on_standard_rated_taxable_supplies
+    country: uk
+    program: vat
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Value Added Tax Act 1994 section 24 output tax is a firm-level VAT accounting helper. PolicyEngine UK does not currently expose a firm entity or a registered one-to-one VAT Act oracle surface for this output.
+
+  - legal_id: uk:statutes/ukpga/1994/23/24#input_tax_on_standard_rated_business_purchases
+    country: uk
+    program: vat
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Value Added Tax Act 1994 section 24 input tax is a firm-level deductible-purchase helper. PolicyEngine UK does not currently expose a firm entity or a registered one-to-one VAT Act oracle surface for this output.
+
+  - legal_id: uk:statutes/ukpga/1994/23/25#net_vat_liability_after_input_tax_credit
+    country: uk
+    program: vat
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Value Added Tax Act 1994 section 25 net VAT liability is a firm-level accounting output after input tax credit. PolicyEngine UK does not currently expose a firm entity or a registered one-to-one VAT Act oracle surface for this output.
+
+  - legal_id: uk:statutes/ukpga/1994/23/26#allowable_input_tax_credit
+    country: uk
+    program: vat
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Value Added Tax Act 1994 section 26 allowable input tax credit is a firm-level deductible-input output. PolicyEngine UK does not currently expose a firm entity or a registered one-to-one VAT Act oracle surface for this output.
+
 prefixes:
   - legal_id_prefix: uk:policies/govuk/council-tax-reduction#
     country: uk

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1077,6 +1077,76 @@ def test_policyengine_registry_resolves_wic_and_chip_eligibility_prefixes():
         assert mapping.policyengine_variable == variable
 
 
+def test_policyengine_coverage_classifies_uk_vat_act_firm_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "uk/statutes/ukpga/1994/23/2.yaml",
+        """format: rulespec/v1
+rules:
+  - name: standard_rate_of_vat
+    kind: parameter
+    versions:
+      - effective_from: '2024-01-01'
+        formula: 0.20
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "uk/statutes/ukpga/1994/23/24.yaml",
+        """format: rulespec/v1
+rules:
+  - name: output_tax_on_standard_rated_taxable_supplies
+    kind: derived
+    versions:
+      - effective_from: '2024-01-01'
+        formula: standard_rated_taxable_supplies_value * standard_rate_of_vat
+  - name: input_tax_on_standard_rated_business_purchases
+    kind: derived
+    versions:
+      - effective_from: '2024-01-01'
+        formula: standard_rated_deductible_business_purchase_value * standard_rate_of_vat
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "uk/statutes/ukpga/1994/23/25.yaml",
+        """format: rulespec/v1
+rules:
+  - name: net_vat_liability_after_input_tax_credit
+    kind: derived
+    versions:
+      - effective_from: '2024-01-01'
+        formula: output_tax_on_standard_rated_taxable_supplies - allowable_input_tax_credit
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-uk" / "uk/statutes/ukpga/1994/23/26.yaml",
+        """format: rulespec/v1
+rules:
+  - name: allowable_input_tax_credit
+    kind: derived
+    versions:
+      - effective_from: '2024-01-01'
+        formula: input_tax_on_standard_rated_business_purchases * allowable_input_tax_proportion
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="vat")
+
+    assert report["total_outputs"] == 5
+    assert report["status_counts"] == {"known_not_comparable": 5}
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    for legal_id in (
+        "uk:statutes/ukpga/1994/23/2#standard_rate_of_vat",
+        "uk:statutes/ukpga/1994/23/24#output_tax_on_standard_rated_taxable_supplies",
+        "uk:statutes/ukpga/1994/23/24#input_tax_on_standard_rated_business_purchases",
+        "uk:statutes/ukpga/1994/23/25#net_vat_liability_after_input_tax_credit",
+        "uk:statutes/ukpga/1994/23/26#allowable_input_tax_credit",
+    ):
+        item = items_by_id[legal_id]
+        assert item["program"] == "vat"
+        assert item["status"] == "known_not_comparable"
+        assert item["mapping_type"] == "not_comparable"
+        assert item["candidate_priority"] == "P4"
+
+
 def test_policyengine_program_surface_local_tax_credit_uses_local_weight(tmp_path):
     manifest = tmp_path / "program_surfaces.yaml"
     manifest.write_text(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1042"
+version = "0.2.1043"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify five UK VAT Act 1994 firm-level outputs as reviewed not-comparable PolicyEngine oracle surfaces
- add a coverage regression test for the VAT Act outputs used by rulespec-uk VAT firm microsimulation

## Validation
- uv run --with pytest --with pytest-cov python -m pytest -q tests/test_policyengine_coverage.py::test_policyengine_coverage_classifies_uk_vat_act_firm_outputs
- uv run python - <<'PY'
from pathlib import Path
from axiom_encode.oracles.policyengine.coverage import build_policyengine_coverage_report
report = build_policyengine_coverage_report(Path('/Users/maxghenis/TheAxiomFoundation/rulespec-uk'), program='vat')
print(report['status_counts'])
for item in report['items']:
    if 'uk:statutes/ukpga/1994/23' in item['legal_id']:
        print(item['legal_id'], item['status'], item['mapping_type'])
PY

Note: an attempted All checks passed! against the YAML mapping file failed because Ruff parses Python, not YAML. All checks passed! passed.