### PR TITLE
Wire Oregon and Utah SNAP ECPS comparison

### DIFF
--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -2242,8 +2242,16 @@ def main():
     eval_suite_parser.add_argument(
         "--output",
         type=Path,
-        default=Path("/tmp/axiom_encode-suite-evals"),
-        help="Directory for suite artifacts and traces",
+        default=None,
+        help=(
+            "Directory for suite artifacts and traces "
+            "(defaults to artifacts/eval-suites/work/<manifest-stem>)"
+        ),
+    )
+    eval_suite_parser.add_argument(
+        "--allow-ephemeral-output",
+        action="store_true",
+        help="Allow eval-suite output under the system temp directory",
     )
     eval_suite_parser.add_argument(
         "--resume",
@@ -43916,6 +43924,39 @@ def _suite_auto_resume_reason(state: dict | None, total_cases: int) -> str | Non
     return status or "incomplete state"
 
 
+def _default_eval_suite_output_path(manifest_path: Path) -> Path:
+    """Return a durable default output path for an eval-suite run."""
+    root = _default_eval_suite_archive_root() / "work"
+    manifest_stem = re.sub(r"[^a-zA-Z0-9._-]+", "-", manifest_path.stem).strip("-")
+    return root / (manifest_stem or "eval-suite")
+
+
+def _is_system_temp_path(path: Path) -> bool:
+    """Return True when `path` resolves inside the system temp directory."""
+    resolved = Path(path).expanduser().resolve()
+    temp_root = Path(tempfile.gettempdir()).resolve()
+    return resolved == temp_root or temp_root in resolved.parents
+
+
+def _resolve_eval_suite_output_path(args) -> Path:
+    """Resolve and guard the eval-suite output directory."""
+    output = args.output or _default_eval_suite_output_path(args.manifest)
+    output = Path(output).expanduser()
+    allow_ephemeral = bool(getattr(args, "allow_ephemeral_output", False)) or bool(
+        os.environ.get("AXIOM_ENCODE_ALLOW_EPHEMERAL_EVAL_SUITE_OUTPUT")
+    )
+    if _is_system_temp_path(output) and not allow_ephemeral:
+        print(
+            "Refusing eval-suite output under the system temp directory: "
+            f"{output}\n"
+            "Use a durable path under artifacts/eval-suites, or pass "
+            "--allow-ephemeral-output for an intentionally disposable run.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return output
+
+
 def cmd_eval_suite(args):
     """Run a manifest-driven benchmark suite and evaluate readiness gates."""
     manifest = load_eval_suite_manifest(args.manifest)
@@ -43924,6 +43965,7 @@ def cmd_eval_suite(args):
         "axiom-rules-engine"
     )
     corpus_path = args.corpus_path or _resolve_repo_checkout("axiom-corpus")
+    output_root = _resolve_eval_suite_output_path(args)
 
     if not axiom_rules_path.exists():
         print(f"axiom-rules-engine repo not found: {axiom_rules_path}")
@@ -43945,7 +43987,7 @@ def cmd_eval_suite(args):
         try:
             results = run_eval_suite(
                 manifest=manifest,
-                output_root=args.output,
+                output_root=output_root,
                 axiom_rules_path=axiom_rules_path,
                 corpus_path=corpus_path if has_corpus_case else None,
                 runner_specs=effective_runners,
@@ -43970,7 +44012,7 @@ def cmd_eval_suite(args):
             continue
 
         auto_resume_reason = _suite_auto_resume_reason(
-            _load_eval_suite_run_state(args.output),
+            _load_eval_suite_run_state(output_root),
             total_cases=len(manifest.cases),
         )
         if auto_resume_reason and recovery_count < auto_resume_attempts:
@@ -44003,9 +44045,9 @@ def cmd_eval_suite(args):
         readiness=readiness,
         all_ready=all_ready,
     )
-    args.output.mkdir(parents=True, exist_ok=True)
-    (args.output / "results.json").write_text(json.dumps(payload, indent=2) + "\n")
-    (args.output / "summary.json").write_text(
+    output_root.mkdir(parents=True, exist_ok=True)
+    (output_root / "results.json").write_text(json.dumps(payload, indent=2) + "\n")
+    (output_root / "summary.json").write_text(
         json.dumps(
             {
                 "manifest": payload["manifest"],
@@ -44023,7 +44065,7 @@ def cmd_eval_suite(args):
 
     print(f"Manifest: {manifest.path}")
     print(f"Suite: {manifest.name}")
-    print(f"Output root: {args.output}")
+    print(f"Output root: {output_root}")
     print(f"Runners: {', '.join(effective_runners)}")
     print(f"Axiom rules engine: {axiom_rules_path}")
     if has_corpus_case:

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -292,6 +292,83 @@ JURISDICTION_CONFIGS = {
             "ny_snap_categorical_member_of_household",
         ),
     ),
+    "us-or": JurisdictionConfig(
+        jurisdiction="us-or",
+        state_code="OR",
+        repo_name="rulespec-us-or",
+        program_relative_path=Path(
+            "policies/odhs/open/fy-2026-benefit-calculation.yaml"
+        ),
+        output_id_by_label={
+            "snap_regular_month_allotment": (
+                "us-or:policies/odhs/open/fy-2026-benefit-calculation"
+                "#snap_regular_month_allotment"
+            ),
+            "snap_gross_monthly_income": (
+                "us-or:policies/odhs/open/fy-2026-benefit-calculation"
+                "#snap_gross_monthly_income"
+            ),
+            "snap_net_income": (
+                "us-or:policies/odhs/open/fy-2026-benefit-calculation"
+                "#snap_net_income"
+            ),
+            "snap_eligible": (
+                "us-or:policies/odhs/open/fy-2026-benefit-calculation#snap_eligible"
+            ),
+            "snap_maximum_allotment": (
+                "us-or:policies/odhs/open/fy-2026-benefit-calculation"
+                "#snap_maximum_allotment"
+            ),
+            "snap_excess_shelter_deduction": (
+                "us-or:policies/odhs/open/fy-2026-benefit-calculation"
+                "#snap_excess_shelter_deduction"
+            ),
+        },
+        utility_allowance_labels=(),
+        relation_id=AXIOM_RELATION_ID_BY_LABEL["member_of_household"],
+        member_entity_type="Person",
+        temp_prefix="or-snap-pe-ecps-",
+        display_name="Oregon SNAP",
+    ),
+    "us-ut": JurisdictionConfig(
+        jurisdiction="us-ut",
+        state_code="UT",
+        repo_name="rulespec-us-ut",
+        program_relative_path=Path(
+            "policies/dws/eligibility-manual/fy-2026-benefit-calculation.yaml"
+        ),
+        output_id_by_label={
+            "snap_regular_month_allotment": (
+                "us-ut:policies/dws/eligibility-manual/fy-2026-benefit-calculation"
+                "#snap_regular_month_allotment"
+            ),
+            "snap_gross_monthly_income": (
+                "us-ut:policies/dws/eligibility-manual/fy-2026-benefit-calculation"
+                "#snap_gross_monthly_income"
+            ),
+            "snap_net_income": (
+                "us-ut:policies/dws/eligibility-manual/fy-2026-benefit-calculation"
+                "#snap_net_income"
+            ),
+            "snap_eligible": (
+                "us-ut:policies/dws/eligibility-manual/fy-2026-benefit-calculation"
+                "#snap_eligible"
+            ),
+            "snap_maximum_allotment": (
+                "us-ut:policies/dws/eligibility-manual/fy-2026-benefit-calculation"
+                "#snap_maximum_allotment"
+            ),
+            "snap_excess_shelter_deduction": (
+                "us-ut:policies/dws/eligibility-manual/fy-2026-benefit-calculation"
+                "#snap_excess_shelter_deduction"
+            ),
+        },
+        utility_allowance_labels=(),
+        relation_id=AXIOM_RELATION_ID_BY_LABEL["member_of_household"],
+        member_entity_type="Person",
+        temp_prefix="ut-snap-pe-ecps-",
+        display_name="Utah SNAP",
+    ),
 }
 AXIOM_MEMBER_INPUT_ID_BY_LABEL = {
     "snap_member_is_elderly_or_disabled": (
@@ -738,6 +815,29 @@ def resolve_test_template_path(program: Path, override: Path | None) -> Path:
     return program.with_name(f"{program.stem}.test.yaml")
 
 
+def validate_comparison_files(
+    config: JurisdictionConfig,
+    *,
+    program: Path,
+    test_template: Path,
+) -> None:
+    missing: list[str] = []
+    if not program.exists():
+        missing.append(f"program module: {program}")
+    if not test_template.exists():
+        missing.append(f"test template: {test_template}")
+    if not missing:
+        return
+    details = "\n  - ".join(missing)
+    raise SystemExit(
+        f"{config.display_name} ECPS comparison is configured, but required "
+        f"RuleSpec file(s) are missing:\n  - {details}\n"
+        "Create the configured SNAP benefit-calculation composition and companion "
+        "test template, or pass --program and --test-template to compare a "
+        "different executable module."
+    )
+
+
 def resolve_axiom_binary(workspace_root: Path, override: Path | None) -> Path:
     if override is not None:
         return override.resolve()
@@ -927,7 +1027,7 @@ def project_income_resource_inputs(
                 values["meets_snap_categorical_eligibility"][idx]
             ),
         }
-    if config.jurisdiction == "us-az":
+    if config.jurisdiction in {"us-az", "us-or", "us-ut"}:
         return {
             "snap_gross_monthly_earned_income": earned_income,
             "snap_total_monthly_unearned_income": unearned_income,
@@ -1259,7 +1359,6 @@ def load_policyengine_cases(
         inputs = dict(base_inputs)
         projected_inputs = {
             **project_income_resource_inputs(config, values, idx),
-            "household_size": int(values["snap_unit_size"][idx]),
             "household_shelter_costs_incurred": money(values["housing_cost"][idx]),
             "household_lives_in_application_state": True,
             "household_in_project_area_solely_for_vacation": False,
@@ -1275,7 +1374,13 @@ def load_policyengine_cases(
             **utility_inputs,
         }
         for input_name, value in projected_inputs.items():
-            set_input_value(inputs, input_name, value)
+            set_input_value(inputs, input_name, value, required=False)
+        set_input_value(
+            inputs,
+            "household_size",
+            int(values["snap_unit_size"][idx]),
+            required=False,
+        )
         set_input_value(
             inputs,
             "snap_claimed_homeless_shelter_deduction",
@@ -1315,17 +1420,20 @@ def load_policyengine_cases(
         pe_outputs["all_members_receive_ssi"] = bool(
             all_members_receive_ssi_by_spm.get(spm_id, False)
         )
+        projected_member_inputs = [
+            legalize_inputs(
+                member_inputs,
+                member_input_ref_by_name,
+            )
+        ]
+        if uses_household_only_bridge(config):
+            projected_member_inputs = []
         cases.append(
             ProjectedCase(
                 spm_unit_id=spm_id,
                 household_id=int(household_ids[idx]),
                 inputs=legalize_inputs(inputs, household_input_ref_by_name),
-                member_inputs=[
-                    legalize_inputs(
-                        member_inputs,
-                        member_input_ref_by_name,
-                    )
-                ],
+                member_inputs=projected_member_inputs,
                 pe_outputs=pe_outputs,
             )
         )
@@ -1369,6 +1477,23 @@ def project_jurisdiction_household_inputs(
                 values["snap_excess_shelter_expense_deduction"][idx]
             ),
         }
+    if config.jurisdiction in {"us-or", "us-ut"}:
+        return {
+            "projected_snap_net_income": money(values["snap_net_income"][idx]),
+            "projected_snap_eligible": bool(values["is_snap_eligible"][idx]),
+            "projected_snap_categorically_eligible": bool(
+                values["meets_snap_categorical_eligibility"][idx]
+            ),
+            "projected_snap_maximum_allotment": money(
+                values["snap_max_allotment"][idx]
+            ),
+            "projected_snap_minimum_allotment": money(
+                values["snap_min_allotment"][idx]
+            ),
+            "projected_snap_excess_shelter_deduction": money(
+                values["snap_excess_shelter_expense_deduction"][idx]
+            ),
+        }
     return {}
 
 
@@ -1384,6 +1509,10 @@ def project_jurisdiction_member_inputs(config: JurisdictionConfig) -> dict[str, 
             f"{base}member_family_assistance_or_nonemergency_safety_net_grant_amount": 0,
         }
     return {}
+
+
+def uses_household_only_bridge(config: JurisdictionConfig) -> bool:
+    return config.jurisdiction in {"us-az", "us-or", "us-ut"}
 
 
 def projected_child_support_payment(values: dict[str, Any], idx: int) -> float:
@@ -1936,6 +2065,7 @@ def main(args: argparse.Namespace | None = None) -> int:
     workspace_root = resolve_workspace_root(args.workspace_root)
     program = resolve_program_path(config, workspace_root, args.program)
     test_template = resolve_test_template_path(program, args.test_template)
+    validate_comparison_files(config, program=program, test_template=test_template)
     axiom_binary = resolve_axiom_binary(workspace_root, args.axiom_binary)
     state = (args.state or config.state_code).upper()
     env = axiom_rules_env(program, workspace_root)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,7 @@ from axiom_encode.cli import (
     _complete_missing_imported_test_inputs,
     _convert_indexed_parameter_values_to_derived_formulas,
     _convert_versioned_boolean_parameters_to_indicators,
+    _default_eval_suite_output_path,
     _default_generated_test_input_value,
     _discover_rulespec_test_files,
     _effective_runner_specs,
@@ -115,6 +116,7 @@ from axiom_encode.cli import (
     _repair_unit_scoped_person_definition_entities,
     _repair_upstream_placement_duplicate_imports,
     _require_axiom_encode_version_provenance,
+    _resolve_eval_suite_output_path,
     _rewrite_gpt_runner_backend,
     _rewrite_import_output_test_input_refs,
     _rewrite_judgment_conditional_formulas,
@@ -472,6 +474,35 @@ class TestRunnerOverrides:
         ]
 
 
+class TestEvalSuiteOutputPaths:
+    def test_default_eval_suite_output_path_is_durable(self):
+        output = _default_eval_suite_output_path(Path("benchmarks/snap suite.yaml"))
+
+        assert output == Path("artifacts/eval-suites/work/snap-suite").resolve()
+
+    def test_resolve_eval_suite_output_rejects_system_temp(self):
+        args = SimpleNamespace(
+            manifest=Path("benchmarks/snap.yaml"),
+            output=Path(tempfile.gettempdir()) / "axiom-suite",
+            allow_ephemeral_output=False,
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            _resolve_eval_suite_output_path(args)
+
+        assert exc_info.value.code == 2
+
+    def test_resolve_eval_suite_output_allows_explicit_ephemeral_opt_in(self):
+        output = Path(tempfile.gettempdir()) / "axiom-suite"
+        args = SimpleNamespace(
+            manifest=Path("benchmarks/snap.yaml"),
+            output=output,
+            allow_ephemeral_output=True,
+        )
+
+        assert _resolve_eval_suite_output_path(args) == output
+
+
 class TestMain:
     def test_no_command_shows_help_and_exits(self):
         """main() with no command should print help and exit 1."""
@@ -705,6 +736,7 @@ class TestCmdEvalSuite:
             resume=False,
             auto_resume_attempts=0,
             auto_resume_delay_seconds=0,
+            allow_ephemeral_output=True,
         )
         args.axiom_rules_path.mkdir()
         args.corpus_path.mkdir()
@@ -786,6 +818,7 @@ class TestCmdEvalSuite:
             resume=True,
             auto_resume_attempts=0,
             auto_resume_delay_seconds=0,
+            allow_ephemeral_output=True,
         )
         args.axiom_rules_path.mkdir()
         args.corpus_path.mkdir()
@@ -861,6 +894,7 @@ class TestCmdEvalSuite:
             resume=False,
             auto_resume_attempts=1,
             auto_resume_delay_seconds=0,
+            allow_ephemeral_output=True,
         )
         args.axiom_rules_path.mkdir()
         args.corpus_path.mkdir()
@@ -942,6 +976,7 @@ class TestCmdEvalSuite:
             resume=False,
             auto_resume_attempts=2,
             auto_resume_delay_seconds=0,
+            allow_ephemeral_output=True,
         )
         args.axiom_rules_path.mkdir()
         args.corpus_path.mkdir()

--- a/tests/test_policyengine_ecps_snap.py
+++ b/tests/test_policyengine_ecps_snap.py
@@ -1,4 +1,5 @@
 import shutil
+from argparse import ArgumentParser, Namespace
 from datetime import date
 from pathlib import Path
 from types import SimpleNamespace
@@ -21,6 +22,7 @@ from axiom_encode.oracles.policyengine.ecps_snap import (
     projected_child_support_payment,
     run_axiom_cases,
     set_input_value,
+    uses_household_only_bridge,
 )
 from axiom_encode.oracles.snapscreener import (
     project_payload,
@@ -81,6 +83,40 @@ def test_set_input_value_can_skip_optional_unknown_inputs():
     )
 
 
+def test_optional_household_size_projection_updates_only_when_present():
+    inputs = {
+        "us-az:policies/des/faa5/na-eligibility-and-benefit-determination/"
+        "fy-2026-benefit-calculation#input.na_net_income": 0,
+    }
+
+    set_input_value(inputs, "household_size", 3, required=False)
+
+    assert "household_size" not in inputs
+
+    inputs[
+        "us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size"
+    ] = 1
+    set_input_value(inputs, "household_size", 3, required=False)
+
+    assert (
+        inputs[
+            "us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size"
+        ]
+        == 3
+    )
+
+
+def test_optional_projection_fields_do_not_create_bare_inputs():
+    inputs = {
+        "us-az:policies/des/faa5/na-eligibility-and-benefit-determination/"
+        "fy-2026-benefit-calculation#input.na_net_income": 0,
+    }
+
+    set_input_value(inputs, "household_shelter_costs_incurred", 1200, required=False)
+
+    assert "household_shelter_costs_incurred" not in inputs
+
+
 def test_all_by_id_requires_every_member_to_hold():
     result = all_by_id(
         [1, 1, 2, 2, 3],
@@ -127,6 +163,31 @@ def test_new_york_projector_uses_repaired_work_disqualification_input():
         ]
         is True
     )
+
+
+def test_oregon_utah_bridge_projector_includes_categorical_minimum_signal():
+    values = {
+        "snap_dependent_care_deduction": [0],
+        "snap_net_income": [800],
+        "is_snap_eligible": [True],
+        "meets_snap_categorical_eligibility": [True],
+        "snap_max_allotment": [546],
+        "snap_min_allotment": [24],
+        "snap_excess_shelter_expense_deduction": [150],
+    }
+
+    projected = project_jurisdiction_household_inputs(
+        JURISDICTION_CONFIGS["us-ut"], values, 0
+    )
+
+    assert projected == {
+        "projected_snap_net_income": 800,
+        "projected_snap_eligible": True,
+        "projected_snap_categorically_eligible": True,
+        "projected_snap_maximum_allotment": 546,
+        "projected_snap_minimum_allotment": 24,
+        "projected_snap_excess_shelter_deduction": 150,
+    }
 
 
 def test_california_projectors_use_california_snap_input_surface():
@@ -237,6 +298,61 @@ def test_run_axiom_cases_uses_configured_california_member_entity(
     assert inputs_by_name["member-input"]["entity"] == "Person"
 
 
+def test_run_axiom_cases_allows_household_only_projection(monkeypatch, tmp_path):
+    runtime_requests = []
+
+    def fake_run(cmd, **kwargs):
+        runtime_requests.append(ecps_snap.json.loads(kwargs["input"]))
+        return ecps_snap.subprocess.CompletedProcess(
+            cmd,
+            0,
+            stdout=ecps_snap.json.dumps({"results": [{"outputs": {}}]}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(ecps_snap.subprocess, "run", fake_run)
+    period = Period(
+        label="2026-01",
+        year=2026,
+        month=1,
+        start=date(2026, 1, 1),
+        end=date(2026, 1, 31),
+    )
+    config = JURISDICTION_CONFIGS["us-az"]
+
+    run_axiom_cases(
+        binary=tmp_path / "axiom-rules-engine",
+        artifact=tmp_path / "program.json",
+        cases=[
+            ProjectedCase(
+                spm_unit_id=42,
+                household_id=420,
+                inputs={"household-input": 1},
+                member_inputs=[],
+                pe_outputs={},
+            )
+        ],
+        period=period,
+        output_ids=["output-id"],
+        relation_id=config.relation_id,
+        additional_relation_ids=config.additional_relation_ids,
+        member_entity_type=config.member_entity_type,
+        env={},
+    )
+
+    request = runtime_requests[0]
+    assert request["dataset"]["relations"] == []
+    assert request["dataset"]["inputs"] == [
+        {
+            "name": "household-input",
+            "entity": "Household",
+            "entity_id": "spm-42",
+            "interval": {"start": "2026-01-01", "end": "2026-01-31"},
+            "value": {"kind": "integer", "value": 1},
+        }
+    ]
+
+
 def test_common_snap_outputs_track_current_federal_rulespec_surface():
     assert COMMON_AXIOM_OUTPUT_ID_BY_LABEL["snap_gross_monthly_income"] == (
         "us:regulations/7-cfr/273/10#snap_total_gross_income"
@@ -244,6 +360,82 @@ def test_common_snap_outputs_track_current_federal_rulespec_surface():
     assert COMMON_AXIOM_OUTPUT_ID_BY_LABEL["snap_excess_shelter_deduction"] == (
         "us:regulations/7-cfr/273/10#snap_excess_shelter_deduction_for_net_income"
     )
+
+
+def test_snap_ecps_parser_includes_oregon_and_utah():
+    parser = ArgumentParser()
+    ecps_snap.configure_parser(parser)
+
+    parsed = parser.parse_args(["--jurisdiction", "us-or"])
+    assert parsed.jurisdiction == "us-or"
+    parsed = parser.parse_args(["--jurisdiction", "us-ut"])
+    assert parsed.jurisdiction == "us-ut"
+
+
+def test_oregon_and_utah_configs_point_to_expected_program_modules():
+    oregon = JURISDICTION_CONFIGS["us-or"]
+    utah = JURISDICTION_CONFIGS["us-ut"]
+
+    assert oregon.state_code == "OR"
+    assert oregon.repo_name == "rulespec-us-or"
+    assert oregon.program_relative_path.as_posix() == (
+        "policies/odhs/open/fy-2026-benefit-calculation.yaml"
+    )
+    assert oregon.output_id_by_label["snap_regular_month_allotment"] == (
+        "us-or:policies/odhs/open/fy-2026-benefit-calculation"
+        "#snap_regular_month_allotment"
+    )
+    assert utah.state_code == "UT"
+    assert utah.repo_name == "rulespec-us-ut"
+    assert utah.program_relative_path.as_posix() == (
+        "policies/dws/eligibility-manual/fy-2026-benefit-calculation.yaml"
+    )
+    assert utah.output_id_by_label["snap_eligible"] == (
+        "us-ut:policies/dws/eligibility-manual/fy-2026-benefit-calculation"
+        "#snap_eligible"
+    )
+
+
+def test_household_only_snap_bridge_jurisdictions_do_not_project_member_inputs():
+    assert uses_household_only_bridge(JURISDICTION_CONFIGS["us-az"])
+    assert uses_household_only_bridge(JURISDICTION_CONFIGS["us-or"])
+    assert uses_household_only_bridge(JURISDICTION_CONFIGS["us-ut"])
+    assert not uses_household_only_bridge(JURISDICTION_CONFIGS["us-co"])
+    assert not uses_household_only_bridge(JURISDICTION_CONFIGS["us-ny"])
+
+
+def test_snap_ecps_main_fails_before_policyengine_when_program_module_missing(
+    tmp_path,
+):
+    args = Namespace(
+        jurisdiction="us-or",
+        workspace_root=tmp_path,
+        program=None,
+        test_template=None,
+        axiom_binary=None,
+        state=None,
+        year=2026,
+        month=1,
+        sample_size=1,
+        positive_snap_only=False,
+        utility_projection="raw-expenses",
+        tolerance=1.5,
+        max_differences=20,
+        fail_on_mismatch=False,
+        min_match_rate=None,
+        write_csv=None,
+        external_oracle=[],
+        snapscreener_api_js=None,
+        snapscreener_cache_dir=None,
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        ecps_snap.main(args)
+
+    message = str(exc_info.value)
+    assert "Oregon SNAP ECPS comparison is configured" in message
+    assert "program module:" in message
+    assert "fy-2026-benefit-calculation.yaml" in message
 
 
 def test_colorado_snap_outputs_use_composed_allotment_and_cfr_net_income():

--- a/tests/test_snap_readiness.py
+++ b/tests/test_snap_readiness.py
@@ -153,6 +153,28 @@ def test_snap_readiness_flags_rules_without_policyengine_config(tmp_path):
     )
 
 
+def test_snap_readiness_reports_configured_jurisdiction_missing_program_module(
+    tmp_path,
+):
+    root = tmp_path / "workspace"
+    corpus_root = root / "axiom-corpus"
+    repo = root / "rulespec-us-or"
+    _write_rulespec(repo, "policies/odhs/open/page-274.yaml")
+    _write_corpus_provision(corpus_root, "us-or/manual/odhs/open/page-274")
+
+    report = build_snap_readiness_report(root, corpus_root=corpus_root)
+
+    by_jurisdiction = {item["jurisdiction"]: item for item in report["items"]}
+    oregon = by_jurisdiction["us-or"]
+    assert oregon["status"] == "missing_program_module"
+    assert oregon["policyengine_populace_configured"] is True
+    assert oregon["program_module"] == (
+        "policies/odhs/open/fy-2026-benefit-calculation.yaml"
+    )
+    assert oregon["program_module_exists"] is False
+    assert "missing configured SNAP program module" in oregon["blockers"]
+
+
 def test_snap_readiness_distinguishes_empty_repo_without_corpus(tmp_path):
     root = tmp_path / "workspace"
     corpus_root = root / "axiom-corpus"


### PR DESCRIPTION
## Summary
- Adds Oregon and Utah SNAP ECPS comparison configuration.
- Adds validation for missing configured program/test files before invoking PolicyEngine.
- Makes eval-suite default output durable under artifacts/eval-suites/work and requires opt-in for temp output.

## Checks
- uv run ruff check pyproject.toml src/axiom_encode scripts tests
- python -m compileall -q src/axiom_encode scripts
- uv run pytest tests/test_cli.py::TestEvalSuiteOutputPaths tests/test_policyengine_ecps_snap.py tests/test_snap_readiness.py

## Known status
- Draft PR pending the required review/fix cycle.
- Full uv run pytest currently has an unrelated pre-existing rulespec-us cross-statute import failure in tests/test_repo_cross_statute_imports.py.
- Generated ECPS CSV/JSON artifacts were preserved locally in stash: generated policyengine oracle artifacts 2026-07-01.