### PR TITLE
Classify Hawaii TANF oracle coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axiom-encode"
-version = "0.2.1085"
+version = "0.2.1086"
 description = "AI-assisted RuleSpec encoding infrastructure - fully self-contained"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/axiom_encode/__init__.py
+++ b/src/axiom_encode/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.1085"
+__version__ = "0.2.1086"
 # Axiom Encode - AI-assisted RuleSpec encoding
 # Self-contained encoding infrastructure -- no external plugin dependencies.
 

--- a/src/axiom_encode/oracles/policyengine/mappings/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/mappings/us.yaml
@@ -21002,6 +21002,14 @@ prefixes:
     candidate_priority: P4
     rationale: Georgia DFCS TANF manual outputs decompose source-level assistance standards, gross and net income tests, countable-income construction, work and dependent-care deductions, resource/income eligibility, and cash-assistance benefit slices. PolicyEngine-US exposes ga_tanf as a final monthly SPM-unit benefit built from PE's own eligibility graph and parameter tables, so these legal outputs are adjacent TANF coverage but not one-to-one oracle targets unless a narrower exact mapping overrides this prefix.
 
+  - legal_id_prefix: us-hi:regulations/har/17/680/17-680-12#
+    country: us
+    program: tanf
+    mapping_type: not_comparable
+    policyengine_variable: hi_tanf
+    candidate_priority: P4
+    rationale: Hawaii HAR §17-680-12 outputs decompose the source-level monthly assistance payment, initial-month proration, quotient truncation, whole-dollar rounding, and no-payment thresholds. PolicyEngine-US exposes hi_tanf as a final SPM-unit TANF benefit built from its own eligibility, income, and maximum-benefit graph; it does not expose this section's source-specific payment-determination helpers as one-to-one oracle variables.
+
   - legal_id_prefix: us-ks:policies/dcf/keesm/keesm7410#
     country: us
     program: tanf

--- a/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
+++ b/src/axiom_encode/oracles/policyengine/program_surfaces/us.yaml
@@ -619,10 +619,11 @@ surfaces:
   variable: hi_tanf
   source_type: state_implementation
   state: HI
-  axiom_status: pending_rulespec_encoding
+  axiom_status: known_not_comparable
   priority: P1
-  rationale: PolicyEngine models this program variable; Axiom should encode the governing law and add a legal-ID oracle mapping
-    before claiming parity.
+  rationale: Axiom encodes HAR §17-680-12 payment-determination mechanics and classifies that source slice against hi_tanf,
+    but the current RuleSpec surface is not yet a one-to-one final-benefit oracle because PolicyEngine's hi_tanf includes
+    PE eligibility, income, and maximum-benefit graph components beyond this section.
 - country: us
   program_id: tanf
   program_name: Delaware TANF

--- a/uv.lock
+++ b/uv.lock
@@ -53,7 +53,7 @@ wheels = [
 
 [[package]]
 name = "axiom-encode"
-version = "0.2.1085"
+version = "0.2.1086"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- classify Hawaii HAR §17-680-12 outputs as known-not-comparable against PolicyEngine's final hi_tanf surface
- mark the Hawaii TANF program surface accordingly
- bump axiom-encode to 0.2.1086 for downstream RuleSpec toolchain pinning

## Tests
- uv run pytest tests/test_policyengine_classifier.py tests/test_policyengine_coverage.py -q
- uv run pytest tests/test_cli.py::test_current_encoder_affecting_changes_are_behind_version_bump -q
- uv run axiom-encode oracle-coverage --root /tmp/axiom-oracle-root --fail-on-unmapped --fail-on-untested-comparable --limit 80