### PR TITLE
Map Connecticut SSP income cap rate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1049"
+version = "0.2.1050"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1049"
+__version__ = "0.2.1050"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -1632,6 +1632,65 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec encodes the one-time 1983 statutory dollar increase for couple SSI rates; PolicyEngine stores final monthly federal benefit-rate parameters rather than this source-specific transitional increase.
 
+  - legal_id: us-ct:statutes/17b-600#ct_ssp_income_cap_rate
+    country: us
+    program: ssi_state_supplement
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ct.dss.ssp.eligibility.income_cap_rate
+    period: month
+    unit: /1
+    comparison: numeric
+    rationale: Conn. Gen. Stat. § 17b-600 states the Connecticut optional state supplementation income-cap condition as three hundred percent of the maximum SSI individual benefit; PolicyEngine stores the same 3x monthly income-cap parameter for Connecticut SSP.
+
+  - legal_id: us-ct:statutes/17b-600#ct_ssp_income_cap_multiplier
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the source multiplier used to derive the Connecticut SSP income-cap rate. PolicyEngine stores the derived income-cap rate itself, which is mapped separately, and does not expose this source multiplier as a distinct parameter.
+
+  - legal_id: us-ct:statutes/17b-600#extended_ineligibility_uncompensated_value_threshold
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the statutory uncompensated-value threshold for an extended Connecticut SSP transfer-of-assets ineligibility period. PolicyEngine does not model this source-level transfer-of-assets threshold as a one-to-one parameter or variable.
+
+  - legal_id: us-ct:statutes/17b-600#ordinary_transfer_ineligibility_period_months
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the statutory ordinary Connecticut SSP transfer-of-assets ineligibility period. PolicyEngine does not expose Connecticut SSP transfer-of-assets ineligibility periods as one-to-one parameters.
+
+  - legal_id: us-ct:statutes/17b-600#transfer_has_extended_ineligibility_period
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes a source-level predicate for the extended Connecticut SSP transfer-of-assets ineligibility period. PolicyEngine does not expose this transfer predicate as a one-to-one variable.
+
+  - legal_id: us-ct:statutes/17b-600#transfer_ineligibility_applies
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Connecticut SSP transfer-of-assets ineligibility predicate. PolicyEngine does not model this source-level transfer predicate as a one-to-one variable.
+
+  - legal_id: us-ct:statutes/17b-600#transfer_lookback_period_months
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Connecticut SSP statutory transfer lookback period. PolicyEngine does not expose this Connecticut SSP transfer lookback period as a one-to-one parameter.
+
+  - legal_id: us-ct:statutes/17b-600#trust_income_disregard_applies
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the Connecticut SSP trust-income disregard predicate for recipients under the statutory income cap. PolicyEngine does not expose this trust-income disregard predicate as a one-to-one variable.
+
   - legal_id: us-ak:policies/dpa/apa/standards/2026/state-supplement-payment-standard#a_individual_apa_payment_standard
     country: us
     program: ssi_state_supplement

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -1645,10 +1645,12 @@ surfaces:
   variable: ct_ssp
   source_type: state_implementation
   state: CT
-  axiom_status: deferred_jurisdiction
+  axiom_status: pending_rulespec_encoding
   priority: P2
-  rationale: PolicyEngine models this jurisdiction-specific surface, but Axiom is prioritizing national, Colorado, Arizona,
-    and Georgia law before other jurisdictions.
+  rationale: Axiom now encodes Conn. Gen. Stat. § 17b-600, including the statutory 300% SSI income-cap
+    rate mapped to PolicyEngine, but the final monthly Connecticut SSP amount still requires upstream
+    regulation/manual sources for resource limits, living arrangements, income disregards, allowances,
+    and standards before the PE final benefit surface can be compared.
 - country: us
   program_id: ssi_state_supplement
   program_name: Colorado SSP

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -1736,6 +1736,61 @@ def test_policyengine_program_surface_marks_alaska_ssp_known_not_comparable():
     assert "final benefit-composition surface" in ak_ssp["rationale"]
 
 
+def test_policyengine_program_surface_marks_connecticut_ssp_pending_encoding():
+    report = build_policyengine_program_surface_report(program="ct_ssp")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    ct_ssp = items_by_variable["ct_ssp"]
+
+    assert ct_ssp["program_id"] == "ssi_state_supplement"
+    assert ct_ssp["state"] == "CT"
+    assert ct_ssp["axiom_status"] == "pending_rulespec_encoding"
+    assert "Conn. Gen. Stat. § 17b-600" in ct_ssp["rationale"]
+    assert "final monthly Connecticut SSP amount" in ct_ssp["rationale"]
+
+
+def test_policyengine_coverage_maps_connecticut_ssp_income_cap_rate(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "us-ct" / "statutes/17b-600.yaml",
+        """format: rulespec/v1
+rules:
+  - name: ct_ssp_income_cap_rate
+    kind: derived
+    entity: Person
+    dtype: Rate
+    period: Month
+    versions:
+      - effective_from: '0001-01-01'
+        formula: ct_ssp_income_cap_multiplier
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "us-ct" / "statutes/17b-600.test.yaml",
+        """- name: connecticut_ssp_income_cap_rate
+  period: 2026-01
+  input: {}
+  output:
+    us-ct:statutes/17b-600#ct_ssp_income_cap_rate: 3.0
+""",
+    )
+
+    report = build_policyengine_coverage_report(
+        tmp_path,
+        program="ssi_state_supplement",
+    )
+
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    income_cap = items_by_id["us-ct:statutes/17b-600#ct_ssp_income_cap_rate"]
+
+    assert income_cap["status"] == "comparable"
+    assert income_cap["mapping_type"] == "parameter_value"
+    assert (
+        income_cap["policyengine_parameter"]
+        == "gov.states.ct.dss.ssp.eligibility.income_cap_rate"
+    )
+    assert income_cap["tested"] is True
+
+
 def test_policyengine_coverage_maps_alabama_ssp_amount_cells(tmp_path):
     _write_rulespec_file(
         tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1049"
+version = "0.2.1050"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Map the Connecticut SSP section 17b-600 income-cap RuleSpec output to PolicyEngine's `gov.states.ct.dss.ssp.eligibility.income_cap_rate` parameter.
- Mark the other section 17b-600 generated outputs as source-level intermediates that are not one-to-one PolicyEngine oracle targets.
- Move the CT SSP program surface from deferred jurisdictional work to pending RuleSpec encoding now that the upstream statute foundation is encoded.

## Checks
- `uv run ruff format tests/test_policyengine_coverage.py`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run --extra dev pytest tests/test_policyengine_coverage.py::test_policyengine_program_surface_marks_connecticut_ssp_pending_encoding tests/test_policyengine_coverage.py::test_policyengine_coverage_maps_connecticut_ssp_income_cap_rate`
- `uv run --extra dev pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump`

## Dependency
- Pairs with TheAxiomFoundation/rulespec-us#508, which adds `us-ct:statutes/17b-600` through the signed Axiom encoder apply path.
