### PR TITLE
Map Utah FEP payment standard oracle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1063"
+version = "0.2.1064"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1063"
+__version__ = "0.2.1064"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/adapters.py
+++ b/src/axiom_encode/oracles/policyengine/adapters.py
@@ -416,6 +416,14 @@ PE_US_VAR_ADAPTERS = (
         default_state_code="MA",
     ),
     PolicyEngineUSVarAdapter(
+        rule_names=("ut_fep_payment_standard",),
+        pe_var="ut_fep_payment_standard",
+        monthly=True,
+        spm=True,
+        annual_direct_spm_overrides=(("assistance_unit_size", "spm_unit_size"),),
+        default_state_code="UT",
+    ),
+    PolicyEngineUSVarAdapter(
         rule_names=("ma_tafdc_infant_benefit",),
         pe_var="ma_tafdc_infant_benefit",
         boolean_person_inputs=(

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -20176,6 +20176,41 @@ mappings:
     comparison: money
     rationale: Same Minnesota monthly MFIP cash-benefit surface after subtracting the food portion from the total MFIP grant, which is the boundary PolicyEngine exposes as mn_mfip.
 
+  - legal_id: us-ut:policies/dws/eligibility-manual/table-1-financial-monthly-income-limits#gross_income_test_limit
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ut_fep_gross_income_eligible
+    candidate_priority: P4
+    rationale: Utah DWS Table 1 exposes the monthly gross-income-test dollar threshold as a source-table value. PolicyEngine's ut_fep_gross_income_eligible computes a boolean eligibility predicate from standard-needs-budget and gross-income-limit parameters, not this source-table dollar row as a one-to-one oracle output.
+
+  - legal_id: us-ut:policies/dws/eligibility-manual/table-1-financial-monthly-income-limits#net_income_test_snb
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ut_fep_net_income_eligible
+    candidate_priority: P4
+    rationale: Utah DWS Table 1 exposes the standard-needs-budget net-income-test dollar row. PolicyEngine's ut_fep_net_income_eligible exposes the downstream boolean eligibility predicate, so the raw source-table dollar row is adjacent legal coverage rather than a one-to-one oracle target.
+
+  - legal_id: us-ut:policies/dws/eligibility-manual/table-1-financial-monthly-income-limits#fep_fep_tp_max_assistance
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ut_fep_payment_standard
+    candidate_priority: P4
+    rationale: Utah DWS Table 1's FEP/FEP-TP maximum-assistance column is the raw source table used by the executable ut_fep_payment_standard output. Compare the derived payment-standard legal output to PolicyEngine, rather than treating the raw table column as a second independent oracle surface.
+
+  - legal_id: us-ut:policies/dws/eligibility-manual/table-1-financial-monthly-income-limits#ut_fep_payment_standard
+    country: us
+    program: tanf
+    mapping_type: direct_variable
+    policyengine_variable: ut_fep_payment_standard
+    entity: spm_unit
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Utah DWS FEP/FEP-TP monthly payment standard by assistance-unit size, represented in PolicyEngine as ut_fep_payment_standard.
+
 prefixes:
   - legal_id_prefix: us:statutes/42/426
     country: us

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -865,8 +865,9 @@ surfaces:
   state: UT
   axiom_status: pending_rulespec_encoding
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom has a source-backed Utah DWS Table 1 payment-standard encoding and oracle mapping for
+    ut_fep_payment_standard. Final ut_fep parity still requires encoding the remaining income, eligibility, assistance-unit,
+    and benefit-composition rules from Utah's upstream R986-200/DWS sources before claiming full program parity.
 - country: us
   program_id: tanf
   program_name: Kentucky K-TAP

--- a/tests/test_policyengine_coverage_monorepo.py
+++ b/tests/test_policyengine_coverage_monorepo.py
@@ -40,6 +40,30 @@ rules:
         formula: tanf_basic_allowance + tanf_shelter_allowance
 """
 
+_UT_FEP_TABLE_RULESPEC = """format: rulespec/v1
+rules:
+  - name: gross_income_test_limit
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 927
+  - name: net_income_test_snb
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 796
+  - name: fep_fep_tp_max_assistance
+    kind: parameter
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 531
+  - name: ut_fep_payment_standard
+    kind: derived
+    versions:
+      - effective_from: '2026-01-01'
+        formula: fep_fep_tp_max_assistance
+"""
+
 _UNMAPPED_UK_RULESPEC = """format: rulespec/v1
 rules:
   - name: brand_new_local_helper_xyz
@@ -176,6 +200,54 @@ def test_kansas_tanf_keesm_prefix_is_classified_not_comparable(tmp_path):
     assert item["status"] == "known_not_comparable"
     assert item["mapping_type"] == "not_comparable"
     assert item["policyengine_variable"] == "ks_tanf_maximum_benefit"
+
+
+def test_utah_fep_payment_standard_is_comparable_but_table_rows_are_not(tmp_path):
+    """Utah DWS Table 1 has one PE oracle surface and three raw table rows."""
+    root = tmp_path / "rulespec-us"
+    rulespec_path = (
+        root
+        / "us-ut"
+        / "policies"
+        / "dws"
+        / "eligibility-manual"
+        / "table-1-financial-monthly-income-limits.yaml"
+    )
+    _write(rulespec_path, _UT_FEP_TABLE_RULESPEC)
+    _write(
+        rulespec_path.with_name("table-1-financial-monthly-income-limits.test.yaml"),
+        """- name: Utah FEP payment standard size two
+  period: 2026-01
+  input:
+    us-ut:policies/dws/eligibility-manual/table-1-financial-monthly-income-limits#input.assistance_unit_size: 2
+  output:
+    us-ut:policies/dws/eligibility-manual/table-1-financial-monthly-income-limits#ut_fep_payment_standard: 531
+""",
+    )
+
+    report = build_policyengine_coverage_report(root, program="tanf")
+    items_by_rule = {item["rule_name"]: item for item in report["items"]}
+
+    assert report["status_counts"] == {
+        "comparable": 1,
+        "known_not_comparable": 3,
+    }
+
+    payment_standard = items_by_rule["ut_fep_payment_standard"]
+    assert payment_standard["status"] == "comparable"
+    assert payment_standard["mapping_type"] == "direct_variable"
+    assert payment_standard["policyengine_variable"] == "ut_fep_payment_standard"
+    assert payment_standard["tested"] is True
+    assert payment_standard["test_output_count"] == 1
+
+    for rule_name in (
+        "gross_income_test_limit",
+        "net_income_test_snb",
+        "fep_fep_tp_max_assistance",
+    ):
+        item = items_by_rule[rule_name]
+        assert item["status"] == "known_not_comparable"
+        assert item["mapping_type"] == "not_comparable"
 
 
 def test_medicaid_emergency_exact_mapping_overrides_source_prefix(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1063"
+version = "0.2.1064"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add PolicyEngine oracle mapping for Utah FEP payment standard
- add PE-US adapter metadata so Utah FEP payment-standard oracle checks compare monthly SPM-unit values with assistance-unit size mapped to spm_unit_size
- classify raw Utah DWS Table 1 rows as source-table intermediates rather than standalone oracle outputs
- keep the Utah FEP program surface pending for the remaining income, eligibility, assistance-unit, and benefit-composition rules
- add regression coverage for the Utah FEP mapping behavior
- bump axiom-encode to 0.2.1064

## Checks
- uv run pytest tests/test_policyengine_coverage_monorepo.py -q
- uv run pytest tests/test_policyengine_coverage_monorepo.py tests/test_policyengine_coverage.py -q
- uv run ruff check src/axiom_encode/oracles/policyengine tests/test_policyengine_coverage_monorepo.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees --json
- uv run axiom-encode validate /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ut-fep-20260702/us-ut/policies/dws/eligibility-manual/table-1-financial-monthly-income-limits.yaml --json --skip-reviewers --oracle policyengine --require-oracle-classification