### PR TITLE
Support European decimal percentage grounding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1067"
+version = "0.2.1068"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1067"
+__version__ = "0.2.1068"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -575,7 +575,7 @@ SOURCE_TEXT_NUMBER_PATTERN = re.compile(
 )
 EUROPEAN_DECIMAL_NUMBER_PATTERN = re.compile(
     r"(?:^|(?<=[\s$£€(\[,+\-−*/\"'`“”‘’]))"
-    r"(-?(?:\d{1,3}(?:[.\u00a0\u202f]\d{3})+|\d+),\d{1,4})"
+    r"(-?(?:\d{1,3}(?:[.\u00a0\u202f]\d{3})+|\d+),(?:\d{1,2}|\d{4}))"
     r"(?!\d)",
     re.IGNORECASE,
 )
@@ -2993,6 +2993,19 @@ def _iter_standalone_fraction_word_matches(
 def _extract_percentage_context_values(text: str) -> set[float]:
     """Return decimal rate equivalents for numbers in percentage table contexts."""
     values: set[float] = set()
+    for match in re.finditer(
+        r"(?:^|(?<=[\s(\[,+\-−*/\"'`“”‘’]))"
+        r"(-?(?:\d{1,3}(?:[.\u00a0\u202f]\d{3})+|\d+),\d{1,4})"
+        r"\s*(?:%|\b(?:percent|per\s*cent(?:um)?)\b)",
+        text,
+        re.IGNORECASE,
+    ):
+        raw = _normalize_european_decimal_number(match.group(1))
+        with contextlib.suppress(ValueError):
+            value = float(raw)
+            values.add(value / 100)
+            values.add(value)
+
     for match in SOURCE_TEXT_NUMBER_PATTERN.finditer(text):
         raw = match.group(1).replace(",", "")
         with contextlib.suppress(ValueError):

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -575,7 +575,7 @@ SOURCE_TEXT_NUMBER_PATTERN = re.compile(
 )
 EUROPEAN_DECIMAL_NUMBER_PATTERN = re.compile(
     r"(?:^|(?<=[\s$£€(\[,+\-−*/\"'`“”‘’]))"
-    r"(-?(?:\d{1,3}(?:[.\u00a0\u202f]\d{3})+|\d+),(?:\d{1,2}|\d{4}))"
+    r"(-?(?:\d{1,3}(?:[.\u00a0\u202f]\d{3})+|\d+),\d{1,4})"
     r"(?!\d)",
     re.IGNORECASE,
 )

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5952,6 +5952,26 @@ rules:
     assert 0.7933 in extract_numbers_from_text(source_text)
 
 
+def test_rulespec_grounding_accepts_three_place_european_decimal_percentage():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be/regulation/example/article/1
+rules:
+  - name: belgium_pit_autonomy_factor
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2018-01-01'
+        formula: '0.24957'
+"""
+
+    source_text = "Le facteur d'autonomie definitif est determine a 24,957 %."
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 24.957 in extract_numbers_from_text(source_text)
+
+
 def test_rulespec_grounding_does_not_trust_module_summary():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1067"
+version = "0.2.1068"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- keep general European decimal extraction from treating US-style comma thousands like 1,000 as decimal 1.0
- add context-aware European comma percentage grounding for values like Belgian 24,957 % -> 0.24957
- bump axiom-encode to 0.2.1068 for the encoder-affecting validator change

## Tests
- uv run python -m pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_evals.py::TestEvaluateArtifact::test_uses_fallback_source_text_for_grounding tests/test_evals.py::TestEvaluateArtifact::test_parameter_table_grounding_uses_corpus_source_with_compact_summary tests/test_evals.py::TestEvaluateArtifact::test_numeric_occurrence_check_ignores_leading_zero_manual_sections tests/test_rulespec_validation.py::test_rulespec_grounding_uses_declared_corpus_source_text tests/test_rulespec_validation.py::test_rulespec_grounding_treats_filing_status_codes_as_structural tests/test_rulespec_validation.py::test_numeric_occurrence_extraction_accepts_european_decimal_money_table_cell tests/test_rulespec_validation.py::test_validator_pipeline_maps_in_memory_source_text_to_declared_corpus_path tests/test_rulespec_validation.py::test_rulespec_grounding_accepts_three_place_european_decimal_percentage -q
- uv run ruff check src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py pyproject.toml src/axiom_encode/__init__.py