### PR TITLE
Add Minnesota MFIP Populace adapter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1047"
+version = "0.2.1048"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1047"
+__version__ = "0.2.1048"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -541,6 +541,35 @@ PE_US_VAR_ADAPTERS = (
         ),
     ),
     PolicyEngineUSVarAdapter(
+        rule_names=("mfip_cash_portion_issued_as_cash",),
+        pe_var="mn_mfip",
+        monthly=True,
+        spm=True,
+        default_state_code="MN",
+        direct_spm_overrides=(
+            (
+                "transitional_standard_for_corresponding_payment_month",
+                "mn_mfip_full_transitional_standard",
+            ),
+            (
+                "family_wage_level_for_corresponding_payment_month",
+                "mn_mfip_family_wage_level",
+            ),
+            (
+                "net_earned_income_in_budget_month",
+                "mn_mfip_countable_earned_income",
+            ),
+            (
+                "unearned_income_in_budget_month",
+                "mn_mfip_countable_unearned_income",
+            ),
+            (
+                "mfip_food_portion_amount_under_section_0020_09",
+                "mn_mfip_food_portion",
+            ),
+        ),
+    ),
+    PolicyEngineUSVarAdapter(
         rule_names=("ca_capi",),
         pe_var="ca_capi",
         default_state_code="CA",

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -661,10 +661,14 @@ surfaces:
     surface. The RuleSpec module records the higher-authority check against Minnesota Statutes 142G.16, 142G.17, and
     256P.03 before relying on DHS manual operational procedure.
   populace_validation:
-    status: pending_validator
-    command: uv run axiom-encode us-populace-compare --variable mn_mfip --sample-size 1 --state MN --json
-    rationale: The current US Populace comparator exits with "No PolicyEngine US adapter is configured for mn_mfip";
-      add the Minnesota MFIP adapter before claiming Populace-verified parity.
+    status: validated
+    command: AXIOM_POPULACE_US_2024_H5=/Users/maxghenis/.codex-artifacts/populace-us-fiscal-refresh-703bd81-no-oos-20260620/artifacts/populace_us_2024.h5 uv run --extra dev --with /Users/maxghenis/.cache/uv/sdists-v9/path/f08f6e929a1989dd/bP-zFPqTOCCpXVEGGxK3G/policyengine_us-1.751.2-py3-none-any.whl --with policyengine-core==3.26.0 --with '/Users/maxghenis/PolicyEngine/populace/packages/populace-data[us]' --with numpy --with pandas axiom-encode us-populace-compare --root /Users/maxghenis/TheAxiomFoundation --rulespec-root /Users/maxghenis/TheAxiomFoundation/rulespec-us --axiom-rules-engine-path /Users/maxghenis/TheAxiomFoundation/axiom-rules-engine --year 2026 --month 1 --populace-year 2024 --variable mn_mfip --state MN --sample-size 0 --max-differences 10 --allow-policyengine-us-version
+    dataset: populace-us-2024 local H5
+    last_run: '2026-07-02'
+    rationale: Full Minnesota Populace run compared 74 eligible person rows across 22 SPM units with 0 mismatches.
+      The comparator skips 2,000 ineligible person rows because the encoded RuleSpec module covers the MFIP grant and
+      cash-issuance calculation after eligibility, while PolicyEngine's final mn_mfip variable is defined only for
+      eligible SPM units.
 - country: us
   program_id: tanf
   program_name: Tennessee Families First

--- a/src/axiom_encode/oracles/policyengine/us_populace.py
+++ b/src/axiom_encode/oracles/policyengine/us_populace.py
@@ -573,6 +573,11 @@ def source_variables_for_adapters(
             *adapter.monthly_boolean_person_inputs,
         ):
             person_vars[pe_key] = None
+        for _rule_key, pe_key in (
+            *adapter.direct_spm_overrides,
+            *adapter.annual_direct_spm_overrides,
+        ):
+            spm_vars[pe_key] = None
         if variable == "co_oap":
             person_vars["ssi"] = None
         if variable == "ca_capi":
@@ -590,6 +595,8 @@ def source_variables_for_adapters(
                     "spm_unit_is_married": None,
                 }
             )
+        if variable == "mn_mfip":
+            spm_vars["mn_mfip_eligible"] = None
     return {"person": person_vars, "spm_unit": spm_vars}
 
 
@@ -602,6 +609,10 @@ def project_case_inputs(
 ) -> tuple[dict[str, Any], str | None]:
     if variable == "ca_capi":
         return project_ca_capi_inputs(row=row, spm_row=spm_row)
+    if spm_row is None and (
+        adapter.direct_spm_overrides or adapter.annual_direct_spm_overrides
+    ):
+        return {}, f"{variable}_missing_spm_unit"
     inputs: dict[str, Any] = {}
     for rule_key, pe_key in adapter.direct_person_inputs:
         inputs[rule_key] = money(row_value(row, pe_key))
@@ -627,12 +638,38 @@ def project_case_inputs(
         inputs[rule_key] = bool_value(row_value(row, pe_key))
     for rule_key, pe_key in adapter.monthly_boolean_person_inputs:
         inputs[rule_key] = bool_value(row_value(row, pe_key))
+    for rule_key, pe_key in adapter.direct_spm_overrides:
+        inputs[rule_key] = money(row_value(spm_row, pe_key))
+    for rule_key, pe_key in adapter.annual_direct_spm_overrides:
+        inputs[rule_key] = money(row_value(spm_row, pe_key)) / 12.0
     for key in adapter.unsupported_truthy_input_keys:
         inputs.setdefault(key, False)
     for key in adapter.unsupported_falsy_input_keys:
         inputs.setdefault(key, True)
     if variable == "co_state_supplement":
         inputs.setdefault("ssa_is_recovering_ssi_payment_due_to_overpayment", False)
+    if variable == "mn_mfip":
+        if not bool_value(row_value(spm_row, "mn_mfip_eligible")):
+            return {}, "mn_mfip_ineligible_spm_unit"
+        earned = money(inputs.get("net_earned_income_in_budget_month", 0.0))
+        unearned = money(inputs.get("unearned_income_in_budget_month", 0.0))
+        if unearned < 0:
+            return {}, "mn_mfip_negative_unearned_income"
+        inputs.update(
+            {
+                "unit_receives_no_income_other_than_mfip": (
+                    earned <= 0 and unearned <= 0
+                ),
+                "unit_receives_unearned_income_only": (earned <= 0 and unearned > 0),
+                "unit_has_earned_income_only": earned > 0 and unearned <= 0,
+                "unit_has_both_earned_and_unearned_income": (
+                    earned > 0 and unearned > 0
+                ),
+                "unit_is_applicant_case": False,
+                "prorated_benefit_under_section_0022_12_03": 0.0,
+                "recoupment_amount_if_applicable": 0.0,
+            }
+        )
     return inputs, None
 
 
@@ -781,6 +818,9 @@ def compare_outputs(
             "California CAPI is compared only on individual, non-couple SPM units; "
             "PE exposes CAPI as an SPM-unit surface while the encoded legal rule is "
             "a person-level final-benefit formula.",
+            "Minnesota MFIP is compared only on PE-eligible SPM units because the "
+            "encoded RuleSpec module covers the post-eligibility grant and cash "
+            "issuance calculation.",
         ],
     )
 
@@ -837,7 +877,16 @@ def calculate_policyengine(sim: Any, name: str, period: str | int) -> Any:
 
 
 def policyengine_source_period(variable: str, *, year: int, month: int) -> str | int:
-    monthly_sources = {"ssi", "ssi_countable_income", "ssi_amount_if_eligible"}
+    monthly_sources = {
+        "ssi",
+        "ssi_countable_income",
+        "ssi_amount_if_eligible",
+        "mn_mfip_countable_earned_income",
+        "mn_mfip_countable_unearned_income",
+        "mn_mfip_family_wage_level",
+        "mn_mfip_food_portion",
+        "mn_mfip_full_transitional_standard",
+    }
     if variable in monthly_sources:
         return f"{year:04d}-{month:02d}"
     return year

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2264,7 +2264,7 @@ def test_policyengine_program_surface_marks_kansas_tanf_known_not_comparable():
     assert "countable income" in kansas_tanf["rationale"]
 
 
-def test_policyengine_program_surface_marks_minnesota_mfip_wired_pending_populace_validator():
+def test_policyengine_program_surface_marks_minnesota_mfip_wired_and_populace_validated():
     report = build_policyengine_program_surface_report(program="tanf")
 
     items_by_variable = {item["variable"]: item for item in report["items"]}
@@ -2279,11 +2279,11 @@ def test_policyengine_program_surface_marks_minnesota_mfip_wired_pending_populac
         "us-mn:policies/dhs/combined-manual/0022-12/mfip-total-grant#"
         "mfip_cash_portion_issued_as_cash" in minnesota_mfip["legal_ids"]
     )
-    assert minnesota_mfip["populace_validation_status"] == "pending_validator"
+    assert minnesota_mfip["populace_validation_status"] == "validated"
+    assert minnesota_mfip["populace_validation_dataset"] == "populace-us-2024 local H5"
+    assert minnesota_mfip["populace_validation_last_run"] == "2026-07-02"
     assert "mn_mfip" in minnesota_mfip["populace_validation_command"]
-    assert (
-        "No PolicyEngine US adapter" in minnesota_mfip["populace_validation_rationale"]
-    )
+    assert "74 eligible person rows" in minnesota_mfip["populace_validation_rationale"]
 
 
 def test_policyengine_program_surface_marks_florida_tca_known_not_comparable():

--- a/tests/test_policyengine_us_populace.py
+++ b/tests/test_policyengine_us_populace.py
@@ -300,6 +300,80 @@ def test_project_co_state_supplement_keeps_monthly_pe_income_monthly():
     assert projected["ssi_payment_received_amount"] == 600
 
 
+def test_project_mn_mfip_spm_inputs_to_cash_portion_boundary():
+    adapter = get_pe_us_var_adapter("mn_mfip")
+    assert adapter is not None
+
+    projected, reason = us_populace.project_case_inputs(
+        "mn_mfip",
+        adapter,
+        row={},
+        spm_row={
+            "mn_mfip_eligible": True,
+            "mn_mfip_full_transitional_standard": 1087,
+            "mn_mfip_family_wage_level": 1195.7,
+            "mn_mfip_countable_earned_income": 467.5,
+            "mn_mfip_countable_unearned_income": 0,
+            "mn_mfip_food_portion": 445,
+        },
+    )
+
+    assert reason is None
+    assert projected["transitional_standard_for_corresponding_payment_month"] == 1087
+    assert projected["family_wage_level_for_corresponding_payment_month"] == 1195.7
+    assert projected["net_earned_income_in_budget_month"] == 467.5
+    assert projected["unearned_income_in_budget_month"] == 0
+    assert projected["mfip_food_portion_amount_under_section_0020_09"] == 445
+    assert projected["unit_has_earned_income_only"] is True
+    assert projected["unit_receives_no_income_other_than_mfip"] is False
+    assert projected["unit_is_applicant_case"] is False
+    assert projected["recoupment_amount_if_applicable"] == 0
+
+
+def test_project_mn_mfip_skips_negative_unearned_income():
+    adapter = get_pe_us_var_adapter("mn_mfip")
+    assert adapter is not None
+
+    projected, reason = us_populace.project_case_inputs(
+        "mn_mfip",
+        adapter,
+        row={},
+        spm_row={
+            "mn_mfip_eligible": True,
+            "mn_mfip_full_transitional_standard": 1087,
+            "mn_mfip_family_wage_level": 1195.7,
+            "mn_mfip_countable_earned_income": 0,
+            "mn_mfip_countable_unearned_income": -10,
+            "mn_mfip_food_portion": 445,
+        },
+    )
+
+    assert projected == {}
+    assert reason == "mn_mfip_negative_unearned_income"
+
+
+def test_project_mn_mfip_skips_ineligible_spm_units():
+    adapter = get_pe_us_var_adapter("mn_mfip")
+    assert adapter is not None
+
+    projected, reason = us_populace.project_case_inputs(
+        "mn_mfip",
+        adapter,
+        row={},
+        spm_row={
+            "mn_mfip_eligible": False,
+            "mn_mfip_full_transitional_standard": 1087,
+            "mn_mfip_family_wage_level": 1195.7,
+            "mn_mfip_countable_earned_income": 0,
+            "mn_mfip_countable_unearned_income": 0,
+            "mn_mfip_food_portion": 445,
+        },
+    )
+
+    assert projected == {}
+    assert reason == "mn_mfip_ineligible_spm_unit"
+
+
 def test_policyengine_target_period_uses_mapping_multiplier_before_monthly_adapter():
     co_oap_adapter = get_pe_us_var_adapter("co_oap")
     assert co_oap_adapter is not None
@@ -343,14 +417,17 @@ def test_policyengine_target_period_uses_mapping_multiplier_before_monthly_adapt
 
 def test_source_variables_for_adapters_excludes_target_variables():
     source_vars = us_populace.source_variables_for_adapters(
-        ("co_oap", "co_state_supplement", "ca_capi")
+        ("co_oap", "co_state_supplement", "ca_capi", "mn_mfip")
     )
 
     assert "co_oap" not in source_vars["person"]
     assert "co_state_supplement" not in source_vars["person"]
     assert "ca_capi" not in source_vars["person"]
+    assert "mn_mfip" not in source_vars["spm_unit"]
     assert "ca_capi" not in source_vars["spm_unit"]
     assert "ca_capi_eligible" in source_vars["spm_unit"]
+    assert "mn_mfip_eligible" in source_vars["spm_unit"]
+    assert "mn_mfip_full_transitional_standard" in source_vars["spm_unit"]
 
 
 def test_configure_us_populace_parser_accepts_repeated_variables():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1047"
+version = "0.2.1048"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add a PolicyEngine US adapter for Minnesota MFIP to project Populace SPM-unit component values into the encoded MFIP cash issuance rule
- compare MN MFIP only on PE-eligible SPM units because the RuleSpec module covers the post-eligibility grant/cash issuance calculation, while PE's final `mn_mfip` is zero for ineligible units
- mark the MN MFIP program surface as Populace-validated and keep the copy-runnable validation command in the manifest

## Validation
- `uv run --extra dev pytest tests/test_policyengine_us_populace.py tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_minnesota_mfip_wired_and_populace_validated`
- `uv run --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_minnesota_mfip_wired_and_populace_validated tests/test_policyengine_us_populace.py`
- `git diff --check`
- Full local Populace comparison using the real Axiom Rust rules engine: `mn_mfip` compared 74 values across 22 eligible SPM units with 0 mismatches; skipped 2,000 ineligible person rows as `mn_mfip_ineligible_spm_unit`.
