### PR TITLE
Classify Delaware TANF oracle coverage

### DIFF
--- a/changelog.d/de-tanf-oracle-coverage.changed.md
+++ b/changelog.d/de-tanf-oracle-coverage.changed.md
@@ -1,0 +1,1 @@
+Classify the Delaware TANF 16 DE Admin. Code 4008.1.2 grant-calculation RuleSpec output against the PolicyEngine oracle registry and mark the `de_tanf` program surface as reviewed but not one-to-one comparable yet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1087"
+version = "0.2.1088"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1087"
+__version__ = "0.2.1088"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -5539,6 +5539,14 @@ mappings:
     candidate_priority: P4
     rationale: The Texas TANF program wrapper composes the HHSC Texas Works Handbook C-111 payment-standard table, A-1340 grant calculation, and C-112 first-month proration, but does not yet encode nonfinancial eligibility, resources, sanctions, time limits, or the full income-budget path. PolicyEngine-US tx_tanf applies PE's broader SPM-unit TANF graph, so this bridge is source-faithful progress but not a one-to-one oracle target.
 
+  - legal_id: us-de:regulations/title-16/4000-financial-responsibility/4008/1/2#de_tanf
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: de_tanf
+    candidate_priority: P4
+    rationale: Axiom's 16 DE Admin. Code 4008.1.2 output calculates the recipient grant after the gross-income screen, earned-income disregards, child-care deduction, net-income test, 50% deficit step, and payment-standard cap. PolicyEngine's de_tanf is a final monthly TANF benefit surface over PE's broader eligibility, income, standard, and payment graph, while this legal slice still takes the applicable standard of need and payment standard as inputs, so it is not a one-to-one oracle target until the remaining Delaware TANF components are composed.
+
   - legal_id: us-in:policies/dfr/snap-tanf-program-policy-manual/3450-35-05-benefit-calculation#tanf_thirty_dollar_earned_income_disregard
     country: us
     program: tanf

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -634,10 +634,12 @@ surfaces:
   variable: de_tanf
   source_type: state_implementation
   state: DE
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Current RuleSpec encodes the official 16 DE Admin. Code 4008.1.2 recipient grant calculation, with applicable
+    standard-of-need and payment-standard values supplied as legal inputs. PolicyEngine's de_tanf is a final monthly TANF
+    benefit surface over PE's broader eligibility, income, standard, and payment graph, so this is source-faithful progress
+    but not a one-to-one oracle target until the remaining Delaware TANF legal components are composed.
 - country: us
   program_id: tanf
   program_name: Oregon TANF

--- a/tests/test_policyengine_coverage.py
+++ b/tests/test_policyengine_coverage.py
@@ -2581,6 +2581,62 @@ def test_policyengine_program_surface_marks_kansas_tanf_known_not_comparable():
     assert "countable income" in kansas_tanf["rationale"]
 
 
+def test_policyengine_program_surface_marks_delaware_tanf_known_not_comparable():
+    report = build_policyengine_program_surface_report(program="tanf")
+
+    items_by_variable = {item["variable"]: item for item in report["items"]}
+    delaware_tanf = items_by_variable["de_tanf"]
+
+    assert delaware_tanf["program_id"] == "tanf"
+    assert delaware_tanf["state"] == "DE"
+    assert delaware_tanf["axiom_status"] == "known_not_comparable"
+    assert delaware_tanf["mapping_count"] == 1
+    assert delaware_tanf["comparable_mapping_count"] == 0
+    assert (
+        "us-de:regulations/title-16/4000-financial-responsibility/4008/1/2#de_tanf"
+        in delaware_tanf["legal_ids"]
+    )
+    assert "16 DE Admin. Code 4008.1.2" in delaware_tanf["rationale"]
+    assert (
+        "payment-standard values supplied as legal inputs" in delaware_tanf["rationale"]
+    )
+
+
+def test_policyengine_coverage_classifies_delaware_tanf_grant_calculation(tmp_path):
+    _write_rulespec_file(
+        tmp_path
+        / "rulespec-us"
+        / "us-de"
+        / "regulations/title-16/4000-financial-responsibility/4008/1/2.yaml",
+        """format: rulespec/v1
+rules:
+  - name: de_tanf
+    kind: derived
+    entity: TanfUnit
+    dtype: Money
+    unit: USD
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: 0
+""",
+    )
+
+    report = build_policyengine_coverage_report(tmp_path, program="tanf")
+
+    assert report["status_counts"] == {"known_not_comparable": 1}
+    item = report["items"][0]
+    assert item["legal_id"] == (
+        "us-de:regulations/title-16/4000-financial-responsibility/4008/1/2#de_tanf"
+    )
+    assert item["status"] == "known_not_comparable"
+    assert item["program"] == "tanf"
+    assert item["mapping_type"] == "not_comparable"
+    assert item["policyengine_variable"] == "de_tanf"
+    assert item["candidate_priority"] == "P4"
+    assert "4008.1.2 output calculates the recipient grant" in item["rationale"]
+
+
 def test_policyengine_program_surface_marks_minnesota_mfip_wired_and_populace_validated():
     report = build_policyengine_program_surface_report(program="tanf")
 

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1087"
+version = "0.2.1088"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- map the merged Delaware TANF grant-calculation RuleSpec output to PolicyEngine `de_tanf` as an exact, reviewed `not_comparable` oracle entry
- mark the Delaware TANF program surface as `known_not_comparable` now that RuleSpec exists for 16 DE Admin. Code 4008.1.2
- add regression coverage so the broad `us-de:` fallback cannot hide the PolicyEngine variable or leave the surface pending

## Context

`rulespec-us` PR #526 merged the generated RuleSpec for the official Delaware TANF recipient grant calculation, grounded in `axiom-corpus` PR #175. That legal slice still takes the applicable standard of need and payment standard as inputs, while PolicyEngine `de_tanf` is a final monthly TANF benefit surface over PE's broader eligibility, income, standard, and payment graph. This PR records that reviewed non-one-to-one status in the oracle registry.

## Validation

- `uv run --extra dev python -m pytest tests/test_policyengine_coverage.py -k "delaware_tanf"`
- `uv run ruff check pyproject.toml src/axiom_encode scripts tests`
- `uv run python -m compileall -q src/axiom_encode scripts`
- `uv run axiom-encode oracle-coverage --root /Users/maxghenis/TheAxiomFoundation --program tanf --json | jq '.items[] | select(.legal_id == "us-de:regulations/title-16/4000-financial-responsibility/4008/1/2#de_tanf")'`
- `uv run axiom-encode cloud-queue --root /Users/maxghenis/TheAxiomFoundation --country us --limit 10` now drops `de_tanf` from the active queue; first item is `hi_tanf` and queue count is 28

## Review cycle

Draft pending the required independent review cycle. Local checks are green.
