### PR TITLE
Classify DC OSSP selector oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1070"
+version = "0.2.1071"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1070"
+__version__ = "0.2.1071"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -2448,6 +2448,13 @@ mappings:
     candidate_priority: P4
     rationale: RuleSpec exposes the POMS SI 01415.058 block 13 Federal Code D Title XIX payment cap column as a source-table input. PolicyEngine's DC OSSP parameter stores the District supplement amount, not this federal payment cap.
 
+  - legal_id: us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#adult_foster_care_home_os_code_resident_threshold
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS SI 01415.058 block 11 resident-count cutoff used to select State OS Code A or B. PolicyEngine's DC OSSP surface stores District supplement amounts in tables keyed by OS_A and OS_B, and does not expose this source-level row-selection cutoff as a separate parameter.
+
   - legal_id: us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-individual-state-supplement-levels#adult_foster_care_small_individual_state_supplement_level
     country: us
     program: ssi_state_supplement
@@ -20522,6 +20529,20 @@ mappings:
     rationale: Same Utah FEP resource-test eligibility predicate under R986-200-230, represented in PolicyEngine as ut_fep_resources_eligible.
 
 prefixes:
+  - legal_id_prefix: us-dc:statutes/4/4-205/49#
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the D.C. Code § 4-205.49 source authority, payment components, residence-size thresholds, and statutory allocation formulas. PolicyEngine's DC OSSP surface stores current POMS payment table cells separately by OS code and does not expose these statute-level authority and composition boundaries as one-to-one parameters or variables.
+
+  - legal_id_prefix: us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#
+    country: us
+    program: ssi_state_supplement
+    mapping_type: not_comparable
+    candidate_priority: P4
+    rationale: RuleSpec exposes the POMS SI 01415.058 block 11 State OS Code selector and source-local predicates used to choose living-arrangement rows. PolicyEngine's DC OSSP surface stores District supplement amounts in tables keyed by those OS codes, not the row-selection predicates themselves.
+
   - legal_id_prefix: us-ut:regulations/admin-rules/r986/200/204#
     country: us
     program: tanf

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -3672,6 +3672,33 @@ def test_policyengine_registry_includes_minnesota_msa_assistance_standard_mappin
 def test_policyengine_registry_includes_dc_ossp_payment_level_mappings():
     registry = load_policyengine_registry()
 
+    living_arrangement_threshold = registry.mapping_for_legal_id(
+        "us-dc:policies/ssa/poms/si-01415-058/2026/"
+        "dc-ossp-living-arrangement-variations"
+        "#adult_foster_care_home_os_code_resident_threshold",
+        country="us",
+    )
+    assert living_arrangement_threshold.mapping_type == "not_comparable"
+    assert living_arrangement_threshold.candidate_priority == "P4"
+
+    living_arrangement_selector = registry.mapping_for_legal_id(
+        "us-dc:policies/ssa/poms/si-01415-058/2026/"
+        "dc-ossp-living-arrangement-variations"
+        "#dc_ossp_living_arrangement_os_code",
+        country="us",
+    )
+    assert living_arrangement_selector.mapping_type == "not_comparable"
+    assert living_arrangement_selector.match_type == "prefix"
+    assert living_arrangement_selector.candidate_priority == "P4"
+
+    statute_component = registry.mapping_for_legal_id(
+        "us-dc:statutes/4/4-205/49#small_residence_base_total_payment_amount",
+        country="us",
+    )
+    assert statute_component.mapping_type == "not_comparable"
+    assert statute_component.match_type == "prefix"
+    assert statute_component.candidate_priority == "P4"
+
     individual_selector = registry.mapping_for_legal_id(
         "us-dc:policies/ssa/poms/si-01415-058/2026/"
         "dc-ossp-individual-state-supplement-levels"

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1070"
+version = "0.2.1071"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify D.C. Code § 4-205.49 generated outputs as source-level not-comparable PolicyEngine oracle coverage
- classify the POMS SI 01415.058 block 11 living-arrangement selector outputs as source-level not-comparable coverage
- keep the existing exact DC OSSP payment-cell mappings intact so comparable amount parameters still resolve exactly

## Validation
- uv run --with pytest --with pytest-cov --reinstall-package axiom-encode python -m pytest tests/test_rulespec_validation.py -k dc_ossp -q
- uv run --reinstall-package axiom-encode axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-dc-ossp-selector-20260703 --oracle policyengine --fail-on-unmapped --limit 80