### PR TITLE
Repair nonnegative floor fixes for quoted formulas

### DIFF
--- a/changelog.d/ak-atap-source-oracle-mappings.changed.md
+++ b/changelog.d/ak-atap-source-oracle-mappings.changed.md
@@ -1,0 +1,1 @@
+Classify Alaska ATAP source-level RuleSpec outputs in the PolicyEngine oracle registry.

--- a/changelog.d/nonnegative-min-quoted-formula-repair.fixed.md
+++ b/changelog.d/nonnegative-min-quoted-formula-repair.fixed.md
@@ -1,0 +1,1 @@
+Repair generated quoted formulas and multiple `min(...)` income-base arguments when applying nonnegative amount floor fixes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1043"
+version = "0.2.1044"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1043"
+__version__ = "0.2.1044"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -10602,11 +10602,32 @@ def find_nonnegative_amount_reduction_issues(content: str) -> list[str]:
 
 
 def _nonnegative_income_base_missing_zero_floor(expression: str) -> bool:
-    if _final_expression_has_zero_floor(expression):
+    stripped_expression = expression.strip()
+    if any(
+        start == 0 and end == len(stripped_expression)
+        for start, end, _argument in _zero_floor_call_spans(stripped_expression)
+    ):
         return False
     if not _NONNEGATIVE_INCOME_BASE_FORMULA_PATTERN.search(expression):
         return False
-    return not _ZERO_FLOORED_INCOME_BASE_PATTERN.search(expression)
+    return any(
+        _min_argument_has_unfloored_income_base(argument)
+        for _start, _end, arguments in _min_call_spans(expression)
+        for argument in arguments
+    )
+
+
+def _min_argument_has_unfloored_income_base(argument: str) -> bool:
+    return any(
+        not _income_base_identifier_is_parameter_cap(match.group(0))
+        for match in _INCOME_BASE_IDENTIFIER_PATTERN.finditer(
+            _expression_without_zero_floor_calls(argument.strip())
+        )
+    )
+
+
+def _income_base_identifier_is_parameter_cap(identifier: str) -> bool:
+    return identifier.lower().endswith("_amount")
 
 
 def repair_nonnegative_amount_reductions(content: str) -> tuple[str, list[str]]:
@@ -10709,7 +10730,12 @@ def _taxable_income_expression_has_zero_floor(expression: str) -> bool:
 
 def _repair_nonnegative_amount_reduction_formula(formula: str) -> str:
     if _nonnegative_income_base_missing_zero_floor(formula):
-        repaired_formula = _repair_nonnegative_income_base_expression(formula.strip())
+        repaired_formula = formula.strip()
+        for _ in range(20):
+            next_formula = _repair_nonnegative_income_base_expression(repaired_formula)
+            if next_formula == repaired_formula:
+                break
+            repaired_formula = next_formula
         if repaired_formula != formula.strip():
             return repaired_formula
 
@@ -10759,9 +10785,7 @@ def _repair_nonnegative_income_base_expression(expression: str) -> str:
         repaired_arguments = [argument.strip() for argument in arguments]
         for index, argument in enumerate(arguments):
             stripped_argument = argument.strip()
-            if not _INCOME_BASE_IDENTIFIER_PATTERN.search(stripped_argument):
-                continue
-            if _ZERO_FLOORED_INCOME_BASE_PATTERN.search(stripped_argument):
+            if not _min_argument_has_unfloored_income_base(stripped_argument):
                 continue
             repaired_arguments[index] = f"max(0, {stripped_argument})"
             return (
@@ -11153,7 +11177,14 @@ def _replace_folded_formula_scalar_text_once(content: str, old: str, new: str) -
     )
     for match in formula_scalar_pattern.finditer(content):
         body = match.group("body")
-        if _normalize_yaml_folded_scalar_text(body) != old_normalized:
+        scalar_value: str | None = body
+        with contextlib.suppress(yaml.YAMLError):
+            loaded_scalar = yaml.safe_load(match.group(0))
+            if isinstance(loaded_scalar, dict) and isinstance(
+                loaded_scalar.get("formula"), str
+            ):
+                scalar_value = loaded_scalar["formula"]
+        if _normalize_yaml_folded_scalar_text(scalar_value or "") != old_normalized:
             continue
         line_start = content.rfind("\n", 0, match.start()) + 1
         indent_match = re.match(r"[ \t]*", content[line_start : match.start()])

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -4073,6 +4073,330 @@ mappings:
     candidate_priority: P4
     rationale: Axiom's Arizona Cash Assistance wrapper composes DES FAA5 payment-standard, needy-family, prospective-eligibility, and eligible-no-pay issuance rules, including the under-$10 no-pay boundary. PolicyEngine's az_tanf is a final monthly SPM-unit benefit gated by PE's demographic, immigration, resource, and income graph and does not share the DES eligible-no-pay issuance boundary, so this is not a one-to-one oracle target yet.
 
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#adult_included_need_standard_by_family_size
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.ak.dpa.atap.need_standard.amount
+    candidate_priority: P4
+    rationale: Axiom exposes the official 2026 Alaska DPA adult-included need-standard table through family size 10. PolicyEngine's need_standard.amount parameter currently stores a historical size-1-to-8 table and a separate additional-person amount, so this full source table is adjacent but not a one-to-one oracle target.
+
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#adult_included_need_standard_each_additional
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.atap.need_standard.additional_person
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Alaska ATAP adult-included need-standard each-additional-person amount from the official 2026 DPA standards, represented in PolicyEngine as the need_standard additional_person parameter.
+
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#adult_included_max_payment_by_family_size
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.ak.dpa.atap.payment.base
+    candidate_priority: P4
+    rationale: Axiom exposes the official 2026 Alaska DPA adult-included maximum-payment table through family size 10. PolicyEngine decomposes maximum payment into a size-2 base amount plus an additional-child parameter and does not expose the full source table as a one-to-one oracle target.
+
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#adult_included_max_payment_each_additional
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_parameter: gov.states.ak.dpa.atap.payment.additional_child
+    candidate_priority: P4
+    rationale: The official DPA standards row is an each-additional-person amount for the adult-included maximum-payment table. PolicyEngine stores an additional_child payment parameter used by its dependent-count formula, so the value is adjacent but the legal surface and indexing are not the same.
+
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#adult_included_max_shelter_by_family_size
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the official 2026 Alaska DPA maximum-shelter table used by low-shelter-cost ATAP reductions. PolicyEngine's current Alaska ATAP model explicitly omits the shelter-cost reduction and has no corresponding parameter table.
+
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#adult_included_max_shelter_each_additional
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the official 2026 Alaska DPA each-additional maximum-shelter amount used by low-shelter-cost ATAP reductions. PolicyEngine's current Alaska ATAP model explicitly omits the shelter-cost reduction and has no corresponding parameter.
+
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#adult_included_ratable_reduction
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap
+    candidate_priority: P4
+    rationale: Axiom records the official DPA 43.13 percent ratable-reduction standard as a source parameter. PolicyEngine derives an effective payment ratio from its size-2 payment and need-standard parameters inside ak_atap rather than exposing this published percentage, and the derived PE ratio is not the same legal source surface.
+
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#ak_atap_need_standard
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_need_standard
+    candidate_priority: P4
+    rationale: Axiom's source-level output selects the official adult-included DPA need-standard table and applies the each-additional amount beyond the table maximum. PolicyEngine's ak_atap_need_standard also includes PE's pregnant-woman branch and SPM-unit composition, so it is not a one-to-one oracle target.
+
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included-gross-income-limit#ak_atap_gross_income_limit_family_size_lookup
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_gross_income_limit
+    candidate_priority: P4
+    rationale: Axiom exposes the family-size selector helper used to read the official adult-included 185 percent standards table. PolicyEngine compares the final derived gross-income-limit amount and does not expose this source-table selector.
+
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included-gross-income-limit#ak_atap_gross_income_limit
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_gross_income_limit
+    candidate_priority: P4
+    rationale: Axiom exposes the official adult-included 185 percent standard table and each-additional row from the 2026 DPA standards. PolicyEngine derives ak_atap_gross_income_limit as 185 percent of its broader ak_atap_need_standard graph, including non-adult-included branches, so this source-table output is adjacent rather than directly comparable.
+
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included-maximum-payment#ak_atap_maximum_payment_family_size_lookup
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_maximum_payment
+    candidate_priority: P4
+    rationale: Axiom exposes the family-size selector helper used to read the official adult-included maximum-payment table. PolicyEngine compares a derived maximum-payment variable from dependent counts and does not expose this source-table selector.
+
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included-maximum-payment#ak_atap_maximum_payment
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_maximum_payment
+    candidate_priority: P4
+    rationale: Axiom exposes the official adult-included maximum-payment table and each-additional row from the 2026 DPA standards. PolicyEngine's ak_atap_maximum_payment uses a simplified size-2 base plus additional-child formula and a separate pregnant-woman branch, so this source-table output is adjacent rather than directly comparable.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-280-resource-limit#atap_standard_resource_limit
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.atap.resource_limit.standard.amount
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same 7 AAC 45.280 standard ATAP resource limit, represented in PolicyEngine as the Alaska ATAP standard resource-limit amount.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-280-resource-limit#atap_resource_limit_with_older_individual
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.atap.resource_limit.elderly.amount
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same 7 AAC 45.280 higher ATAP resource limit for an assistance unit with an older individual, represented in PolicyEngine as the elderly resource-limit amount.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-280-resource-limit#older_individual_resource_limit_minimum_age
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.atap.resource_limit.elderly.age_threshold
+    period: year
+    comparison: count
+    rationale: Same 7 AAC 45.280 age threshold for the higher ATAP resource limit, represented in PolicyEngine as the elderly resource-limit age_threshold parameter.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-280-resource-limit#ak_atap_resources_eligible
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_resources_eligible
+    candidate_priority: P4
+    rationale: Axiom applies 7 AAC 45.280 to nonexempt resources valued under the Alaska regulation and the source-level older-individual threshold. PolicyEngine's helper is projected through PE's SPM-unit assets and age graph, so it is adjacent but not a one-to-one legal oracle target.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-400-child-support-income#atap_monthly_direct_child_support_retention_disregard
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.atap.income.deductions.child_support
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same 7 AAC 45.400 monthly direct child-support retention disregard, represented in PolicyEngine as the Alaska ATAP child-support deduction parameter.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-400-child-support-income#ak_atap_countable_unearned_income
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_countable_unearned_income
+    candidate_priority: P4
+    rationale: Axiom encodes the 7 AAC 45.400 cash child-support timing, direct-payment retention, noncash-payment, repayment, and noncooperation rules. PolicyEngine subtracts a generic child-support exclusion from gross unearned income, so the source-level legal output is not directly comparable.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-400-child-support-income#atap_child_support_overpayment_repayment_required
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_countable_unearned_income
+    candidate_priority: P4
+    rationale: Axiom exposes the 7 AAC 45.400 overpayment-repayment consequence for recipients who retain excess direct child-support payments. PolicyEngine's child-support surface is an income deduction and does not expose this administrative repayment determination.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-400-child-support-income#atap_child_support_noncooperation_due_to_excess_retention
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_countable_unearned_income
+    candidate_priority: P4
+    rationale: Axiom exposes the 7 AAC 45.400 noncooperation determination for recipients who retain excess direct child-support payments. PolicyEngine's child-support surface is an income deduction and does not expose this administrative cooperation status.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-470-gross-income-eligibility#atap_gross_income_standard_percentage
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.atap.gross_income_limit_rate
+    period: month
+    comparison: ratio
+    rationale: Same 7 AAC 45.470 gross-income standard percentage, represented in PolicyEngine as the Alaska ATAP gross_income_limit_rate parameter.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-470-gross-income-eligibility#atap_income_excess_denial_threshold
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the one-cent excess-income denial threshold stated in 7 AAC 45.470. PolicyEngine tests eligibility with direct less-than-or-equal comparisons and does not expose this administrative threshold as a parameter.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-470-gross-income-eligibility#ak_atap_countable_income_for_income_eligibility
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_countable_income
+    candidate_priority: P4
+    rationale: Axiom computes the 7 AAC 45.470 countable-income amount after source-level deductions and disregards under 7 AAC 45.475-45.500. PolicyEngine's ak_atap_countable_income uses its own earned and unearned income graph and omits several Alaska source-level branches, so this is not a direct oracle target.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-470-gross-income-eligibility#ak_atap_gross_income_initial_screen_met
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_gross_income_eligible
+    candidate_priority: P4
+    rationale: Axiom's initial screen combines source-level resource eligibility with the gross-income limit. PolicyEngine's ak_atap_gross_income_eligible checks only PE gross income against the PE gross-income-limit variable, so the eligibility predicate is not one-to-one.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-470-gross-income-eligibility#ak_atap_gross_income_eligible
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_eligible
+    candidate_priority: P4
+    rationale: Axiom's 7 AAC 45.470 gross-income eligibility output requires both the gross-income screen and countable income not exceeding the need standard. PolicyEngine separates gross-income and net-income tests and then composes them with demographic and immigration gates in ak_atap_eligible, so there is no one-to-one variable.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-470-gross-income-eligibility#atap_payment_calculation_required_after_income_eligibility
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_eligible
+    candidate_priority: P4
+    rationale: Axiom exposes the source-level trigger for proceeding to ATAP payment calculation after income eligibility and all other chapter eligibility requirements are met. PolicyEngine exposes final PE eligibility, not this procedural calculation trigger.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-470-gross-income-eligibility#atap_income_excess_requires_denial_suspension_or_termination_under_gross_income_rule
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_eligible
+    candidate_priority: P4
+    rationale: Axiom exposes the 7 AAC 45.470 denial, suspension, or termination consequence when income exceeds the gross-income rule thresholds. PolicyEngine exposes eligibility booleans and does not expose this administrative consequence as a one-to-one variable.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-470-income-eligibility#income_excess_minimum_for_denial
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the one-cent excess-income threshold stated in 7 AAC 45.470. PolicyEngine tests eligibility with direct less-than-or-equal comparisons and does not expose this administrative threshold as a parameter.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-470-income-eligibility#countable_income_under_7_aac_45_470_b
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_countable_income
+    candidate_priority: P4
+    rationale: Axiom computes the source-level 7 AAC 45.470(b) countable-income amount after deductions and disregards under 7 AAC 45.475-45.500. PolicyEngine's ak_atap_countable_income uses its own earned and unearned income graph and omits several Alaska source-level branches, so this is not a direct oracle target.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-470-income-eligibility#atap_initial_income_screen_met
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_gross_income_eligible
+    candidate_priority: P4
+    rationale: Axiom's initial screen combines source-level resource eligibility with the gross-income limit. PolicyEngine's ak_atap_gross_income_eligible checks only PE gross income against the PE gross-income-limit variable, so the eligibility predicate is not one-to-one.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-470-income-eligibility#ak_atap_eligible
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_eligible
+    candidate_priority: P4
+    rationale: Axiom's 7 AAC 45.470 income-eligibility output combines source-level resource, gross-income, countable-income, and other-eligibility inputs. PolicyEngine's ak_atap_eligible adds PE federal TANF demographic and immigration projections and separate PE helper tests, so this is adjacent rather than directly comparable.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-470-income-eligibility#atap_income_excess_requires_denial_suspension_or_termination
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_eligible
+    candidate_priority: P4
+    rationale: Axiom exposes the 7 AAC 45.470 denial, suspension, or termination consequence when income exceeds source-level thresholds. PolicyEngine exposes eligibility booleans and does not expose this administrative consequence as a one-to-one variable.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-485-care-disregard#dependent_child_under_two_monthly_care_disregard_cap
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.atap.income.deductions.childcare
+    parameter_calc_value: 0
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same 7 AAC 45.485 dependent-child care disregard cap for a child under age two, represented in PolicyEngine by evaluating the childcare deduction scale at age 0.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-485-care-disregard#dependent_child_two_or_older_monthly_care_disregard_cap
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ak.dpa.atap.income.deductions.childcare
+    parameter_calc_value: 2
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same 7 AAC 45.485 dependent-child care disregard cap for a child age two or older, represented in PolicyEngine by evaluating the childcare deduction scale at age 2.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-485-care-disregard#incapacitated_parent_monthly_care_disregard_cap
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_childcare_deduction
+    candidate_priority: P4
+    rationale: Axiom exposes the 7 AAC 45.485 monthly care-disregard cap for an incapacitated parent. PolicyEngine's childcare deduction models dependent-child care expenses only and does not expose this incapacitated-parent care branch.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-485-care-disregard#ak_atap_childcare_deduction
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_childcare_deduction
+    candidate_priority: P4
+    rationale: Axiom encodes 7 AAC 45.485 child and incapacitated-parent care disregards, including the 7 AAC 45.495 and 45.500 exception inputs. PolicyEngine models only a dependent-child childcare-expense cap, so the source-level deduction is not a one-to-one oracle target.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-525-payment-amount#assistance_unit_size_for_two_individuals
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap
+    candidate_priority: P4
+    rationale: Axiom exposes the 7 AAC 45.525 size-two assistance-unit constant used in the statutory payment ratio. PolicyEngine hard-codes the size-two ratio inside ak_atap through payment.base and need_standard.amount['2'] rather than exposing this source constant as a parameter.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-525-payment-amount#atap_minimum_payment_threshold
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap
+    candidate_priority: P4
+    rationale: Axiom exposes the 7 AAC 45.525 under-$10 no-payment threshold. PolicyEngine's current ak_atap formula does not implement the minimum-payment threshold, so there is no one-to-one oracle target.
+
+  - legal_id: us-ak:regulations/aac/title-7/chapter-45/45-525-payment-amount#ak_atap
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap
+    candidate_priority: P4
+    rationale: Axiom preserves 7 AAC 45.525 payment mechanics, including low-shelter-cost reduction, floor-to-dollar rounding, the under-$10 payment rule, and mandatory recoupment treatment. PolicyEngine's ak_atap omits several Alaska ATAP features and uses PE's SPM-unit graph, so this source-level payment amount is adjacent but not directly comparable.
+
   - legal_id: us-ak:programs/tanf/fy-2026#ak_atap_need_standard
     country: us
     program: tanf

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2138,9 +2138,13 @@ def test_policyengine_program_surface_marks_alaska_atap_known_not_comparable():
     assert alaska_atap["program_id"] == "tanf"
     assert alaska_atap["state"] == "AK"
     assert alaska_atap["axiom_status"] == "known_not_comparable"
-    assert alaska_atap["mapping_count"] == 1
+    assert alaska_atap["mapping_count"] >= 1
     assert alaska_atap["comparable_mapping_count"] == 0
     assert "us-ak:programs/tanf/fy-2026#ak_atap" in alaska_atap["legal_ids"]
+    assert (
+        "us-ak:regulations/aac/title-7/chapter-45/45-525-payment-amount#ak_atap"
+        in alaska_atap["legal_ids"]
+    )
     assert "Alaska ATAP FY 2026 program bridge" in alaska_atap["rationale"]
     assert "earned-income deductions" in alaska_atap["rationale"]
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -20885,6 +20885,64 @@ rules:
     assert find_nonnegative_amount_reduction_issues(repaired) == []
 
 
+def test_repair_nonnegative_amount_reductions_floors_each_min_income_argument():
+    content = """format: rulespec/v1
+rules:
+  - name: earned_income_deduction_amount_person
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if initial_deduction_category_applies:
+            min(total_gross_monthly_earned_income, initial_earned_income_deduction_amount)
+          else:
+            min(total_gross_monthly_earned_income, continuing_earned_income_deduction_base_amount + continuing_deduction_rate * max(0, total_gross_monthly_earned_income - continuing_earned_income_deduction_base_amount))
+"""
+
+    repaired, rules = repair_nonnegative_amount_reductions(content)
+
+    assert rules == ["earned_income_deduction_amount_person"]
+    assert (
+        "min(max(0, total_gross_monthly_earned_income), "
+        "initial_earned_income_deduction_amount)" in repaired
+    )
+    assert (
+        "min(max(0, total_gross_monthly_earned_income), "
+        "continuing_earned_income_deduction_base_amount + "
+        "continuing_deduction_rate * max(0, "
+        "total_gross_monthly_earned_income - "
+        "continuing_earned_income_deduction_base_amount))" in repaired
+    )
+    assert find_nonnegative_amount_reduction_issues(repaired) == []
+
+
+def test_repair_nonnegative_amount_reductions_replaces_quoted_formula_scalar():
+    content = """format: rulespec/v1
+rules:
+  - name: earned_income_deduction_amount_person
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: "if initial_deduction_category_applies:\\n  min(total_gross_monthly_earned_income, initial_earned_income_deduction_amount)\\nelse:\\n  0"
+"""
+
+    repaired, rules = repair_nonnegative_amount_reductions(content)
+
+    assert rules == ["earned_income_deduction_amount_person"]
+    assert "formula: |-" in repaired
+    assert (
+        "min(max(0, total_gross_monthly_earned_income), "
+        "initial_earned_income_deduction_amount)" in repaired
+    )
+    assert find_nonnegative_amount_reduction_issues(repaired) == []
+
+
 def test_current_year_final_amount_table_rejects_recomputed_maximum(tmp_path):
     repo = tmp_path / "rulespec-us"
     imported = repo / "policies/irs/rev-proc-2025-32/earned-income-credit.yaml"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1043"
+version = "0.2.1044"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair quoted generated formula scalars when applying deterministic nonnegative floor fixes
- floor each min(...) income-base argument independently instead of stopping after the first top-level fix
- preserve parameter caps such as *_amount while flooring actual income inputs
- classify Alaska ATAP source-level RuleSpec outputs against PolicyEngine, using not-comparable mappings where PE exposes only adjacent/simplified surfaces

## Verification
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py -k "nonnegative_amount_reduction" -q
- uv run --extra dev python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py tests/test_rulespec_validation.py -k "parameter_scale_calc_input or policyengine_program_surface_marks_alaska_atap" -q
- git diff --check origin/main...HEAD