### PR TITLE
Cover section 85 recipient exclusion helper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1077"
+version = "0.2.1078"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1077"
+__version__ = "0.2.1078"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -15431,13 +15431,14 @@ def _section_85_unemployment_test_content() -> str:
     return """- name: unemployment_compensation_definition_amount_received
   period:
     period_kind: tax_year
-    start: '2024-01-01'
-    end: '2024-12-31'
+    start: '2020-01-01'
+    end: '2020-12-31'
   input:
     us:statutes/26/85#input.amount_received_under_united_states_or_state_law_in_nature_of_unemployment_compensation: 15000
   output:
     us:statutes/26/85#unemployment_compensation: 15000
     us:statutes/26/85#section_85_unemployment_compensation_recipient_has_unemployment_compensation: holds
+    us:statutes/26/85#temporary_unemployment_compensation_exclusion_for_recipient: 10200
 - name: temporary_2020_exclusion_caps_single_recipient
   period:
     period_kind: tax_year

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1077"
+version = "0.2.1078"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- assert generated companion coverage for the section 85 recipient-level temporary exclusion helper in tax year 2020
- bump axiom-encode to 0.2.1078

## Validation
- uv run pytest tests/test_cli.py -k section_85_unemployment
- uv run ruff check src/axiom_encode/cli.py tests/test_cli.py
- uv run ruff format --check src/axiom_encode/cli.py tests/test_cli.py