### PR TITLE
Baseline legacy upstream source checks

### DIFF
--- a/changelog.d/upstream-source-baseline.changed.md
+++ b/changelog.d/upstream-source-baseline.changed.md
@@ -1,0 +1,1 @@
+Allow RuleSpec repositories to baseline legacy lower-authority source files while preserving strict upstream-source checks for new files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1044"
+version = "0.2.1045"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1044"
+__version__ = "0.2.1045"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1225,6 +1225,9 @@ _PE_UNSUPPORTED_ERROR_PATTERNS = (
     re.compile(r"was not found in the .*tax and benefit system", re.IGNORECASE),
 )
 _APPLIED_ENCODING_MANIFEST_DIR = Path(".axiom") / "encoding-manifests"
+_UPSTREAM_SOURCE_CHECK_BASELINE_PATH = (
+    Path(".axiom") / "upstream-source-check-baseline.txt"
+)
 _DEFINITION_CROSS_REFERENCE_PATTERN = re.compile(
     r"(?:as defined in|defined in|meaning given in|within the meaning of|described in)\s+"
     r"section\s+(?P<section>[0-9A-Za-z.-]+(?:\([^)]+\))*)"
@@ -6888,6 +6891,91 @@ def find_upstream_source_authority_issues(content: str) -> list[str]:
             "for this encoding."
         )
 
+    return issues
+
+
+def _upstream_source_check_baseline_roots(
+    policy_repo_path: Path | None,
+) -> tuple[Path, ...]:
+    if policy_repo_path is None:
+        return ()
+    root = Path(policy_repo_path).resolve(strict=False)
+    roots = [root]
+    parent = root.parent
+    if (
+        not root.name.startswith("rulespec-")
+        and parent.name.startswith("rulespec-")
+        and is_jurisdiction_content_root(root)
+    ):
+        roots.append(parent)
+
+    deduped: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in roots:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        deduped.append(candidate)
+    return tuple(deduped)
+
+
+def _load_upstream_source_check_baseline(baseline_root: Path | None) -> set[str]:
+    if baseline_root is None:
+        return set()
+    baseline_path = Path(baseline_root) / _UPSTREAM_SOURCE_CHECK_BASELINE_PATH
+    try:
+        text = baseline_path.read_text()
+    except OSError:
+        return set()
+    entries: set[str] = set()
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        entries.add(Path(line).as_posix().lstrip("./"))
+    return entries
+
+
+def _rules_file_baseline_key(
+    rules_file: Path,
+    policy_repo_path: Path | None,
+) -> str | None:
+    if policy_repo_path is None:
+        return None
+    try:
+        return (
+            Path(rules_file)
+            .resolve(strict=False)
+            .relative_to(Path(policy_repo_path).resolve(strict=False))
+            .as_posix()
+        )
+    except (OSError, ValueError):
+        return None
+
+
+def _upstream_source_issue_is_missing_check_only(issue: str) -> bool:
+    return issue.startswith("Upstream source check required: ")
+
+
+def upstream_source_authority_issues_for_rules_file(
+    content: str,
+    *,
+    rules_file: Path,
+    policy_repo_path: Path | None,
+) -> list[str]:
+    """Apply the strict upstream-source check, honoring explicit legacy baselines."""
+    issues = find_upstream_source_authority_issues(content)
+    if not issues or not all(
+        _upstream_source_issue_is_missing_check_only(issue) for issue in issues
+    ):
+        return issues
+
+    for baseline_root in _upstream_source_check_baseline_roots(policy_repo_path):
+        key = _rules_file_baseline_key(rules_file, baseline_root)
+        if key is None:
+            continue
+        if key in _load_upstream_source_check_baseline(baseline_root):
+            return []
     return issues
 
 
@@ -21602,7 +21690,13 @@ class ValidatorPipeline:
         issues.extend(find_deprecated_source_url_issues(content))
         issues.extend(find_source_claim_reference_issues(content))
         issues.extend(find_empty_rules_module_issues(content))
-        issues.extend(find_upstream_source_authority_issues(content))
+        issues.extend(
+            upstream_source_authority_issues_for_rules_file(
+                content,
+                rules_file=rules_file,
+                policy_repo_path=self.policy_repo_path,
+            )
+        )
         proof_issues = (
             validate_rulespec_proofs(
                 content,

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -105,6 +105,7 @@ from axiom_encode.harness.validator_pipeline import (
     repair_source_table_band_scalar_parameters,
     repair_source_table_interval_row_alignment,
     repair_source_table_interval_tests,
+    upstream_source_authority_issues_for_rules_file,
 )
 from axiom_encode.oracles.policyengine.registry import (
     PolicyEngineMapping,
@@ -1077,6 +1078,123 @@ rules:
 """
 
     assert find_upstream_source_authority_issues(content) == []
+
+
+def test_upstream_source_authority_baseline_suppresses_legacy_missing_audit(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "us-ga/policies/cms/eligibility-levels.yaml"
+    rules_file.parent.mkdir(parents=True)
+    baseline = repo / ".axiom" / "upstream-source-check-baseline.txt"
+    baseline.parent.mkdir()
+    baseline.write_text(
+        "# Legacy lower-authority files awaiting upstream-source audit.\n"
+        "us-ga/policies/cms/eligibility-levels.yaml\n"
+    )
+    content = """format: rulespec/v1
+module:
+  summary: CMS table states Georgia Medicaid child eligibility levels.
+  source_verification:
+    corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+rules:
+  - name: georgia_children_medicaid_ages_6_to_18_fpl_limit
+    kind: parameter
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row
+    versions:
+      - effective_from: '2023-12-01'
+        formula: '1.33'
+"""
+
+    assert find_upstream_source_authority_issues(content)
+    assert (
+        upstream_source_authority_issues_for_rules_file(
+            content,
+            rules_file=rules_file,
+            policy_repo_path=repo,
+        )
+        == []
+    )
+
+
+def test_upstream_source_authority_baseline_resolves_country_monorepo_parent(
+    tmp_path,
+):
+    repo = tmp_path / "rulespec-us"
+    content_root = repo / "us-in"
+    rules_file = (
+        content_root
+        / "policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml"
+    )
+    rules_file.parent.mkdir(parents=True)
+    baseline = repo / ".axiom" / "upstream-source-check-baseline.txt"
+    baseline.parent.mkdir()
+    baseline.write_text(
+        "# Legacy lower-authority files awaiting upstream-source audit.\n"
+        "us-in/policies/dfr/snap-tanf-program-policy-manual/3010-15-cash-assistance-income-standards.yaml\n"
+    )
+    content = """format: rulespec/v1
+module:
+  summary: Indiana TANF cash assistance income standards.
+  source_verification:
+    corpus_citation_path: us-in/manual/dfr/snap-tanf-program-policy-manual/page-296
+rules:
+  - name: indiana_tanf_income_standard
+    kind: parameter
+    dtype: Money
+    source: Indiana SNAP/TANF Program Policy Manual section 3010.15
+    versions:
+      - effective_from: '2024-01-01'
+        formula: '592'
+"""
+
+    assert (
+        upstream_source_authority_issues_for_rules_file(
+            content,
+            rules_file=rules_file,
+            policy_repo_path=content_root,
+        )
+        == []
+    )
+
+
+def test_upstream_source_authority_baseline_does_not_hide_invalid_audit(tmp_path):
+    repo = tmp_path / "rulespec-us"
+    rules_file = repo / "us-ga/policies/cms/eligibility-levels.yaml"
+    rules_file.parent.mkdir(parents=True)
+    baseline = repo / ".axiom" / "upstream-source-check-baseline.txt"
+    baseline.parent.mkdir()
+    baseline.write_text("us-ga/policies/cms/eligibility-levels.yaml\n")
+    content = """format: rulespec/v1
+module:
+  summary: CMS table states Georgia Medicaid child eligibility levels.
+  source_verification:
+    corpus_citation_path: us/form/cms/medicaid-chip-bhp-eligibility-levels
+    upstream_source_check:
+      status: checked_higher_authority
+      checked_paths:
+        - us/form/cms/medicaid-chip-bhp-eligibility-levels
+      rationale: CMS table checked before encoding.
+rules:
+  - name: georgia_children_medicaid_ages_6_to_18_fpl_limit
+    kind: parameter
+    dtype: Rate
+    source: CMS Medicaid, CHIP and BHP Eligibility Levels table, Georgia row
+    versions:
+      - effective_from: '2023-12-01'
+        formula: '1.33'
+"""
+
+    issues = upstream_source_authority_issues_for_rules_file(
+        content,
+        rules_file=rules_file,
+        policy_repo_path=repo,
+    )
+
+    assert issues == [
+        "Upstream source check must include higher authority: "
+        "`module.source_verification.upstream_source_check.checked_paths` must "
+        "include at least one statute/regulation corpus path or RuleSpec target."
+    ]
 
 
 def test_upstream_source_authority_requires_checked_primary_path():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1044"
+version = "0.2.1045"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a repo-local .axiom/upstream-source-check-baseline.txt allowlist for legacy RuleSpec files missing upstream-source audits
- suppress only the missing upstream_source_check issue for explicitly listed legacy files
- keep invalid or fake upstream_source_check metadata failing, including checks that do not cite higher authority

## Why
The new upstream-source authority gate is correct for new work, but rulespec-us has a large pre-existing backlog of lower-authority files. This lets country repos make that debt explicit without blocking unrelated validation/toolchain updates.

## Checks
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py -k 'upstream_source_authority' -q
- uv run --extra dev python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_rulespec_validation.py -k 'current_encoder_affecting_changes_are_behind_version_bump or upstream_source_authority' -q
- git diff --check origin/main...HEAD