### PR TITLE
Ground two-line table values in encoder validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1055"
+version = "0.2.1056"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1056"
+version = "0.2.1057"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1055"
+__version__ = "0.2.1056"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1056"
+__version__ = "0.2.1057"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -1004,7 +1004,12 @@ _TWO_LINE_TABLE_CONTEXT_PATTERN = re.compile(
     r"rate|standard|standards|threshold)\b",
     re.IGNORECASE,
 )
-_TWO_LINE_TABLE_ROW_KEY_PATTERN = re.compile(r"^\s*\d{1,3}\s*$")
+_TWO_LINE_TABLE_ROW_KEY_PATTERN = re.compile(
+    r"^\s*(?:\d{1,3}|"
+    r"(?:(?:\d{1,3}(?:st|nd|rd|th)|first|second|third|fourth|fifth|sixth|"
+    r"seventh|eighth|ninth|tenth)\s+[A-Za-z][A-Za-z -]*))\s*$",
+    re.IGNORECASE,
+)
 _SOURCE_SUBDIVISION_LINE_PATTERN = re.compile(
     r"^\s*\((?:\d+[A-Za-z]?|[a-z]|[ivxlcdm]+)\)\s*", re.IGNORECASE
 )

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -999,6 +999,15 @@ _SCHEDULE_SPLIT_VALUE_PATTERN = re.compile(
     r"^\s*(?:[$£€]\s*)?(-?[\d,]+(?:\.\d+)?)\s*$",
     re.IGNORECASE,
 )
+_TWO_LINE_TABLE_CONTEXT_PATTERN = re.compile(
+    r"\b(?:allowance|amount|benefit|benefits|deduction|income|limit|payment|"
+    r"rate|standard|standards|threshold)\b",
+    re.IGNORECASE,
+)
+_TWO_LINE_TABLE_ROW_KEY_PATTERN = re.compile(r"^\s*\d{1,3}\s*$")
+_SOURCE_SUBDIVISION_LINE_PATTERN = re.compile(
+    r"^\s*\((?:\d+[A-Za-z]?|[a-z]|[ivxlcdm]+)\)\s*", re.IGNORECASE
+)
 _VALUE_BEARING_TABLE_ROW_PATTERN = re.compile(
     r"^\s*[-*]?\s*[^:]+:\s*(?:[$£€]\s*)?(-?[\d,]+(?:\.\d+)?)\s*$",
     re.IGNORECASE,
@@ -2641,10 +2650,12 @@ def _call_body_contains_any(
 def extract_numbers_from_text(text: str) -> set[float]:
     """Extract numeric values from embedded statute text."""
     original_text = text
+    two_line_table_occurrences = _extract_two_line_table_value_occurrences(text)
     text = _clean_source_text_for_numeric_extraction(text)
     schedule_occurrences, text = _extract_collapsed_schedule_row_occurrences(text)
     numbers = set()
     occupied_spans: list[tuple[int, int]] = []
+    numbers.update(two_line_table_occurrences)
     numbers.update(schedule_occurrences)
 
     for match in re.finditer(
@@ -3175,14 +3186,53 @@ def _extract_collapsed_schedule_row_occurrences(
     return occurrences, "\n".join(retained_lines)
 
 
+def _extract_two_line_table_value_occurrences(text: str) -> list[float]:
+    """Extract values from official tables that alternate row key and value lines."""
+    occurrences: list[float] = []
+    table_context_active = False
+    pending_table_key = False
+
+    for line in text.splitlines():
+        stripped = line.strip().strip(_STRUCTURAL_SOURCE_QUOTE_CHARS).strip()
+        if not stripped:
+            table_context_active = False
+            pending_table_key = False
+            continue
+        if _SOURCE_SUBDIVISION_LINE_PATTERN.match(stripped):
+            table_context_active = False
+            pending_table_key = False
+            continue
+        if _TWO_LINE_TABLE_CONTEXT_PATTERN.search(stripped):
+            table_context_active = True
+
+        if table_context_active and pending_table_key:
+            value_match = _SCHEDULE_SPLIT_VALUE_PATTERN.fullmatch(stripped)
+            if value_match:
+                with contextlib.suppress(ValueError):
+                    occurrences.append(float(value_match.group(1).replace(",", "")))
+                pending_table_key = False
+                continue
+            pending_table_key = False
+
+        if table_context_active and _TWO_LINE_TABLE_ROW_KEY_PATTERN.fullmatch(stripped):
+            pending_table_key = True
+            continue
+
+        pending_table_key = False
+
+    return occurrences
+
+
 def extract_numeric_occurrences_from_text(text: str) -> list[float]:
     """Extract substantive numeric occurrences from source text, preserving repeats."""
+    two_line_table_occurrences = _extract_two_line_table_value_occurrences(text)
     cleaned = _clean_source_text_for_numeric_extraction(text)
     collapsed_schedule_occurrences, cleaned = (
         _extract_collapsed_schedule_row_occurrences(cleaned)
     )
 
-    occurrences: list[float] = list(collapsed_schedule_occurrences)
+    occurrences: list[float] = list(two_line_table_occurrences)
+    occurrences.extend(collapsed_schedule_occurrences)
     spans: list[tuple[int, int]] = []
 
     for span, value in _iter_normalized_special_numeric_matches(cleaned):

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7237,6 +7237,17 @@ rules:
           1: 557
           2: 777
           3: 979
+  - name: tanf_post_employment_payment_standard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: post_employment_program_month
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          1: 375
+          2: 275
+          3: 175
 """
 
     source_text = """GROSS MONTHLY INCOME STANDARDS (GMI)
@@ -7253,10 +7264,20 @@ $ 557
 979
 (b)
 Net monthly income standards are used to compute gross monthly income standards.
+POST-EMPLOYMENT
+PAYMENT STANDARDS
+1st Month
+$ 375
+2nd Month
+275
+3rd Month
+175
 """
 
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
-    assert {557.0, 777.0, 979.0}.issubset(extract_numbers_from_text(source_text))
+    assert {557.0, 777.0, 979.0, 375.0, 275.0, 175.0}.issubset(
+        extract_numbers_from_text(source_text)
+    )
 
 
 def test_rulespec_grounding_treats_household_size_match_keys_as_structural():

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -7220,6 +7220,45 @@ def test_numeric_occurrence_extraction_treats_escaped_newline_as_line_break():
     assert extract_numbers_from_text(escaped) == extract_numbers_from_text(actual)
 
 
+def test_rulespec_grounding_accepts_alternating_table_key_value_lines():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-mt/regulation/example/table
+rules:
+  - name: tanf_gross_monthly_income_standard
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: assistance_unit_size
+    versions:
+      - effective_from: '2026-01-01'
+        values:
+          1: 557
+          2: 777
+          3: 979
+"""
+
+    source_text = """GROSS MONTHLY INCOME STANDARDS (GMI)
+Number of
+Persons in
+Household
+Gross Monthly Income
+(GMI)
+1
+$ 557
+2
+777
+3
+979
+(b)
+Net monthly income standards are used to compute gross monthly income standards.
+"""
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert {557.0, 777.0, 979.0}.issubset(extract_numbers_from_text(source_text))
+
+
 def test_rulespec_grounding_treats_household_size_match_keys_as_structural():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1056"
+version = "0.2.1057"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1055"
+version = "0.2.1056"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- recognize official tables that alternate row-key and value lines during numeric grounding
- add a regression test for Montana-style TANF income-standard tables
- bump axiom-encode to 0.2.1056 for signed apply provenance

## Tests
- uv run --extra dev ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- uv run --extra dev python -m pytest tests/test_rulespec_validation.py -k 'alternating_table_key_value_lines or household_size_match_keys_as_structural or table_lookup_keys_as_structural or escaped_newline'