### PR TITLE
Accept over-100 percent ranges as rates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1086"
+version = "0.2.1087"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1086"
+__version__ = "0.2.1087"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -579,10 +579,28 @@ EUROPEAN_DECIMAL_NUMBER_PATTERN = re.compile(
     r"(?!\d)",
     re.IGNORECASE,
 )
+SPACED_EUROPEAN_DECIMAL_MONEY_PATTERN = re.compile(
+    r"(?:^|(?<=[\s$£€(\[,+\-−*/\"'`“”‘’]))"
+    r"(-?\d{1,3}(?: \d{3})+,\d{1,4})"
+    r"(?=\s*(?:euro|euros|eur\b|€))",
+    re.IGNORECASE,
+)
+EUROPEAN_LEADING_ZERO_DECIMAL_NUMBER_PATTERN = re.compile(
+    r"(?:^|(?<=[\s$£€(\[,+\-−*/=<>\"'`“”‘’]))"
+    r"(-?0,\d{3,4})"
+    r"(?!\d)",
+    re.IGNORECASE,
+)
 EUROPEAN_THOUSANDS_NUMBER_PATTERN = re.compile(
     r"(?:^|(?<=[\s$£€(\[,+\-−*/\"'`“”‘’]))"
     r"(-?\d{1,3}(?:[.\u00a0\u202f ]\d{3})+)"
     r"(?=\s*(?:euro|euros|eur\b|€|\bchildren?\b|\bpersons?\b|\bhouseholds?\b))",
+    re.IGNORECASE,
+)
+EUROPEAN_DOT_THOUSANDS_NUMBER_PATTERN = re.compile(
+    r"(?:^|(?<=[\s$£€(\[,+\-−*/\"'`“”‘’]))"
+    r"(-?[1-9]\d{0,2}(?:\.\d{3})+)"
+    r"(?![\d,])",
     re.IGNORECASE,
 )
 SOURCE_TEXT_RATIO_NUMBER_PATTERN = re.compile(
@@ -1172,6 +1190,21 @@ _CARDINAL_VALUE_WORDS = {
     for word, value in _CARDINAL_WORD_VALUES.items()
     if float(value).is_integer()
 }
+_FRENCH_CARDINAL_PHRASE_VALUES = {
+    "cent quatre vingts": 180.0,
+    "cent quatre vingt": 180.0,
+    "cent quatre-vingts": 180.0,
+    "cent quatre-vingt": 180.0,
+}
+_FRENCH_CARDINAL_PHRASE_PATTERN = re.compile(
+    r"\b("
+    + "|".join(
+        re.escape(phrase)
+        for phrase in sorted(_FRENCH_CARDINAL_PHRASE_VALUES, key=len, reverse=True)
+    )
+    + r")\b",
+    re.IGNORECASE,
+)
 _CARDINAL_WORD_SEQUENCE = (
     r"(?:"
     + "|".join(re.escape(word) for word in _CARDINAL_WORD_VALUES)
@@ -2688,14 +2721,42 @@ def extract_numbers_from_text(text: str) -> set[float]:
             continue
         numbers.add(value)
         occupied_spans.append(span)
+    for span, value in _iter_french_cardinal_phrase_matches(text):
+        if _span_overlaps(span, occupied_spans):
+            continue
+        numbers.add(value)
+        occupied_spans.append(span)
+
+    for match in SPACED_EUROPEAN_DECIMAL_MONEY_PATTERN.finditer(text):
+        span = match.span(1)
+        raw = _normalize_european_decimal_number(match.group(1))
+        with contextlib.suppress(ValueError):
+            numbers.add(float(raw))
+            occupied_spans.append(span)
 
     for match in EUROPEAN_DECIMAL_NUMBER_PATTERN.finditer(text):
+        span = match.span(1)
         raw = _normalize_european_decimal_number(match.group(1))
+        with contextlib.suppress(ValueError):
+            numbers.add(float(raw))
+            occupied_spans.append(span)
+
+    for match in EUROPEAN_LEADING_ZERO_DECIMAL_NUMBER_PATTERN.finditer(text):
+        span = match.span(1)
+        raw = _normalize_european_decimal_number(match.group(1))
+        with contextlib.suppress(ValueError):
+            numbers.add(float(raw))
+            occupied_spans.append(span)
+
+    for match in EUROPEAN_THOUSANDS_NUMBER_PATTERN.finditer(text):
+        if _span_overlaps(match.span(1), occupied_spans):
+            continue
+        raw = _normalize_grouped_thousands_number(match.group(1))
         with contextlib.suppress(ValueError):
             numbers.add(float(raw))
             occupied_spans.append(match.span(1))
 
-    for match in EUROPEAN_THOUSANDS_NUMBER_PATTERN.finditer(text):
+    for match in EUROPEAN_DOT_THOUSANDS_NUMBER_PATTERN.finditer(text):
         if _span_overlaps(match.span(1), occupied_spans):
             continue
         raw = _normalize_grouped_thousands_number(match.group(1))
@@ -2892,6 +2953,19 @@ def _iter_cardinal_word_number_matches(
     return matches
 
 
+def _iter_french_cardinal_phrase_matches(
+    text: str,
+) -> list[tuple[tuple[int, int], float]]:
+    matches: list[tuple[tuple[int, int], float]] = []
+    for match in _FRENCH_CARDINAL_PHRASE_PATTERN.finditer(text):
+        normalized = re.sub(r"\s+", " ", match.group(1).strip().lower())
+        value = _FRENCH_CARDINAL_PHRASE_VALUES.get(normalized)
+        if value is None:
+            continue
+        matches.append((match.span(1), value))
+    return matches
+
+
 def _split_flat_coordinated_cardinal_phrase(
     phrase: str,
     *,
@@ -2993,10 +3067,29 @@ def _iter_standalone_fraction_word_matches(
 def _extract_percentage_context_values(text: str) -> set[float]:
     """Return decimal rate equivalents for numbers in percentage table contexts."""
     values: set[float] = set()
+    percentage_number = (
+        r"-?(?:\d{1,3}(?:[.\u00a0\u202f ]\d{3})+|\d+)"
+        r"(?:,\d{1,4})?"
+    )
+    range_separator = (
+        "(?:and|to|through|thru|et|\\u00e0|a|tot|bis|en|[-\\u2010-\\u2015])"
+    )
+    for match in re.finditer(
+        rf"\b({percentage_number})\s+{range_separator}\s+({percentage_number})"
+        r"\s*(?:%|\bp\.?\s*c\.?\b|\b(?:percent|per\s*cent(?:um)?)\b)",
+        text,
+        re.IGNORECASE,
+    ):
+        for raw in match.groups():
+            normalized = _normalize_european_decimal_number(raw)
+            with contextlib.suppress(ValueError):
+                value = float(normalized)
+                values.add(value / 100)
+
     for match in re.finditer(
         r"(?:^|(?<=[\s(\[,+\-−*/\"'`“”‘’]))"
-        r"(-?(?:\d{1,3}(?:[.\u00a0\u202f]\d{3})+|\d+),\d{1,4})"
-        r"\s*(?:%|\b(?:percent|per\s*cent(?:um)?)\b)",
+        r"(-?(?:\d{1,3}(?:[.\u00a0\u202f ]\d{3})+|\d+),\d{1,4})"
+        r"\s*(?:%|\bp\.?\s*c\.?\b|\b(?:percent|per\s*cent(?:um)?)\b)",
         text,
         re.IGNORECASE,
     ):
@@ -3124,6 +3217,8 @@ def _strip_superseded_bracketed_numeric_text(match: re.Match[str]) -> str:
     """Drop superseded bracketed numerics but preserve bracketed formulas."""
     bracketed = match.group(0)
     inner = bracketed[1:-1]
+    if re.search(r"\d+,\d+", inner):
+        return bracketed
     if re.search(r"[+\-−*/]", inner) or re.search(r"[A-Za-z_]", inner):
         return bracketed
     return " "
@@ -3274,6 +3369,14 @@ def extract_numeric_occurrences_from_text(text: str) -> list[float]:
         occurrences.append(value)
         spans.append(span)
 
+    for match in SPACED_EUROPEAN_DECIMAL_MONEY_PATTERN.finditer(cleaned):
+        span = match.span(1)
+        with contextlib.suppress(ValueError):
+            occurrences.append(
+                float(_normalize_european_decimal_number(match.group(1)))
+            )
+            spans.append(span)
+
     for match in EUROPEAN_DECIMAL_NUMBER_PATTERN.finditer(cleaned):
         span = match.span(1)
         if _span_overlaps(span, spans):
@@ -3328,6 +3431,14 @@ def extract_numeric_occurrences_from_text(text: str) -> list[float]:
             continue
         if value not in GROUNDING_ALLOWED_VALUES:
             occurrences.append(value)
+        spans.append(span)
+
+    for span, value in _iter_french_cardinal_phrase_matches(cleaned):
+        if _span_overlaps(span, spans):
+            continue
+        if value not in GROUNDING_ALLOWED_VALUES:
+            occurrences.append(value)
+        spans.append(span)
 
     occurrence_counts = Counter(occurrences)
     normalized: list[float] = []

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5993,6 +5993,29 @@ rules:
     assert 5110 in extract_numbers_from_text(source_text)
 
 
+def test_rulespec_grounding_accepts_dot_thousands_table_value_without_unit():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be/guidance/example/page-3
+rules:
+  - name: belgium_company_car_minimum_annual_benefit
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '1690'
+"""
+
+    source_text = (
+        "Exercice d'imposition Montant indexe 2025 1.600 2026 1.650 2027 1.690"
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 1690 in extract_numbers_from_text(source_text)
+
+
 def test_rulespec_grounding_accepts_spaced_thousands_separator_money():
     content = """format: rulespec/v1
 module:
@@ -6033,6 +6056,29 @@ rules:
 
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
     assert 6765.89 in extract_numbers_from_text(source_text)
+
+
+def test_rulespec_grounding_accepts_spaced_european_decimal_money():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be/regulation/example/article/6
+rules:
+  - name: belgium_guaranteed_family_benefits_resource_base_quarterly_ceiling
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2002-01-01'
+        formula: '3079.06'
+"""
+
+    source_text = (
+        "Les ressources ne depassent pas le montant de 3 079,06 euros par trimestre."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 3079.06 in extract_numbers_from_text(source_text)
 
 
 def test_rulespec_grounding_accepts_european_decimal_money_table_cell():
@@ -6097,6 +6143,49 @@ rules:
     assert 0.7933 in extract_numbers_from_text(source_text)
 
 
+def test_rulespec_grounding_preserves_bracketed_justel_decimal_amount():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be/regulation/example/article/214
+rules:
+  - name: belgium_incapacity_minimum_daily_amount
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '45.6685'
+"""
+
+    source_text = (
+        "le montant journalier minimum est egal [ 5 a [ 7 45,6685] 7 euros] 5 ;"
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 45.6685 in extract_numbers_from_text(source_text)
+
+
+def test_rulespec_grounding_accepts_three_place_european_decimal_coefficient():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be-vlg/statute/example/article/2-3-4-2
+rules:
+  - name: flemish_vehicle_tax_dual_fuel_factor
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '0.744'
+"""
+
+    source_text = "f = 0,744 voor wegvoertuigen die aangedreven worden door aardgas."
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 0.744 in extract_numbers_from_text(source_text)
+
+
 def test_rulespec_grounding_accepts_three_place_european_decimal_percentage():
     content = """format: rulespec/v1
 module:
@@ -6115,6 +6204,61 @@ rules:
 
     assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
     assert 24.957 in extract_numbers_from_text(source_text)
+
+
+def test_rulespec_grounding_accepts_three_place_p_c_percentage():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be/regulation/example/article/219bis
+rules:
+  - name: belgium_maternity_indemnity_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '0.78237'
+"""
+
+    source_text = (
+        "l'indemnite de maternite est fixee a 78,237 p.c. de la remuneration perdue."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert any(
+        math.isclose(value, 0.78237) for value in extract_numbers_from_text(source_text)
+    )
+
+
+def test_rulespec_grounding_accepts_over_100_percent_ranges_as_coefficients():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be-bru/regulation/example/article/61
+rules:
+  - name: brussels_social_housing_normal_rental_value_minimum_coefficient
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '1.10'
+  - name: brussels_social_housing_normal_rental_value_maximum_coefficient
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2026-01-01'
+        formula: '3.00'
+"""
+
+    source_text = (
+        "Le coefficient applique au loyer de base varie entre 110 et 300 % "
+        "du montant de ce loyer."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    numbers = extract_numbers_from_text(source_text)
+    assert 1.1 in numbers
+    assert 3.0 in numbers
 
 
 def test_rulespec_grounding_does_not_trust_module_summary():
@@ -7256,6 +7400,29 @@ rules:
     )
 
 
+def test_rulespec_grounding_accepts_french_cardinal_180_days():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: be/regulation/example/article/5
+rules:
+  - name: belgium_guaranteed_family_benefits_birth_stillbirth_min_pregnancy_days
+    kind: parameter
+    dtype: Count
+    versions:
+      - effective_from: '1972-01-01'
+        formula: 180
+"""
+
+    source_text = (
+        "L'allocation de naissance est accordee si est survenue une fausse "
+        "couche apres une grossesse d'au moins cent quatre-vingts jours."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+    assert 180 in extract_numbers_from_text(source_text)
+
+
 def test_rulespec_grounding_accepts_coordinated_cardinal_age_bounds():
     content = """format: rulespec/v1
 rules:
@@ -7653,6 +7820,21 @@ def test_numeric_occurrence_extraction_accepts_european_decimal_money():
     )
 
     assert extract_numeric_occurrences_from_text(text) == [6765.89]
+
+
+def test_numeric_occurrence_extraction_accepts_spaced_european_decimal_money():
+    text = (
+        "Le montant trimestriel est 3 079,06 euros. "
+        "Dotted legal reference 4.304.3 remains a citation."
+    )
+
+    assert extract_numeric_occurrences_from_text(text) == [3079.06]
+
+
+def test_numeric_occurrence_extraction_accepts_french_cardinal_180_days():
+    text = "grossesse d'au moins cent quatre-vingts jours."
+
+    assert extract_numeric_occurrences_from_text(text) == [180.0]
 
 
 def test_numeric_occurrence_extraction_accepts_european_decimal_money_table_cell():

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1086"
+version = "0.2.1087"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- treat source text ranges like `110 et 300 %` as decimal rate evidence for `1.10` and `3.00`
- bump axiom-encode to `0.2.1082` so generated RuleSpec repairs can cite this validator behavior in provenance
- add a regression covering Brussels social-housing-style percentage coefficients

## Tests
- `uv run pytest -q tests/test_cli.py -k 'package_version_metadata_matches_pyproject or current_encoder_affecting_changes_are_behind_version_bump'`
- `uv run pytest -q tests/test_rulespec_validation.py -k 'over_100_percent_ranges or three_place_european_decimal_percentage'`
