### PR TITLE
Combine current local corpus records for grounding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1183"
+version = "0.2.1184"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1183"
+__version__ = "0.2.1184"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -19560,7 +19560,7 @@ def _read_local_corpus_provision_file(
 
 
 def _select_local_corpus_record_body(records: list[dict[str, Any]]) -> str | None:
-    """Select the best body when local corpus files contain duplicate citations."""
+    """Select source text from local corpus records for an exact citation path."""
     body_records = [
         record for record in records if _local_corpus_record_text(record) is not None
     ]
@@ -19574,8 +19574,24 @@ def _select_local_corpus_record_body(records: list[dict[str, Any]]) -> str | Non
         version = str(record.get("version") or "")
         return (source_as_of, official_source, version)
 
-    selected = max(body_records, key=record_key)
-    return _local_corpus_record_text(selected)
+    best_key = max(record_key(record) for record in body_records)
+    selected_records = [
+        record for record in body_records if record_key(record) == best_key
+    ]
+
+    def selected_order_key(record: dict[str, Any]) -> tuple[int, str, str]:
+        raw_ordinal = record.get("ordinal")
+        ordinal = raw_ordinal if isinstance(raw_ordinal, int) else 0
+        source_id = str(record.get("source_id") or "")
+        heading = str(record.get("heading") or "")
+        return (ordinal, source_id, heading)
+
+    selected_texts = [
+        text
+        for record in sorted(selected_records, key=selected_order_key)
+        if (text := _local_corpus_record_text(record)) is not None
+    ]
+    return "\n\n".join(selected_texts)
 
 
 def _local_corpus_record_text(record: dict[str, Any]) -> str | None:

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -16999,6 +16999,86 @@ rules:
     assert find_ungrounded_numeric_issues(content) == []
 
 
+def test_source_verification_combines_current_exact_local_corpus_records(
+    tmp_path,
+    monkeypatch,
+):
+    provisions_dir = tmp_path / "provisions" / "us" / "guidance"
+    provisions_dir.mkdir(parents=True)
+    citation_path = "us/guidance/example/multi-source"
+    (provisions_dir / "test-source.jsonl").write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "citation_path": citation_path,
+                        "body": "Older source states the stale amount is $999.",
+                        "ordinal": 1,
+                        "source_as_of": "2025-01-01",
+                        "version": "example",
+                    },
+                    sort_keys=True,
+                ),
+                json.dumps(
+                    {
+                        "citation_path": citation_path,
+                        "body": "First current source states the amount is $123.",
+                        "ordinal": 1,
+                        "source_as_of": "2026-01-01",
+                        "version": "example",
+                    },
+                    sort_keys=True,
+                ),
+                json.dumps(
+                    {
+                        "citation_path": citation_path,
+                        "body": "Second current source states the add-on is $456.",
+                        "ordinal": 2,
+                        "source_as_of": "2026-01-01",
+                        "version": "example",
+                    },
+                    sort_keys=True,
+                ),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AXIOM_CORPUS_ARTIFACT_ROOT", str(tmp_path))
+    validator_pipeline._fetch_corpus_source_text.cache_clear()
+    validator_pipeline._fetch_local_corpus_source_text.cache_clear()
+
+    source_text = validator_pipeline._fetch_local_corpus_source_text(citation_path)
+
+    assert source_text is not None
+    assert "$123" in source_text
+    assert "$456" in source_text
+    assert "$999" not in source_text
+
+    content = f"""format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: {citation_path}
+rules:
+  - name: first_current_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '123'
+  - name: second_current_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '456'
+"""
+
+    assert find_ungrounded_numeric_issues(content) == []
+
+
 def test_validator_pipeline_maps_in_memory_source_text_to_declared_corpus_path(
     tmp_path,
     monkeypatch,

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1183"
+version = "0.2.1184"
 source = { editable = "." }
 dependencies = [
     { name = "axiom-oracles" },


### PR DESCRIPTION
## Summary
- combine all current exact local corpus records when grounding source text
- keep newest/official/version selection before combining records
- add regression coverage for multi-record exact citation paths

## Checks
- uv run pytest tests/test_rulespec_validation.py -k combines_current_exact_local_corpus_records
- AXIOM_CORPUS_REPO=/Users/pavelmakarchuk/axiom-corpus-canada-tax uv run axiom-encode validate /Users/pavelmakarchuk/rulespec-ca/policies/cra/t1-2025/rrsp-prpp-spp-hbp-llp.yaml --skip-reviewers --json
- uv run ruff check pyproject.toml src/axiom_encode scripts tests
- python -m compileall -q src/axiom_encode scripts
- uv run pytest

## Review Cycle
- Draft PR opened; independent review cycle still pending before ready for review.