### PR TITLE
Map section 85 outputs to PolicyEngine oracle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1078"
+version = "0.2.1079"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1078"
+__version__ = "0.2.1079"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -10041,6 +10041,58 @@ mappings:
     comparison: money
     rationale: Same federal taxable income after exemptions and taxable-income deductions.
 
+  - legal_id: us:statutes/26/85#temporary_unemployment_exclusion_adjusted_gross_income_threshold
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.unemployment_compensation.exemption.cutoff
+    parameter_keys:
+      - SINGLE
+      - JOINT
+      - SEPARATE
+      - HEAD_OF_HOUSEHOLD
+      - SURVIVING_SPOUSE
+    period: year
+    unit: USD
+    comparison: money
+    tested_by_legal_ids:
+      - us:statutes/26/85#temporary_unemployment_compensation_exclusion
+    rationale: Same section 85(c)(1) temporary unemployment-compensation exclusion AGI threshold; PolicyEngine stores the uniform statutory threshold as filing-status-keyed parameter cells.
+
+  - legal_id: us:statutes/26/85#temporary_unemployment_exclusion_cap_per_taxpayer_or_spouse
+    country: us
+    program: tax
+    mapping_type: parameter_value
+    policyengine_parameter: gov.irs.unemployment_compensation.exemption.amount
+    period: year
+    unit: USD
+    comparison: money
+    tested_by_legal_ids:
+      - us:statutes/26/85#temporary_unemployment_compensation_exclusion_for_recipient
+    rationale: Same section 85(c)(1) $10,200 temporary unemployment-compensation exclusion cap per taxpayer or spouse.
+
+  - legal_id: us:statutes/26/85#unemployment_compensation
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: unemployment_compensation
+    entity: person
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same section 85(b) unemployment compensation amount received by a person.
+
+  - legal_id: us:statutes/26/85#unemployment_compensation_included_in_gross_income
+    country: us
+    program: tax
+    mapping_type: direct_variable
+    policyengine_variable: tax_unit_taxable_unemployment_compensation
+    entity: tax_unit
+    period: year
+    unit: USD
+    comparison: money
+    rationale: Same section 85(a) unemployment compensation included in gross income after applying the temporary section 85(c) exclusion.
+
   - legal_id: us:statutes/26/68/b#section_68_applied_after_other_itemized_deduction_limitations
     country: us
     program: tax
@@ -22244,6 +22296,12 @@ prefixes:
     program: tax
     mapping_type: not_comparable
     rationale: Section 63(f) aged-or-blind additional-standard-deduction outputs are statutory parameters and predicates unless an exact PolicyEngine mapping overrides this prefix.
+
+  - legal_id_prefix: us:statutes/26/85#
+    country: us
+    program: tax
+    mapping_type: not_comparable
+    rationale: Section 85 unemployment-compensation outputs are statutory temporary-exclusion predicates, helper amounts, and recipient relations unless an exact PolicyEngine mapping overrides this prefix.
 
   - legal_id_prefix: us:statutes/26/86#
     country: us

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -111,6 +111,102 @@ rules:
     )
 
 
+def test_policyengine_coverage_classifies_section_85_unemployment_outputs(tmp_path):
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "us" / "statutes" / "26" / "85.yaml",
+        """format: rulespec/v1
+rules:
+  - name: temporary_unemployment_exclusion_adjusted_gross_income_threshold
+    kind: parameter
+    versions:
+      - effective_from: '2020-01-01'
+        value: 150000
+  - name: temporary_unemployment_exclusion_cap_per_taxpayer_or_spouse
+    kind: parameter
+    versions:
+      - effective_from: '2020-01-01'
+        value: 10200
+  - name: unemployment_compensation
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: reported_unemployment_compensation
+  - name: section_85_unemployment_compensation_recipient_has_unemployment_compensation
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: unemployment_compensation > 0
+  - name: temporary_unemployment_compensation_exclusion_for_recipient
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: min(unemployment_compensation, temporary_unemployment_exclusion_cap_per_taxpayer_or_spouse)
+  - name: temporary_unemployment_compensation_exclusion
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: temporary_unemployment_compensation_exclusion_for_recipient
+  - name: unemployment_compensation_included_in_gross_income
+    kind: derived
+    versions:
+      - effective_from: '1990-01-01'
+        formula: unemployment_compensation - temporary_unemployment_compensation_exclusion
+""",
+    )
+    _write_rulespec_file(
+        tmp_path / "rulespec-us" / "us" / "statutes" / "26" / "85.test.yaml",
+        """- name: section_85_temporary_exclusion
+  period: 2020
+  output:
+    us:statutes/26/85#unemployment_compensation: 15000
+    us:statutes/26/85#temporary_unemployment_compensation_exclusion_for_recipient: 10200
+    us:statutes/26/85#temporary_unemployment_compensation_exclusion: 10200
+    us:statutes/26/85#unemployment_compensation_included_in_gross_income: 4800
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tax")
+
+    assert report["total_outputs"] == 7
+    assert report["status_counts"] == {
+        "comparable": 4,
+        "known_not_comparable": 3,
+    }
+    assert report["untested_comparable"] == 0
+    assert report["status_counts"].get("unmapped", 0) == 0
+    items_by_id = {item["legal_id"]: item for item in report["items"]}
+    assert (
+        items_by_id["us:statutes/26/85#unemployment_compensation"][
+            "policyengine_variable"
+        ]
+        == "unemployment_compensation"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/85#unemployment_compensation_included_in_gross_income"
+        ]["policyengine_variable"]
+        == "tax_unit_taxable_unemployment_compensation"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/85#temporary_unemployment_exclusion_adjusted_gross_income_threshold"
+        ]["policyengine_parameter"]
+        == "gov.irs.unemployment_compensation.exemption.cutoff"
+    )
+    assert (
+        items_by_id[
+            "us:statutes/26/85#temporary_unemployment_exclusion_cap_per_taxpayer_or_spouse"
+        ]["policyengine_parameter"]
+        == "gov.irs.unemployment_compensation.exemption.amount"
+    )
+    assert (
+        items_by_id["us:statutes/26/85#temporary_unemployment_compensation_exclusion"][
+            "status"
+        ]
+        == "known_not_comparable"
+    )
+
+
 def test_direct_policyengine_mapping_with_upstream_placeholders_is_incomplete(
     tmp_path,
 ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1078"
+version = "0.2.1079"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- map 26 USC 85 unemployment compensation outputs to PolicyEngine oracle variables/parameters where one-to-one surfaces exist
- classify remaining section 85 helper outputs with a section prefix fallback
- add a coverage regression for section 85 so generated RuleSpec does not fail unmapped or untested-comparable gates

## Tests
- uv run pytest tests/test_policyengine_coverage.py
- uv run ruff check tests/test_policyengine_coverage.py src/axiom_encode/__init__.py
- uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation/_worktrees/rulespec-us-usc85-20260703 --fail-on-unmapped --fail-on-untested-comparable --limit 20