### PR TITLE
Use single-version section 85 repair output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1076"
+version = "0.2.1077"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1076"
+__version__ = "0.2.1077"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -15359,7 +15359,7 @@ rules:
               corpus_citation_path: us/statute/26/85
               excerpt: unemployment compensation received by the taxpayer as does not exceed $10,200
     versions:
-      - effective_from: '2020-01-01'
+      - effective_from: '1990-01-01'
         formula: |-
           min(
               max(0, unemployment_compensation),
@@ -15381,16 +15381,13 @@ rules:
             source:
               corpus_citation_path: us/statute/26/85
               excerpt: gross income includes unemployment compensation
-          - path: versions[1].formula
+          - path: versions[0].formula
             kind: formula
             source:
               corpus_citation_path: us/statute/26/85
               excerpt: in the case of a joint return, the unemployment compensation received by each spouse
     versions:
       - effective_from: '1990-01-01'
-        formula: |-
-          0
-      - effective_from: '2020-01-01'
         formula: |-
           if taxable_year_begins_in_temporary_unemployment_exclusion_year and adjusted_gross_income_for_temporary_unemployment_exclusion < temporary_unemployment_exclusion_adjusted_gross_income_threshold:
               sum_where(

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1076"
+version = "0.2.1077"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- keep the generated section 85 temporary exclusion as a single derived formula version
- preserve the pre-2020 zero behavior via the statutory temporary-year condition
- bump axiom-encode to 0.2.1077

## Validation
- uv run pytest tests/test_cli.py -k section_85_unemployment
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py