### PR TITLE
Fix country-relative repair anchors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1080"
+version = "0.2.1081"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1080"
+__version__ = "0.2.1081"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -7164,10 +7164,7 @@ def cmd_repair_nonnegative_floors(args):
             backend="deterministic",
             model="nonnegative-floor-v1",
             tool="axiom-encode repair-nonnegative-floors",
-            citation=(
-                f"{_repo_jurisdiction_prefix(repo_path)}:"
-                f"{_relative_rulespec_import_target(relative_output)}"
-            ),
+            citation=_rulespec_anchor_base_for_output(repo_path, relative_output),
             generation_prompt_sha256=None,
             trace_file=None,
             context_manifest_file=None,
@@ -10250,10 +10247,7 @@ def cmd_repair_current_year_final_amounts(args):
             backend="deterministic",
             model="current-year-final-amount-v1",
             tool="axiom-encode repair-current-year-final-amounts",
-            citation=(
-                f"{_repo_jurisdiction_prefix(repo_path)}:"
-                f"{_relative_rulespec_import_target(relative_output)}"
-            ),
+            citation=_rulespec_anchor_base_for_output(repo_path, relative_output),
             generation_prompt_sha256=None,
             trace_file=None,
             context_manifest_file=None,
@@ -10566,10 +10560,7 @@ def cmd_repair_zero_branch_tests(args):
             backend="deterministic",
             model="zero-branch-test-v1",
             tool="axiom-encode repair-zero-branch-tests",
-            citation=(
-                f"{_repo_jurisdiction_prefix(repo_path)}:"
-                f"{_relative_rulespec_import_target(relative_output)}"
-            ),
+            citation=_rulespec_anchor_base_for_output(repo_path, relative_output),
             generation_prompt_sha256=None,
             trace_file=None,
             context_manifest_file=None,
@@ -19515,10 +19506,7 @@ def _append_generic_zero_branch_tests_if_missing(
         and str(rule.get("kind") or "").strip().lower() in {"derived", "parameter"}
         and str(rule.get("name") or "").strip()
     }
-    target_base = (
-        f"{_repo_jurisdiction_prefix(repo_path)}:"
-        f"{_relative_rulespec_import_target(relative_output)}"
-    )
+    target_base = _rulespec_anchor_base_for_output(repo_path, relative_output)
     factual_inputs = _local_factual_input_names_from_rules_content(rules_content)
     input_defaults = {
         f"{target_base}#input.{input_name}": _default_generated_test_input_value(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12945,6 +12945,55 @@ rules:
         assert "auto_zero_compiled_zero_branch_amount" in test_content
         assert "auto_zero_hidden_zero_branch_amount" not in test_content
 
+    def test_zero_branch_repair_uses_country_relative_anchor_for_be_repo(
+        self, tmp_path
+    ):
+        repo = tmp_path / "rulespec-be"
+        rules_file = repo / "be" / "statutes" / "family_benefits" / "routing.yaml"
+        test_file = rules_file.with_name("routing.test.yaml")
+        rules_file.parent.mkdir(parents=True)
+        rules_file.write_text(
+            """format: rulespec/v1
+rules:
+  - name: belgium_family_benefits_selected_monthly_amount
+    kind: derived
+    entity: Child
+    dtype: Money
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if belgium_family_benefits_region == 1:
+              selected_amount
+          else:
+              0
+"""
+        )
+        test_file.write_text("[]\n")
+
+        repaired = _append_generated_zero_branch_tests_if_missing(
+            rules_file=rules_file,
+            test_file=test_file,
+            repo_path=repo,
+            relative_output=Path("be/statutes/family_benefits/routing.yaml"),
+            issues=[
+                "Zero branch test coverage missing: "
+                "`belgium_family_benefits_selected_monthly_amount` "
+                "has a formula branch that returns 0."
+            ],
+        )
+
+        assert repaired == ["auto_zero_belgium_family_benefits_selected_monthly_amount"]
+        cases = yaml.safe_load(test_file.read_text())
+        assert cases[0]["input"] == {
+            "be:statutes/family_benefits/routing#input.belgium_family_benefits_region": 0,
+            "be:statutes/family_benefits/routing#input.selected_amount": 0,
+        }
+        assert cases[0]["output"] == {
+            "be:statutes/family_benefits/routing#belgium_family_benefits_selected_monthly_amount": 0
+        }
+        assert "be:be/" not in test_file.read_text()
+
     def test_repair_zero_branch_tests_keeps_unmasked_legacy_issues(
         self, capsys, tmp_path
     ):

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1080"
+version = "0.2.1081"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- Use the jurisdiction-aware RuleSpec anchor helper when deterministic repairs generate zero-branch companion test keys.
- Apply the same helper to deterministic repair manifest citations in nearby repair commands that had the same raw-path construction.
- Add a regression test for `rulespec-be` files under a country-relative root so generated keys are `be:statutes/...`, not `be:be/statutes/...`.
- Bump axiom-encode to 0.2.1081.

## Validation

- `uv run --extra dev python -m pytest tests/test_cli.py -k "current_encoder_affecting_changes_are_behind_version_bump or zero_branch or rulespec_anchor_base_for_output" -q`
- `uv run --extra dev python -m ruff check src/axiom_encode/cli.py tests/test_cli.py pyproject.toml src/axiom_encode/__init__.py`
- `git diff --check HEAD~1..HEAD`

## Context

While applying the #968 fix to Belgium, zero-branch repair still generated malformed test anchors like `be:be/statutes/...` for files stored under the jurisdiction root. That left otherwise valid generated cases non-executable. This patch fixes the anchor source before rerunning Belgium repairs.
