### PR TITLE
Pin Populace loading with sha256 verification and dataset-identity provenance (A2)

### DIFF
--- a/changelog.d/populace-pinned-loading.changed.md
+++ b/changelog.d/populace-pinned-loading.changed.md
@@ -1,0 +1,1 @@
+Pin PolicyEngine Populace loading to verified dense certified artifacts (US populace-us-2024-f0af251, UK populace-uk-2023-dd68c73) with sha256 verification, gate the unpinned HF-latest fallback behind AXIOM_POPULACE_ALLOW_UNPINNED (populace#278 sparse artifact), and record dataset identity (source/path/sha256/revision) in every populace-compare result.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1064"
+version = "0.2.1065"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1064"
+__version__ = "0.2.1065"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/ecps_snap.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_snap.py
@@ -34,6 +34,7 @@ import yaml
 from axiom_encode.oracles import snapscreener
 from axiom_encode.oracles.policyengine.population import (
     DEFAULT_US_POPULACE_YEAR,
+    format_dataset_identity,
     load_populace_dataset,
     populace_data_requirement,
 )
@@ -1108,6 +1109,7 @@ def load_policyengine_cases(
     positive_snap_only: bool,
     utility_projection: str,
     populace_year: int,
+    provenance: dict[str, Any] | None = None,
 ) -> list[ProjectedCase]:
     try:
         from policyengine_us import Microsimulation
@@ -1123,6 +1125,7 @@ def load_policyengine_cases(
         "us",
         year=populace_year,
         command="snap-populace-compare",
+        provenance=provenance,
     )
     sim = Microsimulation(dataset=dataset)
 
@@ -1944,6 +1947,7 @@ def main(args: argparse.Namespace | None = None) -> int:
     print(f"Jurisdiction: {config.jurisdiction}")
     print(f"Program: {program}")
     print(f"Utility projection: {args.utility_projection}")
+    dataset_identity: dict[str, Any] = {}
     cases = load_policyengine_cases(
         config=config,
         base_inputs=base_inputs,
@@ -1953,7 +1957,11 @@ def main(args: argparse.Namespace | None = None) -> int:
         positive_snap_only=args.positive_snap_only,
         utility_projection=args.utility_projection,
         populace_year=args.populace_year,
+        provenance=dataset_identity,
     )
+    identity_line = format_dataset_identity(dataset_identity)
+    if identity_line:
+        print(identity_line)
     if not cases:
         print("No matching Populace SPM units.")
         return 1
@@ -2007,6 +2015,14 @@ def main(args: argparse.Namespace | None = None) -> int:
     if args.write_csv is not None:
         write_csv(args.write_csv, rows)
         print(f"Wrote {args.write_csv}")
+        if dataset_identity:
+            identity_path = args.write_csv.with_suffix(
+                args.write_csv.suffix + ".dataset_identity.json"
+            )
+            identity_path.write_text(
+                json.dumps(dataset_identity, indent=2, sort_keys=True)
+            )
+            print(f"Wrote {identity_path}")
 
     match_rate = sum(1 for row in rows if row["match"]) / len(rows) if rows else 0
     if args.min_match_rate is not None and match_rate < args.min_match_rate:

--- a/src/axiom_encode/oracles/policyengine/ecps_tax.py
+++ b/src/axiom_encode/oracles/policyengine/ecps_tax.py
@@ -32,6 +32,7 @@ from axiom_encode.harness.validator_pipeline import (
 )
 from axiom_encode.oracles.policyengine.population import (
     DEFAULT_US_POPULACE_YEAR,
+    format_dataset_identity,
     load_populace_dataset,
     populace_data_requirement,
     population_table,
@@ -543,6 +544,7 @@ class TaxComparisonReport:
     mismatches: list[TaxComparisonRow]
     output_summary: list[dict[str, Any]]
     projection_notes: list[str]
+    dataset_identity: dict[str, Any] | None = None
 
     def to_json(self) -> dict[str, Any]:
         return {
@@ -553,6 +555,7 @@ class TaxComparisonReport:
             "mismatches": [row.__dict__ for row in self.mismatches],
             "output_summary": self.output_summary,
             "projection_notes": self.projection_notes,
+            "dataset_identity": self.dataset_identity,
         }
 
 
@@ -863,10 +866,12 @@ def load_policyengine_tax_data(
     _ = data_folder
     _ = allow_uncertified_policyengine_data
     log(f"Loading PolicyEngine Populace US {populace_year} dataset...")
+    dataset_identity: dict[str, Any] = {}
     dataset = load_populace_dataset(
         "us",
         year=populace_year,
         command="tax-populace-compare",
+        provenance=dataset_identity,
     )
     sim = Microsimulation(dataset=dataset)
     log("Running PolicyEngine tax outputs...")
@@ -921,6 +926,7 @@ def load_policyengine_tax_data(
         "persons": selected_persons,
         "tax_unit_ids": [int(value) for value in selected["tax_unit_id"]],
         "person_ids": [int(value) for value in selected_persons["person_id"]],
+        "dataset_identity": dataset_identity,
     }
 
 
@@ -2824,6 +2830,7 @@ def compare_outputs(
         compared_values=compared_values,
         mismatches=mismatches,
         output_summary=list(summary.values()),
+        dataset_identity=pe_data.get("dataset_identity") or None,
         projection_notes=[
             "Current CTC projection uses Populace raw tax-unit membership, age, "
             "student status, separation status, and SSN-card type to reconstruct "
@@ -2893,6 +2900,9 @@ def print_report(
     report: TaxComparisonReport, *, tolerance: float, relative_tolerance: float
 ) -> None:
     print("PolicyEngine tax Populace comparison")
+    identity_line = format_dataset_identity(report.dataset_identity)
+    if identity_line:
+        print(identity_line)
     print(f"Compared tax units: {report.compared_tax_units:,}")
     print(f"Compared persons: {report.compared_persons:,}")
     print(f"Compared values: {report.compared_values:,}")

--- a/src/axiom_encode/oracles/policyengine/efrs_uk.py
+++ b/src/axiom_encode/oracles/policyengine/efrs_uk.py
@@ -32,6 +32,7 @@ from .ecps_tax import (
 )
 from .population import (
     DEFAULT_UK_POPULACE_YEAR,
+    format_dataset_identity,
     load_populace_dataset,
     local_dataset_path,
     populace_data_requirement,
@@ -1920,6 +1921,7 @@ class UKEFRSComparisonReport:
     output_summary: list[dict[str, Any]]
     skipped_surfaces: list[dict[str, str]]
     projection_notes: list[str]
+    dataset_identity: dict[str, Any] | None = None
 
     def to_json(self) -> dict[str, Any]:
         return {
@@ -1933,6 +1935,7 @@ class UKEFRSComparisonReport:
             "output_summary": self.output_summary,
             "skipped_surfaces": self.skipped_surfaces,
             "projection_notes": self.projection_notes,
+            "dataset_identity": self.dataset_identity,
         }
 
 
@@ -2406,13 +2409,15 @@ def load_policyengine_uk_data(
         )
 
     require_policyengine_uk_versions(command="uk-populace-compare")
+    dataset_identity: dict[str, Any] = {}
     pe_dataset = load_populace_dataset(
         "uk",
         year=populace_year,
         command="uk-populace-compare",
+        provenance=dataset_identity,
     )
     log(f"Loading PolicyEngine Populace UK {populace_year} dataset...")
-    return load_policyengine_uk_dataset(
+    pe_data = load_policyengine_uk_dataset(
         pe_dataset=pe_dataset,
         year=year,
         sample_size=sample_size,
@@ -2420,6 +2425,8 @@ def load_policyengine_uk_data(
         person_variables=person_variables,
         benunit_variables=benunit_variables,
     )
+    pe_data["dataset_identity"] = dataset_identity
+    return pe_data
 
 
 def load_local_policyengine_uk_data(
@@ -6723,6 +6730,7 @@ def compare_outputs(
         mismatches=mismatches,
         oracle_divergences=oracle_divergences,
         output_summary=list(summary.values()),
+        dataset_identity=pe_data.get("dataset_identity") or None,
         skipped_surfaces=SKIPPED_SURFACES,
         projection_notes=[
             "Personal allowance projection supplies validation-population adjusted net income "
@@ -7197,6 +7205,9 @@ def print_report(
     relative_tolerance: float,
 ) -> None:
     print("PolicyEngine UK Populace comparison")
+    identity_line = format_dataset_identity(report.dataset_identity)
+    if identity_line:
+        print(identity_line)
     print(f"Compared persons: {report.compared_persons:,}")
     print(f"Compared benefit units: {report.compared_benunits:,}")
     print(f"Compared values: {report.compared_values:,}")

--- a/src/axiom_encode/oracles/policyengine/medicaid_populace.py
+++ b/src/axiom_encode/oracles/policyengine/medicaid_populace.py
@@ -33,6 +33,7 @@ from axiom_encode.oracles.policyengine.ecps_snap import (
 )
 from axiom_encode.oracles.policyengine.population import (
     DEFAULT_US_POPULACE_YEAR,
+    format_dataset_identity,
     load_populace_dataset,
     populace_data_requirement,
 )
@@ -735,6 +736,7 @@ def load_policyengine_cases(
     pre_sample_households_count: int | None,
     positive_only: bool,
     populace_year: int,
+    provenance: dict[str, Any] | None = None,
 ) -> list[PersonCase]:
     try:
         from policyengine_us import Microsimulation
@@ -746,6 +748,7 @@ def load_policyengine_cases(
         "us",
         year=populace_year,
         command="medicaid-populace-compare",
+        provenance=provenance,
     )
     if pre_sample_households_count is not None:
         dataset = pre_sample_households(
@@ -1159,6 +1162,7 @@ def main(args: argparse.Namespace | None = None) -> None:
 
     period = month_period(args.year, args.month)
     base_inputs = load_base_inputs(test_template)
+    dataset_identity: dict[str, Any] = {}
     cases = load_policyengine_cases(
         base_inputs=base_inputs,
         period=period,
@@ -1167,7 +1171,11 @@ def main(args: argparse.Namespace | None = None) -> None:
         pre_sample_households_count=args.pre_sample_households,
         positive_only=args.positive_only,
         populace_year=args.populace_year,
+        provenance=dataset_identity,
     )
+    identity_line = format_dataset_identity(dataset_identity)
+    if identity_line:
+        print(identity_line, flush=True)
     env = axiom_rules_env(program, workspace_root)
     with tempfile.TemporaryDirectory(prefix="medicaid-pe-populace-") as tmp_dir:
         artifact = Path(tmp_dir) / "program.bin"
@@ -1221,6 +1229,14 @@ def main(args: argparse.Namespace | None = None) -> None:
     if args.write_csv is not None:
         write_csv(args.write_csv, rows)
         print(f"Wrote {args.write_csv}", flush=True)
+        if dataset_identity:
+            identity_path = args.write_csv.with_suffix(
+                args.write_csv.suffix + ".dataset_identity.json"
+            )
+            identity_path.write_text(
+                json.dumps(dataset_identity, indent=2, sort_keys=True)
+            )
+            print(f"Wrote {identity_path}", flush=True)
 
     if args.min_match_rate is not None and match_rate < args.min_match_rate:
         raise SystemExit(

--- a/src/axiom_encode/oracles/policyengine/population.py
+++ b/src/axiom_encode/oracles/policyengine/population.py
@@ -127,15 +127,16 @@ def load_populace_dataset(
        compared against the country pin; a mismatch logs a *loud warning* but
        does not fail (local overrides are expected to differ from the pin).
        Recorded as ``source="local-override"``.
-    2. **Pinned Hugging Face download** (the default) — ``hf_hub_download`` at the
+    2. **Unpinned escape hatch** — only when ``AXIOM_POPULACE_ALLOW_UNPINNED`` is
+       set truthy: ``populace.data.load()`` (and, via the cache scan, HF-latest —
+       the sparse #278 artifact for the US dataset). Checked *before* the pin so
+       an operator can deliberately test a new release; emits a warning naming
+       populace#278. Recorded as ``source="unpinned"``. Never reached silently.
+    3. **Pinned Hugging Face download** (the default) — ``hf_hub_download`` at the
        pinned ``revision``, followed by sha256 verification against the pin. A
        mismatch is fatal. Recorded as ``source="pinned"``.
-    3. **Unpinned fallback** — only when ``AXIOM_POPULACE_ALLOW_UNPINNED`` is set
-       truthy: ``populace.data.load()`` then a Hugging Face cache scan, both of
-       which resolve to HF-latest (the sparse #278 artifact for the US dataset).
-       Emits a warning naming populace#278. Recorded as ``source="unpinned"``.
-       Without the escape hatch this path is never taken; the loader fails with
-       a message pointing at the pin and the escape hatch.
+    4. **No pin + no escape hatch** — fails with ``SystemExit`` pointing at the
+       pin and the escape hatch, rather than silently resolving to HF-latest.
 
     When ``provenance`` is a dict it is populated in place with
     ``{source, path, sha256, revision, built_with}`` (``sha256`` truncated to 12
@@ -161,8 +162,27 @@ def load_populace_dataset(
         )
         return _instantiate_dataset(country, local_artifact, command)
 
-    # (2) Pinned Hugging Face download — the default trusted path.
+    # (2) Unpinned escape hatch — opt-in only. Checked before the pin so an
+    # operator can *deliberately* load HF-latest (e.g. to test a new release)
+    # even for a country that has a certified pin. It is never reached silently:
+    # AXIOM_POPULACE_ALLOW_UNPINNED must be set truthy.
     pin = resolve_populace_pin(country)
+    if unpinned_fallback_allowed():
+        warnings.warn(unpinned_fallback_warning(country), stacklevel=2)
+        resolved_year = (
+            year if year is not None else DEFAULT_POPULACE_YEARS.get(country)
+        )
+        dataset = _load_unpinned_populace(country, resolved_year, command)
+        _record_provenance(
+            sink,
+            source=SOURCE_UNPINNED,
+            path=None,
+            revision="latest" if resolved_year is None else str(resolved_year),
+            country=country,
+        )
+        return dataset
+
+    # (3) Pinned Hugging Face download — the default trusted path.
     if pin is not None:
         pinned_path = pinned_populace_download(pin, command=command)
         _record_provenance(
@@ -176,23 +196,9 @@ def load_populace_dataset(
         )
         return _instantiate_dataset(country, pinned_path, command)
 
-    # (3) Unpinned fallback — opt-in escape hatch only.
-    if not unpinned_fallback_allowed():
-        raise SystemExit(unpinned_disallowed_message(country, command))
-    warnings.warn(
-        unpinned_fallback_warning(country),
-        stacklevel=2,
-    )
-    resolved_year = year if year is not None else DEFAULT_POPULACE_YEARS.get(country)
-    dataset = _load_unpinned_populace(country, resolved_year, command)
-    _record_provenance(
-        sink,
-        source=SOURCE_UNPINNED,
-        path=None,
-        revision="latest" if resolved_year is None else str(resolved_year),
-        country=country,
-    )
-    return dataset
+    # (4) No pin for this country and the escape hatch is off — fail loudly
+    # rather than silently resolving to HF-latest.
+    raise SystemExit(unpinned_disallowed_message(country, command))
 
 
 def resolve_populace_pin(country: str) -> PopulacePin | None:

--- a/src/axiom_encode/oracles/policyengine/population.py
+++ b/src/axiom_encode/oracles/policyengine/population.py
@@ -1,8 +1,26 @@
-"""PolicyEngine population loaders for Axiom validation oracles."""
+"""PolicyEngine population loaders for Axiom validation oracles.
+
+Loading is *pinned by default*. A published Populace artifact is only trusted
+when it matches a verified ``(repo_id, filename, revision, sha256)`` pin, so an
+oracle run compares against known input bases rather than whatever Hugging Face
+currently serves as ``latest``. See :data:`POPULACE_PINS` for the certified pins
+and the resolution order documented on :func:`load_populace_dataset`.
+
+Why pinning matters: ``populace.data.load()`` (populace-data 0.1.0) always
+fetches the HF-latest revision with no pin. As of 2026-07-02 HF-latest for the
+US dataset is a *sparse* refit that zeroes untargeted input bases (IRA/HSA/
+self-employed pension/childcare and dozens of other engine inputs) per
+PolicyEngine/populace#278. Comparing an encoder oracle against that artifact
+would silently score against ~$0 bases. The dense certified pin below is the
+last artifact verified to carry those inputs.
+"""
 
 from __future__ import annotations
 
+import hashlib
 import os
+import warnings
+from dataclasses import dataclass
 from importlib import import_module
 from pathlib import Path
 from typing import Any
@@ -22,32 +40,233 @@ POLICYENGINE_DATASET_CLASSES = {
     "uk": ("policyengine_uk.data", "UKSingleYearDataset"),
 }
 
+#: Escape-hatch env var. When set truthy, the loader is allowed to fall back to
+#: the unpinned ``populace.data.load()`` package and the Hugging Face cache scan
+#: (both of which resolve to HF-latest, i.e. the sparse #278 artifact for the US
+#: dataset). Off by default: unpinned data is opt-in, never a silent fallback.
+ALLOW_UNPINNED_ENV = "AXIOM_POPULACE_ALLOW_UNPINNED"
+
+#: Provenance ``source`` values recorded for each loaded artifact.
+SOURCE_PINNED = "pinned"
+SOURCE_LOCAL_OVERRIDE = "local-override"
+SOURCE_UNPINNED = "unpinned"
+
+
+@dataclass(frozen=True)
+class PopulacePin:
+    """A verified Populace artifact pin.
+
+    ``sha256`` is the digest of the artifact file itself (verified after
+    download); ``built_with`` is the PolicyEngine model-package version the
+    artifact was calibrated with, recorded for provenance and compatibility
+    notes. ``repo_type`` is the Hugging Face repo type passed to
+    ``hf_hub_download`` (datasets are ``"dataset"``).
+    """
+
+    country: str
+    repo_id: str
+    filename: str
+    revision: str
+    sha256: str
+    built_with: str
+    repo_type: str = "dataset"
+
+
+# ---------------------------------------------------------------------------
+# UPGRADE NOTE
+# ---------------------------------------------------------------------------
+# These pins are the *dense* certified Populace artifacts (verified 2026-07-02
+# against policyengine.py's certified bundle manifest at bundle 4.18.6 / tag
+# 4.18.0 history: src/policyengine/data/bundle/manifest.json). They intentionally
+# predate the sparse-l0-refit artifact that is currently HF-latest, because that
+# sparse artifact zeroes untargeted engine input bases (PolicyEngine/populace#278,
+# closed 2026-07-02 by pipeline-fix PR #279 — but the rebuilt dense-parity
+# artifact is not yet published/certified).
+#
+# RE-PIN WHEN: a post-#279 sparse (or dense-parity) Populace release is certified
+# as the default in the policyengine.py bundle. At that point, read the new
+# (repo_id, filename, revision, sha256, built_with_model_version) out of that
+# bundle's manifest.json certified_data_artifact/datasets block and update the
+# values below. Do NOT bump to HF-latest without going through that certification.
+# For a one-off re-pin without a code change, set the env overrides:
+#   AXIOM_POPULACE_US_REVISION / AXIOM_POPULACE_US_SHA256 (and UK equivalents).
+# ---------------------------------------------------------------------------
+POPULACE_PINS: dict[str, PopulacePin] = {
+    "us": PopulacePin(
+        country="us",
+        repo_id="policyengine/populace-us",
+        filename="populace_us_2024.h5",
+        revision="populace-us-2024-f0af251-703bd81a565c-20260620T201958Z",
+        sha256="16be6338f9d0b3c339883dae59949e995663b64cf145de6728b3dd0f916c5d5f",
+        built_with="1.729.0",
+    ),
+    "uk": PopulacePin(
+        country="uk",
+        repo_id="policyengine/populace-uk-private",
+        filename="populace_uk_2023.h5",
+        revision="populace-uk-2023-dd68c73-4aa4b14-20260619T023711Z",
+        sha256="f17306ccb2aad7ff0130be3589b560afb2e2a12a943570911cd0c77f07934833",
+        built_with="2.89.2",
+    ),
+}
+
 
 def load_populace_dataset(
     country: str,
     *,
     year: int | None = None,
     command: str,
+    provenance: dict[str, Any] | None = None,
 ) -> Any:
-    """Load a published Populace artifact as a PolicyEngine dataset."""
+    """Load a published Populace artifact as a PolicyEngine dataset.
+
+    Resolution order (first match wins):
+
+    1. **Explicit local override** — an ``AXIOM_POPULACE_*`` env var pointing at
+       a local ``.h5``. Kept for development/experiments. The file's sha256 is
+       compared against the country pin; a mismatch logs a *loud warning* but
+       does not fail (local overrides are expected to differ from the pin).
+       Recorded as ``source="local-override"``.
+    2. **Pinned Hugging Face download** (the default) — ``hf_hub_download`` at the
+       pinned ``revision``, followed by sha256 verification against the pin. A
+       mismatch is fatal. Recorded as ``source="pinned"``.
+    3. **Unpinned fallback** — only when ``AXIOM_POPULACE_ALLOW_UNPINNED`` is set
+       truthy: ``populace.data.load()`` then a Hugging Face cache scan, both of
+       which resolve to HF-latest (the sparse #278 artifact for the US dataset).
+       Emits a warning naming populace#278. Recorded as ``source="unpinned"``.
+       Without the escape hatch this path is never taken; the loader fails with
+       a message pointing at the pin and the escape hatch.
+
+    When ``provenance`` is a dict it is populated in place with
+    ``{source, path, sha256, revision, built_with}`` (``sha256`` truncated to 12
+    hex chars) so callers can thread dataset identity into comparison outputs.
+    Passing ``None`` (the default) keeps every existing call site unchanged.
+    """
     country = country.lower()
+    sink = provenance if provenance is not None else None
+
+    # (1) Explicit local override — verify against the pin, warn (don't fail).
     try:
         local_artifact = local_populace_artifact_path(country, year=year)
     except FileNotFoundError as exc:
         raise SystemExit(str(exc)) from exc
     if local_artifact is not None:
-        try:
-            return load_policyengine_dataset_artifact(country, local_artifact)
-        except ImportError as exc:  # pragma: no cover - optional runtime dependency
-            raise SystemExit(
-                policyengine_dataset_install_message(country, command)
-            ) from exc
-        except Exception as exc:  # pragma: no cover - depends on external dataset shape
-            raise SystemExit(
-                f"Failed to load local Populace {country.upper()} artifact "
-                f"{local_artifact}: {exc}"
-            ) from exc
+        _verify_local_override_against_pin(country, local_artifact)
+        _record_provenance(
+            sink,
+            source=SOURCE_LOCAL_OVERRIDE,
+            path=local_artifact,
+            revision=None,
+            country=country,
+        )
+        return _instantiate_dataset(country, local_artifact, command)
 
+    # (2) Pinned Hugging Face download — the default trusted path.
+    pin = resolve_populace_pin(country)
+    if pin is not None:
+        pinned_path = pinned_populace_download(pin, command=command)
+        _record_provenance(
+            sink,
+            source=SOURCE_PINNED,
+            path=pinned_path,
+            revision=pin.revision,
+            country=country,
+            sha256=pin.sha256,
+            built_with=pin.built_with,
+        )
+        return _instantiate_dataset(country, pinned_path, command)
+
+    # (3) Unpinned fallback — opt-in escape hatch only.
+    if not unpinned_fallback_allowed():
+        raise SystemExit(unpinned_disallowed_message(country, command))
+    warnings.warn(
+        unpinned_fallback_warning(country),
+        stacklevel=2,
+    )
+    resolved_year = year if year is not None else DEFAULT_POPULACE_YEARS.get(country)
+    dataset = _load_unpinned_populace(country, resolved_year, command)
+    _record_provenance(
+        sink,
+        source=SOURCE_UNPINNED,
+        path=None,
+        revision="latest" if resolved_year is None else str(resolved_year),
+        country=country,
+    )
+    return dataset
+
+
+def resolve_populace_pin(country: str) -> PopulacePin | None:
+    """Return the effective pin for ``country``, applying env re-pin overrides.
+
+    ``AXIOM_POPULACE_{CC}_REVISION`` and ``AXIOM_POPULACE_{CC}_SHA256`` (with
+    ``{CC}`` the upper-cased country token, e.g. ``US``/``UK``) let an operator
+    re-pin to a different certified release without a code change. Either may be
+    set independently; unset fields keep the baseline pin value.
+    """
+    country = country.lower()
+    base = POPULACE_PINS.get(country)
+    if base is None:
+        return None
+    token = country.upper().replace("-", "_")
+    revision = os.environ.get(f"AXIOM_POPULACE_{token}_REVISION")
+    sha256 = os.environ.get(f"AXIOM_POPULACE_{token}_SHA256")
+    if not revision and not sha256:
+        return base
+    return PopulacePin(
+        country=base.country,
+        repo_id=base.repo_id,
+        filename=base.filename,
+        revision=revision.strip() if revision else base.revision,
+        sha256=sha256.strip().lower() if sha256 else base.sha256,
+        built_with=base.built_with,
+        repo_type=base.repo_type,
+    )
+
+
+def pinned_populace_download(pin: PopulacePin, *, command: str) -> Path:
+    """Download the pinned artifact from Hugging Face and verify its sha256.
+
+    Raises ``SystemExit`` when ``huggingface_hub`` is unavailable, when the
+    download fails, or when the downloaded file's digest does not match
+    ``pin.sha256`` (a mismatch here is fatal — the pin is the contract).
+    """
+    try:
+        from huggingface_hub import hf_hub_download
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(huggingface_hub_install_message(pin.country, command)) from exc
+    try:
+        downloaded = hf_hub_download(
+            repo_id=pin.repo_id,
+            filename=pin.filename,
+            revision=pin.revision,
+            repo_type=pin.repo_type,
+        )
+    except Exception as exc:  # pragma: no cover - depends on external HF access
+        raise SystemExit(
+            f"Failed to download pinned Populace {pin.country.upper()} artifact "
+            f"{pin.repo_id}/{pin.filename}@{pin.revision}: {exc}"
+        ) from exc
+    path = Path(downloaded)
+    actual = file_sha256(path)
+    if actual.lower() != pin.sha256.lower():
+        raise SystemExit(
+            f"Pinned Populace {pin.country.upper()} artifact sha256 mismatch for "
+            f"{pin.repo_id}/{pin.filename}@{pin.revision}: expected {pin.sha256}, "
+            f"got {actual}. Refusing to load an artifact that does not match the "
+            f"pin. If you intentionally re-pinned, set AXIOM_POPULACE_"
+            f"{pin.country.upper()}_SHA256 to the new digest."
+        )
+    return path
+
+
+def unpinned_fallback_allowed() -> bool:
+    """Return True when the unpinned escape hatch env var is set truthy."""
+    value = os.environ.get(ALLOW_UNPINNED_ENV, "")
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _load_unpinned_populace(country: str, year: int | None, command: str) -> Any:
+    """Load via the unpinned ``populace.data.load`` package (HF-latest)."""
     try:
         from populace.data import load
     except ImportError as exc:  # pragma: no cover - optional runtime dependency
@@ -61,6 +280,108 @@ def load_populace_dataset(
         raise SystemExit(
             f"Failed to load Populace {country.upper()} {year_label} dataset: {exc}"
         ) from exc
+
+
+def _instantiate_dataset(country: str, path: Path, command: str) -> Any:
+    """Instantiate the PolicyEngine dataset class for a local artifact path."""
+    try:
+        return load_policyengine_dataset_artifact(country, path)
+    except ImportError as exc:  # pragma: no cover - optional runtime dependency
+        raise SystemExit(
+            policyengine_dataset_install_message(country, command)
+        ) from exc
+    except Exception as exc:  # pragma: no cover - depends on external dataset shape
+        raise SystemExit(
+            f"Failed to load Populace {country.upper()} artifact {path}: {exc}"
+        ) from exc
+
+
+def _verify_local_override_against_pin(country: str, path: Path) -> None:
+    """Warn loudly when a local-override artifact's sha256 differs from the pin.
+
+    Local overrides are for experiments, so a mismatch is a warning, not a
+    failure. A *matching* digest is silent (the override just re-supplies the
+    pinned artifact).
+    """
+    pin = resolve_populace_pin(country)
+    if pin is None:
+        return
+    actual = file_sha256(path)
+    if actual.lower() == pin.sha256.lower():
+        return
+    warnings.warn(
+        f"Local Populace {country.upper()} override {path} sha256 {actual[:12]} "
+        f"does not match the certified pin {pin.sha256[:12]} "
+        f"(revision {pin.revision}). Loading the override anyway; oracle results "
+        f"will reflect this unpinned artifact, not the certified dataset.",
+        stacklevel=3,
+    )
+
+
+def _record_provenance(
+    sink: dict[str, Any] | None,
+    *,
+    source: str,
+    path: Path | None,
+    revision: str | None,
+    country: str,
+    sha256: str | None = None,
+    built_with: str | None = None,
+) -> None:
+    """Populate a caller-supplied provenance sink in place (no-op when None)."""
+    if sink is None:
+        return
+    digest = sha256
+    if digest is None and path is not None:
+        try:
+            digest = file_sha256(path)
+        except OSError:
+            digest = None
+    sink.clear()
+    sink.update(
+        {
+            "country": country,
+            "source": source,
+            "path": str(path) if path is not None else None,
+            "sha256": digest[:12] if digest else None,
+            "revision": revision,
+            "built_with": built_with,
+        }
+    )
+
+
+def format_dataset_identity(identity: dict[str, Any] | None) -> str:
+    """Render a one-line ``Dataset:`` provenance string for human-readable output.
+
+    Returns an empty string when ``identity`` is falsy so callers can guard on
+    it. The shape matches the sink from :func:`load_populace_dataset`.
+    """
+    if not identity:
+        return ""
+    source = identity.get("source") or "unknown"
+    parts = [f"source={source}"]
+    revision = identity.get("revision")
+    if revision:
+        parts.append(f"revision={revision}")
+    sha256 = identity.get("sha256")
+    if sha256:
+        parts.append(f"sha256={sha256}")
+    built_with = identity.get("built_with")
+    if built_with:
+        parts.append(f"built_with_pe={built_with}")
+    path = identity.get("path")
+    if path and source != SOURCE_PINNED:
+        parts.append(f"path={path}")
+    return "Dataset: " + " ".join(parts)
+
+
+def file_sha256(path: Path, *, chunk_size: int = 1024 * 1024) -> str:
+    """Return the SHA-256 hex digest of a file, read in chunks."""
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for chunk in iter(lambda: handle.read(chunk_size), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def load_policyengine_dataset_artifact(country: str, path: Path) -> Any:
@@ -102,7 +423,13 @@ def local_populace_artifact_path(
     year: int | None = None,
     cache_root: Path | None = None,
 ) -> Path | None:
-    """Return the local Populace H5 artifact for ``country`` when available."""
+    """Return the explicit local Populace artifact override for ``country``.
+
+    Resolves *only* ``AXIOM_POPULACE_*`` env-var overrides. The Hugging Face
+    cache scan is intentionally gated behind the unpinned escape hatch and lives
+    in :func:`unpinned_huggingface_cache_artifact`, so it is not reached here on
+    the default (pinned) path.
+    """
     country = country.lower()
     resolved_year = year or DEFAULT_POPULACE_YEARS.get(country)
     for env_var in local_populace_artifact_env_vars(country, resolved_year):
@@ -115,13 +442,7 @@ def local_populace_artifact_path(
                 f"{env_var} points to a missing Populace artifact: {path}"
             )
         return path
-    if resolved_year is None:
-        return None
-    return huggingface_cache_populace_artifact(
-        country,
-        populace_artifact_filename(country, resolved_year),
-        cache_root=cache_root,
-    )
+    return None
 
 
 def local_populace_artifact_env_vars(country: str, year: int | None) -> tuple[str, ...]:
@@ -142,6 +463,28 @@ def local_populace_artifact_env_vars(country: str, year: int | None) -> tuple[st
 
 def populace_artifact_filename(country: str, year: int) -> str:
     return f"populace_{country.lower()}_{int(year)}.h5"
+
+
+def unpinned_huggingface_cache_artifact(
+    country: str,
+    *,
+    year: int | None = None,
+    cache_root: Path | None = None,
+) -> Path | None:
+    """Resolve a Populace artifact from the Hugging Face cache (unpinned).
+
+    This is the HF-latest cache scan. It is *not* part of the default pinned
+    path; the unpinned fallback uses it only when
+    ``AXIOM_POPULACE_ALLOW_UNPINNED`` is set.
+    """
+    resolved_year = year or DEFAULT_POPULACE_YEARS.get(country)
+    if resolved_year is None:
+        return None
+    return huggingface_cache_populace_artifact(
+        country,
+        populace_artifact_filename(country, resolved_year),
+        cache_root=cache_root,
+    )
 
 
 def huggingface_cache_populace_artifact(
@@ -185,6 +528,41 @@ def huggingface_cache_refs(refs: Path) -> tuple[Path, ...]:
     if main.exists():
         return (main, *others)
     return tuple(others)
+
+
+def huggingface_hub_install_message(country: str, command: str) -> str:
+    return (
+        "Pinned Populace validation requires huggingface-hub and the matching "
+        "PolicyEngine country engine. Run with: "
+        f"uv run --with huggingface-hub --with {populace_data_requirement(country)} "
+        f"axiom-encode {command}"
+    )
+
+
+def unpinned_disallowed_message(country: str, command: str) -> str:
+    pin = resolve_populace_pin(country)
+    pin_hint = (
+        f" The certified pin is {pin.repo_id}/{pin.filename}@{pin.revision}."
+        if pin is not None
+        else ""
+    )
+    return (
+        f"No pinned Populace {country.upper()} artifact could be loaded and the "
+        f"unpinned fallback is disabled. Unpinned loading resolves to HF-latest, "
+        f"which for the US dataset is the sparse artifact that zeroes untargeted "
+        f"engine input bases (PolicyEngine/populace#278). To knowingly load "
+        f"unpinned data, re-run with {ALLOW_UNPINNED_ENV}=1." + pin_hint
+    )
+
+
+def unpinned_fallback_warning(country: str) -> str:
+    return (
+        f"{ALLOW_UNPINNED_ENV} is set: loading UNPINNED Populace {country.upper()} "
+        f"data (HF-latest). For the US dataset this is the sparse refit that "
+        f"zeroes untargeted engine input bases (PolicyEngine/populace#278); oracle "
+        f"comparisons against it may score against ~$0 bases. Prefer the certified "
+        f"pin unless you are deliberately testing the latest release."
+    )
 
 
 def populace_install_message(country: str, command: str) -> str:

--- a/src/axiom_encode/oracles/policyengine/population.py
+++ b/src/axiom_encode/oracles/policyengine/population.py
@@ -152,13 +152,16 @@ def load_populace_dataset(
     except FileNotFoundError as exc:
         raise SystemExit(str(exc)) from exc
     if local_artifact is not None:
-        _verify_local_override_against_pin(country, local_artifact)
+        # Hash once: verification and provenance share the digest (the artifact
+        # can be multi-GB, so a second full-file read is worth avoiding).
+        local_sha256 = _verify_local_override_against_pin(country, local_artifact)
         _record_provenance(
             sink,
             source=SOURCE_LOCAL_OVERRIDE,
             path=local_artifact,
             revision=None,
             country=country,
+            sha256=local_sha256,
         )
         return _instantiate_dataset(country, local_artifact, command)
 
@@ -214,16 +217,19 @@ def resolve_populace_pin(country: str) -> PopulacePin | None:
     if base is None:
         return None
     token = country.upper().replace("-", "_")
-    revision = os.environ.get(f"AXIOM_POPULACE_{token}_REVISION")
-    sha256 = os.environ.get(f"AXIOM_POPULACE_{token}_SHA256")
+    # Treat whitespace-only overrides as unset so a blank env var can never
+    # collapse the pinned revision/sha to "" (which would resolve to HF-latest
+    # or fail verification). Empty string -> fall back to the baseline field.
+    revision = (os.environ.get(f"AXIOM_POPULACE_{token}_REVISION") or "").strip()
+    sha256 = (os.environ.get(f"AXIOM_POPULACE_{token}_SHA256") or "").strip().lower()
     if not revision and not sha256:
         return base
     return PopulacePin(
         country=base.country,
         repo_id=base.repo_id,
         filename=base.filename,
-        revision=revision.strip() if revision else base.revision,
-        sha256=sha256.strip().lower() if sha256 else base.sha256,
+        revision=revision or base.revision,
+        sha256=sha256 or base.sha256,
         built_with=base.built_with,
         repo_type=base.repo_type,
     )
@@ -302,19 +308,18 @@ def _instantiate_dataset(country: str, path: Path, command: str) -> Any:
         ) from exc
 
 
-def _verify_local_override_against_pin(country: str, path: Path) -> None:
+def _verify_local_override_against_pin(country: str, path: Path) -> str:
     """Warn loudly when a local-override artifact's sha256 differs from the pin.
 
     Local overrides are for experiments, so a mismatch is a warning, not a
     failure. A *matching* digest is silent (the override just re-supplies the
-    pinned artifact).
+    pinned artifact). Returns the computed digest so the caller can reuse it for
+    provenance without re-reading a potentially multi-GB file.
     """
-    pin = resolve_populace_pin(country)
-    if pin is None:
-        return
     actual = file_sha256(path)
-    if actual.lower() == pin.sha256.lower():
-        return
+    pin = resolve_populace_pin(country)
+    if pin is None or actual.lower() == pin.sha256.lower():
+        return actual
     warnings.warn(
         f"Local Populace {country.upper()} override {path} sha256 {actual[:12]} "
         f"does not match the certified pin {pin.sha256[:12]} "
@@ -322,6 +327,7 @@ def _verify_local_override_against_pin(country: str, path: Path) -> None:
         f"will reflect this unpinned artifact, not the certified dataset.",
         stacklevel=3,
     )
+    return actual
 
 
 def _record_provenance(

--- a/src/axiom_encode/oracles/policyengine/us_populace.py
+++ b/src/axiom_encode/oracles/policyengine/us_populace.py
@@ -31,6 +31,7 @@ from .ecps_tax import (
 )
 from .population import (
     DEFAULT_US_POPULACE_YEAR,
+    format_dataset_identity,
     load_populace_dataset,
     population_table,
 )
@@ -125,6 +126,7 @@ class USVariableComparisonReport:
     mismatches: list[USVariableComparisonRow]
     output_summary: list[dict[str, Any]]
     projection_notes: list[str]
+    dataset_identity: dict[str, Any] | None = None
 
     def to_json(self) -> dict[str, Any]:
         return {
@@ -138,6 +140,7 @@ class USVariableComparisonReport:
             "mismatches": [row.__dict__ for row in self.mismatches],
             "output_summary": self.output_summary,
             "projection_notes": self.projection_notes,
+            "dataset_identity": self.dataset_identity,
         }
 
 
@@ -341,6 +344,7 @@ def compare_us_populace_variables(
         skipped_reasons=data["skipped_reasons"],
         tolerance=tolerance,
         relative_tolerance=relative_tolerance,
+        dataset_identity=data.get("dataset_identity"),
     )
 
 
@@ -441,10 +445,12 @@ def load_policyengine_variable_data(
             "--with populace-data[us] axiom-encode us-populace-compare"
         ) from exc
 
+    dataset_identity: dict[str, Any] = {}
     dataset = load_populace_dataset(
         "us",
         year=populace_year,
         command=US_VARIABLE_COMMAND,
+        provenance=dataset_identity,
     )
     sim = Microsimulation(dataset=dataset)
     persons = population_table(dataset, "person")
@@ -555,7 +561,11 @@ def load_policyengine_variable_data(
             if sample_size and len(cases) >= sample_size:
                 break
         cases_by_variable[variable] = cases
-    return {"cases_by_variable": cases_by_variable, "skipped_reasons": skipped_reasons}
+    return {
+        "cases_by_variable": cases_by_variable,
+        "skipped_reasons": skipped_reasons,
+        "dataset_identity": dataset_identity,
+    }
 
 
 def source_variables_for_adapters(
@@ -713,6 +723,7 @@ def compare_outputs(
     skipped_reasons: dict[str, int],
     tolerance: float,
     relative_tolerance: float,
+    dataset_identity: dict[str, Any] | None = None,
 ) -> USVariableComparisonReport:
     mismatches: list[USVariableComparisonRow] = []
     summary: dict[str, dict[str, Any]] = {}
@@ -822,6 +833,7 @@ def compare_outputs(
             "encoded RuleSpec module covers the post-eligibility grant and cash "
             "issuance calculation.",
         ],
+        dataset_identity=dataset_identity or None,
     )
 
 
@@ -833,6 +845,9 @@ def print_report(
     max_differences: int,
 ) -> None:
     print("PolicyEngine US Populace variable comparison")
+    identity_line = format_dataset_identity(report.dataset_identity)
+    if identity_line:
+        print(identity_line)
     print(f"Variables: {', '.join(report.variables)}")
     print(f"Compared persons: {report.compared_persons:,}")
     print(f"Compared SPM units: {report.compared_spm_units:,}")

--- a/tests/test_policyengine_population.py
+++ b/tests/test_policyengine_population.py
@@ -272,10 +272,7 @@ def test_unpinned_fallback_disabled_by_default_raises_with_278(monkeypatch):
     assert population.ALLOW_UNPINNED_ENV in message
 
 
-def test_unpinned_fallback_allowed_warns_and_loads(monkeypatch):
-    _clear_populace_env(monkeypatch)
-    monkeypatch.setenv(population.ALLOW_UNPINNED_ENV, "1")
-
+def _install_fake_populace(monkeypatch: pytest.MonkeyPatch) -> None:
     fake = ModuleType("populace")
     data_module = ModuleType("populace.data")
 
@@ -286,10 +283,39 @@ def test_unpinned_fallback_allowed_warns_and_loads(monkeypatch):
     monkeypatch.setitem(sys.modules, "populace", fake)
     monkeypatch.setitem(sys.modules, "populace.data", data_module)
 
+
+def test_unpinned_fallback_allowed_warns_and_loads(monkeypatch):
+    _clear_populace_env(monkeypatch)
+    monkeypatch.setenv(population.ALLOW_UNPINNED_ENV, "1")
+    _install_fake_populace(monkeypatch)
+
     provenance: dict[str, object] = {}
     with pytest.warns(UserWarning, match="populace#278"):
         dataset = population.load_populace_dataset(
             "fr",
+            year=2024,
+            command="tax-populace-compare",
+            provenance=provenance,
+        )
+
+    assert dataset.unpinned is True
+    assert provenance["source"] == population.SOURCE_UNPINNED
+
+
+def test_unpinned_escape_hatch_overrides_pin_for_pinned_country(monkeypatch):
+    """The escape hatch is checked *before* the pin, so an operator can force
+    HF-latest even for a country (US) that has a certified pin."""
+    _clear_populace_env(monkeypatch)
+    monkeypatch.setenv(population.ALLOW_UNPINNED_ENV, "1")
+    _install_fake_populace(monkeypatch)
+    # If the pinned path were taken it would import huggingface_hub; make it
+    # absent so a regression that ignores the escape hatch fails loudly.
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+
+    provenance: dict[str, object] = {}
+    with pytest.warns(UserWarning, match="populace#278"):
+        dataset = population.load_populace_dataset(
+            "us",
             year=2024,
             command="tax-populace-compare",
             provenance=provenance,

--- a/tests/test_policyengine_population.py
+++ b/tests/test_policyengine_population.py
@@ -420,7 +420,9 @@ def test_load_populace_dataset_uses_local_engine_dataset_without_populace_data(
     monkeypatch.setenv("AXIOM_POPULACE_US_2024_H5", str(artifact))
     # Matching pin digest keeps the load quiet (no mismatch warning).
     monkeypatch.setattr(
-        population, "file_sha256", lambda path, **_: population.POPULACE_PINS["us"].sha256
+        population,
+        "file_sha256",
+        lambda path, **_: population.POPULACE_PINS["us"].sha256,
     )
     imports: list[str] = []
 

--- a/tests/test_policyengine_population.py
+++ b/tests/test_policyengine_population.py
@@ -1,13 +1,319 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
+import sys
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
 from axiom_encode.oracles.policyengine import population
 
 
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+def _clear_populace_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop every AXIOM_POPULACE_* env var so tests start from a clean slate."""
+    for key in _env_keys():
+        monkeypatch.delenv(key, raising=False)
+
+
+def _env_keys() -> tuple[str, ...]:
+    return (
+        "AXIOM_POPULACE_US_2024_H5",
+        "AXIOM_POPULACE_UK_2023_H5",
+        "AXIOM_POPULACE_US_H5",
+        "AXIOM_POPULACE_UK_H5",
+        "AXIOM_POPULACE_H5",
+        "AXIOM_POPULACE_DATASET",
+        "AXIOM_POPULACE_DATA_PATH",
+        "AXIOM_POPULACE_US_REVISION",
+        "AXIOM_POPULACE_US_SHA256",
+        "AXIOM_POPULACE_UK_REVISION",
+        "AXIOM_POPULACE_UK_SHA256",
+        population.ALLOW_UNPINNED_ENV,
+    )
+
+
+def _install_fake_hf_hub(
+    monkeypatch: pytest.MonkeyPatch, downloaded_path
+) -> dict[str, object]:
+    """Install a fake ``huggingface_hub`` module and capture download kwargs."""
+    captured: dict[str, object] = {}
+
+    def fake_hf_hub_download(**kwargs):
+        captured.update(kwargs)
+        return str(downloaded_path)
+
+    module = ModuleType("huggingface_hub")
+    module.hf_hub_download = fake_hf_hub_download  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "huggingface_hub", module)
+    return captured
+
+
+def _stub_instantiate(monkeypatch: pytest.MonkeyPatch):
+    """Replace dataset instantiation with a sentinel that echoes its path."""
+
+    def fake_instantiate(country: str, path, command: str):
+        return SimpleNamespace(country=country, file_path=str(path))
+
+    monkeypatch.setattr(population, "_instantiate_dataset", fake_instantiate)
+
+
+# ---------------------------------------------------------------------------
+# Pin structure and env-override resolution
+# ---------------------------------------------------------------------------
+def test_pins_match_certified_bundle_values():
+    us = population.POPULACE_PINS["us"]
+    assert us.repo_id == "policyengine/populace-us"
+    assert us.filename == "populace_us_2024.h5"
+    assert us.revision == "populace-us-2024-f0af251-703bd81a565c-20260620T201958Z"
+    assert us.sha256 == (
+        "16be6338f9d0b3c339883dae59949e995663b64cf145de6728b3dd0f916c5d5f"
+    )
+    assert us.built_with == "1.729.0"
+    assert us.repo_type == "dataset"
+
+    uk = population.POPULACE_PINS["uk"]
+    assert uk.repo_id == "policyengine/populace-uk-private"
+    assert uk.filename == "populace_uk_2023.h5"
+    assert uk.revision == "populace-uk-2023-dd68c73-4aa4b14-20260619T023711Z"
+    assert uk.sha256 == (
+        "f17306ccb2aad7ff0130be3589b560afb2e2a12a943570911cd0c77f07934833"
+    )
+    assert uk.built_with == "2.89.2"
+
+
+def test_resolve_pin_defaults_to_baseline(monkeypatch):
+    _clear_populace_env(monkeypatch)
+    assert population.resolve_populace_pin("us") == population.POPULACE_PINS["us"]
+
+
+def test_resolve_pin_applies_env_revision_and_sha_overrides(monkeypatch):
+    _clear_populace_env(monkeypatch)
+    monkeypatch.setenv("AXIOM_POPULACE_US_REVISION", "custom-rev")
+    monkeypatch.setenv("AXIOM_POPULACE_US_SHA256", "AABBCC")
+
+    pin = population.resolve_populace_pin("us")
+
+    assert pin.revision == "custom-rev"
+    assert pin.sha256 == "aabbcc"  # lower-cased
+    # Unrelated fields keep their baseline values.
+    assert pin.repo_id == "policyengine/populace-us"
+    assert pin.filename == "populace_us_2024.h5"
+
+
+def test_resolve_pin_partial_override_keeps_other_field(monkeypatch):
+    _clear_populace_env(monkeypatch)
+    monkeypatch.setenv("AXIOM_POPULACE_US_REVISION", "only-rev")
+
+    pin = population.resolve_populace_pin("us")
+
+    assert pin.revision == "only-rev"
+    assert pin.sha256 == population.POPULACE_PINS["us"].sha256
+
+
+def test_resolve_pin_unknown_country_is_none(monkeypatch):
+    _clear_populace_env(monkeypatch)
+    assert population.resolve_populace_pin("fr") is None
+
+
+# ---------------------------------------------------------------------------
+# Resolution order: local override > pinned download > unpinned fallback
+# ---------------------------------------------------------------------------
+def test_load_prefers_pinned_download_by_default(monkeypatch, tmp_path):
+    _clear_populace_env(monkeypatch)
+    artifact = tmp_path / "populace_us_2024.h5"
+    artifact.write_bytes(b"pinned-bytes")
+    captured = _install_fake_hf_hub(monkeypatch, artifact)
+    _stub_instantiate(monkeypatch)
+    pin = population.POPULACE_PINS["us"]
+    monkeypatch.setattr(population, "file_sha256", lambda path, **_: pin.sha256)
+
+    provenance: dict[str, object] = {}
+    dataset = population.load_populace_dataset(
+        "us",
+        year=2024,
+        command="tax-populace-compare",
+        provenance=provenance,
+    )
+
+    assert dataset.file_path == str(artifact)
+    # hf_hub_download was called with the pinned revision + repo.
+    assert captured["repo_id"] == pin.repo_id
+    assert captured["filename"] == pin.filename
+    assert captured["revision"] == pin.revision
+    assert captured["repo_type"] == "dataset"
+    assert provenance["source"] == population.SOURCE_PINNED
+    assert provenance["revision"] == pin.revision
+    assert provenance["sha256"] == pin.sha256[:12]
+    assert provenance["built_with"] == pin.built_with
+
+
+def test_local_override_takes_precedence_over_pin(monkeypatch, tmp_path):
+    _clear_populace_env(monkeypatch)
+    artifact = tmp_path / "populace_us_2024.h5"
+    artifact.write_bytes(b"local-bytes")
+    monkeypatch.setenv("AXIOM_POPULACE_US_2024_H5", str(artifact))
+    _stub_instantiate(monkeypatch)
+    # Matching digest -> no warning, source=local-override.
+    pin = population.POPULACE_PINS["us"]
+    monkeypatch.setattr(population, "file_sha256", lambda path, **_: pin.sha256)
+
+    # If the pinned path were taken it would need huggingface_hub; ensure it is
+    # absent so a regression that ignores the override fails loudly.
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+
+    provenance: dict[str, object] = {}
+    dataset = population.load_populace_dataset(
+        "us",
+        year=2024,
+        command="tax-populace-compare",
+        provenance=provenance,
+    )
+
+    assert dataset.file_path == str(artifact)
+    assert provenance["source"] == population.SOURCE_LOCAL_OVERRIDE
+    assert provenance["path"] == str(artifact)
+
+
+def test_local_override_sha_mismatch_warns_but_loads(monkeypatch, tmp_path):
+    _clear_populace_env(monkeypatch)
+    artifact = tmp_path / "populace_us_2024.h5"
+    artifact.write_bytes(b"experimental-bytes")
+    monkeypatch.setenv("AXIOM_POPULACE_US_2024_H5", str(artifact))
+    _stub_instantiate(monkeypatch)
+    monkeypatch.setattr(population, "file_sha256", lambda path, **_: "0" * 64)
+
+    with pytest.warns(UserWarning, match="does not match the certified pin"):
+        dataset = population.load_populace_dataset(
+            "us",
+            year=2024,
+            command="tax-populace-compare",
+        )
+
+    assert dataset.file_path == str(artifact)
+
+
+# ---------------------------------------------------------------------------
+# sha256 verification of the pinned download is fatal on mismatch
+# ---------------------------------------------------------------------------
+def test_pinned_download_fails_on_sha_mismatch(monkeypatch, tmp_path):
+    _clear_populace_env(monkeypatch)
+    artifact = tmp_path / "populace_us_2024.h5"
+    artifact.write_bytes(b"tampered")
+    _install_fake_hf_hub(monkeypatch, artifact)
+    _stub_instantiate(monkeypatch)
+    monkeypatch.setattr(population, "file_sha256", lambda path, **_: "deadbeef" * 8)
+
+    with pytest.raises(SystemExit, match="sha256 mismatch"):
+        population.load_populace_dataset(
+            "us",
+            year=2024,
+            command="tax-populace-compare",
+        )
+
+
+def test_pinned_download_missing_hf_hub_exits_with_install_message(
+    monkeypatch, tmp_path
+):
+    _clear_populace_env(monkeypatch)
+    _stub_instantiate(monkeypatch)
+    # Force ``import huggingface_hub`` to fail inside pinned_populace_download.
+    monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+
+    with pytest.raises(SystemExit, match="huggingface-hub"):
+        population.load_populace_dataset(
+            "us",
+            year=2024,
+            command="tax-populace-compare",
+        )
+
+
+def test_pinned_download_verifies_real_sha256_end_to_end(monkeypatch, tmp_path):
+    """Exercise the real file_sha256 path (no monkeypatched digest)."""
+    _clear_populace_env(monkeypatch)
+    payload = b"real-artifact-bytes-for-hashing"
+    import hashlib
+
+    digest = hashlib.sha256(payload).hexdigest()
+    artifact = tmp_path / "populace_us_2024.h5"
+    artifact.write_bytes(payload)
+    _install_fake_hf_hub(monkeypatch, artifact)
+    _stub_instantiate(monkeypatch)
+    monkeypatch.setenv("AXIOM_POPULACE_US_SHA256", digest)
+
+    provenance: dict[str, object] = {}
+    population.load_populace_dataset(
+        "us",
+        year=2024,
+        command="tax-populace-compare",
+        provenance=provenance,
+    )
+
+    assert provenance["source"] == population.SOURCE_PINNED
+    assert provenance["sha256"] == digest[:12]
+
+
+# ---------------------------------------------------------------------------
+# Unpinned escape hatch gating
+# ---------------------------------------------------------------------------
+def test_unpinned_fallback_disabled_by_default_raises_with_278(monkeypatch):
+    _clear_populace_env(monkeypatch)
+    # Country with no pin -> pinned path is unavailable, so the loader must hit
+    # the escape-hatch gate rather than silently falling through.
+    with pytest.raises(SystemExit) as excinfo:
+        population.load_populace_dataset(
+            "fr",
+            year=2024,
+            command="tax-populace-compare",
+        )
+    message = str(excinfo.value)
+    assert "populace#278" in message
+    assert population.ALLOW_UNPINNED_ENV in message
+
+
+def test_unpinned_fallback_allowed_warns_and_loads(monkeypatch):
+    _clear_populace_env(monkeypatch)
+    monkeypatch.setenv(population.ALLOW_UNPINNED_ENV, "1")
+
+    fake = ModuleType("populace")
+    data_module = ModuleType("populace.data")
+
+    def fake_load(country, year):
+        return SimpleNamespace(country=country, year=year, unpinned=True)
+
+    data_module.load = fake_load  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "populace", fake)
+    monkeypatch.setitem(sys.modules, "populace.data", data_module)
+
+    provenance: dict[str, object] = {}
+    with pytest.warns(UserWarning, match="populace#278"):
+        dataset = population.load_populace_dataset(
+            "fr",
+            year=2024,
+            command="tax-populace-compare",
+            provenance=provenance,
+        )
+
+    assert dataset.unpinned is True
+    assert provenance["source"] == population.SOURCE_UNPINNED
+
+
+def test_unpinned_fallback_allowed_flag_variants(monkeypatch):
+    _clear_populace_env(monkeypatch)
+    for truthy in ("1", "true", "TRUE", "yes", "on"):
+        monkeypatch.setenv(population.ALLOW_UNPINNED_ENV, truthy)
+        assert population.unpinned_fallback_allowed() is True
+    for falsy in ("", "0", "false", "no", "off"):
+        monkeypatch.setenv(population.ALLOW_UNPINNED_ENV, falsy)
+        assert population.unpinned_fallback_allowed() is False
+
+
+# ---------------------------------------------------------------------------
+# Existing local-artifact / env-override behavior (retained)
+# ---------------------------------------------------------------------------
 def test_local_populace_artifact_prefers_specific_env(monkeypatch, tmp_path):
+    _clear_populace_env(monkeypatch)
     artifact = tmp_path / "populace_us_2024.h5"
     artifact.write_text("")
     monkeypatch.setenv("AXIOM_POPULACE_US_2024_H5", str(artifact))
@@ -16,6 +322,7 @@ def test_local_populace_artifact_prefers_specific_env(monkeypatch, tmp_path):
 
 
 def test_local_populace_artifact_rejects_missing_env_override(monkeypatch, tmp_path):
+    _clear_populace_env(monkeypatch)
     missing = tmp_path / "missing.h5"
     monkeypatch.setenv("AXIOM_POPULACE_US_H5", str(missing))
 
@@ -24,6 +331,7 @@ def test_local_populace_artifact_rejects_missing_env_override(monkeypatch, tmp_p
 
 
 def test_load_populace_dataset_exits_for_missing_env_override(monkeypatch, tmp_path):
+    _clear_populace_env(monkeypatch)
     missing = tmp_path / "missing.h5"
     monkeypatch.setenv("AXIOM_POPULACE_US_H5", str(missing))
 
@@ -35,7 +343,10 @@ def test_load_populace_dataset_exits_for_missing_env_override(monkeypatch, tmp_p
         )
 
 
-def test_local_populace_artifact_reads_huggingface_cache_ref(tmp_path):
+def test_local_populace_artifact_no_longer_scans_hf_cache(monkeypatch, tmp_path):
+    """The default resolver returns None with no env override; the HF-cache scan
+    moved behind the unpinned escape hatch (``unpinned_huggingface_cache_artifact``)."""
+    _clear_populace_env(monkeypatch)
     cache_root = tmp_path / "hub"
     repo = cache_root / "datasets--policyengine--populace-us"
     snapshot = repo / "snapshots" / "abc123"
@@ -52,6 +363,15 @@ def test_local_populace_artifact_reads_huggingface_cache_ref(tmp_path):
             year=2024,
             cache_root=cache_root,
         )
+        is None
+    )
+    # The scan still works when invoked explicitly (the unpinned path uses it).
+    assert (
+        population.unpinned_huggingface_cache_artifact(
+            "us",
+            year=2024,
+            cache_root=cache_root,
+        )
         == artifact
     )
 
@@ -59,9 +379,14 @@ def test_local_populace_artifact_reads_huggingface_cache_ref(tmp_path):
 def test_load_populace_dataset_uses_local_engine_dataset_without_populace_data(
     monkeypatch, tmp_path
 ):
+    _clear_populace_env(monkeypatch)
     artifact = tmp_path / "populace_us_2024.h5"
-    artifact.write_text("")
+    artifact.write_bytes(b"local-artifact")
     monkeypatch.setenv("AXIOM_POPULACE_US_2024_H5", str(artifact))
+    # Matching pin digest keeps the load quiet (no mismatch warning).
+    monkeypatch.setattr(
+        population, "file_sha256", lambda path, **_: population.POPULACE_PINS["us"].sha256
+    )
     imports: list[str] = []
 
     class FakeDataset:
@@ -82,3 +407,51 @@ def test_load_populace_dataset_uses_local_engine_dataset_without_populace_data(
 
     assert dataset.file_path == str(artifact)
     assert imports == ["policyengine_us.data"]
+
+
+# ---------------------------------------------------------------------------
+# file_sha256 + provenance formatting
+# ---------------------------------------------------------------------------
+def test_file_sha256_matches_hashlib(tmp_path):
+    import hashlib
+
+    payload = b"x" * (2 * 1024 * 1024 + 7)  # spans multiple chunks
+    path = tmp_path / "blob.bin"
+    path.write_bytes(payload)
+
+    assert population.file_sha256(path) == hashlib.sha256(payload).hexdigest()
+
+
+def test_format_dataset_identity_pinned_hides_path():
+    line = population.format_dataset_identity(
+        {
+            "source": population.SOURCE_PINNED,
+            "revision": "rev-1",
+            "sha256": "abc123def456",
+            "built_with": "1.729.0",
+            "path": "/cache/x.h5",
+        }
+    )
+    assert "source=pinned" in line
+    assert "revision=rev-1" in line
+    assert "sha256=abc123def456" in line
+    assert "built_with_pe=1.729.0" in line
+    assert "path=" not in line  # noise for the pinned cache path
+
+
+def test_format_dataset_identity_local_override_shows_path():
+    line = population.format_dataset_identity(
+        {
+            "source": population.SOURCE_LOCAL_OVERRIDE,
+            "revision": None,
+            "sha256": "deadbeef0000",
+            "path": "/tmp/experiment.h5",
+        }
+    )
+    assert "source=local-override" in line
+    assert "path=/tmp/experiment.h5" in line
+
+
+def test_format_dataset_identity_empty_is_blank():
+    assert population.format_dataset_identity(None) == ""
+    assert population.format_dataset_identity({}) == ""

--- a/tests/test_policyengine_population.py
+++ b/tests/test_policyengine_population.py
@@ -117,6 +117,15 @@ def test_resolve_pin_unknown_country_is_none(monkeypatch):
     assert population.resolve_populace_pin("fr") is None
 
 
+def test_resolve_pin_whitespace_override_is_treated_as_unset(monkeypatch):
+    _clear_populace_env(monkeypatch)
+    monkeypatch.setenv("AXIOM_POPULACE_US_REVISION", "   ")
+    monkeypatch.setenv("AXIOM_POPULACE_US_SHA256", "\t")
+
+    # A blank override must not collapse the pin to "" — it falls back to base.
+    assert population.resolve_populace_pin("us") == population.POPULACE_PINS["us"]
+
+
 # ---------------------------------------------------------------------------
 # Resolution order: local override > pinned download > unpinned fallback
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1064"
+version = "0.2.1065"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Phase-A item **A2** of the Axiom platform plan (`axiom-rebuild-plan-2026-07-02.md`): harden `axiom-encode`'s Populace population-data loading with a **verified pin**, so every oracle run compares against a known input base rather than whatever Hugging Face currently serves as `latest`.

`axiom-encode` was already populace-native — `oracles/policyengine/population.py` centralizes loading for `us_populace`, `ecps_tax`, `ecps_snap`, `medicaid_populace`, `efrs_uk` — but nothing verified **what** it loaded. This PR is **loading + provenance only**: no CLI command is renamed and no comparison semantics change.

## Why not `latest` (populace#278)

`populace.data.load()` (populace-data 0.1.0) always fetches the HF-latest revision with **no pin**. As of 2026-07-02 HF-latest for the US dataset is the sparse `populace-us-2024-sparse-l0-refit-57k-…-national-only-20260701`, which **zeroes untargeted engine input bases** (IRA / HSA / self-employed pension / childcare and dozens more) per [PolicyEngine/populace#278](https://github.com/PolicyEngine/populace/issues/278). An encoder oracle run on that artifact would silently compare against ~$0 bases. #278 was closed 2026-07-02 by pipeline-fix PR #279, but the rebuilt dense-parity artifact is **not yet published/certified**, so we pin the last dense certified artifacts.

## The pin (verified against policyengine.py's certified bundle)

Read out of `policyengine.py`'s certified bundle manifest (`src/policyengine/data/bundle/manifest.json`, bundle 4.18.6):

| | US | UK |
|---|---|---|
| repo_id | `policyengine/populace-us` | `policyengine/populace-uk-private` (needs HF token) |
| filename | `populace_us_2024.h5` | `populace_uk_2023.h5` |
| revision | `populace-us-2024-f0af251-703bd81a565c-20260620T201958Z` | `populace-uk-2023-dd68c73-4aa4b14-20260619T023711Z` |
| sha256 | `16be6338…0f916c5d5f` | `f17306cc…07934833` |
| built_with (pe) | policyengine-us **1.729.0** | policyengine-uk **2.89.2** |

## Resolution order (before → after)

| Priority | Before | After |
|---|---|---|
| 1 | Explicit `AXIOM_POPULACE_*` local artifact (unverified) | Explicit `AXIOM_POPULACE_*` local artifact — **sha256-verified against the pin; loud warning (not failure) on mismatch** (`source=local-override`) |
| 2 | `populace.data.load()` → **HF-latest, silent** | **Unpinned escape hatch** — only when `AXIOM_POPULACE_ALLOW_UNPINNED=1`; checked before the pin so an operator can deliberately test a new release; warns naming #278 (`source=unpinned`) |
| 3 | HF-cache scan → **HF-latest, silent** | **Pinned `hf_hub_download` at `revision` + post-download sha256 verify — the default; fatal on mismatch** (`source=pinned`) |
| 4 | — | No pin + no escape hatch → **`SystemExit`** pointing at the pin and the hatch (never a silent resolve to HF-latest) |

The old `populace.data.load()` and HF-cache scan are **no longer a silent fallback** — they moved behind `AXIOM_POPULACE_ALLOW_UNPINNED`. `AXIOM_POPULACE_US_REVISION` / `AXIOM_POPULACE_US_SHA256` (and UK equivalents) allow **re-pinning without a code change**.

## Dataset identity in comparison outputs

Every `*-populace-compare` result now carries `{source, path, sha256 (first 12 hex), revision, built_with}`, threaded via an optional `provenance` sink kwarg on `load_populace_dataset()` (passing nothing keeps existing call sites unchanged):

- **us / tax / uk** (report dataclasses): new `dataset_identity` field in `to_json()` + a `Dataset:` line in the human report.
- **snap / medicaid** (CSV writers): a `Dataset:` line in the printed summary + a sibling `<csv>.dataset_identity.json` written alongside `--write-csv`.

No `encoding_db` / `supabase_sync` change: the `*-populace-compare` commands don't log to those, so there was nothing to thread there (confirmed by reconnaissance across the compare command handlers).

## UPGRADE NOTE

An `UPGRADE NOTE` comment sits at the pin: **re-pin when a post-#279 sparse (or dense-parity) release is certified as the default in the `policyengine.py` bundle** — read the new `(repo_id, filename, revision, sha256, built_with)` from that bundle's `manifest.json` and update. Do **not** bump to HF-latest without that certification.

## Known compatibility consideration

The pinned artifacts were built with **policyengine-us 1.729.0 / policyengine-uk 2.89.2**, while this repo may have a newer PolicyEngine installed. Comparisons remain valid — PolicyEngine recomputes outputs from the pinned **inputs**, so the comparison is against the encoded rules, not stale precomputed values — but the mismatch is flagged as a known compat consideration and recorded in `built_with` provenance. (The existing `--allow-policyengine-*-version` flags already govern the strict-version gate; this PR does not change them.)

`huggingface_hub` is imported lazily inside the pinned-download path (consistent with how `populace-data` / `policyengine-us` are already runtime-injected via `uv run --with`, not declared in `pyproject.toml`); a missing `huggingface_hub` yields a clean `SystemExit` with an install hint (`uv run --with huggingface-hub …`).

## Tests

New/updated `tests/test_policyengine_population.py` (24 tests) cover: pin values match the certified bundle (US+UK); env re-pin overrides (revision + sha, partial, lower-casing); resolution order (pinned default; local-override precedence; escape-hatch-overrides-pin for a certified country); **sha256 mismatch behavior — local-override warns, pinned-download fails hard**; missing `huggingface_hub` → clean install message; real end-to-end sha256 verification; unpinned escape-hatch gating (disabled → `SystemExit` naming #278; enabled → warns); HF-cache scan moved behind the hatch; `file_sha256` across chunks; provenance formatting.

Results (the repo's `pytest` shim is broken from an unrelated python@3.14 cleanup, so runs go via `uv run --extra dev python -m pytest`):

```
ruff check pyproject.toml src/axiom_encode scripts tests   -> All checks passed!
python -m compileall -q src/axiom_encode scripts           -> ok
pytest tests/test_policyengine_population.py                -> 24 passed
pytest test_cli.py test_rulespec_validation.py \
       test_evals.py -k "rulespec or EncoderPrompt"         -> 743 passed, 842 deselected
pytest <all touched oracle modules + coverage>             -> 690 passed, 26 skipped
```

## Review cycle

Ran an internal self-review pass with the focused checks from the repo's PR-discipline section, plus an independent reviewer agent. Self-review caught and fixed a resolution-order gap (the escape hatch is now checked before the pin so it can override certified countries — commit 2). No unresolved actionable findings at hand-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
