### PR TITLE
Map Utah FEP resource oracle outputs

### DIFF
--- a/changelog.d/ut-fep-oracle-coverage.changed.md
+++ b/changelog.d/ut-fep-oracle-coverage.changed.md
@@ -1,0 +1,1 @@
+Add Utah FEP PolicyEngine oracle mappings for resource eligibility coverage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1066"
+version = "0.2.1067"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1066"
+__version__ = "0.2.1067"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -20211,7 +20211,35 @@ mappings:
     comparison: money
     rationale: Same Utah DWS FEP/FEP-TP monthly payment standard by assistance-unit size, represented in PolicyEngine as ut_fep_payment_standard.
 
+  - legal_id: us-ut:regulations/admin-rules/r986/200/230#ut_fep_resource_limit
+    country: us
+    program: tanf
+    mapping_type: parameter_value
+    policyengine_parameter: gov.states.ut.dwf.fep.resources.limit.amount
+    period: month
+    unit: USD
+    comparison: money
+    rationale: Same Utah Administrative Code R986-200-230 $2,000 FEP resource limit, represented in PolicyEngine as the Utah FEP resources-limit amount parameter.
+
+  - legal_id: us-ut:regulations/admin-rules/r986/200/230#ut_fep_resources_eligible
+    country: us
+    program: tanf
+    mapping_type: direct_variable
+    policyengine_variable: ut_fep_resources_eligible
+    entity: spm_unit
+    period: month
+    comparison: bool
+    rationale: Same Utah FEP resource-test eligibility predicate under R986-200-230, represented in PolicyEngine as ut_fep_resources_eligible.
+
 prefixes:
+  - legal_id_prefix: us-ut:regulations/admin-rules/r986/200/204#
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: ut_fep_eligible
+    candidate_priority: P4
+    rationale: R986-200-204 outputs are source-level FEP/FEP-TP demographic, application-completion, participation, and disqualification prerequisites. PolicyEngine exposes final ut_fep_eligible/ut_fep results after income, resource, household-composition, and benefit-composition rules are assembled, not these section-204 intermediates one-to-one.
+
   - legal_id_prefix: us:statutes/42/426
     country: us
     program: medicare

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1066"
+version = "0.2.1067"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map Utah FEP resource limit to the PolicyEngine Utah FEP resource parameter
- map Utah FEP resource eligibility to the `ut_fep_resources_eligible` variable
- classify R986-200-204 source-level prerequisite outputs as known-not-comparable to PE's final `ut_fep_eligible` surface
- bump axiom-encode to 0.2.1067 for the oracle registry change

## Validation
- `uv run python` registry sanity check for the new Utah FEP mappings
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-ut-fep-final-20260702 --json`
