### PR TITLE
Wire Texas TANF program surface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1062"
+version = "0.2.1063"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1062"
+__version__ = "0.2.1063"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -5234,6 +5234,14 @@ mappings:
     candidate_priority: P4
     rationale: The Kansas TANF program wrapper composes KEESM 7411 maximum benefit with KEESM 7401/7402 cash proration and rounding, but does not yet encode countable income, income/resource eligibility, demographic eligibility, or immigration eligibility. PolicyEngine-US ks_tanf applies those PE graph gates and a maximum-benefit-minus-countable-income formula, so this surface is currently known not comparable.
 
+  - legal_id: us-tx:programs/tanf/fy-2026#tx_tanf
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: tx_tanf
+    candidate_priority: P4
+    rationale: The Texas TANF program wrapper composes the HHSC Texas Works Handbook C-111 payment-standard table, A-1340 grant calculation, and C-112 first-month proration, but does not yet encode nonfinancial eligibility, resources, sanctions, time limits, or the full income-budget path. PolicyEngine-US tx_tanf applies PE's broader SPM-unit TANF graph, so this bridge is source-faithful progress but not a one-to-one oracle target.
+
   - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_thirty_dollar_earned_income_disregard
     country: us
     program: tanf

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -384,10 +384,12 @@ surfaces:
   variable: tx_tanf
   source_type: state_implementation
   state: TX
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Current RuleSpec repos include a Texas TANF FY 2026 program bridge over the HHSC Texas Works Handbook C-111 payment-standard table,
+    A-1340 grant-amount rule, and C-112 first-month proration. The bridge remains incomplete for nonfinancial eligibility, resource,
+    sanction, time-limit, and full income-budget gates, while PolicyEngine's tx_tanf is a final SPM-unit benefit built from PE's broader
+    TANF graph, so this is source-faithful progress but not a one-to-one oracle target yet.
 - country: us
   program_id: tanf
   program_name: Washington TANF

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2280,6 +2280,22 @@ def test_policyengine_program_surface_marks_alaska_atap_known_not_comparable():
     assert "earned-income deductions" in alaska_atap["rationale"]
 
 
+def test_policyengine_program_surface_marks_texas_tanf_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    texas_tanf = items_by_variable["tx_tanf"]
+
+    assert texas_tanf["program_id"] == "tanf"
+    assert texas_tanf["state"] == "TX"
+    assert texas_tanf["axiom_status"] == "known_not_comparable"
+    assert texas_tanf["mapping_count"] == 1
+    assert texas_tanf["comparable_mapping_count"] == 0
+    assert "us-tx:programs/tanf/fy-2026#tx_tanf" in texas_tanf["legal_ids"]
+    assert "Texas TANF FY 2026 program bridge" in texas_tanf["rationale"]
+    assert "C-112 first-month proration" in texas_tanf["rationale"]
+
+
 def test_policyengine_program_surface_marks_massachusetts_tafdc_known_not_comparable():
     report = build_policyengine_program_surface_report(program="tanf")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1062"
+version = "0.2.1063"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- mark Texas TANF as encoded-but-known-not-comparable in the PolicyEngine program-surface manifest
- add an exact oracle mapping for `us-tx:programs/tanf/fy-2026#tx_tanf`
- add a regression test for the Texas TANF program-surface classification

## Verification
- `uv run --with pytest --with pytest-cov python -m pytest tests/test_policyengine_coverage.py -k "texas_tanf or program_surface_marks_alaska_atap_known_not_comparable or classifies_kansas_tanf_program_outputs"`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-tx-tanf-20260702 --oracle policyengine --include-program-surfaces --program tanf --fail-on-untested-comparable --fail-on-incomplete-comparable --limit 40`

## Parity effect
- TANF PolicyEngine program surfaces: active pending drops from 31 to 30 with the paired rulespec-us bridge.
- `tx_tanf` now reports `known_not_comparable` with legal ID `us-tx:programs/tanf/fy-2026#tx_tanf`.

## Notes
- This is paired with TheAxiomFoundation/rulespec-us#516.
- The mapping does not claim Populace parity; the bridge is incomplete for nonfinancial eligibility, resource, sanction, time-limit, and full income-budget gates.
