### PR TITLE
Mark Illinois AABD surface partially encoded

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1048"
+version = "0.2.1049"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1048"
+__version__ = "0.2.1049"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1927,10 +1927,12 @@ surfaces:
   variable: il_aabd
   source_type: state_implementation
   state: IL
-  axiom_status: deferred_jurisdiction
+  axiom_status: known_not_comparable
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: Illinois CSMM WAG 25-06-01 grant-adjustment and 11-01-01 personal-allowance components are encoded with
+    PolicyEngine mappings, including a direct oracle for `il_aabd_personal_allowance`. The final `il_aabd` SPM-unit
+    surface composes eligibility, countable income, shelter, utility, and person aggregation that are not yet all exposed
+    as a single one-to-one RuleSpec output.
 - country: us
   program_id: ssi_state_supplement
   program_name: New Mexico SSI supplement

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2036,6 +2036,36 @@ def test_policyengine_program_surface_marks_georgia_ssp_known_not_comparable():
     )
 
 
+def test_policyengine_program_surface_marks_illinois_aabd_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="il_aabd")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    illinois_aabd = items_by_variable["il_aabd"]
+
+    assert illinois_aabd["program_id"] == "ssi_state_supplement"
+    assert illinois_aabd["state"] == "IL"
+    assert illinois_aabd["axiom_status"] == "known_not_comparable"
+    assert illinois_aabd["mapping_count"] == 0
+    assert illinois_aabd["comparable_mapping_count"] == 0
+    assert "final `il_aabd` SPM-unit" in illinois_aabd["rationale"]
+
+    registry = load_policyengine_registry()
+    grant_amount_mapping = registry.mapping_for_legal_id(
+        "us-il:policies/dhs/csmm/25-06-01#il_aabd_grant_amount",
+        country="us",
+    )
+    assert grant_amount_mapping.policyengine_variable == "il_aabd_grant_amount"
+
+    personal_allowance_mapping = registry.mapping_for_legal_id(
+        "us-il:policies/dhs/csmm/11-01-01/personal-allowance#il_aabd_personal_allowance",
+        country="us",
+    )
+    assert personal_allowance_mapping.mapping_type == "direct_variable"
+    assert (
+        personal_allowance_mapping.policyengine_variable == "il_aabd_personal_allowance"
+    )
+
+
 def test_policyengine_program_surface_marks_michigan_ssp_known_not_comparable():
     report = build_policyengine_program_surface_report(program="mi_ssp")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1048"
+version = "0.2.1049"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- updates the US PolicyEngine program-surface manifest so Illinois AABD is no longer treated as untouched deferred-jurisdiction work
- documents that Axiom has encoded CSMM grant-adjustment and personal-allowance components, while the final `il_aabd` SPM-unit PE surface is not yet one-to-one comparable
- adds a coverage regression asserting the surface status and existing component oracle mappings
- bumps axiom-encode to 0.2.1049 for the encoder-affecting manifest change

## Tests
- `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/`
- `uv run --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_illinois_aabd_known_not_comparable`
- `uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_illinois_aabd_known_not_comparable`