### PR TITLE
Repair source child rule source coverage

### DIFF
--- a/changelog.d/source-child-rule-sources.fixed.md
+++ b/changelog.d/source-child-rule-sources.fixed.md
@@ -1,0 +1,1 @@
+Repair source-subparagraph coverage gaps by adding canonical child corpus citations to matching generated rule sources.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1058"
+version = "0.2.1059"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1058"
+__version__ = "0.2.1059"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -25828,6 +25828,13 @@ def _try_repair_generated_source_child_corpus_paths_for_apply(
     issues: list[str],
 ) -> list[str]:
     """Point generated source verification at the matching child corpus row."""
+    repaired_sources = _try_repair_generated_source_subparagraph_rule_sources_for_apply(
+        result,
+        issues=issues,
+    )
+    if repaired_sources:
+        return repaired_sources
+
     literals = _ungrounded_numeric_literal_issue_values(issues)
     if not literals:
         return []
@@ -25884,6 +25891,200 @@ def _try_repair_generated_source_child_corpus_paths_for_apply(
         return []
     rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
     return [f"{path}->{child_corpus_path}" for path in parent_paths]
+
+
+def _try_repair_generated_source_subparagraph_rule_sources_for_apply(
+    result,
+    *,
+    issues: list[str],
+) -> list[str]:
+    """Add canonical child corpus citations to rules that cover source gaps."""
+    source_gaps = [
+        gap
+        for issue in issues
+        if "Source sub-paragraph coverage missing" in str(issue)
+        for gap in [_parse_source_coverage_gap_issue(str(issue))]
+        if gap is not None
+    ]
+    if not source_gaps:
+        return []
+
+    rules_file = Path(str(getattr(result, "output_file", "") or ""))
+    if not rules_file.exists():
+        return []
+    try:
+        payload = yaml.safe_load(rules_file.read_text()) or {}
+    except (OSError, yaml.YAMLError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    rules = payload.get("rules")
+    if not isinstance(rules, list) or not rules:
+        return []
+
+    repaired: list[str] = []
+    for citation, excerpt in source_gaps:
+        label = _source_coverage_gap_top_level_label(citation)
+        if not label:
+            continue
+        rule = _best_rule_for_source_coverage_gap(
+            rules,
+            label=label,
+            excerpt=excerpt,
+            citation=citation,
+        )
+        if rule is None:
+            continue
+        source = str(rule.get("source") or "").strip()
+        if citation in source:
+            continue
+        rule["source"] = _append_source_citation(source, citation)
+        name = str(rule.get("name") or "rules[]").strip()
+        repaired.append(f"{name}->{citation}")
+
+    if not repaired:
+        return []
+    rules_file.write_text(yaml.safe_dump(payload, sort_keys=False, allow_unicode=False))
+    return repaired
+
+
+def _source_coverage_gap_top_level_label(citation: str) -> str:
+    match = re.search(r"\(([A-Za-z0-9]+)\)\s*$", str(citation or ""))
+    return match.group(1).lower() if match is not None else ""
+
+
+def _append_source_citation(source: str, citation: str) -> str:
+    citation = citation.strip()
+    if not source:
+        return citation
+    if source.endswith((".", ";")):
+        return f"{source} {citation}"
+    return f"{source}; {citation}"
+
+
+def _best_rule_for_source_coverage_gap(
+    rules: list[object],
+    *,
+    label: str,
+    excerpt: str,
+    citation: str,
+) -> dict[str, object] | None:
+    best_rule: dict[str, object] | None = None
+    best_score = 0
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if not _is_executable_rulespec_rule(rule):
+            continue
+        source = str(rule.get("source") or "").strip()
+        if citation in source:
+            continue
+        score = _source_gap_rule_match_score(rule, label=label, excerpt=excerpt)
+        if score > best_score:
+            best_rule = rule
+            best_score = score
+    if best_score <= 0:
+        return None
+    return best_rule
+
+
+_SOURCE_GAP_RULE_MATCH_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "based",
+    "be",
+    "by",
+    "can",
+    "cannot",
+    "each",
+    "for",
+    "from",
+    "has",
+    "if",
+    "in",
+    "is",
+    "it",
+    "level",
+    "monthly",
+    "of",
+    "on",
+    "or",
+    "program",
+    "sets",
+    "size",
+    "standard",
+    "standards",
+    "tanf",
+    "the",
+    "to",
+    "used",
+    "which",
+}
+
+
+def _source_gap_rule_match_score(
+    rule: dict[str, object],
+    *,
+    label: str,
+    excerpt: str,
+) -> int:
+    source = str(rule.get("source") or "")
+    source_lower = source.lower()
+    score = 0
+    if re.search(rf"\({re.escape(label)}\)", source_lower):
+        score += 50
+    if re.search(rf"\(\d+\)\s*\({re.escape(label)}\)", source_lower):
+        score += 20
+
+    excerpt_tokens = _source_gap_match_tokens(excerpt)
+    if not excerpt_tokens:
+        return score
+    name_tokens = _source_gap_match_tokens(str(rule.get("name") or ""))
+    source_tokens = _source_gap_match_tokens(source)
+    metadata_tokens = _source_gap_match_tokens(
+        _rulespec_rule_metadata_search_text(rule)
+    )
+    score += 8 * len(excerpt_tokens & name_tokens)
+    score += 3 * len(excerpt_tokens & source_tokens)
+    score += 2 * len(excerpt_tokens & metadata_tokens)
+    return score
+
+
+def _source_gap_match_tokens(text: str) -> set[str]:
+    tokens = {
+        token
+        for token in re.findall(r"[a-z0-9]+", str(text or "").lower())
+        if len(token) > 2 and token not in _SOURCE_GAP_RULE_MATCH_STOPWORDS
+    }
+    if "employment" in tokens or "employed" in tokens:
+        tokens.add("employment")
+    return tokens
+
+
+def _rulespec_rule_metadata_search_text(rule: dict[str, object]) -> str:
+    metadata = rule.get("metadata")
+    if not isinstance(metadata, (dict, list)):
+        return ""
+
+    values: list[str] = []
+
+    def collect(value: object) -> None:
+        if isinstance(value, str):
+            values.append(value)
+            return
+        if isinstance(value, dict):
+            for item in value.values():
+                collect(item)
+            return
+        if isinstance(value, list):
+            for item in value:
+                collect(item)
+
+    collect(metadata)
+    return " ".join(values)
 
 
 def _relative_output_to_child_corpus_citation_path(

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -9897,9 +9897,13 @@ def _rule_source_subparagraph_paths(
     citation_path: str,
 ) -> set[tuple[str, ...]]:
     paths: set[tuple[str, ...]] = set()
-    for _name, _kind, _formula, source, _rule in _rulespec_rule_formula_rule_records(
-        payload
-    ):
+    rules = payload.get("rules")
+    if not isinstance(rules, list):
+        return paths
+    for rule in rules:
+        if not _is_executable_rulespec_rule(rule):
+            continue
+        source = rule.get("source")
         if isinstance(source, str):
             paths.update(_source_citation_subparagraph_paths(source, citation_path))
     return paths

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20196,6 +20196,77 @@ rules:
         proof_source = payload["rules"][0]["metadata"]["proof"]["steps"][0]["source"]
         assert proof_source["corpus_citation_path"] == "us/statute/42/1396a/xx"
 
+    def test_source_child_corpus_path_repair_adds_rule_source_child_citations(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        rules_file = (
+            output_root
+            / "deterministic-repair"
+            / "regulations/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420.yaml"
+        )
+        rules_file.parent.mkdir(parents=True)
+        rules_repo = tmp_path / "rulespec-us" / "us-mt"
+        rules_file.write_text(
+            """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420
+rules:
+  - name: mt_tanf_gross_monthly_income_standard
+    kind: parameter
+    dtype: Money
+    source: ARM 37.78.420(4)(a), Gross Monthly Income Standards
+    versions:
+      - effective_from: '2011-01-28'
+        formula: 557
+  - name: mt_tanf_post_employment_payment_standard
+    kind: parameter
+    dtype: Money
+    source: ARM 37.78.420(4)(e), Post-Employment Payment Standards
+    versions:
+      - effective_from: '2011-01-28'
+        formula: 375
+"""
+        )
+        result = SimpleNamespace(
+            runner="deterministic-repair",
+            output_file=str(rules_file),
+        )
+
+        repaired = _try_repair_generated_source_child_corpus_paths_for_apply(
+            result,
+            output_root=output_root,
+            rules_repo_path=rules_repo,
+            issues=[
+                "ci: Source sub-paragraph coverage missing: "
+                "us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420(a) "
+                "('The gross monthly income (GMI) standard sets the level of gross monthly income') "
+                "has no rule citing it and no entry in `module.deferred_outputs`.",
+                "ci: Source sub-paragraph coverage missing: "
+                "us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420(e) "
+                "('The payment standards for the TANF Cash Assistance Post-Employment Program') "
+                "has no rule citing it and no entry in `module.deferred_outputs`.",
+            ],
+        )
+
+        assert repaired == [
+            "mt_tanf_gross_monthly_income_standard->"
+            "us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420(a)",
+            "mt_tanf_post_employment_payment_standard->"
+            "us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420(e)",
+        ]
+        payload = yaml.safe_load(rules_file.read_text())
+        sources = {rule["name"]: rule["source"] for rule in payload["rules"]}
+        assert (
+            "us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/"
+            "rule-37-78-420(a)" in sources["mt_tanf_gross_monthly_income_standard"]
+        )
+        assert (
+            "us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/"
+            "rule-37-78-420(e)" in sources["mt_tanf_post_employment_payment_standard"]
+        )
+
     def test_source_child_corpus_path_repair_requires_grounded_literal(self, tmp_path):
         output_root = tmp_path / "out"
         rules_file = output_root / "codex-gpt-5.5" / "statutes/42/1396a/xx.yaml"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -19280,6 +19280,37 @@ rules:
     )
 
 
+def test_source_subparagraph_coverage_allows_parameter_rule_citing_child():
+    source_text = """Income standards
+(a) The gross monthly income standard sets the level of gross monthly income.
+"""
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420
+rules:
+  - name: mt_tanf_gross_monthly_income_standard
+    kind: parameter
+    dtype: Money
+    period: Month
+    source: us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420(a)
+    versions:
+      - effective_from: '2011-01-28'
+        values:
+          1: 557
+"""
+
+    assert (
+        find_source_subparagraph_coverage_issues(
+            content,
+            source_texts={
+                "us-mt/regulation/title-37/chapter-37-78/subchapter-37-78-4/rule-37-78-420": source_text
+            },
+        )
+        == []
+    )
+
+
 def test_source_subparagraph_coverage_allows_source_relation_citing_child():
     source_text = """Definitions
 (m) American vessel and aircraft For purposes of this chapter, the term American vessel means any vessel documented or numbered under the laws of the United States; and the term American aircraft means an aircraft registered under the laws of the United States.

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1058"
+version = "0.2.1059"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- teach the source-child repair to handle source-subparagraph coverage failures by appending canonical child corpus citations to matching generated rule sources
- keep the existing numeric child corpus path repair behavior unchanged
- bump axiom-encode to 0.2.1059

## Tests
- uv run pytest tests/test_cli.py -k source_child_corpus_path_repair
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- git diff --check