### PR TITLE
Classify Massachusetts TAFDC surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1046"
+version = "0.2.1047"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/co_snap_manual_stress.py
+++ b/scripts/co_snap_manual_stress.py
@@ -44,9 +44,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--axiom-corpus", type=Path, default=DEFAULT_AXIOM_CORPUS)
     parser.add_argument("--axiom-rules-engine", type=Path, default=DEFAULT_RULES_ENGINE)
     parser.add_argument("--policy-repo", type=Path, default=DEFAULT_POLICY_REPO)
-    parser.add_argument("--backend", choices=["openai", "codex", "claude"], default="openai")
+    parser.add_argument(
+        "--backend", choices=["openai", "codex", "claude"], default="openai"
+    )
     parser.add_argument("--model", default="gpt-5.5")
-    parser.add_argument("--mode", choices=["cold", "repo-augmented"], default="repo-augmented")
+    parser.add_argument(
+        "--mode", choices=["cold", "repo-augmented"], default="repo-augmented"
+    )
     parser.add_argument("--timeout-seconds", type=int, default=210)
     parser.add_argument("--limit", type=int)
     parser.add_argument("--start-index", type=int, default=0)
@@ -335,7 +339,9 @@ def main() -> int:
         print(json.dumps(result, sort_keys=True), flush=True)
 
     print(
-        json.dumps({"event": "stress_done", "results": str(results_path)}, sort_keys=True),
+        json.dumps(
+            {"event": "stress_done", "results": str(results_path)}, sort_keys=True
+        ),
         flush=True,
     )
     return 0

--- a/scripts/run_snap_queue_until_idle.py
+++ b/scripts/run_snap_queue_until_idle.py
@@ -104,7 +104,9 @@ POLICYENGINE_US_PYTHON_CANDIDATES = [
 ]
 WORKSPACES = [
     AXIOM_ENCODE_ROOT,
-    *sorted(path for path in AXIOM_ENCODE_ROOT.parent.glob("rulespec-*") if path.is_dir()),
+    *sorted(
+        path for path in AXIOM_ENCODE_ROOT.parent.glob("rulespec-*") if path.is_dir()
+    ),
 ]
 RETRYABLE_PATTERNS = (
     "usage limit",

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1046"
+__version__ = "0.2.1047"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -4047,6 +4047,14 @@ mappings:
     candidate_priority: P4
     rationale: Axiom's 106 CMR 704.260 rule applies the source-law income test against the applicable Need Standard and treats income equal to that standard as eligible after excluding noncountable income, Full Employment Program wages, and the listed disregards. PolicyEngine's ma_tafdc_financial_eligible uses PE's own income graph and a strict less-than comparison against ma_tafdc_payment_standard, so the legal output is adjacent TAFDC coverage rather than a one-to-one oracle target.
 
+  - legal_id: us-ma:regulations/106-cmr/704/500/block-1#tafdc_monthly_grant_amount
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ma_tafdc
+    candidate_priority: P4
+    rationale: Axiom's 106 CMR 704.500 grant-calculation output preserves the source-law need-standard deficit, whole-dollar rounding, payment-standard cap, and under-$10 no-grant rule. PolicyEngine's ma_tafdc is a final annual benefit surface that composes PE eligibility, income, clothing allowance, infant benefit, and an EAEDC comparison selector, so this legal grant slice is adjacent progress but not a one-to-one oracle target.
+
   - legal_id: us-ma:regulations/106-cmr/704/230/block-1#ma_tafdc_monthly_absent_parent_income_disregard
     country: us
     program: tanf

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -322,10 +322,13 @@ surfaces:
   variable: ma_tafdc
   source_type: state_implementation
   state: MA
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom now has source-law Massachusetts TAFDC coverage for the tested 106 CMR 704.500 monthly grant calculation
+    plus existing payment-standard, work-expense, child-support, financial-eligibility, and infant-benefit legal slices.
+    PolicyEngine's ma_tafdc is a final annual benefit surface with its own eligibility and income graph, clothing and infant
+    additions, and an EAEDC comparison selector, so keep it known-not-comparable until a full legal program bridge composes
+    the same final boundaries.
 - country: us
   program_id: tanf
   program_name: Montana TANF

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2149,6 +2149,27 @@ def test_policyengine_program_surface_marks_alaska_atap_known_not_comparable():
     assert "earned-income deductions" in alaska_atap["rationale"]
 
 
+def test_policyengine_program_surface_marks_massachusetts_tafdc_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    massachusetts_tafdc = items_by_variable["ma_tafdc"]
+
+    assert massachusetts_tafdc["program_id"] == "tanf"
+    assert massachusetts_tafdc["state"] == "MA"
+    assert massachusetts_tafdc["axiom_status"] == "known_not_comparable"
+    assert massachusetts_tafdc["mapping_count"] == 1
+    assert massachusetts_tafdc["comparable_mapping_count"] == 0
+    assert (
+        "us-ma:regulations/106-cmr/704/500/block-1#tafdc_monthly_grant_amount"
+        in massachusetts_tafdc["legal_ids"]
+    )
+    assert (
+        "106 CMR 704.500 monthly grant calculation" in massachusetts_tafdc["rationale"]
+    )
+    assert "EAEDC comparison selector" in massachusetts_tafdc["rationale"]
+
+
 def test_policyengine_coverage_classifies_alaska_atap_adult_included_table_helpers(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1046"
+version = "0.2.1047"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add an explicit not-comparable oracle mapping from 106 CMR 704.500 TAFDC monthly grant amount to PolicyEngine ma_tafdc
- move the Massachusetts TAFDC program surface out of pending RuleSpec encoding and into known-not-comparable with source-law rationale
- bump axiom-encode to 0.2.1047 and cover the surface classification in tests
- apply Ruff formatting to two pre-existing script formatting failures required for CI

## Validation
- uv run pytest tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_massachusetts_tafdc_known_not_comparable tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
- uv run axiom-encode oracle-coverage --root /tmp/axiom-rulespec-us-ma-tafdc-parent --include-program-surfaces --json
- uv run ruff format --check .
- uv run ruff check .
