### PR TITLE
Let oracle mappings close stale program-surface statuses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1071"
+version = "0.2.1072"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1071"
+__version__ = "0.2.1072"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/coverage.py
+++ b/src/axiom_encode/oracles/policyengine/coverage.py
@@ -1494,15 +1494,17 @@ def _program_surface_item_from_payload(
         if not mapping.comparable and mapping.candidate_priority != "P4"
     )
     manifest_status = str(payload["axiom_status"])
-    if manifest_status in PENDING_PROGRAM_SURFACE_STATUSES:
-        axiom_status = manifest_status
-    elif comparable_mapping_count:
+    if comparable_mapping_count:
         axiom_status = "wired"
     elif final_non_comparable_mapping_count and manifest_status in {
         "pending_oracle_mapping",
         "pending_rulespec_encoding",
+        "pending_source_ingestion",
+        "deferred_jurisdiction",
     }:
         axiom_status = "known_not_comparable"
+    elif manifest_status in PENDING_PROGRAM_SURFACE_STATUSES:
+        axiom_status = manifest_status
     else:
         axiom_status = manifest_status
     legal_ids = tuple(mapping.legal_id for mapping in mappings)

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -767,6 +767,80 @@ surfaces:
     ] == pytest.approx(15.65)
 
 
+def test_policyengine_program_surface_registry_mapping_overrides_stale_pending_status(
+    tmp_path,
+):
+    manifest = tmp_path / "program_surfaces.yaml"
+    manifest.write_text(
+        """source:
+  repository: PolicyEngine/policyengine-us
+  ref: test
+  path: policyengine_us/programs.yaml
+surfaces:
+  - country: us
+    program_id: ssi_state_supplement
+    program_name: DC OSSP
+    category: Benefits
+    policyengine_status: complete
+    coverage: DC
+    variable: dc_ossp
+    source_type: state_implementation
+    state: DC
+    axiom_status: deferred_jurisdiction
+    priority: P1
+    rationale: Stale jurisdiction bootstrap status.
+  - country: us
+    program_id: tanf
+    program_name: Vermont Reach Up
+    category: Benefits
+    policyengine_status: complete
+    coverage: VT
+    variable: vt_reach_up
+    source_type: state_implementation
+    state: VT
+    axiom_status: pending_rulespec_encoding
+    priority: P1
+    rationale: Stale encoding status.
+""",
+        encoding="utf-8",
+    )
+    registry = _ProgramSurfaceRegistry(
+        {
+            "dc_ossp": [
+                PolicyEngineMapping(
+                    legal_id="us-dc:programs/ssi-state-supplement/fy-2026#dc_ossp",
+                    country="us",
+                    mapping_type="direct_variable",
+                    policyengine_variable="dc_ossp",
+                )
+            ],
+            "vt_reach_up": [
+                PolicyEngineMapping(
+                    legal_id="us-vt:statutes/title-33/chapter-11#reach_up_amount",
+                    country="us",
+                    mapping_type="not_comparable",
+                    policyengine_variable="vt_reach_up",
+                    rationale="Encoded source slice is not PE's final benefit surface.",
+                )
+            ],
+        }
+    )
+
+    report = build_policyengine_program_surface_report(
+        manifest_path=manifest,
+        registry=registry,
+    )
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    assert items_by_variable["dc_ossp"]["axiom_status"] == "wired"
+    assert items_by_variable["dc_ossp"]["mapping_count"] == 1
+    assert items_by_variable["dc_ossp"]["comparable_mapping_count"] == 1
+    assert items_by_variable["vt_reach_up"]["axiom_status"] == "known_not_comparable"
+    assert items_by_variable["vt_reach_up"]["mapping_count"] == 1
+    assert items_by_variable["vt_reach_up"]["comparable_mapping_count"] == 0
+    assert report["active_pending_surfaces"] == 0
+
+
 def test_policyengine_program_surface_report_accepts_populace_validation_metadata(
     tmp_path,
 ):
@@ -1233,7 +1307,7 @@ surfaces:
     category: Benefits
     policyengine_status: complete
     coverage: AZ
-    variable: az_ccap
+    variable: az_source_ingestion_fixture
     source_type: state_implementation
     state: AZ
     axiom_status: pending_source_ingestion
@@ -1245,7 +1319,7 @@ surfaces:
     category: Benefits
     policyengine_status: complete
     coverage: AL
-    variable: al_tanf
+    variable: al_tanf_fixture
     source_type: state_implementation
     state: AL
     axiom_status: pending_rulespec_encoding
@@ -1303,18 +1377,18 @@ surfaces:
     assert "repo:rulespec-us" in new_tax_surface["lock_scopes"]
     assert new_tax_surface["oracle_expectation"].startswith("encode source-law output")
 
-    al_tanf = items_by_variable["al_tanf"]
+    al_tanf = items_by_variable["al_tanf_fixture"]
     assert al_tanf["action"] == "encode_rulespec"
     assert al_tanf["target_repo"] == "rulespec-us"
     assert al_tanf["target_prefix"] == "us-al"
     assert "repo:rulespec-us" in al_tanf["lock_scopes"]
     assert "target-prefix:us-al" in al_tanf["lock_scopes"]
 
-    az_ccap = items_by_variable["az_ccap"]
+    az_ccap = items_by_variable["az_source_ingestion_fixture"]
     assert az_ccap["action"] == "ingest_source"
     assert az_ccap["target_repo"] == "axiom-corpus"
     assert az_ccap["target_prefix"] == "us-az"
-    assert "corpus-source:us:ccdf:az_ccap" in az_ccap["lock_scopes"]
+    assert "corpus-source:us:ccdf:az_source_ingestion_fixture" in az_ccap["lock_scopes"]
 
 
 def test_policyengine_cloud_queue_can_include_deferred_jurisdictions(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1071"
+version = "0.2.1072"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- let comparable PolicyEngine oracle mappings mark stale pending/deferred program surfaces as wired
- let final non-comparable mappings close stale pending/source-ingestion/deferred surfaces as known_not_comparable
- add a regression for stale manifest statuses being overridden by registry evidence
- bump axiom-encode to 0.2.1072

## Validation
- uv run --with pytest --with pytest-cov --reinstall-package axiom-encode python -m pytest tests/test_policyengine_coverage.py::test_policyengine_program_surface_registry_mapping_overrides_stale_pending_status -q
- uv run --with pytest --with pytest-cov --reinstall-package axiom-encode python -m pytest tests/test_policyengine_coverage.py -k "program_surface" -q
- uv run --with pytest --with pytest-cov --reinstall-package axiom-encode python -m pytest tests/test_cli.py::test_package_version_metadata_matches_pyproject tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump tests/test_policyengine_coverage.py::test_policyengine_program_surface_registry_mapping_overrides_stale_pending_status tests/test_policyengine_coverage.py -k "program_surface" -q

## Follow-up
- The real SSI supplement report still leaves dc_ossp deferred_jurisdiction because DC has comparable component mappings but no final dc_ossp program-surface mapping yet. That remains the next parity item.