### PR TITLE
Map Connecticut TFA oracle surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1061"
+version = "0.2.1062"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1061"
+__version__ = "0.2.1062"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -3865,6 +3865,70 @@ mappings:
     candidate_priority: P4
     rationale: Axiom's Colorado Works FY 2026 program bridge exposes the encoded basic cash assistance grant before pregnancy allowance. PolicyEngine's co_tanf is a final TANF benefit surface built from PE's own Colorado Works graph, so the bridge is adjacent PE coverage but not a one-to-one oracle until the remaining Colorado Works eligibility, allowance, and procedural gates are composed.
 
+  - legal_id: us-ct:programs/tanf/fy-2026#ct_tfa_need_standard
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ct_tfa_need_standard
+    candidate_priority: P4
+    rationale: Axiom's Connecticut TFA FY 2026 bridge exposes the Conn. Gen. Stat. 17b-104 standard-of-need rate applied to a source-law family federal-poverty-level input. PolicyEngine's ct_tfa_need_standard projects the value through PE's SPM-unit TANF FPG graph, so this bridge is adjacent but not yet a one-to-one oracle boundary.
+
+  - legal_id: us-ct:programs/tanf/fy-2026#ct_tfa_payment_standard
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ct_tfa_payment_standard
+    candidate_priority: P4
+    rationale: Axiom's Connecticut TFA FY 2026 bridge composes the statutory 73 percent payment standard from the statutory standard of need. PolicyEngine's ct_tfa_payment_standard also carries historical regional-standard branches and PE SPM-unit projections, so this source-law bridge is adjacent rather than a one-to-one oracle target.
+
+  - legal_id: us-ct:programs/tanf/fy-2026#ct_tfa_subsidized_housing_attributed_income
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ct_tfa
+    candidate_priority: P4
+    rationale: Axiom exposes the Conn. Gen. Stat. 17b-104(d) 8 percent subsidized-housing attributed-income amount as its own legal output. PolicyEngine folds the same concept into the final ct_tfa benefit through a 92 percent adjusted-standard parameter, so this helper is not a one-to-one PE variable.
+
+  - legal_id: us-ct:programs/tanf/fy-2026#ct_tfa_payment_standard_after_housing_attribution
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ct_tfa
+    candidate_priority: P4
+    rationale: Axiom's Connecticut TFA housing-adjusted payment-standard bridge preserves the statute's 8 percent attributed-income framing before final benefit composition. PolicyEngine embeds the equivalent housing adjustment inside ct_tfa's final graph, so this intermediate output is not directly comparable.
+
+  - legal_id: us-ct:programs/tanf/fy-2026#ct_tfa_resources_eligible
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ct_tfa_resources_eligible
+    candidate_priority: P4
+    rationale: Axiom's Connecticut TFA FY 2026 bridge applies the Conn. Gen. Stat. 17b-112 family asset limit. PolicyEngine's adjacent resource helper is projected through PE's SPM-unit asset graph, so this source-law eligibility output is adjacent until shared TFA resource inputs are wired.
+
+  - legal_id: us-ct:programs/tanf/fy-2026#ct_tfa_income_eligible
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ct_tfa_income_eligible
+    candidate_priority: P4
+    rationale: Axiom's Connecticut TFA FY 2026 bridge composes the statutory recipient gross-earnings rule with an incomplete application-income branch. PolicyEngine separates enrolled-recipient and new-applicant income tests through its own countable-income graph, so this output is not yet a direct oracle target.
+
+  - legal_id: us-ct:programs/tanf/fy-2026#ct_tfa_eligible
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ct_tfa_eligible
+    candidate_priority: P4
+    rationale: Axiom's Connecticut TFA FY 2026 wrapper currently composes source-law financial and child-support-cooperation gates. PolicyEngine's ct_tfa_eligible also includes PE demographic and immigration projections, so the wrapper remains incomplete and not one-to-one.
+
+  - legal_id: us-ct:programs/tanf/fy-2026#ct_tfa
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ct_tfa
+    candidate_priority: P4
+    rationale: Axiom's Connecticut TFA FY 2026 bridge composes the 17b-104 payment-standard, housing-attribution, 17b-112 asset, income, child-support, and high-earnings statutory slices, but does not yet encode all demographic, immigration, time-limit, exemption, extension, or application-income mechanics. PolicyEngine's ct_tfa is a final monthly SPM-unit benefit built from PE's own graph, so this is source-faithful progress toward parity but not a one-to-one oracle surface yet.
+
   - legal_id: us-ny:programs/tanf/fy-2026#ny_tanf
     country: us
     program: tanf

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -738,10 +738,14 @@ surfaces:
   variable: ct_tfa
   source_type: state_implementation
   state: CT
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom now has a country-level Connecticut TFA FY 2026 program bridge for the source-grounded
+    standard-of-need, payment-standard, housing-attribution, resource, income, child-support, and high-earnings
+    statute slices. That bridge intentionally remains incomplete for demographic eligibility, immigration
+    eligibility, time-limit exemptions, extensions, and application-vs-recipient income boundaries, while
+    PolicyEngine's ct_tfa is a final monthly SPM-unit benefit built from PE's own graph. Keep as
+    known-not-comparable until the remaining legal gates and shared entity boundary are composed.
 - country: us
   program_id: tanf
   program_name: Ohio Works First

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2228,6 +2228,22 @@ def test_policyengine_program_surface_marks_colorado_tanf_known_not_comparable()
     assert "before pregnancy allowance" in colorado_tanf["rationale"]
 
 
+def test_policyengine_program_surface_marks_connecticut_tfa_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    connecticut_tfa = items_by_variable["ct_tfa"]
+
+    assert connecticut_tfa["program_id"] == "tanf"
+    assert connecticut_tfa["state"] == "CT"
+    assert connecticut_tfa["axiom_status"] == "known_not_comparable"
+    assert connecticut_tfa["mapping_count"] >= 1
+    assert connecticut_tfa["comparable_mapping_count"] == 0
+    assert "us-ct:programs/tanf/fy-2026#ct_tfa" in connecticut_tfa["legal_ids"]
+    assert "Connecticut TFA FY 2026 program bridge" in connecticut_tfa["rationale"]
+    assert "time-limit exemptions" in connecticut_tfa["rationale"]
+
+
 def test_policyengine_program_surface_marks_arizona_tanf_known_not_comparable():
     report = build_policyengine_program_surface_report(program="tanf")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1061"
+version = "0.2.1062"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark Connecticut TFA as a known-not-comparable PolicyEngine program surface
- add explicit not-comparable mappings for the CT TFA FY 2026 RuleSpec bridge outputs
- cover the classification in PolicyEngine coverage tests

## Validation
- uv run ruff check tests/test_policyengine_coverage.py
- uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -k 'connecticut_tfa or includes_program_spec_outputs or classifies_kansas_tanf_program_outputs'
- uv run --with pytest --with pytest-cov python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump
