### PR TITLE
Classify DC TANF payment slice against PolicyEngine

### DIFF
--- a/changelog.d/dc-tanf-oracle-coverage.changed.md
+++ b/changelog.d/dc-tanf-oracle-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify D.C. TANF statute payment-table outputs as known-not-comparable to PolicyEngine's final `dc_tanf` surface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1072"
+version = "0.2.1073"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1072"
+__version__ = "0.2.1073"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -20536,6 +20536,14 @@ prefixes:
     candidate_priority: P4
     rationale: RuleSpec exposes the D.C. Code § 4-205.49 source authority, payment components, residence-size thresholds, and statutory allocation formulas. PolicyEngine's DC OSSP surface stores current POMS payment table cells separately by OS code and does not expose these statute-level authority and composition boundaries as one-to-one parameters or variables.
 
+  - legal_id_prefix: us-dc:statutes/4/4-205/52#
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: dc_tanf
+    candidate_priority: P4
+    rationale: RuleSpec exposes the D.C. Code § 4-205.52 source-law standard and assistance payment tables, historical adjustment rates, and time-limit reduction parameters. PolicyEngine's dc_tanf surface is the final monthly benefit after current DHS/state-plan/DCMR payment standards, countable income, eligibility, enrollment, and work-sanction gates are composed, so these statutory source parameters are not one-to-one oracle targets.
+
   - legal_id_prefix: us-dc:policies/ssa/poms/si-01415-058/2026/dc-ossp-living-arrangement-variations#
     country: us
     program: ssi_state_supplement

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -275,10 +275,12 @@ surfaces:
   variable: dc_tanf
   source_type: state_implementation
   state: DC
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom now has D.C. Code § 4-205.52 source-law coverage for statutory payment tables, adjustment rates,
+    and time-limit reduction parameters. PolicyEngine's dc_tanf remains a composed final monthly benefit surface that
+    also depends on current DHS/state-plan/DCMR payment standards, countable income, eligibility, enrollment, and
+    work-sanction gates; keep known-not-comparable until those current-source components are ingested and composed.
 - country: us
   program_id: tanf
   program_name: Illinois TANF

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1072"
+version = "0.2.1073"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify D.C. Code § 4-205.52 TANF payment-table outputs as known-not-comparable to PolicyEngine's final dc_tanf surface
- mark the DC TANF program surface as known-not-comparable pending current DHS/state-plan/DCMR composition

## Validation
- uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -q
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-dc-tanf-20260703 --json

The coverage command now classifies all 8 us-dc:statutes/4/4-205/52 outputs as known_not_comparable instead of unmapped.