### PR TITLE
docs: mark tax-populace-compare deprecated-for-CI (A9)

### DIFF
--- a/changelog.d/fiit-compare-ci-ownership.changed.md
+++ b/changelog.d/fiit-compare-ci-ownership.changed.md
@@ -1,0 +1,1 @@
+Document that `tax-populace-compare` (alias `tax-ecps-compare`) is deprecated for CI/weekly FIIT reporting — that comparison is now owned by the axiom-oracles standard runner — while remaining supported for local development and residual triage.

--- a/docs/policyengine-oracle-registry.md
+++ b/docs/policyengine-oracle-registry.md
@@ -202,6 +202,24 @@ one is available, including cached `policyengine/populace-*` snapshots. Set
 `AXIOM_POPULACE_DATASET`, or `AXIOM_POPULACE_DATA_PATH` to pin validation to a
 specific local artifact.
 
+### CI ownership of the federal income tax (FIIT) comparison
+
+`axiom-encode tax-populace-compare` (and its `tax-ecps-compare` alias) is the
+FIIT comparison harness. As of the A9 runner unification it is **deprecated for
+CI / weekly reporting**: the reported FIIT number and its dashboard artifact are
+produced by `axiom-oracles`, which wraps this command in its standard
+comparison runner (`comparisons/fiit-ecps.yaml` → `scripts/run_comparison.py`),
+normalizes the `--json` output — including the `dataset_identity` provenance
+block — into the `axiom.comparison_report.v2` schema, and refreshes it through
+the weekly matrix. The ~17k LOC oracle bridge stays here in `axiom-encode`; only
+the run/report entry point moved.
+
+Invoking `tax-populace-compare` directly is still fully supported and is the
+right tool for **local development and residual triage** (e.g. a quick `--json`
+dump or a `--tax-unit-id` re-check). Just don't wire it into CI or treat its
+output as the reported comparison — run `run_comparison.py fiit-ecps` in
+`axiom-oracles` for that.
+
 ```bash
 axiom-encode oracle-coverage \
   --root /path/to/workspace \


### PR DESCRIPTION
## Mark `tax-populace-compare` deprecated-for-CI (Phase-A A9)

Companion docs change to the axiom-oracles A9 runner unification (TheAxiomFoundation/axiom-oracles#86).

Phase-A item **A9** of `axiom-rebuild-plan-2026-07-02.md` unified the federal income tax (FIIT) comparison into the standard `axiom-oracles` runner. This documents the ownership shift in the oracle registry so the split flagged in the 2026-06-09 review §3.5 doesn't silently regrow:

`axiom-encode tax-populace-compare` (and its `tax-ecps-compare` alias) is now **deprecated for CI / weekly reporting**. The reported FIIT number and its dashboard artifact are produced by `axiom-oracles` (`comparisons/fiit-ecps.yaml` → `scripts/run_comparison.py`), which wraps this command, normalizes its `--json` output — including the `dataset_identity` provenance block added in #952 — into the `axiom.comparison_report.v2` schema, and refreshes it through the weekly matrix.

The command stays **fully supported for local development and residual triage** (a quick `--json` dump, a `--tax-unit-id` re-check). The ~17k LOC oracle bridge stays here in `axiom-encode`; only the run/report entry point moved.

### Why docs-only

No code or flag change was needed: the harness already exposes `--json` and already emits `dataset_identity` (#952), which is an output mode adequate for the oracles adapter to normalize. So per the A9 plan ("tiny axiom-encode PR only if a flag/output-format option is strictly needed"), this is a one-paragraph registry note plus a changelog fragment — nothing more.

### Checks
- `towncrier build --draft` includes the new `changelog.d/fiit-compare-ci-ownership.changed.md` fragment cleanly.
- Docs-only; no source touched (lightweight cycle per repo `CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
