### PR TITLE
Handle page-split primary source continuations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1082"
+version = "0.2.1083"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1081"
+version = "0.2.1082"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1084"
+version = "0.2.1085"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1083"
+version = "0.2.1084"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1083"
+__version__ = "0.2.1084"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1084"
+__version__ = "0.2.1085"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1082"
+__version__ = "0.2.1083"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1081"
+__version__ = "0.2.1082"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/cli.py
+++ b/src/axiom_encode/cli.py
@@ -41017,6 +41017,43 @@ def _validate_generated_encoding_in_policy_overlay(
                     dependents=dependents,
                 )
                 continue
+            if target_validation is not None:
+                zero_branch_issues = _zero_branch_coverage_issues_for_files(
+                    rules_file=overlay_target,
+                    test_file=target_test_path,
+                )
+                if not zero_branch_issues:
+                    zero_branch_issues = [
+                        result.error
+                        for result in target_validation.results.values()
+                        if result.error
+                        and "Zero branch test coverage missing: " in result.error
+                    ]
+                zero_branch_repairs = _append_generated_zero_branch_tests_if_missing(
+                    rules_file=overlay_target,
+                    test_file=target_test_path,
+                    repo_path=overlay_repo,
+                    relative_output=relative_output,
+                    issues=zero_branch_issues,
+                    valid_output_names=_compiled_rulespec_test_output_names(
+                        pipeline,
+                        overlay_target,
+                        relative_output=relative_output,
+                    ),
+                )
+                if zero_branch_repairs:
+                    supplemental_files[
+                        _relative_to_rulespec_apply_content_root(
+                            target_test_path, overlay_repo
+                        )
+                    ] = target_test_path.read_text()
+                    validations = _validate_overlay_files(
+                        pipeline,
+                        dependent_pipeline=dependent_pipeline,
+                        overlay_target=overlay_target,
+                        dependents=dependents,
+                    )
+                    continue
             removed_invalid_inputs = _remove_invalid_dependent_test_inputs(
                 overlay_repo=overlay_repo,
                 relative_output=relative_output,

--- a/src/axiom_encode/harness/evals.py
+++ b/src/axiom_encode/harness/evals.py
@@ -737,6 +737,15 @@ class CorpusSourceUnit:
     source: Literal["local", "supabase"]
 
 
+@dataclass(frozen=True)
+class PrimarySourceContinuation:
+    """A context file that explicitly continues the primary source text."""
+
+    source_path: Path
+    corpus_citation_path: str | None
+    body: str
+
+
 @dataclass
 class EvalPromptResponse:
     """Raw model output and trace from a prompt-only eval run."""
@@ -936,6 +945,14 @@ def run_source_eval(
 ) -> list[EvalResult]:
     """Run a deterministic comparison over one corpus-backed source unit."""
     results: list[EvalResult] = []
+    continuations = _primary_source_continuations_from_context_paths(
+        extra_context_paths or []
+    )
+    source_text = _append_primary_source_continuations(source_text, continuations)
+    source_metadata_payload = _source_metadata_with_continuations(
+        source_metadata_payload,
+        continuations,
+    )
 
     for runner in [parse_runner_spec(spec) for spec in runner_specs]:
         results.append(
@@ -990,6 +1007,100 @@ def _sum_token_usage(
         reasoning_output_tokens=(left.reasoning_output_tokens if left else 0)
         + (right.reasoning_output_tokens if right else 0),
     )
+
+
+_PRIMARY_SOURCE_CONTINUATION_HEADER_PATTERN = re.compile(
+    r"^\s*Primary source continuation\b",
+    flags=re.IGNORECASE,
+)
+_CORPUS_CITATION_PATH_LINE_PATTERN = re.compile(
+    r"^\s*Corpus citation path:\s*(?P<path>\S+)\s*$",
+    flags=re.IGNORECASE,
+)
+
+
+def _primary_source_continuations_from_context_paths(
+    extra_context_paths: Sequence[Path],
+) -> list[PrimarySourceContinuation]:
+    """Return explicit primary-source continuations supplied as context files."""
+    continuations: list[PrimarySourceContinuation] = []
+    for raw_path in extra_context_paths:
+        path = Path(raw_path)
+        if not path.is_file():
+            continue
+        try:
+            raw_text = path.read_text()
+        except OSError:
+            continue
+        lines = raw_text.splitlines()
+        first_nonempty = next((line for line in lines if line.strip()), "")
+        if not _PRIMARY_SOURCE_CONTINUATION_HEADER_PATTERN.match(first_nonempty):
+            continue
+
+        corpus_citation_path: str | None = None
+        body_lines: list[str] = []
+        for line in lines:
+            if _PRIMARY_SOURCE_CONTINUATION_HEADER_PATTERN.match(line):
+                continue
+            citation_match = _CORPUS_CITATION_PATH_LINE_PATTERN.match(line)
+            if citation_match:
+                corpus_citation_path = citation_match.group("path").strip()
+                continue
+            body_lines.append(line)
+        body = "\n".join(body_lines).strip()
+        if body:
+            continuations.append(
+                PrimarySourceContinuation(
+                    source_path=path,
+                    corpus_citation_path=corpus_citation_path,
+                    body=body,
+                )
+            )
+    return continuations
+
+
+def _append_primary_source_continuations(
+    source_text: str,
+    continuations: Sequence[PrimarySourceContinuation],
+) -> str:
+    if not continuations:
+        return source_text
+    parts = [source_text.strip()]
+    for continuation in continuations:
+        label = continuation.corpus_citation_path or continuation.source_path.as_posix()
+        parts.append(f"[Primary source continuation: {label}]\n{continuation.body}")
+    return "\n\n".join(part for part in parts if part).strip()
+
+
+def _source_metadata_with_continuations(
+    source_metadata_payload: dict[str, object] | None,
+    continuations: Sequence[PrimarySourceContinuation],
+) -> dict[str, object] | None:
+    if not continuations:
+        return source_metadata_payload
+
+    metadata = dict(source_metadata_payload or {})
+    citation_paths: list[str] = []
+    raw_paths = metadata.get("corpus_citation_paths")
+    if isinstance(raw_paths, list):
+        citation_paths.extend(str(item) for item in raw_paths if str(item).strip())
+    raw_path = metadata.get("corpus_citation_path")
+    if isinstance(raw_path, str) and raw_path.strip():
+        citation_paths.append(raw_path.strip())
+
+    continuation_records: list[dict[str, str]] = []
+    for continuation in continuations:
+        record = {"context_path": str(continuation.source_path)}
+        if continuation.corpus_citation_path:
+            citation_paths.append(continuation.corpus_citation_path)
+            record["corpus_citation_path"] = continuation.corpus_citation_path
+        continuation_records.append(record)
+
+    deduped_paths = list(dict.fromkeys(citation_paths))
+    if deduped_paths:
+        metadata["corpus_citation_paths"] = deduped_paths
+    metadata["primary_source_continuations"] = continuation_records
+    return metadata
 
 
 def _combine_retry_response(
@@ -3915,8 +4026,21 @@ def _run_single_eval(
     policyengine_rule_hint: str | None = None,
 ) -> EvalResult:
     source_unit = resolve_corpus_source_unit(citation, corpus_path)
+    continuations = _primary_source_continuations_from_context_paths(
+        extra_context_paths
+    )
     source_text = source_unit.body
+    source_text = _append_primary_source_continuations(source_text, continuations)
     prompt_corpus_citation_path = _prompt_corpus_citation_path(source_unit)
+    source_metadata_payload = _source_metadata_with_continuations(
+        {
+            "corpus_citation_path": prompt_corpus_citation_path,
+            "corpus_source": source_unit.source,
+            "requested_source": source_unit.requested,
+            "resolved_corpus_citation_path": source_unit.citation_path,
+        },
+        continuations,
+    )
 
     workspace = prepare_eval_workspace(
         citation=citation,
@@ -3925,12 +4049,7 @@ def _run_single_eval(
         source_text=source_text,
         axiom_rules_path=policy_path,
         mode=mode,
-        source_metadata_payload={
-            "corpus_citation_path": prompt_corpus_citation_path,
-            "corpus_source": source_unit.source,
-            "requested_source": source_unit.requested,
-            "resolved_corpus_citation_path": source_unit.citation_path,
-        },
+        source_metadata_payload=source_metadata_payload,
         extra_context_paths=extra_context_paths,
     )
 

--- a/src/axiom_encode/harness/validator_pipeline.py
+++ b/src/axiom_encode/harness/validator_pipeline.py
@@ -3413,6 +3413,31 @@ def extract_embedded_source_text(content: str) -> str:
     return ""
 
 
+_DECIMAL_PLACE_SCALE_SOURCE_PATTERN = re.compile(
+    r"\b(?:to\s+)?(?:an?\s+)?(?:accuracy\s+of\s+)?"
+    rf"(?P<places>\d+|{_CARDINAL_WORD_SEQUENCE})\s+"
+    r"decimal\s+places?\b",
+    flags=re.IGNORECASE,
+)
+
+
+def _decimal_place_scale_values_from_source(source: str) -> set[float]:
+    """Return integer scales implied by source phrases like four decimal places."""
+    values: set[float] = set()
+    for match in _DECIMAL_PLACE_SCALE_SOURCE_PATTERN.finditer(source):
+        raw_places = match.group("places")
+        places: int | None = None
+        if raw_places.isdigit():
+            places = int(raw_places)
+        else:
+            parsed = _parse_cardinal_number_words(raw_places)
+            if parsed is not None and parsed.is_integer():
+                places = int(parsed)
+        if places is not None and 1 <= places <= 12:
+            values.add(float(10**places))
+    return values
+
+
 def find_ungrounded_numeric_issues(
     content: str,
     source_text: str | None = None,
@@ -3435,9 +3460,20 @@ def find_ungrounded_numeric_issues(
         ]
 
     source_numbers = extract_numbers_from_text(source)
+    decimal_place_scale_values = _decimal_place_scale_values_from_source(source)
     issues: list[str] = []
     for _, raw, value in grounding_values:
         if numeric_value_is_grounded(value, source_numbers):
+            continue
+        if any(
+            math.isclose(
+                value,
+                decimal_place_scale_value,
+                rel_tol=0,
+                abs_tol=NUMERIC_GROUNDING_ABS_TOLERANCE,
+            )
+            for decimal_place_scale_value in decimal_place_scale_values
+        ):
             continue
         display = raw if raw == f"{value:g}" else f"{raw} ({value:g})"
         issues.append(

--- a/src/axiom_encode/prompts/encoder.py
+++ b/src/axiom_encode/prompts/encoder.py
@@ -1634,7 +1634,13 @@ def get_encoder_prompt(
     if corpus_citation_path:
         corpus_section = f"""
 Corpus source path: {corpus_citation_path}
-Include `module.source_verification.corpus_citation_path: {corpus_citation_path}` exactly.
+Include `{corpus_citation_path}` in `module.source_verification`.
+Use `module.source_verification.corpus_citation_path: {corpus_citation_path}`
+when the primary corpus row fully states the encoded source slice. If the
+primary row is split by a page break or otherwise continues in supplied
+adjacent source context for the same legal provision, use
+`module.source_verification.corpus_citation_paths` and include both the primary
+path and each continuation corpus path that grounds executable rules.
 """
 
     return f"""{ENCODER_PROMPT}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25677,6 +25677,86 @@ rules: []
         assert issues == []
         assert supplemental == {}
 
+    def test_apply_overlay_validation_repairs_generated_zero_branch_tests(
+        self, tmp_path
+    ):
+        output_root = tmp_path / "out"
+        policy_repo = tmp_path / "rulespec-us"
+        generated = output_root / "codex-test-model" / "statutes/26/151.yaml"
+        generated_test = generated.with_name("151.test.yaml")
+        generated.parent.mkdir(parents=True)
+        policy_repo.mkdir()
+        generated.write_text(
+            """format: rulespec/v1
+rules:
+  - name: section_151_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          if amount_allowed:
+              amount
+          else:
+              0
+"""
+        )
+        generated_test.write_text(
+            """- name: positive_amount
+  period: 2026
+  input:
+    us:statutes/26/151#input.amount_allowed: true
+    us:statutes/26/151#input.amount: 5
+  output:
+    us:statutes/26/151#section_151_amount: 5
+"""
+        )
+        result = SimpleNamespace(output_file=str(generated), runner="codex-test-model")
+        validation_attempts: list[str] = []
+
+        class FakePipeline:
+            policy_repo_path = policy_repo
+
+            def __init__(self, **kwargs):
+                self.policy_repo_path = Path(kwargs["policy_repo_path"])
+
+            def validate(self, path, *, skip_reviewers):
+                assert skip_reviewers is True
+                test_content = Path(path).with_name("151.test.yaml").read_text()
+                validation_attempts.append(test_content)
+                if "auto_zero_section_151_amount" in test_content:
+                    return SimpleNamespace(all_passed=True, results={})
+                return SimpleNamespace(
+                    all_passed=False,
+                    results={
+                        "ci": SimpleNamespace(
+                            error=(
+                                "Zero branch test coverage missing: "
+                                "`section_151_amount` has a formula branch that "
+                                "returns 0."
+                            )
+                        )
+                    },
+                )
+
+        with patch("axiom_encode.cli.ValidatorPipeline", FakePipeline):
+            ok, issues, supplemental = _validate_generated_encoding_in_policy_overlay(
+                result,
+                output_root=output_root,
+                policy_repo_path=policy_repo,
+                axiom_rules_path=tmp_path / "axiom-rules-engine",
+            )
+
+        assert ok is True
+        assert issues == []
+        assert len(validation_attempts) == 2
+        updated = supplemental[Path("statutes/26/151.test.yaml")]
+        assert "auto_zero_section_151_amount" in updated
+        assert "us:statutes/26/151#input.amount_allowed: false" in updated
+        assert "us:statutes/26/151#section_151_amount: 0" in updated
+
     def test_apply_overlay_validation_skips_sibling_with_active_canonical_name(
         self, tmp_path
     ):

--- a/tests/test_encoder_backend.py
+++ b/tests/test_encoder_backend.py
@@ -158,10 +158,10 @@ def test_generic_encoder_prompt_includes_durable_rule_spec_guidance():
     _assert_encoder_prompt_topics(ENCODER_PROMPT)
     _assert_encoder_prompt_topics(prompt)
     assert "For 26 USC 1402(a)(12)" not in ENCODER_PROMPT
-    assert (
-        "Include `module.source_verification.corpus_citation_path: us/statute/26/63` exactly."
-        in prompt
-    )
+    normalized_prompt = " ".join(prompt.split())
+    assert "Include `us/statute/26/63` in `module.source_verification`." in prompt
+    assert "primary row is split by a page break" in normalized_prompt
+    assert "supplied adjacent source context" in normalized_prompt
     assert "Target citation/source id: 26 USC 63(c)(5)" in prompt
     assert "Expected output path: statutes/26/63/c/5.yaml" in prompt
 

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -2959,6 +2959,69 @@ def test_run_source_eval_retries_once_when_first_response_has_no_rulespec(tmp_pa
     assert "Do not narrate your plan" in retry_prompt
 
 
+def test_run_source_eval_appends_primary_source_continuation_context(tmp_path):
+    policy_repo_root = tmp_path / "axiom-rules-engine"
+    policy_repo_root.mkdir()
+    continuation = tmp_path / "continuation.txt"
+    continuation.write_text(
+        "Primary source continuation for sample.\n"
+        "Corpus citation path: us/regulation/example/page-2\n\n"
+        "The amount shall be rounded down to the next lower whole dollar.\n"
+    )
+    response = EvalPromptResponse(
+        text=(
+            "=== FILE: sample.yaml ===\n"
+            "format: rulespec/v1\n"
+            "module:\n"
+            "  source_verification:\n"
+            "    corpus_citation_paths:\n"
+            "      - us/regulation/example/page-1\n"
+            "      - us/regulation/example/page-2\n"
+            "  summary: source states 451.\n"
+            "rules: []\n"
+            "=== FILE: sample.test.yaml ===\n"
+            "[]\n"
+        ),
+        duration_ms=10,
+        trace={},
+    )
+
+    with (
+        patch("axiom_encode.harness.evals._run_prompt_eval", return_value=response),
+        patch("axiom_encode.harness.evals.evaluate_artifact", return_value=None),
+    ):
+        [result] = run_source_eval(
+            source_id="sample",
+            source_text="Primary page text ends mid-sentence.",
+            runner_specs=["codex:gpt-5.4"],
+            output_root=tmp_path / "out",
+            policy_path=policy_repo_root,
+            source_metadata_payload={
+                "corpus_citation_path": "us/regulation/example/page-1"
+            },
+            extra_context_paths=[continuation],
+            mode="cold",
+        )
+
+    manifest = json.loads(Path(result.context_manifest_file).read_text())
+    source_text = (
+        Path(result.context_manifest_file).parent / manifest["source_text_file"]
+    ).read_text()
+    assert "Primary page text ends mid-sentence." in source_text
+    assert "Primary source continuation: us/regulation/example/page-2" in source_text
+    assert "rounded down to the next lower whole dollar" in source_text
+    assert manifest["source_metadata"]["corpus_citation_paths"] == [
+        "us/regulation/example/page-1",
+        "us/regulation/example/page-2",
+    ]
+    assert manifest["source_metadata"]["primary_source_continuations"] == [
+        {
+            "context_path": str(continuation),
+            "corpus_citation_path": "us/regulation/example/page-2",
+        }
+    ]
+
+
 def test_empty_artifact_retry_prompt_uses_minimal_source_scope_protocol():
     from axiom_encode.prompts.encoder import SOURCE_SCOPE_PROTOCOL
 

--- a/tests/test_rulespec_validation.py
+++ b/tests/test_rulespec_validation.py
@@ -5859,6 +5859,53 @@ rules:
     )
 
 
+def test_rulespec_grounding_accepts_decimal_place_scale_derivation():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-hi/regulation/har/17/680/page-12
+rules:
+  - name: quotient_decimal_place_scale
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '2006-11-09'
+        formula: '10000'
+"""
+
+    source_text = (
+        "Drop the remaining decimals and make the quotient to an accuracy of "
+        "four decimal places."
+    )
+
+    assert find_ungrounded_numeric_issues(content, source_text=source_text) == []
+
+
+def test_rulespec_grounding_rejects_unrelated_power_of_ten():
+    content = """format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us-hi/regulation/har/17/680/page-12
+rules:
+  - name: quotient_decimal_place_scale
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '2006-11-09'
+        formula: '10000'
+"""
+
+    issues = find_ungrounded_numeric_issues(
+        content,
+        source_text="The amount is rounded down to the next lower whole dollar.",
+    )
+
+    assert issues == [
+        "Ungrounded generated numeric literal: 10000 does not appear as a "
+        "substantive numeric value in the source text."
+    ]
+
+
 def test_rulespec_grounding_accepts_textual_half_across_line_break():
     content = """format: rulespec/v1
 module:

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1081"
+version = "0.2.1082"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1082"
+version = "0.2.1083"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1083"
+version = "0.2.1084"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1084"
+version = "0.2.1085"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- treat marked primary-source continuation context files as appended source text for encode/eval workspaces
- teach the encoder prompt to cite page-split source continuations with `module.source_verification.corpus_citation_paths`
- allow source phrases like “four decimal places” to ground derived scale literals such as `10000`

## Validation
- `uv run pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q`
- `uv run pytest tests/test_evals.py::test_run_source_eval_appends_primary_source_continuation_context -q`
- `uv run pytest tests/test_encoder_backend.py::test_generic_encoder_prompt_includes_durable_rule_spec_guidance tests/test_rulespec_validation.py -k 'decimal_place_scale' -q`\n- `uv run ruff check src/axiom_encode/harness/evals.py src/axiom_encode/prompts/encoder.py tests/test_evals.py tests/test_encoder_backend.py src/axiom_encode/harness/validator_pipeline.py tests/test_rulespec_validation.py`\n\n## Follow-up\n- Hawaii TANF HAR §17-680-12 was regenerated with this branch and now validates with both page 11 and page 12 source coverage.