### PR TITLE
Classify Alaska ATAP table helpers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1045"
+version = "0.2.1046"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1045"
+__version__ = "0.2.1046"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -4081,6 +4081,43 @@ mappings:
     candidate_priority: P4
     rationale: Axiom exposes the official 2026 Alaska DPA adult-included need-standard table through family size 10. PolicyEngine's need_standard.amount parameter currently stores a historical size-1-to-8 table and a separate additional-person amount, so this full source table is adjacent but not a one-to-one oracle target.
 
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#adult_included_185_percent_standard_by_family_size
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_gross_income_limit
+    candidate_priority: P4
+    rationale: Axiom exposes the official 2026 Alaska DPA adult-included 185 percent standard table through family size 10 as a source-table helper. PolicyEngine derives ak_atap_gross_income_limit from its broader need-standard graph and does not expose this source table as a one-to-one oracle target.
+
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#adult_included_185_percent_standard_each_additional
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ak_atap_gross_income_limit
+    candidate_priority: P4
+    rationale: Axiom exposes the official 2026 Alaska DPA adult-included each-additional amount for the 185 percent standards table. PolicyEngine derives gross-income limits from its own need-standard graph rather than exposing this published source-table increment as a one-to-one oracle target.
+
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#adult_included_family_size_minimum
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the minimum family-size row used to select the official 2026 Alaska DPA adult-included standards tables. PolicyEngine compares final TANF amounts and does not expose this source-table selector boundary.
+
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#adult_included_family_size_table_maximum
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the maximum listed family-size row used before applying the each-additional row in the official 2026 Alaska DPA adult-included standards tables. PolicyEngine does not expose this source-table selector boundary as a one-to-one oracle target.
+
+  - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#adult_included_family_size_lookup
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes the generated family-size lookup used to select the official 2026 Alaska DPA adult-included standards-table row. PolicyEngine compares final derived Alaska ATAP variables and does not expose this source-table lookup helper.
+
   - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#adult_included_need_standard_each_additional
     country: us
     program: tanf

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2149,6 +2149,68 @@ def test_policyengine_program_surface_marks_alaska_atap_known_not_comparable():
     assert "earned-income deductions" in alaska_atap["rationale"]
 
 
+def test_policyengine_coverage_classifies_alaska_atap_adult_included_table_helpers(
+    tmp_path,
+):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-ak/policies/dpa/atap/standards/2026/adult-included.yaml",
+        """format: rulespec/v1
+rules:
+  - name: adult_included_family_size_minimum
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 2
+  - name: adult_included_family_size_table_maximum
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 10
+  - name: adult_included_185_percent_standard_by_family_size
+    kind: parameter
+    dtype: Money
+    indexed_by: adult_included_family_size_lookup
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          2: 3529
+  - name: adult_included_185_percent_standard_each_additional
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 447
+  - name: adult_included_family_size_lookup
+    kind: derived
+    dtype: Count
+    versions:
+      - effective_from: '2026-01-01'
+        formula: adult_included_family_size_minimum
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tanf")
+
+    assert report["status_counts"] == {"known_not_comparable": 5}
+    items_by_rule = {item["rule_name"]: item for item in report["items"]}
+    assert set(items_by_rule) == {
+        "adult_included_185_percent_standard_by_family_size",
+        "adult_included_185_percent_standard_each_additional",
+        "adult_included_family_size_lookup",
+        "adult_included_family_size_minimum",
+        "adult_included_family_size_table_maximum",
+    }
+    for item in items_by_rule.values():
+        assert item["status"] == "known_not_comparable"
+        assert item["mapping_type"] == "not_comparable"
+        assert item["program"] == "tanf"
+        assert "source-table" in item["rationale"]
+
+
 def test_policyengine_program_surface_marks_new_york_tanf_known_not_comparable():
     report = build_policyengine_program_surface_report(program="tanf")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1045"
+version = "0.2.1046"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Alaska ATAP adult-included source-table helper outputs as known not comparable to PolicyEngine
- add a coverage regression for those helper outputs
- bump axiom-encode to 0.2.1046

## Tests
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k 'alaska_atap_adult_included_table_helpers or alaska_atap_known_not_comparable' -q
- uv run --extra dev python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- git diff --check origin/main...HEAD