### PR TITLE
Update Alabama TANF oracle metadata

### DIFF
--- a/changelog.d/al-tanf-oracle-metadata.changed.md
+++ b/changelog.d/al-tanf-oracle-metadata.changed.md
@@ -1,0 +1,1 @@
+Update Alabama TANF PolicyEngine oracle metadata after source-law encoding, wiring the comparable DHR manual entitlement slice while marking Populace validation blocked pending source-hierarchy review.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1053"
+version = "0.2.1054"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1053"
+__version__ = "0.2.1054"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -4513,6 +4513,32 @@ mappings:
     candidate_priority: P4
     rationale: Axiom's Arizona Cash Assistance wrapper composes DES FAA5 payment-standard, needy-family, prospective-eligibility, and eligible-no-pay issuance rules, including the under-$10 no-pay boundary. PolicyEngine's az_tanf is a final monthly SPM-unit benefit gated by PE's demographic, immigration, resource, and income graph and does not share the DES eligible-no-pay issuance boundary, so this is not a one-to-one oracle target yet.
 
+  - legal_id: us-al:policies/dhr/public-assistance-payment-manual/appendix-n/section-2/payment-computation#al_tanf_entitlement_amount
+    country: us
+    program: tanf
+    mapping_type: direct_variable
+    policyengine_variable: al_tanf
+    entity: spm_unit
+    period: month
+    unit: USD
+    comparison: money
+    rationale: >-
+      Same Alabama DHR payment-manual entitlement calculation for the subset of the legal payment computation
+      PolicyEngine models: monthly payment standard minus countable income, floored at zero, before minimum-grant,
+      sanction, recoupment, and proration adjustments.
+
+  - legal_id: us-al:regulations/alabama-administrative-code/660/2/2/10-amount-of-assistance-payment#al_tanf
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: al_tanf
+    candidate_priority: P4
+    rationale: >-
+      Axiom's Alabama Administrative Code assistance-payment output preserves the source-law minimum-grant,
+      recoupment, sanction, and final payment boundaries. PolicyEngine's al_tanf is a simplified DHR payment-manual
+      entitlement amount before those final payment adjustments, so the Admin Code final output is adjacent legal
+      coverage rather than a one-to-one oracle target.
+
   - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#adult_included_need_standard_by_family_size
     country: us
     program: tanf

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -861,10 +861,32 @@ surfaces:
   variable: al_tanf
   source_type: state_implementation
   state: AL
-  axiom_status: pending_rulespec_encoding
+  axiom_status: wired
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: >-
+    Axiom now encodes Alabama TANF payment standards from the 2024 TANF State Plan, the Alabama Administrative Code
+    assistance-payment rule, and the DHR Public Assistance Payment Manual payment-computation slice that aligns most
+    closely to PolicyEngine's simplified al_tanf entitlement calculation. Do not treat the surface as PE-parity-complete:
+    Populace validation is blocked by a source hierarchy conflict where Alabama Admin. Code r. 660-2-2-.24 states a
+    30% earned-income disregard while the DHR payment manual and PolicyEngine use 20%; PolicyEngine/policyengine-us#8840
+    tracks that upstream-law review.
+  populace_validation:
+    status: blocked
+    dataset: populace-us-2024 local H5
+    command: >-
+      AXIOM_POPULACE_US_2024_H5=/Users/maxghenis/.codex-artifacts/populace-us-fiscal-refresh-703bd81-no-oos-20260620/artifacts/populace_us_2024.h5
+      uv run --with policyengine-us --with policyengine-core==3.26.0
+      --with /Users/maxghenis/PolicyEngine/populace/packages/populace-data[us]
+      --with numpy --with pandas axiom-encode us-populace-compare
+      --root /Users/maxghenis/TheAxiomFoundation
+      --rulespec-root /Users/maxghenis/TheAxiomFoundation/rulespec-us
+      --year 2026 --month 1 --populace-year 2024
+      --variable al_tanf --sample-size 0 --max-differences 10
+    rationale: >-
+      Pending source-hierarchy resolution before running or accepting a final Populace parity result. Current RuleSpec
+      preserves both the higher Alabama Administrative Code assistance-payment rule and the delegated DHR manual
+      payment-computation rule; PolicyEngine's al_tanf currently follows the DHR manual's 20% work-expense rate and
+      does not expose every final legal payment adjustment boundary.
 - country: us
   program_id: tanf
   program_name: Alaska ATAP

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1053"
+version = "0.2.1054"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- wire the Alabama TANF DHR payment-manual entitlement slice to PolicyEngine's `al_tanf` oracle surface
- mark the Admin Code final assistance-payment output as not one-to-one comparable to PE's simplified variable
- move the Alabama TANF program surface out of pending encoding and mark Populace validation blocked pending source-hierarchy review

## Source issue
Alabama Admin. Code r. 660-2-2-.24 states a 30% earned-income disregard, while the DHR Public Assistance Payment Manual and PolicyEngine use 20%. Tracked upstream in PolicyEngine/policyengine-us#8840, so this PR does not claim Alabama TANF PE parity is complete.

## Verification
- `uv run pytest tests/test_policyengine_coverage.py tests/test_policyengine_us_populace.py -q`
- `uv run axiom-encode cloud-queue --root /Users/maxghenis/TheAxiomFoundation/rulespec-us --json` -> 34 items; `al_tanf` absent; top pending `ar_tea`
