### PR TITLE
Accept word-form percentages in numeric grounding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1059"
+version = "0.2.1060"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1059"
+__version__ = "0.2.1060"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -2744,6 +2744,17 @@ def _iter_normalized_special_numeric_matches(
     fraction_chars = "".join(re.escape(glyph) for glyph in _UNICODE_FRACTION_VALUES)
 
     for match in re.finditer(
+        rf"\b(?P<number>{_CARDINAL_NUMBER_WORD_PATTERN.pattern})\s+"
+        r"(?:percent|per\s*cent(?:um)?)\b",
+        text,
+        re.IGNORECASE,
+    ):
+        value = _parse_cardinal_number_words(match.group("number"))
+        if value is None:
+            continue
+        matches.append((match.span(), value / 100))
+
+    for match in re.finditer(
         rf"\b(?:(?P<whole>{_CARDINAL_WORD_SEQUENCE})\s+and\s+)?"
         rf"(?P<fraction>{_FRACTION_WORD_PATTERN})\s+"
         r"(?:percent|per\s*cent(?:um)?)\b",

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -23222,6 +23222,42 @@ rules:
     assert issues == []
 
 
+def test_numeric_grounding_accepts_cardinal_word_percentages_above_one():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ct/statute/17b-112
+rules:
+  - name: tfa_transitional_earnings_disregard_limit_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '2.30'
+  - name: tfa_transitional_reduction_lower_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '1.71'
+"""
+
+    source_text = (
+        "Earnings shall be disregarded if income is less than or equal to "
+        "two hundred thirty per cent of the federal poverty level. A family "
+        "with earnings over one hundred seventy-one per cent but less than "
+        "or equal to two hundred thirty per cent shall receive a reduction."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    source_values = extract_numbers_from_text(source_text)
+    assert 2.30 in source_values
+    assert 1.71 in source_values
+    occurrence_values = extract_numeric_occurrences_from_text(source_text)
+    assert 2.30 in occurrence_values
+    assert 1.71 in occurrence_values
+
+
 def test_numeric_grounding_accepts_fpl_percentage_table_rate_values():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1059"
+version = "0.2.1060"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- Treat cardinal word percentages like `two hundred thirty per cent` as grounded numeric rates.
- Add regression coverage for Connecticut-style TANF/TFA thresholds above 100 percent.

## Tests
- `uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`
- `uv run pytest tests/test_rulespec_validation.py -k "cardinal_word_percentages_above_one or decimal_rate_values_as_hyphenated_percentages or fractional_decimal_rate_values_as_word_percentages or unicode_fraction_percentage_rate"`
- `uv run pytest tests/test_rulespec_validation.py -k "ungrounded_numeric_accepts_source or grounding_accepts or source_verification_accepts_decimal_rate_values_as_word_percentages or source_verification_accepts_fractional_decimal_rate_values_as_word_percentages"`