### PR TITLE
Repair generated string selector and text-code table encodes

### DIFF
--- a/changelog.d/string-selector-test-input-repair.fixed.md
+++ b/changelog.d/string-selector-test-input-repair.fixed.md
@@ -1,0 +1,1 @@
+Repair generated test inputs that use boolean placeholders for string selector fields.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1068"
+version = "0.2.1069"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1068"
+__version__ = "0.2.1069"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -37843,6 +37843,10 @@ def _wrong_typed_test_input_replacement(
         if isinstance(value, bool):
             return expected
         return None
+    if isinstance(expected, str):
+        if isinstance(value, bool):
+            return expected
+        return None
     return None
 
 
@@ -39503,13 +39507,47 @@ def _default_generated_test_input_value(
     *,
     rules_payload: dict[str, object],
     prefer_positive_counts: bool = False,
-) -> bool | int:
+) -> bool | int | str:
+    if _factual_input_appears_string_selector(input_name, rules_payload=rules_payload):
+        return ""
     if _factual_input_appears_numeric(input_name, rules_payload=rules_payload):
         if prefer_positive_counts and _factual_input_name_looks_positive_count(
             input_name
         ):
             return 1
         return 0
+    return False
+
+
+def _factual_input_appears_string_selector(
+    input_name: str, *, rules_payload: dict[str, object]
+) -> bool:
+    rules = rules_payload.get("rules")
+    if not isinstance(rules, list):
+        return False
+
+    string_comparison = re.compile(
+        rf"""
+        (?:
+            \b{re.escape(input_name)}\b\s*(?:==|!=)\s*(['"])[^'"]*\1
+            |
+            (['"])[^'"]*\2\s*(?:==|!=)\s*\b{re.escape(input_name)}\b
+        )
+        """,
+        re.VERBOSE,
+    )
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        versions = rule.get("versions")
+        if not isinstance(versions, list):
+            continue
+        for version in versions:
+            if not isinstance(version, dict):
+                continue
+            formula = version.get("formula")
+            if isinstance(formula, str) and string_comparison.search(formula):
+                return True
     return False
 
 

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -238,6 +238,10 @@ _RULESPEC_FORMULA_KEYWORDS = frozenset(
 )
 
 
+def _is_rulespec_local_identifier(value: str | None) -> bool:
+    return bool(value and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", value))
+
+
 def _matching_numeric_occurrence_count(
     occurrences: Counter[float],
     value: float,
@@ -4641,15 +4645,25 @@ Import and context rules:
     )
 
     test_file_name = _rulespec_test_path(Path(target_file_name)).name
+    policyengine_hint_is_rulespec_identifier = _is_rulespec_local_identifier(
+        policyengine_rule_hint
+    )
     if include_tests:
         oracle_rule = ""
-        if policyengine_rule_hint:
+        if policyengine_rule_hint and policyengine_hint_is_rulespec_identifier:
             oracle_rule = (
                 "- Every non-empty test `output:` mapping must assert the "
                 f"canonical RuleSpec output whose local name is "
                 f"`{policyengine_rule_hint}`; use its full "
                 "`jurisdiction:path#rule` id when the artifact has a legal "
                 "pointer.\n"
+            )
+        elif policyengine_rule_hint:
+            oracle_rule = (
+                "- Because the PolicyEngine hint is not a valid local RuleSpec "
+                "identifier, tests must assert the source-faithful RuleSpec "
+                "output generated for this file rather than the dotted "
+                f"PolicyEngine path `{policyengine_rule_hint}`.\n"
             )
         canonical_target_rule = ""
         if target_ref_prefix:
@@ -4772,6 +4786,26 @@ Return ONLY raw RuleSpec YAML for `{target_file_name}`. Do not include fences or
 
     target_hint = ""
     if policyengine_rule_hint:
+        hinted_output_reference = (
+            f"`{policyengine_rule_hint}`"
+            if policyengine_hint_is_rulespec_identifier
+            else "the source-faithful oracle-facing output"
+        )
+        oracle_test_guidance = (
+            "assert the canonical RuleSpec output whose local name is "
+            f"`{policyengine_rule_hint}` in every non-empty `output:` mapping"
+            if policyengine_hint_is_rulespec_identifier
+            else "assert the generated source-faithful output in every non-empty `output:` mapping"
+        )
+        naming_guidance = (
+            f"- Name the main derived rule `{policyengine_rule_hint}` unless the source clearly defines a different canonical concept."
+            if policyengine_hint_is_rulespec_identifier
+            else (
+                "- Choose a source-faithful snake_case RuleSpec concept name "
+                "for the main output; the provided PolicyEngine hint is not a "
+                "valid local RuleSpec identifier."
+            )
+        )
         policyengine_context_exports_section = (
             _format_policyengine_hint_context_exports(
                 context_files,
@@ -4779,9 +4813,17 @@ Return ONLY raw RuleSpec YAML for `{target_file_name}`. Do not include fences or
         )
         target_hint = f"""
 Preferred principal output:
-- Name the main derived rule `{policyengine_rule_hint}` unless the source clearly defines a different canonical concept.
-- Treat `{policyengine_rule_hint}` as a required oracle-facing surface. Do not
-  put `{policyengine_rule_hint}` under `module.deferred_outputs[]` merely
+- Treat the PolicyEngine hint as an oracle-semantic hint, not as a license to
+  copy PolicyEngine internals into RuleSpec. Name the main derived rule
+  `{policyengine_rule_hint}` only when that value is already a valid local
+  RuleSpec identifier. If the hint is a dotted PolicyEngine parameter path,
+  slash path, or other non-RuleSpec identifier, choose a source-faithful
+  snake_case RuleSpec concept name and keep the hinted PolicyEngine path only
+  as oracle/comparison context. Never emit a RuleSpec rule whose `name:` is a
+  dotted path such as `gov.states...`.
+{naming_guidance}
+- Treat the hinted policy surface as a required oracle-facing surface. Do not
+  put the source-faithful output under `module.deferred_outputs[]` merely
   because the source is broad or cites many sibling provisions when an
   executable formula can be composed from source-stated facts, scalar
   parameters, or imported primary-source RuleSpec exports supplied in context.
@@ -4794,8 +4836,8 @@ Preferred principal output:
   output, when the remaining branches are executable and source-grounded.
 - For an aggregate/composite hinted output, first enumerate the executable
   `dtype: Judgment` exports already visible in copied context that match the
-  source's listed categories or branches. Compose `{policyengine_rule_hint}` as
-  a disjunction/conjunction of those imported exports plus only the local
+  source's listed categories or branches. Compose {hinted_output_reference} as a
+  disjunction/conjunction of those imported exports plus only the local
   conditions the current source itself newly states. Do not create broad local
   inputs such as `person_covered_by_*category`,
   `person_covered_by_*subparagraph`, `person_is_described_in_previous_*`,
@@ -4808,7 +4850,7 @@ Preferred principal output:
   rule depend on an aggregate leaf input merely to make the formula executable.
 {policyengine_context_exports_section.rstrip()}
 - Keep oracle-comparable tests at that named semantic level; do not assert only helper parameters or documentary scalars.
-- Keep `.test.yaml` inputs oracle-comparable: prefer the oracle's direct component facts over inverted household proxy inputs, preserve direct component surfaces when available, and assert the canonical RuleSpec output whose local name is `{policyengine_rule_hint}` in every non-empty `output:` mapping.
+- Keep `.test.yaml` inputs oracle-comparable: prefer the oracle's direct component facts over inverted household proxy inputs, preserve direct component surfaces when available, and {oracle_test_guidance}.
 - When PolicyEngine can compare the output but cannot consume the source-level
   legal facts directly, add `oracle_inputs.policyengine` with equivalent
   PolicyEngine-native scenario inputs instead of weakening the RuleSpec `input:`
@@ -4905,7 +4947,7 @@ RuleSpec requirements:
 - Rule kinds are `parameter`, `derived`, `derived_relation`, `data_relation`, or `source_relation`. Use `parameter` for named source scalars when it fits the local schema, `derived` for entity-scoped outputs, `derived_relation` when source text defines a filtered legal membership relation, `data_relation` for runtime predicates, and `source_relation` for non-executable legal/provenance edges. The numeric invariant is the named concept: source-stated amounts, rates, thresholds, caps, limits, and table/grid cells should be named so consuming formulas can reference names instead of embedding literals.
 - This numeric invariant applies in mixed deferred or entity-unsupported provisions too. Defer the unsupported output under `module.deferred_outputs[]`, but keep any independent source-stated scalar legal values as `kind: parameter` rules rather than dropping them into prose.
 - Use `kind: parameter` with `indexed_by` and versioned `values` for source-stated numeric tables/scales keyed by household size, family size, income band, age band, or another row key. Do not encode those cells as `match` arms or numeric literals inside a derived formula. For source tables with interval/range row labels such as "at least / but less than" bands, do not create one scalar parameter per row, bound, or cell with names like `*_row_0_upper_*`, `*_row_3_rate`, or `*_lower_bound_band_9`. Define a source-backed band selector as a `derived` rule, store each substantive output column as a `kind: parameter` with `indexed_by: <band_selector>` and versioned `values`, and have the exported outputs look up the indexed table. Indexed table keys must be integer band ids such as `0`, `1`, and `2`; do not use decimal row thresholds like `1.33`, `2.5`, or strings such as `2_5_to_less_than_3_0` as lookup keys. Store source-stated row bounds as private named bound concepts or private indexed table/grid bound columns, and have the selector reference those names while returning integer band ids. If interpolation or clamping needs the active row bounds before native interval-table support exists, store lower/upper bounds as private indexed parameter columns and reference those names in derived formulas; do not repeat bound literals outside the selector. Preserve source row identity: open lower or upper interval cells are real rows, not defaults and not dropped rows; omit only the open side of the predicate.
-- Indexed parameter `values` keys must be integers. If a source table maps textual labels such as county names, program names, payment codes, provider classes, or other strings to an amount, rate, or numeric classification, do not put those strings under `values:` and do not set `indexed_by` to a text input. Instead encode a `derived` selector/result using string equality or `match` arms over the source-stated text labels, or encode source-stated boolean predicates for listed categories and combine them. Keep the text labels in proof excerpts/tests, not as parameter table keys.
+- Indexed parameter `values` keys must be integers. If a source table maps textual labels such as county names, program names, payment codes, provider classes, or other strings to an amount, rate, or numeric classification, do not put those strings under `values:` and do not set `indexed_by` to a text input. Instead encode a `derived` selector/result using string equality or `match` arms over the source-stated text labels, or encode source-stated boolean predicates for listed categories and combine them. Keep the text labels in proof excerpts/tests, not as parameter table keys. Do not use an `indexed_by` table with numeric keys merely to encode rows whose source keys are text labels; integer table keys are for real numeric bands or explicit source row numbers, not invented positions for code pairs like Federal Code/State OS Code.
 - For long source-stated text-label lists, do not emit one giant `or` chain or one giant `match` with every label. Large nested formula trees can exceed the compiled artifact parser's recursion limit. If a category list has more than about 25 text labels, split it into private source-backed `dtype: Judgment` helper predicates for chunks of that category (for example `zone_3_county_group_1`, `zone_3_county_group_2`), keep each helper formula to at most 25 text comparisons, and make the exported selector combine the helpers with a short conditional.
 - Do not treat the final interval row as open-ended unless the source row is actually open-ended. If the last source row has an upper bound, the selector must return an out-of-table sentinel above that bound and the principal output must handle that sentinel. Include a companion test above the final bounded row so the generated artifact cannot silently extend the table.
 - The out-of-table sentinel is not itself a source table row. Do not add sentinel entries to indexed parameter tables and do not clamp sentinel cases to the final table row's values. Handle the sentinel before table lookups, using the existing target's source-grounded out-of-range branch when repairing an existing artifact. Use a negative sentinel such as `-1`; do not use the next positive band id such as `6` merely because there are six legal rows, because that positive id is not source-stated and will fail numeric grounding.

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -308,6 +308,19 @@ _TABLES_PROTOCOL = """- Use `kind: parameter` with `indexed_by` and versioned `v
   `match` arms over the source-stated text labels, or encode source-stated
   boolean predicates for listed categories and combine them. Keep the text
   labels in proof excerpts/tests, not as parameter table keys.
+- Do not invent synthetic row-number constants for text-label tables. If a table
+  row is identified by labels such as "A/A", "D/G", "OS A", "OS B", or similar
+  codes rather than source-stated numeric bands, either return the source-stated
+  amount directly from the text-label branch or use source-named scalar
+  parameters for each row/cell. Do not create helper outputs that assign row
+  labels to ungrounded numeric ids such as 4 or 5 merely to make `indexed_by`
+  work.
+- Do not use an `indexed_by` table with numeric keys merely to encode rows whose
+  source keys are text labels. Integer table keys are acceptable for real
+  numeric bands or explicit source row numbers; they are not acceptable as
+  invented positions for code pairs like Federal Code/State OS Code. For those
+  text-coded tables, branch on the source labels and return named cell
+  parameters directly.
 - For long source-stated text-label lists, do not emit one giant `or` chain or
   one giant `match` with every label. Large nested formula trees can exceed the
   compiled artifact parser's recursion limit. If a category list has more than

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14421,6 +14421,117 @@ rules:
         assert run.outcome["overlay_validation_success"] is True
         assert run.outcome["status"] == "apply_applied"
 
+    def test_encode_apply_auto_repairs_string_selector_test_input_values(
+        self, capsys, tmp_path
+    ):
+        args = self._make_args(tmp_path, backend="codex", sync=False)
+        args.apply = True
+        result = self._make_eval_result(False)
+        result.error = "Generated RuleSpec failed CI validation"
+        output_file = (
+            tmp_path
+            / "out"
+            / "codex-test-model"
+            / "policies"
+            / "ssa"
+            / "poms"
+            / "dc-ossp-payment-levels.yaml"
+        )
+        output_file.parent.mkdir(parents=True)
+        output_file.write_text(
+            """format: rulespec/v1
+module:
+  proof_validation:
+    required: true
+rules:
+  - name: dc_ossp_total_payment_level
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if federal_code == "A" and state_os_code == "A":
+              1675
+          else:
+              0
+"""
+        )
+        test_file = output_file.with_name("dc-ossp-payment-levels.test.yaml")
+        test_file.write_text(
+            """- name: auto_zero_dc_ossp_total_payment_level
+  period: 2026-01
+  input:
+    us:policies/ssa/poms/dc-ossp-payment-levels#input.federal_code: false
+    us:policies/ssa/poms/dc-ossp-payment-levels#input.state_os_code: false
+  output:
+    us:policies/ssa/poms/dc-ossp-payment-levels#dc_ossp_total_payment_level: 0
+"""
+        )
+        result.output_file = str(output_file)
+        applied_file = (
+            args.policy_repo_path
+            / "policies/ssa/poms/dc-ossp-payment-levels.yaml"
+        )
+
+        with (
+            patch("axiom_encode.cli.run_model_eval", return_value=[result]),
+            patch(
+                "axiom_encode.cli._validate_generated_encoding_in_policy_overlay",
+                side_effect=[
+                    (
+                        False,
+                        [
+                            "policies/ssa/poms/dc-ossp-payment-levels.yaml: ci: "
+                            "Test case `auto_zero_dc_ossp_total_payment_level` "
+                            "execution failed: type mismatch: left side of "
+                            "comparison is not numeric"
+                        ],
+                        {},
+                    ),
+                    (True, [], {}),
+                ],
+            ) as mock_overlay,
+            patch(
+                "axiom_encode.cli._apply_generated_encoding_result",
+                return_value=[applied_file],
+            ) as mock_apply,
+            patch.dict(os.environ, {}, clear=True),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cmd_encode(args)
+
+        assert exc_info.value.code == 0
+        output = capsys.readouterr().out
+        assert (
+            "apply=auto_repaired_wrong_typed_test_inputs:"
+            "auto_zero_dc_ossp_total_payment_level:"
+            "us:policies/ssa/poms/dc-ossp-payment-levels#input.federal_code"
+        ) in output
+        assert mock_overlay.call_count == 2
+        mock_apply.assert_called_once()
+        test_payload = yaml.safe_load(test_file.read_text())
+        inputs = test_payload[0]["input"]
+        assert (
+            inputs["us:policies/ssa/poms/dc-ossp-payment-levels#input.federal_code"]
+            == ""
+        )
+        assert (
+            inputs["us:policies/ssa/poms/dc-ossp-payment-levels#input.state_os_code"]
+            == ""
+        )
+        run = EncodingDB(args.db).get_recent_runs(limit=1)[0]
+        assert sorted(run.outcome["auto_repaired_wrong_typed_test_inputs"]) == [
+            "auto_zero_dc_ossp_total_payment_level:"
+            "us:policies/ssa/poms/dc-ossp-payment-levels#input.federal_code",
+            "auto_zero_dc_ossp_total_payment_level:"
+            "us:policies/ssa/poms/dc-ossp-payment-levels#input.state_os_code",
+        ]
+        assert run.outcome["overlay_validation_success"] is True
+        assert run.outcome["status"] == "apply_applied"
+
     def test_encode_apply_repairs_self_referential_generated_derived_rules(
         self, capsys, tmp_path
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14472,8 +14472,7 @@ rules:
         )
         result.output_file = str(output_file)
         applied_file = (
-            args.policy_repo_path
-            / "policies/ssa/poms/dc-ossp-payment-levels.yaml"
+            args.policy_repo_path / "policies/ssa/poms/dc-ossp-payment-levels.yaml"
         )
 
         with (

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -109,6 +109,8 @@ def _assert_encoder_prompt_topics(prompt: str) -> None:
         "every source-stated amount, rate, threshold, cap, and limit",
         '"per taxpayer per beneficiary"',
         "Do not treat the final interval row as open-ended",
+        "Do not invent synthetic row-number constants for text-label tables",
+        "Do not use an `indexed_by` table with numeric keys merely to encode rows whose",
         "Use a negative sentinel such as `-1`",
         "source text `133%` should be",
         "kind: derived_relation",

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -11477,7 +11477,7 @@ rules:
 
         assert "uc_standard_allowance_single_claimant_aged_under_25" in prompt
         assert (
-            "Treat `uc_standard_allowance_single_claimant_aged_under_25` as a required oracle-facing surface"
+            "Treat the hinted policy surface as a required oracle-facing surface"
             in prompt
         )
         assert "Do not" in prompt

--- a/tests/test_prompt_concept_injection.py
+++ b/tests/test_prompt_concept_injection.py
@@ -210,3 +210,36 @@ def test_build_rulespec_eval_prompt_includes_scoped_exception_test_guidance(
     assert "`subject to`" in test_file_rules
     assert "positive/nonzero" in test_file_rules
     assert "toggle each gate at least once" in test_file_rules
+
+
+def test_build_rulespec_eval_prompt_treats_dotted_policyengine_hint_as_oracle_context(
+    tmp_path: Path,
+):
+    source_text = (
+        "Federal Code A and State OS Code A have a State Supplement Level "
+        "of 681.00."
+    )
+    workspace = _minimal_workspace(tmp_path, source_text)
+
+    prompt = _build_rulespec_eval_prompt(
+        citation="us/guidance/ssa/poms/si-01415-058/2026/block-13",
+        mode="repo-augmented",
+        workspace=workspace,
+        context_files=[],
+        target_file_name=(
+            "policies/ssa/poms/si-01415-058/2026/"
+            "dc-ossp-individual-state-supplement-levels.yaml"
+        ),
+        target_ref_prefix=(
+            "us-dc:policies/ssa/poms/si-01415-058/2026/"
+            "dc-ossp-individual-state-supplement-levels"
+        ),
+        include_tests=True,
+        runner_backend="codex",
+        policyengine_rule_hint="gov.states.dc.dhcf.ossp.payment.individual",
+    )
+
+    assert "oracle-semantic hint" in prompt
+    assert "dotted PolicyEngine parameter path" in prompt
+    assert "Never emit a RuleSpec rule whose `name:` is a" in prompt
+    assert "gov.states.dc.dhcf.ossp.payment.individual" in prompt

--- a/tests/test_prompt_concept_injection.py
+++ b/tests/test_prompt_concept_injection.py
@@ -216,8 +216,7 @@ def test_build_rulespec_eval_prompt_treats_dotted_policyengine_hint_as_oracle_co
     tmp_path: Path,
 ):
     source_text = (
-        "Federal Code A and State OS Code A have a State Supplement Level "
-        "of 681.00."
+        "Federal Code A and State OS Code A have a State Supplement Level of 681.00."
     )
     workspace = _minimal_workspace(tmp_path, source_text)
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1068"
+version = "0.2.1069"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- repair generated test inputs that use boolean placeholders for string selector fields
- treat dotted PolicyEngine hints as oracle context rather than RuleSpec rule names
- harden encoder prompts against synthetic numeric row ids for text-coded source tables such as Federal Code/State OS Code

## Validation
- uv run ruff check src/axiom_encode/cli.py src/axiom_encode/prompts/encoder.py src/axiom_encode/harness/evals.py tests/test_cli.py tests/test_encoder_backend.py tests/test_prompt_concept_injection.py tests/test_rulespec_validation.py
- uv run --extra dev python -m pytest tests/test_cli.py tests/test_encoder_backend.py tests/test_prompt_concept_injection.py tests/test_rulespec_validation.py -q -k "wrong_typed_test_input_values or string_selector_test_input_values or generic_encoder_prompt_includes_durable_rule_spec_guidance or dotted_policyengine_hint or european_decimal"

## Encoding smoke test
- DC OSSP individual state supplement encode against POMS SI 01415.058D.2.a and D.C. Code 4-205.49 now compiles, passes CI, and grounds cleanly; apply is blocked locally only by missing AXIOM_ENCODE_APPLY_SIGNING_KEY.