### PR TITLE
Classify Montana TANF oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1057"
+version = "0.2.1058"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1057"
+__version__ = "0.2.1058"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -4666,6 +4666,53 @@ mappings:
     candidate_priority: P4
     rationale: Axiom follows Arkansas DHS TEA Manual section 2362 and pays the maximum grant for income-eligible units below the $1,026 gross-income trigger, then rounds the 50% reduced payment at or above the trigger. PolicyEngine's current ar_tea subtracts countable income below the trigger; PolicyEngine/policyengine-us#8841 tracks that source-law review, so compare component parameters and helper predicates separately for now.
 
+  - legal_id: us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#mt_tanf_gross_monthly_income_standard
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: mt_tanf_gross_income_standard
+    candidate_priority: P4
+    rationale: Axiom exposes ARM 37.78.420's fixed gross monthly income standards table. PolicyEngine derives mt_tanf_gross_income_standard from its Montana TANF State Plan/manual FPG-year, benefit-rate, and net-to-gross parameters, so this regulatory table is not a one-to-one oracle target until the governing source hierarchy is reconciled.
+
+  - legal_id: us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#mt_tanf_net_monthly_income_standard
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: mt_tanf_net_income_standard
+    candidate_priority: P4
+    rationale: Axiom exposes ARM 37.78.420's fixed net monthly income standards table. PolicyEngine derives mt_tanf_net_income_standard from its State Plan/manual benefit-standard graph and conversion factor rather than exposing this regulatory table as a direct oracle target.
+
+  - legal_id: us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#mt_tanf_benefit_standard
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: mt_tanf_benefit_standard
+    candidate_priority: P4
+    rationale: Axiom exposes ARM 37.78.420's fixed benefit standards table. PolicyEngine derives mt_tanf_benefit_standard from State Plan/manual FPG-year and percentage parameters, so the encoded regulatory table is adjacent legal coverage rather than a one-to-one PE oracle boundary.
+
+  - legal_id: us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#mt_tanf_cash_assistance_payment_standard
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: mt_tanf_payment_standard
+    candidate_priority: P4
+    rationale: Axiom exposes ARM 37.78.420's fixed TANF cash assistance payment standards table. PolicyEngine's mt_tanf_payment_standard derives a payment standard from its State Plan/manual FPG-year and percentage parameters, so compare the legal table separately until the regulatory and state-plan sources are reconciled.
+
+  - legal_id: us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#mt_tanf_post_employment_payment_standard
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: Axiom exposes ARM 37.78.420's separate TANF Cash Assistance Post-Employment Program payment-standard table. PolicyEngine does not model this post-employment payment-standard branch as a distinct Montana TANF oracle surface.
+
+  - legal_id: us-mt:regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420#mt_tanf_payment_standard
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: mt_tanf_payment_standard
+    candidate_priority: P4
+    rationale: Axiom's ARM 37.78.420 output chooses between the fixed cash assistance payment-standard table and the post-employment table. PolicyEngine's mt_tanf_payment_standard uses a State Plan/manual FPG-year/rate formula and does not expose the post-employment branch, so this is not currently a one-to-one comparison target.
+
   - legal_id: us-ak:policies/dpa/atap/standards/2026/adult-included#adult_included_need_standard_by_family_size
     country: us
     program: tanf

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -339,10 +339,13 @@ surfaces:
   variable: mt_tanf
   source_type: state_implementation
   state: MT
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom now encodes ARM 37.78.420's fixed Montana TANF income-standard and payment-standard tables as upstream
+    legal coverage. PolicyEngine's mt_tanf is a final monthly benefit surface using a State Plan/manual FPG-year/rate graph,
+    countable-income calculations, eligibility gates, and no post-employment payment-standard branch, so keep the current
+    ARM slice known-not-comparable until the State Plan/manual versus regulation hierarchy is reconciled and a full legal
+    program composition is encoded.
 - country: us
   program_id: tanf
   program_name: North Carolina TANF

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1057"
+version = "0.2.1058"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify ARM 37.78.420 Montana TANF outputs as PolicyEngine known-not-comparable rather than unmapped
- update the Montana TANF program-surface rationale to reflect the ARM table versus PolicyEngine State Plan/manual formula boundary
- bump axiom-encode to 0.2.1058 for RuleSpec toolchain pinning

## Tests
- uv run --extra dev ruff check src/axiom_encode/oracles/policyengine tests/test_policyengine_coverage.py
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k 'mappings or program_surface or oracle_coverage or tanf'
- AXIOM_RULESPEC_REPO_ROOTS=/tmp/axiom-rulespec-us-mt-tanf-ci-root/rulespec-us:/Users/maxghenis/TheAxiomFoundation/rulespec-us uv run axiom-encode oracle-coverage --root /tmp/axiom-rulespec-us-mt-tanf-ci-root --json > /tmp/axiom-rulespec-us-mt-tanf-ci-root/coverage-1058.json
