### PR TITLE
Support state statute source coverage paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1060"
+version = "0.2.1061"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1060"
+__version__ = "0.2.1061"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -10125,8 +10125,8 @@ def _source_subparagraph_citation_pattern(citation_path: str) -> re.Pattern[str]
             r"(?P<suffix>(?:\([A-Za-z0-9]+\))+)",
             flags=re.IGNORECASE,
         )
-    if len(parts) >= 4 and parts[0].startswith("us-") and parts[1] == "statute":
-        section = re.escape(parts[3])
+    if len(parts) >= 3 and parts[0].startswith("us-") and parts[1] == "statute":
+        section = re.escape(parts[-1])
         return re.compile(
             rf"(?<![\w.-])(?:{exact_corpus_path}|{section}|C\.?\s*R\.?\s*S\.?\s*{section})"
             r"(?P<suffix>(?:\([A-Za-z0-9]+\))+)",
@@ -10178,6 +10178,8 @@ def _rulespec_base_parts_for_corpus_path(citation_path: str) -> tuple[str, ...]:
         and (parts[0] == "us" or parts[0].startswith("us-"))
     ):
         return ("statutes", parts[2], parts[3])
+    if len(parts) >= 3 and parts[0].startswith("us-") and parts[1] == "statute":
+        return ("statutes", parts[2])
     if len(parts) >= 5 and parts[:2] == ["us", "regulation"]:
         return ("regulations", f"{parts[2]}-cfr", parts[3], parts[4])
     if len(parts) >= 3 and parts[0].startswith("us-") and parts[1] == "regulation":
@@ -10210,8 +10212,8 @@ def _format_source_subparagraph_citation(citation_path: str, label: str) -> str:
     parts = citation_path.strip("/").split("/")
     if len(parts) >= 4 and parts[:2] == ["us", "statute"]:
         return f"{parts[2]} USC {parts[3]}({label})"
-    if len(parts) >= 4 and parts[0].startswith("us-") and parts[1] == "statute":
-        return f"{parts[3]}({label})"
+    if len(parts) >= 3 and parts[0].startswith("us-") and parts[1] == "statute":
+        return f"{parts[-1]}({label})"
     if len(parts) >= 5 and parts[:2] == ["us", "regulation"]:
         return f"{parts[2]} CFR {parts[3]}.{parts[4]}({label})"
     return f"{citation_path}({label})"

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -19168,6 +19168,60 @@ rules: []
     )
 
 
+def test_source_subparagraph_coverage_accepts_state_statute_section_rule():
+    source_text = """Temporary family assistance
+(a) Cash assistance benefits shall be provided to a family for not longer than thirty-six months.
+"""
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ct/statute/17b-112
+  summary: Connecticut temporary family assistance.
+rules:
+  - name: initial_time_limited_benefit_limit_months
+    kind: parameter
+    dtype: Count
+    source: us-ct/statute/17b-112(a)
+    versions:
+      - effective_from: '0001-01-01'
+        formula: 36
+"""
+
+    assert (
+        find_source_subparagraph_coverage_issues(
+            content,
+            rules_file=Path("statutes/17b-112.yaml"),
+            source_texts={"us-ct/statute/17b-112": source_text},
+        )
+        == []
+    )
+
+
+def test_source_subparagraph_coverage_accepts_state_statute_section_deferred_output():
+    source_text = """Temporary family assistance
+(f) A family leaving assistance at the end of the time limit shall have a department interview.
+"""
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-ct/statute/17b-112
+  summary: Connecticut temporary family assistance.
+  deferred_outputs:
+    - output: us-ct:statutes/17b-112/f#exit_interview_and_referral_process
+      reason: Administrative workflow is outside the supported benefit computation schema.
+rules: []
+"""
+
+    assert (
+        find_source_subparagraph_coverage_issues(
+            content,
+            rules_file=Path("statutes/17b-112.yaml"),
+            source_texts={"us-ct/statute/17b-112": source_text},
+        )
+        == []
+    )
+
+
 def test_source_subparagraph_coverage_accepts_state_policy_corpus_source():
     source_text = """Standard of need
 (g) Regular recurring monthly needs are set by the statewide schedule.

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1060"
+version = "0.2.1061"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- recognize state statute corpus paths shaped like us-ct/statute/17b-112 in source-subparagraph coverage
- map those sources to statutes/<section> RuleSpec paths for rule and deferred-output coverage
- add regression tests for CT-style state statute rule and deferred-output coverage

## Tests
- uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- uv run ruff format --check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py
- uv run pytest tests/test_rulespec_validation.py -k state_statute_section
- uv run pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump